### PR TITLE
fmt pin insertion (#730 D-3), #| cheatsheet section, round-4 measurements

### DIFF
--- a/docs/cheatsheet.md
+++ b/docs/cheatsheet.md
@@ -89,6 +89,56 @@ let b: Bool = true
 let u: Unit = ()
 ```
 
+### Multi-line raw strings (`#|`)
+
+`#|` spells an ordinary `String` literal (MoonBit-style). Each `#|` takes the
+rest of its physical line **verbatim** — no `\{}` interpolation, no `\n`/`\\`
+escape processing — and consecutive `#|` lines whose `#` sits at the **same
+column** join with `"\n"`. The first following line that does not start with
+`#|` simply ends the literal (that is not an error); a continuation `#|` at a
+*different* column is a located lex error, never a silently shorter block.
+Measured (2026-08-23):
+
+```vibe
+test "same column joins with newline" {
+  let s = #|line one
+          #|line two
+  assert_eq(s, "line one\nline two")
+}
+
+test "content is raw: no interpolation, no escapes" {
+  let s = #|no \{interp} and no \n escapes
+  assert_eq(s, "no \\{interp} and no \\n escapes")
+}
+
+test "an ordinary String: concat and length work" {
+  let s = #|ab
+          #|cd
+  assert_eq(String::length(s), 5)
+  assert_eq(String::concat(s, "!"), "ab\ncd!")
+}
+```
+
+Because the content runs to end of line, nothing else can share the line: a
+closing `)` or `,` after the text becomes part of the string, so `#|` works as
+a binding's right-hand side but not inline inside an argument list. Misaligned
+continuations are rejected with a position:
+
+```vibe skip
+// Both lines are deliberate errors (measured): the first swallows `)` into
+// the string, so the parser reports `expected ) but got }`; the second is
+// the located lex error "#| multi-line string continuation must start at
+// the same column as the opening #|".
+test "what NOT to write" {
+  assert_eq(#|hello, "hello")
+  let s = #|line one
+        #|misaligned
+}
+```
+
+The same alignment rule is what `.vpkg` `description` blocks reuse for their
+`#|` continuation lines (see the `index.vpkg` header section below).
+
 Int の範囲 (±2^61) を超える整数は `@vibe/core` の任意精度 `BigInt`
 (sign + 30-bit limbs) を使う — `parse`/`to_string`/`add`/`sub`/`mul`/`divmod`/`pow`:
 

--- a/docs/module-system-v2.md
+++ b/docs/module-system-v2.md
@@ -154,37 +154,43 @@ export ./syntax as syntax
   contract_hash を宣言ごとに細分化する拡張余地は残す (ADR-0004 の三層 ref
   とはこの点で接続する)。
 
-## 6. `require` — 1 行 = manifest + lock
+## 6. `require` — one line = manifest + lock
 
 ```vibe
-// index.vibei でも、単発スクリプトの先頭でも同じ構文
-require @vibe/core 1.2.3 = #ab12cd34      // bare triple = 完全一致
-require @vibe/http ^1.2.3 = #77aa02ef     // ^ は互換範囲 (full triple 必須)
+// Same syntax in an index.vibei and at the top of a one-off script
+require @vibe/core 1.2.3 = #ab12cd34      // bare triple = exact match
+require @vibe/http ^1.2.3 = #77aa02ef     // ^ = compatible range (full triple required)
 ```
 
-- **semver 表記は厳密**: 演算子は「なし (完全一致)」と `^` の 2 つだけ。
-  `^1` / `^1.2` / `~` / `>=` / `1.x` / `*` は parse error。制約はビルドに
-  使われない (真実は hash) ので grammar は最小でよい。
-- **直接依存だけ書く**。依存先の hash はその依存先自身の `require` 行を
-  含んで計算されるため、直接依存を pin した時点で推移閉包が固定される
-  (git commit hash が tree を固定するのと同じ)。**lock ファイルは廃止**
-  (`index.lock` は retire)。
-- **hash は fmt / normalize が挿入する**: `require @vibe/core 1.2.3` とだけ
-  書けば `vibe fmt` が `= #hash` を補完する (goimports 系の「コードを完成
-  させる formatter」)。**実装済み** (#730 D-3): 3 つの fmt entry すべて
-  (`vibe_fmt.sh` 単発 / batch = CI の `vibe-fmt-check` と `pkf run fmt` /
-  installed `vibe fmt`) が `fill_require_pins_lenient` (loader) で埋める。
-  ただし:
-  - **fmt はオフライン**。workspace store (`.vibe/store/<name>/`) から
-    引けるときだけ挿入。引けない行は verbatim のまま残す (現実装は
-    diagnostics を出さない — unpinned のまま build に渡れば build 側が
-    拒否する。`--check` での fail 化は未着手)。
-  - ネットワークを触るのは `vibe add` / `vibe update` / 初回 `vibe run` 側。
-  - **pinned form が正規形**。store が答えられる unpinned 行は `--check` で
-    DIFF になる。release-check の normalize gate が「コミットされるソースは
-    常に pinned」を強制する (これが実質の lock 検証)。
-- **重複検知と統一提案**: ビルドは解決しない。同名パッケージが複数 hash で
-  閉包に現れたら決定的エラー + 機械可読な衝突列挙 + 提案:
+- **semver spelling is strict**: the only operators are "none (exact)" and
+  `^`. `^1` / `^1.2` / `~` / `>=` / `1.x` / `*` are parse errors. The
+  constraint is never consumed by the build (the hash is the truth), so the
+  grammar stays minimal.
+- **Only direct dependencies are written.** A dependency's hash is computed
+  over its own `require` lines, so pinning the direct dependencies fixes the
+  transitive closure (the same way a git commit hash fixes a tree). **Lock
+  files are abolished** (`index.lock` is retired).
+- **The hash is inserted by fmt / normalize**: write just
+  `require @vibe/core 1.2.3` and `vibe fmt` completes the `= #hash`
+  (a goimports-style "formatter that completes the code"). **Implemented**
+  (#730 D-3): all three fmt entries (single-file `vibe_fmt.sh`, the batch
+  lane behind CI's `vibe-fmt-check` and `pkf run fmt`, and the installed
+  `vibe fmt`) fill via `fill_require_pins_lenient` (loader). Notes:
+  - **fmt is offline.** It fills only when the workspace store
+    (`.vibe/store/<name>/`) can answer; a line the store cannot answer is
+    left verbatim (the current implementation emits no diagnostic — an
+    unpinned require that reaches the build is rejected there; failing
+    `--check` over an unanswerable line is not yet implemented).
+  - Network access belongs to `vibe add` / `vibe update` / the first
+    `vibe run`, never to fmt.
+  - **The pinned form is canonical.** An unpinned line the store can answer
+    is a DIFF under `--check`. The release-check normalize gate enforces
+    "committed sources are always pinned" (this is the effective lock
+    verification).
+- **Duplicate detection with a unification hint**: the build never resolves
+  conflicts. When one package name appears in the closure under multiple
+  hashes, the answer is a deterministic error plus a machine-readable
+  conflict listing and a suggestion:
 
 ```
 error: duplicate package @vibe/core
@@ -193,13 +199,15 @@ error: duplicate package @vibe/core
 hint: require @vibe/core 1.2.5 = #cd34ef override
 ```
 
-- `require ... override` (root のみ) は全依存をその hash に統一する
-  (Nix `inputs.follows` 相当)。override 後の整合性は whole-program check が
-  検証する。
-- `vibe dedupe` が全制約を満たす最大バージョンを選び contract diff で互換を
-  確認して提案、`--apply` で書き込み。
-- content-addressing の副産物: 別名 vendoring された同一コード (package_hash
-  ないしファイル hash の一致) も検知して統一提案できる。
+- `require ... override` (root only) unifies every dependency onto that hash
+  (the Nix `inputs.follows` analogue). Post-override consistency is verified
+  by the whole-program check.
+- `vibe dedupe` picks the highest version satisfying every constraint,
+  confirms compatibility via contract diff, and proposes it; `--apply`
+  writes it.
+- A by-product of content addressing: identical code vendored under
+  different names (matching package_hash or file hash) is also detected and
+  proposed for unification.
 
 ## 7. `where` 契約節 — 段階導入
 

--- a/docs/module-system-v2.md
+++ b/docs/module-system-v2.md
@@ -177,10 +177,15 @@ require @vibe/http ^1.2.3 = #77aa02ef     // ^ = compatible range (full triple r
   lane behind CI's `vibe-fmt-check` and `pkf run fmt`, and the installed
   `vibe fmt`) fill via `fill_require_pins_lenient` (loader). Notes:
   - **fmt is offline.** It fills only when the workspace store
-    (`.vibe/store/<name>/`) can answer; a line the store cannot answer is
-    left verbatim (the current implementation emits no diagnostic — an
-    unpinned require that reaches the build is rejected there; failing
-    `--check` over an unanswerable line is not yet implemented).
+    (`.vibe/store/<name>/`) can answer AND the store copy's declared
+    version satisfies the constraint (exact match, or npm caret semantics
+    for `^`) — the pin is the truth the build verifies, so pinning an
+    installed copy beside a version it does not satisfy would make the
+    build run a release the source never asked for. An absent, versionless,
+    or mismatched copy leaves the line verbatim (the current implementation
+    emits no diagnostic — an unpinned require that reaches the build is
+    rejected there; failing `--check` over an unanswerable line is not yet
+    implemented).
   - Network access belongs to `vibe add` / `vibe update` / the first
     `vibe run`, never to fmt.
   - **The pinned form is canonical.** An unpinned line the store can answer

--- a/docs/module-system-v2.md
+++ b/docs/module-system-v2.md
@@ -184,9 +184,13 @@ require @vibe/http ^1.2.3 = #77aa02ef     // ^ = compatible range (full triple r
   - Network access belongs to `vibe add` / `vibe update` / the first
     `vibe run`, never to fmt.
   - **The pinned form is canonical.** An unpinned line the store can answer
-    is a DIFF under `--check`. The release-check normalize gate enforces
-    "committed sources are always pinned" (this is the effective lock
-    verification).
+    is a DIFF under `--check` — including in an `index.vpkg` header, whose
+    require directives fill the same way. The design also calls for the
+    release-check normalize gate to enforce "committed sources are always
+    pinned" (the effective lock verification); that half is **not yet
+    wired** — `vibe normalize` re-emits unpinned lines unchanged
+    (`normalize_source` deliberately leaves pin filling to the fmt/fill
+    lanes), so today `vibe fmt` is the only canonicalizer.
 - **Duplicate detection with a unification hint**: the build never resolves
   conflicts. When one package name appears in the closure under multiple
   hashes, the answer is a deterministic error plus a machine-readable

