### PR TITLE
Propagate transitive phantom equality

### DIFF
--- a/fixtures/generic_derive_eq_test.vibe
+++ b/fixtures/generic_derive_eq_test.vibe
@@ -62,6 +62,10 @@ struct Phantom[T] {
   id: Int
 } derive (Eq)
 
+struct NestedPhantom[T] {
+  value: Box[Phantom[T]]
+} derive (Eq)
+
 struct FiniteA[T] {
   value: T;
   next: Option[FiniteB[Array[Int]]]
@@ -301,6 +305,18 @@ test "nested unused generic arguments do not block equality adoption" {
   })
   Array::push(right, Box[Phantom[Callback]]::{
     value: Phantom[Callback]::{ id: 1 }
+  })
+  inspect(equality_snapshot(left == right), content = "true")
+}
+
+test "transitively unused generic arguments do not block equality adoption" {
+  let left = []
+  let right = []
+  Array::push(left, NestedPhantom[Callback]::{
+    value: Box[Phantom[Callback]]::{ value: Phantom[Callback]::{ id: 1 } }
+  })
+  Array::push(right, NestedPhantom[Callback]::{
+    value: Box[Phantom[Callback]]::{ value: Phantom[Callback]::{ id: 1 } }
   })
   inspect(equality_snapshot(left == right), content = "true")
 }

--- a/lib/@vibe/compiler/normalize/desugar_trait_dict.vibe
+++ b/lib/@vibe/compiler/normalize/desugar_trait_dict.vibe
@@ -8442,9 +8442,7 @@ fn generic_eq_type_observes_formal(ty: TypeExpr, formal: String, visiting: Array
         if decl.0 == head && Array::length(decl.1) == Array::length(args) {
           let mut ai = 0
           while ai < Array::length(args) {
-            if generic_eq_formal_is_observed(head, Array::get(decl.1, ai), visiting) && ty_mentions_name_in(Array::get(args, ai), Array::slice([
-              formal
-            ], 0, 1)) {
+            if generic_eq_formal_is_observed(head, Array::get(decl.1, ai), visiting) && generic_eq_type_observes_formal(Array::get(args, ai), formal, visiting) {
               observed = true
             } else {
               ()


### PR DESCRIPTION
## Summary

- recurse through nested generic argument observation instead of using textual type-parameter occurrence
- preserve equality adoption through `NestedPhantom[Callback] -> Box[Phantom[Callback]]`
- add a transitive phantom regression for untyped arrays

Follow-up to #2250 and review comment discussion_r3838185200.

## Validation

- `pkf run generation-gate`
- focused generic/structural equality tests (55 tests)
- `tests/gates/early/run.sh`