### PR TITLE
Reject unsound concrete generic impl targets

### DIFF
--- a/docs/cheatsheet.md
+++ b/docs/cheatsheet.md
@@ -853,8 +853,7 @@ let bad = keep([1, 2, 3])     // reject される
 
 container に対して効かせたいなら **trait にメソッドを持たせる** —
 メソッドがあれば witness dictionary 経由でディスパッチするので、
-concrete (`impl M for Array[Int]`) でも generic (`impl [T] M for Array[T]`)
-でも解決する:
+generic impl (`impl [T] M for Array[T]`) を解決できる:
 
 ```vibe
 trait Measured {
@@ -897,13 +896,11 @@ the same diagnostic, naming the declaration (`` in the signature of
 `Functor::fmap` ``). A trait or effect may still DECLARE type parameters and
 use them unapplied (`trait Iter[A] { nth(Self, Int) -> Option[A] }`).
 
-> #1503 以前は、**concrete な impl (`impl M for Array[Int]`) が method-bearing
-> trait でも解決しなかった**。パーサが `for` の後ろの `[Int]` を捨てるため、
-> 環境には `Array` という頭だけが残る。今は generic 版と同じく**コンストラクタで
-> 照合する**ので両方の綴りが同じ挙動になる。裏を返すと、
-> `impl M for Array[Int]` は今のところ `Array[String]` にも効く
-> (パーサが型引数を保持していないため) — 特定の instantiation だけに
-> 絞る書き方はまだ無い。
+> A concrete generic impl target such as `impl M for Array[Int]` is rejected
+> (#2262). The impl AST cannot retain the `[Int]` argument; accepting it would
+> silently widen the impl to `Array[String]` and every other instantiation.
+> Write the honest generic form, `impl [T] M for Array[T]`. Impl specialization
+> for one generic instantiation is not supported yet.
 
 ## Collections
 

--- a/docs/cheatsheet.md
+++ b/docs/cheatsheet.md
@@ -828,32 +828,34 @@ impl [T: Eq] Eq for Array[T]              // 宣言はできるが bound には�
 // T 型の引数 (または Array[T] 引数) を witness carrier にすること。
 ```
 
-### marker trait の impl は container には効かない (#1503)
+### Marker-trait impls do not satisfy bounds for containers (#1503)
 
-**メソッドを持たない trait (marker trait) の impl は、`Array` / `Bytes` の
-ような container に対して bound として使えない。** 宣言自体は通るが、
-その型を bound 付きの関数へ渡すと拒否される:
+**An impl of a trait with no methods (a marker trait) cannot satisfy a bound
+for a container such as `Array` or `Bytes`.** The declaration itself is
+accepted, but passing that type to a bounded function is rejected:
 
 ```vibe skip
-trait Eq                      // メソッド無し = marker trait
-impl [T: Eq] Eq for Array[T]  // 宣言は通る
+trait Eq                      // No methods: this is a marker trait
+impl [T: Eq] Eq for Array[T]  // The declaration is accepted
 
 fn keep[T: Eq](x: T) -> T { x }
-let bad = keep([1, 2, 3])     // reject される
+let bad = keep([1, 2, 3])     // Rejected
 ```
 
-理由は marker trait の**ディスパッチ先**にある。marker trait は builtin の
-`==` / `<` に落ちる。`==` が配列を構造的に比較できるのは**要素型が静的に
-分かるとき**だけ (下の「`Array` の `==`」参照) で、`keep[T: Eq]` の中の `T` は
-消去済み — 要素型は無い。つまりこの impl を認めると `==` は参照等価に落ちて
-黙って間違った答えを返す。診断がその旨を述べる。
+The reason is the marker trait's **dispatch target**. Marker traits lower to
+the builtin `==` / `<`. Array `==` can compare structurally only when the
+element type is statically known (see "`Array` equality" below), while the `T`
+inside `keep[T: Eq]` is erased and carries no element type. Honouring this impl
+would therefore let `==` fall back to reference equality and silently answer
+incorrectly. The diagnostic explains this restriction.
 
-> このゲートは ADR-0097 (`==` を全文脈で構造的等価に統一) の完了時に**解除
-> される** — 根拠そのものが無くなるため。それまでは上の規則が有効。
+> This gate will be removed when ADR-0097 makes `==` structural in every
+> context, because its justification will then be gone. Until that work is
+> complete, the rule above remains in force.
 
