### PR TITLE
Avoid redundant region provenance rechecking

### DIFF
--- a/lib/@vibe/compiler/checker/checker.vibe
+++ b/lib/@vibe/compiler/checker/checker.vibe
@@ -4904,26 +4904,58 @@ fn tail_returns_binding(expr: Expr, name: String) -> Bool {
   }
 }
 
+/// Region-provenance scanning runs after the expression has already passed
+/// ordinary checking. Ground literals cannot mention a region and cannot
+/// change substitution state, so re-entering the full checker for them only
+/// pays its large RC parameter-dup plan again.
+fn tail_region_check(expr: Expr, env: TypeEnv, defs: Array[TypeDef], s: Subst, c: Int, ce: (Expr, TypeEnv, Array[TypeDef], Subst, Int, Array[String], Array[(Int, Type)]) -> (Type, Subst, Int)) -> (Type, Subst, Int) {
+  match expr {
+    EInt(_) => (CtInt, s, c),
+    EFloat(_) => (CtDouble, s, c),
+    EString(_) => (CtString, s, c),
+    EBool(_) => (CtBool, s, c),
+    EUnit => (CtUnit, s, c),
+    _ => ce(expr, env, defs, s, c, array_empty(), array_empty())
+  }
+}
+
+fn tail_region_closed_ground_fn(expr: Expr) -> Bool {
+  match expr {
+    EFn(tparams, tbounds, params, ret_ty, effect, body) => if Array::length(tparams) == 0 && Array::length(tbounds) == 0 && Array::length(params) == 0 && ret_ty == None && effect == None {
+      match body {
+        EInt(_) => true,
+        EFloat(_) => true,
+        EString(_) => true,
+        EBool(_) => true,
+        EUnit => true,
+        _ => false
+      }
+    } else {
+      false
+    },
+    _ => false
+  }
+}
+
 fn tail_named_record_mentions_region(expr: Expr, env: TypeEnv, defs: Array[TypeDef], s: Subst, c: Int, region_name: String, ce: (Expr, TypeEnv, Array[TypeDef], Subst, Int, Array[String], Array[(Int, Type)]) -> (Type, Subst, Int)) -> Bool {
   match expr {
     ELet(name, val, body, _) => {
-      let throwaway = array_empty()
-      let throwtab = array_empty()
-      let (val_ty, s1, c1) = ce(val, env, defs, s, c, throwaway, throwtab)
+      let (val_ty, s1, c1) = tail_region_check(val, env, defs, s, c, ce)
       let next_env = bind_named_record_provenance(name, val, env_bind(env, name, val_ty), defs, s1, c1, ce)
       (tail_returns_binding(body, name) && tail_named_record_mentions_region(val, env, defs, s, c, region_name, ce)) || tail_named_record_mentions_region(body, next_env, defs, s1, c1, region_name, ce)
     },
     ELetMut(name, val, body, _) => {
-      let throwaway = array_empty()
-      let throwtab = array_empty()
-      let (val_ty, s1, c1) = ce(val, env, defs, s, c, throwaway, throwtab)
+      let (val_ty, s1, c1) = tail_region_check(val, env, defs, s, c, ce)
       let next_env = bind_named_record_provenance(name, val, env_bind_mut(env, name, val_ty, false), defs, s1, c1, ce)
       tail_named_record_mentions_region(body, next_env, defs, s1, c1, region_name, ce)
     },
     ESeq(left, right) => {
-      let throwaway = array_empty()
-      let throwtab = array_empty()
-      let (_, s1, c1) = ce(left, env, defs, s, c, throwaway, throwtab)
+      let (s1, c1) = if tail_region_closed_ground_fn(left) {
+        (s, c)
+      } else {
+        let (_, next_s, next_c) = tail_region_check(left, env, defs, s, c, ce)
+        (next_s, next_c)
+      }
       tail_named_record_mentions_region(right, env, defs, s1, c1, region_name, ce)
     },
     ECall(callee, args, _) => {


### PR DESCRIPTION
Closes #2242.\n\nThe active-region provenance pass runs after ordinary checking, but re-entered the full checker for ground literal let-values and closed, annotation-free ground closures. GuestProfiler attributed about 90% of the probe's rc_dup self time to check_expr_capture_impl reached through this secondary scan.\n\nThis change handles only those syntactically closed cases locally; all potentially region-dependent expressions continue through the existing checker path. TypeEnv representation and public checker contracts are unchanged.\n\nApple arm64, 128 bindings + 32 closures, 50 iterations:\n- p50: 739.12 -> 401.33 us/op (-45.7%)\n- bytes/op: 237,824 -> 157,272 (-33.9%)\n- GuestProfiler __rt_rc_dup self: 66.5 -> 36.4 ms (-45.4%)\n- __rt_rc_dup share: 80.5% -> 71.3%\n\nValidation:\n- fresh named stage2 fixpoint and Wasm validation\n- 7 focused region/checker files: 100 tests passed\n- full battery: 1004/1018 passed; the remaining 14 are the checkout's existing missing generated-bundle/cache-fixture failures\n- 219 generated runtime fixtures passed, including region capture/unwind cases\n- vibe-fmt: 1025 files, 0 violations