### PR TITLE
Attach Perceus dup actions to owning use sites

### DIFF
--- a/lib/@vibe/compiler/perceus/index.vpkg
+++ b/lib/@vibe/compiler/perceus/index.vpkg
@@ -44,7 +44,8 @@ opaque type PerceusActionKind
 struct PerceusAction {
   kind: PerceusActionKind;
   name: String;
-  binding_id: Int
+  binding_id: Int;
+  use_offset: Int
 }
 
 // --- plan-action predicates

--- a/lib/@vibe/compiler/perceus/perceus.vibe
+++ b/lib/@vibe/compiler/perceus/perceus.vibe
@@ -1779,7 +1779,13 @@ export fn pc_emit(ctx: PCtx, scope: Map[String, Int], expr: Expr) -> Int {
       // only the duplicate sibling dup disappears. Anything but this exact
       // shape keeps the general per-branch walk below unchanged.
       if eif_same_ident_branches(then_e, else_e) {
-        pc_emit(ctx, scope, then_e)
+        // This action represents either branch, not the first branch's
+        // concrete syntax node. Keep it on the declaration-site fallback
+        // until codegen can represent a set of alternative use sites.
+        match then_e {
+          EIdent(name, _) => pe_use(ctx, scope, name, -1),
+          _ => 0
+        }
       } else {
         let snap = copy_ints(ctx.remaining)
         pc_emit(ctx, scope, then_e)
@@ -1928,7 +1934,12 @@ export fn pc_emit(ctx: PCtx, scope: Map[String, Int], expr: Expr) -> Int {
             k = k + 1
           }
           if a == 0 {
-            pc_emit(ctx, s, arm.1)
+            // The one merged action represents every arm. It must not inherit
+            // only the first arm's source position (see the EIf case above).
+            match arm.1 {
+              EIdent(name, _) => pe_use(ctx, s, name, -1),
+              _ => 0
+            }
           } else {
             ()
           }

--- a/lib/@vibe/compiler/perceus/perceus.vibe
+++ b/lib/@vibe/compiler/perceus/perceus.vibe
@@ -107,16 +107,17 @@ fn name_in(arr: Array[String], s: String) -> Bool {
   found
 }
 
-fn pe_push_for(ctx: PCtx, kind: PerceusActionKind, name: String, binding_id: Int) -> Int {
+fn pe_push_for(ctx: PCtx, kind: PerceusActionKind, name: String, binding_id: Int, use_offset: Int) -> Int {
   Array::push(ctx.actions, PerceusAction::{
     kind: kind,
     name: name,
-    binding_id: binding_id
+    binding_id: binding_id,
+    use_offset: use_offset
   })
   0
 }
 
-fn pe_use(ctx: PCtx, scope: Map[String, Int], name: String) -> Int {
+fn pe_use(ctx: PCtx, scope: Map[String, Int], name: String, use_offset: Int) -> Int {
   if Map::has_key(scope, name) {
     let id = Map::get(scope, name)
     let rem = Array::get(ctx.remaining, id)
@@ -126,7 +127,7 @@ fn pe_use(ctx: PCtx, scope: Map[String, Int], name: String) -> Int {
     // ref" transfer would consume a reference the binding never acquired.
     let last_view_use = rem == 1 && Array::get(ctx.view_call_let, id)
     if (rem > 1 || last_view_use) && !Array::get(ctx.scalar, id) {
-      pe_push_for(ctx, PaDup, name, id)
+      pe_push_for(ctx, PaDup, name, id, use_offset)
     } else {
       0
     }
@@ -288,7 +289,7 @@ fn pe_scope_end(ctx: PCtx, id: Int, name: String) -> Int {
     if Array::get(ctx.view_call_let, id) {
       ()
     } else {
-      pe_push_for(ctx, PaDrop, name, id)
+      pe_push_for(ctx, PaDrop, name, id, -1)
     }
     Array::set(ctx.remaining, id, 0)
   }
@@ -1604,7 +1605,7 @@ export fn pc_emit(ctx: PCtx, scope: Map[String, Int], expr: Expr) -> Int {
     EBool(_) => 0,
     EUnit => 0,
     EStringInterp(_) => 0,
-    EIdent(x, _) => pe_use(ctx, scope, x),
+    EIdent(x, off) => pe_use(ctx, scope, x, off),
     ECall(callee, args, _) => {
       // Same lexical-shadow guard as pc_count (and compile_call #875).
       let bmask = pe_borrow_mask(ctx, scope, callee)
@@ -1635,7 +1636,7 @@ export fn pc_emit(ctx: PCtx, scope: Map[String, Int], expr: Expr) -> Int {
     ELet(name, value, body, _) => {
       let mut elide_dead_alias = false
       match value {
-        EIdent(src, _) => {
+        EIdent(src, src_off) => {
           if Map::has_key(scope, src) {
             let sid = Map::get(scope, src)
             let rem = Array::get(ctx.remaining, sid)
@@ -1676,7 +1677,7 @@ export fn pc_emit(ctx: PCtx, scope: Map[String, Int], expr: Expr) -> Int {
                 elide_dead_alias = true
                 0
               } else {
-                pe_push_for(ctx, PaAliasDup, name, ctx.next_id)
+                pe_push_for(ctx, PaAliasDup, name, ctx.next_id, src_off)
               }
             } else {
               0
@@ -1833,7 +1834,7 @@ export fn pc_emit(ctx: PCtx, scope: Map[String, Int], expr: Expr) -> Int {
       let caps = collect_free_vars(fbody, fn_param_names(params), [])
       let mut i = 0
       while i < Array::length(caps) {
-        pe_use(ctx, scope, Array::get(caps, i))
+        pe_use(ctx, scope, Array::get(caps, i), -1)
         i = i + 1
       }
       0

--- a/lib/@vibe/compiler/tests/perceus_rc_test.vibe
+++ b/lib/@vibe/compiler/tests/perceus_rc_test.vibe
@@ -408,10 +408,11 @@ test "perceus: multi-alias dups all but the last (elision does not fire when use
 test "perceus: exclusive if-branch mentions merge to one dup" {
   // let out = (1, 2); match out { _ => 0 }; if true { out } else { out }
   let borrow_use = EMatch(EIdent("out", -1), [(PWild, EInt(0))])
-  let tail = EIf(EBool(true), EIdent("out", -1), EIdent("out", -1))
+  let tail = EIf(EBool(true), EIdent("out", 101), EIdent("out", 202))
   let body = ELet("out", ETuple([EInt(1), EInt(2)]), ESeq(borrow_use, tail), -1)
   let plan = build_perceus_plan(body)
   inspect(count_dups(plan, "out"), "1")
+  inspect(dup_use_offsets(plan, "out"), "[-1]")
   inspect(count_drops(plan, "out"), "1")
 }
 
@@ -420,12 +421,13 @@ test "perceus: exclusive match-arm mentions merge to one dup" {
   // let out = (1, 2); match out { _ => 0 }; match 1 { p => out, _ => out }
   let borrow_use = EMatch(EIdent("out", -1), [(PWild, EInt(0))])
   let tail = EMatch(EInt(1), [
-    (PBind("p"), EIdent("out", -1)),
-    (PWild, EIdent("out", -1))
+    (PBind("p"), EIdent("out", 303)),
+    (PWild, EIdent("out", 404))
   ])
   let body = ELet("out", ETuple([EInt(1), EInt(2)]), ESeq(borrow_use, tail), -1)
   let plan = build_perceus_plan(body)
   inspect(count_dups(plan, "out"), "1")
+  inspect(dup_use_offsets(plan, "out"), "[-1]")
   inspect(count_drops(plan, "out"), "1")
 }
 

--- a/lib/@vibe/compiler/tests/perceus_rc_test.vibe
+++ b/lib/@vibe/compiler/tests/perceus_rc_test.vibe
@@ -76,6 +76,21 @@ fn dup_binding_ids(plan: Array[PerceusAction], name: String) -> Array[Int] {
   out
 }
 
+fn dup_use_offsets(plan: Array[PerceusAction], name: String) -> Array[Int] {
+  let out: Array[Int] = []
+  let mut i = 0
+  while i < Array::length(plan) {
+    let a = Array::get(plan, i)
+    if pa_is_dup(a) && a.name == name {
+      Array::push(out, a.use_offset)
+    } else {
+      ()
+    }
+    i = i + 1
+  }
+  out
+}
+
 /// A heap binding only borrowed (field access) is dropped once at scope end.
 test "perceus: pure-borrow binding is dropped once" {
   // let t = (1, 2); t.0
@@ -421,13 +436,14 @@ test "perceus: branch-local shadow keeps its dups through the merge" {
   // let out = (1, 2); match out { _ => 0 };
   // if true { let out = (3, 4); (out, out) } else { out }
   let borrow_use = EMatch(EIdent("out", -1), [(PWild, EInt(0))])
-  let shadow_body = ETuple([EIdent("out", -1), EIdent("out", -1)])
+  let shadow_body = ETuple([EIdent("out", 202), EIdent("out", 303)])
   let then_e = ELet("out", ETuple([EInt(3), EInt(4)]), shadow_body, -1)
-  let tail = EIf(EBool(true), then_e, EIdent("out", -1))
+  let tail = EIf(EBool(true), then_e, EIdent("out", 404))
   let body = ELet("out", ETuple([EInt(1), EInt(2)]), ESeq(borrow_use, tail), -1)
   let plan = build_perceus_plan(body)
   // One dup for the shadow's double use + one for the outer else mention.
   inspect(count_dups(plan, "out"), "2")
   // The ESeq scratch binding is id 1, so the branch-local shadow is id 2.
   inspect(dup_binding_ids(plan, "out"), "[2, 0]")
+  inspect(dup_use_offsets(plan, "out"), "[202, 404]")
 }


### PR DESCRIPTION
Stacked on #2255. Part of #1980.

This adds the second contract coordinate needed for use-site RC realization:

- `PerceusAction.use_offset` records the owning `EIdent` source position for `PaDup`.
- Alias dups record their source-ident position.
- Closure-capture and scope-drop actions explicitly use `-1` because they do not correspond to a direct source use site.
- Tests pin both lexical binding identity and use-site identity across same-named shadows.

No codegen behavior changes in this slice. The following slice will split positioned dups from synthetic fallback dups and emit the positioned actions while compiling the owning `EIdent`.

Validation:
- Fresh stage2 self-host fixpoint passed.
- Perceus test file: 29/29 tests passed.
- Formatting and pre-commit structural gates passed.