### PR TITLE
Map::keys answers with the receiver's key slot (#2263 first slice)

### DIFF
--- a/fixtures/typecheck/expected.tsv
+++ b/fixtures/typecheck/expected.tsv
@@ -419,3 +419,5 @@ formal_application_trait_method_reject	reject	type parameter `F` cannot take typ
 formal_application_value_shadow_ok	ok	
 formal_application_local_let_reject	reject	type parameter `F` cannot take type arguments in a local let annotation
 reserved_formal_marker_ident_reject	reject	uses a reserved compiler-internal prefix
+map_keys_key_slot_reject	reject	argument type mismatch
+map_keys_string_slot_ok	ok	

--- a/fixtures/typecheck/map_keys_key_slot_reject.vibe
+++ b/fixtures/typecheck/map_keys_key_slot_reject.vibe
@@ -1,0 +1,11 @@
+// #2263: keys() must answer with the receiver's KEY slot. The shape table
+// answered Array[String] for every receiver, so these keys reached
+// String::length and compiled clean -- an annotation that disables checking
+// at the slot (the #2125 class).
+fn f(m: Map[Int, String]) -> Int {
+  let ks = Map::keys(m)
+  String::length(Array::get(ks, 0))
+}
+fn main {
+  ()
+}

--- a/fixtures/typecheck/map_keys_string_slot_ok.vibe
+++ b/fixtures/typecheck/map_keys_string_slot_ok.vibe
@@ -1,0 +1,9 @@
+// #2263 control: an ordinary String-keyed map keeps answering Array[String],
+// so the same body is accepted here.
+fn f(m: Map[String, Int]) -> Int {
+  let ks = Map::keys(m)
+  String::length(Array::get(ks, 0))
+}
+fn main {
+  ()
+}

--- a/lib/@vibe/compiler/checker/checker.vibe
+++ b/lib/@vibe/compiler/checker/checker.vibe
@@ -6961,6 +6961,25 @@ fn check_expr_capture_impl(expr: Expr, env: TypeEnv, defs: Array[TypeDef], s: Su
             _ => CtOption(CtUnknown)
           }
           (tab_call_ty(tytab, call_off, mbresult, capture, lane), s3, c2)
+        } else if name == "Map::keys" && Array::length(args) == 1 {
+          // #2263: keys() of a key-slotted map is `Array[k]`. The shape table
+          // answers `Array[String]` for every receiver, so a `Map[Int, V]`
+          // annotation handed its keys to `String::length` and compiled clean
+          // -- an annotation that disables checking at the slot, the #2125
+          // class. Every map the builtins can BUILD is still String-keyed
+          // (Map::set and from_pairs reject a non-String key), so for real
+          // programs this is the same answer; it stops the type from lying
+          // where the annotation says otherwise.
+          let (m_ty, s1, c1) = check_expr_capture(Array::get(args, 0), env, defs, s, c, errors, tytab, capture, lane)
+          let result = match subst_apply(s1, m_ty) {
+            CtNamed(mn, margs) => if mn == "Map" && Array::length(margs) == 2 {
+              CtArray(subst_apply(s1, Array::get(margs, 0)))
+            } else {
+              CtArray(CtString)
+            },
+            _ => CtArray(CtString)
+          }
+          (tab_call_ty(tytab, call_off, result, capture, lane), s1, c1)
         } else if name == "Map::values" && Array::length(args) == 1 {
           // #983: values() of a value-slotted map is `Array[v]`, not
           // `Array[CtUnknown]`.


### PR DESCRIPTION
First slice of the generic-`Map`-keys work (#2263), landed ahead of the shape decision because **both** candidate shapes need it and it closes a live type-level hole.

## The hole

`Map::keys` answered `Array[String]` for **every** receiver — the return came from the name-keyed shape table, which never sees the receiver. So an annotation could disable checking at the slot (the #2125 class). Measured Red on stage2 @ 1cc6d73:

```vibe
fn f(m: Map[Int, String]) -> Int {
  let ks = Map::keys(m)
  String::length(Array::get(ks, 0))   // accepted, compiled clean
}
```

## The fix

The ECall arm refines `keys()` from the receiver's **key** slot, exactly the way the #983 arms refine `get` / `values` / `delete` from the value slot; a receiver with no key slot keeps answering `Array[String]`.

Green, measured on a stage2 built from this branch: the probe above now rejects with a located ``argument type mismatch for String::length: receiver type Int``, and a String-keyed map's keys still feed `String::length` / `Array::length` (test passes).

This changes **no** real program's typing: every map the builtins can build is still String-keyed — `Map::set(m, 1, "x")` and `Map::from_pairs([(1, "one")])` both reject a non-String key (measured). It only stops the type from lying where an annotation says otherwise.

## Context for the rest of #2263

The measurement that motivated splitting this out is recorded in [the issue comment](https://github.com/mizchi/vibe-lang/issues/2263#issuecomment-5397187272): map storage is already key-agnostic (raw `i64` entry slot) and the probe's equality is already the generic runtime `eq` — only the **hash** is String-specific. But there is no runtime type tag (the runtime `eq` is bit-equality plus a `looks_like_string` heuristic), so generic keys need the key kind carried in the map header and dispatched by `build_index`/`probe`, not a `hash_key → String` encoding. That is a multi-PR program and is not in this PR.

## Verification

Typecheck fixture gate ok (244 rows, incl. the new reject + `ok` control pair), full `unit_test_runner` (255 files) ok, early gate ok, `vibe fmt` fixpoint.

---
_Generated by [Claude Code](https://claude.ai/code/session_012BesqGvopmB2byi8gB4HXG)_