-container に対して効かせたいなら **trait にメソッドを持たせる** —
-メソッドがあれば witness dictionary 経由でディスパッチするので、
-generic impl (`impl [T] M for Array[T]`) を解決できる:
+To use a trait bound with a container, **give the trait a method**. A
+method-bearing trait dispatches through a witness dictionary, so a generic
+impl such as `impl [T] M for Array[T]` can be resolved:
 
 ```vibe
 trait Measured {

--- a/docs/spec/syntax.md
+++ b/docs/spec/syntax.md
@@ -307,9 +307,12 @@ it was refused (`` no impl `Eq` for `Array[Int]` ``). An UNBOUNDED formal
 (`fn f[T](x: Array[T], y: Array[T]) { x == y }`) has no witness either way;
 measured (2026-08-24), it never answers by identity — a comparison it cannot
 resolve structurally traps at run time, and a length/element difference
-answers `false`. Give the trait a method and the impl
-resolves through the witness dictionary instead, in either spelling
-(`impl M for Array[Int]` or `impl [T] M for Array[T]`). See #1503.
+answers `false`. Give the trait a method and use a generic impl
+(`impl [T] M for Array[T]`) so it resolves through the witness dictionary.
+A concrete generic target such as `impl M for Array[Int]` is rejected because
+the impl AST cannot retain its type arguments; accepting it would silently
+widen the impl to every `Array[T]` (#2262). Specialization for one generic
+instantiation is not supported. See #1503.
 
 ### Effects
 

--- a/fixtures/typecheck/expected.tsv
+++ b/fixtures/typecheck/expected.tsv
@@ -185,6 +185,7 @@ effect_row_local_alias_declared	ok
 effect_row_local_alias_pure	ok	
 trait_marker_impl_container	reject	IS declared, but `Eq` is a marker trait
 trait_concrete_impl_param_type	reject	generic impl target
+trait_generic_impl_concrete_target	reject	generic impl target
 trait_supertrait_bound_struct	ok	
 trait_supertrait_bound_param_type	ok	
 trait_supertrait_bound_marker	reject	no impl `MBase` for `Array[Int]`

--- a/fixtures/typecheck/expected.tsv
+++ b/fixtures/typecheck/expected.tsv
@@ -190,6 +190,7 @@ trait_generic_impl_target_arity	reject	type argument(s), got
 trait_generic_impl_arraybuilder_arity	reject	type argument(s), got
 trait_generic_impl_local_shadow_arity	reject	type argument(s), got
 trait_generic_impl_effect_arity	ok
+trait_generic_impl_late_effect_arity	reject	type argument(s), got
 unknown_result_without_import	reject	unknown type `Result`
 trait_supertrait_bound_struct	ok	
 trait_supertrait_bound_param_type	ok	

--- a/fixtures/typecheck/expected.tsv
+++ b/fixtures/typecheck/expected.tsv
@@ -184,7 +184,7 @@ effect_row_local_alias	reject	effect row mismatch for 'caller': missing { Log::E
 effect_row_local_alias_declared	ok	
 effect_row_local_alias_pure	ok	
 trait_marker_impl_container	reject	IS declared, but `Eq` is a marker trait
-trait_concrete_impl_param_type	ok	
+trait_concrete_impl_param_type	reject	generic impl target
 trait_supertrait_bound_struct	ok	
 trait_supertrait_bound_param_type	ok	
 trait_supertrait_bound_marker	reject	no impl `MBase` for `Array[Int]`

--- a/fixtures/typecheck/expected.tsv
+++ b/fixtures/typecheck/expected.tsv
@@ -186,6 +186,7 @@ effect_row_local_alias_pure	ok
 trait_marker_impl_container	reject	IS declared, but `Eq` is a marker trait
 trait_concrete_impl_param_type	reject	generic impl target
 trait_generic_impl_concrete_target	reject	generic impl target
+trait_generic_impl_target_arity	reject	type argument(s), got
 trait_supertrait_bound_struct	ok	
 trait_supertrait_bound_param_type	ok	
 trait_supertrait_bound_marker	reject	no impl `MBase` for `Array[Int]`

--- a/fixtures/typecheck/expected.tsv
+++ b/fixtures/typecheck/expected.tsv
@@ -189,6 +189,8 @@ trait_generic_impl_concrete_target	reject	generic impl target
 trait_generic_impl_target_arity	reject	type argument(s), got
 trait_generic_impl_arraybuilder_arity	reject	type argument(s), got
 trait_generic_impl_local_shadow_arity	reject	type argument(s), got
+trait_generic_impl_effect_arity	ok
+unknown_result_without_import	reject	unknown type `Result`
 trait_supertrait_bound_struct	ok	
 trait_supertrait_bound_param_type	ok	
 trait_supertrait_bound_marker	reject	no impl `MBase` for `Array[Int]`

--- a/fixtures/typecheck/expected.tsv
+++ b/fixtures/typecheck/expected.tsv
@@ -187,6 +187,8 @@ trait_marker_impl_container	reject	IS declared, but `Eq` is a marker trait
 trait_concrete_impl_param_type	reject	generic impl target
 trait_generic_impl_concrete_target	reject	generic impl target
 trait_generic_impl_target_arity	reject	type argument(s), got
+trait_generic_impl_arraybuilder_arity	reject	type argument(s), got
+trait_generic_impl_local_shadow_arity	reject	type argument(s), got
 trait_supertrait_bound_struct	ok	
 trait_supertrait_bound_param_type	ok	
 trait_supertrait_bound_marker	reject	no impl `MBase` for `Array[Int]`

--- a/fixtures/typecheck/trait_concrete_impl_param_type.vibe
+++ b/fixtures/typecheck/trait_concrete_impl_param_type.vibe
@@ -1,9 +1,6 @@
-// #1503: a CONCRETE impl on a parameterized type (`impl M for Array[Int]`) must
-// resolve. `parse_impl_stmt` drops the `[Int]`, so the env only ever held the
-// head `Array`; matching by constructor makes this spelling behave like the
-// generic `impl [T] M for Array[T]`, which already worked. `Measured` is
-// method-bearing, so it dispatches through the witness dictionary -- the
-// marker-trait gate (trait_marker_impl_container.vibe) does not apply.
+// #2262: a concrete impl on one generic instantiation must fail closed. The
+// impl AST cannot retain `[Int]`; accepting this declaration would therefore
+// widen it to every `Array[T]` and run an Int-checked body on other payloads.
 trait Measured {
   measure(Self) -> Int
 }

--- a/fixtures/typecheck/trait_generic_impl_arraybuilder_arity.vibe
+++ b/fixtures/typecheck/trait_generic_impl_arraybuilder_arity.vibe
@@ -1,0 +1,11 @@
+// #2262 review regression: compiler-owned generic constructors share one
+// complete arity authority; ArrayBuilder has exactly one type parameter.
+trait Measured {
+  measure(Self) -> Int
+}
+
+impl [K, V] Measured for ArrayBuilder[K, V] {
+  measure(self) -> Int {
+    Array::length(ArrayBuilder::freeze(self))
+  }
+}

--- a/fixtures/typecheck/trait_generic_impl_concrete_target.vibe
+++ b/fixtures/typecheck/trait_generic_impl_concrete_target.vibe
@@ -1,0 +1,11 @@
+// #2262 review regression: declaring an unrelated formal must not let a
+// concrete target argument bypass the fail-closed parser check.
+trait Measured {
+  measure(Self) -> Int
+}
+
+impl [U] Measured for Array[Int] {
+  measure(self) -> Int {
+    Array::get(self, 0) + 1
+  }
+}

--- a/fixtures/typecheck/trait_generic_impl_effect_arity.vibe
+++ b/fixtures/typecheck/trait_generic_impl_effect_arity.vibe
@@ -1,0 +1,14 @@
+// #2262 review regression: generic effects carry their declared type params.
+effect State[T] {
+  Get() -> T
+}
+
+trait Marker {
+}
+
+impl [T] Marker for State[T] {
+}
+
+fn main() -> Int {
+  0
+}

--- a/fixtures/typecheck/trait_generic_impl_late_effect_arity.vibe
+++ b/fixtures/typecheck/trait_generic_impl_late_effect_arity.vibe
@@ -1,0 +1,14 @@
+// #2262 review regression: effect arity is declaration-order independent.
+trait Marker {
+}
+
+impl [K, V] Marker for State[K, V] {
+}
+
+effect State[T] {
+  Get() -> T
+}
+
+fn main() -> Int {
+  0
+}

--- a/fixtures/typecheck/trait_generic_impl_local_shadow_arity.vibe
+++ b/fixtures/typecheck/trait_generic_impl_local_shadow_arity.vibe
@@ -1,0 +1,15 @@
+// #2262 review regression: a local declaration is the authority even when its
+// name is also used by a compiler-owned generic constructor.
+struct Task {
+  value: Int
+}
+
+trait Measured {
+  measure(Self) -> Int
+}
+
+impl [T] Measured for Task[T] {
+  measure(self) -> Int {
+    self.value
+  }
+}

--- a/fixtures/typecheck/trait_generic_impl_target_arity.vibe
+++ b/fixtures/typecheck/trait_generic_impl_target_arity.vibe
@@ -1,0 +1,11 @@
+// #2262 review regression: erasing the target arguments must not hide that
+// Map declares two parameters while this family impl supplies only one.
+trait Measured {
+  measure(Self) -> Int
+}
+
+impl [T] Measured for Map[T] {
+  measure(self) -> Int {
+    Map::length(self)
+  }
+}

--- a/fixtures/typecheck/unknown_result_without_import.vibe
+++ b/fixtures/typecheck/unknown_result_without_import.vibe
@@ -1,0 +1,5 @@
+// #2262 review regression: Result is declared by wit_runtime, not intrinsic.
+// Without an import or local declaration, its use must remain an unknown type.
+fn unwrap(value: Result[Int, String]) -> Int {
+  0
+}

--- a/lib/@vibe/compiler/checker/checker_resolve.vibe
+++ b/lib/@vibe/compiler/checker/checker_resolve.vibe
@@ -65,7 +65,7 @@ export fn resolve_type_expr_shadowed(te: TypeExpr, defs: Array[TypeDef], shadow:
 export fn compiler_owned_type_arity(name: String) -> Option[Int] {
   if name == "Array" || name == "Option" || name == "Future" || name == "Task" || name == "ArrayBuilder" || name == "FrozenArray" || name == "FixedArray" || name == "MutBytes" {
     Some(1)
-  } else if name == "Map" || name == "MapBuilder" || name == "Attempt" || name == "Result" || name == "TaskGroup" || name == "MutList" {
+  } else if name == "Map" || name == "MapBuilder" || name == "Attempt" || name == "TaskGroup" || name == "MutList" {
     Some(2)
   } else if name == "TaskHandle" || name == "Sender" || name == "Receiver" || name == "MutMap" {
     Some(3)

--- a/lib/@vibe/compiler/checker/checker_resolve.vibe
+++ b/lib/@vibe/compiler/checker/checker_resolve.vibe
@@ -62,26 +62,25 @@ export fn resolve_type_expr_shadowed(te: TypeExpr, defs: Array[TypeDef], shadow:
 /// which is a loud failure, not a silent one -- `PromptText` joined the list
 /// that way (`declare PromptText::new(String) -> PromptText`,
 /// builtins/declarations.vibe, names a type `resolve_builtin` does not carry).
+export fn compiler_owned_type_arity(name: String) -> Option[Int] {
+  if name == "Array" || name == "Option" || name == "Future" || name == "Task" || name == "ArrayBuilder" || name == "FrozenArray" || name == "FixedArray" || name == "MutBytes" {
+    Some(1)
+  } else if name == "Map" || name == "MapBuilder" || name == "Attempt" || name == "Result" || name == "TaskGroup" || name == "MutList" {
+    Some(2)
+  } else if name == "TaskHandle" || name == "Sender" || name == "Receiver" || name == "MutMap" {
+    Some(3)
+  } else if name == "ByteStream" || name == "HostStream" || name == "StringBuilder" || name == "PromptText" {
+    Some(0)
+  } else {
+    None
+  }
+}
+
 fn is_wellknown_nominal_head(name: String) -> Bool {
-  name == "Future"
-  || name == "ByteStream"
-  || name == "HostStream"
-  || name == "Task"
-  || name == "TaskHandle"
-  || name == "TaskGroup"
-  || name == "Sender"
-  || name == "Receiver"
-  || name == "Map"
-  || name == "MapBuilder"
-  || name == "MutList"
-  || name == "MutBytes"
-  || name == "MutMap"
-  || name == "ArrayBuilder"
-  || name == "StringBuilder"
-  || name == "FrozenArray"
-  || name == "FixedArray"
-  || name == "Attempt"
-  || name == "PromptText"
+  match compiler_owned_type_arity(name) {
+    Some(_) => true,
+    None => false
+  }
 }
 // `Self` is deliberately NOT in the list (Codex round 4 on #2147): it is a
 // type only inside a trait declaration's method signatures, and those are

--- a/lib/@vibe/compiler/checker/checker_stmt.vibe
+++ b/lib/@vibe/compiler/checker/checker_stmt.vibe
@@ -86,7 +86,7 @@ import ./checked_expression_structure_core.vibe {
 }
 
 import ./checker_resolve.vibe {
-  resolve_type_expr, resolve_type_expr_shadowed, subst_type_params
+  compiler_owned_type_arity, resolve_type_expr, resolve_type_expr_shadowed, subst_type_params
 }
 
 import @vibe/compiler/normalize {
@@ -115,18 +115,15 @@ import @vibe/parser {
 /// SImpl AST cannot carry the target TypeExpr far enough to check its arity.
 /// Keep builtin container authority here; user declarations come from defs.
 fn impl_target_declared_arity(defs: Array[TypeDef], name: String) -> Option[Int] {
-  if name == "Array" || name == "Option" || name == "FrozenArray" || name == "Future" || name == "Stream" || name == "Task" {
-    Some(1)
-  } else if name == "Map" || name == "MapBuilder" || name == "Result" {
-    Some(2)
-  } else {
-    match find_typedef(defs, name) {
-      Some(td) => match td {
-        TDEnum(_, params, _) => Some(Array::length(params)),
-        TDStruct(_, _, _, params) => Some(Array::length(params)),
-        TDAlias(_, params, _) => Some(Array::length(params)),
-        TDEffect(_, _, _)|TDEffectSet(_, _) => Some(0)
-      },
+  match find_typedef(defs, name) {
+    Some(td) => match td {
+      TDEnum(_, params, _) => Some(Array::length(params)),
+      TDStruct(_, _, _, params) => Some(Array::length(params)),
+      TDAlias(_, params, _) => Some(Array::length(params)),
+      TDEffect(_, _, _)|TDEffectSet(_, _) => Some(0)
+    },
+    None => match compiler_owned_type_arity(name) {
+      Some(arity) => Some(arity),
       None => match resolve_builtin(name) {
         Some(_) => Some(0),
         None => None

--- a/lib/@vibe/compiler/checker/checker_stmt.vibe
+++ b/lib/@vibe/compiler/checker/checker_stmt.vibe
@@ -1655,12 +1655,14 @@ fn stmt_is_type_decl(stmt: Stmt) -> Bool {
     SSuberror(_, _, _) => true,
     SStruct(_, _, _, _, _, _) => true,
     STypeAlias(_, _, _, _) => true,
+    SEffectDef(_, _, _, _) => true,
     _ => false
   }
 }
 
-/// #613: process type declarations (enum / struct / type-alias / suberror) before
-/// value definitions so a `let` may construct or reference a type or constructor
+/// #613: process type declarations (enum / struct / type-alias / suberror /
+/// effect) before value definitions so a `let` or impl may reference a type
+/// or constructor
 /// declared LATER in the same statement list (a forward reference). check_stmts
 /// records each type into `defs` and binds its constructors into `env` only when
 /// the declaration statement is reached, so without this a value defined before

--- a/lib/@vibe/compiler/checker/checker_stmt.vibe
+++ b/lib/@vibe/compiler/checker/checker_stmt.vibe
@@ -110,6 +110,31 @@ import @vibe/parser {
   located_program_binder_authority_program
 }
 
+/// Declared arity of a type constructor used by an erased generic impl target.
+/// The parser can prove that target arguments mirror the impl formals, but the
+/// SImpl AST cannot carry the target TypeExpr far enough to check its arity.
+/// Keep builtin container authority here; user declarations come from defs.
+fn impl_target_declared_arity(defs: Array[TypeDef], name: String) -> Option[Int] {
+  if name == "Array" || name == "Option" || name == "FrozenArray" || name == "Future" || name == "Stream" || name == "Task" {
+    Some(1)
+  } else if name == "Map" || name == "MapBuilder" || name == "Result" {
+    Some(2)
+  } else {
+    match find_typedef(defs, name) {
+      Some(td) => match td {
+        TDEnum(_, params, _) => Some(Array::length(params)),
+        TDStruct(_, _, _, params) => Some(Array::length(params)),
+        TDAlias(_, params, _) => Some(Array::length(params)),
+        TDEffect(_, _, _)|TDEffectSet(_, _) => Some(0)
+      },
+      None => match resolve_builtin(name) {
+        Some(_) => Some(0),
+        None => None
+      }
+    }
+  }
+}
+
 //# Types
 
 /// Successful production-check boundary. `checked_stmts` is the same
@@ -2479,6 +2504,18 @@ fn check_stmts_with_binders(raw_stmts: Array[Stmt], i: Int, env: TypeEnv, defs: 
         // would let a non-sendable type cross task/channel boundaries.
         if trait_name == "Send" {
           Array::push(errors, "`Send` is a compiler-judged structural marker and cannot be implemented; remove `impl Send`")
+        } else {
+          ()
+        }
+        if Array::length(tparams) > 0 {
+          match impl_target_declared_arity(defs, type_name) {
+            Some(want) => if want != Array::length(tparams) {
+              Array::push(errors, String::concat("type `", String::concat(type_name, String::concat("` expects ", String::concat(__to_string(want), String::concat(" type argument(s), got ", String::concat(__to_string(Array::length(tparams)), " in impl target")))))))
+            } else {
+              ()
+            },
+            None => ()
+          }
         } else {
           ()
         }

--- a/lib/@vibe/compiler/checker/checker_stmt.vibe
+++ b/lib/@vibe/compiler/checker/checker_stmt.vibe
@@ -120,7 +120,8 @@ fn impl_target_declared_arity(defs: Array[TypeDef], name: String) -> Option[Int]
       TDEnum(_, params, _) => Some(Array::length(params)),
       TDStruct(_, _, _, params) => Some(Array::length(params)),
       TDAlias(_, params, _) => Some(Array::length(params)),
-      TDEffect(_, _, _)|TDEffectSet(_, _) => Some(0)
+      TDEffect(_, _, params) => Some(Array::length(params)),
+      TDEffectSet(_, _) => Some(0)
     },
     None => match compiler_owned_type_arity(name) {
       Some(arity) => Some(arity),

--- a/lib/@vibe/compiler/checker/index.vpkg
+++ b/lib/@vibe/compiler/checker/index.vpkg
@@ -168,6 +168,7 @@ fn check_pattern(pat: Pat, scrutinee_ty: Type, env: TypeEnv, defs: Array[TypeDef
 fn check_qualified_pattern_refs(refs: Array[(String, String)], defs: Array[TypeDef], errors: Array[String]) -> Unit
 
 // --- checker_resolve.vibe
+fn compiler_owned_type_arity(name: String) -> Option[Int]
 fn subst_type_params(ty: Type, params: Array[String], args: Array[Type]) -> Type
 fn collect_unknown_type_names(te: TypeExpr, defs: Array[TypeDef], shadow: Array[String], out: Array[String]) -> Unit
 fn collect_unknown_type_names_regionwise(te: TypeExpr, defs: Array[TypeDef], shadow: Array[String], region_binders: Array[String], out: Array[String]) -> Unit

--- a/lib/@vibe/compiler/core/types.vibe
+++ b/lib/@vibe/compiler/core/types.vibe
@@ -2848,21 +2848,12 @@ fn struct_impl_target_matches(target: Type, resolved: Type) -> Bool {
   }
 }
 
-/// #1503: a CONCRETE impl on a parameterized type (`impl Show for Array[Int]`)
-/// records only the head name -- `parse_impl_stmt` reads the identifier after
-/// `for` and `skip_bracketed_args` discards `[Int]` -- so the target lands in
-/// the env as the bare `CtNamed("Array", [])`. `types_equal` then never matches
-/// the concrete `CtArray(CtInt)` at the use site and the impl is invisible,
-/// while the GENERIC spelling of the same impl (`impl [T] Show for Array[T]`,
-/// which goes through EnvTraitImplGen) resolves by constructor and works.
-///
-/// Match by constructor here so the two spellings behave identically. Erasing
-/// the type args on the concrete side loses nothing the env ever had: the
-/// parser already threw them away, so `impl Show for Array[Int]` and
-/// `impl Show for Array[String]` are the same declaration today. Narrowing an
-/// impl to one instantiation needs the parser to keep the args first (that is a
-/// separate, larger change; noted on #1503).
-fn concrete_impl_ctor_matches(target: Type, resolved: Type) -> Bool {
+/// #1503: a bare constructor impl (`impl Show for Array`) records
+/// `CtNamed("Array", [])`, which `types_equal` cannot match against a concrete
+/// `CtArray(CtInt)` use site. Match those intentionally erased targets by
+/// constructor. A concrete generic target (`impl Show for Array[Int]`) is
+/// rejected by the parser (#2262), so it can never be widened through here.
+fn erased_impl_ctor_matches(target: Type, resolved: Type) -> Bool {
   let head = type_constructor_name(resolved)
   match target {
     CtNamed(tname, targs) => Array::length(targs) == 0 && head != "" && tname == head,
@@ -2882,7 +2873,7 @@ fn type_implements_check_env(e: TypeEnv, full: TypeEnv, trait_name: String, reso
       // builtin `==` / `<`, and those are reference equality on `Array` /
       // `Bytes`, so honouring `impl Eq for Array[Int]` would make `==` silently
       // wrong on the very type the bound was written for.
-      if types_equal(target, resolved) || struct_impl_target_matches(target, resolved) || (concrete_impl_ctor_matches(target, resolved) && trait_is_method_bearing(full, trait_name)) {
+      if types_equal(target, resolved) || struct_impl_target_matches(target, resolved) || (erased_impl_ctor_matches(target, resolved) && trait_is_method_bearing(full, trait_name)) {
         true
       }
       else type_implements_check_env(rest, full, trait_name, resolved)
@@ -2895,7 +2886,7 @@ fn type_implements_check_env(e: TypeEnv, full: TypeEnv, trait_name: String, reso
 }
 
 /// #1503 diagnostics: an impl for this trait IS declared on the resolved type's
-/// constructor (either spelling), it just did not satisfy the bound. Lets the
+/// constructor (bare or generic spelling), it just did not satisfy the bound. Lets the
 /// bound checker say "declared but not usable, and here is why" instead of the
 /// flatly false `no impl \`Eq\` for \`Array[Int]\`` when the user wrote that
 /// impl three lines above.