--- a/docs/module-system-v2.md
+++ b/docs/module-system-v2.md
@@ -171,12 +171,18 @@ require @vibe/http ^1.2.3 = #77aa02ef     // ^ は互換範囲 (full triple 必�
   (`index.lock` は retire)。
 - **hash は fmt / normalize が挿入する**: `require @vibe/core 1.2.3` とだけ
   書けば `vibe fmt` が `= #hash` を補完する (goimports 系の「コードを完成
-  させる formatter」)。ただし:
-  - **fmt はオフライン**。ローカル store / registry キャッシュから引ける
-    ときだけ挿入。引けなければ行を残して diagnostics (`--check` では fail)。
+  させる formatter」)。**実装済み** (#730 D-3): 3 つの fmt entry すべて
+  (`vibe_fmt.sh` 単発 / batch = CI の `vibe-fmt-check` と `pkf run fmt` /
+  installed `vibe fmt`) が `fill_require_pins_lenient` (loader) で埋める。
+  ただし:
+  - **fmt はオフライン**。workspace store (`.vibe/store/<name>/`) から
+    引けるときだけ挿入。引けない行は verbatim のまま残す (現実装は
+    diagnostics を出さない — unpinned のまま build に渡れば build 側が
+    拒否する。`--check` での fail 化は未着手)。
   - ネットワークを触るのは `vibe add` / `vibe update` / 初回 `vibe run` 側。
-  - **pinned form が正規形**。release-check の normalize gate が「コミット
-    されるソースは常に pinned」を強制する (これが実質の lock 検証)。
+  - **pinned form が正規形**。store が答えられる unpinned 行は `--check` で
+    DIFF になる。release-check の normalize gate が「コミットされるソースは
+    常に pinned」を強制する (これが実質の lock 検証)。
 - **重複検知と統一提案**: ビルドは解決しない。同名パッケージが複数 hash で
   閉包に現れたら決定的エラー + 機械可読な衝突列挙 + 提案:
 

--- a/eval/book-review/probes/p21_perform_optional.vibe
+++ b/eval/book-review/probes/p21_perform_optional.vibe
@@ -1,9 +1,10 @@
 // ch09 (round 2, R2-5): `perform?` types as Attempt but codegen cannot
 // lower it, so the compiler rejects it up front (#2145) -- the book
-// quotes the rejection. Measure the quote. SEED DIVERGENCE recorded in
-// rounds/2026-08-22-r2.md: stage2 rejects here (check AND build); the
-// committed seed accepts silently and only fails later. Re-measure
-// after the next seed bump.
+// quotes the rejection. Measure the quote. The r2/r3 seed divergence
+// (seed accepted silently, stage2 rejected) CLOSED with the
+// qualified-handler-syntax-2026-08-22 seed bump: measured 2026-08-23
+// (round 4), the committed seed now rejects with the same #2145
+// message, so both compilers answer alike here.
 fn main with () allows Console + Fs::read_file? {
   let a = perform? Fs::read_file("config.json")
   match a {

--- a/eval/book-review/rounds/2026-08-23-r4.md
+++ b/eval/book-review/rounds/2026-08-23-r4.md
@@ -1,0 +1,100 @@
+# book-review round 4 — 2026-08-23
+
+Follow-up to [2026-08-23-r3.md](2026-08-23-r3.md) §4: three candidates,
+all gated on external events at the time. The gating event — a bootstrap
+bump — happened the same day (`seed/qualified-handler-syntax-2026-08-22`,
+seed.json bump 8242aff via #2254), which resolves one candidate, splits a
+second, and left the third (fmt pin insertion) fully unblocked. Everything
+below is measured; the compiling seed is 77c4f98e… (source 475b8761).
+
+## 1. p21 (`perform?`) — the seed divergence is CLOSED
+
+Re-measured through the committed seed (`bash scripts/vibe_test.sh` on the
+probe): the seed now rejects `perform?` up front with the exemplary #2145
+message (`drop the `?` from `allows Fs::read_file?` … `perform?` is not
+lowered yet`), byte-identical to stage2's answer. The r2/r3 note ("seed
+accepts silently, defers to codegen") is retired; the probe's comment now
+records the closure instead of the divergence.
+
+## 2. #2219 (assert-abort ablk fallback) — still blocked, and now we know why
+
+The r3 note said the same bump would unblock #2219's legacy-fallback
+deletion. It did not: the bump's source commit 475b8761 (2026-08-22
+20:09 +0900, 11:09Z) predates #2213's marker merge (4b44aef, 13:55Z the
+same day) by about three hours. Verified two ways — the seed source has
+zero occurrences of `assert failed: aborting`, and a failing `assert_eq`
+compiled by the seed prints the failed/expected/actual block and traps
+with no marker line in the raw stream. So the consecutive-block (`ablk`)
+recognizers in `scripts/vibe_test.sh` and `runtime/vibe` stay, and the
+p21/#2219 pairing from r3 ("gated on the same event") was wrong by a
+three-hour window: one bump closed p21 and not #2219. Recorded on the
+issue; the deletion re-arms at the NEXT bump whose source contains
+`lower_assert_eq`'s marker.
+
+## 3. Phase D fmt pin insertion (#730 D-3) — landed
+
+The r3 condition "when the store side is ready" turned out to be already
+true: the by-name workspace store (`.vibe/store/<name>/`,
+`vibe_pkg.sh install --store`), the offline fill engine
+(`fill_require_pins_fs_mode`, loader), and the strict adapter lane
+(`VIBE_FILL_PINS=1`) all existed — what was missing was exactly the slot
+r3 named: no fmt entry called any of it (the launcher only *unsets* the
+env var).
+
+Landed in this round's PR:
+
+- `fill_require_pins_lenient` (loader): the fmt lane's fill. Same store
+  lookup as the strict lane, but TOTAL — a package absent from the store
+  leaves its `require` line verbatim (fetching belongs to
+  `vibe add`/`update`), and any error along the way returns the source
+  unchanged. Not filling is not wrong (the build still refuses an
+  unpinned require); aborting the format over it would be.
+- All three fmt entries fill before formatting: `fmt_entry.vibe`
+  (`vibe_fmt.sh`), the `fmt.vibe` batch lane (CI's `vibe-fmt-check`,
+  `pkf run fmt`), and `cli_adapter`'s installed `vibe fmt`. `.vpkg` files
+  are exempt (their headers have their own writer and carry `deps`, not
+  pins). The parse guard's head boundary comes from the filled source,
+  so its body question is unchanged.
+
+Measured, single-file lane: `require @r2probe/demo 0.1.0` came back
+`require @r2probe/demo 0.1.0 = #pkg:sha1:dfd1c758…` with the body
+formatted, a `--check` fixpoint; an uninstalled package's line came back
+byte-identical with exit 0. Batch lane: same fill, reported `DIFF`.
+End-to-end: the filled pin is exactly the hash the loader verifies —
+the build of a file importing the store package succeeds and runs
+(prints 6), and corrupting one hex digit fails with
+`pin mismatch … requires #pkg:sha1:000000… but the store copy is
+#pkg:sha1:dfd1c758…`. Pinned in `scripts/vibe_fmt_parse_guard_test.sh`
+(fill + fixpoint + absent-package + batch lane, against a store fixture
+the test creates itself — the workspace store is gitignored).
+
+Not implemented (recorded in module-system-v2 §6): diagnostics /
+`--check` failure for a require the store cannot answer. Today the line
+is left silently and the build is the enforcement point; making
+unanswerable pins loud in `--check` is a separate slice.
+
+## 4. The `#|` multi-line string now has a language-side home
+
+r3 §4's last item: the rule existed only as an aside in the cheatsheet's
+`.vpkg` section. Measured the language-side behavior (4 passing tests +
+2 deliberate errors) and wrote it up as "Multi-line raw strings (`#|`)"
+under the cheatsheet's Values & Types: same-column continuation joined
+with `\n`, verbatim content (no interpolation, no escapes), a
+non-`#|` line ends the block, a misaligned continuation is a located lex
+error, and — found while measuring — the content runs to end of line, so
+`assert_eq(#|hello, "hello")` swallows the `)` and cannot work inline in
+an argument list. The doctest run over the edited cheatsheet is green
+(36 pass, 0 fail), so the examples are held by the gate; the `.vpkg`
+section's "same alignment rule" aside now has a section to point at.
+
+## 5. Round 5 candidates
+
+- #2219's fallback deletion re-arms at the next bootstrap bump whose
+  source includes 4b44aef (the marker); check the bump's `source_commit`
+  against that hash before starting.
+- Make an unanswerable `require` loud in fmt `--check` (the deferred
+  half of §6's design) once the desired report shape for the batch lane
+  (`ERROR` row vs `DIFF`) is decided.
+- The seed's condensed assert report renders `actual:` as
+  `<unprintable>` for a plain Int on the failing-test lane (seen while
+  probing the marker); stage2 may already differ — worth one measurement.

--- a/eval/book-review/rounds/2026-08-23-r4.md
+++ b/eval/book-review/rounds/2026-08-23-r4.md
@@ -48,13 +48,24 @@ Landed in this round's PR:
   leaves its `require` line verbatim (fetching belongs to
   `vibe add`/`update`), and any error along the way returns the source
   unchanged. Not filling is not wrong (the build still refuses an
-  unpinned require); aborting the format over it would be.
+  unpinned require); aborting the format over it would be. The fill also
+  refuses to pin a store copy whose declared version does not satisfy
+  the constraint (Codex round 4): the pin is the truth the build
+  verifies, so pinning the installed 0.1.0 beside a claimed 0.2.0 would
+  make the build run a release the source never asked for. Versionless
+  and mismatched copies leave the line verbatim.
 - All three fmt entries fill before formatting: `fmt_entry.vibe`
   (`vibe_fmt.sh`), the `fmt.vibe` batch lane (CI's `vibe-fmt-check`,
-  `pkf run fmt`), and `cli_adapter`'s installed `vibe fmt`. `.vpkg` files
-  are exempt (their headers have their own writer and carry `deps`, not
-  pins). The parse guard's head boundary comes from the filled source,
-  so its body question is unchanged.
+  `pkf run fmt`), and `cli_adapter`'s installed `vibe fmt`. `.vpkg`
+  contracts fill too (Codex round 3 — their headers carry `require`
+  directives and `format_vpkg` re-emits them; an earlier revision
+  exempted them, which left a formatted contract unpinned while
+  `--check` said success). Which lines are require directives is decided
+  by the loader's own header scanner — extract_require_pins blanks every
+  recognized directive byte-length-preserving, so the fill needs no
+  second region scan that could drift from the grammar. The parse
+  guard's head boundary comes from the filled source, so its body
+  question is unchanged.
 
 Measured, single-file lane: `require @r2probe/demo 0.1.0` came back
 `require @r2probe/demo 0.1.0 = #pkg:sha1:dfd1c758…` with the body

--- a/lib/@vibe/cli/fmt.vibe
+++ b/lib/@vibe/cli/fmt.vibe
@@ -42,6 +42,10 @@ import ../compiler/fmt {
   format_source
 }
 
+import ../compiler/loader {
+  fill_require_pins_lenient
+}
+
 import ../process {
   sh_capture
 }
@@ -104,9 +108,24 @@ fn read_manifest(path: String) -> Array[String] with Fs {
 //# Sequential formatting (always the actual work -- shards just call this
 //# recursively on a slice of the manifest).
 
+fn path_is_vpkg(path: String) -> Bool {
+  let n = String::length(path)
+  n >= 5 && String::substring(path, n - 5, n) == ".vpkg"
+}
+
 fn format_one_line(mode: String, rel_path: String) -> String with Fs {
   let source = Fs::read_file(rel_path)
-  let formatted = format_source(rel_path, source)
+  // #730 (D-3): pinned form is canonical -- complete an unpinned leading
+  // `require` line from the workspace store when it can answer offline
+  // (best-effort; an uninstalled package leaves its line verbatim). Check
+  // mode reports the fillable file as DIFF via the comparison below, which
+  // is exactly "not canonical yet".
+  let pre = if path_is_vpkg(rel_path) {
+    source
+  } else {
+    fill_require_pins_lenient(source)
+  }
+  let formatted = format_source(rel_path, pre)
   let is_fixpoint = formatted == source
   if mode == "write" && !is_fixpoint {
     Fs::write_file(rel_path, formatted)

--- a/lib/@vibe/cli/fmt.vibe
+++ b/lib/@vibe/cli/fmt.vibe
@@ -108,23 +108,14 @@ fn read_manifest(path: String) -> Array[String] with Fs {
 //# Sequential formatting (always the actual work -- shards just call this
 //# recursively on a slice of the manifest).
 
-fn path_is_vpkg(path: String) -> Bool {
-  let n = String::length(path)
-  n >= 5 && String::substring(path, n - 5, n) == ".vpkg"
-}
-
 fn format_one_line(mode: String, rel_path: String) -> String with Fs {
   let source = Fs::read_file(rel_path)
-  // #730 (D-3): pinned form is canonical -- complete an unpinned leading
-  // `require` line from the workspace store when it can answer offline
-  // (best-effort; an uninstalled package leaves its line verbatim). Check
-  // mode reports the fillable file as DIFF via the comparison below, which
-  // is exactly "not canonical yet".
-  let pre = if path_is_vpkg(rel_path) {
-    source
-  } else {
-    fill_require_pins_lenient(source)
-  }
+  // #730 (D-3): pinned form is canonical -- complete an unpinned `require`
+  // directive from the workspace store when it can answer offline
+  // (best-effort; an uninstalled package leaves its line verbatim). `.vpkg`
+  // headers included (#2260 round 3). Check mode reports the fillable file
+  // as DIFF via the comparison below, which is exactly "not canonical yet".
+  let pre = fill_require_pins_lenient(source)
   let formatted = format_source(rel_path, pre)
   let is_fixpoint = formatted == source
   if mode == "write" && !is_fixpoint {

--- a/lib/@vibe/cli/fmt_entry.vibe
+++ b/lib/@vibe/cli/fmt_entry.vibe
@@ -32,6 +32,10 @@ import ../compiler/fmt {
   format_source, source_header_end
 }
 
+import ../compiler/loader {
+  fill_require_pins_lenient
+}
+
 import ../parser {
   lex, parse_program
 }
@@ -57,24 +61,36 @@ export fn main() -> Int with Fs + Env + Stderr {
   let input = Env::args_get(0)
   let output = Env::args_get(1)
   let src = Fs::read_file(input)
+  // #730 (D-3): pinned form is canonical, so fmt completes an unpinned
+  // `require @scope/name x.y.z` head line with `= #hash` when the package is
+  // installed in the workspace store -- offline, best-effort (a package the
+  // store cannot answer leaves its line verbatim; fetching belongs to
+  // `vibe add`/`update`). Runs BEFORE format_source so the reattached-verbatim
+  // head is the filled one; the body is untouched either way.
+  let pre = if has_suffix(input, ".vpkg") {
+    src
+  } else {
+    fill_require_pins_lenient(src)
+  }
   // format_source dispatches on the extension: `.vpkg` package contracts get
   // the canonical header writer, plain vibe sources get the verbatim
   // require-head split (#1435, #2253 round 6).
-  let formatted = format_source(input, src)
+  let formatted = format_source(input, pre)
   // The head is reattached verbatim, so the body of both source and output
   // starts at the same boundary; -1 (refused head) and 0 (no head) both mean
-  // "the body is the whole file".
+  // "the body is the whole file". The boundary comes from the FILLED source
+  // (pin filling changes head-line lengths, never the body).
   let head_end = if has_suffix(input, ".vpkg") {
     0
   } else {
-    let e = source_header_end(src)
+    let e = source_header_end(pre)
     if e > 0 {
       e
     } else {
       0
     }
   }
-  let body = String::substring(src, head_end, String::length(src))
+  let body = String::substring(pre, head_end, String::length(pre))
   let formatted_body = String::substring(formatted, head_end, String::length(formatted))
   // A `.vpkg` header is not vibe syntax, so a whole-file parse never succeeds
   // for one and the comparison below would say nothing. format_vpkg already

--- a/lib/@vibe/cli/fmt_entry.vibe
+++ b/lib/@vibe/cli/fmt_entry.vibe
@@ -65,13 +65,11 @@ export fn main() -> Int with Fs + Env + Stderr {
   // `require @scope/name x.y.z` head line with `= #hash` when the package is
   // installed in the workspace store -- offline, best-effort (a package the
   // store cannot answer leaves its line verbatim; fetching belongs to
-  // `vibe add`/`update`). Runs BEFORE format_source so the reattached-verbatim
-  // head is the filled one; the body is untouched either way.
-  let pre = if has_suffix(input, ".vpkg") {
-    src
-  } else {
-    fill_require_pins_lenient(src)
-  }
+  // `vibe add`/`update`). Applies to `.vpkg` contracts too -- their headers
+  // carry require directives and format_vpkg re-emits them (#2260 round 3).
+  // Runs BEFORE format_source so the reattached-verbatim head (or the
+  // canonical vpkg header) is the filled one; the body is untouched.
+  let pre = fill_require_pins_lenient(src)
   // format_source dispatches on the extension: `.vpkg` package contracts get
   // the canonical header writer, plain vibe sources get the verbatim
   // require-head split (#1435, #2253 round 6).

--- a/lib/@vibe/compiler/cli_adapter.vibe
+++ b/lib/@vibe/compiler/cli_adapter.vibe
@@ -1441,14 +1441,11 @@ export fn cli_main() -> Int with Exception + Fs + Env + Stdin + Stdout {
   if Env::get("VIBE_FMT") == "1" {
     let src = Fs::read_file(input_path)
     // #730 (D-3): pinned form is canonical, so fmt completes an unpinned
-    // leading `require` line with `= #hash` when the workspace store can
+    // `require` directive with `= #hash` when the workspace store can
     // answer offline (best-effort; an uninstalled package leaves its line
-    // verbatim -- fetching belongs to `vibe add`/`update`).
-    let fmt_pre = if adapter_path_has_suffix(input_path, ".vpkg") {
-      src
-    } else {
-      fill_require_pins_lenient(src)
-    }
+    // verbatim -- fetching belongs to `vibe add`/`update`). `.vpkg` headers
+    // included (#2260 round 3).
+    let fmt_pre = fill_require_pins_lenient(src)
     // format_source dispatches on the extension: `.vpkg` package contracts
     // get the canonical header writer, plain vibe sources get the verbatim
     // require-head split (#1435, #2253 round 6).

--- a/lib/@vibe/compiler/cli_adapter.vibe
+++ b/lib/@vibe/compiler/cli_adapter.vibe
@@ -56,6 +56,7 @@ import @vibe/compiler/loader {
   collect_source_groups_fs,
   contract_package_hashes_fs,
   fill_require_pins_fs_mode,
+  fill_require_pins_lenient,
   find_deps_missing,
   find_missing_vpkg_dirs,
   ingest_source_text_fs,
@@ -1439,10 +1440,19 @@ export fn cli_main() -> Int with Exception + Fs + Env + Stdin + Stdout {
   // is how a refusal once looked exactly like "nothing to change" (#1821).
   if Env::get("VIBE_FMT") == "1" {
     let src = Fs::read_file(input_path)
+    // #730 (D-3): pinned form is canonical, so fmt completes an unpinned
+    // leading `require` line with `= #hash` when the workspace store can
+    // answer offline (best-effort; an uninstalled package leaves its line
+    // verbatim -- fetching belongs to `vibe add`/`update`).
+    let fmt_pre = if adapter_path_has_suffix(input_path, ".vpkg") {
+      src
+    } else {
+      fill_require_pins_lenient(src)
+    }
     // format_source dispatches on the extension: `.vpkg` package contracts
     // get the canonical header writer, plain vibe sources get the verbatim
     // require-head split (#1435, #2253 round 6).
-    let formatted = format_source(input_path, src)
+    let formatted = format_source(input_path, fmt_pre)
     // A `.vpkg` header is not vibe syntax, so a whole-file parse never
     // succeeds for one and the comparison would say nothing. format_vpkg
     // already refuses to touch a header it cannot read -- the same policy
@@ -1458,14 +1468,14 @@ export fn cli_main() -> Int with Exception + Fs + Env + Stdin + Stdout {
     let fmt_head_end = if adapter_path_has_suffix(input_path, ".vpkg") {
       0
     } else {
-      let e = source_header_end(src)
+      let e = source_header_end(fmt_pre)
       if e > 0 {
         e
       } else {
         0
       }
     }
-    let fmt_body = String::substring(src, fmt_head_end, String::length(src))
+    let fmt_body = String::substring(fmt_pre, fmt_head_end, String::length(fmt_pre))
     let fmt_formatted_body = String::substring(formatted, fmt_head_end, String::length(formatted))
     if !adapter_path_has_suffix(input_path, ".vpkg") && adapter_program_parses(fmt_body) && !adapter_program_parses(fmt_formatted_body) {
       Fs::write_bytes(output_path, adapter_string_to_bytes(src))

--- a/lib/@vibe/compiler/contract/contract.vibe
+++ b/lib/@vibe/compiler/contract/contract.vibe
@@ -2157,7 +2157,7 @@ fn digits_to_int(raw: String) -> Int {
   result
 }
 
-fn semver_parts(v: String) -> Option[(Int, Int, Int)] {
+export fn semver_parts(v: String) -> Option[(Int, Int, Int)] {
   if is_strict_semver(v) && !String::starts_with(v, "^") {
     let parts = String::split(v, ".")
     Some((digits_to_int(Array::get(parts, 0)), digits_to_int(Array::get(parts, 1)), digits_to_int(Array::get(parts, 2))))

--- a/lib/@vibe/compiler/contract/contract.vibe
+++ b/lib/@vibe/compiler/contract/contract.vibe
@@ -1444,7 +1444,10 @@ export fn package_hash_from_sources(sources: Array[(String, String)]) -> String 
 // and therefore diagnostics — are preserved (same philosophy as #cfg's
 // tail-append). semver is strict: bare x.y.z or ^x.y.z, full triple only.
 // The constraint is edit-time tooling metadata; the build consumes only the
-// hash. The hash is REQUIRED here until fmt pin-insertion lands (D-3).
+// hash. The unpinned 3-field form is accepted at parse so `vibe fmt` can
+// complete it offline from the workspace store (D-3, fill_require_pins_lenient
+// in loader/loader.vibe); the BUILD still refuses to resolve an unpinned
+// package (hash-only, resolver-free).
 //
 // #1128: the leading directive region additionally carries the package
 // HEADER itself (`index.vpkg` only, though nothing here special-cases the

--- a/lib/@vibe/compiler/contract/index.vpkg
+++ b/lib/@vibe/compiler/contract/index.vpkg
@@ -84,4 +84,5 @@ fn deps_missing_for_imports(deps: Array[(String, String)], impl_sources: Array[S
 fn contract_surface_lines(fn_decls: Array[(String, String)], opaque_names: Array[(String, Int)], type_defs: Array[Stmt]) -> Array[String]
 fn classify_contract_change(old_lines: Array[String], new_lines: Array[String]) -> String
 fn semver_bump_kind(prev: String, next: String) -> Option[String]
+fn semver_parts(v: String) -> Option[(Int, Int, Int)]
 fn verify_publish_bump(prev_version: String, next_version: String, old_lines: Array[String], new_lines: Array[String]) -> Array[String]

--- a/lib/@vibe/compiler/loader/index.vpkg
+++ b/lib/@vibe/compiler/loader/index.vpkg
@@ -107,6 +107,7 @@ fn check_module(source: String, path: String, sources: Array[(String, String)], 
 fn contract_package_hashes_fs(path: String) -> (String, String) with Exception + Fs
 fn fill_require_pins_fs(source: String) -> String with Exception + Fs
 fn fill_require_pins_fs_mode(source: String, repin: Bool) -> String with Exception + Fs
+fn fill_require_pins_lenient(source: String) -> String with Fs
 fn publish_check_fs(prev_contract_path: String, next_contract_path: String, prev_version: String, next_version: String) -> Array[String] with Exception + Fs
 fn collect_all_sources_fs(entry_path: String) -> Array[(String, String)] with Exception + Fs
 fn collect_source_groups_fs(entry_path: String) -> Array[(String, Array[(String, String)])] with Exception + Fs

--- a/lib/@vibe/compiler/loader/loader.vibe
+++ b/lib/@vibe/compiler/loader/loader.vibe
@@ -2257,6 +2257,26 @@ export fn fill_require_pins_lenient(source: String) -> String with Fs {
   } with { Exception::Throw(_) => source }
 }
 
+/// digits_to_int (behind semver_parts) folds digit runs with the wrapping
+/// 63-bit arithmetic every Int operation has (#1877), so a long-enough
+/// component wraps -- `^0.1.4611686018427387904` gets a NEGATIVE patch
+/// bound and an installed 0.1.0 "satisfies" it (#2260 round 6, measured).
+/// 18 decimal digits max out below 2^62-1, so components up to that length
+/// convert exactly; anything longer is unverifiable and never fills.
+fn semver_components_convert_exactly(v: String) -> Bool {
+  let start = if String::starts_with(v, "^") {
+    1
+  } else {
+    0
+  }
+  let parts = String::split(String::substring(v, start, String::length(v)), ".")
+  if Array::length(parts) != 3 {
+    false
+  } else {
+    String::length(Array::get(parts, 0)) <= 18 && String::length(Array::get(parts, 1)) <= 18 && String::length(Array::get(parts, 2)) <= 18
+  }
+}
+
 /// Does the store copy's declared version satisfy a require constraint?
 /// The grammar (ADR-0063 §6) has exactly two operators: none (exact match)
 /// and `^` (compatible range, npm caret semantics: the leftmost non-zero
@@ -2265,6 +2285,9 @@ export fn fill_require_pins_lenient(source: String) -> String with Fs {
 /// the exact triple satisfies, #2260 round 5). An empty or non-triple
 /// declared version satisfies nothing -- unverifiable never fills.
 fn require_constraint_satisfied(constraint: String, version: String) -> Bool {
+  if !semver_components_convert_exactly(constraint) || !semver_components_convert_exactly(version) {
+    return false
+  }
   match semver_parts(version) {
     None => false,
     Some(vparts) => {

--- a/lib/@vibe/compiler/loader/loader.vibe
+++ b/lib/@vibe/compiler/loader/loader.vibe
@@ -2256,11 +2256,20 @@ export fn fill_require_pins_lenient(source: String) -> String with Fs {
   } with { Exception::Throw(_) => source }
 }
 
+// Which lines are require directives is decided by the loader's own header
+// scanner, not by a second region scan here (#2260 Codex round 3): the
+// scanner blanks every recognized directive line to spaces with byte length
+// preserved, so a line that starts with `require ` in the source and is
+// all-blank in the blanked output IS a recognized require directive --
+// including one sitting after `name =`/`version =`/`deps = { .. }` in an
+// `index.vpkg` header, which a "stop at the first non-require line" scan
+// (this function's previous shape) never reached. A `require`-looking line
+// the scanner did NOT blank (i.e. body text) is left alone.
 fn fill_require_pins_impl(source: String, repin: Bool, lenient: Bool) -> String with Exception + Fs {
+  let (_, blanked) = extract_require_pins(source)
   let sb = StringBuilder::new()
   let len = String::length(source)
   let mut pos = 0
-  let mut scanning = true
   while pos < len {
     let mut nl = pos
     while nl < len && String::char_code_at(source, nl) != 10 {
@@ -2269,7 +2278,7 @@ fn fill_require_pins_impl(source: String, repin: Bool, lenient: Bool) -> String 
     let line = String::substring(source, pos, nl)
     let trimmed = String::trim(line)
     let mut emitted = false
-    if scanning && String::starts_with(trimmed, "require ") {
+    if String::starts_with(trimmed, "require ") && String::length(String::trim(String::substring(blanked, pos, nl))) == 0 {
       let (pins_one, _) = extract_require_pins(String::concat(trimmed, "\n"))
       if Array::length(pins_one) == 1 {
         let (pname, pver, ppin) = Array::get(pins_one, 0)
@@ -2296,13 +2305,7 @@ fn fill_require_pins_impl(source: String, repin: Bool, lenient: Bool) -> String 
           }
         } else ()
       } else ()
-    } else {
-      if String::length(trimmed) == 0 || String::starts_with(trimmed, "//") {
-        ()
-      } else {
-        scanning = false
-      }
-    }
+    } else ()
     if emitted {
       ()
     } else {

--- a/lib/@vibe/compiler/loader/loader.vibe
+++ b/lib/@vibe/compiler/loader/loader.vibe
@@ -2237,6 +2237,26 @@ export fn fill_require_pins_fs(source: String) -> String with Exception + Fs {
 /// by-name store there is one installed version per package, so repinning
 /// IS conflict resolution.
 export fn fill_require_pins_fs_mode(source: String, repin: Bool) -> String with Exception + Fs {
+  fill_require_pins_impl(source, repin, false)
+}
+
+/// The `vibe fmt` lane's fill (#730 D-3): the same offline store lookup as
+/// fill_require_pins_fs, but TOTAL. fmt must format the body whatever the
+/// state of the store, so a package absent from the store leaves its
+/// require line verbatim instead of failing the run, and any error along
+/// the way (a malformed require line the head classifier will refuse
+/// anyway, a store copy the hasher rejects) returns the source unchanged.
+/// Not filling is not wrong -- the build still refuses to resolve an
+/// unpinned require -- whereas aborting the format over it would be; the
+/// strict lane (VIBE_FILL_PINS, above) keeps the loud answer for callers
+/// who asked for pins specifically.
+export fn fill_require_pins_lenient(source: String) -> String with Fs {
+  handle {
+    fill_require_pins_impl(source, false, true)
+  } with { Exception::Throw(_) => source }
+}
+
+fn fill_require_pins_impl(source: String, repin: Bool, lenient: Bool) -> String with Exception + Fs {
   let sb = StringBuilder::new()
   let len = String::length(source)
   let mut pos = 0
@@ -2264,13 +2284,16 @@ export fn fill_require_pins_fs_mode(source: String, repin: Bool) -> String with 
             store_index_vibei
           }
           if Fs::exists(store_index) {
+            let (pkg_hash, _) = contract_package_hashes_fs(store_index)
+            StringBuilder::push(sb, "require \{pname} \{pver} = #\{pkg_hash}")
+            emitted = true
+          } else if lenient {
+            // fmt lane: leave the unpinned line for the build to reject;
+            // fetching belongs to `vibe add`/`update`, never to fmt.
             ()
           } else {
             throw("cannot pin \{pname} offline: not installed in the store (.vibe/store/\{pname}/)")
           }
-          let (pkg_hash, _) = contract_package_hashes_fs(store_index)
-          StringBuilder::push(sb, "require \{pname} \{pver} = #\{pkg_hash}")
-          emitted = true
         } else ()
       } else ()
     } else {

--- a/lib/@vibe/compiler/loader/loader.vibe
+++ b/lib/@vibe/compiler/loader/loader.vibe
@@ -2259,10 +2259,11 @@ export fn fill_require_pins_lenient(source: String) -> String with Fs {
 
 /// Does the store copy's declared version satisfy a require constraint?
 /// The grammar (ADR-0063 §6) has exactly two operators: none (exact match)
-/// and `^` (compatible range, npm caret semantics: same major and >= the
-/// triple; for major 0 the minor is the compatibility line, so same minor
-/// and >= patch). An empty or non-triple declared version satisfies
-/// nothing -- unverifiable never fills.
+/// and `^` (compatible range, npm caret semantics: the leftmost non-zero
+/// digit is the compatibility line -- same major and >= the triple; for
+/// major 0 same minor and >= patch; for 0.0.z the patch itself, so only
+/// the exact triple satisfies, #2260 round 5). An empty or non-triple
+/// declared version satisfies nothing -- unverifiable never fills.
 fn require_constraint_satisfied(constraint: String, version: String) -> Bool {
   match semver_parts(version) {
     None => false,
@@ -2275,6 +2276,8 @@ fn require_constraint_satisfied(constraint: String, version: String) -> Bool {
             let (cmaj, cmin, cpat) = cparts
             if vmaj != cmaj {
               false
+            } else if cmaj == 0 && cmin == 0 {
+              vmin == 0 && vpat == cpat
             } else if cmaj == 0 {
               vmin == cmin && vpat >= cpat
             } else if vmin != cmin {

--- a/lib/@vibe/compiler/loader/loader.vibe
+++ b/lib/@vibe/compiler/loader/loader.vibe
@@ -70,6 +70,7 @@ import @vibe/compiler/contract {
   package_hash_from_sources,
   parse_contract_program,
   replace_generated_hash_directive,
+  semver_parts,
   verify_publish_bump,
   vpkg_shared_import_marker
 }
@@ -2256,6 +2257,40 @@ export fn fill_require_pins_lenient(source: String) -> String with Fs {
   } with { Exception::Throw(_) => source }
 }
 
+/// Does the store copy's declared version satisfy a require constraint?
+/// The grammar (ADR-0063 §6) has exactly two operators: none (exact match)
+/// and `^` (compatible range, npm caret semantics: same major and >= the
+/// triple; for major 0 the minor is the compatibility line, so same minor
+/// and >= patch). An empty or non-triple declared version satisfies
+/// nothing -- unverifiable never fills.
+fn require_constraint_satisfied(constraint: String, version: String) -> Bool {
+  match semver_parts(version) {
+    None => false,
+    Some(vparts) => {
+      let (vmaj, vmin, vpat) = vparts
+      if String::starts_with(constraint, "^") {
+        match semver_parts(String::substring(constraint, 1, String::length(constraint))) {
+          None => false,
+          Some(cparts) => {
+            let (cmaj, cmin, cpat) = cparts
+            if vmaj != cmaj {
+              false
+            } else if cmaj == 0 {
+              vmin == cmin && vpat >= cpat
+            } else if vmin != cmin {
+              vmin > cmin
+            } else {
+              vpat >= cpat
+            }
+          }
+        }
+      } else {
+        constraint == version
+      }
+    }
+  }
+}
+
 // Which lines are require directives is decided by the loader's own header
 // scanner, not by a second region scan here (#2260 Codex round 3): the
 // scanner blanks every recognized directive line to spaces with byte length
@@ -2293,9 +2328,23 @@ fn fill_require_pins_impl(source: String, repin: Bool, lenient: Bool) -> String 
             store_index_vibei
           }
           if Fs::exists(store_index) {
-            let (pkg_hash, _) = contract_package_hashes_fs(store_index)
-            StringBuilder::push(sb, "require \{pname} \{pver} = #\{pkg_hash}")
-            emitted = true
+            // #2260 Codex round 4: the pin is the truth the build verifies,
+            // so writing the installed copy's hash beside a version it does
+            // not satisfy would make the build accept and run a release the
+            // source never asked for -- silently. Fill only when the store
+            // copy DECLARES a version and it satisfies the constraint; a
+            // versionless or mismatched copy leaves the line for `vibe
+            // add`/`update` (lenient) or reports both versions (strict).
+            let store_version = extract_package_version(Fs::read_file(store_index))
+            if require_constraint_satisfied(pver, store_version) {
+              let (pkg_hash, _) = contract_package_hashes_fs(store_index)
+              StringBuilder::push(sb, "require \{pname} \{pver} = #\{pkg_hash}")
+              emitted = true
+            } else if lenient {
+              ()
+            } else {
+              throw("cannot pin \{pname}: the store copy declares version '\{store_version}' which does not satisfy the required \{pver} (install the matching release with `vibe add`/`update`, or fix the require line)")
+            }
           } else if lenient {
             // fmt lane: leave the unpinned line for the build to reject;
             // fetching belongs to `vibe add`/`update`, never to fmt.

--- a/scripts/ensure_entry_wasm.sh
+++ b/scripts/ensure_entry_wasm.sh
@@ -8,12 +8,22 @@
 #
 # The closure comes from the compiler's own module plan (VIBE_MODULE_PLAN,
 # the same resolution `vibe deps` reports), captured into a sibling
-# `<wasm>.deps` manifest at build time. A change that alters the import
-# graph necessarily edits a file already IN the old closure, so checking
-# mtimes of the captured manifest is sound: that edit triggers the rebuild,
-# and the rebuild recaptures the closure. A manifest that cannot be
-# produced is simply not written, which leaves the artifact permanently
-# stale -- always-rebuild is the safe failure mode, never stale-reuse.
+# `<wasm>.deps` manifest at build time. Three staleness signals cover the
+# ways the closure can drift (#2260 Codex round 2 -- mtimes of the old path
+# set alone do not):
+#   1. a recorded file newer than the wasm -- an edit anywhere in the old
+#      closure, which is also how every import-graph change made BY editing
+#      reaches us;
+#   2. a recorded file that no longer exists -- deletions and renames,
+#      where -nt alone would answer "fresh";
+#   3. a closure member's parent DIRECTORY newer than the wasm -- the
+#      loader auto-discovers `.vpkg` sibling implementations, so a newly
+#      created file can join the closure without any recorded file
+#      changing; creating/removing/renaming an entry updates its
+#      directory's mtime.
+# A manifest that cannot be produced is simply not written, which leaves
+# the artifact permanently stale -- always-rebuild is the safe failure
+# mode, never stale-reuse.
 #
 # Usage: ensure_entry_wasm.sh <entry_src_rel> <wasm_rel>
 # Prints the repo-root-relative wasm path on stdout; all build noise on
@@ -37,13 +47,25 @@ if [ ! -s "$ROOT_DIR/$wasm_rel" ] || [ ! -s "$ROOT_DIR/$deps_rel" ] \
    || [ "$seed" -nt "$ROOT_DIR/$wasm_rel" ]; then
   stale=1
 else
+  declare -A dep_dirs=()
   while IFS= read -r dep; do
     [ -n "$dep" ] || continue
-    if [ "$dep" -nt "$ROOT_DIR/$wasm_rel" ]; then
+    if [ ! -e "$ROOT_DIR/$dep" ] || [ "$ROOT_DIR/$dep" -nt "$ROOT_DIR/$wasm_rel" ]; then
       stale=1
       break
     fi
+    d="${dep%/*}"
+    [ "$d" = "$dep" ] && d="."
+    dep_dirs["$d"]=1
   done < "$ROOT_DIR/$deps_rel"
+  if [ "$stale" = "0" ]; then
+    for d in "${!dep_dirs[@]}"; do
+      if [ "$ROOT_DIR/$d" -nt "$ROOT_DIR/$wasm_rel" ]; then
+        stale=1
+        break
+      fi
+    done
+  fi
 fi
 
 if [ "$stale" = "1" ]; then

--- a/scripts/ensure_entry_wasm.sh
+++ b/scripts/ensure_entry_wasm.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# Compile a .vibe entry to wasm with the committed seed iff it is missing or
+# stale, tracking the ENTRY'S RESOLVED IMPORT CLOSURE rather than a
+# hand-maintained file list (#2260 Codex round 1: a hand list cannot see
+# transitive dependencies -- loader/header_cache.vibe was reachable from
+# fmt_entry through contract_package_hashes_fs and tracked by nothing, so an
+# edit there left the cached formatter answering with stale behavior).
+#
+# The closure comes from the compiler's own module plan (VIBE_MODULE_PLAN,
+# the same resolution `vibe deps` reports), captured into a sibling
+# `<wasm>.deps` manifest at build time. A change that alters the import
+# graph necessarily edits a file already IN the old closure, so checking
+# mtimes of the captured manifest is sound: that edit triggers the rebuild,
+# and the rebuild recaptures the closure. A manifest that cannot be
+# produced is simply not written, which leaves the artifact permanently
+# stale -- always-rebuild is the safe failure mode, never stale-reuse.
+#
+# Usage: ensure_entry_wasm.sh <entry_src_rel> <wasm_rel>
+# Prints the repo-root-relative wasm path on stdout; all build noise on
+# stderr (callers capture stdout).
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+entry_src="${1:?usage: ensure_entry_wasm.sh <entry_src_rel> <wasm_rel>}"
+wasm_rel="${2:?usage: ensure_entry_wasm.sh <entry_src_rel> <wasm_rel>}"
+deps_rel="$wasm_rel.deps"
+
+bash "$ROOT_DIR/scripts/ensure_seed.sh" >&2
+seed="$ROOT_DIR/bootstrap/seed/compiler.wasm"
+mkdir -p "$(dirname "$ROOT_DIR/$wasm_rel")"
+
+stale=0
+if [ ! -s "$ROOT_DIR/$wasm_rel" ] || [ ! -s "$ROOT_DIR/$deps_rel" ] \
+   || [ "$entry_src" -nt "$ROOT_DIR/$wasm_rel" ] \
+   || [ "$seed" -nt "$ROOT_DIR/$wasm_rel" ]; then
+  stale=1
+else
+  while IFS= read -r dep; do
+    [ -n "$dep" ] || continue
+    if [ "$dep" -nt "$ROOT_DIR/$wasm_rel" ]; then
+      stale=1
+      break
+    fi
+  done < "$ROOT_DIR/$deps_rel"
+fi
+
+if [ "$stale" = "1" ]; then
+  VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
+    bash "$ROOT_DIR/scripts/run_wasm_vibe_host_runner.sh" \
+    --invoke cli_main "$seed" "$entry_src" "$wasm_rel" main >&2
+  [ -s "$ROOT_DIR/$wasm_rel" ] || { echo "ensure_entry_wasm.sh: failed to compile $entry_src" >&2; exit 1; }
+  # Capture the closure the compiler just resolved. The plan mode also
+  # writes one `.N.src` sidecar per module; keep them in a scratch dir so
+  # only the manifest survives. Best-effort: on failure no manifest is
+  # written and the next run rebuilds again rather than reusing stale.
+  plan_dir="$(mktemp -d "$ROOT_DIR/_build/ensure_entry_plan.XXXXXX")"
+  plan_rel="${plan_dir#"$ROOT_DIR"/}/plan.tsv"
+  if VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_MODULE_PLAN=1 \
+      bash "$ROOT_DIR/scripts/run_wasm_vibe_host_runner.sh" \
+      --invoke cli_main "$seed" "$entry_src" "$plan_rel" "__no_entry__" >&2 \
+      && [ -s "$ROOT_DIR/$plan_rel" ]; then
+    awk -F'\t' '$1 == "module" { print $4 }' "$ROOT_DIR/$plan_rel" > "$ROOT_DIR/$deps_rel"
+  else
+    rm -f "$ROOT_DIR/$deps_rel"
+    echo "ensure_entry_wasm.sh: could not capture the dependency closure for $entry_src; the artifact will rebuild every run until it can" >&2
+  fi
+  rm -rf "$plan_dir"
+fi
+
+echo "$wasm_rel"

--- a/scripts/ensure_entry_wasm.sh
+++ b/scripts/ensure_entry_wasm.sh
@@ -47,24 +47,31 @@ if [ ! -s "$ROOT_DIR/$wasm_rel" ] || [ ! -s "$ROOT_DIR/$deps_rel" ] \
    || [ "$seed" -nt "$ROOT_DIR/$wasm_rel" ]; then
   stale=1
 else
-  declare -A dep_dirs=()
   while IFS= read -r dep; do
     [ -n "$dep" ] || continue
     if [ ! -e "$ROOT_DIR/$dep" ] || [ "$ROOT_DIR/$dep" -nt "$ROOT_DIR/$wasm_rel" ]; then
       stale=1
       break
     fi
-    d="${dep%/*}"
-    [ "$d" = "$dep" ] && d="."
-    dep_dirs["$d"]=1
   done < "$ROOT_DIR/$deps_rel"
   if [ "$stale" = "0" ]; then
-    for d in "${!dep_dirs[@]}"; do
+    # Dedupe the parent directories without an associative array -- stock
+    # macOS runs Bash 3.2, where `declare -A` is a hard error (#2260
+    # round 7; scripts/test_affected_test.sh documents 3.2 as supported).
+    while IFS= read -r d; do
+      [ -n "$d" ] || continue
       if [ "$ROOT_DIR/$d" -nt "$ROOT_DIR/$wasm_rel" ]; then
         stale=1
         break
       fi
-    done
+    done < <(
+      while IFS= read -r dep; do
+        [ -n "$dep" ] || continue
+        d="${dep%/*}"
+        [ "$d" = "$dep" ] && d="."
+        printf '%s\n' "$d"
+      done < "$ROOT_DIR/$deps_rel" | sort -u
+    )
   fi
 fi
 

--- a/scripts/ensure_vibe_fmt_batch.sh
+++ b/scripts/ensure_vibe_fmt_batch.sh
@@ -21,6 +21,9 @@ batch_wasm_rel="_build/vibe_fmt/fmt_batch.wasm"
 if [ ! -s "$ROOT_DIR/$batch_wasm_rel" ] || [ "$entry_src" -nt "$ROOT_DIR/$batch_wasm_rel" ] \
    || [ "lib/@vibe/compiler/fmt/format.vibe" -nt "$ROOT_DIR/$batch_wasm_rel" ] \
    || [ "lib/@vibe/compiler/fmt/index.vpkg" -nt "$ROOT_DIR/$batch_wasm_rel" ] \
+   || [ "lib/@vibe/compiler/loader/loader.vibe" -nt "$ROOT_DIR/$batch_wasm_rel" ] \
+   || [ "lib/@vibe/compiler/loader/index.vpkg" -nt "$ROOT_DIR/$batch_wasm_rel" ] \
+   || [ "lib/@vibe/compiler/contract/contract.vibe" -nt "$ROOT_DIR/$batch_wasm_rel" ] \
    || [ "lib/@vibe/process/process.vibe" -nt "$ROOT_DIR/$batch_wasm_rel" ] \
    || [ "lib/@vibe/process/index.vpkg" -nt "$ROOT_DIR/$batch_wasm_rel" ]; then
   VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \

--- a/scripts/ensure_vibe_fmt_batch.sh
+++ b/scripts/ensure_vibe_fmt_batch.sh
@@ -5,31 +5,14 @@
 # separate because fmt.vibe pulls in @vibe/process (Process effect) which
 # the single-file fmt_entry.vibe does not need.
 #
+# Staleness tracks the entry's RESOLVED import closure (captured into
+# fmt_batch.wasm.deps by ensure_entry_wasm.sh), not a hand-maintained file
+# list -- a hand list cannot see transitive dependencies (#2260).
+#
 # Prints the repo-root-relative path to the compiled wasm on stdout.
 set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-cd "$ROOT_DIR"
 
-bash "$ROOT_DIR/scripts/ensure_seed.sh" >&2
-seed="$ROOT_DIR/bootstrap/seed/compiler.wasm"
-entry_src="lib/@vibe/cli/fmt.vibe"
-work="$ROOT_DIR/_build/vibe_fmt"
-mkdir -p "$work"
-batch_wasm_rel="_build/vibe_fmt/fmt_batch.wasm"
-
-if [ ! -s "$ROOT_DIR/$batch_wasm_rel" ] || [ "$entry_src" -nt "$ROOT_DIR/$batch_wasm_rel" ] \
-   || [ "lib/@vibe/compiler/fmt/format.vibe" -nt "$ROOT_DIR/$batch_wasm_rel" ] \
-   || [ "lib/@vibe/compiler/fmt/index.vpkg" -nt "$ROOT_DIR/$batch_wasm_rel" ] \
-   || [ "lib/@vibe/compiler/loader/loader.vibe" -nt "$ROOT_DIR/$batch_wasm_rel" ] \
-   || [ "lib/@vibe/compiler/loader/index.vpkg" -nt "$ROOT_DIR/$batch_wasm_rel" ] \
-   || [ "lib/@vibe/compiler/contract/contract.vibe" -nt "$ROOT_DIR/$batch_wasm_rel" ] \
-   || [ "lib/@vibe/process/process.vibe" -nt "$ROOT_DIR/$batch_wasm_rel" ] \
-   || [ "lib/@vibe/process/index.vpkg" -nt "$ROOT_DIR/$batch_wasm_rel" ]; then
-  VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
-    bash "$ROOT_DIR/scripts/run_wasm_vibe_host_runner.sh" \
-    --invoke cli_main "$seed" "$entry_src" "$batch_wasm_rel" main >&2
-  [ -s "$ROOT_DIR/$batch_wasm_rel" ] || { echo "ensure_vibe_fmt_batch.sh: failed to compile fmt batch entry" >&2; exit 1; }
-fi
-
-echo "$batch_wasm_rel"
+bash "$ROOT_DIR/scripts/ensure_entry_wasm.sh" \
+  "lib/@vibe/cli/fmt.vibe" "_build/vibe_fmt/fmt_batch.wasm"

--- a/scripts/ensure_vibe_fmt_entry.sh
+++ b/scripts/ensure_vibe_fmt_entry.sh
@@ -21,6 +21,9 @@ entry_wasm_rel="_build/vibe_fmt/fmt_entry.wasm"
 if [ ! -s "$ROOT_DIR/$entry_wasm_rel" ] || [ "$entry_src" -nt "$ROOT_DIR/$entry_wasm_rel" ] \
    || [ "lib/@vibe/compiler/fmt/format.vibe" -nt "$ROOT_DIR/$entry_wasm_rel" ] \
    || [ "lib/@vibe/compiler/fmt/index.vpkg" -nt "$ROOT_DIR/$entry_wasm_rel" ] \
+   || [ "lib/@vibe/compiler/loader/loader.vibe" -nt "$ROOT_DIR/$entry_wasm_rel" ] \
+   || [ "lib/@vibe/compiler/loader/index.vpkg" -nt "$ROOT_DIR/$entry_wasm_rel" ] \
+   || [ "lib/@vibe/compiler/contract/contract.vibe" -nt "$ROOT_DIR/$entry_wasm_rel" ] \
    || [ "lib/@vibe/parser/lexer.vibe" -nt "$ROOT_DIR/$entry_wasm_rel" ] \
    || [ "lib/@vibe/parser/parser.vibe" -nt "$ROOT_DIR/$entry_wasm_rel" ] \
    || [ "lib/@vibe/parser/index.vpkg" -nt "$ROOT_DIR/$entry_wasm_rel" ]; then

--- a/scripts/ensure_vibe_fmt_entry.sh
+++ b/scripts/ensure_vibe_fmt_entry.sh
@@ -5,32 +5,14 @@
 # (multi-worker bulk apply/check) so both compile the exact same way and
 # reuse the exact same cached artifact.
 #
+# Staleness tracks the entry's RESOLVED import closure (captured into
+# fmt_entry.wasm.deps by ensure_entry_wasm.sh), not a hand-maintained file
+# list -- a hand list cannot see transitive dependencies (#2260).
+#
 # Prints the repo-root-relative path to the compiled wasm on stdout.
 set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-cd "$ROOT_DIR"
 
-bash "$ROOT_DIR/scripts/ensure_seed.sh" >&2
-seed="$ROOT_DIR/bootstrap/seed/compiler.wasm"
-entry_src="lib/@vibe/cli/fmt_entry.vibe"
-work="$ROOT_DIR/_build/vibe_fmt"
-mkdir -p "$work"
-entry_wasm_rel="_build/vibe_fmt/fmt_entry.wasm"
-
-if [ ! -s "$ROOT_DIR/$entry_wasm_rel" ] || [ "$entry_src" -nt "$ROOT_DIR/$entry_wasm_rel" ] \
-   || [ "lib/@vibe/compiler/fmt/format.vibe" -nt "$ROOT_DIR/$entry_wasm_rel" ] \
-   || [ "lib/@vibe/compiler/fmt/index.vpkg" -nt "$ROOT_DIR/$entry_wasm_rel" ] \
-   || [ "lib/@vibe/compiler/loader/loader.vibe" -nt "$ROOT_DIR/$entry_wasm_rel" ] \
-   || [ "lib/@vibe/compiler/loader/index.vpkg" -nt "$ROOT_DIR/$entry_wasm_rel" ] \
-   || [ "lib/@vibe/compiler/contract/contract.vibe" -nt "$ROOT_DIR/$entry_wasm_rel" ] \
-   || [ "lib/@vibe/parser/lexer.vibe" -nt "$ROOT_DIR/$entry_wasm_rel" ] \
-   || [ "lib/@vibe/parser/parser.vibe" -nt "$ROOT_DIR/$entry_wasm_rel" ] \
-   || [ "lib/@vibe/parser/index.vpkg" -nt "$ROOT_DIR/$entry_wasm_rel" ]; then
-  VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
-    bash "$ROOT_DIR/scripts/run_wasm_vibe_host_runner.sh" \
-    --invoke cli_main "$seed" "$entry_src" "$entry_wasm_rel" main >&2
-  [ -s "$ROOT_DIR/$entry_wasm_rel" ] || { echo "ensure_vibe_fmt_entry.sh: failed to compile formatter" >&2; exit 1; }
-fi
-
-echo "$entry_wasm_rel"
+bash "$ROOT_DIR/scripts/ensure_entry_wasm.sh" \
+  "lib/@vibe/cli/fmt_entry.vibe" "_build/vibe_fmt/fmt_entry.wasm"

--- a/scripts/vibe_fmt_parse_guard_test.sh
+++ b/scripts/vibe_fmt_parse_guard_test.sh
@@ -197,6 +197,30 @@ if ! head -1 "$fill_abs" | grep -q "^require $store_pkg 0\.2\.0\$"; then
   exit 1
 fi
 
+# npm caret for 0.0.z (#2260 round 5): the leftmost non-zero digit is the
+# compatibility line, so ^0.0.1 has upper bound <0.0.2 -- an installed 0.0.2
+# must NOT satisfy ^0.0.1, and only the exact ^0.0.2 fills.
+zero_pkg="@fmtpin/z$$"
+zero_dir="$ROOT_DIR/.vibe/store/$zero_pkg"
+trap 'rm -rf "$work" "$batch_pin" "$store_dir" "$zero_dir" "$fill_abs" "$vpkg_fill_abs"' EXIT
+mkdir -p "$zero_dir"
+printf 'version 0.0.2\nimport ./impl.vibe {}\nfn quintuple(x: Int) -> Int\n' >"$zero_dir/index.vibei"
+printf 'export fn quintuple(x: Int) -> Int { x * 5 }\n' >"$zero_dir/impl.vibe"
+printf 'require %s ^0.0.1\n\nfn id(n:Int)->Int {\n  n\n}\n' "$zero_pkg" >"$fill_abs"
+bash "$ROOT_DIR/scripts/vibe_fmt.sh" "$fill_abs" >/dev/null 2>&1 || true
+if ! head -1 "$fill_abs" | grep -q "^require $zero_pkg \^0\.0\.1\$"; then
+  echo "vibe_fmt_parse_guard_test: ^0.0.1 was pinned to an installed 0.0.2 (npm caret upper bound violated)" >&2
+  head -1 "$fill_abs" >&2
+  exit 1
+fi
+printf 'require %s ^0.0.2\n\nfn id(n:Int)->Int {\n  n\n}\n' "$zero_pkg" >"$fill_abs"
+bash "$ROOT_DIR/scripts/vibe_fmt.sh" "$fill_abs" >/dev/null 2>&1 || true
+if ! head -1 "$fill_abs" | grep -Eq "^require $zero_pkg \^0\.0\.2 = #pkg:sha1:[0-9a-f]{40}\$"; then
+  echo "vibe_fmt_parse_guard_test: the exact ^0.0.2 against an installed 0.0.2 did not fill" >&2
+  head -1 "$fill_abs" >&2
+  exit 1
+fi
+
 # A package absent from the store: the line comes back byte-identical and the
 # run still succeeds (the body is formatted; the build is what rejects an
 # unpinned require).

--- a/scripts/vibe_fmt_parse_guard_test.sh
+++ b/scripts/vibe_fmt_parse_guard_test.sh
@@ -190,4 +190,26 @@ if ! head -1 "$fill_abs" | grep -Eq "^require $store_pkg 0\.1\.0 = #pkg:sha1:[0-
   exit 1
 fi
 
+# #2260 Codex round 1: the formatter artifact's staleness must track the
+# entry's RESOLVED import closure, not a hand list -- a hand list cannot see
+# transitive dependencies (loader/header_cache.vibe is reachable from
+# fmt_entry through contract_package_hashes_fs and was tracked by nothing).
+# ensure_entry_wasm.sh captures the closure into <wasm>.deps at build time;
+# prove a transitive dep is IN the manifest and that touching it rebuilds.
+entry_wasm="$ROOT_DIR/_build/vibe_fmt/fmt_entry.wasm"
+bash "$ROOT_DIR/scripts/ensure_vibe_fmt_entry.sh" >/dev/null
+if ! grep -q '^lib/@vibe/compiler/loader/header_cache\.vibe$' "$entry_wasm.deps"; then
+  echo "vibe_fmt_parse_guard_test: fmt_entry's captured closure is missing a transitive dep (header_cache.vibe)" >&2
+  exit 1
+fi
+before_mtime="$(stat -c %Y "$entry_wasm")"
+sleep 1
+touch "$ROOT_DIR/lib/@vibe/compiler/loader/header_cache.vibe"
+bash "$ROOT_DIR/scripts/ensure_vibe_fmt_entry.sh" >/dev/null
+after_mtime="$(stat -c %Y "$entry_wasm")"
+if [ "$after_mtime" -le "$before_mtime" ]; then
+  echo "vibe_fmt_parse_guard_test: touching a transitive dep did not rebuild the cached formatter" >&2
+  exit 1
+fi
+
 echo "vibe_fmt_parse_guard_test: ok"

--- a/scripts/vibe_fmt_parse_guard_test.sh
+++ b/scripts/vibe_fmt_parse_guard_test.sh
@@ -221,6 +221,18 @@ if ! head -1 "$fill_abs" | grep -Eq "^require $zero_pkg \^0\.0\.2 = #pkg:sha1:[0
   exit 1
 fi
 
+# A component long enough to wrap 63-bit Int conversion (#2260 round 6):
+# digits_to_int wraps, so ^0.1.4611686018427387904 used to get a NEGATIVE
+# patch bound that an installed 0.1.0 "satisfied". Unconvertible components
+# are unverifiable and never fill.
+printf 'require %s ^0.1.4611686018427387904\n\nfn id(n:Int)->Int {\n  n\n}\n' "$store_pkg" >"$fill_abs"
+bash "$ROOT_DIR/scripts/vibe_fmt.sh" "$fill_abs" >/dev/null 2>&1 || true
+if ! head -1 "$fill_abs" | grep -q "^require $store_pkg \^0\.1\.4611686018427387904\$"; then
+  echo "vibe_fmt_parse_guard_test: an Int-wrapping version component was pinned (lower bound defeated)" >&2
+  head -1 "$fill_abs" >&2
+  exit 1
+fi
+
 # A package absent from the store: the line comes back byte-identical and the
 # run still succeeds (the body is formatted; the build is what rejects an
 # unpinned require).

--- a/scripts/vibe_fmt_parse_guard_test.sh
+++ b/scripts/vibe_fmt_parse_guard_test.sh
@@ -137,7 +137,7 @@ fill_in="_build/vibe_fmt_pin_fill.$$.vibe"
 fill_abs="$ROOT_DIR/$fill_in"
 trap 'rm -rf "$work" "$batch_pin" "$store_dir" "$fill_abs"' EXIT
 mkdir -p "$store_dir"
-printf 'import ./impl.vibe {}\nfn quadruple(x: Int) -> Int\n' >"$store_dir/index.vibei"
+printf 'version 0.1.0\nimport ./impl.vibe {}\nfn quadruple(x: Int) -> Int\n' >"$store_dir/index.vibei"
 printf 'export fn quadruple(x: Int) -> Int { x * 4 }\n' >"$store_dir/impl.vibe"
 
 printf 'require %s 0.1.0\n\nfn double(n:Int)->Int {\n  n*2\n}\n' "$store_pkg" >"$fill_abs"
@@ -167,18 +167,33 @@ fi
 vpkg_fill="_build/vibe_fmt_pin_fill.$$.vpkg"
 vpkg_fill_abs="$ROOT_DIR/$vpkg_fill"
 trap 'rm -rf "$work" "$batch_pin" "$store_dir" "$fill_abs" "$vpkg_fill_abs"' EXIT
-printf 'name = @fmtpin/consumer\nversion = 0.1.0\nrequire %s 0.1.0\n\nfn double(n: Int) -> Int\n' "$store_pkg" >"$vpkg_fill_abs"
+printf 'name = @fmtpin/consumer\nversion = 0.1.0\nrequire %s ^0.1.0\n\nfn double(n: Int) -> Int\n' "$store_pkg" >"$vpkg_fill_abs"
 if ! bash "$ROOT_DIR/scripts/vibe_fmt.sh" "$vpkg_fill_abs" >/dev/null 2>&1; then
   echo "vibe_fmt_parse_guard_test: formatter declined a .vpkg with an unpinned require" >&2
   exit 1
 fi
-if ! grep -Eq "^require $store_pkg 0\.1\.0 = #pkg:sha1:[0-9a-f]{40}\$" "$vpkg_fill_abs"; then
+if ! grep -Eq "^require $store_pkg \^0\.1\.0 = #pkg:sha1:[0-9a-f]{40}\$" "$vpkg_fill_abs"; then
   echo "vibe_fmt_parse_guard_test: fmt did not fill the require pin in a .vpkg header" >&2
   sed -n '1,4p' "$vpkg_fill_abs" >&2
   exit 1
 fi
 if ! bash "$ROOT_DIR/scripts/vibe_fmt.sh" --check "$vpkg_fill_abs" >/dev/null 2>&1; then
   echo "vibe_fmt_parse_guard_test: .vpkg pin filling is not a --check fixpoint" >&2
+  exit 1
+fi
+
+# A version the store copy does not satisfy is NOT filled (#2260 round 4):
+# the pin is the truth the build verifies, so pinning the installed 0.1.0's
+# hash beside a claimed 0.2.0 would make the build run a release the source
+# never asked for. The line comes back verbatim instead.
+printf 'require %s 0.2.0\n\nfn id(n:Int)->Int {\n  n\n}\n' "$store_pkg" >"$fill_abs"
+if ! bash "$ROOT_DIR/scripts/vibe_fmt.sh" "$fill_abs" >/dev/null 2>&1; then
+  echo "vibe_fmt_parse_guard_test: formatter failed on a version the store cannot satisfy" >&2
+  exit 1
+fi
+if ! head -1 "$fill_abs" | grep -q "^require $store_pkg 0\.2\.0\$"; then
+  echo "vibe_fmt_parse_guard_test: a version-mismatched require was pinned to the wrong release" >&2
+  head -1 "$fill_abs" >&2
   exit 1
 fi
 

--- a/scripts/vibe_fmt_parse_guard_test.sh
+++ b/scripts/vibe_fmt_parse_guard_test.sh
@@ -269,17 +269,23 @@ fi
 # fmt_entry through contract_package_hashes_fs and was tracked by nothing).
 # ensure_entry_wasm.sh captures the closure into <wasm>.deps at build time;
 # prove a transitive dep is IN the manifest and that touching it rebuilds.
+# GNU stat spells the mtime query -c %Y, BSD (macOS) stat spells it -f %m
+# (#2260 round 8); try GNU first, fall back to BSD.
+mtime_of() {
+  stat -c %Y "$1" 2>/dev/null || stat -f %m "$1"
+}
+
 entry_wasm="$ROOT_DIR/_build/vibe_fmt/fmt_entry.wasm"
 bash "$ROOT_DIR/scripts/ensure_vibe_fmt_entry.sh" >/dev/null
 if ! grep -q '^lib/@vibe/compiler/loader/header_cache\.vibe$' "$entry_wasm.deps"; then
   echo "vibe_fmt_parse_guard_test: fmt_entry's captured closure is missing a transitive dep (header_cache.vibe)" >&2
   exit 1
 fi
-before_mtime="$(stat -c %Y "$entry_wasm")"
+before_mtime="$(mtime_of "$entry_wasm")"
 sleep 1
 touch "$ROOT_DIR/lib/@vibe/compiler/loader/header_cache.vibe"
 bash "$ROOT_DIR/scripts/ensure_vibe_fmt_entry.sh" >/dev/null
-after_mtime="$(stat -c %Y "$entry_wasm")"
+after_mtime="$(mtime_of "$entry_wasm")"
 if [ "$after_mtime" -le "$before_mtime" ]; then
   echo "vibe_fmt_parse_guard_test: touching a transitive dep did not rebuild the cached formatter" >&2
   exit 1
@@ -291,10 +297,10 @@ fi
 # CREATED next to a closure member can join the closure via `.vpkg` sibling
 # auto-discovery without any recorded file changing, so a closure member's
 # parent-directory mtime is a staleness signal too.
-before_mtime="$(stat -c %Y "$entry_wasm")"
+before_mtime="$(mtime_of "$entry_wasm")"
 echo "lib/@vibe/no_such_recorded_dep.vibe" >> "$entry_wasm.deps"
 bash "$ROOT_DIR/scripts/ensure_vibe_fmt_entry.sh" >/dev/null
-after_mtime="$(stat -c %Y "$entry_wasm")"
+after_mtime="$(mtime_of "$entry_wasm")"
 if [ "$after_mtime" -le "$before_mtime" ]; then
   echo "vibe_fmt_parse_guard_test: a missing recorded dep did not read as stale" >&2
   exit 1
@@ -303,11 +309,11 @@ if grep -q 'no_such_recorded_dep' "$entry_wasm.deps"; then
   echo "vibe_fmt_parse_guard_test: the rebuild did not recapture the closure manifest" >&2
   exit 1
 fi
-before_mtime="$(stat -c %Y "$entry_wasm")"
+before_mtime="$(mtime_of "$entry_wasm")"
 sleep 1
 touch "$ROOT_DIR/lib/@vibe/cli"
 bash "$ROOT_DIR/scripts/ensure_vibe_fmt_entry.sh" >/dev/null
-after_mtime="$(stat -c %Y "$entry_wasm")"
+after_mtime="$(mtime_of "$entry_wasm")"
 if [ "$after_mtime" -le "$before_mtime" ]; then
   echo "vibe_fmt_parse_guard_test: a newer closure-member directory did not read as stale" >&2
   exit 1

--- a/scripts/vibe_fmt_parse_guard_test.sh
+++ b/scripts/vibe_fmt_parse_guard_test.sh
@@ -123,4 +123,71 @@ if ! grep -q '^fn double(n: Int) -> Int {$' "$batch_pin"; then
   exit 1
 fi
 
+# #730 D-3 (module-system-v2 §6): pinned form is canonical, so fmt COMPLETES
+# an unpinned `require @scope/name x.y.z` head line with `= #hash` when the
+# package is installed in the workspace store -- offline, best-effort. A
+# package the store cannot answer leaves its line byte-identical (fetching
+# belongs to `vibe add`/`update`, and a formatter that fails over an absent
+# store entry would be unusable on machines that never use the pin lane).
+# The store fixture is created here because the workspace store is
+# gitignored -- nothing in a fresh clone provides one.
+store_pkg="@fmtpin/p$$"
+store_dir="$ROOT_DIR/.vibe/store/$store_pkg"
+fill_in="_build/vibe_fmt_pin_fill.$$.vibe"
+fill_abs="$ROOT_DIR/$fill_in"
+trap 'rm -rf "$work" "$batch_pin" "$store_dir" "$fill_abs"' EXIT
+mkdir -p "$store_dir"
+printf 'import ./impl.vibe {}\nfn quadruple(x: Int) -> Int\n' >"$store_dir/index.vibei"
+printf 'export fn quadruple(x: Int) -> Int { x * 4 }\n' >"$store_dir/impl.vibe"
+
+printf 'require %s 0.1.0\n\nfn double(n:Int)->Int {\n  n*2\n}\n' "$store_pkg" >"$fill_abs"
+if ! bash "$ROOT_DIR/scripts/vibe_fmt.sh" "$fill_abs" >/dev/null 2>&1; then
+  echo "vibe_fmt_parse_guard_test: formatter declined an unpinned-require file" >&2
+  exit 1
+fi
+if ! head -1 "$fill_abs" | grep -Eq "^require $store_pkg 0\.1\.0 = #pkg:sha1:[0-9a-f]{40}\$"; then
+  echo "vibe_fmt_parse_guard_test: fmt did not fill the require pin from the store" >&2
+  head -1 "$fill_abs" >&2
+  exit 1
+fi
+if ! grep -q '^fn double(n: Int) -> Int {$' "$fill_abs"; then
+  echo "vibe_fmt_parse_guard_test: body under a filled pin head was not formatted" >&2
+  sed -n '1,6p' "$fill_abs" >&2
+  exit 1
+fi
+if ! bash "$ROOT_DIR/scripts/vibe_fmt.sh" --check "$fill_abs" >/dev/null 2>&1; then
+  echo "vibe_fmt_parse_guard_test: pin filling is not a --check fixpoint" >&2
+  exit 1
+fi
+
+# A package absent from the store: the line comes back byte-identical and the
+# run still succeeds (the body is formatted; the build is what rejects an
+# unpinned require).
+printf 'require @fmtpin/absent%s 0.1.0\n\nfn id(n:Int)->Int {\n  n\n}\n' "$$" >"$fill_abs"
+if ! bash "$ROOT_DIR/scripts/vibe_fmt.sh" "$fill_abs" >/dev/null 2>&1; then
+  echo "vibe_fmt_parse_guard_test: formatter failed on a require the store cannot answer" >&2
+  exit 1
+fi
+if ! head -1 "$fill_abs" | grep -q "^require @fmtpin/absent$$ 0\.1\.0\$"; then
+  echo "vibe_fmt_parse_guard_test: an unanswerable require line was not left verbatim" >&2
+  head -1 "$fill_abs" >&2
+  exit 1
+fi
+
+# The batch lane (CI's vibe-fmt-check / `pkf run fmt`) fills the same way.
+printf 'require %s 0.1.0\n\nfn double(n:Int)->Int {\n  n*2\n}\n' "$store_pkg" >"$fill_abs"
+fill_report="$(printf '%s\n' "$fill_in" | bash "$ROOT_DIR/scripts/run_vibe_fmt_batch.sh" write 1)"
+case "$fill_report" in
+  DIFF*) : ;;
+  *)
+    echo "vibe_fmt_parse_guard_test: batch lane did not fill the pin (report: $fill_report)" >&2
+    exit 1
+    ;;
+esac
+if ! head -1 "$fill_abs" | grep -Eq "^require $store_pkg 0\.1\.0 = #pkg:sha1:[0-9a-f]{40}\$"; then
+  echo "vibe_fmt_parse_guard_test: BATCH lane did not fill the require pin" >&2
+  head -1 "$fill_abs" >&2
+  exit 1
+fi
+
 echo "vibe_fmt_parse_guard_test: ok"

--- a/scripts/vibe_fmt_parse_guard_test.sh
+++ b/scripts/vibe_fmt_parse_guard_test.sh
@@ -160,6 +160,28 @@ if ! bash "$ROOT_DIR/scripts/vibe_fmt.sh" --check "$fill_abs" >/dev/null 2>&1; t
   exit 1
 fi
 
+# A `.vpkg` header's require directive fills the same way (#2260 round 3):
+# it sits AFTER name=/version=, which the old "stop at the first non-require
+# line" scan never reached -- directive recognition now comes from the
+# loader's own header scanner (the blanked output of extract_require_pins).
+vpkg_fill="_build/vibe_fmt_pin_fill.$$.vpkg"
+vpkg_fill_abs="$ROOT_DIR/$vpkg_fill"
+trap 'rm -rf "$work" "$batch_pin" "$store_dir" "$fill_abs" "$vpkg_fill_abs"' EXIT
+printf 'name = @fmtpin/consumer\nversion = 0.1.0\nrequire %s 0.1.0\n\nfn double(n: Int) -> Int\n' "$store_pkg" >"$vpkg_fill_abs"
+if ! bash "$ROOT_DIR/scripts/vibe_fmt.sh" "$vpkg_fill_abs" >/dev/null 2>&1; then
+  echo "vibe_fmt_parse_guard_test: formatter declined a .vpkg with an unpinned require" >&2
+  exit 1
+fi
+if ! grep -Eq "^require $store_pkg 0\.1\.0 = #pkg:sha1:[0-9a-f]{40}\$" "$vpkg_fill_abs"; then
+  echo "vibe_fmt_parse_guard_test: fmt did not fill the require pin in a .vpkg header" >&2
+  sed -n '1,4p' "$vpkg_fill_abs" >&2
+  exit 1
+fi
+if ! bash "$ROOT_DIR/scripts/vibe_fmt.sh" --check "$vpkg_fill_abs" >/dev/null 2>&1; then
+  echo "vibe_fmt_parse_guard_test: .vpkg pin filling is not a --check fixpoint" >&2
+  exit 1
+fi
+
 # A package absent from the store: the line comes back byte-identical and the
 # run still succeeds (the body is formatted; the build is what rejects an
 # unpinned require).

--- a/scripts/vibe_fmt_parse_guard_test.sh
+++ b/scripts/vibe_fmt_parse_guard_test.sh
@@ -212,4 +212,32 @@ if [ "$after_mtime" -le "$before_mtime" ]; then
   exit 1
 fi
 
+# #2260 Codex round 2: mtimes of the recorded path set alone are not enough.
+# A recorded dependency that no longer exists (deletion, rename) must read
+# as stale -- `-nt` against a missing path answers "fresh" -- and a file
+# CREATED next to a closure member can join the closure via `.vpkg` sibling
+# auto-discovery without any recorded file changing, so a closure member's
+# parent-directory mtime is a staleness signal too.
+before_mtime="$(stat -c %Y "$entry_wasm")"
+echo "lib/@vibe/no_such_recorded_dep.vibe" >> "$entry_wasm.deps"
+bash "$ROOT_DIR/scripts/ensure_vibe_fmt_entry.sh" >/dev/null
+after_mtime="$(stat -c %Y "$entry_wasm")"
+if [ "$after_mtime" -le "$before_mtime" ]; then
+  echo "vibe_fmt_parse_guard_test: a missing recorded dep did not read as stale" >&2
+  exit 1
+fi
+if grep -q 'no_such_recorded_dep' "$entry_wasm.deps"; then
+  echo "vibe_fmt_parse_guard_test: the rebuild did not recapture the closure manifest" >&2
+  exit 1
+fi
+before_mtime="$(stat -c %Y "$entry_wasm")"
+sleep 1
+touch "$ROOT_DIR/lib/@vibe/cli"
+bash "$ROOT_DIR/scripts/ensure_vibe_fmt_entry.sh" >/dev/null
+after_mtime="$(stat -c %Y "$entry_wasm")"
+if [ "$after_mtime" -le "$before_mtime" ]; then
+  echo "vibe_fmt_parse_guard_test: a newer closure-member directory did not read as stale" >&2
+  exit 1
+fi
+
 echo "vibe_fmt_parse_guard_test: ok"

--- a/scripts/vibe_fmt_smoke.sh
+++ b/scripts/vibe_fmt_smoke.sh
@@ -251,6 +251,11 @@ fi
 # dropped, gluing them into a single `returnhandle` token, which cascaded
 # into an unrelated far-later "unexpected token: with" parse error (the
 # merge-flatten compile step of scripts/generate_bundle.sh).
+# Since the ADR-0102 migration the formatter also rewrites the legacy
+# `with Exception { Throw(msg) => .. }` header into the qualified
+# `with { Exception::Throw(msg) => .. }` form, so the input is no longer a
+# byte-fixpoint -- the guard here is only that `return handle` keeps its
+# space (and the migrated output is itself a fixpoint).
 cat > "$WORK/return_handle.in.vibe" <<'EOF'
 fn foo() -> Int with Exception {
   return handle {
@@ -260,10 +265,28 @@ fn foo() -> Int with Exception {
   }
 }
 EOF
+cat > "$WORK/return_handle.expected.vibe" <<'EOF'
+fn foo() -> Int with Exception {
+  return handle {
+    1
+  } with { Exception::Throw(msg) => 0 }
+}
+EOF
 bash "$ROOT_DIR/scripts/vibe_fmt.sh" --stdout "$WORK/return_handle.in.vibe" > "$WORK/return_handle.got.vibe" 2>/dev/null
-if ! cmp -s "$WORK/return_handle.in.vibe" "$WORK/return_handle.got.vibe"; then
+if grep -q 'returnhandle' "$WORK/return_handle.got.vibe"; then
   echo "[vibe-fmt-smoke] FAIL: 'return handle {' lost its space and glued into 'returnhandle'" >&2
-  diff "$WORK/return_handle.in.vibe" "$WORK/return_handle.got.vibe" >&2 || true
+  sed -n '1,8p' "$WORK/return_handle.got.vibe" >&2
+  exit 1
+fi
+if ! cmp -s "$WORK/return_handle.expected.vibe" "$WORK/return_handle.got.vibe"; then
+  echo "[vibe-fmt-smoke] FAIL: 'return handle' did not format to the qualified-handler canonical form" >&2
+  diff "$WORK/return_handle.expected.vibe" "$WORK/return_handle.got.vibe" >&2 || true
+  exit 1
+fi
+bash "$ROOT_DIR/scripts/vibe_fmt.sh" --stdout "$WORK/return_handle.expected.vibe" > "$WORK/return_handle.again.vibe" 2>/dev/null
+if ! cmp -s "$WORK/return_handle.expected.vibe" "$WORK/return_handle.again.vibe"; then
+  echo "[vibe-fmt-smoke] FAIL: qualified return-handle form is not a fixpoint" >&2
+  diff "$WORK/return_handle.expected.vibe" "$WORK/return_handle.again.vibe" >&2 || true
   exit 1
 fi
 

--- a/tests/gates/early/run.sh
+++ b/tests/gates/early/run.sh
@@ -520,7 +520,10 @@ echo "[compiler-gate] cross-package contract import resolution regression ok"
 echo "[compiler-gate] 6c content-addressed store regression (#730)"
 sdir=".vibe/store/@gate/d2pkg"
 rm -rf ".vibe/store/@gate"; mkdir -p "$sdir"
-printf 'import ./impl.vibe {}\nfn triple(x: Int) -> Int\n' > "$sdir/index.vibei"
+# The store copy declares its version (the vibe_pkg.sh publish contract
+# requires the directive) -- the fill verifies it against the require
+# constraint before pinning, and a versionless copy never fills (#2260).
+printf 'version 1.0.0\nimport ./impl.vibe {}\nfn triple(x: Int) -> Int\n' > "$sdir/index.vibei"
 printf 'export fn triple(x: Int) -> Int { x * 3 }\n' > "$sdir/impl.vibe"
 cdir2="_build/_gate_store"
 rm -rf "$cdir2"; mkdir -p "$cdir2"


### PR DESCRIPTION
Book-review round 4: the three r3 §4 candidates, all measured on the new `qualified-handler-syntax-2026-08-22` seed. Record: `eval/book-review/rounds/2026-08-23-r4.md`.

## 1. `vibe fmt` require-pin insertion (#730 D-3, module-system-v2 §6)

The fill engine (`fill_require_pins_fs_mode`, `VIBE_FILL_PINS`) existed since D-2; no fmt entry called it. Now all three fmt entries (`vibe_fmt.sh` single-file, the batch lane behind CI's `vibe-fmt-check` / `pkf run fmt`, and the installed `vibe fmt` adapter) complete an unpinned `require @scope/name x.y.z` directive with `= #hash` when the workspace store (`.vibe/store/<name>/`) can answer — offline, via a new TOTAL `fill_require_pins_lenient` (loader). Hardened across the Codex rounds:

- `.vpkg` contract headers fill too (their headers carry require directives and `format_vpkg` re-emits them); which lines are require directives is decided by the loader's own header scanner (the blanked output of `extract_require_pins`), not a second region scan that could drift from the grammar.
- The fill verifies the store copy's **declared version** against the constraint before pinning (exact match, npm caret semantics for `^` including the `^0.0.z` upper bound), and components long enough to wrap 63-bit Int conversion are unverifiable — a versionless, mismatched, or unconvertible copy leaves the line verbatim. The pin is the truth the build verifies, so pinning a copy the constraint doesn't cover would silently run the wrong release.
- A package absent from the store leaves its line verbatim instead of failing the format (the build is still the enforcement point for unpinned requires).

Measured end-to-end: the filled pin is exactly the hash the loader verifies — a build of a file importing the store package succeeds and runs; corrupting one hex digit fails with the loader's `pin mismatch` message. All cases pinned in `scripts/vibe_fmt_parse_guard_test.sh` against store fixtures the test creates itself. Deferred (recorded in §6): making an unanswerable require loud in `--check`, and the normalize-gate pinned-form enforcement (design, not yet wired — `vibe fmt` is the only canonicalizer today).

The formatter-artifact caches (`ensure_vibe_fmt_{entry,batch}.sh`) also stop using hand-maintained staleness lists: new `scripts/ensure_entry_wasm.sh` captures the entry's resolved import closure (the compiler's own module plan) into a `<wasm>.deps` manifest and treats an edited, missing, or renamed closure member — or a newer closure-member directory, which covers `.vpkg` sibling auto-discovery — as stale. Bash-3.2-portable (no `declare -A`, portable `stat`).

## 2. `#|` multi-line raw strings get a language-side home

New "Multi-line raw strings (`#|`)" section in the cheatsheet's Values & Types, from measurement (4 passing tests + 2 deliberate errors): same-column continuations join with `\n`, verbatim content, a non-`#|` line ends the block, misaligned continuation is a located lex error — and the content runs to end of line, so a closing paren after the text is swallowed into the string (new gotcha found while measuring). Doctest over the edited cheatsheet: 36 pass, 0 fail.

## 3. Round-4 measurements (p21 / #2219)

- **p21 closed**: the committed seed now rejects `perform?` with the same #2145 message as stage2; the probe's seed-divergence note is retired.
- **#2219 still blocked**: the bump's source (475b8761) predates #2213's marker merge (4b44aef) by ~3 hours — zero marker occurrences in the seed source, and no marker line in the raw abort stream of a seed-compiled failing `assert_eq`. Commented on the issue with the check to run at the next bump.

## 4. Drive-by: `vibe_fmt_smoke.sh` was red on main

The return-handle case asserted a byte-fixpoint over a legacy `with Exception { Throw(msg) => .. }` handler, which #2254's ADR-0102 migration now rewrites — failing on unmodified main (measured before/after stash). The case now pins the space guard, the qualified canonical output, and its fixpoint. Also from the rounds: the gate 6c store fixture now declares its version (the `vibe_pkg.sh publish` contract requires the directive), and module-system-v2 §6 is rewritten in English per the migration policy.

Also noteworthy for CI hygiene: `pkf run test` fails in this container on unmodified main with a nix-glibc `sort` error (`GLIBC_ABI_DT_X86_64_PLT`); gates for this PR were run via `bash scripts/compiler_gate.sh` directly plus the targeted suites (parse-guard, fmt smoke, doctest, preflight — all green), and CI is green on the final head.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012BesqGvopmB2byi8gB4HXG