### PR TITLE
0.1.0 freeze prep: == and Exception[E] contracts, fail-closed type-formal applications

### DIFF
--- a/docs/cheatsheet.md
+++ b/docs/cheatsheet.md
@@ -889,10 +889,13 @@ struct Holder[F] {
 }
 ```
 
-A `trait Functor[F] { .. }` **declaration** still parses (trait type
-parameters ride the #636 erasure path), but dispatching its operations
-through a bound stops at the witness-carrier diagnostic — a declarable but
-unusable shape, so do not write it.
+The same rejection covers every declaration surface: a parameterized alias
+body (`type Apply[F, A] = F[A]`), a generic effect operation
+(`effect Bad[F, A] { Put(F[A]) -> Unit }`), and a trait method signature
+(`trait Functor[F] { fmap[A, B](F[A], (A) -> B) -> F[B] }`) all reject with
+the same diagnostic, naming the declaration (`` in the signature of
+`Functor::fmap` ``). A trait or effect may still DECLARE type parameters and
+use them unapplied (`trait Iter[A] { nth(Self, Int) -> Option[A] }`).
 
 > #1503 以前は、**concrete な impl (`impl M for Array[Int]`) が method-bearing
 > trait でも解決しなかった**。パーサが `for` の後ろの `[Int]` を捨てるため、

--- a/docs/cheatsheet.md
+++ b/docs/cheatsheet.md
@@ -879,6 +879,31 @@ fn keep[T: Measured](x: T) -> T { x }
 let ok = keep([1, 2, 3])
 ```
 
