### PR TITLE
Book-review round 3: fmt/`--single-file` stop breaking require-pin heads; ch12's console transcripts get a gate

### DIFF
--- a/Taskfile.pkl
+++ b/Taskfile.pkl
@@ -1510,6 +1510,21 @@ local checkTutorialTranslationParity = new Task {
   cache = false
 }
 
+local checkBookConsole = new Task {
+  name = "check-book-console"
+  description =
+    "prove book ch12's ```console transcripts by running the real launcher `vibe test` against the chapter's own source (book-review round 3)"
+  cmd =
+    "gen=\"$(ls -dt _build/selfhost/generations/*/ | head -1)\"; BOOK_CONSOLE_STAGE2=\"${gen}stage2.wasm\" bash scripts/check_book_console.sh"
+  // ```console blocks were the only output in the book's own format no gate
+  // verified: doctest compiles ```vibe blocks and vibe-md checks ```output
+  // pairs, but a CLI transcript needs the VERB run for real. Which compiler
+  // answers is explicit (the #2138 rule): the launcher runs this checkout's
+  // stage2, never whatever pick_cli would find.
+  cache = false
+  deps { selfhostGeneration }
+}
+
 local vibeMdFmtCheck = new Task {
   name = "vibe-md-fmt-check"
   description =
@@ -1607,6 +1622,7 @@ local releaseCheck = new Task {
     doctestGated
     vibeMdTutorialGated
     checkTutorialTranslationParity
+    checkBookConsole
     checkExamplesTypecheck
     checkPlaygroundPresets
     // Skips itself when wasm-tools is absent (it is the oracle), so this
@@ -1799,6 +1815,7 @@ tasks {
   vibeMdTutorial
   vibeMdTutorialGated
   checkTutorialTranslationParity
+  checkBookConsole
   vibeMdFmtCheck
   vibeMdFmt
   bookBuild

--- a/Taskfile.pkl
+++ b/Taskfile.pkl
@@ -1514,13 +1514,13 @@ local checkBookConsole = new Task {
   name = "check-book-console"
   description =
     "prove book ch12's ```console transcripts by running the real launcher `vibe test` against the chapter's own source (book-review round 3)"
-  cmd =
-    "gen=\"$(ls -dt _build/selfhost/generations/*/ | head -1)\"; BOOK_CONSOLE_STAGE2=\"${gen}stage2.wasm\" bash scripts/check_book_console.sh"
+  cmd = "bash scripts/check_book_console.sh"
   // ```console blocks were the only output in the book's own format no gate
   // verified: doctest compiles ```vibe blocks and vibe-md checks ```output
   // pairs, but a CLI transcript needs the VERB run for real. Which compiler
-  // answers is explicit (the #2138 rule): the launcher runs this checkout's
-  // stage2, never whatever pick_cli would find.
+  // answers is resolve_stage2's question (the #2138 rule): the HEAD-named
+  // generation, never the newest directory by mtime -- a reused workspace
+  // can hold a newer generation from an unrelated checkout.
   cache = false
   deps { selfhostGeneration }
 }

--- a/eval/book-review/rounds/2026-08-22-r2.md
+++ b/eval/book-review/rounds/2026-08-22-r2.md
@@ -222,17 +222,23 @@ listed in SUMMARY.md.
 
 ## 4. Round 3 candidates
 
-- Re-measure p21 after the next seed bump (the gap closes by itself);
-  drop the seed-divergence note then.
-- `vibe check --single-file` on a require-head file, and `vibe fmt` on
-  one (module-system-v2 §6 says fmt inserts pins — unmeasured).
+(Worked in [2026-08-23-r3.md](2026-08-23-r3.md); struck items carry
+their outcome.)
+
+- ~~Re-measure p21 after the next seed bump~~ — re-measured round 3:
+  no bump yet, divergence unchanged; carried to round 4.
+- ~~`vibe check --single-file` on a require-head file, and `vibe fmt`
+  on one~~ — both measured broken in round 3 and fixed the same day:
+  fmt mangled the head into loader-rejected text (past the #1821
+  guard), and --single-file answered `unexpected token: =`.
 - ~~Whether the `from_char_code` deprecation hint should fire from
   `vibe check` the way `HashMap`'s does~~ — resolved: it always did for
   plain uses; the apparent silence was the interpolation blind spot,
   fixed with #2203 (see R2-4).
-- Ch12's console blocks could be doctest-checked if `vibe_md.sh` grew a
-  ```console verifier — today they are the only unproven output in the
-  book's own format.
+- ~~Ch12's console blocks could be doctest-checked~~ — round 3 built
+  `scripts/check_book_console.sh` (release-check task
+  `check-book-console`): both transcripts proven verbatim against the
+  real launcher, ja parity held.
 - ~~The `[@fn=]` by-name anchor (`find_fn_anchor_off`) scans raw source
   text and does not skip comments~~ — measured while pinning the #2198
   fix (p11's own header comment captured the anchor), then fixed the

--- a/eval/book-review/rounds/2026-08-23-r3.md
+++ b/eval/book-review/rounds/2026-08-23-r3.md
@@ -1,0 +1,87 @@
+# book-review round 3 — 2026-08-23
+
+Follow-up to [2026-08-22-r2.md](2026-08-22-r2.md) §4. This round is
+narrower than rounds 1–2 by design: the §4 list was three measurements
+and one missing gate, not a fresh read-through. Everything below is
+measured on a stage2 built from this checkout (main at 2f0f181, the
+#2244 merge); the full probe corpus (rounds 1+2, 38 probes) re-runs
+green on it with zero harness errors.
+
+## 1. p21 (`perform?`) — the seed divergence remains
+
+Re-measured both ways. Stage2 rejects with the exemplary #2145 message
+(the edit named, `try`/`handle` steered to); the committed seed
+(`seed/import-kind-phase-a-2026-08-21`, source 9c32a79) still accepts
+silently and defers the failure to codegen. No bootstrap bump has
+happened since round 2, so the round-2 note stands unchanged. Nothing
+to do here — the gap closes at the next bump, and #2219's fallback
+cleanup is gated on the same event.
+
+## 2. The require-pin head, in the two unmeasured lanes
+
+Round 2 established the lane table for `require @scope/name x.y.z =
+#pkg:sha1:` heads and #2227 made check/build/vibex agree. §4 left two
+lanes unmeasured, and both were broken:
+
+- **`vibe fmt` mangled the head into text the loader rejects.**
+  `require @vibe/core 0.2.0 = #pkg:sha1:0000…` came back as
+  `require @vibe / core0.2.0 = #pkg: sha1: 0000…`, and the rewritten
+  file fails to load (`malformed require line`). The #1821 parse guard
+  could not see it: the RAW input does not parse either (the head is a
+  loader directive, not vibe syntax — the same fact that gave `.vpkg`
+  headers their own writer in #1435), so "input was not a program"
+  excused the wreckage, and the run exited 0. **Fixed in this round's
+  PR**: `fmt_entry` splits the head off with the loader's own
+  classifier (`extract_require_pins`), formats only the body, and
+  reattaches the head verbatim; the parse guard asks its question of
+  the body. Measured: the head comes back byte-identical, the body
+  formats normally, the result is a `--check` fixpoint, and a head the
+  loader itself rejects falls back to the old whole-file path. Pinned
+  in `scripts/vibe_fmt_parse_guard_test.sh`.
+- **`vibe check --single-file` answered `error: line 1:26: unexpected
+  token: =`** for the same file every build lane accepts — the #2227
+  fix covered the import lane and the `.vibex` validation but not the
+  single-file (editor-buffer) lane. **Fixed in this round's PR**:
+  `collect_all_diagnostics` blanks the head the way every ingestion
+  does (offset-preserving, so positions stay exact). Measured: the
+  pin-head file is clean (`--json` answers `[]`), a malformed head
+  reports the loader's own `malformed require line` message — the same
+  answer the import lane gives — and ordinary files are unchanged.
+
+Not touched: module-system-v2 §6's Phase D (`vibe fmt` *completing* a
+hashless `require @scope/name x.y.z` with `= #hash` from the store,
+goimports-style) remains unimplemented design. This round only made
+fmt stop destroying what is already written.
+
+## 3. Ch12's console transcripts are now proven (`check-book-console`)
+
+The §4 gap — ` ```console ` blocks were the only output in the book's
+own format no gate verified. Now `scripts/check_book_console.sh`
+(`pkf run check-book-console`, wired into release-check) proves them
+the way `run_probes.sh` proves its `//! cli:` directives: the chapter's
+own first ` ```vibe ` block is materialized as `demo_test.vibe`, the
+real launcher `vibe test` runs it with this checkout's stage2, and the
+merged output must match the transcript verbatim (exit 0 for the
+passing block). The failing block applies exactly the prose-documented
+edit ("Change the expected value to 43") and must match with exit 1.
+The ja chapter's transcripts are held byte-identical to the en ones
+(translation parity: same program, same report).
+
+First run: **both transcripts verbatim-accurate** — direct evidence
+that the #2228 reporter unification holds on the shipped launcher. The
+gate is red-tested (a corrupted summary line fails it; restoring
+passes), and each case runs from a fresh working directory so the
+launcher's pass-cache cannot answer `(cached)` for a report the book
+shows uncached.
+
+## 4. Round 4 candidates
+
+- Re-measure p21 and delete its seed-divergence note after the next
+  bootstrap bump (also unblocks #2219's fallback deletion).
+- Phase D fmt pin insertion (module-system-v2 §6) when the store side
+  is ready — the fmt head-preservation split in `fmt_entry` is where it
+  would slot in.
+- The `#|` multiline string is documented only in the cheatsheet's
+  `.vpkg` section ("同じインデント一致ルール") — the language-side rule
+  has no spec/book home, and round-3 work elsewhere (#2244 review) had
+  to measure it from scratch to learn it exists.

--- a/lib/@vibe/cli/fmt_entry.vibe
+++ b/lib/@vibe/cli/fmt_entry.vibe
@@ -16,6 +16,23 @@
 //#
 //# The check lives at the entry rather than inside the formatter because
 //# lib/@vibe/compiler/fmt has no dependencies by design, and the parser is one.
+//#
+//# A leading `require @scope/name x.y.z = #pkg:sha1:...` head is a loader
+//# directive, not vibe syntax (the same reason `.vpkg` headers get their own
+//# writer, #1435) -- every build-lane ingestion blanks it before parsing.
+//# The formatter used to feed those lines to the CST formatter and mangle
+//# them into text the loader rejects (`require @vibe / core0.2.0 = #pkg:
+//# sha1: ...`), and the #1821 parse guard could not see it: the RAW input
+//# does not parse either, so "input was not a program" excused the wreckage.
+//# The head is now split off with the loader's own classifier
+//# (extract_require_pins) and reattached verbatim; only the body is
+//# formatted, and the guard parses the body. A head the loader itself
+//# rejects (a malformed require line throws) falls back to the old
+//# whole-file path -- the promise stays "no worse", not "only valid input".
+
+import ../compiler/contract {
+  extract_require_pins
+}
 
 import ../compiler/fmt {
   format_source
@@ -44,13 +61,75 @@ fn has_suffix(s: String, suffix: String) -> Bool {
   }
 }
 
+/// The number of leading lines belonging to the require-pin head: the
+/// blanked twin (offset-preserving, pins overwritten with spaces) differs
+/// from the source exactly on the directive lines, so the head extends to
+/// the LAST differing line. 0 when the file has no pin head.
+fn require_head_line_count(src: String) -> Int with Exception {
+  let (pins, blanked) = extract_require_pins(src)
+  if Array::length(pins) == 0 {
+    0
+  } else {
+    let src_lines = String::split(src, "\n")
+    let blank_lines = String::split(blanked, "\n")
+    let mut last = 0 - 1
+    let mut i = 0
+    while i < Array::length(src_lines) && i < Array::length(blank_lines) {
+      if Array::get(src_lines, i) == Array::get(blank_lines, i) {
+        ()
+      } else {
+        last = i
+      }
+      i = i + 1
+    }
+    last + 1
+  }
+}
+
+fn join_lines(lines: Array[String], from: Int, to: Int) -> String {
+  let out = StringBuilder::new()
+  let mut i = from
+  while i < to {
+    if i > from {
+      StringBuilder::push(out, "\n")
+    } else {
+      ()
+    }
+    StringBuilder::push(out, Array::get(lines, i))
+    i = i + 1
+  }
+  StringBuilder::freeze(out)
+}
+
 export fn main() -> Int with Fs + Env + Stderr {
   let input = Env::args_get(0)
   let output = Env::args_get(1)
   let src = Fs::read_file(input)
+  // `.vpkg` package contracts get header handling inside format_source
+  // (#1435); the require-head split below is for plain vibe sources only.
+  let head_lines = if has_suffix(input, ".vpkg") {
+    0
+  } else {
+    handle {
+      require_head_line_count(src)
+    } with Exception {
+      Throw(_) => 0
+    }
+  }
+  let (head, body) = if head_lines > 0 {
+    let lines = String::split(src, "\n")
+    (join_lines(lines, 0, head_lines), join_lines(lines, head_lines, Array::length(lines)))
+  } else {
+    ("", src)
+  }
   // format_source dispatches on the extension: `.vpkg` package contracts
   // get header handling, everything else is plain vibe source (#1435).
-  let formatted = format_source(input, src)
+  let formatted_body = format_source(input, body)
+  let formatted = if head_lines > 0 {
+    head + "\n" + formatted_body
+  } else {
+    formatted_body
+  }
   // A `.vpkg` header is not vibe syntax, so a whole-file parse never succeeds
   // for one and the comparison below would say nothing. format_vpkg already
   // refuses to touch a header it cannot read, which is the same policy reached
@@ -58,8 +137,9 @@ export fn main() -> Int with Fs + Env + Stderr {
   //
   // Only a rewrite that BREAKS something is rejected. A file that did not parse
   // to begin with is still formatted: the promise is "no worse", not "only
-  // valid input".
-  if !has_suffix(input, ".vpkg") && program_parses(src) && !program_parses(formatted) {
+  // valid input". With a pin head split off, the parse question is asked of
+  // the BODY -- the head is not vibe syntax and is reattached verbatim.
+  if !has_suffix(input, ".vpkg") && program_parses(body) && !program_parses(formatted_body) {
     Fs::write_file(output, src)
     Stderr::write_stream("vibe fmt: refusing to rewrite " + input + "\n" + "  The formatted output does not parse, and the input did. This is a bug in\n" + "  the formatter, not a problem with the file. The file is unchanged; please\n" + "  report it with the source (see #1821).\n")
     1

--- a/lib/@vibe/cli/fmt_entry.vibe
+++ b/lib/@vibe/cli/fmt_entry.vibe
@@ -19,23 +19,17 @@
 //#
 //# A leading `require @scope/name x.y.z = #pkg:sha1:...` head is a loader
 //# directive, not vibe syntax (the same reason `.vpkg` headers get their own
-//# writer, #1435) -- every build-lane ingestion blanks it before parsing.
-//# The formatter used to feed those lines to the CST formatter and mangle
-//# them into text the loader rejects (`require @vibe / core0.2.0 = #pkg:
-//# sha1: ...`), and the #1821 parse guard could not see it: the RAW input
-//# does not parse either, so "input was not a program" excused the wreckage.
-//# The head is now split off with the loader's own classifier
-//# (extract_require_pins) and reattached verbatim; only the body is
-//# formatted, and the guard parses the body. A head the loader itself
-//# rejects (a malformed require line throws) falls back to the old
-//# whole-file path -- the promise stays "no worse", not "only valid input".
-
-import ../compiler/contract {
-  extract_require_pins
-}
+//# writer, #1435). The head split itself lives INSIDE format_source
+//# (format_vibe, #2253 round 6) so every formatter entry -- this one, the
+//# fmt.vibe batch, cli_adapter's `vibe fmt` -- preserves the head verbatim;
+//# this entry only re-derives the boundary (source_header_end) so the parse
+//# guard can ask its question of the BODY, which is the part that is vibe
+//# syntax. A head the classifier refuses (-1) is left untouched by
+//# format_source, so the guard's body is the whole file there and the
+//# comparison stays "no worse".
 
 import ../compiler/fmt {
-  format_source
+  format_source, source_header_end
 }
 
 import ../parser {
@@ -61,75 +55,29 @@ fn has_suffix(s: String, suffix: String) -> Bool {
   }
 }
 
-/// The number of leading lines belonging to the require-pin head: the
-/// blanked twin (offset-preserving, pins overwritten with spaces) differs
-/// from the source exactly on the directive lines, so the head extends to
-/// the LAST differing line. 0 when the file has no pin head.
-fn require_head_line_count(src: String) -> Int with Exception {
-  let (pins, blanked) = extract_require_pins(src)
-  if Array::length(pins) == 0 {
-    0
-  } else {
-    let src_lines = String::split(src, "\n")
-    let blank_lines = String::split(blanked, "\n")
-    let mut last = 0 - 1
-    let mut i = 0
-    while i < Array::length(src_lines) && i < Array::length(blank_lines) {
-      if Array::get(src_lines, i) == Array::get(blank_lines, i) {
-        ()
-      } else {
-        last = i
-      }
-      i = i + 1
-    }
-    last + 1
-  }
-}
-
-fn join_lines(lines: Array[String], from: Int, to: Int) -> String {
-  let out = StringBuilder::new()
-  let mut i = from
-  while i < to {
-    if i > from {
-      StringBuilder::push(out, "\n")
-    } else {
-      ()
-    }
-    StringBuilder::push(out, Array::get(lines, i))
-    i = i + 1
-  }
-  StringBuilder::freeze(out)
-}
-
 export fn main() -> Int with Fs + Env + Stderr {
   let input = Env::args_get(0)
   let output = Env::args_get(1)
   let src = Fs::read_file(input)
-  // `.vpkg` package contracts get header handling inside format_source
-  // (#1435); the require-head split below is for plain vibe sources only.
-  let head_lines = if has_suffix(input, ".vpkg") {
+  // format_source dispatches on the extension: `.vpkg` package contracts get
+  // the canonical header writer, plain vibe sources get the verbatim
+  // require-head split (#1435, #2253 round 6).
+  let formatted = format_source(input, src)
+  // The head is reattached verbatim, so the body of both source and output
+  // starts at the same boundary; -1 (refused head) and 0 (no head) both mean
+  // "the body is the whole file".
+  let head_end = if has_suffix(input, ".vpkg") {
     0
   } else {
-    handle {
-      require_head_line_count(src)
-    } with Exception {
-      Throw(_) => 0
+    let e = source_header_end(src)
+    if e > 0 {
+      e
+    } else {
+      0
     }
   }
-  let (head, body) = if head_lines > 0 {
-    let lines = String::split(src, "\n")
-    (join_lines(lines, 0, head_lines), join_lines(lines, head_lines, Array::length(lines)))
-  } else {
-    ("", src)
-  }
-  // format_source dispatches on the extension: `.vpkg` package contracts
-  // get header handling, everything else is plain vibe source (#1435).
-  let formatted_body = format_source(input, body)
-  let formatted = if head_lines > 0 {
-    head + "\n" + formatted_body
-  } else {
-    formatted_body
-  }
+  let body = String::substring(src, head_end, String::length(src))
+  let formatted_body = String::substring(formatted, head_end, String::length(formatted))
   // A `.vpkg` header is not vibe syntax, so a whole-file parse never succeeds
   // for one and the comparison below would say nothing. format_vpkg already
   // refuses to touch a header it cannot read, which is the same policy reached

--- a/lib/@vibe/compiler/cli_adapter.vibe
+++ b/lib/@vibe/compiler/cli_adapter.vibe
@@ -90,7 +90,7 @@ import @vibe/compiler/normalize {
 // while 21 documents told them to run `vibe fmt`. The package has `deps = {}`
 // and format.vibe has no imports, so joining the compiler costs it nothing.
 import @vibe/compiler/fmt {
-  format_source
+  format_source, source_header_end
 }
 
 import ./inspect_update.vibe {
@@ -1472,7 +1472,8 @@ export fn cli_main() -> Int with Exception + Fs + Env + Stdin + Stdout {
   if Env::get("VIBE_FMT") == "1" {
     let src = Fs::read_file(input_path)
     // format_source dispatches on the extension: `.vpkg` package contracts
-    // get header handling, everything else is plain vibe source (#1435).
+    // get the canonical header writer, plain vibe sources get the verbatim
+    // require-head split (#1435, #2253 round 6).
     let formatted = format_source(input_path, src)
     // A `.vpkg` header is not vibe syntax, so a whole-file parse never
     // succeeds for one and the comparison would say nothing. format_vpkg
@@ -1481,8 +1482,24 @@ export fn cli_main() -> Int with Exception + Fs + Env + Stdin + Stdout {
     //
     // Only a rewrite that BREAKS something is rejected. A file that did not
     // parse to begin with is still formatted: the promise is "no worse", not
-    // "only valid input".
-    if !adapter_path_has_suffix(input_path, ".vpkg") && adapter_program_parses(src) && !adapter_program_parses(formatted) {
+    // "only valid input". A require-pin head is not vibe syntax either and
+    // is reattached verbatim, so the parse question is asked of the BODY --
+    // both source and output start their body at the same boundary
+    // (source_header_end; -1 refused and 0 absent both mean "the body is
+    // the whole file").
+    let fmt_head_end = if adapter_path_has_suffix(input_path, ".vpkg") {
+      0
+    } else {
+      let e = source_header_end(src)
+      if e > 0 {
+        e
+      } else {
+        0
+      }
+    }
+    let fmt_body = String::substring(src, fmt_head_end, String::length(src))
+    let fmt_formatted_body = String::substring(formatted, fmt_head_end, String::length(formatted))
+    if !adapter_path_has_suffix(input_path, ".vpkg") && adapter_program_parses(fmt_body) && !adapter_program_parses(fmt_formatted_body) {
       Fs::write_bytes(output_path, adapter_string_to_bytes(src))
       return 1
     }

--- a/lib/@vibe/compiler/fmt/format.vibe
+++ b/lib/@vibe/compiler/fmt/format.vibe
@@ -3153,17 +3153,48 @@ export fn format_vpkg(src: String) -> String {
   }
 }
 
+/// Byte offset just past a plain vibe source's leading loader-directive
+/// head (`require @scope/name x.y.z = #pkg:sha1:...` pins and the other
+/// scan_package_header directives), 0 when there is none, -1 when the head
+/// is malformed in a way that makes the split unsafe (vp_header_end's
+/// contract). Exported for the entries' #1821 parse guards, which must ask
+/// the parse question of the BODY -- the head is not vibe syntax.
+export fn source_header_end(src: String) -> Int {
+  vp_header_end(src)
+}
+
+/// Format a plain vibe source. A leading require-pin head is a loader
+/// directive region, not vibe syntax (#2227) -- feeding it to the CST
+/// formatter mangles it into text the loader rejects (`require @vibe /
+/// core0.2.0 = ...`). Split it off VERBATIM (unlike `.vpkg`, whose header
+/// gets a canonical writer) and format only the body. A head vp_header_end
+/// cannot classify safely (-1) leaves the file untouched, the same policy
+/// as format_vpkg: refusing beats mangling. This lives here, not in an
+/// entry, so every formatter entry (fmt_entry single-file, fmt.vibe batch,
+/// cli_adapter `vibe fmt`) behaves the same (#2253 round 6).
+fn format_vibe(src: String) -> String {
+  let end = vp_header_end(src)
+  if end < 0 {
+    src
+  } else if end == 0 {
+    format_script(src)
+  } else {
+    String::concat(String::substring(src, 0, end), format_script(String::substring(src, end, String::length(src))))
+  }
+}
+
 /// Format `src` the way `path`'s extension calls for. The dispatch lives
-/// here rather than in the two entries that drive the formatter
-/// (lib/@vibe/cli/fmt_entry.vibe single-file, lib/@vibe/cli/fmt.vibe batch)
-/// so they cannot drift apart on which files get header handling.
+/// here rather than in the entries that drive the formatter
+/// (lib/@vibe/cli/fmt_entry.vibe single-file, lib/@vibe/cli/fmt.vibe batch,
+/// cli_adapter.vibe's `vibe fmt`) so they cannot drift apart on which
+/// files get header handling.
 export fn format_source(path: String, src: String) -> String {
   let n = String::length(path)
   if n < 5 {
-    format_script(src)
+    format_vibe(src)
   } else if String::substring(path, n - 5, n) == ".vpkg" {
     format_vpkg(src)
   } else {
-    format_script(src)
+    format_vibe(src)
   }
 }

--- a/lib/@vibe/compiler/fmt/index.vpkg
+++ b/lib/@vibe/compiler/fmt/index.vpkg
@@ -30,3 +30,4 @@ generated_hash =
 fn format_script(src: String) -> String
 fn format_vpkg(src: String) -> String
 fn format_source(path: String, src: String) -> String
+fn source_header_end(src: String) -> Int

--- a/lib/@vibe/compiler/fmt/vpkg_format_test.vibe
+++ b/lib/@vibe/compiler/fmt/vpkg_format_test.vibe
@@ -126,7 +126,15 @@ test "#1429: normalize_effect_rows still converts the spelling the parser remove
 test "format_source dispatches on the .vpkg extension" {
   let src = "name = @vibe/parser\nversion = 0.1.0\n\ngenerated_hash =\n\nfn f() -> Int\n"
   assert(format_source("lib/@vibe/parser/index.vpkg", src) == format_vpkg(src))
-  assert(format_source("lib/@vibe/parser/lexer.vibe", src) == format_script(src))
+  // #2253 round 6: a plain .vibe whose leading lines are loader directives
+  // keeps that head VERBATIM (it is not vibe syntax -- format_script would
+  // mangle it) and formats only the body. This assertion used to demand
+  // format_script over the whole file, i.e. the mangling.
+  let head = "name = @vibe/parser\nversion = 0.1.0\n\ngenerated_hash =\n"
+  let body = "\nfn f() -> Int\n"
+  assert(format_source("lib/@vibe/parser/lexer.vibe", src) == String::concat(head, format_script(body)))
+  // A headerless .vibe still formats whole.
+  assert(format_source("lib/@vibe/parser/lexer.vibe", "fn f() -> Int\n") == format_script("fn f() -> Int\n"))
   // A path too short to carry the extension must not index out of bounds.
   assert(format_source("x", "fn f() -> Int\n") == "fn f() -> Int\n")
 }

--- a/lib/@vibe/compiler/runtime/index.vpkg
+++ b/lib/@vibe/compiler/runtime/index.vpkg
@@ -9,6 +9,7 @@ deps = {
   @vibe/compiler/codegen : 0.0.1
   @vibe/compiler/codegen/common_analysis : 0.0.1
   @vibe/compiler/codegen/wasi : 0.0.1
+  @vibe/compiler/contract : 0.0.1
   @vibe/compiler/core : 0.0.1
   @vibe/compiler/entry/source_compile/wasi_only : 0.0.1
   @vibe/compiler/incremental : 0.0.1

--- a/lib/@vibe/compiler/runtime/typecheck_fs.vibe
+++ b/lib/@vibe/compiler/runtime/typecheck_fs.vibe
@@ -5359,7 +5359,9 @@ export fn collect_all_diagnostics(source: String) -> Array[String] with Exceptio
       ()
     }
     if hit_count == 1 {
-      return [String::concat("line ", String::concat(__to_string(hit_line + 1), String::concat(":1: ", pin_err)))]
+      return [
+        String::concat("line ", String::concat(__to_string(hit_line + 1), String::concat(":1: ", pin_err)))
+      ]
     } else {
       return [pin_err]
     }

--- a/lib/@vibe/compiler/runtime/typecheck_fs.vibe
+++ b/lib/@vibe/compiler/runtime/typecheck_fs.vibe
@@ -5330,7 +5330,17 @@ export fn collect_all_diagnostics(source: String) -> Array[String] with Exceptio
     let tail = if sep >= 0 {
       String::substring(pin_err, sep + 3, String::length(pin_err))
     } else {
-      ""
+      // #2253 review round 3: not every loader message parenthesizes its
+      // expectation -- `require package name must start with '@': bad/pkg`
+      // ends with a plain `: <offender>`. Take the text after the LAST
+      // `: ` then; the unique-match gate below still refuses ambiguous
+      // fragments.
+      let last = String::last_index_of(pin_err, ": ")
+      if last >= 0 {
+        String::substring(pin_err, last + 2, String::length(pin_err))
+      } else {
+        ""
+      }
     }
     let mut hit_line = 0 - 1
     let mut hit_count = 0

--- a/lib/@vibe/compiler/runtime/typecheck_fs.vibe
+++ b/lib/@vibe/compiler/runtime/typecheck_fs.vibe
@@ -5295,6 +5295,31 @@ export fn check_inline_wasm_fns(stmts: Array[Stmt]) -> Option[String] {
   }
   result
 }
+/// Does the k-line prefix of `lines` make the package-header scanner throw
+/// exactly `pin_err`? The locator's probe (see collect_all_diagnostics):
+/// asking the loader itself, instead of mirroring its grammar, is what keeps
+/// the located line from drifting (#2253 rounds 3-6).
+fn header_prefix_throws(lines: Array[String], k: Int, pin_err: String) -> Bool {
+  let sb = StringBuilder::new()
+  let mut j = 0
+  while j < k {
+    if j > 0 {
+      StringBuilder::push(sb, "\n")
+    } else {
+      ()
+    }
+    StringBuilder::push(sb, Array::get(lines, j))
+    j = j + 1
+  }
+  let m = handle {
+    let (_pins2, _blanked2) = extract_require_pins(StringBuilder::freeze(sb))
+    ""
+  } with Exception {
+    Throw(m2) => m2
+  }
+  m == pin_err
+}
+
 /// Collect ALL diagnostics for `source` as located (`line:col`) message strings.
 /// Lexer errors come first (#946): the recovering lexer records every offending
 /// position instead of throwing, so a lex-broken file reports located lexer
@@ -5319,53 +5344,42 @@ export fn collect_all_diagnostics(source: String) -> Array[String] with Exceptio
     Throw(m) => (source, m)
   }
   if pin_err != "" {
-    // #2253 review rounds 3-4: the loader's message carries no position, and
-    // the JSON lane renders an unlocated diagnostic as the synthetic 0:0
+    // #2253 review rounds 3-4/6: the loader's message carries no position,
+    // and the JSON lane renders an unlocated diagnostic as the synthetic 0:0
     // range. Two rounds of parsing the MESSAGE for the offending line drifted
     // from the header grammar each time (parenthesized vs plain `: ` tails,
     // then require-only line classification vs the scanner's comments /
-    // version / deps blocks). Ask the scanner itself instead: feed it
-    // line-prefixes of the source and anchor at the FIRST prefix that throws
-    // this exact message -- the scanner is line-oriented, so that prefix's
-    // last line is where its own scan stopped. No grammar mirror, so nothing
-    // to drift; an error only raised at a block opener (unterminated block)
-    // anchors on the opener, which is the actionable line. The probe runs on
-    // the error path only; the cap bounds a pathological file, and past it
-    // the message stays bare -- missing information beats misinformation.
+    // version / deps blocks). Ask the scanner itself instead: probe it with
+    // line-prefixes of the source and anchor at the SMALLEST prefix that
+    // throws this exact message -- the scanner is line-oriented, so that
+    // prefix's last line is where its own scan stopped. No grammar mirror, so
+    // nothing to drift; an error only raised at a block opener (unterminated
+    // block) anchors on the opener, which is the actionable line. The
+    // predicate "a k-line prefix throws pin_err" is monotone in k (once the
+    // throwing line is included, every longer prefix stops at that same line
+    // with the same message, deterministically), so binary search finds the
+    // boundary in O(log n) probes with no length cap (round 6: the previous
+    // linear probe capped at 256 lines and left a longer header bare). The
+    // probe runs on the error path only.
     let lines = String::split(source, "\n")
     let nlines = Array::length(lines)
-    let cap = if nlines < 256 {
-      nlines
-    } else {
-      256
-    }
+    // The full-source prefix reproduces pin_err by construction; confirm it
+    // anyway so a violated assumption answers bare instead of wrong.
     let mut hit_line = 0 - 1
-    let mut k = 1
-    while hit_line < 0 && k <= cap {
-      let sb = StringBuilder::new()
-      let mut j = 0
-      while j < k {
-        if j > 0 {
-          StringBuilder::push(sb, "\n")
+    if nlines > 0 && header_prefix_throws(lines, nlines, pin_err) {
+      let mut lo = 0
+      let mut hi = nlines
+      while hi - lo > 1 {
+        let mid = (lo + hi) / 2
+        if header_prefix_throws(lines, mid, pin_err) {
+          hi = mid
         } else {
-          ()
+          lo = mid
         }
-        StringBuilder::push(sb, Array::get(lines, j))
-        j = j + 1
       }
-      let prefix = StringBuilder::freeze(sb)
-      let m = handle {
-        let (_pins2, _blanked2) = extract_require_pins(prefix)
-        ""
-      } with Exception {
-        Throw(m2) => m2
-      }
-      if m == pin_err {
-        hit_line = k - 1
-      } else {
-        ()
-      }
-      k = k + 1
+      hit_line = hi - 1
+    } else {
+      ()
     }
     if hit_line >= 0 {
       return [

--- a/lib/@vibe/compiler/runtime/typecheck_fs.vibe
+++ b/lib/@vibe/compiler/runtime/typecheck_fs.vibe
@@ -76,6 +76,10 @@ import @vibe/compiler/entry/source_compile/wasi_only {
   expand_interp_stmts
 }
 
+import @vibe/compiler/contract {
+  extract_require_pins
+}
+
 import @vibe/compiler/loader {
   ingest_source_text_fs, ingestion_pipeline_telemetry_add, load_or_parse_module_header_fs
 }
@@ -5301,6 +5305,28 @@ export fn check_inline_wasm_fns(stmts: Array[Stmt]) -> Option[String] {
 /// Returns [] when the source lexes, parses, and checks cleanly.
 /// Foundation for `vibe check` / LSP multi-diagnostic reporting.
 export fn collect_all_diagnostics(source: String) -> Array[String] with Exception {
+  // #2227, round 3 of the book-review eval: a leading `require @scope/name
+  // x.y.z = #pkg:sha1:` head is a loader directive that every build-lane
+  // ingestion blanks before parsing -- but this single-file lane parsed the
+  // RAW buffer and answered `unexpected token: =` for a file the build
+  // accepts. Blank it the same way; the blanked twin is offset-preserving,
+  // so every position below stays exact. A head the loader itself rejects
+  // becomes the diagnostic, the same answer the import lane gives.
+  let (pin_blanked, pin_err) = handle {
+    let (_pins, blanked) = extract_require_pins(source)
+    (blanked, "")
+  } with Exception {
+    Throw(m) => (source, m)
+  }
+  if pin_err != "" {
+    return [pin_err]
+  } else {
+    ()
+  }
+  collect_all_diagnostics_on(pin_blanked)
+}
+
+fn collect_all_diagnostics_on(source: String) -> Array[String] with Exception {
   let (tokens, starts, _ends, lex_err_offsets, lex_err_msgs) = lex_with_offsets_recovering(source)
   if Array::length(lex_err_msgs) > 0 {
     // Report ONLY the lexer errors: the recovered token stream has holes, so

--- a/lib/@vibe/compiler/runtime/typecheck_fs.vibe
+++ b/lib/@vibe/compiler/runtime/typecheck_fs.vibe
@@ -5319,56 +5319,55 @@ export fn collect_all_diagnostics(source: String) -> Array[String] with Exceptio
     Throw(m) => (source, m)
   }
   if pin_err != "" {
-    // #2253 review: the loader's message carries no position, and the JSON
-    // lane renders an unlocated diagnostic as the synthetic 0:0 range. The
-    // message quotes the offending text after its `): ` -- when that quote
-    // matches exactly ONE of the leading `require` directive lines, anchor
-    // there (line, column 1). Anything ambiguous -- a short fragment
-    // appearing in several directive lines -- stays unlocated: a bare
-    // message beats a confidently wrong line.
-    let sep = String::index_of(pin_err, "): ")
-    let tail = if sep >= 0 {
-      String::substring(pin_err, sep + 3, String::length(pin_err))
+    // #2253 review rounds 3-4: the loader's message carries no position, and
+    // the JSON lane renders an unlocated diagnostic as the synthetic 0:0
+    // range. Two rounds of parsing the MESSAGE for the offending line drifted
+    // from the header grammar each time (parenthesized vs plain `: ` tails,
+    // then require-only line classification vs the scanner's comments /
+    // version / deps blocks). Ask the scanner itself instead: feed it
+    // line-prefixes of the source and anchor at the FIRST prefix that throws
+    // this exact message -- the scanner is line-oriented, so that prefix's
+    // last line is where its own scan stopped. No grammar mirror, so nothing
+    // to drift; an error only raised at a block opener (unterminated block)
+    // anchors on the opener, which is the actionable line. The probe runs on
+    // the error path only; the cap bounds a pathological file, and past it
+    // the message stays bare -- missing information beats misinformation.
+    let lines = String::split(source, "\n")
+    let nlines = Array::length(lines)
+    let cap = if nlines < 256 {
+      nlines
     } else {
-      // #2253 review round 3: not every loader message parenthesizes its
-      // expectation -- `require package name must start with '@': bad/pkg`
-      // ends with a plain `: <offender>`. Take the text after the LAST
-      // `: ` then; the unique-match gate below still refuses ambiguous
-      // fragments.
-      let last = String::last_index_of(pin_err, ": ")
-      if last >= 0 {
-        String::substring(pin_err, last + 2, String::length(pin_err))
-      } else {
-        ""
-      }
+      256
     }
     let mut hit_line = 0 - 1
-    let mut hit_count = 0
-    if String::length(tail) > 0 {
-      let lines = String::split(source, "\n")
-      let mut li = 0
-      let mut in_head = true
-      while in_head && li < Array::length(lines) {
-        let line = Array::get(lines, li)
-        let t = String::trim(line)
-        if String::starts_with(t, "require ") {
-          if String::contains(line, tail) {
-            hit_count = hit_count + 1
-            hit_line = li
-          } else {
-            ()
-          }
-          li = li + 1
-        } else if t == "" {
-          li = li + 1
+    let mut k = 1
+    while hit_line < 0 && k <= cap {
+      let sb = StringBuilder::new()
+      let mut j = 0
+      while j < k {
+        if j > 0 {
+          StringBuilder::push(sb, "\n")
         } else {
-          in_head = false
+          ()
         }
+        StringBuilder::push(sb, Array::get(lines, j))
+        j = j + 1
       }
-    } else {
-      ()
+      let prefix = StringBuilder::freeze(sb)
+      let m = handle {
+        let (_pins2, _blanked2) = extract_require_pins(prefix)
+        ""
+      } with Exception {
+        Throw(m2) => m2
+      }
+      if m == pin_err {
+        hit_line = k - 1
+      } else {
+        ()
+      }
+      k = k + 1
     }
-    if hit_count == 1 {
+    if hit_line >= 0 {
       return [
         String::concat("line ", String::concat(__to_string(hit_line + 1), String::concat(":1: ", pin_err)))
       ]

--- a/lib/@vibe/compiler/runtime/typecheck_fs.vibe
+++ b/lib/@vibe/compiler/runtime/typecheck_fs.vibe
@@ -5319,7 +5319,50 @@ export fn collect_all_diagnostics(source: String) -> Array[String] with Exceptio
     Throw(m) => (source, m)
   }
   if pin_err != "" {
-    return [pin_err]
+    // #2253 review: the loader's message carries no position, and the JSON
+    // lane renders an unlocated diagnostic as the synthetic 0:0 range. The
+    // message quotes the offending text after its `): ` -- when that quote
+    // matches exactly ONE of the leading `require` directive lines, anchor
+    // there (line, column 1). Anything ambiguous -- a short fragment
+    // appearing in several directive lines -- stays unlocated: a bare
+    // message beats a confidently wrong line.
+    let sep = String::index_of(pin_err, "): ")
+    let tail = if sep >= 0 {
+      String::substring(pin_err, sep + 3, String::length(pin_err))
+    } else {
+      ""
+    }
+    let mut hit_line = 0 - 1
+    let mut hit_count = 0
+    if String::length(tail) > 0 {
+      let lines = String::split(source, "\n")
+      let mut li = 0
+      let mut in_head = true
+      while in_head && li < Array::length(lines) {
+        let line = Array::get(lines, li)
+        let t = String::trim(line)
+        if String::starts_with(t, "require ") {
+          if String::contains(line, tail) {
+            hit_count = hit_count + 1
+            hit_line = li
+          } else {
+            ()
+          }
+          li = li + 1
+        } else if t == "" {
+          li = li + 1
+        } else {
+          in_head = false
+        }
+      }
+    } else {
+      ()
+    }
+    if hit_count == 1 {
+      return [String::concat("line ", String::concat(__to_string(hit_line + 1), String::concat(":1: ", pin_err)))]
+    } else {
+      return [pin_err]
+    }
   } else {
     ()
   }

--- a/lib/@vibe/compiler/tests/diagnostic_anchor_test.vibe
+++ b/lib/@vibe/compiler/tests/diagnostic_anchor_test.vibe
@@ -133,6 +133,19 @@ test "a malformed require directive is located on its own line" {
   let d5 = first_diag(open_deps)
   assert(String::contains(d5, "malformed deps entry"))
   assert(String::contains(d5, "line 4:1:"))
+  // #2253 review round 6: the probe binary-searches the prefix boundary, so
+  // there is no length cap -- an offending directive past line 256 still
+  // locates (the previous linear probe gave up there).
+  let mut long_head = ""
+  let mut li = 0
+  while li < 300 {
+    long_head = long_head + "// filler\n"
+    li = li + 1
+  }
+  let long_src = long_head + "require bad/pkg 1.2.3 = #pkg:sha1:0000000000000000000000000000000000000000\n\nfn f() -> Int {\n  1\n}\n"
+  let d6 = first_diag(long_src)
+  assert(String::contains(d6, "must start with '@'"))
+  assert(String::contains(d6, "line 301:1:"))
 }
 
 test "a comment spelling the binder does not capture the anchor" {

--- a/lib/@vibe/compiler/tests/diagnostic_anchor_test.vibe
+++ b/lib/@vibe/compiler/tests/diagnostic_anchor_test.vibe
@@ -107,6 +107,12 @@ test "a malformed require directive is located on its own line" {
   // A clean pin head stays clean.
   let ok = "require @vibe/core 0.2.0 = #pkg:sha1:0000000000000000000000000000000000000000\n\nfn f() -> Int {\n  1\n}\n"
   assert(first_diag(ok) == "")
+  // #2253 review round 3: a message with no parenthesized expectation
+  // (plain `: <offender>` tail) locates too.
+  let scoped = "require @vibe/core 0.2.0 = #pkg:sha1:0000000000000000000000000000000000000000\nrequire bad/pkg 1.2.3 = #pkg:sha1:0000000000000000000000000000000000000000\n\nfn f() -> Int {\n  1\n}\n"
+  let d2 = first_diag(scoped)
+  assert(String::contains(d2, "must start with '@'"))
+  assert(String::contains(d2, "line 2:1:"))
 }
 
 test "a comment spelling the binder does not capture the anchor" {

--- a/lib/@vibe/compiler/tests/diagnostic_anchor_test.vibe
+++ b/lib/@vibe/compiler/tests/diagnostic_anchor_test.vibe
@@ -98,8 +98,10 @@ test "a malformed require directive is located on its own line" {
   // #2253 review: the single-file lane blanks require-pin heads (#2227),
   // and a head the loader rejects becomes the diagnostic -- but the
   // loader's message carries no position, which the JSON lane renders as
-  // the synthetic 0:0 range. When the message's quoted offender matches
-  // exactly one leading require line, the diagnostic anchors there.
+  // the synthetic 0:0 range. The locator probes line-prefixes of the
+  // source through the loader's own scanner and anchors at the first one
+  // that throws the same message, so every message form and every header
+  // line kind locates without a second copy of the header grammar.
   let src = "require @vibe/core 0.2.0 = #pkg:sha1:0000000000000000000000000000000000000000\nrequire @vibe/extra 9.9.9 = #pkg:sha1:zzz\n\nfn f() -> Int {\n  1\n}\n"
   let d = first_diag(src)
   assert(String::contains(d, "require pin must be"))
@@ -113,6 +115,24 @@ test "a malformed require directive is located on its own line" {
   let d2 = first_diag(scoped)
   assert(String::contains(d2, "must start with '@'"))
   assert(String::contains(d2, "line 2:1:"))
+  // #2253 review round 4: the header grammar continues across comments and
+  // the other directives, so a malformed require AFTER one of those must
+  // locate too (the previous locator classified only require/blank lines
+  // as header and gave up at the comment).
+  let after_comment = "// header comment\nrequire bad/pkg 1.2.3 = #pkg:sha1:0000000000000000000000000000000000000000\n\nfn f() -> Int {\n  1\n}\n"
+  let d3 = first_diag(after_comment)
+  assert(String::contains(d3, "must start with '@'"))
+  assert(String::contains(d3, "line 2:1:"))
+  let after_version = "version = 1.2.3\nrequire bad/pkg 1.2.3 = #pkg:sha1:0000000000000000000000000000000000000000\n\nfn f() -> Int {\n  1\n}\n"
+  let d4 = first_diag(after_version)
+  assert(String::contains(d4, "must start with '@'"))
+  assert(String::contains(d4, "line 2:1:"))
+  // An unterminated `deps = {` swallows the first code line as a deps
+  // entry; the probe anchors on that line -- where the scanner stopped.
+  let open_deps = "deps = {\n  @vibe/core : 0.2.0\n\nfn f() -> Int {\n  1\n}\n"
+  let d5 = first_diag(open_deps)
+  assert(String::contains(d5, "malformed deps entry"))
+  assert(String::contains(d5, "line 4:1:"))
 }
 
 test "a comment spelling the binder does not capture the anchor" {

--- a/lib/@vibe/compiler/tests/diagnostic_anchor_test.vibe
+++ b/lib/@vibe/compiler/tests/diagnostic_anchor_test.vibe
@@ -94,6 +94,21 @@ test "all-literal if branches anchor on the binder" {
   assert(anchored_at(src, 2, 7))
 }
 
+test "a malformed require directive is located on its own line" {
+  // #2253 review: the single-file lane blanks require-pin heads (#2227),
+  // and a head the loader rejects becomes the diagnostic -- but the
+  // loader's message carries no position, which the JSON lane renders as
+  // the synthetic 0:0 range. When the message's quoted offender matches
+  // exactly one leading require line, the diagnostic anchors there.
+  let src = "require @vibe/core 0.2.0 = #pkg:sha1:0000000000000000000000000000000000000000\nrequire @vibe/extra 9.9.9 = #pkg:sha1:zzz\n\nfn f() -> Int {\n  1\n}\n"
+  let d = first_diag(src)
+  assert(String::contains(d, "require pin must be"))
+  assert(String::contains(d, "line 2:1:"))
+  // A clean pin head stays clean.
+  let ok = "require @vibe/core 0.2.0 = #pkg:sha1:0000000000000000000000000000000000000000\n\nfn f() -> Int {\n  1\n}\n"
+  assert(first_diag(ok) == "")
+}
+
 test "a comment spelling the binder does not capture the anchor" {
   // #2244 review: find_fn_anchor_off scans raw text; before the fix a
   // comment like this source's line 2 anchored the diagnostic at the

--- a/scripts/check_book_console.sh
+++ b/scripts/check_book_console.sh
@@ -78,7 +78,13 @@ run_transcript() {
   local rc=0
   (
     cd "$workdir"
-    VIBE_RUNNER="$SHIM" VIBE_CLI_WASM="$STAGE2" VIBE_TEST_CLI_WASM="$STAGE2" \
+    # The launcher's pass-cache is PERSISTENT ($VIBE_HOME/cache/test, keyed
+    # on the compiled wasm's sha256); a warm cache answers
+    # `ok <file> (cached)`, which is not the transcript the book shows.
+    # Point the cache inside this gate's own scratch tree so every run is a
+    # first run.
+    VIBE_TEST_CACHE="$workdir/tcache" \
+      VIBE_RUNNER="$SHIM" VIBE_CLI_WASM="$STAGE2" VIBE_TEST_CLI_WASM="$STAGE2" \
       bash "$ROOT_DIR/runtime/vibe" test demo_test.vibe >transcript.actual 2>&1
   ) || rc=$?
   if [ "$rc" != "$want_rc" ]; then

--- a/scripts/check_book_console.sh
+++ b/scripts/check_book_console.sh
@@ -96,8 +96,10 @@ run_transcript() {
   fi
 }
 
-WORK="$ROOT_DIR/_build/_book_console"
-rm -rf "$WORK"; mkdir -p "$WORK"
+# Unique per invocation (#2253 review round 5): two overlapping gate runs in
+# the same checkout must not delete each other's shim, fixtures, or cache.
+mkdir -p "$ROOT_DIR/_build"
+WORK="$(mktemp -d "$ROOT_DIR/_build/_book_console.XXXXXX")"
 trap 'rm -rf "$WORK"' EXIT
 
 # Launcher shim: route the compiler wasm (matched by exact path) to cli_main,

--- a/scripts/check_book_console.sh
+++ b/scripts/check_book_console.sh
@@ -1,0 +1,142 @@
+#!/usr/bin/env bash
+# Prove book ch12's ```console transcripts against the real launcher
+# `vibe test` (book-review round 3: they were the only output in the book's
+# own format that no gate verified -- doctest compiles ```vibe blocks and
+# checks ```output pairs, but a CLI transcript needs the VERB run for real,
+# the way eval/book-review/run_probes.sh runs its `//! cli:` directives).
+#
+# Contract proven here:
+#   - the chapter's first ```vibe block IS the demo file the transcripts run;
+#   - console block 1 is the passing report for that file, verbatim;
+#   - console block 2 is the failing report for the prose-documented edit
+#     ("Change the expected value to 43"), verbatim, with exit 1;
+#   - the ja chapter's transcripts are byte-identical to the en ones
+#     (the same program prints the same report -- translation parity).
+#
+# Which compiler answers is explicit (the #2138 rule): the launcher runs the
+# stage2 this script is handed, never whatever `pick_cli` would find.
+#   BOOK_CONSOLE_STAGE2=<path>  override; otherwise scripts/resolve_stage2.sh
+set -euo pipefail
+ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT_DIR"
+
+. "$ROOT_DIR/scripts/resolve_stage2.sh"
+STAGE2="$(resolve_stage2 book-console "${BOOK_CONSOLE_STAGE2:-}")" || exit 1
+case "$STAGE2" in
+  /*) : ;;
+  *) STAGE2="$ROOT_DIR/$STAGE2" ;;
+esac
+
+fails=0
+bad() { printf 'book-console: FAIL: %s\n' "$1" >&2; fails=1; }
+
+# Extract fenced blocks from a chapter: prints each block as
+#   <marker>\t<info>
+# followed by its lines, so the caller can split with awk. Simpler: use
+# python3 to write each wanted block to a file.
+extract() { # extract <doc> <outdir>  -> writes vibe0.txt console0.txt console1.txt
+  python3 - "$1" "$2" <<'PY'
+import sys
+doc, outdir = sys.argv[1], sys.argv[2]
+lines = open(doc, encoding="utf-8").read().split("\n")
+blocks = []  # (info, [lines])
+cur = None
+for l in lines:
+    if l.startswith("```"):
+        if cur is None:
+            cur = (l[3:].strip(), [])
+        else:
+            blocks.append(cur)
+            cur = None
+    elif cur is not None:
+        cur[1].append(l)
+vibes = [b for b in blocks if b[0] == "vibe"]
+consoles = [b for b in blocks if b[0] == "console"]
+if not vibes:
+    print("no ```vibe block found", file=sys.stderr); sys.exit(1)
+if len(consoles) != 2:
+    print(f"expected exactly 2 ```console blocks, found {len(consoles)}", file=sys.stderr); sys.exit(1)
+open(f"{outdir}/vibe0.txt", "w").write("\n".join(vibes[0][1]) + "\n")
+for i, c in enumerate(consoles):
+    open(f"{outdir}/console{i}.txt", "w").write("\n".join(c[1]) + "\n")
+PY
+}
+
+# run_transcript <workdir> <transcript-file> <expected-exit>
+# The transcript's first line must be `$ vibe test demo_test.vibe`; the rest
+# is the expected merged stdout+stderr. Runs from a FRESH cwd so the
+# launcher's pass-cache cannot answer `(cached)` for a report the book shows
+# uncached.
+run_transcript() {
+  local workdir="$1" transcript="$2" want_rc="$3"
+  local cmd
+  cmd="$(head -1 "$transcript")"
+  if [ "$cmd" != "\$ vibe test demo_test.vibe" ]; then
+    bad "unexpected transcript command: $cmd"
+    return
+  fi
+  local rc=0
+  (
+    cd "$workdir"
+    VIBE_RUNNER="$SHIM" VIBE_CLI_WASM="$STAGE2" VIBE_TEST_CLI_WASM="$STAGE2" \
+      bash "$ROOT_DIR/runtime/vibe" test demo_test.vibe >transcript.actual 2>&1
+  ) || rc=$?
+  if [ "$rc" != "$want_rc" ]; then
+    bad "exit $rc, transcript implies $want_rc ($transcript)"
+  fi
+  tail -n +2 "$transcript" >"$workdir/transcript.expected"
+  if ! diff -u "$workdir/transcript.expected" "$workdir/transcript.actual" >&2; then
+    bad "transcript diverged from the launcher's real report ($transcript)"
+  fi
+}
+
+WORK="$ROOT_DIR/_build/_book_console"
+rm -rf "$WORK"; mkdir -p "$WORK"
+trap 'rm -rf "$WORK"' EXIT
+
+# Launcher shim: route the compiler wasm (matched by exact path) to cli_main,
+# program wasm to _start -- the same wiring run_probes.sh generates. Mode env
+# vars are the launcher's to set; the shim adds none.
+SHIM="$WORK/viberun"
+cat >"$SHIM" <<SH
+#!/usr/bin/env bash
+first="\$1"; shift
+if [ "\$first" = "$STAGE2" ]; then
+  : "\${VIBE_PREOPEN_DIR:=\$PWD}"; export VIBE_PREOPEN_DIR
+  : "\${VIBE_IMPORT_ABI:=raw}"; export VIBE_IMPORT_ABI
+  exec bash "$ROOT_DIR/scripts/run_wasm_vibe_host_runner.sh" --invoke cli_main "\$first" "\$@"
+fi
+exec bash "$ROOT_DIR/scripts/run_wasm_vibe_host_runner.sh" --invoke _start "\$first" "\$@"
+SH
+chmod +x "$SHIM"
+
+extract "book/en/12_tests.vibe.md" "$WORK" || { bad "block extraction failed (book/en/12_tests.vibe.md)"; exit 1; }
+
+# ja parity: the program in each block is the same program, so the reports
+# are the same bytes. Prove the en transcripts for real; hold ja to en.
+mkdir -p "$WORK/ja"
+extract "book/ja/12_tests.vibe.md" "$WORK/ja" || bad "block extraction failed (book/ja/12_tests.vibe.md)"
+for i in 0 1; do
+  if ! cmp -s "$WORK/console$i.txt" "$WORK/ja/console$i.txt"; then
+    bad "ja console block $i differs from en (translation parity)"
+  fi
+done
+
+# Pass case: the chapter's own source, verbatim.
+mkdir -p "$WORK/pass"
+cp "$WORK/vibe0.txt" "$WORK/pass/demo_test.vibe"
+run_transcript "$WORK/pass" "$WORK/console0.txt" 0
+
+# Fail case: the prose says "Change the expected value to 43 and the report
+# names the test, shows both sides, and stops" -- apply exactly that edit.
+mkdir -p "$WORK/fail"
+sed 's/assert_eq(double(21), 42)/assert_eq(double(21), 43)/' "$WORK/vibe0.txt" >"$WORK/fail/demo_test.vibe"
+if cmp -s "$WORK/vibe0.txt" "$WORK/fail/demo_test.vibe"; then
+  bad "the documented edit (42 -> 43) no longer applies to the chapter's source"
+fi
+run_transcript "$WORK/fail" "$WORK/console1.txt" 1
+
+if [ "$fails" -ne 0 ]; then
+  exit 1
+fi
+echo "book-console: ok (2 transcripts proven against the launcher, ja parity held)"

--- a/scripts/ensure_vibe_fmt_entry.sh
+++ b/scripts/ensure_vibe_fmt_entry.sh
@@ -21,6 +21,8 @@ entry_wasm_rel="_build/vibe_fmt/fmt_entry.wasm"
 if [ ! -s "$ROOT_DIR/$entry_wasm_rel" ] || [ "$entry_src" -nt "$ROOT_DIR/$entry_wasm_rel" ] \
    || [ "lib/@vibe/compiler/fmt/format.vibe" -nt "$ROOT_DIR/$entry_wasm_rel" ] \
    || [ "lib/@vibe/compiler/fmt/index.vpkg" -nt "$ROOT_DIR/$entry_wasm_rel" ] \
+   || [ "lib/@vibe/compiler/contract/contract.vibe" -nt "$ROOT_DIR/$entry_wasm_rel" ] \
+   || [ "lib/@vibe/compiler/contract/index.vpkg" -nt "$ROOT_DIR/$entry_wasm_rel" ] \
    || [ "lib/@vibe/parser/lexer.vibe" -nt "$ROOT_DIR/$entry_wasm_rel" ] \
    || [ "lib/@vibe/parser/parser.vibe" -nt "$ROOT_DIR/$entry_wasm_rel" ] \
    || [ "lib/@vibe/parser/index.vpkg" -nt "$ROOT_DIR/$entry_wasm_rel" ]; then

--- a/scripts/ensure_vibe_fmt_entry.sh
+++ b/scripts/ensure_vibe_fmt_entry.sh
@@ -21,8 +21,6 @@ entry_wasm_rel="_build/vibe_fmt/fmt_entry.wasm"
 if [ ! -s "$ROOT_DIR/$entry_wasm_rel" ] || [ "$entry_src" -nt "$ROOT_DIR/$entry_wasm_rel" ] \
    || [ "lib/@vibe/compiler/fmt/format.vibe" -nt "$ROOT_DIR/$entry_wasm_rel" ] \
    || [ "lib/@vibe/compiler/fmt/index.vpkg" -nt "$ROOT_DIR/$entry_wasm_rel" ] \
-   || [ "lib/@vibe/compiler/contract/contract.vibe" -nt "$ROOT_DIR/$entry_wasm_rel" ] \
-   || [ "lib/@vibe/compiler/contract/index.vpkg" -nt "$ROOT_DIR/$entry_wasm_rel" ] \
    || [ "lib/@vibe/parser/lexer.vibe" -nt "$ROOT_DIR/$entry_wasm_rel" ] \
    || [ "lib/@vibe/parser/parser.vibe" -nt "$ROOT_DIR/$entry_wasm_rel" ] \
    || [ "lib/@vibe/parser/index.vpkg" -nt "$ROOT_DIR/$entry_wasm_rel" ]; then

--- a/scripts/vibe_fmt_parse_guard_test.sh
+++ b/scripts/vibe_fmt_parse_guard_test.sh
@@ -65,4 +65,32 @@ if ! bash "$ROOT_DIR/scripts/vibe_fmt.sh" "$broken" >/dev/null 2>&1; then
   exit 1
 fi
 
+
+# #2244 round-3 finding: a leading `require ... = #pkg:sha1:` pin head is a
+# loader directive, not vibe syntax. The formatter used to feed it to the CST
+# formatter and mangle it into text the loader rejects (`require @vibe /
+# core0.2.0 = ...`), and the parse guard could not see it -- the RAW input
+# does not parse either. The head must come back byte-identical, the body
+# formatted, and the result must be a --check fixpoint.
+pin="$work/pin_head.vibe"
+printf 'require @vibe/core 0.2.0 = #pkg:sha1:0000000000000000000000000000000000000000\n\nfn double(n:Int)->Int {\n  n*2\n}\n' >"$pin"
+if ! bash "$ROOT_DIR/scripts/vibe_fmt.sh" "$pin" >/dev/null 2>&1; then
+  echo "vibe_fmt_parse_guard_test: formatter declined a require-pin-head file" >&2
+  exit 1
+fi
+if ! head -1 "$pin" | grep -q '^require @vibe/core 0\.2\.0 = #pkg:sha1:0000000000000000000000000000000000000000$'; then
+  echo "vibe_fmt_parse_guard_test: formatter mangled the require-pin head" >&2
+  head -1 "$pin" >&2
+  exit 1
+fi
+if ! grep -q '^fn double(n: Int) -> Int {$' "$pin"; then
+  echo "vibe_fmt_parse_guard_test: body under a pin head was not formatted" >&2
+  sed -n '1,6p' "$pin" >&2
+  exit 1
+fi
+if ! bash "$ROOT_DIR/scripts/vibe_fmt.sh" --check "$pin" >/dev/null 2>&1; then
+  echo "vibe_fmt_parse_guard_test: pin-head formatting is not a --check fixpoint" >&2
+  exit 1
+fi
+
 echo "vibe_fmt_parse_guard_test: ok"

--- a/scripts/vibe_fmt_parse_guard_test.sh
+++ b/scripts/vibe_fmt_parse_guard_test.sh
@@ -93,4 +93,34 @@ if ! bash "$ROOT_DIR/scripts/vibe_fmt.sh" --check "$pin" >/dev/null 2>&1; then
   exit 1
 fi
 
+# #2253 round-6 finding: the head split must reach EVERY formatter entry, not
+# just fmt_entry -- the batch lane (lib/@vibe/cli/fmt.vibe, what CI's
+# vibe-fmt-check and `pkf run fmt` run) calls format_source directly and used
+# to mangle the same pin head. The split now lives inside format_source, so
+# the batch lane preserves it too; prove it through the real batch runner.
+# (run_vibe_fmt_batch.sh wants repo-relative paths under the preopen root, so
+# the fixture lives under _build.)
+batch_pin_rel="_build/vibe_fmt_parse_guard_batch_pin.$$.vibe"
+batch_pin="$ROOT_DIR/$batch_pin_rel"
+trap 'rm -rf "$work" "$batch_pin"' EXIT
+printf 'require @vibe/core 0.2.0 = #pkg:sha1:0000000000000000000000000000000000000000\n\nfn double(n:Int)->Int {\n  n*2\n}\n' >"$batch_pin"
+batch_report="$(printf '%s\n' "$batch_pin_rel" | bash "$ROOT_DIR/scripts/run_vibe_fmt_batch.sh" write 1)"
+case "$batch_report" in
+  DIFF*) : ;;
+  *)
+    echo "vibe_fmt_parse_guard_test: batch lane did not rewrite the pin-head file (report: $batch_report)" >&2
+    exit 1
+    ;;
+esac
+if ! head -1 "$batch_pin" | grep -q '^require @vibe/core 0\.2\.0 = #pkg:sha1:0000000000000000000000000000000000000000$'; then
+  echo "vibe_fmt_parse_guard_test: BATCH lane mangled the require-pin head" >&2
+  head -1 "$batch_pin" >&2
+  exit 1
+fi
+if ! grep -q '^fn double(n: Int) -> Int {$' "$batch_pin"; then
+  echo "vibe_fmt_parse_guard_test: batch lane did not format the body under a pin head" >&2
+  sed -n '1,6p' "$batch_pin" >&2
+  exit 1
+fi
+
 echo "vibe_fmt_parse_guard_test: ok"


### PR DESCRIPTION
Round 3 of the book read-through eval works the r2 §4 candidate list ([record](eval/book-review/rounds/2026-08-23-r3.md)). Narrower than rounds 1–2 by design: three measurements and one missing gate. Every Red and Green is measured through a stage2 built from this branch (main at 2f0f181); the full 38-probe corpus re-runs green on it.

## `vibe fmt` mangled require-pin heads (`6c5ed4d`)

The unmeasured r2 lane, and it was broken: `require @vibe/core 0.2.0 = #pkg:sha1:0000…` came back as `require @vibe / core0.2.0 = #pkg: sha1: 0000…`, and the rewritten file **fails to load** (`malformed require line`). The #1821 parse guard could not see it — the raw input does not parse either (the head is a loader directive, not vibe syntax, the same fact that gave `.vpkg` headers their own writer in #1435), so "input was not a program" excused the wreckage with exit 0.

`fmt_entry` now splits the head off with the loader's own classifier (`extract_require_pins`), formats only the body, and reattaches the head verbatim; the guard asks its question of the body. A head the loader itself rejects falls back to the old whole-file path ("no worse", not "only valid input"). The entry compiles the checkout's sources with the seed, so the fix is live without a bootstrap bump. Pinned in `vibe_fmt_parse_guard_test.sh` (mangle / body-format / `--check` fixpoint).

## `vibe check --single-file` rejected the same heads (`a6d817d`)

#2227 covered the import lane and the `.vibex` validation; the single-file (editor-buffer) lane still parsed the raw buffer and answered `error: line 1:26: unexpected token: =`. `collect_all_diagnostics` now blanks the head like every ingestion (offset-preserving, positions exact). Measured: pin-head file clean in `--single-file` and `--json` (`[]`); a malformed head reports the loader's own message — the import lane's answer; ordinary files unchanged.

## Ch12's console transcripts are now proven (`b86ae1b`)

The last unproven output in the book's own format. `scripts/check_book_console.sh` (`pkf run check-book-console`, wired into release-check) materializes the chapter's own first ` ```vibe ` block as `demo_test.vibe`, runs the real launcher `vibe test` with this checkout's stage2 (explicit, per the #2138 which-compiler rule), and requires the merged output to match each transcript verbatim — exit 0 for the passing block; for the failing block, the prose-documented edit ("Change the expected value to 43") with exit 1. Ja transcripts are held byte-identical to en (same program, same report); each case runs from a fresh cwd so the pass-cache cannot answer `(cached)`.

First run: **both transcripts verbatim-accurate** — direct evidence the #2228 reporter unification holds on the shipped launcher. The gate is red-tested (a corrupted summary line fails it).

## Also measured, no action

- **p21 (`perform?`)**: seed still silent-accepts what stage2 rejects with the #2145 message — no bootstrap bump since round 2, note carried to round 4 (same event gates #2219).
- Phase D fmt pin *insertion* (module-system-v2 §6) stays unimplemented design; this PR only makes fmt stop destroying what is already written.

## Verification

- `bash scripts/compiler_gate.sh` (all lanes, direct): `[compiler-gate] ok`.
- Probe corpus: 38/38, zero harness errors, on the fix stage2.
- Targeted: `diagnostic_anchor_test` + `cli_support_test` + `dispatch_test` + `deprecated_scan_test` (150 tests) through the fix stage2; `vibe_fmt_parse_guard_test` incl. the new pin-head case; `check_book_console` green and red-tested.
- `pkf list` parses with the new task; `vibe_fmt --check` clean on every touched `.vibe`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012BesqGvopmB2byi8gB4HXG

---
_Generated by [Claude Code](https://claude.ai/code/session_012BesqGvopmB2byi8gB4HXG)_