### PR TITLE
Hide fingerprint runtime primitive from checker

### DIFF
--- a/lib/@vibe/compiler/core/builtin_registry.vibe
+++ b/lib/@vibe/compiler/core/builtin_registry.vibe
@@ -296,7 +296,9 @@ let registry_typed_rows: Array[(String, Type, Bool, Bool, Bool)] = [
   ("str_lex_diff", CtFn(reg_p2(CtString, CtString), CtInt, None), true, true, true),
   // Internal cache primitive. It packs both 31-bit hashes into one Int;
   // formatting remains in @vibe/cache to preserve the public key contract.
-  ("__compact_fingerprint_hash", CtFn(reg_p1(CtString), CtInt, None), true, false, true),
+  // The source fallback is a local function with the same name; user code
+  // must not resolve this linear-only runtime row, especially on the GC lane.
+  ("__compact_fingerprint_hash", CtFn(reg_p1(CtString), CtInt, None), true, false, false),
   // #973: erased-generic `[T: Ord]`/`[T: Add]` runtime dispatch for `<` `>`
   // `<=` `>=` `+` (desugar_trait_dict.vibe rewrites the binop when the
   // operand's static type is the bare, unresolved type parameter itself --

--- a/lib/@vibe/compiler/tests/builtins_test.vibe
+++ b/lib/@vibe/compiler/tests/builtins_test.vibe
@@ -24,6 +24,13 @@ test "lookup_builtin hides codegen-internal registry rows" {
   }
 }
 
+test "compact fingerprint runtime primitive stays checker-invisible" {
+  match lookup_builtin("__compact_fingerprint_hash") {
+    Some(_) => assert(false),
+    None => assert(true)
+  }
+}
+
 test "#1539 stdin provider raw names remain checker-invisible" {
   let names = [
     "vibe_stdin_provider_acquire_raw",


### PR DESCRIPTION
Follow-up to #2245 and review discussion r3837935290.\n\nMarks the linear-only compact fingerprint runtime primitive checker-invisible, so direct user calls cannot pass checking and later fail in GC codegen. Adds a registry lookup regression test.\n\nValidated with a fresh stage2 build, builtins tests (86), persistent-cache tests (13), heap e2e tests (150), builtin parity, and vibe-fmt.