@@ -2988,9 +2979,9 @@ export fn generalize(s: Subst, ty: Type) -> Type {
 /// incomplete in the same way as the direct scan was.
 ///
 ///   * `EnvTraitImpl` matched only `types_equal` / `struct_impl_target_matches`,
-///     so a concrete impl on a parameterized type (whose target the parser
-///     erased to the bare `CtNamed("Array", [])`) never matched -- the same hole
-///     `concrete_impl_ctor_matches` closes for the direct scan, with the same
+///     so a bare constructor impl (`impl Child for Array`) never matched a
+///     concrete instantiation -- the same hole `erased_impl_ctor_matches`
+///     closes for the direct scan, with the same
 ///     method-bearing gate on the BOUND trait (that is the trait the caller
 ///     dispatches through).
 ///   * `EnvTraitImplGen` was skipped outright, so `impl [T] Child for Array[T]`
@@ -3001,7 +2992,7 @@ fn type_implements_check_super(e2: TypeEnv, full_env: TypeEnv, s: Subst, trait_n
     EnvBind(_, _, rest) => type_implements_check_super(rest, full_env, s, trait_name, resolved),
     EnvMutCell(_, _, rest) => type_implements_check_super(rest, full_env, s, trait_name, resolved),
     EnvTraitDef(_, _, _, _, rest, _, _) => type_implements_check_super(rest, full_env, s, trait_name, resolved),
-    EnvTraitImpl(tname, target, rest) => if types_equal(target, resolved) || struct_impl_target_matches(target, resolved) || (concrete_impl_ctor_matches(target, resolved) && trait_is_method_bearing(full_env, trait_name)) {
+    EnvTraitImpl(tname, target, rest) => if types_equal(target, resolved) || struct_impl_target_matches(target, resolved) || (erased_impl_ctor_matches(target, resolved) && trait_is_method_bearing(full_env, trait_name)) {
       if trait_is_subtrait(full_env, tname, trait_name) {
         true
       }

--- a/lib/@vibe/parser/parser_base.vibe
+++ b/lib/@vibe/parser/parser_base.vibe
@@ -948,6 +948,54 @@ fn skip_bracketed_args(tokens: Array[Token], pos: Int) -> Int {
   }
 }
 
+/// True only for the erased generic target shape that SImpl can represent
+/// soundly: `[T1, ..., Tn]` in the same order as the impl formals. Nested,
+/// concrete, reordered, repeated, missing, and extra arguments all fail
+/// closed until SImpl retains the target TypeExpr (#2262).
+fn impl_target_args_match_formals(tokens: Array[Token], pos: Int, formals: Array[String]) -> Bool {
+  match peek(tokens, pos) {
+    TLBracket => {
+      let mut p = pos + 1
+      let mut i = 0
+      let mut valid = Array::length(formals) > 0
+      while valid && i < Array::length(formals) {
+        match peek(tokens, p) {
+          TIdent(name) => if name == Array::get(formals, i) {
+            p = p + 1
+          } else {
+            valid = false
+          },
+          _ => {
+            valid = false
+          }
+        }
+        if valid {
+          i = i + 1
+          if i < Array::length(formals) {
+            match peek(tokens, p) {
+              TComma => {
+                p = p + 1
+              },
+              _ => {
+                valid = false
+              }
+            }
+          } else {
+            ()
+          }
+        } else {
+          ()
+        }
+      }
+      valid && i == Array::length(formals) && match peek(tokens, p) {
+        TRBracket => true,
+        _ => false
+      }
+    },
+    _ => false
+  }
+}
+
 /// #829: collect the declared type-parameter NAMES of a `[T, U, ...]` header
 /// (returning ([], pos) when there is no bracket). Mirrors parse_enum_stmt's
 /// inline collector: only depth-1 identifiers in name position are kept, so a
@@ -1896,14 +1944,15 @@ fn parse_impl_stmt_with_binder_context(tokens: Array[Token], pos: Int, context: 
           // #2262: SImpl records only the target constructor name. Silently
           // dropping a concrete argument here widens `Array[Int]` to every
           // `Array[T]`, allowing an Int-checked method body to run on values
-          // such as Array[String]. Reject until SImpl can retain target args.
-          if Array::length(type_params) == 0 {
-            match peek(tokens, fp + 1) {
-              TLBracket => throw(String::concat("concrete generic impl target `", String::concat(type_name, "[...]` is not supported; write a generic impl such as `impl [T] Trait for Type[T]`"))),
-              _ => ()
-            }
-          } else {
-            ()
+          // such as Array[String]. Only the exact `[T1, ..., Tn]` family shape
+          // is safe to erase until SImpl can retain target args.
+          match peek(tokens, fp + 1) {
+            TLBracket => if !impl_target_args_match_formals(tokens, fp + 1, type_params) {
+              throw(String::concat("concrete generic impl target `", String::concat(type_name, "[...]` is not supported; write a generic impl such as `impl [T] Trait for Type[T]`")))
+            } else {
+              ()
+            },
+            _ => ()
           }
           // Return the position at the impl body `{` (or the next token when
           // the impl is body-less). The caller (parser.vibe) either expands the

--- a/lib/@vibe/parser/parser_base.vibe
+++ b/lib/@vibe/parser/parser_base.vibe
@@ -987,6 +987,16 @@ fn impl_target_args_match_formals(tokens: Array[Token], pos: Int, formals: Array
           ()
         }
       }
+      if valid && i == Array::length(formals) {
+        match peek(tokens, p) {
+          TComma => {
+            p = p + 1
+          },
+          _ => ()
+        }
+      } else {
+        ()
+      }
       valid && i == Array::length(formals) && match peek(tokens, p) {
         TRBracket => true,
         _ => false

--- a/lib/@vibe/parser/parser_base.vibe
+++ b/lib/@vibe/parser/parser_base.vibe
@@ -952,6 +952,28 @@ fn skip_bracketed_args(tokens: Array[Token], pos: Int) -> Int {
 /// soundly: `[T1, ..., Tn]` in the same order as the impl formals. Nested,
 /// concrete, reordered, repeated, missing, and extra arguments all fail
 /// closed until SImpl retains the target TypeExpr (#2262).
+fn impl_target_formal_end(tokens: Array[Token], pos: Int, formal: String) -> Int {
+  match peek(tokens, pos) {
+    TIdent(name) => if name == formal {
+      pos + 1
+    } else {
+      0 - 1
+    },
+    TLParen => {
+      let inner_end = impl_target_formal_end(tokens, pos + 1, formal)
+      if inner_end >= 0 {
+        match peek(tokens, inner_end) {
+          TRParen => inner_end + 1,
+          _ => 0 - 1
+        }
+      } else {
+        0 - 1
+      }
+    },
+    _ => 0 - 1
+  }
+}
+
 fn impl_target_args_match_formals(tokens: Array[Token], pos: Int, formals: Array[String]) -> Bool {
   match peek(tokens, pos) {
     TLBracket => {
@@ -959,15 +981,11 @@ fn impl_target_args_match_formals(tokens: Array[Token], pos: Int, formals: Array
       let mut i = 0
       let mut valid = Array::length(formals) > 0
       while valid && i < Array::length(formals) {
-        match peek(tokens, p) {
-          TIdent(name) => if name == Array::get(formals, i) {
-            p = p + 1
-          } else {
-            valid = false
-          },
-          _ => {
-            valid = false
-          }
+        let arg_end = impl_target_formal_end(tokens, p, Array::get(formals, i))
+        if arg_end >= 0 {
+          p = arg_end
+        } else {
+          valid = false
         }
         if valid {
           i = i + 1

--- a/lib/@vibe/parser/parser_base.vibe
+++ b/lib/@vibe/parser/parser_base.vibe
@@ -1893,6 +1893,18 @@ fn parse_impl_stmt_with_binder_context(tokens: Array[Token], pos: Int, context: 
       let fp = expect_tk(tokens, after_tp + 1, "for")
       match peek(tokens, fp) {
         TIdent(type_name) => {
+          // #2262: SImpl records only the target constructor name. Silently
+          // dropping a concrete argument here widens `Array[Int]` to every
+          // `Array[T]`, allowing an Int-checked method body to run on values
+          // such as Array[String]. Reject until SImpl can retain target args.
+          if Array::length(type_params) == 0 {
+            match peek(tokens, fp + 1) {
+              TLBracket => throw(String::concat("concrete generic impl target `", String::concat(type_name, "[...]` is not supported; write a generic impl such as `impl [T] Trait for Type[T]`"))),
+              _ => ()
+            }
+          } else {
+            ()
+          }
           // Return the position at the impl body `{` (or the next token when
           // the impl is body-less). The caller (parser.vibe) either expands the
           // method block into `Type::method` let-bindings or skips it; this

--- a/lib/@vibe/parser/parser_smoke_test.vibe
+++ b/lib/@vibe/parser/parser_smoke_test.vibe
@@ -291,6 +291,8 @@ test "parse_program: `Exception` is accepted in both positions" {
 test "#2262: generic impl targets must exactly mirror their formals" {
   let accepted = parse_program(lex("trait M\nimpl [K, V] M for Map[K, V]"))
   assert(Array::length(accepted) == 2)
+  let trailing = parse_program(lex("trait M\nimpl [T] M for Array[T,]"))
+  assert(Array::length(trailing) == 2)
   let concrete = handle {
     let _ = parse_program(lex("trait M\nimpl [U] M for Array[Int]"))
     "OK"

--- a/lib/@vibe/parser/parser_smoke_test.vibe
+++ b/lib/@vibe/parser/parser_smoke_test.vibe
@@ -288,6 +288,21 @@ test "parse_program: `Exception` is accepted in both positions" {
   assert(Array::length(stmts) == 2)
 }
 
+test "#2262: generic impl targets must exactly mirror their formals" {
+  let accepted = parse_program(lex("trait M\nimpl [K, V] M for Map[K, V]"))
+  assert(Array::length(accepted) == 2)
+  let concrete = handle {
+    let _ = parse_program(lex("trait M\nimpl [U] M for Array[Int]"))
+    "OK"
+  } with { Exception::Throw(e) => e }
+  assert(String::contains(concrete, "concrete generic impl target `Array[...]` is not supported"))
+  let reordered = handle {
+    let _ = parse_program(lex("trait M\nimpl [K, V] M for Map[V, K]"))
+    "OK"
+  } with { Exception::Throw(e) => e }
+  assert(String::contains(reordered, "concrete generic impl target `Map[...]` is not supported"))
+}
+
 test "parse_program: an empty handler arm set is rejected (#1678)" {
   let result = handle {
     let _ =

--- a/lib/@vibe/parser/parser_smoke_test.vibe
+++ b/lib/@vibe/parser/parser_smoke_test.vibe
@@ -293,6 +293,8 @@ test "#2262: generic impl targets must exactly mirror their formals" {
   assert(Array::length(accepted) == 2)
   let trailing = parse_program(lex("trait M\nimpl [T] M for Array[T,]"))
   assert(Array::length(trailing) == 2)
+  let grouped = parse_program(lex("trait M\nimpl [T] M for Array[((T))]"))
+  assert(Array::length(grouped) == 2)
   let concrete = handle {
     let _ = parse_program(lex("trait M\nimpl [U] M for Array[Int]"))
     "OK"


### PR DESCRIPTION
## Summary

- reject concrete generic impl targets such as `impl M for Array[Int]` before their type arguments can be erased
- point users to the honest generic spelling, `impl [T] M for Array[T]`
- turn the existing concrete-target fixture into a rejection regression and update the language docs
- clarify the remaining bare-constructor matching path in the checker

Closes #2262.

## Validation

- `bash scripts/check_typecheck_fixtures.sh` (244 rows passed in both lanes)
- `pkf run test`: compiler gate 106/106 passed; stage2 == stage3; final local gate self-test step hit the existing macOS Bash 3.2 `mapfile` limitation
- `scripts/lint_method_style_naming_test.sh` passed under Homebrew Bash 5.3
- formatter checks and `git diff --check` passed