### PR TITLE
Backlog round: located diagnostics (#2198), from_char_code deprecation warning (#2203), continuation hint (#2206), ch05 direct interpolation (#2205 follow-up)

### DIFF
--- a/book/en/05_types_strings.vibe.md
+++ b/book/en/05_types_strings.vibe.md
@@ -69,7 +69,7 @@ fn main with Console {
   let p = Point::{
     x: 3, y: 4
   }
-  println("p = \{Point::to_string(p)}")
+  println("p = \{p}")
   println("opt = \{Some(1)}")
   println("pair = \{(2, 3)}")
 }

--- a/book/ja/05_types_strings.vibe.md
+++ b/book/ja/05_types_strings.vibe.md
@@ -68,7 +68,7 @@ fn main with Console {
   let p = Point::{
     x: 3, y: 4
   }
-  println("p = \{Point::to_string(p)}")
+  println("p = \{p}")
   println("opt = \{Some(1)}")
   println("pair = \{(2, 3)}")
 }


### PR DESCRIPTION
Works through the open backlog from the book read-through rounds: #2198, #2203 (remainder), #2206, and the #2205 follow-up edit. #2219 was checked and stays blocked — the pinned seed (`seed/import-kind-phase-a-2026-08-21`, source 9c32a79) predates the #2213 abort marker, so the legacy-fallback deletion still waits for the next bootstrap bump.

Landed so far:

- **#2205 follow-up** — book ch05 (en+ja) now demonstrates `derive (Show)` with the direct `\{p}` interpolation instead of the `Point::to_string(p)` workaround; the merge lane renders the source type name since the fix measured in the issue. Verified: vibe_md 3/3 both files on a stage2 from 7c8caf6, translation parity 20/20.

In progress on this branch (commits to follow):

- **#2198** — attach positions to the interpolation-needs-Show diagnostic (currently carries no file at all) and the if-branch mismatch (file, no line). Re-measured on a stage2 from 7c8caf6: the third case, non-exhaustive match, already answers with `line 12:9:` on current main, so the fix covers the remaining two.
- **#2203 remainder** — make `vibe check` warn on `String::from_char_code` the way it warns on `HashMap`, and measure/document the `from_byte` bounds behavior.
- **#2206** — when a line-leading binary operator glues onto the previous expression and the type check fails, say so in the diagnostic and name the `(-1)` edit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012BesqGvopmB2byi8gB4HXG

---
_Generated by [Claude Code](https://claude.ai/code/session_012BesqGvopmB2byi8gB4HXG)_