### PR TITLE
Refactor Perceus actions around binding IDs

### DIFF
--- a/lib/@vibe/compiler/perceus/index.vpkg
+++ b/lib/@vibe/compiler/perceus/index.vpkg
@@ -43,7 +43,8 @@ opaque type PerceusActionKind
 
 struct PerceusAction {
   kind: PerceusActionKind;
-  name: String
+  name: String;
+  binding_id: Int
 }
 
 // --- plan-action predicates

--- a/lib/@vibe/compiler/perceus/perceus.vibe
+++ b/lib/@vibe/compiler/perceus/perceus.vibe
@@ -27,7 +27,10 @@ export enum PerceusActionKind {
 
 // PerceusAction is defined transparently in this package's contract
 // (index.vpkg): its field layout (.kind/.name) is real public API surface
-// read directly by tests/perceus_rc_test.vibe. Struct record literals and
+// read directly by tests/perceus_rc_test.vibe. `binding_id` is the lexical
+// binding identity assigned by the count/emit passes; unlike `name`, it keeps
+// shadowed bindings distinct and is the contract needed for per-use RC
+// realization. Struct record literals and
 // field access resolve fine from impl units against the facade definition
 // (@vibe/process ShResult precedent, PR #920), so no local def is kept.
 
@@ -104,10 +107,11 @@ fn name_in(arr: Array[String], s: String) -> Bool {
   found
 }
 
-fn pe_push(ctx: PCtx, kind: PerceusActionKind, name: String) -> Int {
+fn pe_push_for(ctx: PCtx, kind: PerceusActionKind, name: String, binding_id: Int) -> Int {
   Array::push(ctx.actions, PerceusAction::{
     kind: kind,
-    name: name
+    name: name,
+    binding_id: binding_id
   })
   0
 }
@@ -122,7 +126,7 @@ fn pe_use(ctx: PCtx, scope: Map[String, Int], name: String) -> Int {
     // ref" transfer would consume a reference the binding never acquired.
     let last_view_use = rem == 1 && Array::get(ctx.view_call_let, id)
     if (rem > 1 || last_view_use) && !Array::get(ctx.scalar, id) {
-      pe_push(ctx, PaDup, name)
+      pe_push_for(ctx, PaDup, name, id)
     } else {
       0
     }
@@ -284,7 +288,7 @@ fn pe_scope_end(ctx: PCtx, id: Int, name: String) -> Int {
     if Array::get(ctx.view_call_let, id) {
       ()
     } else {
-      pe_push(ctx, PaDrop, name)
+      pe_push_for(ctx, PaDrop, name, id)
     }
     Array::set(ctx.remaining, id, 0)
   }
@@ -1672,7 +1676,7 @@ export fn pc_emit(ctx: PCtx, scope: Map[String, Int], expr: Expr) -> Int {
                 elide_dead_alias = true
                 0
               } else {
-                pe_push(ctx, PaAliasDup, name)
+                pe_push_for(ctx, PaAliasDup, name, ctx.next_id)
               }
             } else {
               0

--- a/lib/@vibe/compiler/tests/perceus_rc_test.vibe
+++ b/lib/@vibe/compiler/tests/perceus_rc_test.vibe
@@ -61,6 +61,21 @@ fn count_alias_dups(plan: Array[PerceusAction], name: String) -> Int {
   n
 }
 
+fn dup_binding_ids(plan: Array[PerceusAction], name: String) -> Array[Int] {
+  let out: Array[Int] = []
+  let mut i = 0
+  while i < Array::length(plan) {
+    let a = Array::get(plan, i)
+    if pa_is_dup(a) && a.name == name {
+      Array::push(out, a.binding_id)
+    } else {
+      ()
+    }
+    i = i + 1
+  }
+  out
+}
+
 /// A heap binding only borrowed (field access) is dropped once at scope end.
 test "perceus: pure-borrow binding is dropped once" {
   // let t = (1, 2); t.0
@@ -413,4 +428,6 @@ test "perceus: branch-local shadow keeps its dups through the merge" {
   let plan = build_perceus_plan(body)
   // One dup for the shadow's double use + one for the outer else mention.
   inspect(count_dups(plan, "out"), "2")
+  // The ESeq scratch binding is id 1, so the branch-local shadow is id 2.
+  inspect(dup_binding_ids(plan, "out"), "[2, 0]")
 }


### PR DESCRIPTION
Part of #1980.

This is the behavior-preserving contract phase required before moving dup realization from binding declarations to use sites.

- Add lexical `binding_id` to every Perceus action.
- Attribute dup, drop, and alias-dup actions at their planner emission points.
- Pin same-named outer/shadow actions to distinct IDs.

Validation:
- Fresh stage2 self-host fixpoint passed.
- Focused Perceus tests passed.
- Full unit battery: 1006/1020 passed; the remaining 14 are the existing fresh-checkout generated-bundle/cache-fixture failures (missing compiler/CLI bundles and dependent assertions).
- Historical checked-artifact smoke: all 3 fixtures compiled and ran with `VIBE_RC=shadow`.

This PR intentionally does not change codegen consumption yet: consumers continue reading `.name`, so emitted RC behavior remains unchanged. The next phase will key codegen realization on this identity and place `PaDup` at owning use sites.