### PR TITLE
Make `vibe fmt` a real command (#2149)

### DIFF
--- a/docs/cheatsheet.md
+++ b/docs/cheatsheet.md
@@ -32,6 +32,7 @@ vibe run hello.vibex       # compile & execute
 vibe shell                 # interactive shell
 vibe test file.vibe        # run tests
 vibe check file.vibe       # type check only
+vibe fmt file.vibe         # format in place (--check / --stdout)
 vibe build --release app.vibe  # standalone .wasm
 ```
 

--- a/lib/@vibe/compiler/cli_adapter.vibe
+++ b/lib/@vibe/compiler/cli_adapter.vibe
@@ -84,6 +84,15 @@ import @vibe/compiler/normalize {
   normalize_source
 }
 
+// #2149: `vibe fmt`. Until now the formatter was reachable only through
+// lib/@vibe/cli/fmt_entry.vibe, a separate wasm that scripts/vibe_fmt.sh
+// FS-compiles on demand -- so an INSTALLED user could not format at all,
+// while 21 documents told them to run `vibe fmt`. The package has `deps = {}`
+// and format.vibe has no imports, so joining the compiler costs it nothing.
+import @vibe/compiler/fmt {
+  format_source
+}
+
 import ./inspect_update.vibe {
   compute_updated_source
 }
@@ -429,6 +438,30 @@ fn adapter_split_nonempty_lines(text: String) -> Array[String] {
     i = i + 1
   }
   out
+}
+
+/// #2149: does `s` end with `suffix`? Used only to spot a `.vpkg` path, whose
+/// header is not vibe syntax and so can never be parse-checked as a whole file.
+fn adapter_path_has_suffix(s: String, suffix: String) -> Bool {
+  let n = String::length(s)
+  let m = String::length(suffix)
+  if n < m {
+    false
+  } else {
+    String::substring(s, n - m, n) == suffix
+  }
+}
+
+/// #2149: is `src` a program the parser accepts? The `vibe fmt` guard's whole
+/// question -- see the VIBE_FMT branch for why it is asked by parsing rather
+/// than by enumerating token shapes.
+fn adapter_program_parses(src: String) -> Bool {
+  handle {
+    let _ = parse_program(lex(src))
+    true
+  } with Exception {
+    Throw(_) => false
+  }
 }
 
 fn adapter_string_to_bytes(s: String) -> Bytes {
@@ -1416,6 +1449,45 @@ export fn cli_main() -> Int with Exception + Fs + Env + Stdin + Stdout {
       // stripped, unlocated message as before.
       Throw(msg) => emit_compile_diag_fs_located(output_path, msg, input_path)
     }
+  }
+  // #2149 `vibe fmt`: format a source file and write the result. Same
+  // (input, output) interface as `vibe normalize` below.
+  //
+  // The GUARD is the reason this is not a bare call to format_source. The
+  // formatter turned source that compiles into source that does not on four
+  // separate occasions (#945, #1429, #1505, #1821), and `--check` then
+  // reported the wreckage as correctly formatted. So the output is PARSED:
+  // if the input was a program and the output is not, the rewrite is
+  // discarded and the run reports non-zero. That question has a bounded
+  // answer, and it holds for the next spelling nobody has thought of yet.
+  //
+  // Ported from lib/@vibe/cli/fmt_entry.vibe rather than restated: this is
+  // the path an installed user runs, where no CI fmt gate is watching.
+  //
+  // On refusal the INPUT is written back, so the caller always has a valid
+  // file at output_path; the non-zero return is what says "I refused". The
+  // runner exits 0 whatever this returns and prints the value as the last
+  // stdout line, so runtime/vibe's `fmt` arm reads that line -- discarding it
+  // is how a refusal once looked exactly like "nothing to change" (#1821).
+  if Env::get("VIBE_FMT") == "1" {
+    let src = Fs::read_file(input_path)
+    // format_source dispatches on the extension: `.vpkg` package contracts
+    // get header handling, everything else is plain vibe source (#1435).
+    let formatted = format_source(input_path, src)
+    // A `.vpkg` header is not vibe syntax, so a whole-file parse never
+    // succeeds for one and the comparison would say nothing. format_vpkg
+    // already refuses to touch a header it cannot read -- the same policy
+    // reached by a different route (#1435).
+    //
+    // Only a rewrite that BREAKS something is rejected. A file that did not
+    // parse to begin with is still formatted: the promise is "no worse", not
+    // "only valid input".
+    if !adapter_path_has_suffix(input_path, ".vpkg") && adapter_program_parses(src) && !adapter_program_parses(formatted) {
+      Fs::write_bytes(output_path, adapter_string_to_bytes(src))
+      return 1
+    }
+    Fs::write_bytes(output_path, adapter_string_to_bytes(formatted))
+    return 0
   }
   // #594 `vibe normalize`: canonicalize a source file (module flatten + DCE +
   // section layout) and write the result. Same (input, output) interface.

--- a/lib/@vibe/compiler/compiler_sources_manifest.tsv
+++ b/lib/@vibe/compiler/compiler_sources_manifest.tsv
@@ -277,6 +277,8 @@ normalize	normalize/unbox_tuple_loop.vibe
 normalize	normalize/erase_ascription.vibe
 normalize	codegen/common_base/self_tail_call.vibe
 normalize	codegen/common_base/inline_direct_perform.vibe
+fmt	fmt/index.vpkg
+fmt	fmt/format.vibe
 entry	entry/source_compile/index.vpkg
 entry	entry/source_compile/source_compile.vibe
 entry	entry/source_compile/wasi_only/index.vpkg

--- a/lib/@vibe/compiler/index.vpkg
+++ b/lib/@vibe/compiler/index.vpkg
@@ -17,6 +17,7 @@ deps = {
   @vibe/compiler/entry/source_compile : 0.0.1
   @vibe/compiler/entry/source_compile/gc_only : 0.0.1
   @vibe/compiler/entry/source_compile/wasi_only : 0.0.1
+  @vibe/compiler/fmt : 0.0.1
   @vibe/compiler/incremental : 0.0.1
   @vibe/compiler/loader : 0.0.1
   @vibe/compiler/module_graph : 0.0.1

--- a/lib/@vibe/parser/parser_expr_dispatch.vibe
+++ b/lib/@vibe/parser/parser_expr_dispatch.vibe
@@ -289,17 +289,37 @@ fn desugar_guarded(arms: Array[(Pat, Expr, Expr)], i: Int, scrut: Expr, context:
   }
 }
 
-/// #2197: the compound-assignment token's operator, or None when `tk` is not
-/// one. Kept separate so the arm-body tail below states each target shape once
-/// instead of once per operator, the way parse_block_steps has to.
-fn arm_assign_op(tk: Token) -> Option[String] {
+/// #2197: does an assignment tail begin at `tk`? The arm parsers ask this
+/// BEFORE calling parse_arm_assign_tail, because the answer is `false` for
+/// almost every arm and the call is not free: its `(Expr, Int)` result is a
+/// heap tuple, and paying for one per arm cost 15.4 B/arm -- +5.4% B/op on
+/// parser_bench's parse_wide_match, +5.1% on parse_expr_match (measured).
+///
+/// parse_arm_assign_tail stays TOTAL on its own -- it answers `(body, at)` for
+/// a token that is not an assignment. This predicate only skips the call, so a
+/// disagreement between the two costs a missed tail or a wasted call, never a
+/// wrong parse.
+fn arm_assign_follows(tk: Token) -> Bool {
   match tk {
-    TPlusEq => Some("+"),
-    TMinusEq => Some("-"),
-    TStarEq => Some("*"),
-    TSlashEq => Some("/"),
-    TPercentEq => Some("%"),
-    _ => None
+    TEq => true,
+    TPlusEq => true,
+    TMinusEq => true,
+    TStarEq => true,
+    TSlashEq => true,
+    TPercentEq => true,
+    _ => false
+  }
+}
+
+/// #2197: `body op= <rhs>` as an arm body. Split out so each compound operator
+/// is named exactly once in the dispatch below, without an Option to carry it.
+fn parse_arm_compound_assign(tokens: Array[Token], body: Expr, at: Int, op: String, parse_recur: (Array[Token], Int, Int, Option[ParserBinderContext]) -> (Expr, Int) with Exception, context: Option[ParserBinderContext]) -> (Expr, Int) with Exception {
+  match body {
+    EIdent(name, _) => {
+      let (val, next) = parse_recur(tokens, at + 1, 0, context)
+      (EAssignOp(name, op, val, EUnit), next)
+    },
+    _ => throw("invalid assignment target")
   }
 }
 
@@ -321,49 +341,44 @@ fn arm_assign_op(tk: Token) -> Option[String] {
 /// same `invalid assignment target` a block statement gets, not the pattern
 /// error.
 fn parse_arm_assign_tail(tokens: Array[Token], body: Expr, at: Int, parse_recur: (Array[Token], Int, Int, Option[ParserBinderContext]) -> (Expr, Int) with Exception, context: Option[ParserBinderContext]) -> (Expr, Int) with Exception {
-  let tk = peek(tokens, at)
-  match arm_assign_op(tk) {
-    Some(op) => match body {
+  match peek(tokens, at) {
+    TPlusEq => parse_arm_compound_assign(tokens, body, at, "+", parse_recur, context),
+    TMinusEq => parse_arm_compound_assign(tokens, body, at, "-", parse_recur, context),
+    TStarEq => parse_arm_compound_assign(tokens, body, at, "*", parse_recur, context),
+    TSlashEq => parse_arm_compound_assign(tokens, body, at, "/", parse_recur, context),
+    TPercentEq => parse_arm_compound_assign(tokens, body, at, "%", parse_recur, context),
+    TEq => match body {
       EIdent(name, _) => {
         let (val, next) = parse_recur(tokens, at + 1, 0, context)
-        (EAssignOp(name, op, val, EUnit), next)
+        (EAssign(name, val, EUnit), next)
+      },
+      EDot(obj, field, _, _) => {
+        let (val, next) = parse_recur(tokens, at + 1, 0, context)
+        let set_args = empty_exprs()
+        Array::push(set_args, obj)
+        Array::push(set_args, EString(field))
+        Array::push(set_args, val)
+        (ECall(EIdent("__set_field", -1), set_args, -1), next)
+      },
+      ECall(idx_callee, idx_args, _) => {
+        let is_index = match idx_callee {
+          EIdent(icn, _) => icn == "__index",
+          _ => false
+        }
+        if is_index && Array::length(idx_args) == 2 {
+          let (val, next) = parse_recur(tokens, at + 1, 0, context)
+          let set_args = empty_exprs()
+          Array::push(set_args, Array::get(idx_args, 0))
+          Array::push(set_args, Array::get(idx_args, 1))
+          Array::push(set_args, val)
+          (ECall(EIdent("Array::set", -1), set_args, -1), next)
+        } else {
+          throw("invalid assignment target")
+        }
       },
       _ => throw("invalid assignment target")
     },
-    None => match tk {
-      TEq => match body {
-        EIdent(name, _) => {
-          let (val, next) = parse_recur(tokens, at + 1, 0, context)
-          (EAssign(name, val, EUnit), next)
-        },
-        EDot(obj, field, _, _) => {
-          let (val, next) = parse_recur(tokens, at + 1, 0, context)
-          let set_args = empty_exprs()
-          Array::push(set_args, obj)
-          Array::push(set_args, EString(field))
-          Array::push(set_args, val)
-          (ECall(EIdent("__set_field", -1), set_args, -1), next)
-        },
-        ECall(idx_callee, idx_args, _) => {
-          let is_index = match idx_callee {
-            EIdent(icn, _) => icn == "__index",
-            _ => false
-          }
-          if is_index && Array::length(idx_args) == 2 {
-            let (val, next) = parse_recur(tokens, at + 1, 0, context)
-            let set_args = empty_exprs()
-            Array::push(set_args, Array::get(idx_args, 0))
-            Array::push(set_args, Array::get(idx_args, 1))
-            Array::push(set_args, val)
-            (ECall(EIdent("Array::set", -1), set_args, -1), next)
-          } else {
-            throw("invalid assignment target")
-          }
-        },
-        _ => throw("invalid assignment target")
-      },
-      _ => (body, at)
-    }
+    _ => (body, at)
   }
 }
 
@@ -392,7 +407,15 @@ fn collect_match_arms(tokens: Array[Token], starts: Array[Int], pos: Int, b: Arr
   let body_mark = binder_capture_mark(context)
   let (raw_body, raw_bn) = parse_recur(tokens, arrow, 0, context)
   // #2197: `_ => ok = false` -- the assignment is part of THIS arm's body.
-  let (body, bn) = parse_arm_assign_tail(tokens, raw_body, raw_bn, parse_recur, context)
+  // Guarded so an ordinary arm does not pay for the helper's result tuple; see
+  // arm_assign_follows. These stay wasm locals (nothing captures them).
+  let mut body = raw_body
+  let mut bn = raw_bn
+  if arm_assign_follows(peek(tokens, raw_bn)) {
+    let (assigned, after_assign) = parse_arm_assign_tail(tokens, raw_body, raw_bn, parse_recur, context)
+    body = assigned
+    bn = after_assign
+  }
   let body_rows = binder_capture_take_from(context, body_mark)
   ArrayBuilder::push(b, (pat, arm_guard, body))
   match row_b {
@@ -462,9 +485,16 @@ fn parse_handle_arm(tokens: Array[Token], starts: Array[Int], pos: Int, effect_n
   let (pat, pat_next) = parse_pattern_with_binder_context(tokens, pos, context)
   let qualified_pat = qualify_handle_arm_pattern(effect_name, pat, context)
   let arrow_pos = expect_tk(tokens, pat_next, "=>")
-  // #2197: a handler body is an arm body too -- same bare-assignment tail.
+  // #2197: a handler body is an arm body too -- same bare-assignment tail,
+  // same guard against paying for its result tuple on every arm.
   let (raw_expr, raw_next) = parse_recur(tokens, arrow_pos, 0, context)
-  let (expr, next) = parse_arm_assign_tail(tokens, raw_expr, raw_next, parse_recur, context)
+  let mut expr = raw_expr
+  let mut next = raw_next
+  if arm_assign_follows(peek(tokens, raw_next)) {
+    let (assigned, after_assign) = parse_arm_assign_tail(tokens, raw_expr, raw_next, parse_recur, context)
+    expr = assigned
+    next = after_assign
+  }
   ((qualified_pat, expr), next)
 }
 
@@ -489,9 +519,16 @@ fn parse_qualified_handle_arm(tokens: Array[Token], starts: Array[Int], pos: Int
     _ => throw("handler-set arms must name a fully qualified operation such as `Exception::Throw(_)`")
   }
   let arrow_pos = expect_tk(tokens, pat_next, "=>")
-  // #2197: a handler body is an arm body too -- same bare-assignment tail.
+  // #2197: a handler body is an arm body too -- same bare-assignment tail,
+  // same guard against paying for its result tuple on every arm.
   let (raw_expr, raw_next) = parse_recur(tokens, arrow_pos, 0, context)
-  let (expr, next) = parse_arm_assign_tail(tokens, raw_expr, raw_next, parse_recur, context)
+  let mut expr = raw_expr
+  let mut next = raw_next
+  if arm_assign_follows(peek(tokens, raw_next)) {
+    let (assigned, after_assign) = parse_arm_assign_tail(tokens, raw_expr, raw_next, parse_recur, context)
+    expr = assigned
+    next = after_assign
+  }
   ((qualified_pat, expr), next)
 }
 

--- a/runtime/vibe
+++ b/runtime/vibe
@@ -960,7 +960,10 @@ case "$cmd" in
       cli="$(pick_cli)"
       mkdir -p "$(dirname "$out")"
       rm -f "$out" "$out.diag"
-      env VIBE_EMIT_WIT=1 VIBE_IMPORT_ABI=raw \
+      # -u VIBE_FMT: the fmt branch is evaluated BEFORE VIBE_EMIT_WIT in
+      # cli_adapter, so a leaked selector writes formatted vibe source as the
+      # .wit artifact -- non-empty, so the check below reports success (#2239).
+      env -u VIBE_FMT VIBE_EMIT_WIT=1 VIBE_IMPORT_ABI=raw \
         "$RUNNER" "$cli" "$src" "$out" main >/dev/null 2>&1 || true
       if [ ! -s "$out" ]; then
         [ -s "$out.diag" ] && echo "error: $(cat "$out.diag")" >&2
@@ -1058,7 +1061,8 @@ case "$cmd" in
     cli="$(pick_cli)"
     mkdir -p "$(dirname "$out")"
     rm -f "$out" "$out.diag"
-    env VIBE_SERVE_COMPONENT=1 VIBE_SERVE_WIT_OUT="${out%.component.wasm}.wit" \
+    # -u VIBE_FMT: same precedence hazard as the --wit arm above (#2239).
+    env -u VIBE_FMT VIBE_SERVE_COMPONENT=1 VIBE_SERVE_WIT_OUT="${out%.component.wasm}.wit" \
       VIBE_IMPORT_ABI=raw \
       "$RUNNER" "$cli" "$src" "$out" main >/dev/null 2>&1 || true
     if [ ! -s "$out" ]; then
@@ -2192,7 +2196,10 @@ PY
       local usrc="$1" ucaptured="$2"
       local ucli="$CLI_WASM"; [ -f "$ucli" ] || ucli="$(pick_cli)"
       local upatched; upatched="$(mktemp -t vibe-test-patched-XXXXXX.vibe)"
-      if env VIBE_INSPECT_UPDATE=1 VIBE_INSPECT_UPDATE_STDOUT="$ucaptured" VIBE_IMPORT_ABI=raw \
+      # -u VIBE_FMT: same precedence hazard (#2239). A leak here would write
+      # a FORMATTED copy of the test file as the "patched" source, and the
+      # cmp below would then copy it over the user's test.
+      if env -u VIBE_FMT VIBE_INSPECT_UPDATE=1 VIBE_INSPECT_UPDATE_STDOUT="$ucaptured" VIBE_IMPORT_ABI=raw \
           "$RUNNER" "$ucli" "$usrc" "$upatched" >/dev/null 2>/dev/null \
           && [ -s "$upatched" ] && ! cmp -s "$usrc" "$upatched"; then
         cp "$upatched" "$usrc"

--- a/runtime/vibe
+++ b/runtime/vibe
@@ -91,6 +91,11 @@
 #                                           --where-row '$f with Async'  effect row
 #                                           --only-ill-typed / --only-well-typed
 #                                         --json for machine-readable output
+#   vibe fmt     [--check|--stdout] <file.vibe|file.vpkg>
+#                                         format a source file in place with the
+#                                         canonical CST-token formatter
+#                                         (--check: exit 1 if not formatted;
+#                                          --stdout: print, don't write)
 #   vibe normalize [--check|--stdout] <file.vibe>
 #                                         canonicalize a source file in place
 #                                         (--check: exit 1 if not normalized;
@@ -1197,7 +1202,7 @@ case "$cmd" in
       out="$(mktemp -t vibe-check-sf-XXXXXX)"
       trap 'rm -f "$out" "$out.diag"' EXIT
       env -u VIBE_FS_COMPILE -u VIBE_CHECK_ONLY -u VIBE_TYPE_AT -u VIBE_DOC_AT \
-          -u VIBE_BINDING_AT -u VIBE_ESCAPES -u VIBE_ESCAPES_STRICT -u VIBE_ALLOCS -u VIBE_SYMBOLS -u VIBE_NORMALIZE \
+          -u VIBE_BINDING_AT -u VIBE_ESCAPES -u VIBE_ESCAPES_STRICT -u VIBE_ALLOCS -u VIBE_SYMBOLS -u VIBE_NORMALIZE -u VIBE_FMT \
           -u VIBE_COVERAGE -u VIBE_DEBUG -u VIBE_DEBUG_BREAK -u VIBE_EMIT_MODULE_SOURCE \
         VIBE_DIAGNOSTICS=1 \
         VIBE_DIAGNOSTICS_JSON="$([ "$chk_json" = "1" ] && echo 1 || echo "")" \
@@ -1280,7 +1285,7 @@ case "$cmd" in
       out="$(mktemp -t vibe-check-XXXXXX)"
       trap 'rm -f "$out" "$out.diag"' EXIT
       env -u VIBE_FS_COMPILE -u VIBE_DIAGNOSTICS -u VIBE_TYPE_AT -u VIBE_DOC_AT -u VIBE_BINDING_AT -u VIBE_ESCAPES -u VIBE_ESCAPES_STRICT -u VIBE_ALLOCS \
-          -u VIBE_SYMBOLS -u VIBE_NORMALIZE -u VIBE_COVERAGE -u VIBE_DEBUG \
+          -u VIBE_SYMBOLS -u VIBE_NORMALIZE -u VIBE_FMT -u VIBE_COVERAGE -u VIBE_DEBUG \
           -u VIBE_DEBUG_BREAK -u VIBE_EMIT_MODULE_SOURCE \
         VIBE_CHECK_ONLY=1 \
         VIBE_IMPORT_ABI=raw \
@@ -1341,7 +1346,7 @@ case "$cmd" in
     # the compile path (which would emit wasm bytes instead of the type string).
     # Don't `die` on a non-zero exit — emit whatever (possibly empty) result was
     # written so the LSP degrades gracefully instead of the whole query failing.
-    env -u VIBE_FS_COMPILE -u VIBE_DIAGNOSTICS -u VIBE_NORMALIZE -u VIBE_ESCAPES -u VIBE_ESCAPES_STRICT -u VIBE_ALLOCS \
+    env -u VIBE_FS_COMPILE -u VIBE_DIAGNOSTICS -u VIBE_NORMALIZE -u VIBE_FMT -u VIBE_ESCAPES -u VIBE_ESCAPES_STRICT -u VIBE_ALLOCS \
         -u VIBE_COVERAGE -u VIBE_DEBUG -u VIBE_DEBUG_BREAK -u VIBE_EMIT_MODULE_SOURCE \
       VIBE_TYPE_AT=1 VIBE_TYPE_LINE="$ta_line" VIBE_TYPE_COL="$ta_col" \
       VIBE_IMPORT_ABI=raw \
@@ -1366,7 +1371,7 @@ case "$cmd" in
     # the compile path (which would emit wasm bytes instead of the doc text).
     # Don't `die` on a non-zero exit — emit whatever (possibly empty) result was
     # written so the LSP degrades gracefully instead of the whole query failing.
-    env -u VIBE_FS_COMPILE -u VIBE_DIAGNOSTICS -u VIBE_NORMALIZE -u VIBE_TYPE_AT \
+    env -u VIBE_FS_COMPILE -u VIBE_DIAGNOSTICS -u VIBE_NORMALIZE -u VIBE_FMT -u VIBE_TYPE_AT \
         -u VIBE_BINDING_AT -u VIBE_SYMBOLS -u VIBE_ESCAPES -u VIBE_ESCAPES_STRICT -u VIBE_ALLOCS -u VIBE_COVERAGE -u VIBE_DEBUG -u VIBE_DEBUG_BREAK \
         -u VIBE_EMIT_MODULE_SOURCE \
       VIBE_DOC_AT=1 VIBE_TYPE_LINE="$da_line" VIBE_TYPE_COL="$da_col" \
@@ -1394,7 +1399,7 @@ case "$cmd" in
     # compile path (which would emit wasm bytes instead of the occurrence list).
     # Don't `die` on a non-zero exit — emit whatever (possibly empty) result was
     # written so the LSP degrades gracefully instead of the whole query failing.
-    env -u VIBE_FS_COMPILE -u VIBE_DIAGNOSTICS -u VIBE_NORMALIZE -u VIBE_TYPE_AT -u VIBE_DOC_AT -u VIBE_ESCAPES -u VIBE_ESCAPES_STRICT -u VIBE_ALLOCS \
+    env -u VIBE_FS_COMPILE -u VIBE_DIAGNOSTICS -u VIBE_NORMALIZE -u VIBE_FMT -u VIBE_TYPE_AT -u VIBE_DOC_AT -u VIBE_ESCAPES -u VIBE_ESCAPES_STRICT -u VIBE_ALLOCS \
         -u VIBE_COVERAGE -u VIBE_DEBUG -u VIBE_DEBUG_BREAK -u VIBE_EMIT_MODULE_SOURCE \
       VIBE_BINDING_AT=1 VIBE_TYPE_LINE="$ba_line" VIBE_TYPE_COL="$ba_col" \
       VIBE_IMPORT_ABI=raw \
@@ -1455,7 +1460,7 @@ case "$cmd" in
     trap 'rm -f "$out" "$out.diag"' EXIT
     # Clear any inherited compile-mode envs so this query can't be diverted to the
     # compile path (which would emit wasm bytes instead of the symbol list).
-    env -u VIBE_FS_COMPILE -u VIBE_DIAGNOSTICS -u VIBE_NORMALIZE -u VIBE_TYPE_AT -u VIBE_DOC_AT \
+    env -u VIBE_FS_COMPILE -u VIBE_DIAGNOSTICS -u VIBE_NORMALIZE -u VIBE_FMT -u VIBE_TYPE_AT -u VIBE_DOC_AT \
         -u VIBE_BINDING_AT -u VIBE_ESCAPES -u VIBE_ESCAPES_STRICT -u VIBE_ALLOCS -u VIBE_COVERAGE -u VIBE_DEBUG -u VIBE_DEBUG_BREAK \
         -u VIBE_EMIT_MODULE_SOURCE \
       VIBE_SYMBOLS=1 \
@@ -1498,7 +1503,7 @@ case "$cmd" in
     cli="$CLI_WASM"; [ -f "$cli" ] || cli="$(pick_cli)"
     out="$(mktemp -t vibe-escapes-XXXXXX)"
     trap 'rm -f "$out" "$out.diag"' EXIT
-    env -u VIBE_FS_COMPILE -u VIBE_DIAGNOSTICS -u VIBE_NORMALIZE -u VIBE_TYPE_AT -u VIBE_DOC_AT \
+    env -u VIBE_FS_COMPILE -u VIBE_DIAGNOSTICS -u VIBE_NORMALIZE -u VIBE_FMT -u VIBE_TYPE_AT -u VIBE_DOC_AT \
         -u VIBE_BINDING_AT -u VIBE_SYMBOLS -u VIBE_ALLOCS -u VIBE_COVERAGE -u VIBE_DEBUG -u VIBE_DEBUG_BREAK \
         -u VIBE_EMIT_MODULE_SOURCE \
       VIBE_ESCAPES=1 \
@@ -1531,7 +1536,7 @@ case "$cmd" in
     cli="$CLI_WASM"; [ -f "$cli" ] || cli="$(pick_cli)"
     out="$(mktemp -t vibe-rc-classify-XXXXXX)"
     trap 'rm -f "$out" "$out.diag"' EXIT
-    env -u VIBE_FS_COMPILE -u VIBE_DIAGNOSTICS -u VIBE_NORMALIZE -u VIBE_TYPE_AT -u VIBE_DOC_AT \
+    env -u VIBE_FS_COMPILE -u VIBE_DIAGNOSTICS -u VIBE_NORMALIZE -u VIBE_FMT -u VIBE_TYPE_AT -u VIBE_DOC_AT \
         -u VIBE_BINDING_AT -u VIBE_SYMBOLS -u VIBE_ESCAPES -u VIBE_ESCAPES_STRICT -u VIBE_ALLOCS \
         -u VIBE_RC_PLAN -u VIBE_RC_PLAN_FN -u VIBE_COVERAGE -u VIBE_DEBUG -u VIBE_DEBUG_BREAK \
         -u VIBE_EMIT_MODULE_SOURCE \
@@ -1586,7 +1591,7 @@ case "$cmd" in
     cli="$CLI_WASM"; [ -f "$cli" ] || cli="$(pick_cli)"
     out="$(mktemp -t vibe-rc-plan-XXXXXX)"
     trap 'rm -f "$out" "$out.diag"' EXIT
-    env -u VIBE_FS_COMPILE -u VIBE_DIAGNOSTICS -u VIBE_NORMALIZE -u VIBE_TYPE_AT -u VIBE_DOC_AT \
+    env -u VIBE_FS_COMPILE -u VIBE_DIAGNOSTICS -u VIBE_NORMALIZE -u VIBE_FMT -u VIBE_TYPE_AT -u VIBE_DOC_AT \
         -u VIBE_BINDING_AT -u VIBE_SYMBOLS -u VIBE_ESCAPES -u VIBE_ESCAPES_STRICT -u VIBE_ALLOCS \
         -u VIBE_RC_CLASSIFY -u VIBE_COVERAGE -u VIBE_DEBUG -u VIBE_DEBUG_BREAK \
         -u VIBE_EMIT_MODULE_SOURCE \
@@ -1621,7 +1626,7 @@ case "$cmd" in
         -u VIBE_MISSING_VPKG_SCAN -u VIBE_DEPS_MISSING_SCAN -u VIBE_FILL_PINS \
         -u VIBE_PUBLISH_CHECK -u VIBE_MODULE_JOB_DIR -u VIBE_PUBLISH_ENV_CACHE \
         -u VIBE_LIST_DEPS -u VIBE_MODULE_PLAN -u VIBE_CHECK_ONLY \
-        -u VIBE_NORMALIZE -u VIBE_INSPECT_UPDATE -u VIBE_TYPE_AT -u VIBE_DOC_AT \
+        -u VIBE_NORMALIZE -u VIBE_FMT -u VIBE_INSPECT_UPDATE -u VIBE_TYPE_AT -u VIBE_DOC_AT \
         -u VIBE_BINDING_AT -u VIBE_SYMBOLS -u VIBE_ESCAPES -u VIBE_ESCAPES_STRICT \
         -u VIBE_ALLOCS -u VIBE_DEPS -u VIBE_DEPS_DIRECT -u VIBE_GREP \
         -u VIBE_DIAGNOSTICS -u VIBE_DIAGNOSTICS_JSON \
@@ -1687,7 +1692,7 @@ case "$cmd" in
     trap 'rm -f "$out" "$out.diag"' EXIT
     deps_direct_env=""
     [ "$deps_direct" = "1" ] && deps_direct_env="VIBE_DEPS_DIRECT=1"
-    env -u VIBE_FS_COMPILE -u VIBE_DIAGNOSTICS -u VIBE_NORMALIZE -u VIBE_TYPE_AT -u VIBE_DOC_AT \
+    env -u VIBE_FS_COMPILE -u VIBE_DIAGNOSTICS -u VIBE_NORMALIZE -u VIBE_FMT -u VIBE_TYPE_AT -u VIBE_DOC_AT \
         -u VIBE_BINDING_AT -u VIBE_SYMBOLS -u VIBE_ESCAPES -u VIBE_ESCAPES_STRICT -u VIBE_ALLOCS -u VIBE_COVERAGE -u VIBE_DEBUG \
         -u VIBE_DEBUG_BREAK -u VIBE_EMIT_MODULE_SOURCE -u VIBE_CHECK_ONLY \
       VIBE_DEPS=1 ${deps_direct_env} \
@@ -1740,7 +1745,7 @@ case "$cmd" in
     # failure) so the LSP treats empty as "no diagnostics" / falls back.
     diag_json_env=""
     [ "$diag_json" = "1" ] && diag_json_env=1
-    env -u VIBE_FS_COMPILE -u VIBE_TYPE_AT -u VIBE_DOC_AT -u VIBE_NORMALIZE -u VIBE_ESCAPES -u VIBE_ESCAPES_STRICT -u VIBE_ALLOCS \
+    env -u VIBE_FS_COMPILE -u VIBE_TYPE_AT -u VIBE_DOC_AT -u VIBE_NORMALIZE -u VIBE_FMT -u VIBE_ESCAPES -u VIBE_ESCAPES_STRICT -u VIBE_ALLOCS \
         -u VIBE_COVERAGE -u VIBE_DEBUG -u VIBE_DEBUG_BREAK -u VIBE_EMIT_MODULE_SOURCE \
       VIBE_DIAGNOSTICS=1 \
       VIBE_DIAGNOSTICS_JSON="$diag_json_env" \
@@ -1837,7 +1842,7 @@ case "$cmd" in
       [ -e "$g_path" ] || die "not found: $g_path"
       # Clear inherited adapter-mode envs so a leaked selector can't divert this
       # into compiling and emitting wasm bytes as "matches".
-      env -u VIBE_FS_COMPILE -u VIBE_DIAGNOSTICS -u VIBE_NORMALIZE -u VIBE_TYPE_AT -u VIBE_DOC_AT \
+      env -u VIBE_FS_COMPILE -u VIBE_DIAGNOSTICS -u VIBE_NORMALIZE -u VIBE_FMT -u VIBE_TYPE_AT -u VIBE_DOC_AT \
           -u VIBE_BINDING_AT -u VIBE_SYMBOLS -u VIBE_ESCAPES -u VIBE_ESCAPES_STRICT -u VIBE_ALLOCS -u VIBE_DEPS -u VIBE_COVERAGE -u VIBE_DEBUG \
           -u VIBE_DEBUG_BREAK -u VIBE_EMIT_MODULE_SOURCE \
         VIBE_GREP=1 \
@@ -1858,6 +1863,78 @@ case "$cmd" in
       if [ -s "$out" ]; then cat "$out"; fi
       : >"$out"; : >"$out.warn"
     done
+    ;;
+  fmt)
+    # vibe fmt [--check|--stdout] <file.vibe|file.vpkg>  (#2149)
+    # Format a source file with the selfhost CST-token formatter
+    # (lib/@vibe/compiler/fmt/format.vibe). Default rewrites in place;
+    # --check exits 1 without writing when the file is not formatted;
+    # --stdout prints the result without writing. Same engine
+    # scripts/vibe_fmt.sh drives in-repo -- but that script needs the repo
+    # checkout (its paths must live under VIBE_PREOPEN_DIR), which is why an
+    # installed user could not format at all before this arm existed.
+    fmode="write"
+    case "${1:-}" in
+      --check) fmode="check"; shift ;;
+      --stdout) fmode="stdout"; shift ;;
+      -*) die "vibe fmt: unknown flag: $1" ;;
+    esac
+    [ "$#" -ge 1 ] || die "usage: vibe fmt [--check|--stdout] <file.vibe>"
+    src="$1"
+    [ -f "$src" ] || die "not found: $src"
+    cli="$CLI_WASM"; [ -f "$cli" ] || cli="$(pick_cli)"
+    out="$(mktemp -t vibe-fmt-XXXXXX.vibe)"
+    trap 'rm -f "$out" "$out.diag" "$out.err" "$out.rc"' EXIT
+    # Clear inherited adapter-mode envs, for the reason spelled out on the
+    # normalize arm below: the adapter handles VIBE_HASH / VIBE_HASH_WRITE /
+    # VIBE_MISSING_VPKG_SCAN / VIBE_DEPS_MISSING_SCAN / VIBE_FILL_PINS /
+    # VIBE_PUBLISH_CHECK BEFORE VIBE_FMT, so a leaked selector would write a
+    # hash/report as $out and the default write mode would copy it OVER the
+    # user's source file.
+    #
+    # stdout is CAPTURED rather than discarded: the runner exits 0 whatever
+    # cli_main returns and prints the value as the last stdout line, so that
+    # line is the formatter's only way to say "I refused to rewrite this".
+    # Throwing it away is exactly how a refusal came to look like "nothing to
+    # change" (#1821).
+    env -u VIBE_FS_COMPILE -u VIBE_DIAGNOSTICS -u VIBE_NORMALIZE -u VIBE_TYPE_AT -u VIBE_DOC_AT \
+        -u VIBE_BINDING_AT -u VIBE_SYMBOLS -u VIBE_ESCAPES -u VIBE_ESCAPES_STRICT -u VIBE_ALLOCS -u VIBE_DEPS -u VIBE_COVERAGE -u VIBE_DEBUG \
+        -u VIBE_DEBUG_BREAK -u VIBE_EMIT_MODULE_SOURCE -u VIBE_INSPECT_UPDATE \
+        -u VIBE_HASH -u VIBE_HASH_WRITE \
+        -u VIBE_MISSING_VPKG_SCAN -u VIBE_DEPS_MISSING_SCAN -u VIBE_FILL_PINS \
+        -u VIBE_PUBLISH_CHECK \
+      VIBE_FMT=1 \
+      VIBE_IMPORT_ABI=raw \
+      "$RUNNER" "$cli" "$src" "$out" >"$out.rc" 2>"$out.err" || true
+    if [ ! -s "$out" ]; then
+      [ -s "$out.diag" ] && cat "$out.diag" >&2
+      [ -s "$out.err" ] && cat "$out.err" >&2
+      die "fmt failed: $src"
+    fi
+    frc="$(tail -1 "$out.rc" 2>/dev/null || true)"
+    if [ "$frc" != "0" ]; then
+      # The guard fired: the formatted output does not parse and the input
+      # did. $out holds the INPUT unchanged, so writing it would be a silent
+      # no-op that --check would then call "formatted". Refuse instead.
+      [ -s "$out.err" ] && cat "$out.err" >&2
+      echo "vibe fmt: refusing to rewrite $src" >&2
+      echo "  The formatted output does not parse, and the input did. This is a bug in" >&2
+      echo "  the formatter, not a problem with the file. The file is unchanged; please" >&2
+      echo "  report it with the source (see #1821)." >&2
+      exit 1
+    fi
+    case "$fmode" in
+      stdout) cat "$out" ;;
+      check)
+        if cmp -s "$src" "$out"; then
+          exit 0
+        else
+          echo "not formatted: $src" >&2
+          exit 1
+        fi
+        ;;
+      write) cp "$out" "$src" ;;
+    esac
     ;;
   normalize)
     # vibe normalize [--check|--stdout] <file.vibe>  (#882)

--- a/runtime/vibe
+++ b/runtime/vibe
@@ -1880,6 +1880,15 @@ case "$cmd" in
       -*) die "vibe fmt: unknown flag: $1" ;;
     esac
     [ "$#" -ge 1 ] || die "usage: vibe fmt [--check|--stdout] <file.vibe>"
+    # EXACTLY one file. `src="$1"` alone silently ignored the rest, so
+    # `vibe fmt a.vibe b.vibe` formatted `a`, left `b` untouched, and exited 0
+    # -- a green that means nothing. scripts/vibe_fmt.sh rejects this for the
+    # same reason: that shape is how an unformatted file reached CI in #2156.
+    if [ "$#" -gt 1 ]; then
+      echo "vibe fmt: takes ONE file, got $#: $*" >&2
+      echo "  for several: for f in ...; do vibe fmt \"\$f\"; done" >&2
+      exit 2
+    fi
     src="$1"
     [ -f "$src" ] || die "not found: $src"
     cli="$CLI_WASM"; [ -f "$cli" ] || cli="$(pick_cli)"
@@ -1903,15 +1912,30 @@ case "$cmd" in
         -u VIBE_HASH -u VIBE_HASH_WRITE \
         -u VIBE_MISSING_VPKG_SCAN -u VIBE_DEPS_MISSING_SCAN -u VIBE_FILL_PINS \
         -u VIBE_PUBLISH_CHECK \
-      VIBE_FMT=1 \
+        -u VIBE_CHECK_ONLY -u VIBE_LSP -u VIBE_MODULE_JOB_DIR \
+        -u VIBE_PUBLISH_ENV_CACHE -u VIBE_LIST_DEPS -u VIBE_MODULE_PLAN \
+        VIBE_FMT=1 \
       VIBE_IMPORT_ABI=raw \
       "$RUNNER" "$cli" "$src" "$out" >"$out.rc" 2>"$out.err" || true
-    if [ ! -s "$out" ]; then
+    # An EMPTY result is legitimate: an empty (or whitespace-only) file formats
+    # to an empty one. So existence, not size, is the "did it run" test -- and
+    # the captured return value, not the output, is the verdict. Testing `-s`
+    # here rejected those files with "fmt failed"; it also happened to catch a
+    # leaked selector that writes an empty output, which is why the env -u list
+    # above has to be complete rather than lucky.
+    if [ ! -f "$out" ]; then
       [ -s "$out.diag" ] && cat "$out.diag" >&2
       [ -s "$out.err" ] && cat "$out.err" >&2
       die "fmt failed: $src"
     fi
     frc="$(tail -1 "$out.rc" 2>/dev/null || true)"
+    # No rc line at all means the runner died before returning; that is a
+    # failure, not a refusal, and must not be reported as one.
+    if [ -z "$frc" ]; then
+      [ -s "$out.diag" ] && cat "$out.diag" >&2
+      [ -s "$out.err" ] && cat "$out.err" >&2
+      die "fmt failed: $src"
+    fi
     if [ "$frc" != "0" ]; then
       # The guard fired: the formatted output does not parse and the input
       # did. $out holds the INPUT unchanged, so writing it would be a silent
@@ -1968,8 +1992,10 @@ case "$cmd" in
         -u VIBE_DEBUG_BREAK -u VIBE_EMIT_MODULE_SOURCE \
         -u VIBE_HASH -u VIBE_HASH_WRITE \
         -u VIBE_MISSING_VPKG_SCAN -u VIBE_DEPS_MISSING_SCAN -u VIBE_FILL_PINS \
-        -u VIBE_PUBLISH_CHECK \
-      VIBE_NORMALIZE=1 \
+        -u VIBE_PUBLISH_CHECK -u VIBE_FMT \
+        -u VIBE_CHECK_ONLY -u VIBE_LSP -u VIBE_MODULE_JOB_DIR \
+        -u VIBE_PUBLISH_ENV_CACHE -u VIBE_LIST_DEPS -u VIBE_MODULE_PLAN \
+        VIBE_NORMALIZE=1 \
       VIBE_IMPORT_ABI=raw \
       "$RUNNER" "$cli" "$src" "$out" >/dev/null 2>"$out.err" || true
     if [ ! -s "$out" ]; then

--- a/runtime/vibe
+++ b/runtime/vibe
@@ -1898,6 +1898,14 @@ case "$cmd" in
     cli="$CLI_WASM"; [ -f "$cli" ] || cli="$(pick_cli)"
     out="$(mktemp -t vibe-fmt-XXXXXX.vibe)"
     trap 'rm -f "$out" "$out.diag" "$out.err" "$out.rc"' EXIT
+    # mktemp CREATES the file, so `-f "$out"` below would be true before the
+    # runner has written anything -- and a runner that exits 0 without writing
+    # (a VIBE_RUNNER wrapper that terminates early) would then be read as a
+    # legitimate empty format, and write mode would copy the zero-byte temp
+    # OVER the user's source. Measured: it truncated the input to 0 bytes and
+    # reported success. Unlink it here so `-f` distinguishes "no output" from
+    # "legitimately empty output"; mktemp's value is the reserved PATHNAME.
+    rm -f "$out"
     # Clear inherited adapter-mode envs, for the reason spelled out on the
     # normalize arm below: the adapter handles VIBE_HASH / VIBE_HASH_WRITE /
     # VIBE_MISSING_VPKG_SCAN / VIBE_DEPS_MISSING_SCAN / VIBE_FILL_PINS /

--- a/runtime/vibe
+++ b/runtime/vibe
@@ -1910,7 +1910,10 @@ case "$cmd" in
     # line is the formatter's only way to say "I refused to rewrite this".
     # Throwing it away is exactly how a refusal came to look like "nothing to
     # change" (#1821).
-    env -u VIBE_FS_COMPILE -u VIBE_DIAGNOSTICS -u VIBE_NORMALIZE -u VIBE_TYPE_AT -u VIBE_DOC_AT \
+    # `if ...; then` rather than a bare call: the launcher runs under `set -e`,
+    # so a non-zero runner exit -- which is exactly how the installed viberun
+    # signals a refusal -- would abort the script before $? could be read.
+    if env -u VIBE_FS_COMPILE -u VIBE_DIAGNOSTICS -u VIBE_NORMALIZE -u VIBE_TYPE_AT -u VIBE_DOC_AT \
         -u VIBE_BINDING_AT -u VIBE_SYMBOLS -u VIBE_ESCAPES -u VIBE_ESCAPES_STRICT -u VIBE_ALLOCS -u VIBE_DEPS -u VIBE_COVERAGE -u VIBE_DEBUG \
         -u VIBE_DEBUG_BREAK -u VIBE_EMIT_MODULE_SOURCE -u VIBE_INSPECT_UPDATE \
         -u VIBE_HASH -u VIBE_HASH_WRITE \
@@ -1920,22 +1923,35 @@ case "$cmd" in
         -u VIBE_PUBLISH_ENV_CACHE -u VIBE_LIST_DEPS -u VIBE_MODULE_PLAN \
         VIBE_FMT=1 \
       VIBE_IMPORT_ABI=raw \
-      "$RUNNER" "$cli" "$src" "$out" >"$out.rc" 2>"$out.err" || true
+      "$RUNNER" "$cli" "$src" "$out" >"$out.rc" 2>"$out.err"; then
+      fmt_status=0
+    else
+      fmt_status=$?
+    fi
+    # THE TWO RUNNER CONVENTIONS. The node runner prints cli_main's return as
+    # the last stdout line and exits 0 regardless; the installed `viberun`
+    # running the shipped CLI turns that value into the PROCESS exit status and
+    # prints nothing (`lib/@vibe/cli/main.vibex`: returning it from `main`
+    # "would only be PRINTED by the host _start", which is why it calls
+    # vibe_process_exit_raw instead). Reading only the printed line -- the
+    # convention scripts/vibe_fmt.sh relies on, against a different wasm through
+    # a different runner -- reports EVERY successful format as "fmt failed" for
+    # an installed user, which is exactly the user #2149 exists for.
+    #
+    # So: a bare-integer last line is the verdict when one is printed, and the
+    # process status is the verdict when one is not. Both runners are correct
+    # under this rule and neither is assumed.
+    frc="$(tail -1 "$out.rc" 2>/dev/null || true)"
+    case "$frc" in
+      ''|*[!0-9]*) frc="$fmt_status" ;;
+    esac
     # An EMPTY result is legitimate: an empty (or whitespace-only) file formats
     # to an empty one. So existence, not size, is the "did it run" test -- and
-    # the captured return value, not the output, is the verdict. Testing `-s`
-    # here rejected those files with "fmt failed"; it also happened to catch a
-    # leaked selector that writes an empty output, which is why the env -u list
-    # above has to be complete rather than lucky.
+    # the verdict above, not the output, decides. Testing `-s` here rejected
+    # those files with "fmt failed"; it also happened to catch a leaked selector
+    # that writes an empty output, which is why the env -u list above has to be
+    # complete rather than lucky.
     if [ ! -f "$out" ]; then
-      [ -s "$out.diag" ] && cat "$out.diag" >&2
-      [ -s "$out.err" ] && cat "$out.err" >&2
-      die "fmt failed: $src"
-    fi
-    frc="$(tail -1 "$out.rc" 2>/dev/null || true)"
-    # No rc line at all means the runner died before returning; that is a
-    # failure, not a refusal, and must not be reported as one.
-    if [ -z "$frc" ]; then
       [ -s "$out.diag" ] && cat "$out.diag" >&2
       [ -s "$out.err" ] && cat "$out.err" >&2
       die "fmt failed: $src"

--- a/scripts/check_selector_precedence.sh
+++ b/scripts/check_selector_precedence.sh
@@ -59,8 +59,23 @@ for m in re.finditer(r'\benv\b((?:[^\n]*\\\n)*[^\n]*)', src):
     for i, sel in enumerate(order):
         if not re.search(r'(?<![-\w])' + sel + r'=1\b', block):
             continue
-        candidates = order[:i] if mode == "all" else [e for e in order[:i] if e in enforced]
-        missing = [e for e in candidates if e not in cleared]
+        preds = order[:i]
+        if mode == "all":
+            required = preds
+        elif sel in enforced:
+            # Rule 1 -- a block that SETS an enforced selector must clear every
+            # predecessor. This is what protects `vibe fmt` itself, and it is
+            # the rule the first version of this check silently omitted:
+            # filtering the PREDECESSOR list by `enforced` left the fmt block
+            # with nothing to require, because a selector cannot precede
+            # itself. A new adapter selector added before VIBE_FMT would have
+            # sailed through the gate built to catch exactly that.
+            required = preds
+        else:
+            # Rule 2 -- every other block must clear an enforced selector that
+            # precedes it. This is what stops VIBE_FMT hijacking other verbs.
+            required = [e for e in preds if e in enforced]
+        missing = [e for e in required if e not in cleared]
         if missing:
             problems.append((line_no, sel, missing))
 

--- a/scripts/check_selector_precedence.sh
+++ b/scripts/check_selector_precedence.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# Adapter-selector precedence (#2239).
+#
+# cli_adapter.vibe dispatches on VIBE_* selectors in SOURCE ORDER, so a
+# selector that leaks into the environment hijacks every verb whose own
+# selector is evaluated later. That is not theoretical: measured on a real
+# stage2, `VIBE_CHECK_ONLY=1 vibe fmt f.vibe` wrote `ok` OVER the source file,
+# and `VIBE_FMT=1 vibe compile --wit f.vibe` wrote formatted vibe source as
+# the .wit artifact -- both reporting success, because the output was
+# non-empty.
+#
+# The launcher's defence is the `env -u` list on each arm. Keeping those lists
+# right by hand does not work: #2239 shipped an arm whose list was copied from
+# a neighbour and was missing six selectors, and the follow-up fixed one arm at
+# a time and still missed three. So this check DERIVES the requirement from
+# cli_adapter.vibe rather than restating it:
+#
+#   for every launcher `env` invocation that SETS selector S,
+#   every selector cli_adapter evaluates BEFORE S must be cleared by that
+#   invocation.
+#
+# Adding a selector to cli_adapter, or a verb to the launcher, cannot silently
+# reopen the hole -- the requirement is recomputed from the source each run.
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+# ENFORCED is the ratchet. The invariant below holds for these selectors and
+# is gated; `--all` audits every selector and is NOT gated, because the audit
+# reports ~23 pre-existing arms that predate this check (filed separately).
+# Move a selector into ENFORCED once its arms are fixed.
+ENFORCED="${VIBE_SELECTOR_PRECEDENCE_ENFORCED:-VIBE_FMT}"
+MODE="enforced"
+if [ "${1:-}" = "--all" ]; then MODE="all"; shift; fi
+
+ADAPTER="${1:-lib/@vibe/compiler/cli_adapter.vibe}"
+LAUNCHER="${2:-runtime/vibe}"
+
+python3 - "$ADAPTER" "$LAUNCHER" "$MODE" "$ENFORCED" <<'PY'
+import re, sys
+
+adapter, launcher, mode, enforced = sys.argv[1], sys.argv[2], sys.argv[3], sys.argv[4].split()
+
+# Selector branch order, as cli_main evaluates it. VIBE_RC is a mode modifier
+# read inside a branch, not a branch of its own.
+order = []
+for line in open(adapter, encoding="utf-8"):
+    m = re.match(r'\s*(?:\} else )?if Env::get\("(VIBE_[A-Z_]+)"\) == "1" \{', line)
+    if m and m.group(1) != "VIBE_RC" and m.group(1) not in order:
+        order.append(m.group(1))
+
+src = open(launcher, encoding="utf-8").read()
+problems = []
+for m in re.finditer(r'\benv\b((?:[^\n]*\\\n)*[^\n]*)', src):
+    block = m.group(0)
+    cleared = set(re.findall(r'-u (VIBE_[A-Z_]+)', block))
+    line_no = src[:m.start()].count("\n") + 1
+    for i, sel in enumerate(order):
+        if not re.search(r'(?<![-\w])' + sel + r'=1\b', block):
+            continue
+        candidates = order[:i] if mode == "all" else [e for e in order[:i] if e in enforced]
+        missing = [e for e in candidates if e not in cleared]
+        if missing:
+            problems.append((line_no, sel, missing))
+
+if problems:
+    print("[selector-precedence] FAIL: launcher arms that a leaked selector can hijack:", file=sys.stderr)
+    for line_no, sel, missing in problems:
+        print("  %s:%d sets %s but does not clear: %s"
+              % (launcher, line_no, sel, " ".join(missing)), file=sys.stderr)
+    print("  cli_adapter evaluates those BEFORE %s, so an inherited one wins and"
+          % problems[0][1], file=sys.stderr)
+    print("  its output is written as this verb's artifact.", file=sys.stderr)
+    sys.exit(1)
+
+if mode == "all":
+    print("[selector-precedence] ok (audit: %d selectors, no arm can be hijacked)" % len(order))
+else:
+    print("[selector-precedence] ok (%d selectors; enforced: %s)" % (len(order), " ".join(enforced)))
+PY

--- a/scripts/test_vibe_fmt_launcher.sh
+++ b/scripts/test_vibe_fmt_launcher.sh
@@ -166,4 +166,36 @@ if VIBE_RUNNER="$OK_RUNNER" VIBE_CLI_WASM="$CLI" \
 fi
 [ "$(cat "$SRC2")" = "let   b=2" ] || fail "the second path was rewritten by a call that should have been rejected"
 
+# THE OTHER RUNNER CONVENTION. Every fake above prints cli_main's return as the
+# last stdout line, which is what the node runner does. The installed `viberun`
+# running the shipped CLI prints NOTHING and turns that value into the process
+# exit status instead (lib/@vibe/cli/main.vibex). Modelling only the printed
+# path is how an arm that reports every successful format as "fmt failed" for
+# installed users passed its own tests.
+EXIT_OK_RUNNER="$TMP_DIR/exit-ok-runner"
+printf '%s\n' '#!/usr/bin/env bash' 'printf "let a = 1\n" > "$3"' 'exit 0' > "$EXIT_OK_RUNNER"
+chmod +x "$EXIT_OK_RUNNER"
+printf 'let   a=1\n' > "$SRC"
+VIBE_RUNNER="$EXIT_OK_RUNNER" VIBE_CLI_WASM="$CLI" \
+  bash "$ROOT_DIR/runtime/vibe" fmt "$SRC" > "$OUT" 2> "$ERR" \
+  || fail "a runner that reports success by EXIT STATUS was treated as a failure"
+[ "$(cat "$SRC")" = "let a = 1" ] || fail "a status-only runner's successful format was not written"
+
+VIBE_RUNNER="$EXIT_OK_RUNNER" VIBE_CLI_WASM="$CLI" \
+  bash "$ROOT_DIR/runtime/vibe" fmt --stdout "$SRC" > "$OUT" 2> "$ERR" \
+  || fail "--stdout failed against a status-only runner"
+[ "$(cat "$OUT")" = "let a = 1" ] || fail "--stdout printed nothing against a status-only runner"
+
+# ...and a refusal signalled the same way: input echoed back, non-zero EXIT.
+EXIT_REFUSE_RUNNER="$TMP_DIR/exit-refuse-runner"
+printf '%s\n' '#!/usr/bin/env bash' 'cat "$2" > "$3"' 'exit 1' > "$EXIT_REFUSE_RUNNER"
+chmod +x "$EXIT_REFUSE_RUNNER"
+printf 'let   a=1\n' > "$SRC"
+if VIBE_RUNNER="$EXIT_REFUSE_RUNNER" VIBE_CLI_WASM="$CLI" \
+  bash "$ROOT_DIR/runtime/vibe" fmt "$SRC" > "$OUT" 2> "$ERR"; then
+  fail "a refusal signalled by exit status was reported as success"
+fi
+grep -q "refusing to rewrite" "$ERR" || fail "a status-signalled refusal did not say so"
+[ "$(cat "$SRC")" = "let   a=1" ] || fail "a status-signalled refusal still rewrote the source"
+
 echo "[vibe-fmt-launcher] ok"

--- a/scripts/test_vibe_fmt_launcher.sh
+++ b/scripts/test_vibe_fmt_launcher.sh
@@ -98,19 +98,72 @@ fi
 # Adapter-mode envs must be cleared. cli_adapter evaluates VIBE_HASH before
 # VIBE_FMT, so a leaked selector would write a HASH as $out -- and write mode
 # would then copy it over the user's source file.
+# The fake runner must divert on EVERY selector under test, not just the two
+# the first draft named -- a loop over eight variables against a runner that
+# only knows two is a test that cannot fail for the other six. (It didn't:
+# removing `-u VIBE_CHECK_ONLY` from the arm left this green.)
 ENV_RUNNER="$TMP_DIR/env-runner"
-printf '%s\n' \
-  '#!/usr/bin/env bash' \
-  'if [ "${VIBE_HASH:-}" = "1" ]; then printf "deadbeef\n" > "$3"; echo 0; exit 0; fi' \
-  'if [ "${VIBE_NORMALIZE:-}" = "1" ]; then printf "normalized\n" > "$3"; echo 0; exit 0; fi' \
-  'printf "let a = 1\n" > "$3"' \
-  'echo 0' > "$ENV_RUNNER"
+cat > "$ENV_RUNNER" <<'RUNNER'
+#!/usr/bin/env bash
+for v in VIBE_HASH VIBE_NORMALIZE VIBE_CHECK_ONLY VIBE_LSP VIBE_MODULE_JOB_DIR \
+         VIBE_PUBLISH_ENV_CACHE VIBE_LIST_DEPS VIBE_MODULE_PLAN; do
+  if [ "${!v:-}" = "1" ]; then printf 'DIVERTED-%s\n' "$v" > "$3"; echo 0; exit 0; fi
+done
+printf 'let a = 1\n' > "$3"
+echo 0
+RUNNER
 chmod +x "$ENV_RUNNER"
-for leak in VIBE_HASH VIBE_NORMALIZE; do
+# EVERY selector cli_adapter evaluates before VIBE_FMT, not just the two the
+# normalize arm's list happened to name. Measured on a real stage2: with
+# VIBE_CHECK_ONLY=1 inherited, the check branch wrote "ok" to the output and
+# write mode copied THAT over the source file.
+for leak in VIBE_HASH VIBE_NORMALIZE VIBE_CHECK_ONLY VIBE_LSP VIBE_MODULE_JOB_DIR \
+            VIBE_PUBLISH_ENV_CACHE VIBE_LIST_DEPS VIBE_MODULE_PLAN; do
   printf 'let   a=1\n' > "$SRC"
   env "$leak=1" VIBE_RUNNER="$ENV_RUNNER" VIBE_CLI_WASM="$CLI" \
     bash "$ROOT_DIR/runtime/vibe" fmt "$SRC" > "$OUT" 2> "$ERR"
   [ "$(cat "$SRC")" = "let a = 1" ] || fail "inherited $leak diverted vibe fmt and overwrote the source"
 done
+
+# The reverse direction: VIBE_FMT inherited by `vibe normalize` must not
+# preempt it. The fmt branch is evaluated FIRST in cli_adapter, so without a
+# clear the command would format and report success without normalizing.
+NORM_RUNNER="$TMP_DIR/norm-runner"
+printf '%s\n' \
+  '#!/usr/bin/env bash' \
+  'if [ "${VIBE_FMT:-}" = "1" ]; then printf "formatted\n" > "$3"; echo 0; exit 0; fi' \
+  'printf "normalized\n" > "$3"' \
+  'echo 0' > "$NORM_RUNNER"
+chmod +x "$NORM_RUNNER"
+printf 'let a = 1\n' > "$SRC"
+VIBE_FMT=1 VIBE_RUNNER="$NORM_RUNNER" VIBE_CLI_WASM="$CLI" \
+  bash "$ROOT_DIR/runtime/vibe" normalize "$SRC" > "$OUT" 2> "$ERR"
+[ "$(cat "$SRC")" = "normalized" ] || fail "inherited VIBE_FMT preempted vibe normalize"
+
+# An EMPTY result is legitimate -- an empty or whitespace-only file formats to
+# an empty one. Testing output SIZE rejected those with "fmt failed".
+EMPTY_OUT_RUNNER="$TMP_DIR/empty-out-runner"
+printf '%s\n' '#!/usr/bin/env bash' ': > "$3"' 'echo 0' > "$EMPTY_OUT_RUNNER"
+chmod +x "$EMPTY_OUT_RUNNER"
+: > "$SRC"
+VIBE_RUNNER="$EMPTY_OUT_RUNNER" VIBE_CLI_WASM="$CLI" \
+  bash "$ROOT_DIR/runtime/vibe" fmt --check "$SRC" > "$OUT" 2> "$ERR" \
+  || fail "an empty file that is already formatted was reported as a failure"
+printf 'x\n' > "$SRC"
+VIBE_RUNNER="$EMPTY_OUT_RUNNER" VIBE_CLI_WASM="$CLI" \
+  bash "$ROOT_DIR/runtime/vibe" fmt "$SRC" > "$OUT" 2> "$ERR" \
+  || fail "an empty formatted result was reported as a failure"
+[ ! -s "$SRC" ] || fail "an empty formatted result was not written"
+
+# More than one path must be REJECTED, not silently half-done. Formatting the
+# first and exiting 0 is how an unformatted file reached CI in #2156.
+printf 'let   a=1\n' > "$SRC"
+SRC2="$TMP_DIR/in2.vibe"
+printf 'let   b=2\n' > "$SRC2"
+if VIBE_RUNNER="$OK_RUNNER" VIBE_CLI_WASM="$CLI" \
+  bash "$ROOT_DIR/runtime/vibe" fmt "$SRC" "$SRC2" > "$OUT" 2> "$ERR"; then
+  fail "two source paths were accepted and only one was formatted"
+fi
+[ "$(cat "$SRC2")" = "let   b=2" ] || fail "the second path was rewritten by a call that should have been rejected"
 
 echo "[vibe-fmt-launcher] ok"

--- a/scripts/test_vibe_fmt_launcher.sh
+++ b/scripts/test_vibe_fmt_launcher.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+# `vibe fmt` launcher arm (#2149). Drives runtime/vibe with a FAKE runner, so
+# this pins the shell arm's own decisions -- mode dispatch, the refusal path,
+# and adapter-mode env clearing -- without a compiler build.
+#
+# The refusal case is the one that matters. On refusal the adapter writes the
+# INPUT back to $out and returns non-zero, so $out is non-empty and identical
+# to the source. A `--check` that looked only at `cmp` would call that
+# "formatted" -- which is exactly how a declining formatter came to look like
+# one with nothing to change (#1821). The arm must read the runner's last
+# stdout line instead.
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+TMP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/vibe-fmt-launcher.XXXXXX")"
+cleanup() {
+  local status=$?
+  rm -rf "$TMP_DIR"
+  exit "$status"
+}
+trap cleanup EXIT
+
+SRC="$TMP_DIR/in.vibe"
+CLI="$TMP_DIR/vibe-cli.wasm"
+OUT="$TMP_DIR/stdout.txt"
+ERR="$TMP_DIR/stderr.txt"
+: > "$CLI"
+
+fail() {
+  echo "[vibe-fmt-launcher] FAIL: $1" >&2
+  [ -s "$ERR" ] && cat "$ERR" >&2
+  exit 1
+}
+
+# A runner that "formats" by writing a fixed canonical text and returning 0.
+OK_RUNNER="$TMP_DIR/ok-runner"
+printf '%s\n' \
+  '#!/usr/bin/env bash' \
+  'printf "let a = 1\n" > "$3"' \
+  'echo 0' > "$OK_RUNNER"
+chmod +x "$OK_RUNNER"
+
+# --stdout prints the formatted result and leaves the file alone.
+printf 'let   a=1\n' > "$SRC"
+VIBE_RUNNER="$OK_RUNNER" VIBE_CLI_WASM="$CLI" \
+  bash "$ROOT_DIR/runtime/vibe" fmt --stdout "$SRC" > "$OUT" 2> "$ERR"
+[ "$(cat "$OUT")" = "let a = 1" ] || fail "--stdout did not print the formatted result"
+[ "$(cat "$SRC")" = "let   a=1" ] || fail "--stdout rewrote the source file"
+
+# --check exits 1 on an unformatted file, 0 on a formatted one.
+if VIBE_RUNNER="$OK_RUNNER" VIBE_CLI_WASM="$CLI" \
+  bash "$ROOT_DIR/runtime/vibe" fmt --check "$SRC" > "$OUT" 2> "$ERR"; then
+  fail "--check reported an unformatted file as formatted"
+fi
+grep -q "not formatted" "$ERR" || fail "--check did not name the unformatted file"
+printf 'let a = 1\n' > "$SRC"
+VIBE_RUNNER="$OK_RUNNER" VIBE_CLI_WASM="$CLI" \
+  bash "$ROOT_DIR/runtime/vibe" fmt --check "$SRC" > "$OUT" 2> "$ERR" \
+  || fail "--check rejected an already-formatted file"
+
+# Write mode rewrites in place.
+printf 'let   a=1\n' > "$SRC"
+VIBE_RUNNER="$OK_RUNNER" VIBE_CLI_WASM="$CLI" \
+  bash "$ROOT_DIR/runtime/vibe" fmt "$SRC" > "$OUT" 2> "$ERR"
+[ "$(cat "$SRC")" = "let a = 1" ] || fail "write mode did not rewrite the file"
+
+# THE REFUSAL. The runner echoes the input back and reports 1, exactly as the
+# adapter's guard does when the formatted output does not parse and the input
+# did. $out is then byte-identical to the source, so `cmp` alone would say
+# "formatted".
+REFUSE_RUNNER="$TMP_DIR/refuse-runner"
+printf '%s\n' \
+  '#!/usr/bin/env bash' \
+  'cat "$2" > "$3"' \
+  'echo 1' > "$REFUSE_RUNNER"
+chmod +x "$REFUSE_RUNNER"
+
+printf 'let   a=1\n' > "$SRC"
+for mode in "" "--check" "--stdout"; do
+  # shellcheck disable=SC2086
+  if VIBE_RUNNER="$REFUSE_RUNNER" VIBE_CLI_WASM="$CLI" \
+    bash "$ROOT_DIR/runtime/vibe" fmt $mode "$SRC" > "$OUT" 2> "$ERR"; then
+    fail "a refused format exited 0 in mode '${mode:-write}'"
+  fi
+  grep -q "refusing to rewrite" "$ERR" || fail "a refused format did not say so in mode '${mode:-write}'"
+done
+[ "$(cat "$SRC")" = "let   a=1" ] || fail "a refused format still rewrote the source file"
+
+# A runner that produces no output must not be reported as a clean format.
+EMPTY_RUNNER="$TMP_DIR/empty-runner"
+printf '%s\n' '#!/usr/bin/env bash' 'exit 23' > "$EMPTY_RUNNER"
+chmod +x "$EMPTY_RUNNER"
+if VIBE_RUNNER="$EMPTY_RUNNER" VIBE_CLI_WASM="$CLI" \
+  bash "$ROOT_DIR/runtime/vibe" fmt "$SRC" > "$OUT" 2> "$ERR"; then
+  fail "a runner that wrote nothing was reported as a clean format"
+fi
+
+# Adapter-mode envs must be cleared. cli_adapter evaluates VIBE_HASH before
+# VIBE_FMT, so a leaked selector would write a HASH as $out -- and write mode
+# would then copy it over the user's source file.
+ENV_RUNNER="$TMP_DIR/env-runner"
+printf '%s\n' \
+  '#!/usr/bin/env bash' \
+  'if [ "${VIBE_HASH:-}" = "1" ]; then printf "deadbeef\n" > "$3"; echo 0; exit 0; fi' \
+  'if [ "${VIBE_NORMALIZE:-}" = "1" ]; then printf "normalized\n" > "$3"; echo 0; exit 0; fi' \
+  'printf "let a = 1\n" > "$3"' \
+  'echo 0' > "$ENV_RUNNER"
+chmod +x "$ENV_RUNNER"
+for leak in VIBE_HASH VIBE_NORMALIZE; do
+  printf 'let   a=1\n' > "$SRC"
+  env "$leak=1" VIBE_RUNNER="$ENV_RUNNER" VIBE_CLI_WASM="$CLI" \
+    bash "$ROOT_DIR/runtime/vibe" fmt "$SRC" > "$OUT" 2> "$ERR"
+  [ "$(cat "$SRC")" = "let a = 1" ] || fail "inherited $leak diverted vibe fmt and overwrote the source"
+done
+
+echo "[vibe-fmt-launcher] ok"

--- a/scripts/test_vibe_fmt_launcher.sh
+++ b/scripts/test_vibe_fmt_launcher.sh
@@ -95,6 +95,21 @@ if VIBE_RUNNER="$EMPTY_RUNNER" VIBE_CLI_WASM="$CLI" \
   fail "a runner that wrote nothing was reported as a clean format"
 fi
 
+# ...and the same with a SUCCESSFUL exit. mktemp creates the output file, so
+# the existence check was true before the runner had written anything: a
+# status-0 runner that writes nothing was read as a legitimate empty format,
+# and write mode copied the zero-byte temp OVER the source. Measured: it
+# truncated the input to 0 bytes and reported success.
+NOOP_RUNNER="$TMP_DIR/noop-runner"
+printf '%s\n' '#!/usr/bin/env bash' 'exit 0' > "$NOOP_RUNNER"
+chmod +x "$NOOP_RUNNER"
+printf 'let a = 1\n' > "$SRC"
+if VIBE_RUNNER="$NOOP_RUNNER" VIBE_CLI_WASM="$CLI" \
+  bash "$ROOT_DIR/runtime/vibe" fmt "$SRC" > "$OUT" 2> "$ERR"; then
+  fail "a status-0 runner that wrote nothing was reported as a clean format"
+fi
+[ "$(cat "$SRC")" = "let a = 1" ] || fail "a status-0 runner that wrote nothing TRUNCATED the source"
+
 # Adapter-mode envs must be cleared. cli_adapter evaluates VIBE_HASH before
 # VIBE_FMT, so a leaked selector would write a HASH as $out -- and write mode
 # would then copy it over the user's source file.

--- a/tests/gates/late/run.sh
+++ b/tests/gates/late/run.sh
@@ -5926,6 +5926,12 @@ echo "[compiler-gate] linear source-lane Double call-result offsets ok (#2158)"
 #      the guest branch, not the shell around it.
 echo "[compiler-gate] 106/106 vibe fmt reaches an installed user (#2149)"
 bash "$ROOT_DIR/scripts/test_vibe_fmt_launcher.sh"
+# cli_adapter dispatches on selectors in SOURCE ORDER, so a leaked one hijacks
+# every verb whose selector is evaluated later. Keeping the launcher's `env -u`
+# lists right by hand demonstrably does not work -- this PR shipped an arm
+# missing six selectors, then fixed one arm at a time and still missed three.
+# So the requirement is DERIVED from cli_adapter rather than restated.
+bash "$ROOT_DIR/scripts/check_selector_precedence.sh"
 fmtdir="_build/_gate_vibe_fmt"
 rm -rf "$fmtdir"; mkdir -p "$fmtdir"
 printf 'let   add=(a:Int,b:Int)->Int{a+b}\n' > "$fmtdir/messy.vibe"

--- a/tests/gates/late/run.sh
+++ b/tests/gates/late/run.sh
@@ -5911,3 +5911,41 @@ if ! VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh \
 fi
 rm -rf "$fcodir"
 echo "[compiler-gate] linear source-lane Double call-result offsets ok (#2158)"
+
+# 106/106. `vibe fmt` (#2149). The formatter has always been real and
+#      CI-enforced, but reachable only through lib/@vibe/cli/fmt_entry.vibe --
+#      a separate wasm scripts/vibe_fmt.sh FS-compiles on demand, whose paths
+#      must live under the repo checkout. So an INSTALLED user could not
+#      format at all, while 21 documents told them to run `vibe fmt`.
+#
+#      Two halves, and the second is the one that can rot silently. The
+#      launcher arm's own decisions (mode dispatch, refusal, adapter-mode env
+#      clearing) are pinned by a fake runner, so they are checked even when no
+#      compiler is built. Then the real thing: the stage2 under test formats a
+#      messy file through VIBE_FMT and must produce the canonical layout --
+#      the guest branch, not the shell around it.
+echo "[compiler-gate] 106/106 vibe fmt reaches an installed user (#2149)"
+bash "$ROOT_DIR/scripts/test_vibe_fmt_launcher.sh"
+fmtdir="_build/_gate_vibe_fmt"
+rm -rf "$fmtdir"; mkdir -p "$fmtdir"
+printf 'let   add=(a:Int,b:Int)->Int{a+b}\n' > "$fmtdir/messy.vibe"
+VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_IMPORT_ABI=raw VIBE_FMT=1 \
+  bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
+  "$fmtdir/messy.vibe" "$fmtdir/out.vibe" >"$fmtdir/run.log" 2>&1 || true
+if [ ! -s "$fmtdir/out.vibe" ]; then
+  echo "[compiler-gate] FAIL: VIBE_FMT produced no output -- vibe fmt is not wired into the compiler (#2149)" >&2
+  cat "$fmtdir/run.log" >&2 || true
+  exit 1
+fi
+cat > "$fmtdir/expected.vibe" <<'FMTEXP'
+let add = (a: Int, b: Int) -> Int {
+  a + b
+}
+FMTEXP
+if ! cmp -s "$fmtdir/expected.vibe" "$fmtdir/out.vibe"; then
+  echo "[compiler-gate] FAIL: VIBE_FMT did not produce the canonical layout (#2149)" >&2
+  diff -u "$fmtdir/expected.vibe" "$fmtdir/out.vibe" >&2 || true
+  exit 1
+fi
+rm -rf "$fmtdir"
+echo "[compiler-gate] vibe fmt ok (#2149)"

--- a/tests/gates/registry.tsv
+++ b/tests/gates/registry.tsv
@@ -222,3 +222,4 @@ x-adr-0090-1937-exception-unwind-region-restore	late	ADR-0090 #1937 exception-un
 103/104	late	103/104 vibe check resolves @scope/pkg imports, and package deprecations warn (#1262)
 104/104-2	late	104/104 generic aliases cross index.vpkg transparently (#1700)
 105/105	late	105/105 checker Double call-result offsets on the linear source lane (#2158)
+106/106	late	106/106 vibe fmt reaches an installed user (#2149)


### PR DESCRIPTION
Closes #2149.

## What was wrong

The formatter has always been real and CI-enforced, but reachable only through `lib/@vibe/cli/fmt_entry.vibe` — a separate wasm that `scripts/vibe_fmt.sh` FS-compiles on demand, whose paths must live under `VIBE_PREOPEN_DIR`, i.e. the repo checkout. So `vibe fmt` was not a command at all, and someone who had merely **installed** vibe could not format their own code — while 21 documents told them to run it. For a language that ships a canonical formatter and enforces it in CI, that is a hole in the hands-off story, not a docs bug.

## What changed

Option 1 from the issue: an env selector on the main CLI wasm, the same shape `vibe normalize` already has.

- `cli_adapter.vibe` gains a `VIBE_FMT` branch beside `VIBE_NORMALIZE`, importing `format_source` from `@vibe/compiler/fmt` (`deps = {}`, and `format.vibe` has no imports, so joining the compiler costs it nothing).
- `compiler_sources_manifest.tsv` gains an `fmt` group, and the compiler's own `index.vpkg` declares the new dep.
- `runtime/vibe` gains a `fmt)` arm modeled on `normalize)`, `vibe fmt` in the help block, and `-u VIBE_FMT` in the 13 other arms' clearing lists.

## The guard is ported, not skipped

The formatter turned source that compiles into source that does not on four separate occasions (#945, #1429, #1505, #1821), and `--check` then reported the wreckage as correctly formatted. So the branch **parses its own output** and discards the rewrite if the input was a program and the output is not. This is the path an installed user runs, where no CI fmt gate is watching.

## Two hazards the `normalize)` arm does not have to handle

- **Stdout is captured, not discarded.** The runner exits 0 whatever `cli_main` returns and prints the value as the last stdout line; that line is the formatter's only way to say "I refused". On refusal the input is written back, so `$out` is non-empty **and byte-identical to the source** — a `cmp`-only `--check` would call that "formatted", which is exactly #1821.
- **Adapter-mode envs are cleared.** `cli_adapter` evaluates `VIBE_HASH` before `VIBE_FMT`, so a leaked selector writes a hash as `$out` and write mode copies it **over the user's source file**.

## Test

`scripts/test_vibe_fmt_launcher.sh` pins both with fake runners, so the arm's own decisions are checked without a compiler build. Red-tested: disabling the rc check gives `a refused format exited 0 in mode 'write'`; dropping `-u VIBE_HASH` gives `inherited VIBE_HASH diverted vibe fmt and overwrote the source`. Gate section 106/106 runs that plus a real `VIBE_FMT` format through the stage2 under test, with its `tests/gates/registry.tsv` row.

## Measured end to end

Through the launcher against this stage2 (`viberun` is not built in this checkout, so via a runner shim):

| invocation | result |
|---|---|
| `vibe fmt --stdout f.vibe` | canonical layout, exit 0, file untouched |
| `vibe fmt --check f.vibe` | `not formatted: f.vibe`, exit 1 |
| `vibe fmt f.vibe` | rewrites in place, exit 0 |
| `vibe fmt --check f.vibe` (after) | exit 0 |
| `vibe fmt --stdout x.vpkg` | header preserved, declarations formatted |
| `vibe help` | lists `vibe fmt` |

## Not in scope

The inline-`vibe ` check that #2138 left out of `check_doc_commands.sh`. It was dropped because prose also names fence tags and proposed commands, so re-adding it is its own change with its own false-positive surface.

## Verification

- stage2 == stage3, byte-identical
- `scripts/compiler_gate.sh` exit 0 (106/106 included)
- `scripts/unit_test_runner.sh` 1018/1018

---
_Generated by [Claude Code](https://claude.ai/code/session_01GbtLER6wNT4jsZEN1Zp6xe)_