### PR TITLE
Locate the last two round-2 positionless diagnostics, warn on deprecated names inside interpolations, name the line-leading `-` continuation (#2198, #2203, #2206)

### DIFF
--- a/book/en/20_pitfalls.vibe.md
+++ b/book/en/20_pitfalls.vibe.md
@@ -153,7 +153,7 @@ fn main with Console {
 ```
 
 ```
-line 3:5: type mismatch in '-': operands must be Int or Double (the left operand is Unit -- a `-` at the start of a line continues the previous line's expression instead of starting a new one; parenthesize `(-1)` or bind it with `let` if you meant a negative value)
+line 3:5: type mismatch in '-': operands must be Int or Double (the left operand is Unit -- a `-` at the start of a line continues the previous line's expression instead of starting a new one; parenthesize the negated value, e.g. `(-1)` or `(-x)`, or bind it with `let` if you meant a negative value)
 ```
 
 Write `(-1)`, or bind it first. A negative literal as a match arm's

--- a/book/en/20_pitfalls.vibe.md
+++ b/book/en/20_pitfalls.vibe.md
@@ -153,12 +153,13 @@ fn main with Console {
 ```
 
 ```
-line 3:5: type mismatch in '-': operands must be Int or Double
+line 3:5: type mismatch in '-': operands must be Int or Double (the left operand is Unit -- a `-` at the start of a line continues the previous line's expression instead of starting a new one; parenthesize `(-1)` or bind it with `let` if you meant a negative value)
 ```
 
 Write `(-1)`, or bind it first. A negative literal as a match arm's
-direct body (`None => -1`) is fine. The diagnostic does not yet name
-the continuation as the cause (#2206).
+direct body (`None => -1`) is fine. Since #2206 the diagnostic names
+the continuation and the edit, as quoted above; the position still
+anchors at the start of the glued expression.
 
 ## `fn` is a keyword
 

--- a/book/ja/20_pitfalls.vibe.md
+++ b/book/ja/20_pitfalls.vibe.md
@@ -150,12 +150,12 @@ fn main with Console {
 ```
 
 ```
-line 3:5: type mismatch in '-': operands must be Int or Double
+line 3:5: type mismatch in '-': operands must be Int or Double (the left operand is Unit -- a `-` at the start of a line continues the previous line's expression instead of starting a new one; parenthesize `(-1)` or bind it with `let` if you meant a negative value)
 ```
 
 `(-1)` と書くか、先に束縛する。match 腕の直接の本体としての負リテラル
-(`None => -1`) は問題ない。診断はまだ行継続を原因として名指ししない
-(#2206)。
+(`None => -1`) は問題ない。#2206 以降、診断は上に引用したとおり行継続と
+修正方法を名指しする。位置は引き続き結合された式の先頭を指す。
 
 ## `fn` はキーワード
 

--- a/book/ja/20_pitfalls.vibe.md
+++ b/book/ja/20_pitfalls.vibe.md
@@ -150,7 +150,7 @@ fn main with Console {
 ```
 
 ```
-line 3:5: type mismatch in '-': operands must be Int or Double (the left operand is Unit -- a `-` at the start of a line continues the previous line's expression instead of starting a new one; parenthesize `(-1)` or bind it with `let` if you meant a negative value)
+line 3:5: type mismatch in '-': operands must be Int or Double (the left operand is Unit -- a `-` at the start of a line continues the previous line's expression instead of starting a new one; parenthesize the negated value, e.g. `(-1)` or `(-x)`, or bind it with `let` if you meant a negative value)
 ```
 
 `(-1)` と書くか、先に束縛する。match 腕の直接の本体としての負リテラル

--- a/docs/cheatsheet.md
+++ b/docs/cheatsheet.md
@@ -1613,27 +1613,29 @@ Profiler::heap_bytes()  // with Profiler - current bump-heap pointer
 
 ### Signature reference
 
-上の節が「何があるか」なら、こちらは「どう呼ぶか」。削除した `docs/language-tour/`
-を畳んだときに引き継いだ表で、各行は `lib/` の実体と照合済み
-(`where` / `path` / `String::from_char_codes` の 3 行は実体が無かったので落とした)。
+The section above says what exists; this one says how to call it. The
+tables were inherited when the deleted `docs/language-tour/` was folded in,
+and every row has been checked against the actual `lib/` entity (the three
+rows `where` / `path` / `String::from_char_codes` had no entity behind them
+and were dropped).
 
-**演算子** — 直接呼ぶのではなく演算子として使う:
+**Operators** — used as operators, not called directly:
 
-| 演算子 | 脱糖先 | 型 |
+| operator | desugars to | types |
 |---|---|---|
 | `a + b` / `a - b` / `a * b` / `a / b` / `a % b` | `__add` / `__sub` / `__mul` / `__div` / `__mod` | Int, Float, Double |
 | `-a` | `__neg(a)` | Int, Float, Double |
 | `a == b` | `__eq(a, b)` | Eq types |
 | `a < b` | `__lt(a, b)` | Ord types |
 | `a & b` / `a \| b` / `a ^ b` | `__bit_and` / `__bit_or` / `__bit_xor` | Int |
-| `a << b` / `a >> b` | `__lshift` / `__rshift` (算術シフト) | Int |
+| `a << b` / `a >> b` | `__lshift` / `__rshift` (arithmetic shift) | Int |
 | `a[i]` | `__index(a, i)` | Array, Map |
 
-prelude wrapper: `add`, `sub`, `mul`, `div`, `eq`, `lt`, `not`, `and`, `or`。
+prelude wrappers: `add`, `sub`, `mul`, `div`, `eq`, `lt`, `not`, `and`, `or`.
 
 **String**:
 
-| 関数 | シグネチャ |
+| function | signature |
 |---|---|
 | `String::length` | `(String) -> Int` |
 | `String::concat` | `(String, String) -> String` |
@@ -1658,11 +1660,11 @@ different, currently nonexistent function.
 
 **Array** (builtin): `length: (Array[T]) -> Int`, `get: (Array[T], Int) -> T`,
 `slice: (Array[T], Int, Int) -> Array[T]`,
-`concat: (Array[T], Array[T]) -> Array[T]`, `reverse: (Array[T]) -> Array[T]`。
+`concat: (Array[T], Array[T]) -> Array[T]`, `reverse: (Array[T]) -> Array[T]`.
 
-**Array** (prelude、コレクション先頭・関数末尾):
+**Array** (prelude; collection first, function last):
 
-| 関数 | シグネチャ |
+| function | signature |
 |---|---|
 | `Array::map` | `(Array[T], (T) -> U) -> Array[U]` |
 | `Array::filter` | `(Array[T], (T) -> Bool) -> Array[T]` |
@@ -1690,21 +1692,21 @@ got Int`. For a generic key, use `MutMap[K, V]` from `@vibe/core`.
 
 **Math**: `Int::abs`, `Int::max`, `Int::min`, `Int::clamp`, `Int::signum`,
 `Int::is_even`, `Int::is_odd`, `Double::abs`, `Double::max`, `Double::min`,
-`Double::floor`, `Double::ceil`。
+`Double::floor`, `Double::ceil`.
 
-**変換**: `Int::to_float`, `Int::to_double`, `Float::to_int`,
+**Conversion**: `Int::to_float`, `Int::to_double`, `Float::to_int`,
 `Float::to_double`, `Double::to_int`, `Double::to_float`,
 `__to_string: (Any) -> String`. **A bare `to_string` cannot be called** —
 `to_string(1)` is read as a dot-call on `Int`, and answers
 ``dot-call syntax is not supported for the builtin method `Int::to_string` ``.
 Use the per-type spelling (`Int::to_string(1)`) or `__to_string(x)`.
 
-**I/O** (effect 必須). tty の現行名は `Console`。`Stdin` / `Stdout` /
-`Stderr` は同じ host import を共有する **legacy ラベル**で、row は相互に
-認可しない。`allows Console::write_stream` は `Console::read_stream` を
-許さない (#1496)。
+**I/O** (an effect is required). The current name for the tty is `Console`;
+`Stdin` / `Stdout` / `Stderr` are **legacy labels** sharing the same host
+imports, and the rows do not authorize each other. `allows
+Console::write_stream` does not admit `Console::read_stream` (#1496).
 
-| 関数 | シグネチャ | effect |
+| function | signature | effect |
 |---|---|---|
 | `sh` | `(String) -> String` (captured stdout) | `Process` |
 | `sh_lines` | `(String) -> Array[String]` | `Process` |
@@ -1719,26 +1721,27 @@ Use the per-type spelling (`Int::to_string(1)`) or `__to_string(x)`.
 | `Stdin::read_stream` | `(Int) -> String` | `Stdin` (legacy) |
 | `Stdin::read_char` | `() -> Int` | `Stdin` (legacy) |
 | `Stdin::read_via_stream` | `() -> StdinStream` | `Stdin` |
-| `StdinStream::next` | `(StdinStream) -> Int` (EOF 後は `-1`) | `Async` |
-| `StdinStream::close` | `(StdinStream) -> Unit` (成功後は冪等) | `Async` |
+| `StdinStream::next` | `(StdinStream) -> Int` (`-1` after EOF) | `Async` |
+| `StdinStream::close` | `(StdinStream) -> Unit` (idempotent once it succeeds) | `Async` |
 | `StdinStream::read_chunk` | `(StdinStream, Int) -> Option[String]` | `Async` |
 
-stdin provider の 4 つは**直接呼び出し専用**。値として渡したいときは `with` 行に
-`Stdin` / `Async` を明示した wrapper を定義する — builtin 自体への別名や
-値位置の参照は checker が拒否する。
+The four stdin providers are **direct-call only**. To pass one as a value,
+define a wrapper whose `with` row names `Stdin` / `Async` explicitly — the
+checker rejects an alias to the builtin itself or a value-position
+reference.
 
 **JSON**: `Json::stringify: (Any) -> String`, `parse: (String) -> Json`,
 `type_of: (Json) -> String`, `get: (Json, String) -> Json`,
-`index: (Json, Int) -> Json`, `string` / `number` / `bool` の取り出し,
+`index: (Json, Int) -> Json`, the `string` / `number` / `bool` extractors,
 `is_null: (Json) -> Bool`, `length: (Json) -> Int`,
 `keys: (Json) -> Array[String]`, `stringify_lines: (Array[Json]) -> String`,
-`parse_lines: (String) -> Array[Json]`。
+`parse_lines: (String) -> Array[Json]`.
 
-**行操作**: `Lines::parse: (String) -> Array[String]`,
-`Lines::stringify: (Array[String]) -> String`。
+**Lines**: `Lines::parse: (String) -> Array[String]`,
+`Lines::stringify: (Array[String]) -> String`.
 
-**assertion**: `assert: (Bool) -> Unit`, `eq: (Eq, Eq) -> Bool`,
-`assert_eq: (Eq, Eq) -> Unit`。
+**Assertions**: `assert: (Bool) -> Unit`, `eq: (Eq, Eq) -> Bool`,
+`assert_eq: (Eq, Eq) -> Unit`.
 
 ## Shell integration
 

--- a/docs/cheatsheet.md
+++ b/docs/cheatsheet.md
@@ -1638,8 +1638,8 @@ prelude wrapper: `add`, `sub`, `mul`, `div`, `eq`, `lt`, `not`, `and`, `or`。
 | `String::length` | `(String) -> Int` |
 | `String::concat` | `(String, String) -> String` |
 | `String::substring` | `(String, Int, Int) -> String` (start, end) |
-| `String::char_code_at` | `(String, Int) -> Int` (別名 `String::byte_at`) |
-| `String::from_char_code` | `(Int) -> String` (別名 `String::from_byte`) |
+| `String::byte_at` | `(String, Int) -> Int` (deprecated alias `String::char_code_at` — `vibe check` warns per use) |
+| `String::from_byte` | `(Int) -> String` (deprecated alias `String::from_char_code` — `vibe check` warns per use, including inside `\{...}` interpolations, #2203) |
 | `String::equals` | `(String, String) -> Bool` |
 | `String::split` / `String::join` | `(String, String) -> Array[String]` / `(Array[String], String) -> String` |
 | `String::contains` | `(String, String) -> Bool` |
@@ -1649,6 +1649,12 @@ prelude wrapper: `add`, `sub`, `mul`, `div`, `eq`, `lt`, `not`, `and`, `or`。
 | `String::replace` / `String::replace_all` | `(String, String, String) -> String` |
 | `String::to_upper` / `String::to_lower` | `(String) -> String` |
 | `String::count` | `(String, String) -> Int` |
+
+`String::from_byte(n)` always builds a 1-byte string from the low 8 bits of
+`n` (two's complement) and never traps — measured (#2203): `256` → byte 0,
+`257` → byte 1, `-1` → byte 255, `1000` → byte 232. A value above 127 is a
+raw byte, not a code point (ADR-0098); UTF-8-encoding a code point is a
+different, currently nonexistent function.
 
 **Array** (builtin): `length: (Array[T]) -> Int`, `get: (Array[T], Int) -> T`,
 `slice: (Array[T], Int, Int) -> Array[T]`,

--- a/eval/book-review/probes/p04_interpolate_struct_no_show.vibe
+++ b/eval/book-review/probes/p04_interpolate_struct_no_show.vibe
@@ -1,6 +1,17 @@
 // ch05/ch20 (finding D4): interpolating a struct without derive(Show)
 // "is a compile error" (#1445). Measure the diagnostic: does it name
-// derive(Show) as the edit, and does it carry a position?
+// derive(Show) as the edit, and does it carry a position? Round 2
+// measured it carrying NO position and not even the file (#2198 case
+// 1). Fixed: the message rides the enclosing binding's [@fn=] anchor
+// and vibe check prefixes the entry path -- expected now:
+// `<path>: line 19:4-8: cannot interpolate a value of type `Point` ...`
+// (19:4-8 is `main`; the anchor is the enclosing fn, not the `\{p}`,
+// because the synthesized __to_string call carries no offset). The
+// compile lane stays positionless by design -- it strips unresolved
+// side markers rather than guessing (#1514) -- so the located answer
+// is the check directive's, and the bare message below it is the
+// compile lane's.
+//! cli: check
 struct Point {
   x: Int; y: Int
 }

--- a/eval/book-review/probes/p11_if_branch_type_mismatch.vibe
+++ b/eval/book-review/probes/p11_if_branch_type_mismatch.vibe
@@ -1,6 +1,13 @@
 // ch04: "Both branches must produce the same type." Measure the
 // diagnostic for the mismatch — above all whether it carries a source
-// position (#1567 says type errors often do not).
+// position (#1567 says type errors often do not). Round 2 measured
+// file-but-no-line (#2198 case 2: both branches are literals, so every
+// offset fallback comes up empty). Fixed: the [@fn=] binder anchor
+// recovers the v binding on line 12 -- expected now:
+// `<path>: line 12:7-8: if branches have incompatible types: ...`.
+// (The binder name must not be spelled as declaration syntax in this
+// header: the by-name anchor scans raw source text and would anchor on
+// the comment's occurrence first — measured, see the round-2 record.)
 fn main with Console {
   let v = if true {
     "yes"

--- a/eval/book-review/probes/p11_if_branch_type_mismatch.vibe
+++ b/eval/book-review/probes/p11_if_branch_type_mismatch.vibe
@@ -3,11 +3,13 @@
 // position (#1567 says type errors often do not). Round 2 measured
 // file-but-no-line (#2198 case 2: both branches are literals, so every
 // offset fallback comes up empty). Fixed: the [@fn=] binder anchor
-// recovers the v binding on line 12 -- expected now:
-// `<path>: line 12:7-8: if branches have incompatible types: ...`.
-// (The binder name must not be spelled as declaration syntax in this
-// header: the by-name anchor scans raw source text and would anchor on
-// the comment's occurrence first — measured, see the round-2 record.)
+// recovers the v binding on line 14 -- expected now:
+// `<path>: line 14:7-8: if branches have incompatible types: ...`.
+// (A first draft of this header spelled the binder as declaration
+// syntax and captured the anchor — the by-name scan then read raw
+// text. Since the #2244 review it skips comments/strings and anchors
+// only on a unique declaration, so the hazard is closed; the wording
+// stays as a record of the measurement.)
 fn main with Console {
   let v = if true {
     "yes"

--- a/eval/book-review/probes/p23_from_byte_alias.vibe
+++ b/eval/book-review/probes/p23_from_byte_alias.vibe
@@ -1,10 +1,14 @@
 // ch03/ch05 (round 2, R2-4): #2203 decided String::from_byte is the
 // honest name for the byte-out builtin; the book now leads with it.
 // Measure both spellings compile and agree. Second half of the
-// question is CLI-side, run by the directive below: `vibe check` on
-// this file prints NO deprecation warning for from_char_code today
-// (unlike HashMap's per-use warning, p29) -- expected: empty output,
-// exit 0.
+// question is CLI-side, run by the directive below. Round 2 recorded
+// "no deprecation warning fires" -- that was the #2203 blind spot,
+// specific to THIS probe's shape: the scan skipped names inside
+// string interpolations, and a bare `String::from_char_code(65)`
+// statement warned all along. Fixed with #2203: `vibe check` on this
+// file now warns once, on the from_char_code use inside the
+// interpolation (line 16), to stderr with exit 0; from_byte stays
+// silent.
 //! cli: check
 fn main with Console {
   let s = "hi"

--- a/eval/book-review/rounds/2026-08-22-r2.md
+++ b/eval/book-review/rounds/2026-08-22-r2.md
@@ -113,11 +113,21 @@ Located, names the missing entry, hint is the edit. The book never said
 
 `String::from_byte` resolves and runs on both seed and stage2 (p23);
 `core/builtin_name.vibe` canonicalizes it and marks `from_char_code`
-deprecated with hint "use String::from_byte" — but **no deprecation
-warning fires from `vibe check`** today (p23: exit 0, no output), unlike
-`HashMap` which warns per use (p29b). Ch03/ch05 (en+ja) now lead with
+deprecated with hint "use String::from_byte". This round recorded "no
+deprecation warning fires from `vibe check`" (p23: exit 0, no output) —
+**that claim was a measurement artifact of the probe's shape**: a bare
+`String::from_char_code(65)` statement warned all along
+(`warning: line N:col M: 'String::from_char_code' is deprecated: use
+String::from_byte`, stderr, exit 0), and p23 got silence only because
+the deprecated-use scan skipped names inside string interpolations —
+which is exactly the shape ch03/ch05 recommend. That interpolation
+blind spot was the real #2203 remainder and is fixed (the scan re-lexes
+each `\{...}` snippet, positions shifted back to file coordinates);
+p23's directive now pins the warning. Ch03/ch05 (en+ja) lead with
 `from_byte` and call `from_char_code` the older name. The raw-byte
-contract above 0x7F is unchanged and stays documented as #2203 decided.
+contract above 0x7F is unchanged; bounds are now measured and in the
+cheatsheet: always 1 byte, low 8 bits, no trap (`256` → byte 0, `-1` →
+byte 255, `1000` → byte 232).
 
 ### R2-5. Ch09's quoted diagnostics — all three verbatim-accurate on stage2
 
@@ -216,8 +226,17 @@ listed in SUMMARY.md.
   drop the seed-divergence note then.
 - `vibe check --single-file` on a require-head file, and `vibe fmt` on
   one (module-system-v2 §6 says fmt inserts pins — unmeasured).
-- Whether the `from_char_code` deprecation hint should fire from
-  `vibe check` the way `HashMap`'s does (one mechanism, two behaviors).
+- ~~Whether the `from_char_code` deprecation hint should fire from
+  `vibe check` the way `HashMap`'s does~~ — resolved: it always did for
+  plain uses; the apparent silence was the interpolation blind spot,
+  fixed with #2203 (see R2-4).
 - Ch12's console blocks could be doctest-checked if `vibe_md.sh` grew a
   ```console verifier — today they are the only unproven output in the
   book's own format.
+- The `[@fn=]` by-name anchor (`find_fn_anchor_off`) scans raw source
+  text and does not skip comments — measured while pinning the #2198
+  fix: p11's own header comment spelled the binder as declaration
+  syntax and the diagnostic anchored on the comment line. Real code
+  hits this with a comment like `// let v used to be ...` above the
+  binding. Known #1941-family limitation; a comment-skipping scan (or
+  lexer-token search) would close it.

--- a/eval/book-review/rounds/2026-08-22-r2.md
+++ b/eval/book-review/rounds/2026-08-22-r2.md
@@ -233,10 +233,10 @@ listed in SUMMARY.md.
 - Ch12's console blocks could be doctest-checked if `vibe_md.sh` grew a
   ```console verifier — today they are the only unproven output in the
   book's own format.
-- The `[@fn=]` by-name anchor (`find_fn_anchor_off`) scans raw source
-  text and does not skip comments — measured while pinning the #2198
-  fix: p11's own header comment spelled the binder as declaration
-  syntax and the diagnostic anchored on the comment line. Real code
-  hits this with a comment like `// let v used to be ...` above the
-  binding. Known #1941-family limitation; a comment-skipping scan (or
-  lexer-token search) would close it.
+- ~~The `[@fn=]` by-name anchor (`find_fn_anchor_off`) scans raw source
+  text and does not skip comments~~ — measured while pinning the #2198
+  fix (p11's own header comment captured the anchor), then fixed the
+  same day after the #2244 review flagged the shadowed-binder variant:
+  the scan now skips `//` comments and string literals and anchors only
+  on a unique declaration; an ambiguous name (shadowing) reports
+  without a position. Pinned by two diagnostic_anchor_test cases.

--- a/eval/book-review/rounds/2026-08-22-r2.md
+++ b/eval/book-review/rounds/2026-08-22-r2.md
@@ -238,5 +238,7 @@ listed in SUMMARY.md.
   fix (p11's own header comment captured the anchor), then fixed the
   same day after the #2244 review flagged the shadowed-binder variant:
   the scan now skips `//` comments and string literals and anchors only
-  on a unique declaration; an ambiguous name (shadowing) reports
-  without a position. Pinned by two diagnostic_anchor_test cases.
+  when the name has exactly one declaration across both kinds (`fn` and
+  `let` combined); an ambiguous name (shadowing, a same-named fn/let
+  pair) reports without a position. Pinned by three
+  diagnostic_anchor_test cases.

--- a/lib/@vibe/compiler/checker/checker.vibe
+++ b/lib/@vibe/compiler/checker/checker.vibe
@@ -133,7 +133,10 @@ export fn attach_unlocated_decl_name_marker(errors: Array[String], from: Int, na
       // #2125: `unknown type` is reported from a function literal's parameter
       // and return annotations, which carry no offset of their own -- so it
       // anchors on the declaration name exactly like the two above.
-      let anchorable = String::starts_with(msg, "return type mismatch") || String::starts_with(msg, "binding type mismatch for ") || String::starts_with(msg, "unknown type `")
+      // #2198: `if branches have incompatible types` joins them for the
+      // all-literal case (`if c { "yes" } else { 0 }`) where the else
+      // branch, the then-tail and the condition are all offset-less.
+      let anchorable = String::starts_with(msg, "return type mismatch") || String::starts_with(msg, "binding type mismatch for ") || String::starts_with(msg, "unknown type `") || String::starts_with(msg, "if branches have incompatible types")
       if anchorable && unlocated {
         Array::set(errors, i, String::concat(msg, String::concat(" [@fn=", String::concat(name, "]"))))
       }

--- a/lib/@vibe/compiler/checker/checker.vibe
+++ b/lib/@vibe/compiler/checker/checker.vibe
@@ -4221,7 +4221,26 @@ fn infer_binop_type(op: String, left_ty: Type, right_ty: Type, env: TypeEnv, s: 
         None => match infer_named_trait_binop(env, left_ty, right_ty, trait_name, s) {
           Some((resolved, s1)) => (resolved, s1),
           None => {
-            Array::push(errors, binop_mismatch_msg(op, "': operands must be Int or Double", off))
+            // #2206: a Unit LHS under `-` is almost always a line-leading
+            // `-` glued onto the previous statement (a newline does not end
+            // an expression when the next line starts with an operator).
+            // The checker never sees line layout, so the clause states the
+            // language rule rather than claiming this line started with
+            // `-`; the base text stays a prefix so substring pins hold.
+            let minus_unit_lhs = if op == "-" {
+              match subst_apply(s, left_ty) {
+                CtUnit => true,
+                _ => false
+              }
+            } else {
+              false
+            }
+            let tail = if minus_unit_lhs {
+              "': operands must be Int or Double (the left operand is Unit -- a `-` at the start of a line continues the previous line's expression instead of starting a new one; parenthesize `(-1)` or bind it with `let` if you meant a negative value)"
+            } else {
+              "': operands must be Int or Double"
+            }
+            Array::push(errors, binop_mismatch_msg(op, tail, off))
             (CtUnknown, s)
           }
         }

--- a/lib/@vibe/compiler/checker/checker.vibe
+++ b/lib/@vibe/compiler/checker/checker.vibe
@@ -4239,7 +4239,7 @@ fn infer_binop_type(op: String, left_ty: Type, right_ty: Type, env: TypeEnv, s: 
               false
             }
             let tail = if minus_unit_lhs {
-              "': operands must be Int or Double (the left operand is Unit -- a `-` at the start of a line continues the previous line's expression instead of starting a new one; parenthesize `(-1)` or bind it with `let` if you meant a negative value)"
+              "': operands must be Int or Double (the left operand is Unit -- a `-` at the start of a line continues the previous line's expression instead of starting a new one; parenthesize the negated value, e.g. `(-1)` or `(-x)`, or bind it with `let` if you meant a negative value)"
             } else {
               "': operands must be Int or Double"
             }

--- a/lib/@vibe/compiler/cli_support.vibe
+++ b/lib/@vibe/compiler/cli_support.vibe
@@ -516,12 +516,23 @@ export fn check_linked_file_source_groups(input_path: String) -> Array[(String, 
                 ()
               } else {
                 Array::push(seen_paths, mpath)
-                if String::starts_with(locate_type_error(msource, msg), "line ") {
-                  owners = owners + 1
-                  owner_path = mpath
-                  owner_source = msource
-                } else {
-                  ()
+                // #2244 review round 5: a directory-shared vpkg import or a
+                // contract facade makes the ingested group source differ
+                // from the physical file (imports prepended / contract
+                // replaced), so an offset computed on it names a line below
+                // the real one. Recover the physical bytes the way
+                // checked_entry_source does -- re-ingest and require an
+                // exact match -- and drop the candidate (not an owner) when
+                // they cannot be verified.
+                match owner_locating_source(mpath, msource) {
+                  Some(mlocating) => if String::starts_with(locate_type_error(mlocating, msg), "line ") {
+                    owners = owners + 1
+                    owner_path = mpath
+                    owner_source = mlocating
+                  } else {
+                    ()
+                  },
+                  None => ()
                 }
               }
               mi2 = mi2 + 1
@@ -562,6 +573,32 @@ export fn check_redundant_import_warnings(input_path: String) -> Array[String] w
   check_redundant_import_warnings_from_source_groups(input_path, [
     ("entry", [(input_path, source)])
   ])
+}
+
+/// The source text an offset-bearing diagnostic may be located against for
+/// one (path, source) member of a consumed group set. A plain member locates
+/// against its snapshot as-is. A member whose snapshot carries the loader's
+/// shared-import or contract-facade transform (imports prepended / contract
+/// replaced) must locate against the PHYSICAL file, recovered the same way
+/// checked_entry_source recovers the entry: re-ingest the current bytes and
+/// require the complete synthetic snapshot to match. None when the physical
+/// text cannot be verified -- the caller must then treat the member as
+/// unlocatable rather than emit coordinates computed on synthetic text.
+fn owner_locating_source(path: String, source: String) -> Option[String] with Exception + Fs {
+  if String::starts_with(source, vpkg_shared_import_marker) || String::starts_with(source, contract_facade_marker) {
+    if Fs::exists(path) {
+      let physical = Fs::read_file(path)
+      if source == ingest_source_text_fs(path, physical) {
+        Some(physical)
+      } else {
+        None
+      }
+    } else {
+      None
+    }
+  } else {
+    Some(source)
+  }
 }
 
 fn checked_entry_source(input_path: String, source_groups: Array[(String, Array[(String, String)])]) -> Option[String] with Exception + Fs {

--- a/lib/@vibe/compiler/cli_support.vibe
+++ b/lib/@vibe/compiler/cli_support.vibe
@@ -479,11 +479,64 @@ export fn check_linked_file_source_groups(input_path: String) -> Array[(String, 
         // Prefix this one message class here; every other message reaching
         // this catch is already path-prefixed by its module job, and
         // prefixing unconditionally would double those.
-        let located = locate_type_error(entry_source, msg)
+        //
+        // #2244 review (Codex P1): the throw itself carries no source
+        // identity -- the desugar ran on the MERGED statements, so the
+        // culprit can live in a dependency. Naming the entry file for a
+        // dep-file error would be confidently wrong, so the path is added
+        // only when exactly one source in the consumed group set resolves
+        // the message's [@fn=] anchor (locate_type_error answers with a
+        // `line ` prefix only when it does): that source owns the culprit,
+        // and its own path and text locate it. Zero owners (the marker was
+        // absent or the merge renamed the binder) or two-plus owners (the
+        // #1596 same-name collision) fail closed to the unlocated message
+        // with no path -- missing information beats misinformation.
         if String::starts_with(msg, "cannot interpolate a value of type `") {
-          throw(String::concat(input_path, String::concat(": ", located)))
+          let mut owner_path = ""
+          let mut owner_source = ""
+          let mut owners = 0
+          let seen_paths: Array[String] = array_empty()
+          let mut gi2 = 0
+          while gi2 < Array::length(source_groups) {
+            let (_gname2, members2) = Array::get(source_groups, gi2)
+            let mut mi2 = 0
+            while mi2 < Array::length(members2) {
+              let (mpath, msource) = Array::get(members2, mi2)
+              let mut seen2 = false
+              let mut si2 = 0
+              while si2 < Array::length(seen_paths) {
+                if Array::get(seen_paths, si2) == mpath {
+                  seen2 = true
+                } else {
+                  ()
+                }
+                si2 = si2 + 1
+              }
+              if seen2 {
+                ()
+              } else {
+                Array::push(seen_paths, mpath)
+                if String::starts_with(locate_type_error(msource, msg), "line ") {
+                  owners = owners + 1
+                  owner_path = mpath
+                  owner_source = msource
+                } else {
+                  ()
+                }
+              }
+              mi2 = mi2 + 1
+            }
+            gi2 = gi2 + 1
+          }
+          if owners == 1 {
+            throw(String::concat(owner_path, String::concat(": ", locate_type_error(owner_source, msg))))
+          } else {
+            // locate against an empty source: the anchor cannot resolve, so
+            // this only strips the side marker from the message.
+            throw(locate_type_error("", msg))
+          }
         } else {
-          throw(located)
+          throw(locate_type_error(entry_source, msg))
         }
       }
     }

--- a/lib/@vibe/compiler/cli_support.vibe
+++ b/lib/@vibe/compiler/cli_support.vibe
@@ -472,7 +472,19 @@ export fn check_linked_file_source_groups(input_path: String) -> Array[(String, 
         let (snapshot_entry_source, verified) = verify_culprit_off_marker_snapshot(input_path, source_groups, msg)
         throw(locate_type_error(snapshot_entry_source, verified))
       } else {
-        throw(locate_type_error(entry_source, msg))
+        // #2198: the missing-Show interpolation throw escapes the desugar
+        // (reached via check_file_fs_mode's effect_lowering_prelude, or via
+        // expand_interp_stmts below) with no `<path>: ` prefix -- path
+        // prefixing lives in check_module_job, which that throw bypasses.
+        // Prefix this one message class here; every other message reaching
+        // this catch is already path-prefixed by its module job, and
+        // prefixing unconditionally would double those.
+        let located = locate_type_error(entry_source, msg)
+        if String::starts_with(msg, "cannot interpolate a value of type `") {
+          throw(String::concat(input_path, String::concat(": ", located)))
+        } else {
+          throw(located)
+        }
       }
     }
   }

--- a/lib/@vibe/compiler/normalize/desugar_trait_dict.vibe
+++ b/lib/@vibe/compiler/normalize/desugar_trait_dict.vibe
@@ -5993,17 +5993,26 @@ fn interp_missing_show_type(arg: Expr, struct_sets: Array[(String, Array[String]
   }
 }
 
-/// #1514 note (measured, not a guess): this message carries NO `line:col`, and
-/// the ` [@off=N]` marker convention does not help here. `locate_type_error`
-/// decodes that marker, but only the TYPECHECK path calls it -- the compile path
-/// writes the thrown string verbatim (`emit_compile_diag` in cli_adapter.vibe,
-/// 11+ call sites, none of which is handed the source text; for a merged
-/// multi-file compile there is not even one obvious source to resolve an offset
-/// against). Emitting the marker anyway just leaks `[@off=135]` into the user's
-/// message, which is worse than no position -- verified by doing it. Wiring the
-/// compile path is #1514's job, not this one's.
+/// #2198: the synthesized `__to_string` call has no offset (the interp
+/// snippet is re-lexed without offsets), so `[@off=]` cannot help -- but the
+/// enclosing top-level binding's name is in `dtd_show_self_fn`, so the
+/// message carries `[@fn=name]` and `locate_type_error` recovers the
+/// `fn name` / `let name` token in both check lanes. The compile lane
+/// strips unresolved side markers (`strip_side_marker` via
+/// `emit_compile_diag`), so nothing leaks there; wiring a real position
+/// through the compile path stays #1514's job. An interpolation inside a
+/// `test { }` block has no self_fn and stays positionless. Known accepted
+/// hazard (same as every `[@fn=]` use, #1941/#1596): a dep-file culprit
+/// whose binder name also exists in the entry text anchors on the entry's
+/// spelling.
 fn interp_missing_show_msg(tn: String) -> String {
-  String::concat("cannot interpolate a value of type `", String::concat(tn, String::concat("`: it has no Show renderer -- add `derive(Show)` to `", String::concat(tn, String::concat("`, or define `fn ", String::concat(tn, "::to_string(v) -> String` (#1445)"))))))
+  let base = String::concat("cannot interpolate a value of type `", String::concat(tn, String::concat("`: it has no Show renderer -- add `derive(Show)` to `", String::concat(tn, String::concat("`, or define `fn ", String::concat(tn, "::to_string(v) -> String` (#1445)"))))))
+  let self_fn = Array::get(dtd_show_self_fn, 0)
+  if String::length(self_fn) > 0 {
+    String::concat(base, String::concat(" [@fn=", String::concat(self_fn, "]")))
+  } else {
+    base
+  }
 }
 
 // ---- #1392: structural interpolation ----

--- a/lib/@vibe/compiler/runtime/deprecated_scan.vibe
+++ b/lib/@vibe/compiler/runtime/deprecated_scan.vibe
@@ -254,7 +254,11 @@ export fn legacy_handler_warning_lines(source: String) -> Array[String] with Exc
 
 /// Scan `tokens` (with `starts` offsets into `source`) for uses of any
 /// deprecated name; one formatted warning line per use, in source order.
-fn deprecated_use_warnings_tokens(source: String, tokens: Array[Token], starts: Array[Int], deprecated: Array[(String, String)]) -> Array[String] {
+/// `base` shifts every reported offset: 0 for a whole-file scan, and the
+/// snippet's absolute source offset when re-scanning a string
+/// interpolation's expression fragment (whose own starts are
+/// fragment-relative). Nested interpolations accumulate their bases.
+fn deprecated_use_warnings_tokens(source: String, tokens: Array[Token], starts: Array[Int], deprecated: Array[(String, String)], base: Int) -> Array[String] {
   let out = dep_empty_strs()
   if Array::length(deprecated) == 0 {
     return out
@@ -305,7 +309,7 @@ fn deprecated_use_warnings_tokens(source: String, tokens: Array[Token], starts: 
         }
         if hit2 >= 0 {
           let (dn, dm) = Array::get(deprecated, hit2)
-          Array::push(out, dep_warning_line(source, Array::get(starts, i), dn, dm))
+          Array::push(out, dep_warning_line(source, base + Array::get(starts, i), dn, dm))
         } else {
           ()
         }
@@ -314,6 +318,39 @@ fn deprecated_use_warnings_tokens(source: String, tokens: Array[Token], starts: 
         } else {
           i = i + 1
         }
+      },
+      TStringInterp(iparts, ioffsets) => {
+        // #2203: a deprecated name used inside a string interpolation
+        // (`"\{String::from_char_code(n)}"`) must warn like any other use --
+        // this arm was the measured blind spot behind "no warning fires".
+        // Expression snippets carry their absolute source offset (#947);
+        // literal chunks carry -1 and hold no code. Each snippet re-lexes in
+        // isolation and scans recursively with its base accumulated, so a
+        // nested interpolation still reports real file positions. A snippet
+        // that fails to re-lex is skipped: a warning pass must never fail a
+        // clean check (unreachable in practice -- the whole file already
+        // lexed once to produce this token).
+        let mut pi = 0
+        while pi < Array::length(iparts) {
+          let part_base = Array::get(ioffsets, pi)
+          if part_base >= 0 {
+            handle {
+              let (sub_tokens, sub_starts, _sub_ends) = lex_with_offsets(Array::get(iparts, pi))
+              let sub = deprecated_use_warnings_tokens(source, sub_tokens, sub_starts, deprecated, base + part_base)
+              let mut wi = 0
+              while wi < Array::length(sub) {
+                Array::push(out, Array::get(sub, wi))
+                wi = wi + 1
+              }
+            } with Exception {
+              Throw(_) => ()
+            }
+          } else {
+            ()
+          }
+          pi = pi + 1
+        }
+        i = i + 1
       },
       _ => {
         i = i + 1
@@ -385,7 +422,7 @@ export fn deprecated_warning_lines_visible(entry_source: String, dep_sources: Ar
     }
     d = d + 1
   }
-  let out = deprecated_use_warnings_tokens(entry_source, tokens, starts, deprecated)
+  let out = deprecated_use_warnings_tokens(entry_source, tokens, starts, deprecated, 0)
   let syntax_warnings = legacy_handler_warning_lines(entry_source)
   let mut wi = 0
   while wi < Array::length(syntax_warnings) {

--- a/lib/@vibe/compiler/runtime/deprecated_scan_test.vibe
+++ b/lib/@vibe/compiler/runtime/deprecated_scan_test.vibe
@@ -268,6 +268,43 @@ test "String::byte_at is silent" {
   assert_eq(warn_count(entry, no_deps()), 0)
 }
 
+test "String::from_char_code warns and names from_byte" {
+  let entry = "fn n() -> String {\n  String::from_char_code(65)\n}"
+  let lines = deprecated_warning_lines(entry, no_deps())
+  assert_eq(Array::length(lines), 1)
+  assert(contains(Array::get(lines, 0), "'String::from_char_code' is deprecated: use String::from_byte"))
+}
+
+test "String::from_byte is silent" {
+  let entry = "fn n() -> String {\n  String::from_byte(65)\n}"
+  assert_eq(warn_count(entry, no_deps()), 0)
+}
+
+//# #2203: uses inside a string interpolation were the measured blind spot --
+//# the book's own recommended shape (`"\{String::from_char_code(n)}"`)
+//# never warned because the scan skipped TStringInterp tokens entirely.
+
+test "deprecated use inside a string interpolation warns with a real position" {
+  let entry = "fn n() -> String {\n  \"c = \\{String::from_char_code(65)}\"\n}"
+  let lines = deprecated_warning_lines(entry, no_deps())
+  assert_eq(Array::length(lines), 1)
+  // The snippet's fragment-relative col shifts back by its absolute source
+  // offset (#947): `String` starts at byte 27 of line 2 -> col 10.
+  assert(contains(Array::get(lines, 0), "line 2:col 10: 'String::from_char_code' is deprecated: use String::from_byte"))
+}
+
+test "non-deprecated use inside a string interpolation is silent" {
+  let entry = "fn n() -> String {\n  \"c = \\{String::from_byte(65)}\"\n}"
+  assert_eq(warn_count(entry, no_deps()), 0)
+}
+
+test "deprecated use inside a nested interpolation warns" {
+  let entry = "fn n(b: Bool) -> String {\n  \"x = \\{if b { \"\\{String::from_char_code(65)}\" } else { \"n\" }}\"\n}"
+  let lines = deprecated_warning_lines(entry, no_deps())
+  assert_eq(Array::length(lines), 1)
+  assert(contains(Array::get(lines, 0), "'String::from_char_code' is deprecated"))
+}
+
 test "StringBuilder::freeze stays silent until a bootstrap bump" {
   let entry = "fn n() -> Array[Int] {\n  ArrayBuilder::freeze(ArrayBuilder::new())\n}"
   assert_eq(warn_count(entry, no_deps()), 0)

--- a/lib/@vibe/compiler/runtime/typecheck_fs.vibe
+++ b/lib/@vibe/compiler/runtime/typecheck_fs.vibe
@@ -3629,6 +3629,17 @@ fn find_fn_anchor_off(source: String, name: String) -> Int {
         } else {
           ()
         }
+      } else if c == 35 && i + 1 < slen && String::char_code_at(source, i + 1) == 124 {
+        // #2244 round 11 (measured: `let s = #|raw text` compiles): a
+        // `#|` line is a RAW multiline-string segment running to end of
+        // line -- its text can spell declarations and quotes, and reading
+        // it as code both counted a fake declaration and flipped string
+        // mode (anchoring INSIDE the raw text). Skip the whole line; each
+        // continuation line's own `#|` is skipped the same way when the
+        // scan reaches it, so the indent-match rule needs no bookkeeping.
+        while i < slen && String::char_code_at(source, i) != 10 {
+          i = i + 1
+        }
       } else if c == 114 && i + 1 < slen && String::char_code_at(source, i + 1) == 34 && (i == 0 || !loc_ident_char(String::char_code_at(source, i - 1))) {
         // #2244 round 10 (measured: `let q = r"\"` compiles): a
         // whole-token `r` before `"` opens a RAW string, which the lexer

--- a/lib/@vibe/compiler/runtime/typecheck_fs.vibe
+++ b/lib/@vibe/compiler/runtime/typecheck_fs.vibe
@@ -3609,6 +3609,26 @@ fn find_fn_anchor_off(source: String, name: String) -> Int {
         while i < slen && String::char_code_at(source, i) != 10 {
           i = i + 1
         }
+      } else if c == 39 {
+        // #2244 round 9: a character literal's byte can be `"` -- letting
+        // it reach the branch below flipped string mode and swallowed the
+        // declarations after it (measured: `let q = '\"'` before the
+        // binder handed a same-named outside fn the anchor). Skip the
+        // literal, honoring one `\` escape. Inside a fragment this stays
+        // brace-parity with the lexer: a `'}'`/`'\"'` there does not lex
+        // (scan_interp_end counts raw bytes the same way), so no compiling
+        // program puts a counted byte inside a fragment char literal.
+        i = i + 1
+        if i < slen && String::char_code_at(source, i) == 92 {
+          i = i + 2
+        } else {
+          i = i + 1
+        }
+        if i < slen && String::char_code_at(source, i) == 39 {
+          i = i + 1
+        } else {
+          ()
+        }
       } else if c == 34 {
         in_string = true
         i = i + 1

--- a/lib/@vibe/compiler/runtime/typecheck_fs.vibe
+++ b/lib/@vibe/compiler/runtime/typecheck_fs.vibe
@@ -3545,15 +3545,19 @@ fn loc_kw_before(source: String, off: Int, kw: String) -> Bool {
 /// Prefer a `fn name` declaration, then `let name` / `let mut name`, then a
 /// plain whole-word occurrence. -1 when the name cannot be found.
 ///
-/// #2244 review: the scan is a raw-text heuristic, and two failure modes
+/// #2244 review: the scan is a raw-text heuristic, and three failure modes
 /// made it confidently wrong -- a comment or string literal spelling the
 /// declaration (`// let v used to be ...`) anchored the diagnostic at the
-/// comment, and a shadowed binder anchored at the FIRST `let v` rather than
-/// the failing one. So the scan now skips `//` comments and string
-/// literals, and each tier anchors only when it is UNIQUE in what remains:
-/// one `fn name`, else one `let name`, else one bare occurrence. An
-/// ambiguous name (shadowing, re-declaration) returns -1 and the message
-/// stays unlocated -- missing information beats misinformation.
+/// comment, a shadowed binder anchored at the FIRST `let v` rather than
+/// the failing one, and a cross-kind collision (`fn v` at top level while
+/// the failing binding is a local `let v`) anchored at the unrelated fn --
+/// the marker records only the NAME, so the kind cannot break the tie.
+/// So the scan skips `//` comments and string literals, and it anchors
+/// only when exactly ONE declaration of the name exists across BOTH
+/// declaration kinds (`fn name` and `let name` combined), falling back to
+/// a bare occurrence only when it is the name's sole appearance. Anything
+/// ambiguous (shadowing, re-declaration, fn/let collision) returns -1 and
+/// the message stays unlocated -- missing information beats misinformation.
 fn find_fn_anchor_off(source: String, name: String) -> Int {
   let nlen = String::length(name)
   if nlen == 0 {
@@ -3630,11 +3634,14 @@ fn find_fn_anchor_off(source: String, name: String) -> Int {
         i = i + 1
       }
     }
-    if fn_count == 1 {
-      fn_off
-    } else if fn_count == 0 && let_count == 1 {
-      let_off
-    } else if fn_count == 0 && let_count == 0 && occ_count == 1 {
+    let decl_count = fn_count + let_count
+    if decl_count == 1 {
+      if fn_count == 1 {
+        fn_off
+      } else {
+        let_off
+      }
+    } else if decl_count == 0 && occ_count == 1 {
       first_off
     } else {
       0 - 1

--- a/lib/@vibe/compiler/runtime/typecheck_fs.vibe
+++ b/lib/@vibe/compiler/runtime/typecheck_fs.vibe
@@ -3542,8 +3542,18 @@ fn loc_kw_before(source: String, off: Int, kw: String) -> Bool {
 }
 
 /// Recover the source offset of a declaration name tagged `[@fn=name]`.
-/// Prefer `fn name`, then `let name` / `let mut name`, then the first
-/// whole-word occurrence. -1 when the name cannot be found.
+/// Prefer a `fn name` declaration, then `let name` / `let mut name`, then a
+/// plain whole-word occurrence. -1 when the name cannot be found.
+///
+/// #2244 review: the scan is a raw-text heuristic, and two failure modes
+/// made it confidently wrong -- a comment or string literal spelling the
+/// declaration (`// let v used to be ...`) anchored the diagnostic at the
+/// comment, and a shadowed binder anchored at the FIRST `let v` rather than
+/// the failing one. So the scan now skips `//` comments and string
+/// literals, and each tier anchors only when it is UNIQUE in what remains:
+/// one `fn name`, else one `let name`, else one bare occurrence. An
+/// ambiguous name (shadowing, re-declaration) returns -1 and the message
+/// stays unlocated -- missing information beats misinformation.
 fn find_fn_anchor_off(source: String, name: String) -> Int {
   let nlen = String::length(name)
   if nlen == 0 {
@@ -3552,26 +3562,61 @@ fn find_fn_anchor_off(source: String, name: String) -> Int {
     let slen = String::length(source)
     let mut i = 0
     let mut fn_off = 0 - 1
+    let mut fn_count = 0
     let mut let_off = 0 - 1
+    let mut let_count = 0
     let mut first_off = 0 - 1
-    while i + nlen <= slen {
-      if loc_word_at(source, i, name) {
+    let mut occ_count = 0
+    while i < slen {
+      let c = String::char_code_at(source, i)
+      if c == 47 && i + 1 < slen && String::char_code_at(source, i + 1) == 47 {
+        // `//` line comment: skip to end of line.
+        while i < slen && String::char_code_at(source, i) != 10 {
+          i = i + 1
+        }
+      } else if c == 34 {
+        // String literal: skip its body, honoring `\` escapes (which also
+        // steps over the `\{` interpolation opener -- text inside a string
+        // never hosts the declaration this anchor is looking for).
+        i = i + 1
+        let mut closed = false
+        while !closed && i < slen {
+          let sc = String::char_code_at(source, i)
+          if sc == 92 {
+            i = i + 2
+          } else if sc == 34 {
+            closed = true
+            i = i + 1
+          } else {
+            i = i + 1
+          }
+        }
+      } else if i + nlen <= slen && loc_word_at(source, i, name) {
+        occ_count = occ_count + 1
         if first_off < 0 {
           first_off = i
         } else {
           ()
         }
-        if fn_off < 0 && loc_kw_before(source, i, "fn") {
-          fn_off = i
+        if loc_kw_before(source, i, "fn") {
+          fn_count = fn_count + 1
+          if fn_off < 0 {
+            fn_off = i
+          } else {
+            ()
+          }
         } else {
-          ()
-        }
-        if let_off < 0 {
-          if loc_kw_before(source, i, "let") {
-            let_off = i
+          let is_let_decl = if loc_kw_before(source, i, "let") {
+            true
           } else if loc_kw_before(source, i, "mut") {
             let before_name = loc_skip_ws_back(source, i)
-            if loc_kw_before(source, before_name - 3, "let") {
+            loc_kw_before(source, before_name - 3, "let")
+          } else {
+            false
+          }
+          if is_let_decl {
+            let_count = let_count + 1
+            if let_off < 0 {
               let_off = i
             } else {
               ()
@@ -3579,20 +3624,20 @@ fn find_fn_anchor_off(source: String, name: String) -> Int {
           } else {
             ()
           }
-        } else {
-          ()
         }
         i = i + nlen
       } else {
         i = i + 1
       }
     }
-    if fn_off >= 0 {
+    if fn_count == 1 {
       fn_off
-    } else if let_off >= 0 {
+    } else if fn_count == 0 && let_count == 1 {
       let_off
-    } else {
+    } else if fn_count == 0 && let_count == 0 && occ_count == 1 {
       first_off
+    } else {
+      0 - 1
     }
   }
 }

--- a/lib/@vibe/compiler/runtime/typecheck_fs.vibe
+++ b/lib/@vibe/compiler/runtime/typecheck_fs.vibe
@@ -3602,7 +3602,19 @@ fn find_fn_anchor_off(source: String, name: String) -> Int {
         } else {
           ()
         }
-        if loc_kw_before(source, i, "fn") {
+        // #2244 review round 6 (measured: `let r#v = 1` compiles): a
+        // raw-identifier binder lexes to the bare name, so the occurrence
+        // matches -- but the `r#` prefix sat between the name and its
+        // keyword, making the scan count it as a bare occurrence and hand
+        // a same-named plain declaration sole ownership. Probe the keyword
+        // from before a whole-word `r#` so raw spellings count as the
+        // declarations they are.
+        let decl_probe = if i >= 2 && String::char_code_at(source, i - 1) == 35 && String::char_code_at(source, i - 2) == 114 && (i - 2 == 0 || !loc_ident_char(String::char_code_at(source, i - 3))) {
+          i - 2
+        } else {
+          i
+        }
+        if loc_kw_before(source, decl_probe, "fn") {
           fn_count = fn_count + 1
           if fn_off < 0 {
             fn_off = i
@@ -3610,10 +3622,10 @@ fn find_fn_anchor_off(source: String, name: String) -> Int {
             ()
           }
         } else {
-          let is_let_decl = if loc_kw_before(source, i, "let") {
+          let is_let_decl = if loc_kw_before(source, decl_probe, "let") {
             true
-          } else if loc_kw_before(source, i, "mut") {
-            let before_name = loc_skip_ws_back(source, i)
+          } else if loc_kw_before(source, decl_probe, "mut") {
+            let before_name = loc_skip_ws_back(source, decl_probe)
             loc_kw_before(source, before_name - 3, "let")
           } else {
             false

--- a/lib/@vibe/compiler/runtime/typecheck_fs.vibe
+++ b/lib/@vibe/compiler/runtime/typecheck_fs.vibe
@@ -3571,30 +3571,60 @@ fn find_fn_anchor_off(source: String, name: String) -> Int {
     let mut let_count = 0
     let mut first_off = 0 - 1
     let mut occ_count = 0
+    // #2244 round 7: a string literal's TEXT never hosts a declaration,
+    // but its `\{...}` interpolation fragments are parsed as expression
+    // code and can declare the very binder this anchor is looking for --
+    // skipping whole literals handed a same-named outside declaration
+    // sole ownership. So the scan is a small mode machine: string text is
+    // skipped, `\{` re-enters code scanning until the fragment's matching
+    // `}` (brace-counted; nested strings and fragments push further), and
+    // `//` comments are skipped in code positions only.
+    let mut in_string = false
+    let depths = [0]
+    let mut frag_top = 0
     while i < slen {
       let c = String::char_code_at(source, i)
-      if c == 47 && i + 1 < slen && String::char_code_at(source, i + 1) == 47 {
+      if in_string {
+        if c == 92 {
+          if i + 1 < slen && String::char_code_at(source, i + 1) == 123 {
+            in_string = false
+            frag_top = frag_top + 1
+            if frag_top >= Array::length(depths) {
+              Array::push(depths, 1)
+            } else {
+              Array::set(depths, frag_top, 1)
+            }
+            i = i + 2
+          } else {
+            i = i + 2
+          }
+        } else if c == 34 {
+          in_string = false
+          i = i + 1
+        } else {
+          i = i + 1
+        }
+      } else if c == 47 && i + 1 < slen && String::char_code_at(source, i + 1) == 47 {
         // `//` line comment: skip to end of line.
         while i < slen && String::char_code_at(source, i) != 10 {
           i = i + 1
         }
       } else if c == 34 {
-        // String literal: skip its body, honoring `\` escapes (which also
-        // steps over the `\{` interpolation opener -- text inside a string
-        // never hosts the declaration this anchor is looking for).
+        in_string = true
         i = i + 1
-        let mut closed = false
-        while !closed && i < slen {
-          let sc = String::char_code_at(source, i)
-          if sc == 92 {
-            i = i + 2
-          } else if sc == 34 {
-            closed = true
-            i = i + 1
-          } else {
-            i = i + 1
-          }
+      } else if frag_top > 0 && c == 123 {
+        Array::set(depths, frag_top, Array::get(depths, frag_top) + 1)
+        i = i + 1
+      } else if frag_top > 0 && c == 125 {
+        let d = Array::get(depths, frag_top) - 1
+        if d == 0 {
+          // The fragment closed; the enclosing string resumes.
+          frag_top = frag_top - 1
+          in_string = true
+        } else {
+          Array::set(depths, frag_top, d)
         }
+        i = i + 1
       } else if i + nlen <= slen && loc_word_at(source, i, name) {
         occ_count = occ_count + 1
         if first_off < 0 {

--- a/lib/@vibe/compiler/runtime/typecheck_fs.vibe
+++ b/lib/@vibe/compiler/runtime/typecheck_fs.vibe
@@ -3652,9 +3652,12 @@ fn find_fn_anchor_off(source: String, name: String) -> Int {
             ()
           }
         } else {
+          // #2244 round 8: `rec` joins `mut` as an intervening keyword --
+          // `let rec v` is a declaration of `v` (both spell 3 bytes, so
+          // one backtrack serves them).
           let is_let_decl = if loc_kw_before(source, decl_probe, "let") {
             true
-          } else if loc_kw_before(source, decl_probe, "mut") {
+          } else if loc_kw_before(source, decl_probe, "mut") || loc_kw_before(source, decl_probe, "rec") {
             let before_name = loc_skip_ws_back(source, decl_probe)
             loc_kw_before(source, before_name - 3, "let")
           } else {

--- a/lib/@vibe/compiler/runtime/typecheck_fs.vibe
+++ b/lib/@vibe/compiler/runtime/typecheck_fs.vibe
@@ -3629,6 +3629,19 @@ fn find_fn_anchor_off(source: String, name: String) -> Int {
         } else {
           ()
         }
+      } else if c == 114 && i + 1 < slen && String::char_code_at(source, i + 1) == 34 && (i == 0 || !loc_ident_char(String::char_code_at(source, i - 1))) {
+        // #2244 round 10 (measured: `let q = r"\"` compiles): a
+        // whole-token `r` before `"` opens a RAW string, which the lexer
+        // ends at the next quote with no escape processing -- the
+        // escape-honoring string mode below would read a trailing
+        // backslash as escaping the closing quote and swallow the
+        // declarations after it. Skip to the next quote verbatim; no
+        // interpolation fires inside a raw string for the same reason.
+        i = i + 2
+        while i < slen && String::char_code_at(source, i) != 34 {
+          i = i + 1
+        }
+        i = i + 1
       } else if c == 34 {
         in_string = true
         i = i + 1

--- a/lib/@vibe/compiler/tests/checker_minus_continuation_test.vibe
+++ b/lib/@vibe/compiler/tests/checker_minus_continuation_test.vibe
@@ -17,7 +17,7 @@ test "unit lhs minus names the line continuation" {
   assert(check_source_err_contains(src, "type mismatch in '-': operands must be Int or Double"))
   assert(check_source_err_contains(src, "the left operand is Unit"))
   assert(check_source_err_contains(src, "continues the previous line's expression"))
-  assert(check_source_err_contains(src, "parenthesize `(-1)`"))
+  assert(check_source_err_contains(src, "parenthesize the negated value"))
 }
 
 test "non-unit lhs minus keeps the plain message" {

--- a/lib/@vibe/compiler/tests/checker_minus_continuation_test.vibe
+++ b/lib/@vibe/compiler/tests/checker_minus_continuation_test.vibe
@@ -1,0 +1,35 @@
+//# Imports
+
+import ./checker_parity_test_support.vibe {
+  check_source_err_contains, check_source_error_message, check_source_ok
+}
+
+//# Misc
+
+// #2206: a line-leading `-` glues onto the previous expression (a newline
+// does not end an expression when the next line starts with an operator),
+// so the checker sees `f() - 1` with a Unit LHS. The diagnostic must name
+// the continuation rule and the `(-1)` edit; the base text stays a prefix
+// so existing substring pins keep matching.
+
+test "unit lhs minus names the line continuation" {
+  let src = "fn f() -> Unit { () }\nfn main() -> Int {\n  let v = {\n    f()\n    -1\n  }\n  v\n}"
+  assert(check_source_err_contains(src, "type mismatch in '-': operands must be Int or Double"))
+  assert(check_source_err_contains(src, "the left operand is Unit"))
+  assert(check_source_err_contains(src, "continues the previous line's expression"))
+  assert(check_source_err_contains(src, "parenthesize `(-1)`"))
+}
+
+test "non-unit lhs minus keeps the plain message" {
+  // String - String misses every candidate but the LHS is not Unit, so
+  // the continuation clause must NOT appear.
+  let src = "fn main() -> Int {\n  let s = \"a\" - \"b\"\n  0\n}"
+  assert(check_source_err_contains(src, "type mismatch in '-': operands must be Int or Double"))
+  let msg = check_source_error_message(src)
+  assert(!String::contains(msg, "the left operand is Unit"))
+}
+
+test "parenthesized negative literal repairs the glue" {
+  let src = "fn f() -> Unit { () }\nfn main() -> Int {\n  let v = {\n    f()\n    (-1)\n  }\n  v\n}"
+  assert(check_source_ok(src))
+}

--- a/lib/@vibe/compiler/tests/cli_support_test.vibe
+++ b/lib/@vibe/compiler/tests/cli_support_test.vibe
@@ -601,3 +601,33 @@ test "dependency missing-Show interpolation does not name the entry file" {
   assert(!String::contains(msg, "entrymod.vibe"))
   assert(!String::contains(msg, " [@fn="))
 }
+
+test "shared-import sibling missing-Show locates against the physical file" {
+  // #2244 review round 5: a sibling under an index.vpkg with a directory-
+  // shared import is ingested with the shared-import marker and the
+  // inherited import line PREPENDED, so an offset computed on the group
+  // snapshot names a line below the real one. The owner scan must recover
+  // the physical bytes (re-ingest + exact match) before locating; `render`
+  // is declared at line 5 of the physical file, byte columns 11-17
+  // (half-open end, the range prefix's convention).
+  let base_dir = "/tmp/vibe_cli_support_show_shared/pkg"
+  Fs::mkdir_p(base_dir)
+  let contract_path = String::concat(base_dir, "/index.vpkg")
+  let impl_path = String::concat(base_dir, "/impl.vibe")
+  Fs::write_bytes(contract_path, string_to_bytes("import @vibe/random { seed }\n\nfn render() -> String\n"))
+  Fs::write_bytes(impl_path, string_to_bytes("struct Hidden {\n  x: Int\n}\n\nexport fn render() -> String {\n  let h = Hidden::{ x: 1 }\n  \"\\{h}\"\n}\n"))
+  let msg = handle {
+    let _ = check_linked_file(impl_path)
+    ""
+  } with Exception {
+    Throw(m) => m
+  }
+  assert(String::contains(msg, "cannot interpolate a value of type"))
+  if String::contains(msg, "line ") {
+    // Located answers must carry the PHYSICAL coordinates and the file.
+    assert(String::contains(msg, "/impl.vibe: line 5:11-17:"))
+  } else {
+    // Fail-closed (unlocatable) is acceptable; a wrong line is not.
+    assert(!String::contains(msg, " [@"))
+  }
+}

--- a/lib/@vibe/compiler/tests/cli_support_test.vibe
+++ b/lib/@vibe/compiler/tests/cli_support_test.vibe
@@ -558,3 +558,46 @@ test "shipped HashMap type alias in core/index.vpkg is still a transparent alias
   assert(String::contains(src, "type HashMap[K, V] = MutMap[K, V]"))
   assert(!String::contains(src, "#deprecated(\"use MutMap\")"))
 }
+
+//# #2198 / #2244 review: the missing-Show interpolation path prefix must
+//# name the culprit's file, never the entry's by default. The throw
+//# carries no source identity, so the prefix rides [@fn=] ownership: added
+//# only when exactly one source in the consumed group set resolves the
+//# anchor; otherwise the message stays unlocated with no path.
+
+test "entry-file missing-Show interpolation names the entry path and line" {
+  let base_dir = "/tmp/vibe_cli_support_show_entry"
+  let main_path = String::concat(base_dir, "/main.vibe")
+  Fs::mkdir_p(base_dir)
+  Fs::write_bytes(main_path, string_to_bytes("struct Bare {\n  x: Int\n}\n\nfn main() -> Unit {\n  let b = Bare::{ x: 1 }\n  let s = \"\\{b}\"\n  ()\n}\n"))
+  let msg = handle {
+    let _ = check_linked_file(main_path)
+    ""
+  } with Exception {
+    Throw(m) => m
+  }
+  assert(String::contains(msg, "cannot interpolate a value of type"))
+  assert(String::contains(msg, "/main.vibe: line 5:4-8:"))
+}
+
+test "dependency missing-Show interpolation does not name the entry file" {
+  // Red before the fix: `<entry path>: cannot interpolate ...` for an
+  // error living entirely in dep.vibe. The merged binder name does not
+  // resolve in any single source (the merge renames dep declarations), so
+  // the fail-closed answer is the bare message: no path, no location.
+  let base_dir = "/tmp/vibe_cli_support_show_dep"
+  let dep_path = String::concat(base_dir, "/dep.vibe")
+  let main_path = String::concat(base_dir, "/entrymod.vibe")
+  Fs::mkdir_p(base_dir)
+  Fs::write_bytes(dep_path, string_to_bytes("struct Hidden {\n  x: Int\n}\n\nexport fn render() -> String {\n  let h = Hidden::{ x: 1 }\n  \"\\{h}\"\n}\n"))
+  Fs::write_bytes(main_path, string_to_bytes("import ./dep.vibe { render }\n\nfn main() -> Unit {\n  let _s = render()\n  ()\n}\n"))
+  let msg = handle {
+    let _ = check_linked_file(main_path)
+    ""
+  } with Exception {
+    Throw(m) => m
+  }
+  assert(String::contains(msg, "cannot interpolate a value of type"))
+  assert(!String::contains(msg, "entrymod.vibe"))
+  assert(!String::contains(msg, " [@fn="))
+}

--- a/lib/@vibe/compiler/tests/diagnostic_anchor_test.vibe
+++ b/lib/@vibe/compiler/tests/diagnostic_anchor_test.vibe
@@ -185,6 +185,24 @@ test "a char literal quote does not swallow later declarations" {
   assert(anchored_at(alone, 3, 7))
 }
 
+test "a raw string's trailing backslash does not swallow later declarations" {
+  // #2244 review round 10 (measured: `let q = r\"\\\"` compiles -- a raw
+  // string ends at the next quote with NO escape processing): the
+  // escape-honoring string skip used to read the trailing backslash as
+  // escaping the closing quote, hiding every later declaration, so a
+  // same-named outside fn owned the anchor. Colliding, the cross-kind
+  // rule fails closed; alone, the binder anchors normally (line 3,
+  // column 7).
+  let src = "fn v() -> Int {\n  1\n}\n\nfn f() -> Bool {\n  let q = r\"\\\"\n  let v = if true { \"yes\" } else { 0 }\n  String::length(q) == 1 && v == \"\"\n}\n"
+  let d = first_diag(src)
+  assert(String::contains(d, "if branches have incompatible types"))
+  assert(!String::contains(d, "line "))
+  assert(!String::contains(d, " [@"))
+  let alone = "fn f() -> Bool {\n  let q = r\"\\\"\n  let v = if true { \"yes\" } else { 0 }\n  String::length(q) == 1 && v == \"\"\n}\n"
+  assert(String::contains(first_diag(alone), "if branches have incompatible types"))
+  assert(anchored_at(alone, 3, 7))
+}
+
 test "a binder declared inside an interpolation fragment counts" {
   // #2244 review round 7: `\{...}` fragments are code, so a binder
   // declared inside one must be visible to the scan. Alone it anchors at

--- a/lib/@vibe/compiler/tests/diagnostic_anchor_test.vibe
+++ b/lib/@vibe/compiler/tests/diagnostic_anchor_test.vibe
@@ -128,6 +128,29 @@ test "a shadowed binder fails closed to no position" {
   assert(!String::contains(d, " [@"))
 }
 
+test "a raw-identifier binder counts as a declaration" {
+  // #2244 review round 6: `let r#v` lexes to binder name `v`, but the
+  // `r#` sat between the name and its keyword, so the scan used to count
+  // it as a bare occurrence. Alone it must anchor like any binding.
+  //    12345678
+  //  `  let r#v` -- `v` is column 9.
+  let src = "fn f() -> Bool {\n  let r#v = if true { \"yes\" } else { 0 }\n  true\n}\n"
+  assert(String::contains(first_diag(src), "if branches have incompatible types"))
+  assert(anchored_at(src, 2, 9))
+}
+
+test "a raw-identifier binder colliding with a plain fn fails closed" {
+  // #2244 review round 6 (the finding's exact shape, reproduced before
+  // the fix anchoring at the unrelated `fn v`): the raw `let r#v` is a
+  // let declaration of `v`, so fn+let cross-kind ambiguity applies and
+  // the message carries no position.
+  let src = "fn v() -> Int {\n  1\n}\n\nfn f() -> Bool {\n  let r#v = if true { \"yes\" } else { 0 }\n  true\n}\n"
+  let d = first_diag(src)
+  assert(String::contains(d, "if branches have incompatible types"))
+  assert(!String::contains(d, "line "))
+  assert(!String::contains(d, " [@"))
+}
+
 test "interpolating a Show-less struct anchors on the enclosing binding" {
   // #2198 (p04 shape): the synthesized __to_string call has no offset (the
   // interp snippet re-lexes without offsets), so the message carries the

--- a/lib/@vibe/compiler/tests/diagnostic_anchor_test.vibe
+++ b/lib/@vibe/compiler/tests/diagnostic_anchor_test.vibe
@@ -94,6 +94,28 @@ test "all-literal if branches anchor on the binder" {
   assert(anchored_at(src, 2, 7))
 }
 
+test "a comment spelling the binder does not capture the anchor" {
+  // #2244 review: find_fn_anchor_off scans raw text; before the fix a
+  // comment like this source's line 2 anchored the diagnostic at the
+  // comment. The scan now skips comments and strings, so the anchor lands
+  // on the real binding (line 3, column 7).
+  let src = "fn f() -> Bool {\n  // let v used to be an Int\n  let v = if true { \"yes\" } else { 0 }\n  true\n}\n"
+  assert(String::contains(first_diag(src), "if branches have incompatible types"))
+  assert(anchored_at(src, 3, 7))
+}
+
+test "a shadowed binder fails closed to no position" {
+  // #2244 review: two `let v` declarations make the by-name anchor
+  // ambiguous -- the old scan picked the FIRST one, reporting line 2 for a
+  // failure on line 3. Ambiguity now returns no anchor at all: the message
+  // keeps its text and carries no line, rather than a confidently wrong one.
+  let src = "fn f() -> Bool {\n  let v = 1\n  let v = if true { \"yes\" } else { 0 }\n  true\n}\n"
+  let d = first_diag(src)
+  assert(String::contains(d, "if branches have incompatible types"))
+  assert(!String::contains(d, "line "))
+  assert(!String::contains(d, " [@"))
+}
+
 test "interpolating a Show-less struct anchors on the enclosing binding" {
   // #2198 (p04 shape): the synthesized __to_string call has no offset (the
   // interp snippet re-lexes without offsets), so the message carries the

--- a/lib/@vibe/compiler/tests/diagnostic_anchor_test.vibe
+++ b/lib/@vibe/compiler/tests/diagnostic_anchor_test.vibe
@@ -203,6 +203,23 @@ test "a raw string's trailing backslash does not swallow later declarations" {
   assert(anchored_at(alone, 3, 7))
 }
 
+test "hash-pipe raw text neither declares nor swallows" {
+  // #2244 review round 11 (measured: `let s = #|raw text` compiles): a
+  // `#|` line's raw text spelling `fn v \"` used to count a FAKE fn
+  // declaration and flip string mode -- the diagnostic anchored inside
+  // the raw string (line 2:16-17). The scan now skips `#|` lines, so
+  // the real binder anchors normally (line 3, column 7); with an
+  // outside same-named fn the cross-kind rule fails closed.
+  let alone = "fn f() -> Bool {\n  let s = #|fn v \"\n  let v = if true { \"yes\" } else { 0 }\n  String::length(s) > 0 && v == \"\"\n}\n"
+  assert(String::contains(first_diag(alone), "if branches have incompatible types"))
+  assert(anchored_at(alone, 3, 7))
+  let src = "fn v() -> Int {\n  1\n}\n\nfn f() -> Bool {\n  let s = #|fn v \"\n  let v = if true { \"yes\" } else { 0 }\n  String::length(s) > 0 && v == \"\"\n}\n"
+  let d = first_diag(src)
+  assert(String::contains(d, "if branches have incompatible types"))
+  assert(!String::contains(d, "line "))
+  assert(!String::contains(d, " [@"))
+}
+
 test "a binder declared inside an interpolation fragment counts" {
   // #2244 review round 7: `\{...}` fragments are code, so a binder
   // declared inside one must be visible to the scan. Alone it anchors at

--- a/lib/@vibe/compiler/tests/diagnostic_anchor_test.vibe
+++ b/lib/@vibe/compiler/tests/diagnostic_anchor_test.vibe
@@ -104,6 +104,18 @@ test "a comment spelling the binder does not capture the anchor" {
   assert(anchored_at(src, 3, 7))
 }
 
+test "a same-named fn and let fail closed to no position" {
+  // #2244 review round 3: the failing binding is the local `let v`, but the
+  // file also declares `fn v` -- the marker records only the name, so the
+  // kind cannot break the tie. Before the fix the unique fn declaration won
+  // and the diagnostic pointed at the unrelated top-level function.
+  let src = "fn v() -> Int {\n  1\n}\n\nfn f() -> Bool {\n  let v = if true { \"yes\" } else { 0 }\n  true\n}\n"
+  let d = first_diag(src)
+  assert(String::contains(d, "if branches have incompatible types"))
+  assert(!String::contains(d, "line "))
+  assert(!String::contains(d, " [@"))
+}
+
 test "a shadowed binder fails closed to no position" {
   // #2244 review: two `let v` declarations make the by-name anchor
   // ambiguous -- the old scan picked the FIRST one, reporting line 2 for a

--- a/lib/@vibe/compiler/tests/diagnostic_anchor_test.vibe
+++ b/lib/@vibe/compiler/tests/diagnostic_anchor_test.vibe
@@ -151,6 +151,27 @@ test "a raw-identifier binder colliding with a plain fn fails closed" {
   assert(!String::contains(d, " [@"))
 }
 
+test "a binder declared inside an interpolation fragment counts" {
+  // #2244 review round 7: `\{...}` fragments are code, so a binder
+  // declared inside one must be visible to the scan. Alone it anchors at
+  // the fragment declaration; the exact columns are pinned by measurement.
+  let src = "fn f() -> String {\n  \"x = \\{ { let v = if true { \"yes\" } else { 0 }\n  v } }\"\n}\n"
+  assert(String::contains(first_diag(src), "if branches have incompatible types"))
+  assert(anchored_at(src, 2, 17))
+}
+
+test "a fragment binder colliding with an outside fn fails closed" {
+  // #2244 review round 7 (the finding's exact shape, reproduced before
+  // the fix anchoring at the unrelated top-level `fn v` on line 1): the
+  // fragment's `let v` now counts as a declaration, so the cross-kind
+  // ambiguity rule reports without a position.
+  let src = "fn v() -> Int {\n  1\n}\n\nfn f() -> String {\n  \"x = \\{ { let v = if true { \"yes\" } else { 0 }\n  v } }\"\n}\n"
+  let d = first_diag(src)
+  assert(String::contains(d, "if branches have incompatible types"))
+  assert(!String::contains(d, "line "))
+  assert(!String::contains(d, " [@"))
+}
+
 test "interpolating a Show-less struct anchors on the enclosing binding" {
   // #2198 (p04 shape): the synthesized __to_string call has no offset (the
   // interp snippet re-lexes without offsets), so the message carries the

--- a/lib/@vibe/compiler/tests/diagnostic_anchor_test.vibe
+++ b/lib/@vibe/compiler/tests/diagnostic_anchor_test.vibe
@@ -82,6 +82,27 @@ test "mismatched if branches with a literal else still anchor on the if" {
   assert(anchored_at(src, 3, 13))
 }
 
+test "all-literal if branches anchor on the binder" {
+  // #2198 (p11 shape): both branches, the then-tail AND the condition are
+  // literals, so every offset fallback comes up empty. The `[@fn=]` binder
+  // anchor recovers `let v` -- coarser than the disagreeing branch, but a
+  // real position instead of a file-only message.
+  //    123456
+  //  `  let v` -- `v` is column 7.
+  let src = "fn f() -> Bool {\n  let v = if true { \"yes\" } else { 0 }\n  true\n}\n"
+  assert(String::contains(first_diag(src), "if branches have incompatible types"))
+  assert(anchored_at(src, 2, 7))
+}
+
+test "interpolating a Show-less struct anchors on the enclosing binding" {
+  // #2198 (p04 shape): the synthesized __to_string call has no offset (the
+  // interp snippet re-lexes without offsets), so the message carries the
+  // enclosing binding's [@fn=] marker instead and anchors at `fn main`.
+  let src = "struct Point {\n  x: Int\n}\n\nfn main() -> Unit {\n  let p = Point::{ x: 3 }\n  let s = \"\\{p}\"\n  ()\n}\n"
+  assert(String::contains(first_diag(src), "cannot interpolate a value of type `Point`"))
+  assert(String::contains(first_diag(src), "line 5:4"))
+}
+
 test "an incompatible array element points at that element" {
   let src = "fn f() -> Int {\n  let s = \"x\"\n  let a = [1, s]\n  1\n}\n"
   assert(String::contains(first_diag(src), "array elements have incompatible types"))

--- a/lib/@vibe/compiler/tests/diagnostic_anchor_test.vibe
+++ b/lib/@vibe/compiler/tests/diagnostic_anchor_test.vibe
@@ -168,6 +168,23 @@ test "a let rec binder counts as a declaration" {
   assert(anchored_at(alone, 2, 11))
 }
 
+test "a char literal quote does not swallow later declarations" {
+  // #2244 review round 9: `'\"'` used to flip the scanner's string mode,
+  // making every later declaration invisible -- a same-named outside fn
+  // then owned the anchor. Colliding, the cross-kind rule fails closed;
+  // alone, the binder after the char literal anchors normally (line 3,
+  // column 7). (The fragment variant of this finding does not lex --
+  // scan_interp_end counts raw bytes the same way this scan does.)
+  let src = "fn v() -> Int {\n  1\n}\n\nfn f() -> Bool {\n  let q = '\"'\n  let v = if true { \"yes\" } else { 0 }\n  q == 34 && v == \"\"\n}\n"
+  let d = first_diag(src)
+  assert(String::contains(d, "if branches have incompatible types"))
+  assert(!String::contains(d, "line "))
+  assert(!String::contains(d, " [@"))
+  let alone = "fn f() -> Bool {\n  let q = '\"'\n  let v = if true { \"yes\" } else { 0 }\n  q == 34 && v == \"\"\n}\n"
+  assert(String::contains(first_diag(alone), "if branches have incompatible types"))
+  assert(anchored_at(alone, 3, 7))
+}
+
 test "a binder declared inside an interpolation fragment counts" {
   // #2244 review round 7: `\{...}` fragments are code, so a binder
   // declared inside one must be visible to the scan. Alone it anchors at

--- a/lib/@vibe/compiler/tests/diagnostic_anchor_test.vibe
+++ b/lib/@vibe/compiler/tests/diagnostic_anchor_test.vibe
@@ -151,6 +151,23 @@ test "a raw-identifier binder colliding with a plain fn fails closed" {
   assert(!String::contains(d, " [@"))
 }
 
+test "a let rec binder counts as a declaration" {
+  // #2244 review round 8: the intervening `rec` (like `mut`, like `r#`)
+  // used to make the binder count as a mere occurrence, handing a
+  // same-named outside fn sole ownership. Colliding, the cross-kind rule
+  // fails closed; alone it anchors at the binder.
+  let src = "fn v() -> Int {\n  1\n}\n\nfn f() -> Bool {\n  let rec v = if true { \"yes\" } else { 0 }\n  true\n}\n"
+  let d = first_diag(src)
+  assert(String::contains(d, "if branches have incompatible types"))
+  assert(!String::contains(d, "line "))
+  assert(!String::contains(d, " [@"))
+  //    1234567890
+  //  `  let rec v` -- `v` is column 11.
+  let alone = "fn f() -> Bool {\n  let rec v = if true { \"yes\" } else { 0 }\n  true\n}\n"
+  assert(String::contains(first_diag(alone), "if branches have incompatible types"))
+  assert(anchored_at(alone, 2, 11))
+}
+
 test "a binder declared inside an interpolation fragment counts" {
   // #2244 review round 7: `\{...}` fragments are code, so a binder
   // declared inside one must be visible to the scan. Alone it anchors at


### PR DESCRIPTION
Follow-up to #2240 (merged with the #2205 chapter edit while these three fixes were still in verification). One commit per issue; every Red and Green below is measured through a stage2 built from this branch, not the seed.

Closes #2198
Closes #2203
Closes #2206

## #2198 — positionless diagnostics (`407ed04`)

Re-measured on current main first: the non-exhaustive-match case already answers `line 12:9:` (fixed by 977dada), so this lands the remaining two:

- **`cannot interpolate ... no Show renderer`** carried no position and not even the file. The synthesized `__to_string` call has no offset, so the message now rides the enclosing top-level binding's `[@fn=]` marker (from `dtd_show_self_fn`), and `check_linked_file_source_groups`' outer catch prefixes the entry path for this one message class — the throw bypasses `check_module_job`, where path prefixing lives, and every other message reaching that catch is already path-prefixed. The compile lane keeps stripping unresolved side markers (fail-closed, #1514). Measured: `<path>: line 19:4-8: cannot interpolate a value of type `Point` ...` (p04, pinned by a new `cli: check` directive).
- **`if branches have incompatible types`** with every fallback offset empty (all-literal branches, then-tail and condition) joins the #1941 anchorable list and anchors on the binder: `<path>: line 12:7-8: ...` (p11).

Two new `diagnostic_anchor_test` cases pin both. Found while pinning and recorded in the round-2 notes: the `[@fn=]` by-name anchor scans raw text and does not skip comments — p11's own header comment briefly captured the anchor.

## #2203 — deprecation warning + bounds (`a74c851`)

The round-2 claim "no deprecation warning fires from `vibe check`" was a measurement artifact with a real bug underneath: a bare `String::from_char_code(65)` warned all along; the probe's call sits **inside a string interpolation**, and the deprecated-use scan skipped `TStringInterp` tokens entirely — exactly the shape the book recommends. The scan now re-lexes each interpolation expression snippet and scans recursively, shifting fragment-relative starts by the snippet's absolute offset (#947), so nested interpolations still report real file positions. A snippet that fails to re-lex is skipped — a warning pass must never fail a clean check.

Measured: `warning: line 16:col 31: 'String::from_char_code' is deprecated: use String::from_byte` on p23 (stderr, exit 0), silence for `from_byte`. Bounds measured and recorded in the cheatsheet: `from_byte` always builds one byte from the low 8 bits, no trap (`256`→0, `257`→1, `-1`→255, `1000`→232). Five new `deprecated_scan_test` cases; the cheatsheet's String rows now lead with the canonical `byte_at`/`from_byte` spellings.

## #2206 — line-leading `-` continuation (`b2d879c`)

When `op == "-"` and the subst-applied LHS is `Unit`, the checker appends: *"(the left operand is Unit -- a `-` at the start of a line continues the previous line's expression instead of starting a new one; parenthesize `(-1)` or bind it with `let` if you meant a negative value)"*. The checker never sees line layout, so the clause states the language rule rather than claiming this line started with `-` (scoping measured `EBinOp` carries no operator offset; moving the position to the `-` token is an AST-contract change across ~350 sites, deliberately out of scope). The base text stays a prefix so the `err_type_string_subtract` fixture pin holds. Book ch20 (en+ja) now quotes the diagnostic; `checker_minus_continuation_test` (3 tests) pins clause-present / clause-absent / `(-1)`-repairs.

## Not in this PR

**#2219** stays blocked: the pinned seed (`seed/import-kind-phase-a-2026-08-21`, source 9c32a79) predates the #2213 abort marker, so the legacy-fallback deletion still waits for the next bootstrap bump; the out-of-band-provenance half is a design decision left open.

## Verification

- `bash scripts/compiler_gate.sh` (all lanes, run directly): `[compiler-gate] ok`. (`pkf run test` in this container dies before reaching the lanes on a nix/system glibc mismatch in `sort` inside pkf-spawned tasks — environmental, reproduced on an untouched step; the direct run is the same gate.)
- Probe corpus: 38/38, zero harness errors; p04/p11/p23 re-pinned with post-fix output.
- Targeted: `diagnostic_anchor_test` + `deprecated_scan_test` + `checker_minus_continuation_test` (61 tests), `dispatch_test` + `cli_support_test` + `interp_show_single_file_diag_test` (80 tests), all through the fix stage2.
- `vibe_fmt --check` clean on every touched `.vibe`; ch20 doctest + translation parity 20/20.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012BesqGvopmB2byi8gB4HXG

---
_Generated by [Claude Code](https://claude.ai/code/session_012BesqGvopmB2byi8gB4HXG)_