+### A type parameter cannot take type arguments (#2268)
+
+**A type formal in constructor position — `F[A]` — is rejected.** A type
+parameter always stands for a complete type; if the shape were accepted, `F`
+would unify with the whole applied type and the bracket arguments would be
+ignored, so a signature spelled `(F[A], (A) -> B) -> F[B]` would silently
+accept the identity function. Higher-kinded parameters are not implemented;
+which release implements them is decided on #2269. The diagnostic reads
+``type parameter `F` cannot take type arguments in parameter `x` ``.
+
+<!-- doctest-skip: deliberately rejected shapes (#2268 fail-close) -->
+```vibe skip
+fn fake_map[F, A, B](x: F[A], f: (A) -> B) -> F[B] {  // rejected
+  x
+}
+struct Holder[F] {
+  inner: F[Int]                                       // also rejected
+}
+```
+
+A `trait Functor[F] { .. }` **declaration** still parses (trait type
+parameters ride the #636 erasure path), but dispatching its operations
+through a bound stops at the witness-carrier diagnostic — a declarable but
+unusable shape, so do not write it.
+
 > #1503 以前は、**concrete な impl (`impl M for Array[Int]`) が method-bearing
 > trait でも解決しなかった**。パーサが `for` の後ろの `[Int]` を捨てるため、
 > 環境には `Array` という頭だけが残る。今は generic 版と同じく**コンストラクタで

--- a/docs/cheatsheet.md
+++ b/docs/cheatsheet.md
@@ -488,29 +488,20 @@ silently wrong answer (an outer `let v = 1` read for an inner `v` of another
 type, so `==` said `false` for two equal `[1, 2]` arrays). With no environment
 the element type can be absent but never wrong.
 
-A **generic** struct literal resolves only when every type argument written at
-it is one whose raw `==` compares content. One generated `Box::equals` serves
-every instantiation and compares the erased field with a raw `==`, so the
-argument decides. Measured, two distinct allocations of equal content:
+A **generic** struct literal preserves its concrete type arguments in the
+equality shape (#2195): the compiler emits a comparator per concrete
+instantiation and substitutes the arguments into its field types, so
+`Box[Int]`, `Box[Double]`, `Box[Bytes]`, `Box[Array[Int]]` — and declared
+fields containing them — all compare structurally (measured 2026-08-24, two
+distinct allocations of equal content answer `true`). A self-describing
+literal with an omitted argument, such as `Box::{ value: [1, 2] }`, recovers a
+single directly-used type parameter from the field value; anything more
+ambiguous remains unresolved and traps.
 
-| `T` in `Box[T]` | `==` | |
-|---|---|---|
-| `Int`, `Bool`, `Unit`, `String` | `true` | resolves |
-| `Double`, `Bytes` | `false` | rejected → traps |
-| `Array[Int]`, a struct | `false` | rejected → traps |
-
-The rejected rows answer `false` under an **annotation** too — that is #2195,
-not something the unannotated form introduces — so rejecting them keeps #2157
-from giving that wrong answer a new spelling to arrive through. `Float` goes
-with `Double`; `Char` is excluded because two distinct equal-content `Char`s
-cannot be constructed to measure it.
-
-The exclusion follows declared **fields** as well, transitively and through
-type aliases. `struct Outer { box: Box[Array[Int]] }` takes no type parameters,
-so nothing about its shape looks wrong — but `Outer::equals` calls
-`Box::equals`, and the wrong answer arrives one level down.
-
-Which field types keep a struct usable is an allow-list, measured on a
+A declared name is excluded when any field has **no structural comparator**,
+transitively and through type aliases — the exclusion follows fields so a
+wrapper cannot smuggle an uncomparable head in one level down. Which field
+types keep a struct usable is an allow-list, measured on a
 `struct W { f: T } derive (Eq)`:
 
 | declared field type | `==` |
@@ -520,12 +511,11 @@ Which field types keep a struct usable is an allow-list, measured on a
 | a declared struct | `true` |
 | `Map[String, Int]` | `true`, since #2218 |
 
-A declared `Double` or `Bytes` field is fine even though `Box[Double]` is not:
-`derive` generates a type-directed comparison when the type is still known
-where the comparison is emitted, and the erased field of a generic struct is
-exactly where it is not. `Map` was the one measured outlier until #2218 gave
-it a comparator; any head nobody has measured still costs its owner a trap
-rather than the benefit of the doubt.
+`derive` generates a type-directed comparison when the type is known where the
+comparison is emitted — since #2195 that includes a generic struct's concrete
+instantiations. `Map` was the one measured outlier until #2218 gave it a
+comparator; any head nobody has measured still costs its owner a trap rather
+than the benefit of the doubt.
 
 **What does not resolve fails at run time** once BOTH sides are non-empty —
 it does not fall back to reference equality or to a length-only answer. Annotate

--- a/docs/spec/stable-surface.md
+++ b/docs/spec/stable-surface.md
@@ -65,8 +65,13 @@ of each item is [spec/syntax.md](syntax.md) and the
   classify **traps at the comparison** once both sides are non-empty rather
   than answering by length or identity; adding a type annotation resolves it.
   An erased type variable (`[T: Eq]`) dispatches through its witness and is
-  rejected at check time for a container with no `Eq` impl. There is **no
-  silent reference equality** anywhere on this surface. SemVer reading: a
+  rejected at check time for a container with no `Eq` impl; an UNBOUNDED
+  formal comparing containers (`fn f[T](x: Array[T], y: Array[T])`) is the
+  trap side of the same contract — measured 2026-08-24, an
+  equal-but-separately-allocated pair traps rather than answering, and a
+  difference answers `false`. There is **no silent reference equality**
+  anywhere on this surface — every lane answers correctly or traps. SemVer
+  reading: a
   currently-trapping comparison later becoming a structural answer is a
   compatible change (the typed lane, #2158); an existing answer changing is
   breaking. The full contract is the cheatsheet's "`==` on `Array` / `Bytes`
@@ -112,14 +117,21 @@ of each item is [spec/syntax.md](syntax.md) and the
   `perform Exception::Throw(x)` (#640); the bracketless `Exception` row is
   erased — its payload is deliberately unconstrained.
 - `suberror` (typed errors) and **typed exception rows `Exception[E]`**
-  (ADR-0085, #1344): the row names the thrown kind (`with Exception[IoError]`,
-  `E` an enum or `suberror`), a handler discharges exactly its kind
-  (`handle .. with { Exception[IoError]::Throw(e) => .. }`), kinds compose by
-  `effectset` union, and a kind missing from the row is a check-time
-  diagnostic. The documented gradual reading is part of this contract: a
-  payload whose kind cannot be resolved (e.g. a local binding) is treated as
-  erased and passes any `Exception[K]` — no false positives, known misses.
-  Tightening that reading rejects programs and is a breaking change.
+  (ADR-0085, #1344): the row names the thrown payload's **static type**
+  (`with Exception[IoError]` — `E` is any payload type: an enum, a
+  `suberror`, or a primitive such as `String`), kinds compose by `effectset`
+  union, and a kind missing from the row is a check-time diagnostic. The
+  exact-kind discharge is a **checker-side** guarantee over statically kinded
+  rows: `Exception[IoError]::Throw` discharges exactly `IoError` where the
+  handled expression's row is kinded. Where that row is **erased**, kinded
+  and erased are compatible in both directions and the runtime carries a
+  single abortive tag, so a kinded handler also discharges an erased throw
+  whose payload may be another kind. The gradual reading is likewise part of
+  the contract: a payload whose kind cannot be resolved (a pattern binder, a
+  field projection — an ordinary local binding IS resolved from its
+  initializer) is treated as erased and passes any `Exception[K]` — no false
+  positives, known misses. Tightening any of this rejects programs and is a
+  breaking change.
 - User-defined algebraic effects: `effect` / `perform` / `handle ... with` /
   `resume` (one-shot, lexically scoped — ADR-0050, ADR-0021 Phase 1
   tail-resumptive).

--- a/docs/spec/stable-surface.md
+++ b/docs/spec/stable-surface.md
@@ -108,8 +108,18 @@ of each item is [spec/syntax.md](syntax.md) and the
 ### 2.6 Effect system
 - Pure by default, with `with E` annotations.
 - `throw` / `handle ... with Exception { ... }`, the `?` operator (ADR-0016,
-  ADR-0050).
-- `suberror` (typed errors).
+  ADR-0050). `throw(x)` is call-form and sugar for
+  `perform Exception::Throw(x)` (#640); the bracketless `Exception` row is
+  erased — its payload is deliberately unconstrained.
+- `suberror` (typed errors) and **typed exception rows `Exception[E]`**
+  (ADR-0085, #1344): the row names the thrown kind (`with Exception[IoError]`,
+  `E` an enum or `suberror`), a handler discharges exactly its kind
+  (`handle .. with { Exception[IoError]::Throw(e) => .. }`), kinds compose by
+  `effectset` union, and a kind missing from the row is a check-time
+  diagnostic. The documented gradual reading is part of this contract: a
+  payload whose kind cannot be resolved (e.g. a local binding) is treated as
+  erased and passes any `Exception[K]` — no false positives, known misses.
+  Tightening that reading rejects programs and is a breaking change.
 - User-defined algebraic effects: `effect` / `perform` / `handle ... with` /
   `resume` (one-shot, lexically scoped — ADR-0050, ADR-0021 Phase 1
   tail-resumptive).

--- a/docs/spec/stable-surface.md
+++ b/docs/spec/stable-surface.md
@@ -57,6 +57,21 @@ of each item is [spec/syntax.md](syntax.md) and the
 - Composite types: tuples `(A, B)`, `Array[T]`, `Map[K, V]`, record, struct,
   enum, function types `(A) -> B`, effectful `(A) -> B with E`, generics `[T]`,
   trait bounds `[T: A + B]`, and the `Option[T]` sugar `T?` (ADR-0046).
+- **Equality (`==`) — the fail-closed contract** (ADR-0097 as shipped; measured
+  2026-08-19, #1526/#2157/#2192): where the operand's element type is known —
+  bare, through a name, inside tuples/structs/nested arrays, through a function
+  result, and for an unannotated `let xs = []` whose pushed values describe
+  themselves — `==` is **structural**. A comparison the compiler cannot
+  classify **traps at the comparison** once both sides are non-empty rather
+  than answering by length or identity; adding a type annotation resolves it.
+  An erased type variable (`[T: Eq]`) dispatches through its witness and is
+  rejected at check time for a container with no `Eq` impl. There is **no
+  silent reference equality** anywhere on this surface. SemVer reading: a
+  currently-trapping comparison later becoming a structural answer is a
+  compatible change (the typed lane, #2158); an existing answer changing is
+  breaking. The full contract is the cheatsheet's "`==` on `Array` / `Bytes`
+  (#1526)" section, pinned by `fixtures/structural_eq_contexts_test.vibe` and
+  the `structural_eq_untyped_empty_*_trap` fixtures.
 
 ### 2.2 Bindings and mutability
 - `let` (immutable), `let rec` (recursive), `let mut` (block-scoped mutable,

--- a/docs/spec/syntax.md
+++ b/docs/spec/syntax.md
@@ -298,10 +298,16 @@ A **marker trait** (one declared with no methods, like `Eq` above) dispatches
 to the builtin `==` / `<`. `==` on `Array` / `Bytes` is rewritten to a
 structural compare **only where the element type is statically known**
 (#1526 / ADR-0097); inside a `[T: Eq]`-bounded function the `T` is erased —
-no element type — so the builtin falls back to reference equality there. A
+no element type — so the comparison goes through the `Eq` witness the bound
+was handed, which answers correctly for witness-having types. A
 marker-trait impl on a container therefore **is declarable but is not
 honoured as a bound** — passing an `Array` to a `[T: Eq]` parameter is
-rejected, with a diagnostic that says the impl exists and why it was refused. Give the trait a method and the impl
+rejected at check time, with a diagnostic that says the impl exists and why
+it was refused (`` no impl `Eq` for `Array[Int]` ``). An UNBOUNDED formal
+(`fn f[T](x: Array[T], y: Array[T]) { x == y }`) has no witness either way;
+measured (2026-08-24), it never answers by identity — a comparison it cannot
+resolve structurally traps at run time, and a length/element difference
+answers `false`. Give the trait a method and the impl
 resolves through the witness dictionary instead, in either spelling
 (`impl M for Array[Int]` or `impl [T] M for Array[T]`). See #1503.
 

--- a/fixtures/typecheck/expected.tsv
+++ b/fixtures/typecheck/expected.tsv
@@ -416,3 +416,4 @@ formal_application_struct_field_reject	reject	type parameter `F` cannot take typ
 formal_application_alias_reject	reject	type parameter `F` cannot take type arguments in the body of type alias `Apply`
 formal_application_effect_op_reject	reject	type parameter `F` cannot take type arguments in the signature of `Bad::Put`
 formal_application_trait_method_reject	reject	type parameter `F` cannot take type arguments in the signature of `Functor::fmap`
+formal_application_value_shadow_ok	ok	

--- a/fixtures/typecheck/expected.tsv
+++ b/fixtures/typecheck/expected.tsv
@@ -414,3 +414,5 @@ perform_question_not_lowered	reject	`perform?` is not lowered yet: the checker t
 formal_application_signature_reject	reject	type parameter `F` cannot take type arguments in parameter `x`
 formal_application_struct_field_reject	reject	type parameter `F` cannot take type arguments in field `inner` of struct `Holder`
 formal_application_alias_reject	reject	type parameter `F` cannot take type arguments in the body of type alias `Apply`
+formal_application_effect_op_reject	reject	type parameter `F` cannot take type arguments in the signature of `Bad::Put`
+formal_application_trait_method_reject	reject	type parameter `F` cannot take type arguments in the signature of `Functor::fmap`

--- a/fixtures/typecheck/expected.tsv
+++ b/fixtures/typecheck/expected.tsv
@@ -418,3 +418,4 @@ formal_application_effect_op_reject	reject	type parameter `F` cannot take type a
 formal_application_trait_method_reject	reject	type parameter `F` cannot take type arguments in the signature of `Functor::fmap`
 formal_application_value_shadow_ok	ok	
 formal_application_local_let_reject	reject	type parameter `F` cannot take type arguments in a local let annotation
+reserved_formal_marker_ident_reject	reject	uses a reserved compiler-internal prefix

--- a/fixtures/typecheck/expected.tsv
+++ b/fixtures/typecheck/expected.tsv
@@ -417,3 +417,4 @@ formal_application_alias_reject	reject	type parameter `F` cannot take type argum
 formal_application_effect_op_reject	reject	type parameter `F` cannot take type arguments in the signature of `Bad::Put`
 formal_application_trait_method_reject	reject	type parameter `F` cannot take type arguments in the signature of `Functor::fmap`
 formal_application_value_shadow_ok	ok	
+formal_application_local_let_reject	reject	type parameter `F` cannot take type arguments in a local let annotation

--- a/fixtures/typecheck/expected.tsv
+++ b/fixtures/typecheck/expected.tsv
@@ -411,3 +411,5 @@ for_over_iterator_impl_struct	ok
 # lib/@vibe/compiler/tests/checker_entry_effect_test.vibe. Flip this row to `ok`
 # when the lowering lands.
 perform_question_not_lowered	reject	`perform?` is not lowered yet: the checker types it as `Attempt[T, String]`, but code generation cannot emit it (#2145).
+formal_application_signature_reject	reject	type parameter `F` cannot take type arguments in parameter `x`
+formal_application_struct_field_reject	reject	type parameter `F` cannot take type arguments in field `inner` of struct `Holder`

--- a/fixtures/typecheck/expected.tsv
+++ b/fixtures/typecheck/expected.tsv
@@ -413,3 +413,4 @@ for_over_iterator_impl_struct	ok
 perform_question_not_lowered	reject	`perform?` is not lowered yet: the checker types it as `Attempt[T, String]`, but code generation cannot emit it (#2145).
 formal_application_signature_reject	reject	type parameter `F` cannot take type arguments in parameter `x`
 formal_application_struct_field_reject	reject	type parameter `F` cannot take type arguments in field `inner` of struct `Holder`
+formal_application_alias_reject	reject	type parameter `F` cannot take type arguments in the body of type alias `Apply`

--- a/fixtures/typecheck/formal_application_alias_reject.vibe
+++ b/fixtures/typecheck/formal_application_alias_reject.vibe
@@ -1,0 +1,8 @@
+// #2268 (Codex P1 on #2267): a formal application hidden in a parameterized
+// alias body must reject the same way the direct signature spelling does --
+// resolve_type_alias_params would otherwise replace the `F` head wholesale
+// and drop its arguments.
+type Apply[F, A] = F[A]
+fn main {
+  ()
+}

--- a/fixtures/typecheck/formal_application_effect_op_reject.vibe
+++ b/fixtures/typecheck/formal_application_effect_op_reject.vibe
@@ -1,0 +1,9 @@
+// #2268 (Codex round 3 on #2267): a generic effect operation applying the
+// effect's own type formal -- #1340 substitutes eparams wholesale, so the
+// bracket arguments would be silently dropped.
+effect Bad[F, A] {
+  Put(F[A]) -> Unit
+}
+fn main {
+  ()
+}

--- a/fixtures/typecheck/formal_application_local_let_reject.vibe
+++ b/fixtures/typecheck/formal_application_local_let_reject.vibe
@@ -1,0 +1,10 @@
+// #2268 (Codex round 5 on #2267): a body-local let annotation applying an
+// enclosing fn's type formal -- binder provenance reaches the ascription
+// path through the EFn formal markers.
+fn g[F](x: F) -> Int {
+  let y: F[Int] = x
+  1
+}
+fn main {
+  ()
+}

--- a/fixtures/typecheck/formal_application_signature_reject.vibe
+++ b/fixtures/typecheck/formal_application_signature_reject.vibe
@@ -1,0 +1,9 @@
+// #2268: a type application whose head is a type formal has no application
+// semantics -- `F` unifies with the whole applied type, so this signature
+// would silently accept the identity function as a "map". Fail closed.
+fn fake_map[F, A, B](x: F[A], f: (A) -> B) -> F[B] {
+  x
+}
+fn main {
+  ()
+}

--- a/fixtures/typecheck/formal_application_struct_field_reject.vibe
+++ b/fixtures/typecheck/formal_application_struct_field_reject.vibe
@@ -1,0 +1,8 @@
+// #2268: same fail-close for a struct field naming an application of the
+// struct's own type formal.
+struct Holder[F] {
+  inner: F[Int]
+}
+fn main {
+  ()
+}

--- a/fixtures/typecheck/formal_application_trait_method_reject.vibe
+++ b/fixtures/typecheck/formal_application_trait_method_reject.vibe
@@ -1,0 +1,9 @@
+// #2268 (Codex round 3 on #2267): a trait method signature applying the
+// trait's own type formal -- stored unchanged by the STrait arm, erased at
+// dispatch, so F[A] and F[B] would mean the same type.
+trait Functor[F] {
+  fmap[A, B](F[A], (A) -> B) -> F[B]
+}
+fn main {
+  ()
+}

--- a/fixtures/typecheck/formal_application_value_shadow_ok.vibe
+++ b/fixtures/typecheck/formal_application_value_shadow_ok.vibe
@@ -1,0 +1,10 @@
+// #2268 (Codex round 4 on #2267): a VALUE parameter sharing its name with a
+// real type constructor must not make annotations using that constructor
+// look like formal applications -- formality comes from declared type
+// binders, never from env value types.
+fn f[T](Array: T, xs: Array[Int]) -> Int {
+  Array::length(xs)
+}
+fn main {
+  ()
+}

--- a/fixtures/typecheck/reserved_formal_marker_ident_reject.vibe
+++ b/fixtures/typecheck/reserved_formal_marker_ident_reject.vibe
@@ -1,0 +1,9 @@
+// #2268 (Codex round 6 on #2267): the compiler-internal formal markers are
+// ordinary env binds; a source identifier spelling one must reject at check
+// time instead of checking clean and dying in codegen.
+fn f[T]() -> Unit {
+  __fapp_formal__T
+}
+fn main {
+  ()
+}

--- a/lib/@vibe/compiler/checker/checker.vibe
+++ b/lib/@vibe/compiler/checker/checker.vibe
@@ -152,6 +152,15 @@ export fn attach_unlocated_decl_name_marker(errors: Array[String], from: Int, na
 /// cached env.
 let trait_erased_type_param_prefix: String = "__trait_erased_tp__"
 
+/// #2268 (Codex round 5 on #2267): binder provenance for declared fn type
+/// formals, carried in the env under a name no source can spell -- the same
+/// mechanism as `trait_erased_type_param_prefix` above. The EFn arm binds
+/// one marker per declared formal; the local-let ascription path reads them
+/// so `let y: F[Int] = x` under `fn g[F]` rejects like every declaration
+/// surface, without consulting value types (a VALUE binding whose type is a
+/// `CtVar` must never read as a formal -- round 4).
+let fapp_formal_marker_prefix: String = "__fapp_formal__"
+
 /// True when some entry of `methods` declares a method named `method_name`.
 fn trait_methods_declare(methods: Array[(String, Array[TypeExpr], TypeExpr)], method_name: String) -> Bool {
   let mut i = 0
@@ -342,10 +351,10 @@ export fn formal_application_error(fname: String, where_label: String) -> String
 /// rejected) -- and never an env lookup: a VALUE binding whose type is a
 /// `CtVar` is indistinguishable from a type formal by env alone, so
 /// `fn f[T](Array: T, xs: Array[Int])` would reject the valid builtin head
-/// (Codex round 4). Binder provenance is the only test. The cost is one
-/// narrow non-declaration site: a let annotation inside a generic fn
-/// (`let x: F[Int]` under `[F]`) has no local binder list and stays
-/// accepted-vacuous -- the same #2130 territory it was in before #2268.
+/// (Codex round 4). Binder provenance is the only test. The one
+/// non-declaration site -- a let annotation inside a generic fn -- is
+/// covered separately through the `fapp_formal_marker_prefix` markers the
+/// EFn arm binds (Codex round 5), which are also binder provenance.
 export fn report_formal_applications(te: TypeExpr, formals: Array[String], where_label: String, errors: Array[String]) -> Unit {
   let applied_formals = array_empty()
   // Bound to a let rather than written inline: vibe fmt's guard refuses a
@@ -7825,6 +7834,23 @@ fn check_expr_capture_impl(expr: Expr, env: TypeEnv, defs: Array[TypeDef], s: Su
             // formals of its own); the env is what knows the enclosing
             // declaration's, which is exactly the #2130 mapping above.
             report_unknown_type_names(ann_te, defs, array_empty(), env, array_empty(), "a local let annotation", errors)
+            // #2268 (Codex round 5): the enclosing EFn marked each declared
+            // formal (`fapp_formal_marker_prefix`), so binder provenance
+            // reaches this non-declaration site and `let y: F[Int] = x`
+            // rejects here too -- without the round-4 value-type misread.
+            let fapp_hits = array_empty()
+            let is_marked_formal = (head) -> {
+              match env_lookup(env, String::concat(fapp_formal_marker_prefix, head)) {
+                Some(_) => true,
+                None => false
+              }
+            }
+            collect_formal_applications_by(ann_te, is_marked_formal, fapp_hits)
+            let mut fapp_i = 0
+            while fapp_i < Array::length(fapp_hits) {
+              Array::push(errors, formal_application_error(Array::get(fapp_hits, fapp_i), "a local let annotation"))
+              fapp_i = fapp_i + 1
+            }
             let actual = subst_apply(ns0, at)
             // #981: `check_assignable` now runs the #844 same-name concrete
             // `CtNamed` check itself (its tolerate branch calls
@@ -8988,7 +9014,7 @@ fn check_expr_capture_impl(expr: Expr, env: TypeEnv, defs: Array[TypeDef], s: Su
             s0 = if Array::length(bounds) == 0 {
               s0
             } else subst_add_bound(s0, vid, bounds)
-            tp_env = env_bind(tp_env, tpname, tv)
+            tp_env = env_bind(env_bind(tp_env, tpname, tv), String::concat(fapp_formal_marker_prefix, tpname), CtUnit)
             c0 = nc
           },
           _ => ()

--- a/lib/@vibe/compiler/checker/checker.vibe
+++ b/lib/@vibe/compiler/checker/checker.vibe
@@ -296,56 +296,81 @@ export fn trait_erased_type_param_env(env: TypeEnv, binding_name: String) -> Typ
 /// `report_unknown_type_names` recognises one: membership in `shadow`, or an
 /// env binding to a `CtVar` (the enclosing binder's formal, visible where
 /// `shadow` is empty -- a local let annotation inside a generic fn).
-fn collect_formal_applications(te: TypeExpr, shadow: Array[String], env: TypeEnv, out: Array[String]) -> Unit {
+export fn collect_formal_applications_by(te: TypeExpr, is_formal: (String) -> Bool, out: Array[String]) -> Unit {
   match te {
     TyName(_) => (),
     TyUnit => (),
     TyApp(head, args) => {
-      let head_is_formal = string_array_has(shadow, head) || (match env_lookup(env, head) {
-        Some(t) => match t {
-          CtVar(_) => true,
-          _ => false
-        },
-        None => false
-      })
-      if head_is_formal && !string_array_has(out, head) {
+      if is_formal(head) && !string_array_has(out, head) {
         Array::push(out, head)
       } else {
         ()
       }
       let mut i = 0
       while i < Array::length(args) {
-        collect_formal_applications(Array::get(args, i), shadow, env, out)
+        collect_formal_applications_by(Array::get(args, i), is_formal, out)
         i = i + 1
       }
     },
     TyFn(params, ret, _) => {
       let mut i = 0
       while i < Array::length(params) {
-        collect_formal_applications(Array::get(params, i), shadow, env, out)
+        collect_formal_applications_by(Array::get(params, i), is_formal, out)
         i = i + 1
       }
-      collect_formal_applications(ret, shadow, env, out)
+      collect_formal_applications_by(ret, is_formal, out)
     },
     TyTuple(items) => {
       let mut i = 0
       while i < Array::length(items) {
-        collect_formal_applications(Array::get(items, i), shadow, env, out)
+        collect_formal_applications_by(Array::get(items, i), is_formal, out)
         i = i + 1
       }
     }
   }
 }
 
-export fn report_unknown_type_names(te: TypeExpr, defs: Array[TypeDef], shadow: Array[String], env: TypeEnv, row_binders: Array[String], where_label: String, errors: Array[String]) -> Unit {
+/// The one diagnostic text for #2268, shared by every surface that rejects a
+/// formal application so the message cannot drift between them.
+export fn formal_application_error(fname: String, where_label: String) -> String {
+  String::concat(String::concat(String::concat(String::concat("type parameter `", fname), "` cannot take type arguments in "), where_label), " -- a type parameter stands for a complete type, so the arguments would be ignored and every application of it would mean the same type. Spell the concrete constructor (e.g. `Array[...]`), or drop the arguments")
+}
+
+fn collect_formal_applications(te: TypeExpr, shadow: Array[String], env: TypeEnv, out: Array[String]) -> Unit {
+  // Bound to a let rather than written inline: vibe fmt's guard refuses a
+  // multiline closure literal in a non-final argument slot (#2271).
+  let is_formal = (head) -> {
+    string_array_has(shadow, head) || (match env_lookup(env, head) {
+      Some(t) => match t {
+        CtVar(_) => true,
+        _ => false
+      },
+      None => false
+    })
+  }
+  collect_formal_applications_by(te, is_formal, out)
+}
+
+/// #2268: the reporting face of `collect_formal_applications_by`. `formals`
+/// must be the declaration's OWN type parameters -- never the merged shadow
+/// `report_unknown_type_names` takes, which also carries deferred
+/// cross-package names (`Map` in a `.vpkg`-derived struct) that are types,
+/// not formals (the Codex round-2 false positive on #2267: every
+/// `Map[String, String]` field in `@vibe/http`'s synthesized types was
+/// rejected). The env test still recognizes an ENCLOSING binder's formal
+/// (bound to a `CtVar`) where the local formal list is empty -- a let
+/// annotation inside a generic fn.
+export fn report_formal_applications(te: TypeExpr, formals: Array[String], env: TypeEnv, where_label: String, errors: Array[String]) -> Unit {
   let applied_formals = array_empty()
-  collect_formal_applications(te, shadow, env, applied_formals)
+  collect_formal_applications(te, formals, env, applied_formals)
   let mut ai = 0
   while ai < Array::length(applied_formals) {
-    let fname = Array::get(applied_formals, ai)
-    Array::push(errors, String::concat(String::concat(String::concat(String::concat("type parameter `", fname), "` cannot take type arguments in "), where_label), " -- a type parameter stands for a complete type, so the arguments would be ignored and every application of it would mean the same type. Spell the concrete constructor (e.g. `Array[...]`), or drop the arguments"))
+    Array::push(errors, formal_application_error(Array::get(applied_formals, ai), where_label))
     ai = ai + 1
   }
+}
+
+export fn report_unknown_type_names(te: TypeExpr, defs: Array[TypeDef], shadow: Array[String], env: TypeEnv, row_binders: Array[String], where_label: String, errors: Array[String]) -> Unit {
   // Which of the unresolved names are region-ish binders at all. Asked over
   // the name candidates first because the positional walk below takes a set,
   // and `#region_` skolem membership is an env question this file owns.
@@ -7809,6 +7834,7 @@ fn check_expr_capture_impl(expr: Expr, env: TypeEnv, defs: Array[TypeDef], s: Su
             // formals of its own); the env is what knows the enclosing
             // declaration's, which is exactly the #2130 mapping above.
             report_unknown_type_names(ann_te, defs, array_empty(), env, array_empty(), "a local let annotation", errors)
+            report_formal_applications(ann_te, array_empty(), env, "a local let annotation", errors)
             let actual = subst_apply(ns0, at)
             // #981: `check_assignable` now runs the #844 same-name concrete
             // `CtNamed` check itself (its tolerate branch calls
@@ -9023,6 +9049,7 @@ fn check_expr_capture_impl(expr: Expr, env: TypeEnv, defs: Array[TypeDef], s: Su
               ()
             } else {
               report_unknown_type_names(te, defs, tparams, fn_env, declared_row_binders, String::concat(String::concat("parameter `", name), "`"), errors)
+              report_formal_applications(te, tparams, fn_env, String::concat(String::concat("parameter `", name), "`"), errors)
             }
             (pt2, s1, c1)
           },
@@ -9058,6 +9085,7 @@ fn check_expr_capture_impl(expr: Expr, env: TypeEnv, defs: Array[TypeDef], s: Su
         Some(rte) => {
           // #2125: see the parameter arm above.
           report_unknown_type_names(rte, defs, tparams, fn_env, declared_row_binders, "the return type", errors)
+          report_formal_applications(rte, tparams, fn_env, "the return type", errors)
           env_bind(fn_env, "__return__", resolve_tparams_in(resolve_type_expr_shadowed(rte, defs, tparams), fn_env))
         },
         None => env_bind(fn_env, "__return__", CtUnknown)

--- a/lib/@vibe/compiler/checker/checker.vibe
+++ b/lib/@vibe/compiler/checker/checker.vibe
@@ -287,7 +287,65 @@ export fn trait_erased_type_param_env(env: TypeEnv, binding_name: String) -> Typ
 ///      `fn fill(l: MutList[Int, r]) -> Unit with r`. Nothing binds `r` as a
 ///      value there; the binder is the row, so the call site passes its
 ///      variables in `row_binders`.
+/// #2268: collect type applications whose head is a type formal in scope --
+/// `F[A]` under `[F, A]`. Resolution has no application semantics for that
+/// shape: `F` unifies with the WHOLE applied type and the bracket arguments
+/// are ignored, so a signature spelled `(F[A], (A) -> B) -> F[B]` silently
+/// accepts the identity function. Fail closed at the annotation site until a
+/// type parameter can carry a kind. A formal is recognised the same two ways
+/// `report_unknown_type_names` recognises one: membership in `shadow`, or an
+/// env binding to a `CtVar` (the enclosing binder's formal, visible where
+/// `shadow` is empty -- a local let annotation inside a generic fn).
+fn collect_formal_applications(te: TypeExpr, shadow: Array[String], env: TypeEnv, out: Array[String]) -> Unit {
+  match te {
+    TyName(_) => (),
+    TyUnit => (),
+    TyApp(head, args) => {
+      let head_is_formal = string_array_has(shadow, head) || (match env_lookup(env, head) {
+        Some(t) => match t {
+          CtVar(_) => true,
+          _ => false
+        },
+        None => false
+      })
+      if head_is_formal && !string_array_has(out, head) {
+        Array::push(out, head)
+      } else {
+        ()
+      }
+      let mut i = 0
+      while i < Array::length(args) {
+        collect_formal_applications(Array::get(args, i), shadow, env, out)
+        i = i + 1
+      }
+    },
+    TyFn(params, ret, _) => {
+      let mut i = 0
+      while i < Array::length(params) {
+        collect_formal_applications(Array::get(params, i), shadow, env, out)
+        i = i + 1
+      }
+      collect_formal_applications(ret, shadow, env, out)
+    },
+    TyTuple(items) => {
+      let mut i = 0
+      while i < Array::length(items) {
+        collect_formal_applications(Array::get(items, i), shadow, env, out)
+        i = i + 1
+      }
+    }
+  }
+}
+
 export fn report_unknown_type_names(te: TypeExpr, defs: Array[TypeDef], shadow: Array[String], env: TypeEnv, row_binders: Array[String], where_label: String, errors: Array[String]) -> Unit {
+  let applied_formals = array_empty()
+  collect_formal_applications(te, shadow, env, applied_formals)
+  let mut ai = 0
+  while ai < Array::length(applied_formals) {
+    let fname = Array::get(applied_formals, ai)
+    Array::push(errors, String::concat(String::concat(String::concat(String::concat("type parameter `", fname), "` cannot take type arguments in "), where_label), " -- a type parameter stands for a complete type, so the arguments would be ignored and every application of it would mean the same type. Spell the concrete constructor (e.g. `Array[...]`), or drop the arguments"))
+    ai = ai + 1
+  }
   // Which of the unresolved names are region-ish binders at all. Asked over
   // the name candidates first because the positional walk below takes a set,
   // and `#region_` skolem membership is an env question this file owns.

--- a/lib/@vibe/compiler/checker/checker.vibe
+++ b/lib/@vibe/compiler/checker/checker.vibe
@@ -287,15 +287,12 @@ export fn trait_erased_type_param_env(env: TypeEnv, binding_name: String) -> Typ
 ///      `fn fill(l: MutList[Int, r]) -> Unit with r`. Nothing binds `r` as a
 ///      value there; the binder is the row, so the call site passes its
 ///      variables in `row_binders`.
-/// #2268: collect type applications whose head is a type formal in scope --
-/// `F[A]` under `[F, A]`. Resolution has no application semantics for that
-/// shape: `F` unifies with the WHOLE applied type and the bracket arguments
-/// are ignored, so a signature spelled `(F[A], (A) -> B) -> F[B]` silently
-/// accepts the identity function. Fail closed at the annotation site until a
-/// type parameter can carry a kind. A formal is recognised the same two ways
-/// `report_unknown_type_names` recognises one: membership in `shadow`, or an
-/// env binding to a `CtVar` (the enclosing binder's formal, visible where
-/// `shadow` is empty -- a local let annotation inside a generic fn).
+/// #2268: collect type applications whose head the caller classifies as a
+/// type formal (`F[A]` under `[F, A]`). Resolution has no application
+/// semantics for that shape: `F` unifies with the WHOLE applied type and the
+/// bracket arguments are ignored, so a signature spelled
+/// `(F[A], (A) -> B) -> F[B]` silently accepts the identity function. Fail
+/// closed at the annotation site until a type parameter can carry a kind.
 export fn collect_formal_applications_by(te: TypeExpr, is_formal: (String) -> Bool, out: Array[String]) -> Unit {
   match te {
     TyName(_) => (),
@@ -336,33 +333,27 @@ export fn formal_application_error(fname: String, where_label: String) -> String
   String::concat(String::concat(String::concat(String::concat("type parameter `", fname), "` cannot take type arguments in "), where_label), " -- a type parameter stands for a complete type, so the arguments would be ignored and every application of it would mean the same type. Spell the concrete constructor (e.g. `Array[...]`), or drop the arguments")
 }
 
-fn collect_formal_applications(te: TypeExpr, shadow: Array[String], env: TypeEnv, out: Array[String]) -> Unit {
-  // Bound to a let rather than written inline: vibe fmt's guard refuses a
-  // multiline closure literal in a non-final argument slot (#2271).
-  let is_formal = (head) -> {
-    string_array_has(shadow, head) || (match env_lookup(env, head) {
-      Some(t) => match t {
-        CtVar(_) => true,
-        _ => false
-      },
-      None => false
-    })
-  }
-  collect_formal_applications_by(te, is_formal, out)
-}
-
 /// #2268: the reporting face of `collect_formal_applications_by`. `formals`
-/// must be the declaration's OWN type parameters -- never the merged shadow
+/// must be the declaration's OWN type binders -- never the merged shadow
 /// `report_unknown_type_names` takes, which also carries deferred
 /// cross-package names (`Map` in a `.vpkg`-derived struct) that are types,
 /// not formals (the Codex round-2 false positive on #2267: every
 /// `Map[String, String]` field in `@vibe/http`'s synthesized types was
-/// rejected). The env test still recognizes an ENCLOSING binder's formal
-/// (bound to a `CtVar`) where the local formal list is empty -- a let
-/// annotation inside a generic fn.
-export fn report_formal_applications(te: TypeExpr, formals: Array[String], env: TypeEnv, where_label: String, errors: Array[String]) -> Unit {
+/// rejected) -- and never an env lookup: a VALUE binding whose type is a
+/// `CtVar` is indistinguishable from a type formal by env alone, so
+/// `fn f[T](Array: T, xs: Array[Int])` would reject the valid builtin head
+/// (Codex round 4). Binder provenance is the only test. The cost is one
+/// narrow non-declaration site: a let annotation inside a generic fn
+/// (`let x: F[Int]` under `[F]`) has no local binder list and stays
+/// accepted-vacuous -- the same #2130 territory it was in before #2268.
+export fn report_formal_applications(te: TypeExpr, formals: Array[String], where_label: String, errors: Array[String]) -> Unit {
   let applied_formals = array_empty()
-  collect_formal_applications(te, formals, env, applied_formals)
+  // Bound to a let rather than written inline: vibe fmt's guard refuses a
+  // multiline closure literal in a non-final argument slot (#2271).
+  let is_formal = (head) -> {
+    string_array_has(formals, head)
+  }
+  collect_formal_applications_by(te, is_formal, applied_formals)
   let mut ai = 0
   while ai < Array::length(applied_formals) {
     Array::push(errors, formal_application_error(Array::get(applied_formals, ai), where_label))
@@ -7834,7 +7825,6 @@ fn check_expr_capture_impl(expr: Expr, env: TypeEnv, defs: Array[TypeDef], s: Su
             // formals of its own); the env is what knows the enclosing
             // declaration's, which is exactly the #2130 mapping above.
             report_unknown_type_names(ann_te, defs, array_empty(), env, array_empty(), "a local let annotation", errors)
-            report_formal_applications(ann_te, array_empty(), env, "a local let annotation", errors)
             let actual = subst_apply(ns0, at)
             // #981: `check_assignable` now runs the #844 same-name concrete
             // `CtNamed` check itself (its tolerate branch calls
@@ -9049,7 +9039,7 @@ fn check_expr_capture_impl(expr: Expr, env: TypeEnv, defs: Array[TypeDef], s: Su
               ()
             } else {
               report_unknown_type_names(te, defs, tparams, fn_env, declared_row_binders, String::concat(String::concat("parameter `", name), "`"), errors)
-              report_formal_applications(te, tparams, fn_env, String::concat(String::concat("parameter `", name), "`"), errors)
+              report_formal_applications(te, tparams, String::concat(String::concat("parameter `", name), "`"), errors)
             }
             (pt2, s1, c1)
           },
@@ -9085,7 +9075,7 @@ fn check_expr_capture_impl(expr: Expr, env: TypeEnv, defs: Array[TypeDef], s: Su
         Some(rte) => {
           // #2125: see the parameter arm above.
           report_unknown_type_names(rte, defs, tparams, fn_env, declared_row_binders, "the return type", errors)
-          report_formal_applications(rte, tparams, fn_env, "the return type", errors)
+          report_formal_applications(rte, tparams, "the return type", errors)
           env_bind(fn_env, "__return__", resolve_tparams_in(resolve_type_expr_shadowed(rte, defs, tparams), fn_env))
         },
         None => env_bind(fn_env, "__return__", CtUnknown)

--- a/lib/@vibe/compiler/checker/checker.vibe
+++ b/lib/@vibe/compiler/checker/checker.vibe
@@ -6033,7 +6033,16 @@ fn check_expr_capture_impl(expr: Expr, env: TypeEnv, defs: Array[TypeDef], s: Su
     EString(_) => (CtString, s, c),
     EBool(_) => (CtBool, s, c),
     EUnit => (CtUnit, s, c),
-    EIdent(name, ident_off) => match env_lookup(env, railway_ident_lookup_name(name)) {
+    EIdent(name, ident_off) => if String::starts_with(name, fapp_formal_marker_prefix) || String::starts_with(name, trait_erased_type_param_prefix) {
+      // #2268 (Codex round 6 on #2267): both prefixes name compiler-internal
+      // env markers bound with ordinary EnvBind. Letting source resolve one
+      // as a value would check clean (the marker's CtUnit) and then die in
+      // codegen, which has no such local -- a check-passes/codegen-fails
+      // hole. Reserve the spellings and reject BEFORE resolution can find
+      // the marker.
+      Array::push(errors, String::concat(String::concat(String::concat("`", name), "` uses a reserved compiler-internal prefix (type-formal markers) -- rename the identifier"), off_marker_len(ident_off, String::length(name))))
+      (CtUnknown, s, c)
+    } else match env_lookup(env, railway_ident_lookup_name(name)) {
       Some(t) => {
         let (ti, c1, new_bounds) = instantiate(t, c)
         let nblen = Array::length(new_bounds)

--- a/lib/@vibe/compiler/checker/checker.vibe
+++ b/lib/@vibe/compiler/checker/checker.vibe
@@ -136,7 +136,14 @@ export fn attach_unlocated_decl_name_marker(errors: Array[String], from: Int, na
       // #2198: `if branches have incompatible types` joins them for the
       // all-literal case (`if c { "yes" } else { 0 }`) where the else
       // branch, the then-tail and the condition are all offset-less.
-      let anchorable = String::starts_with(msg, "return type mismatch") || String::starts_with(msg, "binding type mismatch for ") || String::starts_with(msg, "unknown type `") || String::starts_with(msg, "if branches have incompatible types")
+      // #2268 (Codex round 7 on #2267): `type parameter ...` joins -- the
+      // formal-application rejection reports from the same offset-less
+      // parameter/return/local-let annotations `unknown type` does, so it
+      // anchors on the declaration name the same way. The declaration-sweep
+      // sites (alias bodies, effect ops, trait methods, struct fields, enum
+      // payloads) stay unlocated exactly like their `unknown type` siblings
+      // -- locating those is the #1567 positions program, not this marker.
+      let anchorable = String::starts_with(msg, "return type mismatch") || String::starts_with(msg, "binding type mismatch for ") || String::starts_with(msg, "unknown type `") || String::starts_with(msg, "type parameter `") || String::starts_with(msg, "if branches have incompatible types")
       if anchorable && unlocated {
         Array::set(errors, i, String::concat(msg, String::concat(" [@fn=", String::concat(name, "]"))))
       }

--- a/lib/@vibe/compiler/checker/checker_stmt.vibe
+++ b/lib/@vibe/compiler/checker/checker_stmt.vibe
@@ -1936,7 +1936,6 @@ fn check_stmts_with_binders(raw_stmts: Array[Stmt], i: Int, env: TypeEnv, defs: 
             // `defs` and would be reported as unknown. Inside the
             // `ann_err_before` window so the binder name anchors it.
             report_unknown_type_names(te, defs, array_empty(), env, array_empty(), String::concat(String::concat("the annotation of `", name), "`"), errors)
-            report_formal_applications(te, array_empty(), env, String::concat(String::concat("the annotation of `", name), "`"), errors)
             let ns_b = check_assignable(resolved_te, actual_v, ns0, errors, String::concat("binding type mismatch for ", name), top_stmt_expr_off(val))
             // #1941: a literal value carries no offset, so anchor the binder
             // name instead of emitting the one unlocated diagnostic left in
@@ -2113,7 +2112,7 @@ fn check_stmts_with_binders(raw_stmts: Array[Stmt], i: Int, env: TypeEnv, defs: 
             report_unknown_type_names(Array::get(vtypes, ti), defs, decl_report_shadow(params, array_empty(), deferred_names_for_decl(deferred_type_names, name)), env, array_empty(), String::concat(String::concat(String::concat("the payload of `", name), String::concat("::", vname)), "`"), errors)
             // #2268: formals are the enum's OWN params -- never the merged
             // report shadow, whose deferred cross-package names are types.
-            report_formal_applications(Array::get(vtypes, ti), params, env, String::concat(String::concat(String::concat("the payload of `", name), String::concat("::", vname)), "`"), errors)
+            report_formal_applications(Array::get(vtypes, ti), params, String::concat(String::concat(String::concat("the payload of `", name), String::concat("::", vname)), "`"), errors)
             // #1512: `params` shadow `defs`, so the substitution below still
             // finds `CtNamed(<param>, [])` when an import bound that name.
             let named_vt = resolve_type_expr_shadowed(Array::get(vtypes, ti), defs, params)
@@ -2317,7 +2316,7 @@ fn check_stmts_with_binders(raw_stmts: Array[Stmt], i: Int, env: TypeEnv, defs: 
           // `dict_erased`, so a synthesized `<Trait>Dict` witness struct
           // keeps today's accept-but-undispatchable behavior for a trait
           // spelling its own formal applied.
-          report_formal_applications(ftype_expr, tparams, env, String::concat(String::concat(String::concat("field `", fname), "` of struct `"), String::concat(name, "`")), errors)
+          report_formal_applications(ftype_expr, tparams, String::concat(String::concat(String::concat("field `", fname), "` of struct `"), String::concat(name, "`")), errors)
           // #1512: `tparams` shadow `defs` -- the #829 comment below assumes a
           // param name resolves to a rigid `CtNamed(param, [])` because no
           // typedef/builtin claims it, which an import alias otherwise breaks.

--- a/lib/@vibe/compiler/checker/checker_stmt.vibe
+++ b/lib/@vibe/compiler/checker/checker_stmt.vibe
@@ -65,13 +65,16 @@ import ./checker.vibe {
   check_assignable,
   check_expr,
   check_expr_capture,
+  collect_formal_applications_by,
   constructor_dependency_row,
   fn_return_env_name,
+  formal_application_error,
   is_array_builder_ty,
   is_region_tagged_ty,
   pat_binds_resume,
   preserve_generic_instantiation,
   reject_resume_outside_handler,
+  report_formal_applications,
   report_unknown_type_names,
   trait_erased_type_param_env,
   typed_occurrence_capture_begin_statement,
@@ -1933,6 +1936,7 @@ fn check_stmts_with_binders(raw_stmts: Array[Stmt], i: Int, env: TypeEnv, defs: 
             // `defs` and would be reported as unknown. Inside the
             // `ann_err_before` window so the binder name anchors it.
             report_unknown_type_names(te, defs, array_empty(), env, array_empty(), String::concat(String::concat("the annotation of `", name), "`"), errors)
+            report_formal_applications(te, array_empty(), env, String::concat(String::concat("the annotation of `", name), "`"), errors)
             let ns_b = check_assignable(resolved_te, actual_v, ns0, errors, String::concat("binding type mismatch for ", name), top_stmt_expr_off(val))
             // #1941: a literal value carries no offset, so anchor the binder
             // name instead of emitting the one unlocated diagnostic left in
@@ -2107,6 +2111,9 @@ fn check_stmts_with_binders(raw_stmts: Array[Stmt], i: Int, env: TypeEnv, defs: 
             // #2125: an unknown name in a payload otherwise becomes a wildcard
             // `CtNamed` -- same hole as the annotation sites.
             report_unknown_type_names(Array::get(vtypes, ti), defs, decl_report_shadow(params, array_empty(), deferred_names_for_decl(deferred_type_names, name)), env, array_empty(), String::concat(String::concat(String::concat("the payload of `", name), String::concat("::", vname)), "`"), errors)
+            // #2268: formals are the enum's OWN params -- never the merged
+            // report shadow, whose deferred cross-package names are types.
+            report_formal_applications(Array::get(vtypes, ti), params, env, String::concat(String::concat(String::concat("the payload of `", name), String::concat("::", vname)), "`"), errors)
             // #1512: `params` shadow `defs`, so the substitution below still
             // finds `CtNamed(<param>, [])` when an import bound that name.
             let named_vt = resolve_type_expr_shadowed(Array::get(vtypes, ti), defs, params)
@@ -2304,6 +2311,13 @@ fn check_stmts_with_binders(raw_stmts: Array[Stmt], i: Int, env: TypeEnv, defs: 
           let dict_erased = trait_dict_erasure_for(trait_dict_erasures, name, fname)
           let report_shadow = decl_report_shadow(tparams, dict_erased, deferred_names_for_decl(deferred_type_names, name))
           report_unknown_type_names(ftype_expr, defs, report_shadow, env, array_empty(), String::concat(String::concat(String::concat("field `", fname), "` of struct `"), String::concat(name, "`")), errors)
+          // #2268: formals are the struct's OWN tparams -- never
+          // `report_shadow`, whose deferred cross-package names (`Map` in a
+          // `.vpkg`-derived struct) are types, not formals; and not
+          // `dict_erased`, so a synthesized `<Trait>Dict` witness struct
+          // keeps today's accept-but-undispatchable behavior for a trait
+          // spelling its own formal applied.
+          report_formal_applications(ftype_expr, tparams, env, String::concat(String::concat(String::concat("field `", fname), "` of struct `"), String::concat(name, "`")), errors)
           // #1512: `tparams` shadow `defs` -- the #829 comment below assumes a
           // param name resolves to a rigid `CtNamed(param, [])` because no
           // typedef/builtin claims it, which an import alias otherwise breaks.
@@ -3568,8 +3582,53 @@ fn tps_scan_stmts(stmts: Array[Stmt], local_types: Array[String], errors: Array[
   }
 }
 
+/// #2268 (Codex P1 on #2267): a formal application hidden in a parameterized
+/// alias body -- `type Apply[F, A] = F[A]` -- never reaches
+/// `report_unknown_type_names` (the STypeAlias env arm resolves without
+/// reporting), and `resolve_type_alias_params` then replaces the `F` head
+/// wholesale, dropping its arguments, so an `Apply[F, A]` annotation would
+/// recreate the exact identity-as-map hole the fn-signature check closes.
+/// Validate the body with the alias's own params as the formal set -- an
+/// alias body has no enclosing formal scope, so shadow membership is the
+/// whole test here.
+fn collect_alias_formal_application_errors(stmts: Array[Stmt], errors: Array[String]) -> Unit {
+  let mut i = 0
+  while i < Array::length(stmts) {
+    match Array::get(stmts, i) {
+      STypeAlias(_, name, params, te) => {
+        let hits = array_empty()
+        // Bound to a let rather than written inline: vibe fmt's guard refuses
+        // a multiline closure literal in a non-final argument slot (#2271).
+        let is_param = (head) -> {
+          let mut pi = 0
+          let mut found = false
+          while pi < Array::length(params) {
+            if Array::get(params, pi) == head {
+              found = true
+            } else {
+              ()
+            }
+            pi = pi + 1
+          }
+          found
+        }
+        collect_formal_applications_by(te, is_param, hits)
+        let mut hi = 0
+        while hi < Array::length(hits) {
+          Array::push(errors, formal_application_error(Array::get(hits, hi), String::concat(String::concat("the body of type alias `", name), "`")))
+          hi = hi + 1
+        }
+      },
+      SModule(_, _, body) => collect_alias_formal_application_errors(body, errors),
+      _ => ()
+    }
+    i = i + 1
+  }
+}
+
 fn collect_type_param_shadowing_errors(stmts: Array[Stmt], errors: Array[String]) -> Unit {
   collect_reserved_type_prefix_errors(stmts, errors)
+  collect_alias_formal_application_errors(stmts, errors)
   let local_types = tps_local_type_names(stmts)
   if Array::length(local_types) == 0 {
     ()

--- a/lib/@vibe/compiler/checker/checker_stmt.vibe
+++ b/lib/@vibe/compiler/checker/checker_stmt.vibe
@@ -3582,44 +3582,101 @@ fn tps_scan_stmts(stmts: Array[Stmt], local_types: Array[String], errors: Array[
   }
 }
 
-/// #2268 (Codex P1 on #2267): a formal application hidden in a parameterized
-/// alias body -- `type Apply[F, A] = F[A]` -- never reaches
-/// `report_unknown_type_names` (the STypeAlias env arm resolves without
-/// reporting), and `resolve_type_alias_params` then replaces the `F` head
-/// wholesale, dropping its arguments, so an `Apply[F, A]` annotation would
-/// recreate the exact identity-as-map hole the fn-signature check closes.
-/// Validate the body with the alias's own params as the formal set -- an
-/// alias body has no enclosing formal scope, so shadow membership is the
-/// whole test here.
-fn collect_alias_formal_application_errors(stmts: Array[Stmt], errors: Array[String]) -> Unit {
+/// #2268 (Codex on #2267, rounds 2-3): a formal application can hide in any
+/// declaration whose signatures are resolved WITHOUT passing through
+/// `report_unknown_type_names` -- a parameterized alias body
+/// (`type Apply[F, A] = F[A]`), a generic effect operation
+/// (`effect Bad[F, A] { Put(F[A]) -> Unit }`, #1340 registers eparams as
+/// rigid names and substitutes them wholesale), and a trait method signature
+/// (`trait Functor[F] { fmap[A, B](F[A], (A) -> B) -> F[B] }`, stored
+/// unchanged by the STrait arm). Each declaration's own params are the whole
+/// formal set -- none of these bodies has an enclosing formal scope -- so
+/// shadow membership is the whole test here.
+fn fapp_report(te: TypeExpr, formals: Array[String], where_label: String, errors: Array[String]) -> Unit {
+  let hits = array_empty()
+  // Bound to a let rather than written inline: vibe fmt's guard refuses
+  // a multiline closure literal in a non-final argument slot (#2271).
+  let is_param = (head) -> {
+    let mut pi = 0
+    let mut found = false
+    while pi < Array::length(formals) {
+      if Array::get(formals, pi) == head {
+        found = true
+      } else {
+        ()
+      }
+      pi = pi + 1
+    }
+    found
+  }
+  collect_formal_applications_by(te, is_param, hits)
+  let mut hi = 0
+  while hi < Array::length(hits) {
+    Array::push(errors, formal_application_error(Array::get(hits, hi), where_label))
+    hi = hi + 1
+  }
+}
+
+fn fapp_decl_label(owner: String, member: String) -> String {
+  String::concat(String::concat(String::concat("the signature of `", owner), String::concat("::", member)), "`")
+}
+
+fn collect_decl_formal_application_errors(stmts: Array[Stmt], errors: Array[String]) -> Unit {
   let mut i = 0
   while i < Array::length(stmts) {
     match Array::get(stmts, i) {
-      STypeAlias(_, name, params, te) => {
-        let hits = array_empty()
-        // Bound to a let rather than written inline: vibe fmt's guard refuses
-        // a multiline closure literal in a non-final argument slot (#2271).
-        let is_param = (head) -> {
+      STypeAlias(_, name, params, te) => fapp_report(te, params, String::concat(String::concat("the body of type alias `", name), "`"), errors),
+      SEffectDef(_, ename, eparams, ops) => {
+        let mut oi = 0
+        while oi < Array::length(ops) {
+          let (opname, opparams, opret) = Array::get(ops, oi)
           let mut pi = 0
-          let mut found = false
-          while pi < Array::length(params) {
-            if Array::get(params, pi) == head {
-              found = true
+          while pi < Array::length(opparams) {
+            fapp_report(Array::get(opparams, pi), eparams, fapp_decl_label(ename, opname), errors)
+            pi = pi + 1
+          }
+          fapp_report(opret, eparams, fapp_decl_label(ename, opname), errors)
+          oi = oi + 1
+        }
+      },
+      STrait(_, tname, _, methods, method_gens, tparams) => {
+        let mut mi = 0
+        while mi < Array::length(methods) {
+          let (mname, mparams, mret) = Array::get(methods, mi)
+          // The method's formal set: the trait's own params plus this
+          // method's generic binders (`Self` never takes arguments and an
+          // application of it is equally vacuous, so it is included).
+          let formals = array_empty()
+          Array::push(formals, "Self")
+          let mut ti = 0
+          while ti < Array::length(tparams) {
+            Array::push(formals, Array::get(tparams, ti))
+            ti = ti + 1
+          }
+          let mut gi = 0
+          while gi < Array::length(method_gens) {
+            let (gname, gtp, _) = Array::get(method_gens, gi)
+            if gname == mname {
+              let mut gj = 0
+              while gj < Array::length(gtp) {
+                Array::push(formals, Array::get(gtp, gj))
+                gj = gj + 1
+              }
             } else {
               ()
             }
+            gi = gi + 1
+          }
+          let mut pi = 0
+          while pi < Array::length(mparams) {
+            fapp_report(Array::get(mparams, pi), formals, fapp_decl_label(tname, mname), errors)
             pi = pi + 1
           }
-          found
-        }
-        collect_formal_applications_by(te, is_param, hits)
-        let mut hi = 0
-        while hi < Array::length(hits) {
-          Array::push(errors, formal_application_error(Array::get(hits, hi), String::concat(String::concat("the body of type alias `", name), "`")))
-          hi = hi + 1
+          fapp_report(mret, formals, fapp_decl_label(tname, mname), errors)
+          mi = mi + 1
         }
       },
-      SModule(_, _, body) => collect_alias_formal_application_errors(body, errors),
+      SModule(_, _, body) => collect_decl_formal_application_errors(body, errors),
       _ => ()
     }
     i = i + 1
@@ -3628,7 +3685,7 @@ fn collect_alias_formal_application_errors(stmts: Array[Stmt], errors: Array[Str
 
 fn collect_type_param_shadowing_errors(stmts: Array[Stmt], errors: Array[String]) -> Unit {
   collect_reserved_type_prefix_errors(stmts, errors)
-  collect_alias_formal_application_errors(stmts, errors)
+  collect_decl_formal_application_errors(stmts, errors)
   let local_types = tps_local_type_names(stmts)
   if Array::length(local_types) == 0 {
     ()

--- a/lib/@vibe/compiler/checker/index.vpkg
+++ b/lib/@vibe/compiler/checker/index.vpkg
@@ -135,6 +135,9 @@ fn check_assignable(expected: Type, actual: Type, s: Subst, errors: Array[String
 fn detect_narrowed_generic_mismatch(expected: Type, actual: Type, s: Subst, errors: Array[String], what: String, off: Int) -> Subst
 fn preserve_generic_instantiation(resolved: Type, actual: Type) -> Type
 fn report_unknown_type_names(te: TypeExpr, defs: Array[TypeDef], shadow: Array[String], env: TypeEnv, row_binders: Array[String], where_label: String, errors: Array[String]) -> Unit
+fn collect_formal_applications_by(te: TypeExpr, is_formal: (String) -> Bool, out: Array[String]) -> Unit
+fn report_formal_applications(te: TypeExpr, formals: Array[String], env: TypeEnv, where_label: String, errors: Array[String]) -> Unit
+fn formal_application_error(fname: String, where_label: String) -> String
 fn trait_erased_type_param_env(env: TypeEnv, binding_name: String) -> TypeEnv
 fn fn_return_env_name(name: String) -> String
 fn enum_def_env_name(name: String) -> String

--- a/lib/@vibe/compiler/checker/index.vpkg
+++ b/lib/@vibe/compiler/checker/index.vpkg
@@ -136,7 +136,7 @@ fn detect_narrowed_generic_mismatch(expected: Type, actual: Type, s: Subst, erro
 fn preserve_generic_instantiation(resolved: Type, actual: Type) -> Type
 fn report_unknown_type_names(te: TypeExpr, defs: Array[TypeDef], shadow: Array[String], env: TypeEnv, row_binders: Array[String], where_label: String, errors: Array[String]) -> Unit
 fn collect_formal_applications_by(te: TypeExpr, is_formal: (String) -> Bool, out: Array[String]) -> Unit
-fn report_formal_applications(te: TypeExpr, formals: Array[String], env: TypeEnv, where_label: String, errors: Array[String]) -> Unit
+fn report_formal_applications(te: TypeExpr, formals: Array[String], where_label: String, errors: Array[String]) -> Unit
 fn formal_application_error(fname: String, where_label: String) -> String
 fn trait_erased_type_param_env(env: TypeEnv, binding_name: String) -> TypeEnv
 fn fn_return_env_name(name: String) -> String


### PR DESCRIPTION
Three freeze-prep items from the 0.1.0 scope discussion, each an owner decision recorded and enforced.

**1. `==` fail-closed contract into `spec/stable-surface.md` §2.1.** The tag freezes what `==` means today: structural wherever the element type is known, a **trap** (fixed by an annotation) where classification is impossible, witness dispatch for erased `[T: Eq]`, and an unbounded formal comparing containers on the trap side too — no silent reference equality anywhere. SemVer reading stated explicitly: the typed lane (#2158) later turning a trap into an answer is compatible, so **#2158 leaves the 0.1.0 critical path**. The two canonical documents were reconciled in the same change (measured: `Box[Double]` / `Box[Array[Int]]` are structural since #2195, and `docs/spec/syntax.md`'s "falls back to reference equality" sentence described pre-witness behavior).

**2. `Exception[E]` typed rows into §2.6** (owner decision: include). The frozen contract as measured: call-form `throw(x)`, `suberror`, `Exception[E]` where `E` is the payload's **static type** (a primitive such as `String` qualifies), exact-kind discharge as a **checker-side** guarantee over statically kinded rows (against an erased row, kinded and erased are compatible both ways over the single runtime tag), `effectset` union, and the gradual reading of payloads that cannot be resolved (pattern binders, field projections — an ordinary local binding *is* resolved from its initializer). Tightening any of it later is breaking.

**3. Fail-close type-formal applications (`F[A]`), closes #2268.** Measured before the fix: `F` unified with the whole applied type and the bracket arguments were ignored — `(F[A], (A) -> B) -> F[B]` accepted the identity function. Now **every** declaration surface rejects it: fn parameters and return types, top-level and body-local `let` annotations, enum payloads, struct fields, parameterized type-alias bodies, generic effect operations, and trait method signatures. Formality is decided by **declared binder provenance only** (a value parameter named `Array` does not make `Array[Int]` an application; body-local annotations get provenance through env markers whose spellings are reserved against source use), and the diagnostics anchor on the declaration name where an anchor exists. Unapplied declared params (`trait Iter[A] { nth(Self, Int) -> Option[A] }`) stay accepted. Freeze logic: giving `F[T]` real semantics later (HKT — the target release is decided on #2269) turns today's vacuous acceptances into errors, so rejecting them now is free and after the tag it is breaking.

## Review rounds

Seven Codex rounds, each reproduced Red before the fix: alias-body bypass; the CI failure the first push caused (the check had piggybacked on `report_unknown_type_names` and misread `.vpkg` deferred names such as `Map` as formals); effect/trait signatures; value-parameter name collisions; body-local annotations; markers leaking into the value namespace (check-clean → codegen ICE, which also closed the same latent hole on the pre-existing trait-erasure marker); and diagnostic anchoring.

## Verification (stage2 built from this branch at each round)

Self-compile clean; Red→Green on the probe corpus; typecheck fixture gate **242 rows** (6 new: 5 reject + 1 `ok` for the collision shape that must keep compiling); full `unit_test_runner` **255 files ok**; early gate ok; cheatsheet doctest 36 pass / 0 fail; `vibe fmt` fixpoint. Perf report: execution metrics ±0 across all 9 scenarios, size +0.1%.

## Filed, not fixed here

**#2271** — `vibe fmt` refuses a multiline closure literal in a non-final argument slot, leaving a permanent `--check` diff with no diagnostic. Two call sites here carry the `let`-bound workaround and a pointer.