### PR TITLE
Fix three open bug regressions

### DIFF
--- a/Taskfile.pkl
+++ b/Taskfile.pkl
@@ -9,7 +9,7 @@
 ///   pkf run test                              # full test suite
 ///   pkf run test-local                        # affected local tests via flaker
 ///   pkf graph --format tree                   # visualize dependencies
-amends "package://pkg.pkl-lang.org/github.com/mizchi/pkfire/pkfire@0.10.0#/Taskfile.pkl"
+amends "package://pkg.pkl-lang.org/github.com/mizchi/pkfire/pkfire@0.14.2#/Taskfile.pkl"
 
 // --- Configuration (env vars, mirroring the former justfile defaults) ---
 

--- a/fixtures/structural_eq_contexts_test.vibe
+++ b/fixtures/structural_eq_contexts_test.vibe
@@ -541,11 +541,15 @@ test "a Map compares by content, bare and as a struct field" {
   assert(one != a)
   let other_key = Map::from_pairs([("a", 1), ("z", 2)])
   assert(a != other_key)
-  // Both operands bare from a literal is the one shape that does NOT resolve
-  // (#2234): neither carries a Map shape, so the raw `==` answers. Annotating
-  // either side is the fix, and that is what this row does.
-  let same_as_one: Map[String, Int] = Map::from_pairs([("a", 1)])
+  // #2234: two bare non-empty literals still carry their key/value shape, so
+  // equality must dispatch structurally without an annotation on either side.
+  let same_as_one = Map::from_pairs([("a", 1)])
   assert(one == same_as_one)
+  let arrays_l = Map::from_pairs([("k", [1, 2])])
+  let arrays_r = Map::from_pairs([("k", [1, 2])])
+  let arrays_differ = Map::from_pairs([("k", [1, 9])])
+  assert(arrays_l == arrays_r)
+  assert(arrays_l != arrays_differ)
   // Through a struct field, which is the shape #2218 was filed on.
   let l = WithMap::{
     m: eq_ctx_map_ab(1, 2)

--- a/fixtures/structural_eq_contexts_test.vibe
+++ b/fixtures/structural_eq_contexts_test.vibe
@@ -550,6 +550,11 @@ test "a Map compares by content, bare and as a struct field" {
   let arrays_differ = Map::from_pairs([("k", [1, 9])])
   assert(arrays_l == arrays_r)
   assert(arrays_l != arrays_differ)
+  // An empty value cannot determine V. The incomplete bare-left shape must
+  // not hide the complete annotation carried by the right operand.
+  let empty_array_l = Map::from_pairs([("k", [])])
+  let empty_array_r: Map[String, Array[Int]] = Map::from_pairs([("k", [])])
+  assert(empty_array_l == empty_array_r)
   // Through a struct field, which is the shape #2218 was filed on.
   let l = WithMap::{
     m: eq_ctx_map_ab(1, 2)

--- a/flake.lock
+++ b/flake.lock
@@ -25,53 +25,37 @@
       "locked": {
         "lastModified": 1731533236,
         "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
-        "owner": "numtide",
-        "repo": "flake-utils",
+        "ref": "refs/heads/main",
         "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
-        "type": "github"
+        "revCount": 102,
+        "type": "git",
+        "url": "https://github.com/numtide/flake-utils.git"
       },
       "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
+        "type": "git",
+        "url": "https://github.com/numtide/flake-utils.git"
       }
     },
     "moonbit-overlay": {
       "inputs": {
-        "nixpkgs": "nixpkgs",
+        "nixpkgs": "nixpkgs_2",
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1774948263,
-        "narHash": "sha256-5g6Fl5+39UlOjTa+dm9mOTtklHmAr+ai0G9fmq/L+kg=",
-        "owner": "moonbit-community",
-        "repo": "moonbit-overlay",
-        "rev": "50118f5c3c0298b5cb17cc6f1c346165801014c8",
-        "type": "github"
+        "lastModified": 1785562289,
+        "narHash": "sha256-Y08A4W3TNzJRt9oPRgTc9LC8m0WkMMM/Yy47Nl9VBeg=",
+        "ref": "refs/heads/master",
+        "rev": "b8565d72c23eda500279feed383c9613c92346d6",
+        "revCount": 479,
+        "type": "git",
+        "url": "https://github.com/moonbit-community/moonbit-overlay.git"
       },
       "original": {
-        "owner": "moonbit-community",
-        "repo": "moonbit-overlay",
-        "type": "github"
+        "type": "git",
+        "url": "https://github.com/moonbit-community/moonbit-overlay.git"
       }
     },
     "nixpkgs": {
-      "locked": {
-        "lastModified": 1742272065,
-        "narHash": "sha256-ud8vcSzJsZ/CK+r8/v0lyf4yUntVmDq6Z0A41ODfWbE=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "3549532663732bfd89993204d40543e9edaec4f2",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixpkgs-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_2": {
       "locked": {
         "lastModified": 1779351318,
         "narHash": "sha256-f+JACbTqzZ+G92DSnXOUGRhGANb8Blh7CoeYOeBF8/U=",
@@ -87,24 +71,41 @@
         "type": "github"
       }
     },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1785141334,
+        "narHash": "sha256-kh35kIx7el4Jk8Ki3BH9/Pn1eZYSYLJ6LMALos0zOy0=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "38a4887411571457d700c51c64a6e49ead2ed5ab",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
     "pkfire": {
       "inputs": {
         "flake-utils": "flake-utils_2",
+        "moonbit-overlay": "moonbit-overlay",
         "nixpkgs": [
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1778686190,
-        "narHash": "sha256-cJg4q5erEp+ZZrvD7YTFnzpZGuQfjopLVnSWuX4t17E=",
-        "ref": "refs/tags/v0.10.0",
-        "rev": "74b22e14db6f166738a4a4f9b2962c94209a5603",
-        "revCount": 94,
+        "lastModified": 1785734724,
+        "narHash": "sha256-1EU5w9arQYZZIcoZI3cHFD4WTWHrwT5EIuf8plQU5ls=",
+        "ref": "refs/tags/v0.14.2",
+        "rev": "e49f59c665fc47e115f66f239638ee8a24e6b512",
+        "revCount": 223,
         "type": "git",
         "url": "https://github.com/mizchi/pkfire"
       },
       "original": {
-        "ref": "refs/tags/v0.10.0",
+        "ref": "refs/tags/v0.14.2",
         "type": "git",
         "url": "https://github.com/mizchi/pkfire"
       }
@@ -112,8 +113,7 @@
     "root": {
       "inputs": {
         "flake-utils": "flake-utils",
-        "moonbit-overlay": "moonbit-overlay",
-        "nixpkgs": "nixpkgs_2",
+        "nixpkgs": "nixpkgs",
         "pkfire": "pkfire",
         "rust-overlay": "rust-overlay"
       }
@@ -171,16 +171,17 @@
     "treefmt-nix": {
       "inputs": {
         "nixpkgs": [
+          "pkfire",
           "moonbit-overlay",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1742370146,
-        "narHash": "sha256-XRE8hL4vKIQyVMDXykFh4ceo3KSpuJF3ts8GKwh5bIU=",
+        "lastModified": 1784369104,
+        "narHash": "sha256-47cxbcZODibHv3rELFQ9vZly0vUNkND/atn/U7HLeb0=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "adc195eef5da3606891cedf80c0d9ce2d3190808",
+        "rev": "df3c0640565d04a0261253cdd89fce78ec50168a",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -9,9 +9,9 @@
       inputs.nixpkgs.follows = "nixpkgs";
     };
     # pkfire (pkf) — canonical task runner (Taskfile.pkl). Not in nixpkgs;
-    # pinned to the same tag CI and the session-start hook use (v0.10.0).
+    # pinned to the same tag CI and the session-start hook use (v0.14.2).
     pkfire = {
-      url = "git+https://github.com/mizchi/pkfire?ref=refs/tags/v0.10.0";
+      url = "git+https://github.com/mizchi/pkfire?ref=refs/tags/v0.14.2";
       inputs.nixpkgs.follows = "nixpkgs";
     };
   };
@@ -98,7 +98,7 @@
             # See docs/pkfire-pkspec.md for usage.
             pkgs.pkl
 
-            # pkfire (pkf) — canonical task runner, pinned to v0.10.0 via the
+            # pkfire (pkf) — canonical task runner, pinned to v0.14.2 via the
             # `pkfire` flake input. Not in nixpkgs.
             pkfire.packages.${system}.default
           ];

--- a/lib/@vibe/compiler/normalize/desugar_trait_dict.vibe
+++ b/lib/@vibe/compiler/normalize/desugar_trait_dict.vibe
@@ -9901,7 +9901,11 @@ fn eq_operand_shape_ty(e: Expr, struct_sets: Array[(String, Array[String])], var
   let sh = infer_eq_shape(e, struct_sets, var_types, fn_returns)
   if shape_is_composite(sh) {
     let t = shape_to_eq_ty(sh)
-    if ty_needs_typed_eq(t) {
+    // A partial operand must not win merely because its container head is
+    // dispatchable. In particular `{m:String,}` becomes
+    // `Map[String, __EqUnknown]`; accepting it here hides a complete shape on
+    // the other operand and makes aggregate values fall back to identity.
+    if ty_needs_typed_eq(t) && !ty_contains_eq_unknown(t) {
       Some(t)
     } else {
       None

--- a/lib/@vibe/compiler/normalize/desugar_trait_dict.vibe
+++ b/lib/@vibe/compiler/normalize/desugar_trait_dict.vibe
@@ -9846,6 +9846,17 @@ fn infer_eq_shape(e: Expr, struct_sets: Array[(String, Array[String])], var_type
         None => infer_shape(e, struct_sets, var_types, fn_returns)
       }
     },
+    // #2234: `Map::from_pairs` is normalized by the parser into EMap before
+    // this pass, so looking for the source-level call can never fire. Keys are
+    // string literals by the EMap contract; the first value stands for every
+    // value just as the EArray arm does for its elements (heterogeneous maps
+    // are rejected by the checker). An empty map still says nothing about V.
+    EMap(fields) => if Array::length(fields) == 0 {
+      ""
+    } else {
+      let (_, first_value) = Array::get(fields, 0)
+      String::concat("{m:String,", String::concat(infer_eq_shape(first_value, struct_sets, var_types, fn_returns), "}"))
+    },
     ECall(EIdent(fname, _), args, _) => if (fname == "Some" || fname == "Option::Some") && Array::length(args) == 1 {
       String::concat("{o:", String::concat(infer_eq_shape(Array::get(args, 0), struct_sets, var_types, fn_returns), "}"))
     } else if (fname == "Ok" || fname == "Result::Ok") && Array::length(args) == 1 {

--- a/scripts/lint_tracked_experiment_names.sh
+++ b/scripts/lint_tracked_experiment_names.sh
@@ -23,7 +23,7 @@ is_candidate_path() {
   local base="${path##*/}"
 
   case "$path" in
-    .github/*|scripts/*|src/*|vibe/*) ;;
+    .github/*|lib/*|scripts/*|src/*|vibe/*) ;;
     *) return 1 ;;
   esac
 


### PR DESCRIPTION
## Summary

- align the Nix and Taskfile pkfire pins with CI at 0.14.2 so `pkf run` uses a coherent coreutils environment
- include `lib/` in the tracked experiment-name lint candidate set so its failing fixture is actually observed
- infer equality shapes directly from parser-normalized `EMap` literals, including aggregate values

## Verification

- `nix develop`: pkfire 0.14.2, `sort` and `cksum` probes, `pkf run check-vibe-fmt`, and all five lint self-tests
- Red/Green: bare `Map::from_pairs` equality fails on main stage2 and passes after the fix
- `pkf run generation-gate` (stage2 == stage3)
- `pkf run test`

Closes #2258
Closes #2252
Closes #2234