### PR TITLE
Name the builtin map StringMap[V] and fail-close a concrete non-String key (#2263)

### DIFF
--- a/docs/cheatsheet.md
+++ b/docs/cheatsheet.md
@@ -926,10 +926,15 @@ let nv = {                            // destructure also works in fn/block body
   (n, v)
 }
 
-// Map (#960: the `map { ... }` literal was removed; use the Map:: API)
+// Map (#960: the `map { ... }` literal was removed; use the Map:: API).
+// The builtin map is STRING-KEYED; its type is spelled `StringMap[V]`
+// (no import needed). `Map[K, V]` with a concrete non-String key is
+// rejected where it is written -- generic keys are #2263. For another
+// key type today, use `MutMap[K, V]` from `@vibe/core` (below).
 let m = Map::from_pairs([("key", 42)])
 let e = Map::new()                    // empty map
 let mv = m["key"]
+let sized: (StringMap[Int]) -> Int = (mm) -> { Map::size(mm) }
 
 // Builders (mutable construction)
 let arr2 = {
@@ -1749,9 +1754,13 @@ different, currently nonexistent function.
 `freeze(MapBuilder[String, V]) -> Map[String, V]` — String-keyed, like `Map`.
 A `for-in` comprehension desugars to these builder operations internally.
 
-**Map** — the builtin `Map` is **String-keyed**, not generic in its key.
-`Map::set(m, 7, 1)` is `argument type mismatch for Map::set: expected String,
-got Int`. For a generic key, use `MutMap[K, V]` from `@vibe/core`.
+**Map** — the builtin `Map` is **String-keyed**, not generic in its key, and
+its type is spelled **`StringMap[V]`** (no import needed; the operations keep
+the `Map::` qualifier). `Map::set(m, 7, 1)` is `argument type mismatch for
+Map::set: expected String, got Int`, and an ANNOTATION naming a concrete
+non-String key (`fn f(m: Map[Int, String])`) is rejected where it is written
+rather than at the first op (#2263). For a generic key, use `MutMap[K, V]`
+from `@vibe/core`.
 `get: (Map[String, V], String) -> V` (throws when absent),
 `set: (Map[String, V], String, V) -> Map[String, V]` (returns a new map),
 `has_key: (Map[String, V], String) -> Bool`,

--- a/docs/spec/stable-surface.md
+++ b/docs/spec/stable-surface.md
@@ -54,7 +54,8 @@ of each item is [spec/syntax.md](syntax.md) and the
   `Char` (an `Int` alias), `Bool`, `Unit`.
 - Literals: integers (decimal / `0x` hex), floats (`1.5f` / `3.14`), strings
   (interpolation `\{expr}`), chars `'A'`, `true`/`false`, `()`.
-- Composite types: tuples `(A, B)`, `Array[T]`, `Map[K, V]`, record, struct,
+- Composite types: tuples `(A, B)`, `Array[T]`, `StringMap[V]` (the builtin
+  map; `Map[K, V]`'s generality is not frozen — see §3), record, struct,
   enum, function types `(A) -> B`, effectful `(A) -> B with E`, generics `[T]`,
   trait bounds `[T: A + B]`, and the `Option[T]` sugar `T?` (ADR-0046).
 - **Equality (`==`) — the fail-closed contract** (ADR-0097 as shipped; measured
@@ -161,7 +162,25 @@ The stable symbols listed under "Key Builtins" in the
   registry.
 - **Array**: `length`, `get`, `slice`, `map`, `filter`, `fold`, `find`, `any`,
   `all`, `reverse`, `concat`, plus `ArrayBuilder::new/push/freeze`.
-- **Map**: `get`, `has_key`, `keys`, `values`, `set`, `size`.
+- **StringMap** — the String-keyed builtin map. Its type is spelled
+  `StringMap[V]`; the operations keep the `Map::` qualifier, so the spelling
+  is the type's, not a second operation family. Neither needs an import.
+  `Map::get`, `Map::has_key`, `Map::keys`, `Map::values`, `Map::set`,
+  `Map::size`.
+  `Map::new` and `Map::from_pairs` **cannot be frozen** by this list until
+  #2274 lands: both constructors are real and in daily use, but they are not
+  first-class values, so this document's gate cannot probe them.
+  **`Map[K, V]`'s generality is deliberately NOT frozen** (#2263): the builtin
+  is String-keyed today, and an annotation naming a concrete non-String key is
+  rejected where it is written. The name `Map` is reserved for the generic
+  type; completing it turns a rejection into an answer, which is a compatible
+  change. A key that is a type parameter is unaffected — generic code over
+  `Map[K, V]` keeps compiling.
+  **Another key type is already available today**: `MutMap[K, V]` from
+  `@vibe/core` is the generic open-addressing map, and it is what the
+  rejection points at (`MutMap::new_int()` / `new_string()`, or
+  `MutMap::new(hash_fn, eq_fn)` for any other key). It is a library type, so
+  it is frozen by §3's `@vibe/core` entry rather than by the builtin surface.
 - **Int64Array**: `make`, `get`, `set`, `length` (for 32-bit word workloads).
 - **Conversions**: `Int::to_string`, `Int::to_double`, `Double::to_int`.
 - **Iteration**: the `Iterable` trait and the `for-in` desugar (ADR-0044). The

--- a/fixtures/string_map_shadow_eq_test.vibe
+++ b/fixtures/string_map_shadow_eq_test.vibe
@@ -1,0 +1,10 @@
+// #2263 review regression: equality lowering honors a source-owned StringMap.
+struct StringMap[T] {
+  value: T
+}
+
+test "source StringMap equality remains nominal" {
+  let a = StringMap::{ value: 1 }
+  let b = StringMap::{ value: 1 }
+  assert(a == b)
+}

--- a/fixtures/structural_eq_contexts_test.vibe
+++ b/fixtures/structural_eq_contexts_test.vibe
@@ -599,6 +599,18 @@ test "a Map of aggregates compares by content" {
   assert(a != c)
 }
 
+fn eq_ctx_string_map(a: Int, b: Int) -> StringMap[Int] {
+  Map::from_pairs([("a", a), ("b", b)])
+}
+
+test "StringMap annotations compare by content" {
+  let a = eq_ctx_string_map(1, 2)
+  let b = eq_ctx_string_map(1, 2)
+  assert(a == b)
+  let c = eq_ctx_string_map(1, 9)
+  assert(a != c)
+}
+
 fn eq_ctx_nested(a: Int, b: Int) -> Array[Array[Int]] {
   [[a, b]]
 }

--- a/fixtures/structural_eq_contexts_test.vibe
+++ b/fixtures/structural_eq_contexts_test.vibe
@@ -12,6 +12,10 @@ struct WithMap {
   m: Map[String, Int]
 } derive (Eq)
 
+struct WithStringMap {
+  m: StringMap[Int]
+} derive (Eq)
+
 struct Array_Int {
   tag: Int
 } derive (Eq)
@@ -609,6 +613,11 @@ test "StringMap annotations compare by content" {
   assert(a == b)
   let c = eq_ctx_string_map(1, 9)
   assert(a != c)
+  let wrapped_a = WithStringMap::{ m: a }
+  let wrapped_b = WithStringMap::{ m: b }
+  assert(wrapped_a == wrapped_b)
+  let wrapped_c = WithStringMap::{ m: c }
+  assert(wrapped_a != wrapped_c)
 }
 
 fn eq_ctx_nested(a: Int, b: Int) -> Array[Array[Int]] {

--- a/fixtures/typecheck/array_wrong_arity_reject.vibe
+++ b/fixtures/typecheck/array_wrong_arity_reject.vibe
@@ -1,0 +1,13 @@
+// #2276 (Codex round 1): a structural head applied to the wrong arity was
+// reported by nobody -- exempt from the unknown-name sweep, and unresolved by
+// the resolver, which leaves a `CtNamed` that `check_assignable` tolerates
+// like a wildcard. Measured before the fix, this compiled clean and returned
+// a non-`Int` as `Int`. The `StringMap` sibling is
+// `string_map_wrong_arity_reject`; `Option` is `option_wrong_arity_reject`.
+fn f(m: Array[Int, String]) -> Int {
+  m
+}
+
+fn main {
+  ()
+}

--- a/fixtures/typecheck/expected.tsv
+++ b/fixtures/typecheck/expected.tsv
@@ -447,6 +447,9 @@ map_shadowed_wellknown_key_ok	ok
 map_long_alias_chain_int_key_reject	reject	key has no implementation in the body of type alias `M`
 map_long_alias_chain_string_key_ok	ok
 map_cyclic_alias_key_ok	ok
+map_forward_nullary_alias_key_reject	reject	a `Key` key has no implementation in parameter `m`
+map_forward_nullary_alias_key_ok	ok
+map_key_formal_shadows_alias_ok	ok
 array_wrong_arity_reject	reject	takes 1 type argument
 option_wrong_arity_reject	reject	takes 1 type argument
 map_forward_alias_key_ok	ok	

--- a/fixtures/typecheck/expected.tsv
+++ b/fixtures/typecheck/expected.tsv
@@ -451,6 +451,8 @@ map_forward_nullary_alias_key_reject	reject	a `Key` key has no implementation in
 map_forward_nullary_alias_key_ok	ok
 map_key_formal_shadows_alias_ok	ok
 map_key_formal_named_compiler_type_ok	ok
+map_outer_alias_forward_key_reject	reject	key has no implementation
+map_outer_alias_forward_key_ok	ok
 array_wrong_arity_reject	reject	takes 1 type argument
 option_wrong_arity_reject	reject	takes 1 type argument
 map_forward_alias_key_ok	ok	

--- a/fixtures/typecheck/expected.tsv
+++ b/fixtures/typecheck/expected.tsv
@@ -419,5 +419,8 @@ formal_application_trait_method_reject	reject	type parameter `F` cannot take typ
 formal_application_value_shadow_ok	ok	
 formal_application_local_let_reject	reject	type parameter `F` cannot take type arguments in a local let annotation
 reserved_formal_marker_ident_reject	reject	uses a reserved compiler-internal prefix
-map_keys_key_slot_reject	reject	argument type mismatch
+map_keys_key_slot_reject	reject	the builtin map is String-keyed
 map_keys_string_slot_ok	ok	
+map_non_string_key_reject	reject	the builtin map is String-keyed
+map_alias_non_string_key_reject	reject	the builtin map is String-keyed
+map_generic_key_ok	ok	

--- a/fixtures/typecheck/expected.tsv
+++ b/fixtures/typecheck/expected.tsv
@@ -439,3 +439,5 @@ array_wrong_arity_reject	reject	takes 1 type argument
 option_wrong_arity_reject	reject	takes 1 type argument
 map_forward_alias_key_ok	ok	
 map_forward_alias_int_key_reject	reject	the builtin map is String-keyed
+map_future_key_reject	reject	the builtin map is String-keyed
+map_mutmap_key_reject	reject	the builtin map is String-keyed

--- a/fixtures/typecheck/expected.tsv
+++ b/fixtures/typecheck/expected.tsv
@@ -435,6 +435,8 @@ map_trait_signature_key_reject	reject	the builtin map is String-keyed
 map_local_shadow_alias_ok	ok
 map_extern_key_reject	reject	the builtin map is String-keyed
 map_suberror_payload_key_reject	reject	the builtin map is String-keyed
+map_wellknown_nullary_key_reject	reject	a `PromptText` key has no implementation
+map_shadowed_wellknown_key_ok	ok
 array_wrong_arity_reject	reject	takes 1 type argument
 option_wrong_arity_reject	reject	takes 1 type argument
 map_forward_alias_key_ok	ok	

--- a/fixtures/typecheck/expected.tsv
+++ b/fixtures/typecheck/expected.tsv
@@ -437,3 +437,5 @@ map_extern_key_reject	reject	the builtin map is String-keyed
 map_suberror_payload_key_reject	reject	the builtin map is String-keyed
 array_wrong_arity_reject	reject	takes 1 type argument
 option_wrong_arity_reject	reject	takes 1 type argument
+map_forward_alias_key_ok	ok	
+map_forward_alias_int_key_reject	reject	the builtin map is String-keyed

--- a/fixtures/typecheck/expected.tsv
+++ b/fixtures/typecheck/expected.tsv
@@ -444,6 +444,9 @@ map_extern_key_reject	reject	the builtin map is String-keyed
 map_suberror_payload_key_reject	reject	the builtin map is String-keyed
 map_wellknown_nullary_key_reject	reject	a `PromptText` key has no implementation
 map_shadowed_wellknown_key_ok	ok
+map_long_alias_chain_int_key_reject	reject	key has no implementation in the body of type alias `M`
+map_long_alias_chain_string_key_ok	ok
+map_cyclic_alias_key_ok	ok
 array_wrong_arity_reject	reject	takes 1 type argument
 option_wrong_arity_reject	reject	takes 1 type argument
 map_forward_alias_key_ok	ok	

--- a/fixtures/typecheck/expected.tsv
+++ b/fixtures/typecheck/expected.tsv
@@ -432,3 +432,5 @@ map_deeply_nested_key_reject	reject	the builtin map is String-keyed
 map_alias_declaration_key_reject	reject	the builtin map is String-keyed
 map_effect_signature_key_reject	reject	the builtin map is String-keyed
 map_trait_signature_key_reject	reject	the builtin map is String-keyed
+map_local_shadow_alias_ok	ok
+map_extern_key_reject	reject	the builtin map is String-keyed

--- a/fixtures/typecheck/expected.tsv
+++ b/fixtures/typecheck/expected.tsv
@@ -457,5 +457,6 @@ array_wrong_arity_reject	reject	takes 1 type argument
 option_wrong_arity_reject	reject	takes 1 type argument
 map_forward_alias_key_ok	ok	
 map_forward_alias_int_key_reject	reject	the builtin map is String-keyed
+map_unused_forward_alias_key_reject	reject	the builtin map is String-keyed
 map_future_key_reject	reject	the builtin map is String-keyed
 map_mutmap_key_reject	reject	the builtin map is String-keyed

--- a/fixtures/typecheck/expected.tsv
+++ b/fixtures/typecheck/expected.tsv
@@ -450,6 +450,7 @@ map_cyclic_alias_key_ok	ok
 map_forward_nullary_alias_key_reject	reject	a `Key` key has no implementation in parameter `m`
 map_forward_nullary_alias_key_ok	ok
 map_key_formal_shadows_alias_ok	ok
+map_key_formal_named_compiler_type_ok	ok
 array_wrong_arity_reject	reject	takes 1 type argument
 option_wrong_arity_reject	reject	takes 1 type argument
 map_forward_alias_key_ok	ok	

--- a/fixtures/typecheck/expected.tsv
+++ b/fixtures/typecheck/expected.tsv
@@ -434,3 +434,4 @@ map_effect_signature_key_reject	reject	the builtin map is String-keyed
 map_trait_signature_key_reject	reject	the builtin map is String-keyed
 map_local_shadow_alias_ok	ok
 map_extern_key_reject	reject	the builtin map is String-keyed
+map_suberror_payload_key_reject	reject	the builtin map is String-keyed

--- a/fixtures/typecheck/expected.tsv
+++ b/fixtures/typecheck/expected.tsv
@@ -426,7 +426,7 @@ map_alias_non_string_key_reject	reject	the builtin map is String-keyed
 map_generic_alias_non_string_key_reject	reject	the builtin map is String-keyed
 map_generic_key_ok	ok	
 string_map_local_shadow_ok	ok
-string_map_wrong_arity_reject	reject	unknown type `StringMap`
+string_map_wrong_arity_reject	reject	takes 1 type argument
 map_local_shadow_ok	ok
 map_deeply_nested_key_reject	reject	the builtin map is String-keyed
 map_alias_declaration_key_reject	reject	the builtin map is String-keyed
@@ -435,3 +435,5 @@ map_trait_signature_key_reject	reject	the builtin map is String-keyed
 map_local_shadow_alias_ok	ok
 map_extern_key_reject	reject	the builtin map is String-keyed
 map_suberror_payload_key_reject	reject	the builtin map is String-keyed
+array_wrong_arity_reject	reject	takes 1 type argument
+option_wrong_arity_reject	reject	takes 1 type argument

--- a/fixtures/typecheck/expected.tsv
+++ b/fixtures/typecheck/expected.tsv
@@ -429,3 +429,6 @@ string_map_local_shadow_ok	ok
 string_map_wrong_arity_reject	reject	unknown type `StringMap`
 map_local_shadow_ok	ok
 map_deeply_nested_key_reject	reject	the builtin map is String-keyed
+map_alias_declaration_key_reject	reject	the builtin map is String-keyed
+map_effect_signature_key_reject	reject	the builtin map is String-keyed
+map_trait_signature_key_reject	reject	the builtin map is String-keyed

--- a/fixtures/typecheck/expected.tsv
+++ b/fixtures/typecheck/expected.tsv
@@ -423,4 +423,7 @@ map_keys_key_slot_reject	reject	the builtin map is String-keyed
 map_keys_string_slot_ok	ok	
 map_non_string_key_reject	reject	the builtin map is String-keyed
 map_alias_non_string_key_reject	reject	the builtin map is String-keyed
+map_generic_alias_non_string_key_reject	reject	the builtin map is String-keyed
 map_generic_key_ok	ok	
+string_map_local_shadow_ok	ok
+string_map_wrong_arity_reject	reject	unknown type `StringMap`

--- a/fixtures/typecheck/expected.tsv
+++ b/fixtures/typecheck/expected.tsv
@@ -427,3 +427,5 @@ map_generic_alias_non_string_key_reject	reject	the builtin map is String-keyed
 map_generic_key_ok	ok	
 string_map_local_shadow_ok	ok
 string_map_wrong_arity_reject	reject	unknown type `StringMap`
+map_local_shadow_ok	ok
+map_deeply_nested_key_reject	reject	the builtin map is String-keyed

--- a/fixtures/typecheck/expected.tsv
+++ b/fixtures/typecheck/expected.tsv
@@ -437,6 +437,7 @@ string_map_wrong_arity_reject	reject	takes 1 type argument
 map_local_shadow_ok	ok
 map_deeply_nested_key_reject	reject	the builtin map is String-keyed
 map_alias_declaration_key_reject	reject	the builtin map is String-keyed
+map_applied_alias_caller_binder_ok	ok
 map_effect_signature_key_reject	reject	the builtin map is String-keyed
 map_trait_signature_key_reject	reject	the builtin map is String-keyed
 map_local_shadow_alias_ok	ok

--- a/fixtures/typecheck/map_alias_declaration_key_reject.vibe
+++ b/fixtures/typecheck/map_alias_declaration_key_reject.vibe
@@ -1,0 +1,6 @@
+// #2263 review regression: an unused alias body is still a type boundary.
+type BadMap = Map[Int, String]
+
+fn main {
+  ()
+}

--- a/fixtures/typecheck/map_alias_non_string_key_reject.vibe
+++ b/fixtures/typecheck/map_alias_non_string_key_reject.vibe
@@ -1,0 +1,10 @@
+// #2263: the same key through an alias -- the check walks the RESOLVED type,
+// so an alias body cannot smuggle the key past the annotation surface.
+type IntMap = Map[Int, String]
+
+fn f(m: IntMap) -> Int {
+  1
+}
+fn main {
+  ()
+}

--- a/fixtures/typecheck/map_applied_alias_caller_binder_ok.vibe
+++ b/fixtures/typecheck/map_applied_alias_caller_binder_ok.vibe
@@ -1,0 +1,12 @@
+// #2276 review regression: an argument substituted into an alias body keeps
+// the caller's binder scope. This `Future` is a rigid type parameter, not the
+// compiler-owned Future type with the same spelling.
+type M[K, V] = Map[K, V]
+
+fn f[Future, V](m: M[Future, V]) -> Int {
+  0
+}
+
+fn main {
+  ()
+}

--- a/fixtures/typecheck/map_cyclic_alias_key_ok.vibe
+++ b/fixtures/typecheck/map_cyclic_alias_key_ok.vibe
@@ -1,0 +1,16 @@
+// #2276 review round 13: a CYCLIC alias chain compiles today (nothing rejects
+// it), so the map-key walk has to terminate on its own. The depth cap used to
+// do that; the visited set does it now, and this pins that the walk still
+// halts -- a regression here hangs the compiler rather than failing.
+type A[T] = B[T]
+type B[T] = A[T]
+
+type M[T] = Map[A[T], Int]
+
+fn f(m: M[String]) -> Int {
+  0
+}
+
+fn main {
+  ()
+}

--- a/fixtures/typecheck/map_deeply_nested_key_reject.vibe
+++ b/fixtures/typecheck/map_deeply_nested_key_reject.vibe
@@ -1,0 +1,8 @@
+// #2263 review regression: nesting must not bypass the builtin Map key check.
+fn f(m: Array[Array[Array[Array[Array[Array[Array[Array[Array[Map[Int, String]]]]]]]]]]) -> Int {
+  1
+}
+
+fn main {
+  ()
+}

--- a/fixtures/typecheck/map_effect_signature_key_reject.vibe
+++ b/fixtures/typecheck/map_effect_signature_key_reject.vibe
@@ -1,0 +1,8 @@
+// #2263 review regression: effect operation signatures validate Map keys.
+effect Store {
+  Put(Map[Int, String]) -> Unit
+}
+
+fn main {
+  ()
+}

--- a/fixtures/typecheck/map_extern_key_reject.vibe
+++ b/fixtures/typecheck/map_extern_key_reject.vibe
@@ -1,0 +1,6 @@
+// #2263 review regression: extern annotations validate builtin Map keys.
+extern let % host_map: Map[Int, String]
+
+fn main {
+  ()
+}

--- a/fixtures/typecheck/map_forward_alias_int_key_reject.vibe
+++ b/fixtures/typecheck/map_forward_alias_int_key_reject.vibe
@@ -1,0 +1,15 @@
+// #2276 (Codex round 6), the fail-closed side of `map_forward_alias_key_ok`:
+// accepting a forward alias head must not accept an alias that resolves to an
+// unsupported key. The alias is judged by its BODY, which needs no
+// substitution -- and must not use one, since `resolve_type_alias_params`
+// corrupts the heap (#2279).
+type M[T] = Map[Key[T], Int]
+
+type Key[T] = Int
+
+fn f(m: M[Int]) -> Int {
+  Map::size(m)
+}
+fn main {
+  ()
+}

--- a/fixtures/typecheck/map_forward_alias_key_ok.vibe
+++ b/fixtures/typecheck/map_forward_alias_key_ok.vibe
@@ -1,0 +1,19 @@
+// #2276 (Codex round 6): a FORWARD parameterized alias in the key slot is not
+// a bad key. `Key` is not declared yet when `M`'s body is resolved, so the key
+// is `CtNamed("Key", [T])`; it ultimately resolves to `String`.
+//
+// Rejecting every applied `CtNamed` made this depend on DECLARATION ORDER --
+// measured, the same two declarations were accepted with `Key` first and
+// rejected with `Key` second, while the identical shape under `Array` was
+// accepted either way. `map_forward_alias_int_key_reject` is the fail-closed
+// side: an alias whose body is `Int` still rejects.
+type M[T] = Map[Key[T], Int]
+
+type Key[T] = String
+
+fn f(m: M[Int]) -> Int {
+  Map::size(m)
+}
+fn main {
+  ()
+}

--- a/fixtures/typecheck/map_forward_nullary_alias_key_ok.vibe
+++ b/fixtures/typecheck/map_forward_nullary_alias_key_ok.vibe
@@ -1,0 +1,13 @@
+// #2276 review round 14 control: the same shape whose alias resolves to
+// `String` must still be ACCEPTED, so the rejection cannot be satisfied by
+// giving up on nullary key names.
+type Good = Map[Key, Int]
+type Key = String
+
+fn f(m: Good) -> Int {
+  0
+}
+
+fn main {
+  ()
+}

--- a/fixtures/typecheck/map_forward_nullary_alias_key_reject.vibe
+++ b/fixtures/typecheck/map_forward_nullary_alias_key_reject.vibe
@@ -1,0 +1,14 @@
+// #2276 review round 14: a nullary key name used to be accepted before
+// `find_typedef` was consulted at all, so a key whose alias is declared BELOW
+// the map made the verdict depend on declaration order. This is the same
+// order-dependence round 6 removed for the applied form.
+type Bad = Map[Key, Int]
+type Key = Int
+
+fn f(m: Bad) -> Int {
+  0
+}
+
+fn main {
+  ()
+}

--- a/fixtures/typecheck/map_future_key_reject.vibe
+++ b/fixtures/typecheck/map_future_key_reject.vibe
@@ -1,0 +1,8 @@
+// #2263 review regression: compiler-owned nominal heads are concrete keys.
+fn read(m: Map[Future[Int], String]) -> Int {
+  1
+}
+
+fn main {
+  ()
+}

--- a/fixtures/typecheck/map_generic_alias_non_string_key_reject.vibe
+++ b/fixtures/typecheck/map_generic_alias_non_string_key_reject.vibe
@@ -1,0 +1,10 @@
+// #2263 review regression: applied alias arguments must reach the Map body.
+type M[K, V] = Map[K, V]
+
+fn f(m: M[Int, String]) -> Int {
+  1
+}
+
+fn main {
+  ()
+}

--- a/fixtures/typecheck/map_generic_key_ok.vibe
+++ b/fixtures/typecheck/map_generic_key_ok.vibe
@@ -1,0 +1,11 @@
+// #2263 control: a key that is a type FORMAL stays accepted -- generic code
+// is unaffected, and only a concrete non-String key is rejected.
+fn f[K, V](m: Map[K, V]) -> Int {
+  1
+}
+fn g(m: StringMap[Int]) -> Int {
+  Map::size(m)
+}
+fn main {
+  ()
+}

--- a/fixtures/typecheck/map_key_formal_named_compiler_type_ok.vibe
+++ b/fixtures/typecheck/map_key_formal_named_compiler_type_ok.vibe
@@ -1,0 +1,12 @@
+// #2276 review round 15: a type FORMAL may be spelled with a compiler-owned
+// name. `resolve_type_expr_shadowed` keeps it as the rigid `CtNamed("Future",
+// [])`, so the key walk must read the binder BEFORE testing compiler
+// ownership by name -- testing ownership first rejected a generic function
+// the contract explicitly permits.
+fn f[Future, V](m: Map[Future, V]) -> Int {
+  0
+}
+
+fn main {
+  ()
+}

--- a/fixtures/typecheck/map_key_formal_shadows_alias_ok.vibe
+++ b/fixtures/typecheck/map_key_formal_shadows_alias_ok.vibe
@@ -1,0 +1,14 @@
+// #2276 review round 14 control: consulting `find_typedef` for a nullary key
+// name must not swallow a type FORMAL that happens to share the spelling. A
+// formal shadowing a declared STRUCT is already rejected by #2141; a formal
+// shadowing a declared ALIAS is not, so this shape reaches the key walk and
+// must stay accepted.
+type Key = Int
+
+fn f[Key](m: Map[Key, Int]) -> Int {
+  0
+}
+
+fn main {
+  ()
+}

--- a/fixtures/typecheck/map_keys_key_slot_reject.vibe
+++ b/fixtures/typecheck/map_keys_key_slot_reject.vibe
@@ -1,7 +1,11 @@
-// #2263: keys() must answer with the receiver's KEY slot. The shape table
-// answered Array[String] for every receiver, so these keys reached
-// String::length and compiled clean -- an annotation that disables checking
-// at the slot (the #2125 class).
+// #2263: a `Map[Int, V]` annotation must not hand `Array[String]` keys to
+// String ops. Two rules now stand behind that, and this fixture pins the
+// OUTER one: since the builtin map is String-keyed, the annotation itself is
+// rejected where it is written, so the body below is never reached.
+//
+// The inner rule -- `Map::keys` answering with the receiver's KEY slot rather
+// than a fixed `Array[String]` (#2272) -- still governs a receiver whose key
+// is a type formal, and is what generic keys will need.
 fn f(m: Map[Int, String]) -> Int {
   let ks = Map::keys(m)
   String::length(Array::get(ks, 0))

--- a/fixtures/typecheck/map_local_shadow_alias_ok.vibe
+++ b/fixtures/typecheck/map_local_shadow_alias_ok.vibe
@@ -1,0 +1,15 @@
+// #2263 review regression: alias expansion preserves source ownership of Map.
+struct Map[K, V] {
+  key: K;
+  value: V
+}
+
+type M = Map[Int, String]
+
+fn read(m: M) -> Int {
+  m.key
+}
+
+fn main {
+  ()
+}

--- a/fixtures/typecheck/map_local_shadow_ok.vibe
+++ b/fixtures/typecheck/map_local_shadow_ok.vibe
@@ -1,0 +1,13 @@
+// #2263 review regression: a source declaration owns the Map spelling.
+struct Map[K, V] {
+  key: K;
+  value: V
+}
+
+fn read(m: Map[Int, String]) -> Int {
+  m.key
+}
+
+fn main {
+  ()
+}

--- a/fixtures/typecheck/map_long_alias_chain_int_key_reject.vibe
+++ b/fixtures/typecheck/map_long_alias_chain_int_key_reject.vibe
@@ -1,0 +1,20 @@
+// #2276 review round 13: the alias-chain walk used to stop at four hops and
+// answer "supported" beyond it, so a concrete `Int` key seven hops down was
+// accepted. The chain is now followed to its end.
+type A[T] = B[T]
+type B[T] = C[T]
+type C[T] = D[T]
+type D[T] = E[T]
+type E[T] = F[T]
+type F[T] = G[T]
+type G[T] = Int
+
+type M[T] = Map[A[T], Int]
+
+fn f(m: M[String]) -> Int {
+  0
+}
+
+fn main {
+  ()
+}

--- a/fixtures/typecheck/map_long_alias_chain_string_key_ok.vibe
+++ b/fixtures/typecheck/map_long_alias_chain_string_key_ok.vibe
@@ -1,0 +1,20 @@
+// #2276 review round 13 control: the same seven hops ending in `String` must
+// still be ACCEPTED, so the rejection above cannot be satisfied by giving up
+// on long chains.
+type A[T] = B[T]
+type B[T] = C[T]
+type C[T] = D[T]
+type D[T] = E[T]
+type E[T] = F[T]
+type F[T] = G[T]
+type G[T] = String
+
+type M[T] = Map[A[T], Int]
+
+fn f(m: M[String]) -> Int {
+  0
+}
+
+fn main {
+  ()
+}

--- a/fixtures/typecheck/map_mutmap_key_reject.vibe
+++ b/fixtures/typecheck/map_mutmap_key_reject.vibe
@@ -1,0 +1,8 @@
+// #2263 review regression: generic compiler-owned nominals are not forwards.
+fn read(m: Map[MutMap[Int, Int], String]) -> Int {
+  1
+}
+
+fn main {
+  ()
+}

--- a/fixtures/typecheck/map_non_string_key_reject.vibe
+++ b/fixtures/typecheck/map_non_string_key_reject.vibe
@@ -1,0 +1,9 @@
+// #2263: the builtin map is String-keyed. A concrete non-String key resolved
+// fine and then had every op reject its key argument, so the annotation
+// promised what no operation delivers. Rejected at the annotation instead.
+fn f(m: Map[Int, String]) -> Int {
+  1
+}
+fn main {
+  ()
+}

--- a/fixtures/typecheck/map_outer_alias_forward_key_ok.vibe
+++ b/fixtures/typecheck/map_outer_alias_forward_key_ok.vibe
@@ -1,0 +1,14 @@
+// #2276 review round 16 control: the same two hops ending in `String` must
+// still be ACCEPTED, so following alias heads cannot be satisfied by
+// rejecting every alias-wrapped map.
+type Outer = Inner
+type Inner = Map[Key, Int]
+type Key = String
+
+fn f(m: Outer) -> Int {
+  0
+}
+
+fn main {
+  ()
+}

--- a/fixtures/typecheck/map_outer_alias_forward_key_reject.vibe
+++ b/fixtures/typecheck/map_outer_alias_forward_key_reject.vibe
@@ -1,0 +1,15 @@
+// #2276 review round 16: a name recorded before its target was declared stays
+// an unresolved `CtNamed`, so the map can sit one alias hop further in than
+// the walk used to look. `Outer`'s body is the bare `Inner`, and nothing
+// expanded it.
+type Outer = Inner
+type Inner = Map[Key, Int]
+type Key = Int
+
+fn f(m: Outer) -> Int {
+  0
+}
+
+fn main {
+  ()
+}

--- a/fixtures/typecheck/map_shadowed_wellknown_key_ok.vibe
+++ b/fixtures/typecheck/map_shadowed_wellknown_key_ok.vibe
@@ -1,0 +1,13 @@
+// #2276 review round 12 control: a DECLARATION of one of those names still
+// wins. `resolve_type_expr` expands the alias before the key walk sees it,
+// so the key here is `String` and the annotation is accepted -- the new
+// rejection must not be satisfied by rejecting the spelling.
+type Future[T] = String
+
+fn f(m: Map[Future[Int], String]) -> Int {
+  0
+}
+
+fn main {
+  ()
+}

--- a/fixtures/typecheck/map_suberror_payload_key_reject.vibe
+++ b/fixtures/typecheck/map_suberror_payload_key_reject.vibe
@@ -1,0 +1,6 @@
+// #2263 review regression: suberror payloads validate builtin Map keys.
+suberror Bad(Map[Int, String])
+
+fn main {
+  ()
+}

--- a/fixtures/typecheck/map_trait_signature_key_reject.vibe
+++ b/fixtures/typecheck/map_trait_signature_key_reject.vibe
@@ -1,0 +1,8 @@
+// #2263 review regression: trait method signatures validate Map keys.
+trait Store {
+  put(Self, Map[Int, String]) -> Unit
+}
+
+fn main {
+  ()
+}

--- a/fixtures/typecheck/map_unused_forward_alias_key_reject.vibe
+++ b/fixtures/typecheck/map_unused_forward_alias_key_reject.vibe
@@ -1,0 +1,8 @@
+// #2276 review regression: an unused alias is still a type boundary, and its
+// forward key alias must be revalidated after all definitions are known.
+type Bad = Map[Key, Int]
+type Key = Int
+
+fn main {
+  ()
+}

--- a/fixtures/typecheck/map_wellknown_nullary_key_reject.vibe
+++ b/fixtures/typecheck/map_wellknown_nullary_key_reject.vibe
@@ -1,0 +1,9 @@
+// #2276 review round 12: the same for a compiler-owned head that takes no
+// arguments, which the "no arguments means a rigid formal" arm let through.
+fn f(m: Map[PromptText, String]) -> Int {
+  0
+}
+
+fn main {
+  ()
+}

--- a/fixtures/typecheck/option_wrong_arity_reject.vibe
+++ b/fixtures/typecheck/option_wrong_arity_reject.vibe
@@ -1,0 +1,9 @@
+// #2276 (Codex round 1): the `Option` case of the wrong-arity wildcard --
+// see `array_wrong_arity_reject`.
+fn f(m: Option[Int, String]) -> Int {
+  m
+}
+
+fn main {
+  ()
+}

--- a/fixtures/typecheck/string_map_local_shadow_ok.vibe
+++ b/fixtures/typecheck/string_map_local_shadow_ok.vibe
@@ -1,0 +1,12 @@
+// #2263 review regression: a source declaration owns the StringMap spelling.
+struct StringMap[T] {
+  value: T
+}
+
+fn read(m: StringMap[Int]) -> Int {
+  m.value
+}
+
+fn main {
+  ()
+}

--- a/fixtures/typecheck/string_map_wrong_arity_reject.vibe
+++ b/fixtures/typecheck/string_map_wrong_arity_reject.vibe
@@ -1,0 +1,8 @@
+// #2263 review regression: malformed builtin applications fail loudly.
+fn f(m: StringMap[Int, String]) -> Int {
+  1
+}
+
+fn main {
+  ()
+}

--- a/lib/@vibe/compiler/checker/checker.vibe
+++ b/lib/@vibe/compiler/checker/checker.vibe
@@ -418,6 +418,11 @@ fn map_key_type_is_supported_at(k: Type, defs: Array[TypeDef], depth: Int) -> Bo
     // way. A head that does not resolve at all is the unknown-type check's
     // answer, not this one; a head that DOES resolve while still carrying
     // arguments is a declared generic struct or enum, and stays rejected.
+    //
+    // A user DECLARATION of a compiler-owned name never reaches that first
+    // arm: `resolve_type_expr` expands it first, so `type Future[T] = String`
+    // used as `Map[Future[Int], String]` arrives here as `CtString` and is
+    // still accepted (measured, pinned by `map_shadowed_wellknown_key_ok`).
     CtNamed(kname, kargs) => if is_wellknown_nominal_head(kname) {
       false
     } else if Array::length(kargs) == 0 {

--- a/lib/@vibe/compiler/checker/checker.vibe
+++ b/lib/@vibe/compiler/checker/checker.vibe
@@ -438,12 +438,20 @@ fn map_key_type_is_supported_at(k: Type, defs: Array[TypeDef], shadow: Array[Str
     // arm: `resolve_type_expr` expands it first, so `type Future[T] = String`
     // used as `Map[Future[Int], String]` arrives here as `CtString` and is
     // still accepted (measured, pinned by `map_shadowed_wellknown_key_ok`).
-    CtNamed(kname, kargs) => if is_wellknown_nominal_head(kname) {
-      false
-    } else if string_array_has(shadow, kname) {
-      // A type FORMAL in scope. Judging it would mean judging every future
+    //
+    // The SHADOW is consulted FIRST, before compiler ownership. A type formal
+    // may be spelled with a compiler-owned name -- `fn f[Future, V](m:
+    // Map[Future, V])` -- and `resolve_type_expr_shadowed` correctly keeps it
+    // as the rigid `CtNamed("Future", [])`. Testing ownership by NAME ahead of
+    // the binder read that formal as the builtin and rejected a function the
+    // contract explicitly permits (Codex round 15 on #2276, measured; the
+    // order was wrong when round 14 introduced this arm).
+    CtNamed(kname, kargs) => if string_array_has(shadow, kname) {
+      // A type FORMAL in scope. Judging it would mean judging every
       // instantiation, which is not this check's question.
       true
+    } else if is_wellknown_nominal_head(kname) {
+      false
     } else {
       match find_typedef(defs, kname) {
         // Not declared: a FORWARD reference, a typo, or a formal bound

--- a/lib/@vibe/compiler/checker/checker.vibe
+++ b/lib/@vibe/compiler/checker/checker.vibe
@@ -453,75 +453,71 @@ fn collect_unsupported_map_keys(t: Type, out: Array[Type]) -> Unit {
 /// (a one-node `TypeExpr` in every real spelling), and an alias is read from
 /// the already-resolved `Type` its `TypeDef` carries -- which is also what
 /// catches `type IntMap = Map[Int, String]` at the USE.
-fn report_map_key_types_walk(te: TypeExpr, defs: Array[TypeDef], shadow: Array[String], out: Array[Type], depth: Int) -> Unit {
-  if depth > 8 {
-    ()
-  } else {
-    match te {
-      TyName(name) => if string_array_has(shadow, name) {
-        ()
-      } else {
+fn report_map_key_types_walk(te: TypeExpr, defs: Array[TypeDef], shadow: Array[String], out: Array[Type]) -> Unit {
+  match te {
+    TyName(name) => if string_array_has(shadow, name) {
+      ()
+    } else {
+      match find_typedef(defs, name) {
+        Some(td) => match td {
+          TDAlias(_, _, body) => collect_unsupported_map_keys(body, out),
+          _ => ()
+        },
+        None => ()
+      }
+    },
+    TyUnit => (),
+    TyApp(name, args) => {
+      if name == "Map" && Array::length(args) == 2 && !string_array_has(shadow, name) && find_typedef(defs, name) is None {
+        let k = resolve_type_expr_shadowed(Array::get(args, 0), defs, shadow)
+        if map_key_type_is_supported(k) {
+          ()
+        } else {
+          Array::push(out, k)
+        }
+      } else if !string_array_has(shadow, name) {
         match find_typedef(defs, name) {
           Some(td) => match td {
-            TDAlias(_, _, body) => collect_unsupported_map_keys(body, out),
+            TDAlias(_, params, body) => {
+              let resolved_args = for arg in args {
+                resolve_type_expr_shadowed(arg, defs, shadow)
+              }
+              collect_unsupported_map_keys(resolve_type_alias_params(body, params, resolved_args), out)
+            },
             _ => ()
           },
           None => ()
         }
-      },
-      TyUnit => (),
-      TyApp(name, args) => {
-        if name == "Map" && Array::length(args) == 2 && !string_array_has(shadow, name) {
-          let k = resolve_type_expr_shadowed(Array::get(args, 0), defs, shadow)
-          if map_key_type_is_supported(k) {
-            ()
-          } else {
-            Array::push(out, k)
-          }
-        } else if !string_array_has(shadow, name) {
-          match find_typedef(defs, name) {
-            Some(td) => match td {
-              TDAlias(_, params, body) => {
-                let resolved_args = for arg in args {
-                  resolve_type_expr_shadowed(arg, defs, shadow)
-                }
-                collect_unsupported_map_keys(resolve_type_alias_params(body, params, resolved_args), out)
-              },
-              _ => ()
-            },
-            None => ()
-          }
-        } else {
-          ()
-        }
-        let mut i = 0
-        while i < Array::length(args) {
-          report_map_key_types_walk(Array::get(args, i), defs, shadow, out, depth + 1)
-          i = i + 1
-        }
-      },
-      TyTuple(items) => {
-        let mut i = 0
-        while i < Array::length(items) {
-          report_map_key_types_walk(Array::get(items, i), defs, shadow, out, depth + 1)
-          i = i + 1
-        }
-      },
-      TyFn(params, ret, _) => {
-        let mut i = 0
-        while i < Array::length(params) {
-          report_map_key_types_walk(Array::get(params, i), defs, shadow, out, depth + 1)
-          i = i + 1
-        }
-        report_map_key_types_walk(ret, defs, shadow, out, depth + 1)
+      } else {
+        ()
       }
+      let mut i = 0
+      while i < Array::length(args) {
+        report_map_key_types_walk(Array::get(args, i), defs, shadow, out)
+        i = i + 1
+      }
+    },
+    TyTuple(items) => {
+      let mut i = 0
+      while i < Array::length(items) {
+        report_map_key_types_walk(Array::get(items, i), defs, shadow, out)
+        i = i + 1
+      }
+    },
+    TyFn(params, ret, _) => {
+      let mut i = 0
+      while i < Array::length(params) {
+        report_map_key_types_walk(Array::get(params, i), defs, shadow, out)
+        i = i + 1
+      }
+      report_map_key_types_walk(ret, defs, shadow, out)
     }
   }
 }
 
 export fn report_map_key_types(te: TypeExpr, defs: Array[TypeDef], shadow: Array[String], where_label: String, errors: Array[String]) -> Unit {
   let bad = array_empty()
-  report_map_key_types_walk(te, defs, shadow, bad, 0)
+  report_map_key_types_walk(te, defs, shadow, bad)
   let mut i = 0
   while i < Array::length(bad) {
     Array::push(errors, String::concat(String::concat(String::concat(String::concat("the builtin map is String-keyed, so a `", type_to_string(Array::get(bad, i))), "` key has no implementation in "), where_label), " -- spell the String-keyed map `StringMap[V]`, or use `MutMap[K, V]` from `@vibe/core` for other keys (generic `Map` keys are #2263)"))

--- a/lib/@vibe/compiler/checker/checker.vibe
+++ b/lib/@vibe/compiler/checker/checker.vibe
@@ -506,20 +506,23 @@ fn map_key_type_is_supported_at(k: Type, defs: Array[TypeDef], shadow: Array[Str
   }
 }
 
-/// The actual argument bound to alias parameter `name`, or the rigid name
-/// itself when it is not one of `params`.
-fn alias_arg_for_param(name: String, params: Array[String], args: Array[Type]) -> Type {
+/// The actual argument bound to alias parameter `name`, plus whether a
+/// substitution occurred. The distinction preserves the CALLER's binders for
+/// a substituted argument while keeping the alias's binders for its own body.
+fn alias_arg_for_param(name: String, params: Array[String], args: Array[Type]) -> (Type, Bool) {
   let mut i = 0
   let mut found = CtNamed(name, array_empty())
+  let mut substituted = false
   while i < Array::length(params) {
     if Array::get(params, i) == name && i < Array::length(args) {
       found = Array::get(args, i)
+      substituted = true
     } else {
       ()
     }
     i = i + 1
   }
-  found
+  (found, substituted)
 }
 
 /// `collect_unsupported_map_keys` over an alias BODY that is being applied to
@@ -538,20 +541,25 @@ fn alias_arg_for_param(name: String, params: Array[String], args: Array[Type]) -
 /// Only a KEY that is a bare parameter name needs the mapping: every other
 /// unsupported key is unsupported whatever the parameter stands for, so no
 /// substituted node is ever needed.
-fn collect_unsupported_map_keys_applied(t: Type, defs: Array[TypeDef], params: Array[String], args: Array[Type], out: Array[Type]) -> Unit {
+fn collect_unsupported_map_keys_applied(t: Type, defs: Array[TypeDef], params: Array[String], args: Array[Type], caller_shadow: Array[String], out: Array[Type]) -> Unit {
   match t {
     CtNamed(head, targs) => {
       if head == "Map" && Array::length(targs) == 2 && find_typedef(defs, head) is None {
         let k0 = Array::get(targs, 0)
-        let k = match k0 {
+        let (k, substituted) = match k0 {
           CtNamed(kn, kargs) => if Array::length(kargs) == 0 {
             alias_arg_for_param(kn, params, args)
           } else {
-            k0
+            (k0, false)
           },
-          _ => k0
+          _ => (k0, false)
         }
-        if map_key_type_is_supported(k, defs, params) {
+        let key_shadow = if substituted {
+          caller_shadow
+        } else {
+          params
+        }
+        if map_key_type_is_supported(k, defs, key_shadow) {
           ()
         } else {
           Array::push(out, k)
@@ -561,32 +569,32 @@ fn collect_unsupported_map_keys_applied(t: Type, defs: Array[TypeDef], params: A
       }
       let mut i = 0
       while i < Array::length(targs) {
-        collect_unsupported_map_keys_applied(Array::get(targs, i), defs, params, args, out)
+        collect_unsupported_map_keys_applied(Array::get(targs, i), defs, params, args, caller_shadow, out)
         i = i + 1
       }
     },
-    CtArray(e) => collect_unsupported_map_keys_applied(e, defs, params, args, out),
-    CtOption(e) => collect_unsupported_map_keys_applied(e, defs, params, args, out),
+    CtArray(e) => collect_unsupported_map_keys_applied(e, defs, params, args, caller_shadow, out),
+    CtOption(e) => collect_unsupported_map_keys_applied(e, defs, params, args, caller_shadow, out),
     CtTuple(items) => {
       let mut i = 0
       while i < Array::length(items) {
-        collect_unsupported_map_keys_applied(Array::get(items, i), defs, params, args, out)
+        collect_unsupported_map_keys_applied(Array::get(items, i), defs, params, args, caller_shadow, out)
         i = i + 1
       }
     },
     CtFn(fparams, ret, _) => {
       let mut i = 0
       while i < Array::length(fparams) {
-        collect_unsupported_map_keys_applied(Array::get(fparams, i), defs, params, args, out)
+        collect_unsupported_map_keys_applied(Array::get(fparams, i), defs, params, args, caller_shadow, out)
         i = i + 1
       }
-      collect_unsupported_map_keys_applied(ret, defs, params, args, out)
+      collect_unsupported_map_keys_applied(ret, defs, params, args, caller_shadow, out)
     },
     CtRecord(fields) => {
       let mut i = 0
       while i < Array::length(fields) {
         let (_, ft) = Array::get(fields, i)
-        collect_unsupported_map_keys_applied(ft, defs, params, args, out)
+        collect_unsupported_map_keys_applied(ft, defs, params, args, caller_shadow, out)
         i = i + 1
       }
     },
@@ -742,7 +750,7 @@ fn report_map_key_types_walk(te: TypeExpr, defs: Array[TypeDef], shadow: Array[S
               let resolved_args = for arg in args {
                 resolve_type_expr_shadowed(arg, defs, shadow)
               }
-              collect_unsupported_map_keys_applied(body, defs, params, resolved_args, out)
+              collect_unsupported_map_keys_applied(body, defs, params, resolved_args, shadow, out)
             },
             _ => ()
           },

--- a/lib/@vibe/compiler/checker/checker.vibe
+++ b/lib/@vibe/compiler/checker/checker.vibe
@@ -395,10 +395,25 @@ export fn report_formal_applications(te: TypeExpr, formals: Array[String], where
 /// `CtUnknown`, or an unresolved nominal head is ACCEPTED -- generic code is
 /// unaffected, and a typo is the unknown-type check's answer, not this one.
 fn map_key_type_is_supported(k: Type, defs: Array[TypeDef]) -> Bool {
-  map_key_type_is_supported_at(k, defs, 0)
+  map_key_type_is_supported_at(k, defs, array_empty())
 }
 
-fn map_key_type_is_supported_at(k: Type, defs: Array[TypeDef], depth: Int) -> Bool {
+/// Whether this alias name has already been expanded on the current chain.
+fn map_key_alias_chain_contains(seen: Array[String], name: String) -> Bool {
+  let mut i = 0
+  let mut found = false
+  while i < Array::length(seen) {
+    if Array::get(seen, i) == name {
+      found = true
+    } else {
+      ()
+    }
+    i = i + 1
+  }
+  found
+}
+
+fn map_key_type_is_supported_at(k: Type, defs: Array[TypeDef], seen: Array[String]) -> Bool {
   match k {
     CtString => true,
     CtVar(_) => true,
@@ -449,10 +464,22 @@ fn map_key_type_is_supported_at(k: Type, defs: Array[TypeDef], depth: Int) -> Bo
         // still rejects the key, which is where every map key was caught
         // before this check existed.
         Some(td) => match td {
-          TDAlias(_, _, abody) => if depth > 4 {
+          //
+          // The chain is followed to its END, however long. It used to stop
+          // at a DEPTH CAP of four hops and answer "supported" beyond it, so
+          // a seven-hop chain ending in `Int` was accepted (Codex round 13 on
+          // #2276, measured). The cap was load-bearing, not decoration: a
+          // CYCLIC alias chain -- `type A[T] = B[T]` with `type B[T] = A[T]`
+          // -- compiles today, so this walk has to terminate on its own.
+          // Remembering the names already expanded terminates on exactly the
+          // cycle and on nothing else.
+          TDAlias(_, _, abody) => if map_key_alias_chain_contains(seen, kname) {
+            // An alias that expands to itself has no key type to judge, and
+            // the diagnostic for the cycle belongs to whatever rejects it.
             true
           } else {
-            map_key_type_is_supported_at(abody, defs, depth + 1)
+            Array::push(seen, kname)
+            map_key_type_is_supported_at(abody, defs, seen)
           },
           // A declared struct or enum applied to arguments really is a key
           // with no implementation.

--- a/lib/@vibe/compiler/checker/checker.vibe
+++ b/lib/@vibe/compiler/checker/checker.vibe
@@ -394,8 +394,8 @@ export fn report_formal_applications(te: TypeExpr, formals: Array[String], where
 /// is what expands it. A key that is a type formal, an inference variable,
 /// `CtUnknown`, or an unresolved nominal head is ACCEPTED -- generic code is
 /// unaffected, and a typo is the unknown-type check's answer, not this one.
-fn map_key_type_is_supported(k: Type, defs: Array[TypeDef]) -> Bool {
-  map_key_type_is_supported_at(k, defs, array_empty())
+fn map_key_type_is_supported(k: Type, defs: Array[TypeDef], shadow: Array[String]) -> Bool {
+  map_key_type_is_supported_at(k, defs, shadow, array_empty())
 }
 
 /// Whether this alias name has already been expanded on the current chain.
@@ -413,7 +413,7 @@ fn map_key_alias_chain_contains(seen: Array[String], name: String) -> Bool {
   found
 }
 
-fn map_key_type_is_supported_at(k: Type, defs: Array[TypeDef], seen: Array[String]) -> Bool {
+fn map_key_type_is_supported_at(k: Type, defs: Array[TypeDef], shadow: Array[String], seen: Array[String]) -> Bool {
   match k {
     CtString => true,
     CtVar(_) => true,
@@ -440,19 +440,21 @@ fn map_key_type_is_supported_at(k: Type, defs: Array[TypeDef], seen: Array[Strin
     // still accepted (measured, pinned by `map_shadowed_wellknown_key_ok`).
     CtNamed(kname, kargs) => if is_wellknown_nominal_head(kname) {
       false
-    } else if Array::length(kargs) == 0 {
+    } else if string_array_has(shadow, kname) {
+      // A type FORMAL in scope. Judging it would mean judging every future
+      // instantiation, which is not this check's question.
       true
     } else {
       match find_typedef(defs, kname) {
-        // Not declared (yet): a FORWARD reference or a typo. Either way not
-        // this check's answer.
+        // Not declared: a FORWARD reference, a typo, or a formal bound
+        // somewhere this walk cannot see. Either way not this check's answer.
         None => true,
         // Declared as an alias: judge its BODY. Reading the already-resolved
         // body needs no substitution -- and must not use one, since
-        // `resolve_type_alias_params` corrupts the heap (#2279). A body that
-        // still mentions the alias's own parameters leaves them as rigid
-        // zero-argument names, which the first arm accepts, exactly as an
-        // unbound formal is accepted anywhere else.
+        // `resolve_type_alias_params` corrupts the heap (#2279). The alias's
+        // OWN parameters become the shadow for that body, so a body that
+        // mentions them is judged as a formal rather than as whatever
+        // top-level type happens to share the spelling.
         //
         // KNOWN GAP (#2282, Codex round 8 on #2276): that acceptance lets a
         // FORWARDING alias through. `type Key[T] = T` used as
@@ -463,26 +465,31 @@ fn map_key_type_is_supported_at(k: Type, defs: Array[TypeDef], seen: Array[Strin
         // answer: the annotation is accepted and the first `Map::` operation
         // still rejects the key, which is where every map key was caught
         // before this check existed.
+        //
+        // The chain is followed to its END, however long. It used to stop
+        // at a DEPTH CAP of four hops and answer "supported" beyond it, so
+        // a seven-hop chain ending in `Int` was accepted (Codex round 13 on
+        // #2276, measured). The cap was load-bearing, not decoration: a
+        // CYCLIC alias chain -- `type A[T] = B[T]` with `type B[T] = A[T]`
+        // -- compiles today, so this walk has to terminate on its own.
+        // Remembering the names already expanded terminates on exactly the
+        // cycle and on nothing else.
         Some(td) => match td {
-          //
-          // The chain is followed to its END, however long. It used to stop
-          // at a DEPTH CAP of four hops and answer "supported" beyond it, so
-          // a seven-hop chain ending in `Int` was accepted (Codex round 13 on
-          // #2276, measured). The cap was load-bearing, not decoration: a
-          // CYCLIC alias chain -- `type A[T] = B[T]` with `type B[T] = A[T]`
-          // -- compiles today, so this walk has to terminate on its own.
-          // Remembering the names already expanded terminates on exactly the
-          // cycle and on nothing else.
-          TDAlias(_, _, abody) => if map_key_alias_chain_contains(seen, kname) {
+          TDAlias(_, aparams, abody) => if map_key_alias_chain_contains(seen, kname) {
             // An alias that expands to itself has no key type to judge, and
             // the diagnostic for the cycle belongs to whatever rejects it.
             true
           } else {
             Array::push(seen, kname)
-            map_key_type_is_supported_at(abody, defs, seen)
+            map_key_type_is_supported_at(abody, defs, aparams, seen)
           },
-          // A declared struct or enum applied to arguments really is a key
-          // with no implementation.
+          // A declared struct or enum. `kargs` is not consulted: the nullary
+          // form used to be accepted before `find_typedef` was reached at
+          // all, which made a FORWARD-declared key order-dependent --
+          // measured, `type Bad = Map[Key, Int]` was rejected with `type Key
+          // = Int` above it and accepted with it below (Codex round 14 on
+          // #2276). A declared struct is not a key implementation at either
+          // arity.
           _ => false
         }
       }
@@ -536,7 +543,7 @@ fn collect_unsupported_map_keys_applied(t: Type, defs: Array[TypeDef], params: A
           },
           _ => k0
         }
-        if map_key_type_is_supported(k, defs) {
+        if map_key_type_is_supported(k, defs, params) {
           ()
         } else {
           Array::push(out, k)
@@ -579,12 +586,12 @@ fn collect_unsupported_map_keys_applied(t: Type, defs: Array[TypeDef], params: A
   }
 }
 
-fn collect_unsupported_map_keys(t: Type, defs: Array[TypeDef], out: Array[Type]) -> Unit {
+fn collect_unsupported_map_keys(t: Type, defs: Array[TypeDef], shadow: Array[String], out: Array[Type]) -> Unit {
   match t {
     CtNamed(head, targs) => {
       if head == "Map" && Array::length(targs) == 2 && find_typedef(defs, head) is None {
         let k = Array::get(targs, 0)
-        if map_key_type_is_supported(k, defs) {
+        if map_key_type_is_supported(k, defs, shadow) {
           ()
         } else {
           Array::push(out, k)
@@ -594,32 +601,32 @@ fn collect_unsupported_map_keys(t: Type, defs: Array[TypeDef], out: Array[Type])
       }
       let mut i = 0
       while i < Array::length(targs) {
-        collect_unsupported_map_keys(Array::get(targs, i), defs, out)
+        collect_unsupported_map_keys(Array::get(targs, i), defs, shadow, out)
         i = i + 1
       }
     },
-    CtArray(e) => collect_unsupported_map_keys(e, defs, out),
-    CtOption(e) => collect_unsupported_map_keys(e, defs, out),
+    CtArray(e) => collect_unsupported_map_keys(e, defs, shadow, out),
+    CtOption(e) => collect_unsupported_map_keys(e, defs, shadow, out),
     CtTuple(items) => {
       let mut i = 0
       while i < Array::length(items) {
-        collect_unsupported_map_keys(Array::get(items, i), defs, out)
+        collect_unsupported_map_keys(Array::get(items, i), defs, shadow, out)
         i = i + 1
       }
     },
     CtFn(params, ret, _) => {
       let mut i = 0
       while i < Array::length(params) {
-        collect_unsupported_map_keys(Array::get(params, i), defs, out)
+        collect_unsupported_map_keys(Array::get(params, i), defs, shadow, out)
         i = i + 1
       }
-      collect_unsupported_map_keys(ret, defs, out)
+      collect_unsupported_map_keys(ret, defs, shadow, out)
     },
     CtRecord(fields) => {
       let mut i = 0
       while i < Array::length(fields) {
         let (_, ft) = Array::get(fields, i)
-        collect_unsupported_map_keys(ft, defs, out)
+        collect_unsupported_map_keys(ft, defs, shadow, out)
         i = i + 1
       }
     },
@@ -675,7 +682,7 @@ fn report_map_key_types_walk(te: TypeExpr, defs: Array[TypeDef], shadow: Array[S
     } else {
       match find_typedef(defs, name) {
         Some(td) => match td {
-          TDAlias(_, _, body) => collect_unsupported_map_keys(body, defs, out),
+          TDAlias(_, aparams, body) => collect_unsupported_map_keys(body, defs, aparams, out),
           _ => ()
         },
         None => ()
@@ -691,7 +698,7 @@ fn report_map_key_types_walk(te: TypeExpr, defs: Array[TypeDef], shadow: Array[S
       }
       if name == "Map" && Array::length(args) == 2 && !string_array_has(shadow, name) && find_typedef(defs, name) is None {
         let k = resolve_type_expr_shadowed(Array::get(args, 0), defs, shadow)
-        if map_key_type_is_supported(k, defs) {
+        if map_key_type_is_supported(k, defs, shadow) {
           ()
         } else {
           Array::push(out, k)

--- a/lib/@vibe/compiler/checker/checker.vibe
+++ b/lib/@vibe/compiler/checker/checker.vibe
@@ -594,7 +594,10 @@ fn collect_unsupported_map_keys_applied(t: Type, defs: Array[TypeDef], params: A
   }
 }
 
-fn collect_unsupported_map_keys(t: Type, defs: Array[TypeDef], shadow: Array[String], out: Array[Type]) -> Unit {
+/// `seen` is the alias names already expanded on this walk, for the same
+/// reason `map_key_type_is_supported_at` carries one: a cyclic alias chain
+/// compiles, so following alias heads needs its own termination.
+fn collect_unsupported_map_keys_at(t: Type, defs: Array[TypeDef], shadow: Array[String], seen: Array[String], out: Array[Type]) -> Unit {
   match t {
     CtNamed(head, targs) => {
       if head == "Map" && Array::length(targs) == 2 && find_typedef(defs, head) is None {
@@ -604,42 +607,63 @@ fn collect_unsupported_map_keys(t: Type, defs: Array[TypeDef], shadow: Array[Str
         } else {
           Array::push(out, k)
         }
+      } else if !string_array_has(shadow, head) && !map_key_alias_chain_contains(seen, head) {
+        // An ALIAS head is followed into its body (Codex round 16 on #2276).
+        // A name recorded before its target was declared stays an unresolved
+        // `CtNamed`, so the map can sit one hop further in than this walk used
+        // to look: `type Outer = Inner` above `type Inner = Map[Key, Int]`
+        // above `type Key = Int` was accepted, because `Outer`'s body is the
+        // bare `Inner` and nothing expanded it. Measured before the fix.
+        match find_typedef(defs, head) {
+          Some(td) => match td {
+            TDAlias(_, aparams, abody) => {
+              Array::push(seen, head)
+              collect_unsupported_map_keys_at(abody, defs, aparams, seen, out)
+            },
+            _ => ()
+          },
+          None => ()
+        }
       } else {
         ()
       }
       let mut i = 0
       while i < Array::length(targs) {
-        collect_unsupported_map_keys(Array::get(targs, i), defs, shadow, out)
+        collect_unsupported_map_keys_at(Array::get(targs, i), defs, shadow, seen, out)
         i = i + 1
       }
     },
-    CtArray(e) => collect_unsupported_map_keys(e, defs, shadow, out),
-    CtOption(e) => collect_unsupported_map_keys(e, defs, shadow, out),
+    CtArray(e) => collect_unsupported_map_keys_at(e, defs, shadow, seen, out),
+    CtOption(e) => collect_unsupported_map_keys_at(e, defs, shadow, seen, out),
     CtTuple(items) => {
       let mut i = 0
       while i < Array::length(items) {
-        collect_unsupported_map_keys(Array::get(items, i), defs, shadow, out)
+        collect_unsupported_map_keys_at(Array::get(items, i), defs, shadow, seen, out)
         i = i + 1
       }
     },
     CtFn(params, ret, _) => {
       let mut i = 0
       while i < Array::length(params) {
-        collect_unsupported_map_keys(Array::get(params, i), defs, shadow, out)
+        collect_unsupported_map_keys_at(Array::get(params, i), defs, shadow, seen, out)
         i = i + 1
       }
-      collect_unsupported_map_keys(ret, defs, shadow, out)
+      collect_unsupported_map_keys_at(ret, defs, shadow, seen, out)
     },
     CtRecord(fields) => {
       let mut i = 0
       while i < Array::length(fields) {
         let (_, ft) = Array::get(fields, i)
-        collect_unsupported_map_keys(ft, defs, shadow, out)
+        collect_unsupported_map_keys_at(ft, defs, shadow, seen, out)
         i = i + 1
       }
     },
     _ => ()
   }
+}
+
+fn collect_unsupported_map_keys(t: Type, defs: Array[TypeDef], shadow: Array[String], out: Array[Type]) -> Unit {
+  collect_unsupported_map_keys_at(t, defs, shadow, array_empty(), out)
 }
 
 /// The declared arity of a compiler-known structural head, or -1 when `name`

--- a/lib/@vibe/compiler/checker/checker.vibe
+++ b/lib/@vibe/compiler/checker/checker.vibe
@@ -425,6 +425,16 @@ fn map_key_type_is_supported_at(k: Type, defs: Array[TypeDef], depth: Int) -> Bo
         // still mentions the alias's own parameters leaves them as rigid
         // zero-argument names, which the first arm accepts, exactly as an
         // unbound formal is accepted anywhere else.
+        //
+        // KNOWN GAP (#2282, Codex round 8 on #2276): that acceptance lets a
+        // FORWARDING alias through. `type Key[T] = T` used as
+        // `Map[Key[T], Int]` under `M[Int]` has the concrete key `Int`, but
+        // seeing that means carrying `M`'s argument through `Key`'s binder --
+        // two levels of substitution, which is exactly what #2279 makes
+        // unsafe. The consequence is a MISSED EARLY diagnostic, not a wrong
+        // answer: the annotation is accepted and the first `Map::` operation
+        // still rejects the key, which is where every map key was caught
+        // before this check existed.
         Some(td) => match td {
           TDAlias(_, _, abody) => if depth > 4 {
             true

--- a/lib/@vibe/compiler/checker/checker.vibe
+++ b/lib/@vibe/compiler/checker/checker.vibe
@@ -29,6 +29,7 @@ import @vibe/compiler/core {
   registry_builtin_arity,
   registry_builtin_param_type,
   resolve_builtin,
+  resolve_type_alias_params,
   subst_add_bound,
   subst_apply,
   subst_bounds_for,
@@ -480,7 +481,12 @@ fn report_map_key_types_walk(te: TypeExpr, defs: Array[TypeDef], shadow: Array[S
         } else if !string_array_has(shadow, name) {
           match find_typedef(defs, name) {
             Some(td) => match td {
-              TDAlias(_, _, body) => collect_unsupported_map_keys(body, out),
+              TDAlias(_, params, body) => {
+                let resolved_args = for arg in args {
+                  resolve_type_expr_shadowed(arg, defs, shadow)
+                }
+                collect_unsupported_map_keys(resolve_type_alias_params(body, params, resolved_args), out)
+              },
               _ => ()
             },
             None => ()

--- a/lib/@vibe/compiler/checker/checker.vibe
+++ b/lib/@vibe/compiler/checker/checker.vibe
@@ -389,12 +389,54 @@ export fn report_formal_applications(te: TypeExpr, formals: Array[String], where
 /// is what expands it. A key that is a type formal, an inference variable,
 /// `CtUnknown`, or an unresolved nominal head is ACCEPTED -- generic code is
 /// unaffected, and a typo is the unknown-type check's answer, not this one.
-fn map_key_type_is_supported(k: Type) -> Bool {
+fn map_key_type_is_supported(k: Type, defs: Array[TypeDef]) -> Bool {
+  map_key_type_is_supported_at(k, defs, 0)
+}
+
+fn map_key_type_is_supported_at(k: Type, defs: Array[TypeDef], depth: Int) -> Bool {
   match k {
     CtString => true,
     CtVar(_) => true,
     CtUnknown => true,
-    CtNamed(_, kargs) => Array::length(kargs) == 0,
+    // A nominal head with NO arguments is a formal or an opaque name this
+    // pass cannot judge, and one with arguments is judged by whether it
+    // RESOLVES (Codex round 6 on #2276).
+    //
+    // An unresolved applied head is a FORWARD reference, not a bad key:
+    // `type M[T] = Map[Key[T], Int]` above `type Key[T] = String` sees the
+    // key as `CtNamed("Key", [T])` because `Key` is not declared yet, and it
+    // ultimately resolves to `String`. Rejecting every applied `CtNamed` made
+    // that valid program depend on DECLARATION ORDER -- measured, the same
+    // two declarations were accepted with `Key` first and rejected with `Key`
+    // second, while the identical shape under `Array` was accepted either
+    // way. A head that does not resolve at all is the unknown-type check's
+    // answer, not this one; a head that DOES resolve while still carrying
+    // arguments is a declared generic struct or enum, and stays rejected.
+    CtNamed(kname, kargs) => if Array::length(kargs) == 0 {
+      true
+    } else {
+      match find_typedef(defs, kname) {
+        // Not declared (yet): a FORWARD reference or a typo. Either way not
+        // this check's answer.
+        None => true,
+        // Declared as an alias: judge its BODY. Reading the already-resolved
+        // body needs no substitution -- and must not use one, since
+        // `resolve_type_alias_params` corrupts the heap (#2279). A body that
+        // still mentions the alias's own parameters leaves them as rigid
+        // zero-argument names, which the first arm accepts, exactly as an
+        // unbound formal is accepted anywhere else.
+        Some(td) => match td {
+          TDAlias(_, _, abody) => if depth > 4 {
+            true
+          } else {
+            map_key_type_is_supported_at(abody, defs, depth + 1)
+          },
+          // A declared struct or enum applied to arguments really is a key
+          // with no implementation.
+          _ => false
+        }
+      }
+    },
     _ => false
   }
 }
@@ -444,7 +486,7 @@ fn collect_unsupported_map_keys_applied(t: Type, defs: Array[TypeDef], params: A
           },
           _ => k0
         }
-        if map_key_type_is_supported(k) {
+        if map_key_type_is_supported(k, defs) {
           ()
         } else {
           Array::push(out, k)
@@ -492,7 +534,7 @@ fn collect_unsupported_map_keys(t: Type, defs: Array[TypeDef], out: Array[Type])
     CtNamed(head, targs) => {
       if head == "Map" && Array::length(targs) == 2 && find_typedef(defs, head) is None {
         let k = Array::get(targs, 0)
-        if map_key_type_is_supported(k) {
+        if map_key_type_is_supported(k, defs) {
           ()
         } else {
           Array::push(out, k)
@@ -599,7 +641,7 @@ fn report_map_key_types_walk(te: TypeExpr, defs: Array[TypeDef], shadow: Array[S
       }
       if name == "Map" && Array::length(args) == 2 && !string_array_has(shadow, name) && find_typedef(defs, name) is None {
         let k = resolve_type_expr_shadowed(Array::get(args, 0), defs, shadow)
-        if map_key_type_is_supported(k) {
+        if map_key_type_is_supported(k, defs) {
           ()
         } else {
           Array::push(out, k)

--- a/lib/@vibe/compiler/checker/checker.vibe
+++ b/lib/@vibe/compiler/checker/checker.vibe
@@ -399,6 +399,94 @@ fn map_key_type_is_supported(k: Type) -> Bool {
   }
 }
 
+/// The actual argument bound to alias parameter `name`, or the rigid name
+/// itself when it is not one of `params`.
+fn alias_arg_for_param(name: String, params: Array[String], args: Array[Type]) -> Type {
+  let mut i = 0
+  let mut found = CtNamed(name, array_empty())
+  while i < Array::length(params) {
+    if Array::get(params, i) == name && i < Array::length(args) {
+      found = Array::get(args, i)
+    } else {
+      ()
+    }
+    i = i + 1
+  }
+  found
+}
+
+/// `collect_unsupported_map_keys` over an alias BODY that is being applied to
+/// `args`, without materializing the substituted type.
+///
+/// The obvious spelling -- `collect_unsupported_map_keys(
+/// resolve_type_alias_params(body, params, args), ...)` -- corrupts the heap
+/// (#2279). That function returns `Array::get(args, idx)` directly for a
+/// parameter, so the tree it hands back SHARES subterms with `args` without
+/// owning them; walking that tree drops borrowed nodes and a later, unrelated
+/// allocation traps with `memory access out of bounds at __rt_rc_alloc`.
+/// Measured: calling it and DISCARDING the result is clean, and consuming the
+/// result is what traps, which is what identifies the aliasing rather than the
+/// substitution as the fault.
+///
+/// Only a KEY that is a bare parameter name needs the mapping: every other
+/// unsupported key is unsupported whatever the parameter stands for, so no
+/// substituted node is ever needed.
+fn collect_unsupported_map_keys_applied(t: Type, defs: Array[TypeDef], params: Array[String], args: Array[Type], out: Array[Type]) -> Unit {
+  match t {
+    CtNamed(head, targs) => {
+      if head == "Map" && Array::length(targs) == 2 && find_typedef(defs, head) is None {
+        let k0 = Array::get(targs, 0)
+        let k = match k0 {
+          CtNamed(kn, kargs) => if Array::length(kargs) == 0 {
+            alias_arg_for_param(kn, params, args)
+          } else {
+            k0
+          },
+          _ => k0
+        }
+        if map_key_type_is_supported(k) {
+          ()
+        } else {
+          Array::push(out, k)
+        }
+      } else {
+        ()
+      }
+      let mut i = 0
+      while i < Array::length(targs) {
+        collect_unsupported_map_keys_applied(Array::get(targs, i), defs, params, args, out)
+        i = i + 1
+      }
+    },
+    CtArray(e) => collect_unsupported_map_keys_applied(e, defs, params, args, out),
+    CtOption(e) => collect_unsupported_map_keys_applied(e, defs, params, args, out),
+    CtTuple(items) => {
+      let mut i = 0
+      while i < Array::length(items) {
+        collect_unsupported_map_keys_applied(Array::get(items, i), defs, params, args, out)
+        i = i + 1
+      }
+    },
+    CtFn(fparams, ret, _) => {
+      let mut i = 0
+      while i < Array::length(fparams) {
+        collect_unsupported_map_keys_applied(Array::get(fparams, i), defs, params, args, out)
+        i = i + 1
+      }
+      collect_unsupported_map_keys_applied(ret, defs, params, args, out)
+    },
+    CtRecord(fields) => {
+      let mut i = 0
+      while i < Array::length(fields) {
+        let (_, ft) = Array::get(fields, i)
+        collect_unsupported_map_keys_applied(ft, defs, params, args, out)
+        i = i + 1
+      }
+    },
+    _ => ()
+  }
+}
+
 fn collect_unsupported_map_keys(t: Type, defs: Array[TypeDef], out: Array[Type]) -> Unit {
   match t {
     CtNamed(head, targs) => {
@@ -523,7 +611,7 @@ fn report_map_key_types_walk(te: TypeExpr, defs: Array[TypeDef], shadow: Array[S
               let resolved_args = for arg in args {
                 resolve_type_expr_shadowed(arg, defs, shadow)
               }
-              collect_unsupported_map_keys(resolve_type_alias_params(body, params, resolved_args), defs, out)
+              collect_unsupported_map_keys_applied(body, defs, params, resolved_args, out)
             },
             _ => ()
           },

--- a/lib/@vibe/compiler/checker/checker.vibe
+++ b/lib/@vibe/compiler/checker/checker.vibe
@@ -58,7 +58,12 @@ import ./checker_pattern.vibe {
 }
 
 import ./checker_resolve.vibe {
-  collect_unknown_type_names, collect_unknown_type_names_regionwise, resolve_type_expr, resolve_type_expr_shadowed, subst_type_params
+  collect_unknown_type_names,
+  collect_unknown_type_names_regionwise,
+  is_wellknown_nominal_head,
+  resolve_type_expr,
+  resolve_type_expr_shadowed,
+  subst_type_params
 }
 
 import ./checker_spawnable.vibe {
@@ -398,9 +403,10 @@ fn map_key_type_is_supported_at(k: Type, defs: Array[TypeDef], depth: Int) -> Bo
     CtString => true,
     CtVar(_) => true,
     CtUnknown => true,
-    // A nominal head with NO arguments is a formal or an opaque name this
-    // pass cannot judge, and one with arguments is judged by whether it
-    // RESOLVES (Codex round 6 on #2276).
+    // A compiler-owned nominal is concrete even without a TypeDef, and none
+    // has a builtin Map key implementation. Other heads with NO arguments are
+    // formals or opaque names this pass cannot judge; applied heads are judged
+    // by whether they resolve (Codex rounds 6 and 12 on #2276).
     //
     // An unresolved applied head is a FORWARD reference, not a bad key:
     // `type M[T] = Map[Key[T], Int]` above `type Key[T] = String` sees the
@@ -412,7 +418,9 @@ fn map_key_type_is_supported_at(k: Type, defs: Array[TypeDef], depth: Int) -> Bo
     // way. A head that does not resolve at all is the unknown-type check's
     // answer, not this one; a head that DOES resolve while still carrying
     // arguments is a declared generic struct or enum, and stays rejected.
-    CtNamed(kname, kargs) => if Array::length(kargs) == 0 {
+    CtNamed(kname, kargs) => if is_wellknown_nominal_head(kname) {
+      false
+    } else if Array::length(kargs) == 0 {
       true
     } else {
       match find_typedef(defs, kname) {

--- a/lib/@vibe/compiler/checker/checker.vibe
+++ b/lib/@vibe/compiler/checker/checker.vibe
@@ -399,10 +399,10 @@ fn map_key_type_is_supported(k: Type) -> Bool {
   }
 }
 
-fn collect_unsupported_map_keys(t: Type, out: Array[Type]) -> Unit {
+fn collect_unsupported_map_keys(t: Type, defs: Array[TypeDef], out: Array[Type]) -> Unit {
   match t {
     CtNamed(head, targs) => {
-      if head == "Map" && Array::length(targs) == 2 {
+      if head == "Map" && Array::length(targs) == 2 && find_typedef(defs, head) is None {
         let k = Array::get(targs, 0)
         if map_key_type_is_supported(k) {
           ()
@@ -414,32 +414,32 @@ fn collect_unsupported_map_keys(t: Type, out: Array[Type]) -> Unit {
       }
       let mut i = 0
       while i < Array::length(targs) {
-        collect_unsupported_map_keys(Array::get(targs, i), out)
+        collect_unsupported_map_keys(Array::get(targs, i), defs, out)
         i = i + 1
       }
     },
-    CtArray(e) => collect_unsupported_map_keys(e, out),
-    CtOption(e) => collect_unsupported_map_keys(e, out),
+    CtArray(e) => collect_unsupported_map_keys(e, defs, out),
+    CtOption(e) => collect_unsupported_map_keys(e, defs, out),
     CtTuple(items) => {
       let mut i = 0
       while i < Array::length(items) {
-        collect_unsupported_map_keys(Array::get(items, i), out)
+        collect_unsupported_map_keys(Array::get(items, i), defs, out)
         i = i + 1
       }
     },
     CtFn(params, ret, _) => {
       let mut i = 0
       while i < Array::length(params) {
-        collect_unsupported_map_keys(Array::get(params, i), out)
+        collect_unsupported_map_keys(Array::get(params, i), defs, out)
         i = i + 1
       }
-      collect_unsupported_map_keys(ret, out)
+      collect_unsupported_map_keys(ret, defs, out)
     },
     CtRecord(fields) => {
       let mut i = 0
       while i < Array::length(fields) {
         let (_, ft) = Array::get(fields, i)
-        collect_unsupported_map_keys(ft, out)
+        collect_unsupported_map_keys(ft, defs, out)
         i = i + 1
       }
     },
@@ -460,7 +460,7 @@ fn report_map_key_types_walk(te: TypeExpr, defs: Array[TypeDef], shadow: Array[S
     } else {
       match find_typedef(defs, name) {
         Some(td) => match td {
-          TDAlias(_, _, body) => collect_unsupported_map_keys(body, out),
+          TDAlias(_, _, body) => collect_unsupported_map_keys(body, defs, out),
           _ => ()
         },
         None => ()
@@ -482,7 +482,7 @@ fn report_map_key_types_walk(te: TypeExpr, defs: Array[TypeDef], shadow: Array[S
               let resolved_args = for arg in args {
                 resolve_type_expr_shadowed(arg, defs, shadow)
               }
-              collect_unsupported_map_keys(resolve_type_alias_params(body, params, resolved_args), out)
+              collect_unsupported_map_keys(resolve_type_alias_params(body, params, resolved_args), defs, out)
             },
             _ => ()
           },

--- a/lib/@vibe/compiler/checker/checker.vibe
+++ b/lib/@vibe/compiler/checker/checker.vibe
@@ -447,13 +447,48 @@ fn collect_unsupported_map_keys(t: Type, defs: Array[TypeDef], out: Array[Type])
   }
 }
 
+/// The declared arity of a compiler-known structural head, or -1 when `name`
+/// is not one. `ty_head_is_structural` exempts these heads from the
+/// unknown-name sweep, and `resolve_type_expr_core_shadowed` requires the
+/// EXACT arity and otherwise falls through to an unresolved `CtNamed` --
+/// which `check_assignable` tolerates like a wildcard. Between the two, a
+/// wrong-arity application was reported by nobody and turned the slot off.
+///
+/// Measured on the head before this (Codex round 1 on #2276):
+/// `fn f(m: Array[Int, String]) -> Int { m }` compiled clean and returned a
+/// non-`Int` as `Int`, and `Option[Int, String]` did the same. The
+/// `StringMap` instance was closed by excluding it from the exemption, which
+/// made it loud but named it "unknown type `StringMap`" -- a type the
+/// compiler knows. All three are one defect, so one rule answers for them,
+/// and it names the arity.
+///
+/// A BARE `Array` was already loud, so only the APPLICATION is a hole.
+fn structural_head_arity(name: String) -> Int {
+  if name == "Array" || name == "Option" || name == "StringMap" {
+    1
+  } else {
+    0 - 1
+  }
+}
+
+/// The hint spells `Name[T]`, which is right because every head
+/// `structural_head_arity` recognizes has arity 1. A head added there with
+/// another arity must derive the hint from `want` instead.
+fn structural_arity_error(name: String, given: Int, want: Int, where_label: String) -> String {
+  String::concat(String::concat(String::concat(String::concat(String::concat(String::concat(String::concat("`", name), "` takes "), Int::to_string(want)), " type argument, but "), Int::to_string(given)), " were given in "), String::concat(where_label, String::concat(String::concat(" -- write `", name), "[T]` with a single element type")))
+}
+
 /// Walks the annotation WITHOUT resolving it. Resolution allocates, and this
 /// runs at every one of `report_unknown_type_names`'s ~84 sites, so the whole
 /// annotation is never re-resolved: only a `Map` head's KEY argument is
 /// (a one-node `TypeExpr` in every real spelling), and an alias is read from
 /// the already-resolved `Type` its `TypeDef` carries -- which is also what
 /// catches `type IntMap = Map[Int, String]` at the USE.
-fn report_map_key_types_walk(te: TypeExpr, defs: Array[TypeDef], shadow: Array[String], out: Array[Type]) -> Unit {
+///
+/// Two rules share the walk so an annotation is traversed once: `out`
+/// collects a `Map` head's unsupported KEY types, and `errors` takes a
+/// structural head applied to the wrong ARITY (`structural_head_arity`).
+fn report_map_key_types_walk(te: TypeExpr, defs: Array[TypeDef], shadow: Array[String], out: Array[Type], where_label: String, errors: Array[String]) -> Unit {
   match te {
     TyName(name) => if string_array_has(shadow, name) {
       ()
@@ -468,6 +503,12 @@ fn report_map_key_types_walk(te: TypeExpr, defs: Array[TypeDef], shadow: Array[S
     },
     TyUnit => (),
     TyApp(name, args) => {
+      let want = structural_head_arity(name)
+      if want >= 0 && Array::length(args) != want && !string_array_has(shadow, name) && find_typedef(defs, name) is None {
+        Array::push(errors, structural_arity_error(name, Array::length(args), want, where_label))
+      } else {
+        ()
+      }
       if name == "Map" && Array::length(args) == 2 && !string_array_has(shadow, name) && find_typedef(defs, name) is None {
         let k = resolve_type_expr_shadowed(Array::get(args, 0), defs, shadow)
         if map_key_type_is_supported(k) {
@@ -493,31 +534,35 @@ fn report_map_key_types_walk(te: TypeExpr, defs: Array[TypeDef], shadow: Array[S
       }
       let mut i = 0
       while i < Array::length(args) {
-        report_map_key_types_walk(Array::get(args, i), defs, shadow, out)
+        report_map_key_types_walk(Array::get(args, i), defs, shadow, out, where_label, errors)
         i = i + 1
       }
     },
     TyTuple(items) => {
       let mut i = 0
       while i < Array::length(items) {
-        report_map_key_types_walk(Array::get(items, i), defs, shadow, out)
+        report_map_key_types_walk(Array::get(items, i), defs, shadow, out, where_label, errors)
         i = i + 1
       }
     },
     TyFn(params, ret, _) => {
       let mut i = 0
       while i < Array::length(params) {
-        report_map_key_types_walk(Array::get(params, i), defs, shadow, out)
+        report_map_key_types_walk(Array::get(params, i), defs, shadow, out, where_label, errors)
         i = i + 1
       }
-      report_map_key_types_walk(ret, defs, shadow, out)
+      report_map_key_types_walk(ret, defs, shadow, out, where_label, errors)
     }
   }
 }
 
+/// Despite the name, this reports BOTH of the walk's rules -- the map-key
+/// one it is named for, and the wrong-arity one
+/// (`structural_head_arity`). The name is kept because it is called from
+/// ~90 sites across `checker_stmt.vibe`; renaming it is churn, not clarity.
 export fn report_map_key_types(te: TypeExpr, defs: Array[TypeDef], shadow: Array[String], where_label: String, errors: Array[String]) -> Unit {
   let bad = array_empty()
-  report_map_key_types_walk(te, defs, shadow, bad)
+  report_map_key_types_walk(te, defs, shadow, bad, where_label, errors)
   let mut i = 0
   while i < Array::length(bad) {
     Array::push(errors, String::concat(String::concat(String::concat(String::concat("the builtin map is String-keyed, so a `", type_to_string(Array::get(bad, i))), "` key has no implementation in "), where_label), " -- spell the String-keyed map `StringMap[V]`, or use `MutMap[K, V]` from `@vibe/core` for other keys (generic `Map` keys are #2263)"))

--- a/lib/@vibe/compiler/checker/checker.vibe
+++ b/lib/@vibe/compiler/checker/checker.vibe
@@ -377,7 +377,154 @@ export fn report_formal_applications(te: TypeExpr, formals: Array[String], where
   }
 }
 
+/// #2263: the builtin map is String-keyed -- `Map[K, V]`'s generality is not
+/// implemented, and the name is reserved for it. An annotation spelling a
+/// concrete non-String key resolved fine and then had every op reject its key
+/// argument, so the type promised something no operation delivered. Report it
+/// where the annotation is introduced instead.
+///
+/// Walks the RESOLVED type, not the `TypeExpr`: an alias body
+/// (`type M = Map[Int, String]`) has to be caught at the USE, and resolution
+/// is what expands it. A key that is a type formal, an inference variable,
+/// `CtUnknown`, or an unresolved nominal head is ACCEPTED -- generic code is
+/// unaffected, and a typo is the unknown-type check's answer, not this one.
+fn map_key_type_is_supported(k: Type) -> Bool {
+  match k {
+    CtString => true,
+    CtVar(_) => true,
+    CtUnknown => true,
+    CtNamed(_, kargs) => Array::length(kargs) == 0,
+    _ => false
+  }
+}
+
+fn collect_unsupported_map_keys(t: Type, out: Array[Type]) -> Unit {
+  match t {
+    CtNamed(head, targs) => {
+      if head == "Map" && Array::length(targs) == 2 {
+        let k = Array::get(targs, 0)
+        if map_key_type_is_supported(k) {
+          ()
+        } else {
+          Array::push(out, k)
+        }
+      } else {
+        ()
+      }
+      let mut i = 0
+      while i < Array::length(targs) {
+        collect_unsupported_map_keys(Array::get(targs, i), out)
+        i = i + 1
+      }
+    },
+    CtArray(e) => collect_unsupported_map_keys(e, out),
+    CtOption(e) => collect_unsupported_map_keys(e, out),
+    CtTuple(items) => {
+      let mut i = 0
+      while i < Array::length(items) {
+        collect_unsupported_map_keys(Array::get(items, i), out)
+        i = i + 1
+      }
+    },
+    CtFn(params, ret, _) => {
+      let mut i = 0
+      while i < Array::length(params) {
+        collect_unsupported_map_keys(Array::get(params, i), out)
+        i = i + 1
+      }
+      collect_unsupported_map_keys(ret, out)
+    },
+    CtRecord(fields) => {
+      let mut i = 0
+      while i < Array::length(fields) {
+        let (_, ft) = Array::get(fields, i)
+        collect_unsupported_map_keys(ft, out)
+        i = i + 1
+      }
+    },
+    _ => ()
+  }
+}
+
+/// Walks the annotation WITHOUT resolving it. Resolution allocates, and this
+/// runs at every one of `report_unknown_type_names`'s ~84 sites, so the whole
+/// annotation is never re-resolved: only a `Map` head's KEY argument is
+/// (a one-node `TypeExpr` in every real spelling), and an alias is read from
+/// the already-resolved `Type` its `TypeDef` carries -- which is also what
+/// catches `type IntMap = Map[Int, String]` at the USE.
+fn report_map_key_types_walk(te: TypeExpr, defs: Array[TypeDef], shadow: Array[String], out: Array[Type], depth: Int) -> Unit {
+  if depth > 8 {
+    ()
+  } else {
+    match te {
+      TyName(name) => if string_array_has(shadow, name) {
+        ()
+      } else {
+        match find_typedef(defs, name) {
+          Some(td) => match td {
+            TDAlias(_, _, body) => collect_unsupported_map_keys(body, out),
+            _ => ()
+          },
+          None => ()
+        }
+      },
+      TyUnit => (),
+      TyApp(name, args) => {
+        if name == "Map" && Array::length(args) == 2 && !string_array_has(shadow, name) {
+          let k = resolve_type_expr_shadowed(Array::get(args, 0), defs, shadow)
+          if map_key_type_is_supported(k) {
+            ()
+          } else {
+            Array::push(out, k)
+          }
+        } else if !string_array_has(shadow, name) {
+          match find_typedef(defs, name) {
+            Some(td) => match td {
+              TDAlias(_, _, body) => collect_unsupported_map_keys(body, out),
+              _ => ()
+            },
+            None => ()
+          }
+        } else {
+          ()
+        }
+        let mut i = 0
+        while i < Array::length(args) {
+          report_map_key_types_walk(Array::get(args, i), defs, shadow, out, depth + 1)
+          i = i + 1
+        }
+      },
+      TyTuple(items) => {
+        let mut i = 0
+        while i < Array::length(items) {
+          report_map_key_types_walk(Array::get(items, i), defs, shadow, out, depth + 1)
+          i = i + 1
+        }
+      },
+      TyFn(params, ret, _) => {
+        let mut i = 0
+        while i < Array::length(params) {
+          report_map_key_types_walk(Array::get(params, i), defs, shadow, out, depth + 1)
+          i = i + 1
+        }
+        report_map_key_types_walk(ret, defs, shadow, out, depth + 1)
+      }
+    }
+  }
+}
+
+export fn report_map_key_types(te: TypeExpr, defs: Array[TypeDef], shadow: Array[String], where_label: String, errors: Array[String]) -> Unit {
+  let bad = array_empty()
+  report_map_key_types_walk(te, defs, shadow, bad, 0)
+  let mut i = 0
+  while i < Array::length(bad) {
+    Array::push(errors, String::concat(String::concat(String::concat(String::concat("the builtin map is String-keyed, so a `", type_to_string(Array::get(bad, i))), "` key has no implementation in "), where_label), " -- spell the String-keyed map `StringMap[V]`, or use `MutMap[K, V]` from `@vibe/core` for other keys (generic `Map` keys are #2263)"))
+    i = i + 1
+  }
+}
+
 export fn report_unknown_type_names(te: TypeExpr, defs: Array[TypeDef], shadow: Array[String], env: TypeEnv, row_binders: Array[String], where_label: String, errors: Array[String]) -> Unit {
+  report_map_key_types(te, defs, shadow, where_label, errors)
   // Which of the unresolved names are region-ish binders at all. Asked over
   // the name candidates first because the positional walk below takes a set,
   // and `#region_` skolem membership is an env question this file owns.

--- a/lib/@vibe/compiler/checker/checker_resolve.vibe
+++ b/lib/@vibe/compiler/checker/checker_resolve.vibe
@@ -62,7 +62,7 @@ export fn resolve_type_expr_shadowed(te: TypeExpr, defs: Array[TypeDef], shadow:
 /// which is a loud failure, not a silent one -- `PromptText` joined the list
 /// that way (`declare PromptText::new(String) -> PromptText`,
 /// builtins/declarations.vibe, names a type `resolve_builtin` does not carry).
-fn is_wellknown_nominal_head(name: String) -> Bool {
+export fn is_wellknown_nominal_head(name: String) -> Bool {
   name == "Future"
   || name == "ByteStream"
   || name == "HostStream"

--- a/lib/@vibe/compiler/checker/checker_resolve.vibe
+++ b/lib/@vibe/compiler/checker/checker_resolve.vibe
@@ -116,12 +116,12 @@ export fn collect_unknown_type_names(te: TypeExpr, defs: Array[TypeDef], shadow:
 /// `resolve_type_expr_shadowed` special-cases before any lookup, so they are
 /// never unknown -- and their arguments are ELEMENT types, never a region
 /// slot.
-fn ty_head_is_structural(name: String) -> Bool {
+fn ty_head_is_structural(name: String, argc: Int) -> Bool {
   // #2263: `StringMap` joins them -- `resolve_type_expr_core_shadowed`
   // special-cases it to `Map[String, V]` before any lookup, exactly the way
   // it special-cases these two, so it has no `TypeDef` for the sweep to find
   // and would otherwise be reported as a typo.
-  name == "Array" || name == "Option" || name == "StringMap"
+  name == "Array" || name == "Option" || (name == "StringMap" && argc == 1)
 }
 
 /// The argument index that is the REGION SLOT of an application of `head`
@@ -327,7 +327,7 @@ fn collect_unknown_type_names_walk(te: TypeExpr, defs: Array[TypeDef], shadow: A
         collect_unknown_type_names_walk(Array::get(args, i), defs, shadow, region_binders, at_slot, out)
         i = i + 1
       }
-      if ty_head_is_structural(name) || is_shadowed_tyvar(shadow, name) {
+      if ty_head_is_structural(name, Array::length(args)) || is_shadowed_tyvar(shadow, name) {
         ()
       } else {
         match find_typedef(defs, name) {

--- a/lib/@vibe/compiler/checker/checker_resolve.vibe
+++ b/lib/@vibe/compiler/checker/checker_resolve.vibe
@@ -112,11 +112,16 @@ export fn collect_unknown_type_names(te: TypeExpr, defs: Array[TypeDef], shadow:
   collect_unknown_type_names_walk(te, defs, shadow, array_empty(), false, out)
 }
 
-/// `Array` and `Option` are structural heads that `resolve_type_expr_shadowed`
-/// special-cases before any lookup, so they are never unknown -- and their
-/// arguments are ELEMENT types, never a region slot.
+/// `Array`, `Option` and `StringMap` are structural heads that
+/// `resolve_type_expr_shadowed` special-cases before any lookup, so they are
+/// never unknown -- and their arguments are ELEMENT types, never a region
+/// slot.
 fn ty_head_is_structural(name: String) -> Bool {
-  name == "Array" || name == "Option"
+  // #2263: `StringMap` joins them -- `resolve_type_expr_core_shadowed`
+  // special-cases it to `Map[String, V]` before any lookup, exactly the way
+  // it special-cases these two, so it has no `TypeDef` for the sweep to find
+  // and would otherwise be reported as a typo.
+  name == "Array" || name == "Option" || name == "StringMap"
 }
 
 /// The argument index that is the REGION SLOT of an application of `head`

--- a/lib/@vibe/compiler/checker/checker_resolve.vibe
+++ b/lib/@vibe/compiler/checker/checker_resolve.vibe
@@ -116,12 +116,18 @@ export fn collect_unknown_type_names(te: TypeExpr, defs: Array[TypeDef], shadow:
 /// `resolve_type_expr_shadowed` special-cases before any lookup, so they are
 /// never unknown -- and their arguments are ELEMENT types, never a region
 /// slot.
-fn ty_head_is_structural(name: String, argc: Int) -> Bool {
+fn ty_head_is_structural(name: String) -> Bool {
   // #2263: `StringMap` joins them -- `resolve_type_expr_core_shadowed`
   // special-cases it to `Map[String, V]` before any lookup, exactly the way
   // it special-cases these two, so it has no `TypeDef` for the sweep to find
   // and would otherwise be reported as a typo.
-  name == "Array" || name == "Option" || (name == "StringMap" && argc == 1)
+  //
+  // The exemption is by NAME, not by name-and-arity. A wrong-arity
+  // application of one of these is a real defect, but it is not an unknown
+  // NAME, and reporting it here says "unknown type `Array`" about a type the
+  // compiler knows perfectly well. `structural_head_arity` (checker.vibe)
+  // owns that case instead and names the arity.
+  name == "Array" || name == "Option" || name == "StringMap"
 }
 
 /// The argument index that is the REGION SLOT of an application of `head`
@@ -327,7 +333,7 @@ fn collect_unknown_type_names_walk(te: TypeExpr, defs: Array[TypeDef], shadow: A
         collect_unknown_type_names_walk(Array::get(args, i), defs, shadow, region_binders, at_slot, out)
         i = i + 1
       }
-      if ty_head_is_structural(name, Array::length(args)) || is_shadowed_tyvar(shadow, name) {
+      if ty_head_is_structural(name) || is_shadowed_tyvar(shadow, name) {
         ()
       } else {
         match find_typedef(defs, name) {

--- a/lib/@vibe/compiler/checker/checker_stmt.vibe
+++ b/lib/@vibe/compiler/checker/checker_stmt.vibe
@@ -2255,7 +2255,9 @@ fn check_stmts_with_binders(raw_stmts: Array[Stmt], i: Int, env: TypeEnv, defs: 
           let resolved_vtypes = array_empty()
           let mut ti = 0
           while ti < Array::length(vtypes) {
-            Array::push(resolved_vtypes, resolve_type_expr(Array::get(vtypes, ti), defs))
+            let payload_type = Array::get(vtypes, ti)
+            report_map_key_types(payload_type, defs, array_empty(), String::concat(String::concat(String::concat("the payload of `", name), String::concat("::", vname)), "`"), errors)
+            Array::push(resolved_vtypes, resolve_type_expr(payload_type, defs))
             ti = ti + 1
           }
           Array::push(resolved_variants, (vname, resolved_vtypes))

--- a/lib/@vibe/compiler/checker/checker_stmt.vibe
+++ b/lib/@vibe/compiler/checker/checker_stmt.vibe
@@ -3770,6 +3770,22 @@ fn collect_type_param_shadowing_errors(stmts: Array[Stmt], errors: Array[String]
   }
 }
 
+/// Rechecks alias bodies after the complete type-definition table exists.
+/// Declaration-time validation remains necessary for nested scopes, but a
+/// forward alias head is still unresolved there. Without this final pass an
+/// unused `type Bad = Map[Key, V]` silently escaped validation when `Key` was
+/// declared later as a non-String key type.
+fn check_completed_alias_map_keys(stmts: Array[Stmt], defs: Array[TypeDef], errors: Array[String]) -> Unit {
+  let mut i = 0
+  while i < Array::length(stmts) {
+    match Array::get(stmts, i) {
+      STypeAlias(_, name, params, te) => report_map_key_types(te, defs, params, String::concat(String::concat("the body of type alias `", name), "`"), errors),
+      _ => ()
+    }
+    i = i + 1
+  }
+}
+
 fn check_program_type_defs_observation_impl(stmts: Array[Stmt], capture: Option[CheckerStatementCapture], role_lane_capture: Option[TypedOccurrenceRoleLaneCapture]) -> CheckedProgramTypeDefsObservation with Exception {
   // Rank-1 method generics (#684): re-attach trait-method `[X: Bound]` binders
   // to impl free functions before checking, so `X::method` in an impl body
@@ -3840,6 +3856,7 @@ fn check_program_type_defs_observation_impl(stmts: Array[Stmt], capture: Option[
     }
   }
   let (env, final_s, _) = check_stmts_with_binders(expanded_stmts, 0, seeded_env, empty_defs, type_def_binders, 0, SubstEmpty, 0, frozen_errors, tytab, statement_parent_path, capture, role_lane_capture, false)
+  check_completed_alias_map_keys(expanded_stmts, empty_defs, frozen_errors)
   check_program_bounds(env, final_s, empty_defs, frozen_errors)
   // #1858: a bounded generic whose body calls `T::m` but whose signature has
   // no witness-carrying parameter would sail through checking and ICE in
@@ -4281,6 +4298,7 @@ fn check_program_with_env_type_defs_observation_impl(stmts: Array[Stmt], initial
         }
       }
       let (env, final_s, _) = check_stmts_with_binders(expanded_stmts, 0, seeded_env, empty_defs, type_def_binders, local_defs_start, SubstEmpty, seed_next_c, frozen_errors, tytab, statement_parent_path, capture, role_lane_capture, imports_already_projected)
+      check_completed_alias_map_keys(expanded_stmts, empty_defs, frozen_errors)
       // Selected import projection carries trait definitions and impls into
       // this environment, so user-trait bounds are checked here with the same
       // rule as the standalone path.

--- a/lib/@vibe/compiler/checker/checker_stmt.vibe
+++ b/lib/@vibe/compiler/checker/checker_stmt.vibe
@@ -75,6 +75,7 @@ import ./checker.vibe {
   preserve_generic_instantiation,
   reject_resume_outside_handler,
   report_formal_applications,
+  report_map_key_types,
   report_unknown_type_names,
   trait_erased_type_param_env,
   typed_occurrence_capture_begin_statement,
@@ -2396,6 +2397,7 @@ fn check_stmts_with_binders(raw_stmts: Array[Stmt], i: Int, env: TypeEnv, defs: 
       },
       STypeAlias(exported, name, params, te) => {
         // #1512: `params` shadow `defs` -- see resolve_type_expr_shadowed.
+        report_map_key_types(te, defs, params, String::concat(String::concat("the body of type alias `", name), "`"), errors)
         let t = resolve_type_expr_shadowed(te, defs, params)
         // Record the alias (with its formal params) so an applied use
         // `Name[Arg]` expands via subst in resolve_type_expr's TyApp case.
@@ -2471,6 +2473,38 @@ fn check_stmts_with_binders(raw_stmts: Array[Stmt], i: Int, env: TypeEnv, defs: 
       SAliasDecl(_, _) => (env, s, c)
       ,
       STrait(_, name, supers, methods, method_gens, tparams) => {
+        let mut mi = 0
+        while mi < Array::length(methods) {
+          let (mname, mparams, mret) = Array::get(methods, mi)
+          let shadow = Array::slice(["Self"], 0, 1)
+          let mut ti = 0
+          while ti < Array::length(tparams) {
+            Array::push(shadow, Array::get(tparams, ti))
+            ti = ti + 1
+          }
+          let mut gi = 0
+          while gi < Array::length(method_gens) {
+            let (gname, gtparams, _) = Array::get(method_gens, gi)
+            if gname == mname {
+              let mut gj = 0
+              while gj < Array::length(gtparams) {
+                Array::push(shadow, Array::get(gtparams, gj))
+                gj = gj + 1
+              }
+            } else {
+              ()
+            }
+            gi = gi + 1
+          }
+          let where_label = fapp_decl_label(name, mname)
+          let mut pi = 0
+          while pi < Array::length(mparams) {
+            report_map_key_types(Array::get(mparams, pi), defs, shadow, where_label, errors)
+            pi = pi + 1
+          }
+          report_map_key_types(mret, defs, shadow, where_label, errors)
+          mi = mi + 1
+        }
         let is_open = false
         (EnvTraitDef(name, supers, is_open, methods, env, tparams, method_gens), s, c)
       },
@@ -2517,9 +2551,12 @@ fn check_stmts_with_binders(raw_stmts: Array[Stmt], i: Int, env: TypeEnv, defs: 
             // #1512: `eparams` shadow `defs` -- the rigid-`CtNamed` convention
             // the comment above relies on is only true while no import alias
             // has claimed the formal's name.
-            Array::push(rp, resolve_type_expr_shadowed(Array::get(opparams, pi), defs, eparams))
+            let op_param = Array::get(opparams, pi)
+            report_map_key_types(op_param, defs, eparams, fapp_decl_label(ename, opname), errors)
+            Array::push(rp, resolve_type_expr_shadowed(op_param, defs, eparams))
             pi = pi + 1
           }
+          report_map_key_types(opret, defs, eparams, fapp_decl_label(ename, opname), errors)
           Array::push(resolved_ops, (opname, rp, resolve_type_expr_shadowed(opret, defs, eparams)))
           oi = oi + 1
         }

--- a/lib/@vibe/compiler/checker/checker_stmt.vibe
+++ b/lib/@vibe/compiler/checker/checker_stmt.vibe
@@ -2410,6 +2410,7 @@ fn check_stmts_with_binders(raw_stmts: Array[Stmt], i: Int, env: TypeEnv, defs: 
         }, env_bind(env, name, t)), s, c)
       },
       SExternLet(name, te) => {
+        report_map_key_types(te, defs, array_empty(), String::concat(String::concat("extern declaration `", name), "`"), errors)
         let t = resolve_type_expr(te, defs)
         let env1 = env_bind(env, name, t)
         (bind_annotation_return(env1, name, Some(te), defs), s, c)

--- a/lib/@vibe/compiler/checker/index.vpkg
+++ b/lib/@vibe/compiler/checker/index.vpkg
@@ -135,6 +135,7 @@ fn check_assignable(expected: Type, actual: Type, s: Subst, errors: Array[String
 fn detect_narrowed_generic_mismatch(expected: Type, actual: Type, s: Subst, errors: Array[String], what: String, off: Int) -> Subst
 fn preserve_generic_instantiation(resolved: Type, actual: Type) -> Type
 fn report_unknown_type_names(te: TypeExpr, defs: Array[TypeDef], shadow: Array[String], env: TypeEnv, row_binders: Array[String], where_label: String, errors: Array[String]) -> Unit
+fn report_map_key_types(te: TypeExpr, defs: Array[TypeDef], shadow: Array[String], where_label: String, errors: Array[String]) -> Unit
 fn collect_formal_applications_by(te: TypeExpr, is_formal: (String) -> Bool, out: Array[String]) -> Unit
 fn report_formal_applications(te: TypeExpr, formals: Array[String], where_label: String, errors: Array[String]) -> Unit
 fn formal_application_error(fname: String, where_label: String) -> String

--- a/lib/@vibe/compiler/checker/index.vpkg
+++ b/lib/@vibe/compiler/checker/index.vpkg
@@ -136,6 +136,7 @@ fn detect_narrowed_generic_mismatch(expected: Type, actual: Type, s: Subst, erro
 fn preserve_generic_instantiation(resolved: Type, actual: Type) -> Type
 fn report_unknown_type_names(te: TypeExpr, defs: Array[TypeDef], shadow: Array[String], env: TypeEnv, row_binders: Array[String], where_label: String, errors: Array[String]) -> Unit
 fn report_map_key_types(te: TypeExpr, defs: Array[TypeDef], shadow: Array[String], where_label: String, errors: Array[String]) -> Unit
+fn is_wellknown_nominal_head(name: String) -> Bool
 fn collect_formal_applications_by(te: TypeExpr, is_formal: (String) -> Bool, out: Array[String]) -> Unit
 fn report_formal_applications(te: TypeExpr, formals: Array[String], where_label: String, errors: Array[String]) -> Unit
 fn formal_application_error(fname: String, where_label: String) -> String

--- a/lib/@vibe/compiler/core/types.vibe
+++ b/lib/@vibe/compiler/core/types.vibe
@@ -1597,8 +1597,15 @@ export fn resolve_type_expr_core_shadowed(te: TypeExpr, defs: Array[TypeDef], sh
         // (measured: a bare `Byte` parameter answers "unknown type"), and
         // resolving it to the SAME type the ops take keeps every `Map::` op
         // working on a `StringMap[V]` value with no second op family. A
-        // user declaration of the name still wins -- the shadow test above.
-        CtNamed("Map", [CtString, Array::get(ra, 0)])
+        // user declaration of the name still wins -- generic binders are
+        // covered by the shadow test above, and source declarations by defs.
+        match find_typedef(defs, name) {
+          Some(td) => match td {
+            TDAlias(_, params, body) => resolve_type_alias_params(body, params, ra),
+            _ => CtNamed(name, ra)
+          },
+          None => CtNamed("Map", [CtString, Array::get(ra, 0)])
+        }
       } else if type_expr_name_is_shadowed(shadow, name) {
         CtNamed(name, ra)
       } else {

--- a/lib/@vibe/compiler/core/types.vibe
+++ b/lib/@vibe/compiler/core/types.vibe
@@ -1589,6 +1589,16 @@ export fn resolve_type_expr_core_shadowed(te: TypeExpr, defs: Array[TypeDef], sh
         CtArray(Array::get(ra, 0))
       } else if name == "Option" && Array::length(ra) == 1 {
         CtOption(Array::get(ra, 0))
+      } else if name == "StringMap" && Array::length(ra) == 1 && !type_expr_name_is_shadowed(shadow, name) {
+        // #2263: the concrete name for the builtin map, which is String-keyed
+        // (`Map[K, V]`'s generality is not implemented and the name is
+        // reserved for it). Resolved here rather than declared as a prelude
+        // alias because a prelude type is not in scope without an import
+        // (measured: a bare `Byte` parameter answers "unknown type"), and
+        // resolving it to the SAME type the ops take keeps every `Map::` op
+        // working on a `StringMap[V]` value with no second op family. A
+        // user declaration of the name still wins -- the shadow test above.
+        CtNamed("Map", [CtString, Array::get(ra, 0)])
       } else if type_expr_name_is_shadowed(shadow, name) {
         CtNamed(name, ra)
       } else {

--- a/lib/@vibe/compiler/normalize/desugar_trait_dict.vibe
+++ b/lib/@vibe/compiler/normalize/desugar_trait_dict.vibe
@@ -8392,7 +8392,7 @@ fn eq_ty_field_is_content_comparable(t: TypeExpr, tparams: Array[String]) -> Boo
       false
     } else {
       let args_ok = eq_tys_all_content_comparable(args, tparams)
-      if head == "Array" && Array::length(args) == 1 || head == "Option" && Array::length(args) == 1 || head == "Result" && Array::length(args) == 2 || head == "Map" && Array::length(args) == 2 {
+      if head == "Array" && Array::length(args) == 1 || head == "Option" && Array::length(args) == 1 || head == "Result" && Array::length(args) == 2 || head == "Map" && Array::length(args) == 2 || builtin_string_map_applied(head, args) {
         // The heads `eq_for_typed` has a structural arm for. The arity is part
         // of the condition: a head applied to the wrong number of arguments is
         // not the builtin this admits.

--- a/lib/@vibe/compiler/normalize/desugar_trait_dict.vibe
+++ b/lib/@vibe/compiler/normalize/desugar_trait_dict.vibe
@@ -8201,6 +8201,25 @@ fn generic_eq_struct_declared(name: String) -> Bool {
   found
 }
 
+fn eq_alias_declared(name: String) -> Bool {
+  let mut i = 0
+  let mut found = false
+  while i < Array::length(dtd_eq_type_aliases) {
+    if Array::get(dtd_eq_type_aliases, i).0 == name {
+      found = true
+    } else {
+      ()
+    }
+    i = i + 1
+  }
+  found
+}
+
+/// The compiler-owned spelling applies only when source does not own the name.
+fn builtin_string_map_applied(name: String, args: Array[TypeExpr]) -> Bool {
+  name == "StringMap" && Array::length(args) == 1 && !str_array_contains(dtd_eq_known_types, name) && !eq_alias_declared(name)
+}
+
 /// Declared types with a field this pass cannot show is compared by content,
 /// transitively. Generic instantiations now use concrete specialized
 /// comparators (#2195), and Map has a structural arm (#2218). A nominal opaque
@@ -8908,6 +8927,16 @@ fn eq_for_typed(fty0: TypeExpr, lhs: Expr, rhs: Expr, known_types: Array[String]
       }
       let inner = EMatch(rhs, Array::slice([(PTuple(rpats), conj)], 0, 1))
       EMatch(lhs, Array::slice([(PTuple(lpats), inner)], 0, 1))
+    },
+    TyApp("StringMap", args) => if builtin_string_map_applied("StringMap", args) {
+      let value_ty = Array::get(args, 0)
+      map_eq_needed_record(TyName("String"), value_ty)
+      ECall(EIdent(map_equals_name(TyName("String"), value_ty), -1), Array::slice([
+        lhs,
+        rhs
+      ], 0, 2), -1)
+    } else {
+      EBinOp("==", lhs, rhs)
     },
     TyApp("Map", args) => if Array::length(args) == 2 {
       // #2218: the only site that builds a `__map_equals__` call.
@@ -9695,6 +9724,8 @@ fn ty_to_eq_shape(t: TypeExpr) -> String {
       String::concat("{o:", String::concat(ty_to_eq_shape(Array::get(args, 0)), "}"))
     } else if n == "Result" && Array::length(args) == 2 {
       String::concat("{r:", String::concat(ty_to_eq_shape(Array::get(args, 0)), String::concat(",", String::concat(ty_to_eq_shape(Array::get(args, 1)), "}"))))
+    } else if builtin_string_map_applied(n, args) {
+      String::concat("{m:String,", String::concat(ty_to_eq_shape(Array::get(args, 0)), "}"))
     } else if n == "Map" && Array::length(args) == 2 {
       // #2218: a Map shape, so an ANNOTATED binding (`let m: Map[String, Int]`)
       // or a typed parameter reaches `eq_for_typed`'s Map arm the same way an
@@ -9799,7 +9830,7 @@ fn shape_to_eq_ty(sh: String) -> TypeExpr {
 fn ty_needs_typed_eq(t: TypeExpr) -> Bool {
   match t {
     TyName(n) => n == "Bytes",
-    TyApp(n, args) => if n == "Array" || n == "Map" || generic_eq_struct_declared(n) {
+    TyApp(n, args) => if n == "Array" || n == "Map" || builtin_string_map_applied(n, args) || generic_eq_struct_declared(n) {
       true
     } else {
       let mut i = 0

--- a/lib/@vibe/compiler/normalize/desugar_trait_dict.vibe
+++ b/lib/@vibe/compiler/normalize/desugar_trait_dict.vibe
@@ -8183,6 +8183,11 @@ let dtd_eq_generic_types: Array[String] = empty_str_array()
 // after the rewrite, like the recorded Array comparators.
 let dtd_eq_generic_structs: Array[(String, Array[String], Array[(String, TypeExpr)])] = array_empty()
 let dtd_eq_type_aliases: Array[(String, Array[String], TypeExpr)] = array_empty()
+// Source declarations that own a type spelling. This is deliberately
+// separate from `dtd_eq_known_types`: effects do not have generated
+// `T::equals` functions, but they still prevent a same-named compiler builtin
+// from claiming their representation.
+let dtd_eq_type_owners: Array[String] = empty_str_array()
 let dtd_eq_specializations: Array[TypeExpr] = empty_type_exprs()
 let dtd_eq_specialization_ancestries: Array[Array[TypeExpr]] = array_empty()
 let dtd_eq_specialization_stack: Array[TypeExpr] = empty_type_exprs()
@@ -8201,23 +8206,9 @@ fn generic_eq_struct_declared(name: String) -> Bool {
   found
 }
 
-fn eq_alias_declared(name: String) -> Bool {
-  let mut i = 0
-  let mut found = false
-  while i < Array::length(dtd_eq_type_aliases) {
-    if Array::get(dtd_eq_type_aliases, i).0 == name {
-      found = true
-    } else {
-      ()
-    }
-    i = i + 1
-  }
-  found
-}
-
 /// The compiler-owned spelling applies only when source does not own the name.
 fn builtin_string_map_applied(name: String, args: Array[TypeExpr]) -> Bool {
-  name == "StringMap" && Array::length(args) == 1 && !str_array_contains(dtd_eq_known_types, name) && !eq_alias_declared(name)
+  name == "StringMap" && Array::length(args) == 1 && !str_array_contains(dtd_eq_type_owners, name)
 }
 
 /// Declared types with a field this pass cannot show is compared by content,
@@ -8237,6 +8228,7 @@ fn eq_known_types_reset(stmts: Array[Stmt]) -> Unit {
   Array::truncate(dtd_eq_unsafe_types, 0)
   Array::truncate(dtd_eq_generic_structs, 0)
   Array::truncate(dtd_eq_type_aliases, 0)
+  Array::truncate(dtd_eq_type_owners, 0)
   Array::truncate(dtd_eq_specializations, 0)
   Array::truncate(dtd_eq_specialization_ancestries, 0)
   Array::truncate(dtd_eq_specialization_stack, 0)
@@ -8249,18 +8241,29 @@ fn eq_known_types_reset(stmts: Array[Stmt]) -> Unit {
   let mut j = 0
   while j < Array::length(stmts) {
     match Array::get(stmts, j) {
-      SStruct(_, sname, fields, _, _, decl_tparams) => if Array::length(decl_tparams) > 0 {
-        Array::push(dtd_eq_generic_types, sname)
-        Array::push(dtd_eq_generic_structs, (sname, decl_tparams, fields))
-      } else {
-        ()
+      SStruct(_, sname, fields, _, _, decl_tparams) => {
+        Array::push(dtd_eq_type_owners, sname)
+        if Array::length(decl_tparams) > 0 {
+          Array::push(dtd_eq_generic_types, sname)
+          Array::push(dtd_eq_generic_structs, (sname, decl_tparams, fields))
+        } else {
+          ()
+        }
       },
-      SEnum(_, ename, decl_tparams, _, _) => if Array::length(decl_tparams) > 0 {
-        Array::push(dtd_eq_generic_types, ename)
-      } else {
-        ()
+      SEnum(_, ename, decl_tparams, _, _) => {
+        Array::push(dtd_eq_type_owners, ename)
+        if Array::length(decl_tparams) > 0 {
+          Array::push(dtd_eq_generic_types, ename)
+        } else {
+          ()
+        }
       },
-      STypeAlias(_, aname, alias_tparams, target) => Array::push(dtd_eq_type_aliases, (aname, alias_tparams, target)),
+      SSuberror(_, name, _) => Array::push(dtd_eq_type_owners, name),
+      STypeAlias(_, aname, alias_tparams, target) => {
+        Array::push(dtd_eq_type_owners, aname)
+        Array::push(dtd_eq_type_aliases, (aname, alias_tparams, target))
+      },
+      SEffectDef(_, name, _, _) => Array::push(dtd_eq_type_owners, name),
       _ => ()
     }
     j = j + 1

--- a/lib/@vibe/compiler/tests/generic_formal_scope_mechanism_test.vibe
+++ b/lib/@vibe/compiler/tests/generic_formal_scope_mechanism_test.vibe
@@ -31,6 +31,14 @@ test "#2141: unbounded formal ==  next to a declared struct stays undispatched" 
   inspect(String::contains(desugared(src), "T::equals(a, b)"), content = "false")
 }
 
+test "#2276: an effect-owned StringMap does not use builtin map equality" {
+  let src = "effect StringMap[T] {\n  Read -> T\n}\n\nfn same(a: StringMap[Int], b: StringMap[Int]) -> Bool {\n  a == b\n}\n"
+  let out = desugared(src)
+  inspect(String::contains(out, "Map::size"), content = "false")
+  inspect(String::contains(out, "Map::keys"), content = "false")
+  inspect(String::contains(out, "Map::get"), content = "false")
+}
+
 test "#2141 (Codex P1 on #2183): the dict-threaded generic path scopes its binders too" {
   // A method-bearing bound routes the fn through rewrite_stmt's threaded arm,
   // which unwraps the EFn itself -- the binder frame must be pushed there as

--- a/lib/@vibe/compiler/tests/types_test.vibe
+++ b/lib/@vibe/compiler/tests/types_test.vibe
@@ -23,6 +23,7 @@ import @vibe/compiler/core {
   env_lookup_flat,
   env_mut_escape,
   env_value_binding,
+  resolve_type_expr_core_shadowed,
   type_to_string,
   types_compatible,
   types_equal
@@ -34,6 +35,18 @@ let _types_test_no_methods: Array[(String, Array[TypeExpr], TypeExpr)] = ArrayBu
 
 fn empty_defs() -> Array[TypeDef] {
   array_empty()
+}
+
+test "declared StringMap shadows the builtin structural spelling" {
+  let defs = [
+    TDStruct("StringMap", [("value", CtNamed("T", array_empty()))], ["value"], [
+      "T"
+    ])
+  ]
+  let resolved = resolve_type_expr_core_shadowed(TyApp("StringMap", [
+    TyName("Int")
+  ]), defs, array_empty())
+  assert(types_equal(resolved, CtNamed("StringMap", [CtInt])))
 }
 
 fn mut_escape_text(env: TypeEnv, name: String) -> String {

--- a/lib/@vibe/compiler/tests/types_test.vibe
+++ b/lib/@vibe/compiler/tests/types_test.vibe
@@ -62,6 +62,17 @@ test "#2276 round 18: a TDEffect named StringMap also shadows the builtin" {
   assert(types_equal(resolved, CtNamed("StringMap", [CtInt])))
 }
 
+test "#2276 round 19: a TDEffectSet named StringMap also shadows the builtin" {
+  // The arm next to `TDEffect` in `core/types.vibe` resolves an effectset the
+  // same nominal way, so a local `effectset StringMap = ...` owns the
+  // spelling too. Round 19 named only the effect; this pins the neighbour.
+  let defs = [TDEffectSet("StringMap", array_empty())]
+  let resolved = resolve_type_expr_core_shadowed(TyApp("StringMap", [
+    TyName("Int")
+  ]), defs, array_empty())
+  assert(types_equal(resolved, CtNamed("StringMap", [CtInt])))
+}
+
 test "#2276 round 18: with no typedef the builtin spelling still resolves" {
   // The control for the row above: nothing in `defs` owns the name, so
   // `StringMap[Int]` is the builtin `Map[String, Int]`.

--- a/lib/@vibe/compiler/tests/types_test.vibe
+++ b/lib/@vibe/compiler/tests/types_test.vibe
@@ -73,6 +73,17 @@ test "#2276 round 19: a TDEffectSet named StringMap also shadows the builtin" {
   assert(types_equal(resolved, CtNamed("StringMap", [CtInt])))
 }
 
+test "#2276 round 20: a TDEnum named StringMap also shadows the builtin" {
+  // What a `suberror StringMap(..)` declaration claims. `resolve_type_expr`
+  // gives `CtEnum` for a declared enum, which is nominal either way -- the
+  // point is that it is NOT the builtin map.
+  let defs = [TDEnum("StringMap", array_empty(), array_empty())]
+  let resolved = resolve_type_expr_core_shadowed(TyApp("StringMap", [
+    TyName("Int")
+  ]), defs, array_empty())
+  assert(!types_equal(resolved, CtNamed("Map", [CtString, CtInt])))
+}
+
 test "#2276 round 18: with no typedef the builtin spelling still resolves" {
   // The control for the row above: nothing in `defs` owns the name, so
   // `StringMap[Int]` is the builtin `Map[String, Int]`.

--- a/lib/@vibe/compiler/tests/types_test.vibe
+++ b/lib/@vibe/compiler/tests/types_test.vibe
@@ -49,6 +49,28 @@ test "declared StringMap shadows the builtin structural spelling" {
   assert(types_equal(resolved, CtNamed("StringMap", [CtInt])))
 }
 
+test "#2276 round 18: a TDEffect named StringMap also shadows the builtin" {
+  // `seed_imported_type_defs` puts an IMPORTED effect into `defs` as a
+  // `TDEffect`, and `resolve_type_expr_core_shadowed` consults `defs` before
+  // taking the builtin branch. So `import ./dep.vibe { effect Box as
+  // StringMap }` makes the annotation nominal in the checker, which the WIT
+  // scan has to agree with or it publishes the builtin ABI for another type.
+  let defs = [TDEffect("StringMap", array_empty(), array_empty())]
+  let resolved = resolve_type_expr_core_shadowed(TyApp("StringMap", [
+    TyName("Int")
+  ]), defs, array_empty())
+  assert(types_equal(resolved, CtNamed("StringMap", [CtInt])))
+}
+
+test "#2276 round 18: with no typedef the builtin spelling still resolves" {
+  // The control for the row above: nothing in `defs` owns the name, so
+  // `StringMap[Int]` is the builtin `Map[String, Int]`.
+  let resolved = resolve_type_expr_core_shadowed(TyApp("StringMap", [
+    TyName("Int")
+  ]), empty_defs(), array_empty())
+  assert(types_equal(resolved, CtNamed("Map", [CtString, CtInt])))
+}
+
 fn mut_escape_text(env: TypeEnv, name: String) -> String {
   match env_mut_escape(env, name) {
     Some(true) => "true",

--- a/lib/@vibe/compiler/tests/wit_gen_test.vibe
+++ b/lib/@vibe/compiler/tests/wit_gen_test.vibe
@@ -10,7 +10,7 @@ import @vibe/core {
 }
 
 import @vibe/compiler/core {
-  Expr, Stmt, TypeExpr
+  Expr, ImportItem, Stmt, TypeExpr
 }
 
 import @vibe/compiler/syntax {
@@ -96,6 +96,29 @@ test "wit_from_program: source StringMap is not the builtin projection" {
   ]
   let message = handle {
     let _ = wit_from_program(stmts, stmts, "shadowed")
+    ""
+  } with { Exception::Throw(m) => m }
+  assert(String::contains(message, "no WIT mapping"))
+}
+
+test "wit_from_program: an IMPORTED StringMap is not the builtin projection" {
+  // #2276 (Codex): an import binds the name just as a declaration does --
+  // `import ./dep.vibe { Box as StringMap }` makes `StringMap` a source-owned
+  // nominal type. The WIT CLI parses only the entry file and never resolves
+  // imports, so the ownership scan is the only place this can be seen.
+  // Before the `SImport` arm the projection published
+  // `list<tuple<string, s64>>` for the user's own type -- an ABI that does not
+  // match the function's representation, and silently so.
+  let stmts = [
+    SImport("./dep.vibe", [
+      ImportItem::{ kind: None, name: "Box", alias: Some("StringMap") }
+    ]),
+    SLet(true, false, "read", Some(TyFn([TyApp("StringMap", [TyName("Int")])], TyName("Int"), None)), efn_of_string_params([
+      "m"
+    ]))
+  ]
+  let message = handle {
+    let _ = wit_from_program(stmts, stmts, "imported")
     ""
   } with { Exception::Throw(m) => m }
   assert(String::contains(message, "no WIT mapping"))

--- a/lib/@vibe/compiler/tests/wit_gen_test.vibe
+++ b/lib/@vibe/compiler/tests/wit_gen_test.vibe
@@ -124,6 +124,34 @@ test "wit_from_program: an IMPORTED StringMap is not the builtin projection" {
   assert(String::contains(message, "no WIT mapping"))
 }
 
+test "wit_from_program: a non-String Map key has no WIT mapping" {
+  // #2276 (Codex): both WIT CLI paths parse the entry and call
+  // `wit_from_program` WITHOUT running the checker, so an unrestricted `Map`
+  // arm published `list<tuple<s64, string>>` for an annotation ordinary
+  // compilation now rejects -- an interface for a program that does not
+  // compile. Measured before the fix: it emitted exactly that.
+  let stmts = [
+    SLet(true, false, "f", Some(TyFn([
+      TyApp("Map", [TyName("Int"), TyName("String")])
+    ], TyName("Int"), None)), efn_of_string_params(["m"]))
+  ]
+  let message = handle {
+    let _ = wit_from_program(stmts, stmts, "badkey")
+    ""
+  } with { Exception::Throw(m) => m }
+  assert(String::contains(message, "no WIT mapping"))
+}
+
+test "wit_from_program: a String-keyed Map still projects" {
+  let stmts = [
+    SLet(true, false, "f", Some(TyFn([
+      TyApp("Map", [TyName("String"), TyName("Int")])
+    ], TyName("Int"), None)), efn_of_string_params(["m"]))
+  ]
+  let wit = wit_from_program(stmts, stmts, "goodkey")
+  assert(String::contains(wit, "list<tuple<string, s64>>"))
+}
+
 test "wit_from_program: undeclared capability effect renders as comment" {
   let stats_ann = TyFn([TyName("Int")], TyName("Int"), Some("Fs"))
   let stmts = [

--- a/lib/@vibe/compiler/tests/wit_gen_test.vibe
+++ b/lib/@vibe/compiler/tests/wit_gen_test.vibe
@@ -240,6 +240,23 @@ test "wit_from_program: an UNAPPLIED StringMap binder does not shadow the builti
   assert(String::contains(wit, "list<tuple<string, s64>>"))
 }
 
+test "wit_from_program: a LOCAL suberror named StringMap shadows the builtin" {
+  // #2276 (Codex round 20): a suberror claims a typedef slot as a `TDEnum`, so
+  // the annotation is source-owned and publishing the builtin ABI for it is
+  // silently wrong -- the same shape as rounds 18 and 19, one keyword further.
+  let stmts = [
+    SSuberror(false, "StringMap", array_empty()),
+    SLet(true, false, "read", Some(TyFn([TyApp("StringMap", [TyName("Int")])], TyName("Int"), None)), efn_of_string_params([
+      "m"
+    ]))
+  ]
+  let message = handle {
+    let _ = wit_from_program(stmts, stmts, "localsuberror")
+    ""
+  } with { Exception::Throw(m) => m }
+  assert(String::contains(message, "no WIT mapping"))
+}
+
 test "wit_from_program: a LOCAL effect named StringMap shadows the builtin" {
   // #2276 (Codex round 19): the checker registers a local effect as a
   // `TDEffect`, so the annotation is source-owned exactly as for the imported

--- a/lib/@vibe/compiler/tests/wit_gen_test.vibe
+++ b/lib/@vibe/compiler/tests/wit_gen_test.vibe
@@ -152,12 +152,18 @@ test "wit_from_program: a String-keyed Map still projects" {
   assert(String::contains(wit, "list<tuple<string, s64>>"))
 }
 
-test "wit_from_program: a VALUE import named StringMap does not shadow the builtin" {
-  // #2276 (Codex round 9): the WIT CLI never resolves imports, so
-  // `{ Box as StringMap }` and `{ helper as StringMap }` both parse with
-  // `kind: None` and only the dependency knows which is a type. Treating every
-  // bound name as a type made this valid program fail with `no WIT mapping`
-  // -- measured, it did. The SOURCE name's case separates them.
+test "wit_from_program: an UNKINDED import named StringMap fails closed" {
+  // #2276 (Codex rounds 9 and 11). Round 9 made this case NOT shadow, by
+  // guessing from the source name's case. Round 11 showed the guess is
+  // unsound at its root: this repository REQUIRES effect operations to be
+  // CamelCase (`Log::Emit`), so an upper-case source name is not evidence of
+  // a type and no refinement of the guess can become correct.
+  //
+  // With the guess gone the choice is which way to be wrong, and the design
+  // policy settles it: this now fails LOUDLY rather than publishing an
+  // imported TYPE with the builtin's ABI, which would be silently wrong.
+  // Writing the kind is what makes the answer exact -- see the two tests
+  // below.
   let stmts = [
     SImport("./dep.vibe", [
       ImportItem::{ kind: None, name: "helper", alias: Some("StringMap") }
@@ -166,8 +172,34 @@ test "wit_from_program: a VALUE import named StringMap does not shadow the built
       "m"
     ]))
   ]
-  let wit = wit_from_program(stmts, stmts, "valimport")
-  assert(String::contains(wit, "list<tuple<string, s64>>"))
+  let message = handle {
+    let _ = wit_from_program(stmts, stmts, "unkinded")
+    ""
+  } with { Exception::Throw(m) => m }
+  assert(String::contains(message, "no WIT mapping"))
+}
+
+test "wit_from_program: a RE-EXPORTED StringMap type shadows the builtin" {
+  // #2276 (Codex round 11): `export ./dep.vibe { struct Box as StringMap }`
+  // binds the name in the entry exactly as the import form does. Handling
+  // only `SImport` published the nominal parameter with the builtin's ABI.
+  let stmts = [
+    SReExport("./dep.vibe", [
+      ImportItem::{
+        kind: Some(ImportStruct),
+        name: "Box",
+        alias: Some("StringMap")
+      }
+    ]),
+    SLet(true, false, "read", Some(TyFn([TyApp("StringMap", [TyName("Int")])], TyName("Int"), None)), efn_of_string_params([
+      "m"
+    ]))
+  ]
+  let message = handle {
+    let _ = wit_from_program(stmts, stmts, "reexport")
+    ""
+  } with { Exception::Throw(m) => m }
+  assert(String::contains(message, "no WIT mapping"))
 }
 
 test "wit_from_program: a TRAIT import named StringMap does not shadow the builtin" {

--- a/lib/@vibe/compiler/tests/wit_gen_test.vibe
+++ b/lib/@vibe/compiler/tests/wit_gen_test.vibe
@@ -221,6 +221,25 @@ test "wit_from_program: a GENERIC BINDER named StringMap shadows the builtin" {
   assert(String::contains(message, "no WIT mapping"))
 }
 
+test "wit_from_program: an UNAPPLIED StringMap binder does not shadow the builtin" {
+  // #2276 (Codex round 16): `fn id[StringMap](x: StringMap) -> StringMap` is a
+  // VALID program -- #2268 rejects an APPLIED formal, not a declared one -- so
+  // its binder must not disable the builtin projection for an unrelated export
+  // in the same file. Round 14 tested the binder alone and broke exactly this.
+  let id_params = array_empty()
+  Array::push(id_params, ("x", Some(TyName("StringMap"))))
+  let id_fn = EFn(["StringMap"], array_empty(), id_params, Some(TyName("StringMap")), None, EUnit)
+  let read_params = array_empty()
+  Array::push(read_params, ("m", Some(TyApp("StringMap", [TyName("Int")]))))
+  let read_fn = EFn(no_strings(), array_empty(), read_params, Some(TyName("Int")), None, EUnit)
+  let stmts = [
+    SLet(false, false, "id", Some(TyFn([TyName("StringMap")], TyName("StringMap"), None)), id_fn),
+    SLet(true, false, "read", Some(TyFn([TyApp("StringMap", [TyName("Int")])], TyName("Int"), None)), read_fn)
+  ]
+  let wit = wit_from_program(stmts, stmts, "unapplied")
+  assert(String::contains(wit, "list<tuple<string, s64>>"))
+}
+
 test "wit_from_program: a TRAIT import named StringMap does not shadow the builtin" {
   // #2276 (Codex round 10): a trait lives in the trait environment, not in
   // `defs`, so `import ./dep.vibe { trait StringMap }` leaves the checker

--- a/lib/@vibe/compiler/tests/wit_gen_test.vibe
+++ b/lib/@vibe/compiler/tests/wit_gen_test.vibe
@@ -202,6 +202,25 @@ test "wit_from_program: a RE-EXPORTED StringMap type shadows the builtin" {
   assert(String::contains(message, "no WIT mapping"))
 }
 
+test "wit_from_program: a GENERIC BINDER named StringMap shadows the builtin" {
+  // #2276 (Codex round 14): `export fn f[StringMap](m: StringMap[Int])` makes
+  // `StringMap` the function's own type parameter. The checker rejects that
+  // program (a type parameter cannot take arguments, #2268), but neither
+  // `--wit` path runs the checker, so the projection published the builtin
+  // ABI for a program that does not compile.
+  let params = array_empty()
+  Array::push(params, ("m", Some(TyApp("StringMap", [TyName("Int")]))))
+  let generic_fn = EFn(["StringMap"], array_empty(), params, Some(TyName("Int")), None, EUnit)
+  let stmts = [
+    SLet(true, false, "read", Some(TyFn([TyApp("StringMap", [TyName("Int")])], TyName("Int"), None)), generic_fn)
+  ]
+  let message = handle {
+    let _ = wit_from_program(stmts, stmts, "generic")
+    ""
+  } with { Exception::Throw(m) => m }
+  assert(String::contains(message, "no WIT mapping"))
+}
+
 test "wit_from_program: a TRAIT import named StringMap does not shadow the builtin" {
   // #2276 (Codex round 10): a trait lives in the trait environment, not in
   // `defs`, so `import ./dep.vibe { trait StringMap }` leaves the checker

--- a/lib/@vibe/compiler/tests/wit_gen_test.vibe
+++ b/lib/@vibe/compiler/tests/wit_gen_test.vibe
@@ -258,6 +258,28 @@ test "wit_from_program: a TRAIT import named StringMap does not shadow the built
   assert(String::contains(wit, "list<tuple<string, s64>>"))
 }
 
+test "wit_from_program: an EFFECT import named StringMap shadows the builtin" {
+  // #2276 (Codex round 18): imported effects are stored in the checker's
+  // TypeDef environment, unlike traits, so they own this nominal spelling.
+  let stmts = [
+    SImport("./dep.vibe", [
+      ImportItem::{
+        kind: Some(ImportEffect),
+        name: "Box",
+        alias: Some("StringMap")
+      }
+    ]),
+    SLet(true, false, "read", Some(TyFn([TyApp("StringMap", [TyName("Int")])], TyName("Int"), None)), efn_of_string_params([
+      "m"
+    ]))
+  ]
+  let message = handle {
+    let _ = wit_from_program(stmts, stmts, "effectimport")
+    ""
+  } with { Exception::Throw(m) => m }
+  assert(String::contains(message, "no WIT mapping"))
+}
+
 test "wit_from_program: a STRUCT import named StringMap does shadow the builtin" {
   let stmts = [
     SImport("./dep.vibe", [

--- a/lib/@vibe/compiler/tests/wit_gen_test.vibe
+++ b/lib/@vibe/compiler/tests/wit_gen_test.vibe
@@ -152,6 +152,24 @@ test "wit_from_program: a String-keyed Map still projects" {
   assert(String::contains(wit, "list<tuple<string, s64>>"))
 }
 
+test "wit_from_program: a VALUE import named StringMap does not shadow the builtin" {
+  // #2276 (Codex round 9): the WIT CLI never resolves imports, so
+  // `{ Box as StringMap }` and `{ helper as StringMap }` both parse with
+  // `kind: None` and only the dependency knows which is a type. Treating every
+  // bound name as a type made this valid program fail with `no WIT mapping`
+  // -- measured, it did. The SOURCE name's case separates them.
+  let stmts = [
+    SImport("./dep.vibe", [
+      ImportItem::{ kind: None, name: "helper", alias: Some("StringMap") }
+    ]),
+    SLet(true, false, "read", Some(TyFn([TyApp("StringMap", [TyName("Int")])], TyName("Int"), None)), efn_of_string_params([
+      "m"
+    ]))
+  ]
+  let wit = wit_from_program(stmts, stmts, "valimport")
+  assert(String::contains(wit, "list<tuple<string, s64>>"))
+}
+
 test "wit_from_program: undeclared capability effect renders as comment" {
   let stats_ann = TyFn([TyName("Int")], TyName("Int"), Some("Fs"))
   let stmts = [

--- a/lib/@vibe/compiler/tests/wit_gen_test.vibe
+++ b/lib/@vibe/compiler/tests/wit_gen_test.vibe
@@ -57,6 +57,7 @@ test "wit_type_text: scalar and container mapping" {
   assert(wit_type_text(TyApp("Array", [TyName("Int")])) == "list<s64>")
   assert(wit_type_text(TyApp("Option", [TyName("String")])) == "option<string>")
   assert(wit_type_text(TyApp("Result", [TyName("Int"), TyName("String")])) == "result<s64, string>")
+  assert(wit_type_text(TyApp("StringMap", [TyName("Int")])) == "list<tuple<string, s64>>")
   assert(wit_type_text(TyTuple([TyName("Int"), TyName("Bool")])) == "tuple<s64, bool>")
 }
 

--- a/lib/@vibe/compiler/tests/wit_gen_test.vibe
+++ b/lib/@vibe/compiler/tests/wit_gen_test.vibe
@@ -85,6 +85,22 @@ test "wit_from_program: effect import + exports, Error and Exception filtered" {
   assert(!String::contains(wit, "import exception"))
 }
 
+test "wit_from_program: source StringMap is not the builtin projection" {
+  let stmts = [
+    SStruct(false, "StringMap", [("value", TyName("T"))], array_empty(), array_empty(), [
+      "T"
+    ]),
+    SLet(true, false, "read", Some(TyFn([TyApp("StringMap", [TyName("Int")])], TyName("Int"), None)), efn_of_string_params([
+      "m"
+    ]))
+  ]
+  let message = handle {
+    let _ = wit_from_program(stmts, stmts, "shadowed")
+    ""
+  } with { Exception::Throw(m) => m }
+  assert(String::contains(message, "no WIT mapping"))
+}
+
 test "wit_from_program: undeclared capability effect renders as comment" {
   let stats_ann = TyFn([TyName("Int")], TyName("Int"), Some("Fs"))
   let stmts = [

--- a/lib/@vibe/compiler/tests/wit_gen_test.vibe
+++ b/lib/@vibe/compiler/tests/wit_gen_test.vibe
@@ -10,7 +10,7 @@ import @vibe/core {
 }
 
 import @vibe/compiler/core {
-  Expr, ImportItem, Stmt, TypeExpr
+  Expr, ImportItem, ImportKind, Stmt, TypeExpr
 }
 
 import @vibe/compiler/syntax {
@@ -168,6 +168,40 @@ test "wit_from_program: a VALUE import named StringMap does not shadow the built
   ]
   let wit = wit_from_program(stmts, stmts, "valimport")
   assert(String::contains(wit, "list<tuple<string, s64>>"))
+}
+
+test "wit_from_program: a TRAIT import named StringMap does not shadow the builtin" {
+  // #2276 (Codex round 10): a trait lives in the trait environment, not in
+  // `defs`, so `import ./dep.vibe { trait StringMap }` leaves the checker
+  // resolving `StringMap[V]` to the builtin. Treating every written `kind` as
+  // type-like failed this valid program with `no WIT mapping` -- measured, it
+  // did. Only ImportType / ImportStruct / ImportEnum own a type spelling.
+  let stmts = [
+    SImport("./dep.vibe", [
+      ImportItem::{ kind: Some(ImportTrait), name: "StringMap", alias: None }
+    ]),
+    SLet(true, false, "read", Some(TyFn([TyApp("StringMap", [TyName("Int")])], TyName("Int"), None)), efn_of_string_params([
+      "m"
+    ]))
+  ]
+  let wit = wit_from_program(stmts, stmts, "traitimport")
+  assert(String::contains(wit, "list<tuple<string, s64>>"))
+}
+
+test "wit_from_program: a STRUCT import named StringMap does shadow the builtin" {
+  let stmts = [
+    SImport("./dep.vibe", [
+      ImportItem::{ kind: Some(ImportStruct), name: "StringMap", alias: None }
+    ]),
+    SLet(true, false, "read", Some(TyFn([TyApp("StringMap", [TyName("Int")])], TyName("Int"), None)), efn_of_string_params([
+      "m"
+    ]))
+  ]
+  let message = handle {
+    let _ = wit_from_program(stmts, stmts, "structimport")
+    ""
+  } with { Exception::Throw(m) => m }
+  assert(String::contains(message, "no WIT mapping"))
 }
 
 test "wit_from_program: undeclared capability effect renders as comment" {

--- a/lib/@vibe/compiler/tests/wit_gen_test.vibe
+++ b/lib/@vibe/compiler/tests/wit_gen_test.vibe
@@ -240,6 +240,41 @@ test "wit_from_program: an UNAPPLIED StringMap binder does not shadow the builti
   assert(String::contains(wit, "list<tuple<string, s64>>"))
 }
 
+test "wit_from_program: a LOCAL effect named StringMap shadows the builtin" {
+  // #2276 (Codex round 19): the checker registers a local effect as a
+  // `TDEffect`, so the annotation is source-owned exactly as for the imported
+  // form fixed in round 18. Projecting the builtin ABI for it is silently
+  // wrong. The resolver half is pinned in `types_test.vibe`.
+  let stmts = [
+    SEffectDef(false, "StringMap", array_empty(), array_empty()),
+    SLet(true, false, "read", Some(TyFn([TyApp("StringMap", [TyName("Int")])], TyName("Int"), None)), efn_of_string_params([
+      "m"
+    ]))
+  ]
+  let message = handle {
+    let _ = wit_from_program(stmts, stmts, "localeffect")
+    ""
+  } with { Exception::Throw(m) => m }
+  assert(String::contains(message, "no WIT mapping"))
+}
+
+test "wit_from_program: a LOCAL effectset named StringMap shadows the builtin" {
+  // The neighbour round 19 did not name: an effectset lands in `defs` as
+  // `TDEffectSet` and resolves nominally too, so the same hole sat one
+  // declaration keyword away.
+  let stmts = [
+    SEffectSet(false, "StringMap", array_empty()),
+    SLet(true, false, "read", Some(TyFn([TyApp("StringMap", [TyName("Int")])], TyName("Int"), None)), efn_of_string_params([
+      "m"
+    ]))
+  ]
+  let message = handle {
+    let _ = wit_from_program(stmts, stmts, "localeffectset")
+    ""
+  } with { Exception::Throw(m) => m }
+  assert(String::contains(message, "no WIT mapping"))
+}
+
 test "wit_from_program: a TRAIT import named StringMap does not shadow the builtin" {
   // #2276 (Codex round 10): a trait lives in the trait environment, not in
   // `defs`, so `import ./dep.vibe { trait StringMap }` leaves the checker

--- a/lib/@vibe/compiler/wit_gen.vibe
+++ b/lib/@vibe/compiler/wit_gen.vibe
@@ -682,17 +682,15 @@ fn wit_resolve_effect_names_into(label: String, es_names: Array[String], es_memb
 /// gives a "no WIT mapping" error rather than a silently mismatched ABI.
 fn import_item_is_typeish(item: ImportItem) -> Bool {
   match item.kind {
-    // EXACT when the kind is written: only these three own a type spelling.
-    // An effect and a trait live in their own environments, so
-    // `import ./d.vibe { trait StringMap }` leaves the checker resolving
-    // `StringMap[V]` to the builtin -- and treating every `Some` as type-like
-    // failed that valid program with `no WIT mapping` (Codex round 10;
-    // measured, it did).
+    // EXACT when the kind is written. Structs, enums, aliases, and effects
+    // enter the checker's TypeDef environment; traits live only in the trait
+    // environment. Thus an imported effect owns the nominal spelling while
+    // `import ./d.vibe { trait StringMap }` leaves the builtin visible.
     Some(k) => match k {
       ImportType => true,
       ImportStruct => true,
       ImportEnum => true,
-      ImportEffect => false,
+      ImportEffect => true,
       ImportTrait => false
     },
     // UNWRITTEN kind: unknowable here, so fail CLOSED and assume a type.

--- a/lib/@vibe/compiler/wit_gen.vibe
+++ b/lib/@vibe/compiler/wit_gen.vibe
@@ -695,9 +695,45 @@ fn import_item_is_typeish(item: ImportItem) -> Bool {
       ImportEffect => false,
       ImportTrait => false
     },
-    // Only the unwritten kind needs the name-case heuristic.
-    None => str_starts_upper(item.name)
+    // UNWRITTEN kind: unknowable here, so fail CLOSED and assume a type.
+    //
+    // This deliberately reverses the name-case heuristic added for Codex
+    // round 9. Round 11 showed the heuristic is unsound at its root: this
+    // repository REQUIRES effect operations to be CamelCase
+    // (`Log::Emit`, CLAUDE.md), so an upper-case source name is not evidence
+    // of a type at all, and no refinement of "does it look like a type" can
+    // become correct.
+    //
+    // With the guess gone the choice is which way to be wrong, and the design
+    // policy settles it: a value import named `StringMap` now fails LOUDLY
+    // with "no WIT mapping" (the round 9 complaint, reinstated on purpose),
+    // rather than an imported TYPE being published with the builtin's ABI,
+    // which is silently wrong. Writing the kind
+    // (`import ./d.vibe { helper as StringMap }` -> no kind;
+    // `{ struct Box as StringMap }` -> `ImportStruct`) is what makes the
+    // answer exact, and the arm above honours it.
+    None => true
   }
+}
+
+/// Whether any of `items` binds `needle` as a TYPE.
+fn import_items_bind_type(items: Array[ImportItem], needle: String) -> Bool {
+  let mut i = 0
+  let mut found = false
+  while i < Array::length(items) {
+    let item = Array::get(items, i)
+    let bound = match item.alias {
+      Some(a) => a,
+      None => item.name
+    }
+    if bound == needle && import_item_is_typeish(item) {
+      found = true
+    } else {
+      ()
+    }
+    i = i + 1
+  }
+  found
 }
 
 fn wit_stmts_declare_type(stmts: Array[Stmt], needle: String) -> Bool {
@@ -733,21 +769,20 @@ fn wit_stmts_declare_type(stmts: Array[Stmt], needle: String) -> Bool {
       // the projection published `list<tuple<string, V>>` for a user's own
       // type -- an ABI that does not match the function's representation,
       // and silently so.
-      SImport(_, items) => {
-        let mut ii = 0
-        while ii < Array::length(items) {
-          let item = Array::get(items, ii)
-          let bound = match item.alias {
-            Some(a) => a,
-            None => item.name
-          }
-          if bound == needle && import_item_is_typeish(item) {
-            found = true
-          } else {
-            ()
-          }
-          ii = ii + 1
-        }
+      SImport(_, items) => if import_items_bind_type(items, needle) {
+        found = true
+      } else {
+        ()
+      },
+      // #2276 (Codex round 11): a re-export binds the name in the entry too --
+      // `export ./dep.vibe { struct Box as StringMap }` makes `StringMap` a
+      // source-owned type exactly as the import form does. Handling only
+      // `SImport` published the nominal parameter with the builtin's ABI,
+      // which is the silent-wrong direction.
+      SReExport(_, items) => if import_items_bind_type(items, needle) {
+        found = true
+      } else {
+        ()
       },
       _ => ()
     }

--- a/lib/@vibe/compiler/wit_gen.vibe
+++ b/lib/@vibe/compiler/wit_gen.vibe
@@ -96,6 +96,27 @@ fn wit_is_unit_type(ty: TypeExpr) -> Bool {
   }
 }
 
+/// A `Map` key the WIT projection can represent. The builtin map is
+/// String-keyed; a type PARAMETER is accepted because a generic signature is
+/// projected per instantiation, not here.
+fn map_key_is_string(k: TypeExpr) -> Bool {
+  match k {
+    TyName(n) => n == "String" || !str_starts_upper(n),
+    _ => false
+  }
+}
+
+/// Whether `n` starts with an upper-case letter -- a concrete type name rather
+/// than a lower-case type parameter.
+fn str_starts_upper(n: String) -> Bool {
+  if String::length(n) == 0 {
+    false
+  } else {
+    let c = String::byte_at(n, 0)
+    c >= 65 && c <= 90
+  }
+}
+
 fn wit_type_text_with_shadow(ty: TypeExpr, string_map_shadowed: Bool) -> String with Exception {
   match ty {
     TyName(name) => {
@@ -135,7 +156,16 @@ fn wit_type_text_with_shadow(ty: TypeExpr, string_map_shadowed: Bool) -> String 
         "option<\{wit_type_text_with_shadow(Array::get(args, 0), string_map_shadowed)}>"
       } else if head == "Result" && Array::length(args) == 2 {
         "result<\{wit_type_text_with_shadow(Array::get(args, 0), string_map_shadowed)}, \{wit_type_text_with_shadow(Array::get(args, 1), string_map_shadowed)}>"
-      } else if head == "Map" && Array::length(args) == 2 {
+      } else if head == "Map" && Array::length(args) == 2 && map_key_is_string(Array::get(args, 0)) {
+        // #2276 (Codex): the KEY must be `String`. The builtin map is
+        // String-keyed and the checker now rejects any other concrete key, but
+        // both WIT CLI paths parse the entry and call `wit_from_program`
+        // WITHOUT running the checker -- so an unrestricted arm here published
+        // `list<tuple<s64, string>>` for `Map[Int, String]`, an interface for a
+        // program that no longer compiles. Measured before this: it emitted
+        // exactly that. Falling through instead reports "no WIT mapping",
+        // which is what the boundary should say about a type the language
+        // cannot represent.
         "list<tuple<\{wit_type_text_with_shadow(Array::get(args, 0), string_map_shadowed)}, \{wit_type_text_with_shadow(Array::get(args, 1), string_map_shadowed)}>>"
       } else if head == "StringMap" && Array::length(args) == 1 && !string_map_shadowed {
         "list<tuple<string, \{wit_type_text_with_shadow(Array::get(args, 0), string_map_shadowed)}>>"

--- a/lib/@vibe/compiler/wit_gen.vibe
+++ b/lib/@vibe/compiler/wit_gen.vibe
@@ -863,6 +863,26 @@ fn wit_stmts_declare_type(stmts: Array[Stmt], needle: String) -> Bool {
       } else {
         ()
       },
+      // #2276 (Codex round 19): a LOCAL effect declaration owns the spelling
+      // for the same reason an imported one does -- the checker registers it
+      // as a `TDEffect`, and `resolve_type_expr_core_shadowed` reaches `defs`
+      // before the builtin branch. Handling only the imported side left the
+      // local one publishing a nominal effect type with the builtin map's
+      // ABI, which is the silent-wrong direction.
+      SEffectDef(_, name, _, _) => if name == needle {
+        found = true
+      } else {
+        ()
+      },
+      // An effectset lands in `defs` as `TDEffectSet` and resolves the same
+      // nominal way (`core/types.vibe`, the arm next to `TDEffect`). Round 19
+      // named only `SEffectDef`; leaving this one out would have left the
+      // identical hole one declaration keyword away, so both are pinned.
+      SEffectSet(_, name, _) => if name == needle {
+        found = true
+      } else {
+        ()
+      },
       SModule(_, _, body) => if wit_stmts_declare_type(body, needle) {
         found = true
       } else {

--- a/lib/@vibe/compiler/wit_gen.vibe
+++ b/lib/@vibe/compiler/wit_gen.vibe
@@ -96,8 +96,7 @@ fn wit_is_unit_type(ty: TypeExpr) -> Bool {
   }
 }
 
-/// vibe TypeExpr -> WIT type text. Throws on types with no WIT mapping.
-export fn wit_type_text(ty: TypeExpr) -> String with Exception {
+fn wit_type_text_with_shadow(ty: TypeExpr, string_map_shadowed: Bool) -> String with Exception {
   match ty {
     TyName(name) => {
       if name == "Int" {
@@ -131,15 +130,15 @@ export fn wit_type_text(ty: TypeExpr) -> String with Exception {
     },
     TyApp(head, args) => {
       if head == "Array" && Array::length(args) == 1 {
-        "list<\{wit_type_text(Array::get(args, 0))}>"
+        "list<\{wit_type_text_with_shadow(Array::get(args, 0), string_map_shadowed)}>"
       } else if head == "Option" && Array::length(args) == 1 {
-        "option<\{wit_type_text(Array::get(args, 0))}>"
+        "option<\{wit_type_text_with_shadow(Array::get(args, 0), string_map_shadowed)}>"
       } else if head == "Result" && Array::length(args) == 2 {
-        "result<\{wit_type_text(Array::get(args, 0))}, \{wit_type_text(Array::get(args, 1))}>"
+        "result<\{wit_type_text_with_shadow(Array::get(args, 0), string_map_shadowed)}, \{wit_type_text_with_shadow(Array::get(args, 1), string_map_shadowed)}>"
       } else if head == "Map" && Array::length(args) == 2 {
-        "list<tuple<\{wit_type_text(Array::get(args, 0))}, \{wit_type_text(Array::get(args, 1))}>>"
-      } else if head == "StringMap" && Array::length(args) == 1 {
-        "list<tuple<string, \{wit_type_text(Array::get(args, 0))}>>"
+        "list<tuple<\{wit_type_text_with_shadow(Array::get(args, 0), string_map_shadowed)}, \{wit_type_text_with_shadow(Array::get(args, 1), string_map_shadowed)}>>"
+      } else if head == "StringMap" && Array::length(args) == 1 && !string_map_shadowed {
+        "list<tuple<string, \{wit_type_text_with_shadow(Array::get(args, 0), string_map_shadowed)}>>"
       } else if head == "Future" && Array::length(args) == 1 {
         // ADR-0089 Decision 5 (#1218): `Future[T]` projects to the P3
         // `future<T'>` payload type. Backed by a real lowering since step
@@ -153,7 +152,7 @@ export fn wit_type_text(ty: TypeExpr) -> String with Exception {
         // guest-produced stream value would declare an ABI the lowering
         // cannot implement (spec §3.3: a producer cannot enter the
         // component instance), so it stays a hard error here.
-        "future<\{wit_type_text(Array::get(args, 0))}>"
+        "future<\{wit_type_text_with_shadow(Array::get(args, 0), string_map_shadowed)}>"
       } else {
         throw("wit: no WIT mapping for type '\{head}[..]'")
       }
@@ -166,7 +165,7 @@ export fn wit_type_text(ty: TypeExpr) -> String with Exception {
         if i > 0 {
           StringBuilder::push(sb, ", ")
         }
-        StringBuilder::push(sb, wit_type_text(Array::get(items, i)))
+        StringBuilder::push(sb, wit_type_text_with_shadow(Array::get(items, i), string_map_shadowed))
         i = i + 1
       }
       StringBuilder::push(sb, ">")
@@ -177,10 +176,17 @@ export fn wit_type_text(ty: TypeExpr) -> String with Exception {
   }
 }
 
+/// vibe TypeExpr -> WIT type text. Throws on types with no WIT mapping.
+/// This low-level entry has no source declarations, so compiler-owned names
+/// are unshadowed. Whole-program generation uses the contextual helper above.
+export fn wit_type_text(ty: TypeExpr) -> String with Exception {
+  wit_type_text_with_shadow(ty, false)
+}
+
 /// `func(name: ty, ...) -> ret` text for a signature. Unit return omits `->`.
 /// `is_async` (ADR-0089 Decision 5, #1218) prefixes `async` -- the P3
 /// async-lifted function type an `with Async` export projects to.
-fn wit_func_text_of(param_names: Array[String], param_types: Array[TypeExpr], ret: TypeExpr, is_async: Bool) -> String with Exception {
+fn wit_func_text_of(param_names: Array[String], param_types: Array[TypeExpr], ret: TypeExpr, is_async: Bool, string_map_shadowed: Bool) -> String with Exception {
   let sb = StringBuilder::new()
   if is_async {
     StringBuilder::push(sb, "async ")
@@ -200,19 +206,19 @@ fn wit_func_text_of(param_names: Array[String], param_types: Array[TypeExpr], re
     }
     StringBuilder::push(sb, pname)
     StringBuilder::push(sb, ": ")
-    StringBuilder::push(sb, wit_type_text(Array::get(param_types, i)))
+    StringBuilder::push(sb, wit_type_text_with_shadow(Array::get(param_types, i), string_map_shadowed))
     i = i + 1
   }
   StringBuilder::push(sb, ")")
   if !wit_is_unit_type(ret) {
     StringBuilder::push(sb, " -> ")
-    StringBuilder::push(sb, wit_type_text(ret))
+    StringBuilder::push(sb, wit_type_text_with_shadow(ret, string_map_shadowed))
   }
   StringBuilder::freeze(sb)
 }
 
-fn wit_func_text(param_names: Array[String], param_types: Array[TypeExpr], ret: TypeExpr) -> String with Exception {
-  wit_func_text_of(param_names, param_types, ret, false)
+fn wit_func_text(param_names: Array[String], param_types: Array[TypeExpr], ret: TypeExpr, string_map_shadowed: Bool) -> String with Exception {
+  wit_func_text_of(param_names, param_types, ret, false, string_map_shadowed)
 }
 
 /// Split a parsed effect row ("A, B") into names. The parser joins the
@@ -620,7 +626,40 @@ fn wit_resolve_effect_names_into(label: String, es_names: Array[String], es_memb
   }
 }
 
+fn wit_stmts_declare_type(stmts: Array[Stmt], needle: String) -> Bool {
+  let mut found = false
+  let mut i = 0
+  while i < Array::length(stmts) {
+    match Array::get(stmts, i) {
+      SStruct(_, name, _, _, _, _) => if name == needle {
+        found = true
+      } else {
+        ()
+      },
+      SEnum(_, name, _, _, _) => if name == needle {
+        found = true
+      } else {
+        ()
+      },
+      STypeAlias(_, name, _, _) => if name == needle {
+        found = true
+      } else {
+        ()
+      },
+      SModule(_, _, body) => if wit_stmts_declare_type(body, needle) {
+        found = true
+      } else {
+        ()
+      },
+      _ => ()
+    }
+    i = i + 1
+  }
+  found
+}
+
 export fn wit_from_program(export_stmts: Array[Stmt], effect_stmts: Array[Stmt], world_name: String) -> String with Exception {
+  let string_map_shadowed = wit_stmts_declare_type(export_stmts, "StringMap") || wit_stmts_declare_type(effect_stmts, "StringMap")
   let eff_names = array_empty()
   let eff_ops = array_empty()
   wit_collect_effect_defs(effect_stmts, eff_names, eff_ops)
@@ -717,7 +756,7 @@ export fn wit_from_program(export_stmts: Array[Stmt], effect_stmts: Array[Stmt],
         StringBuilder::push(sb, "    ")
         StringBuilder::push(sb, wit_kebab_ident(op_name))
         StringBuilder::push(sb, ": ")
-        StringBuilder::push(sb, wit_func_text(array_empty(), op_args, op_ret))
+        StringBuilder::push(sb, wit_func_text(array_empty(), op_args, op_ret, string_map_shadowed))
         StringBuilder::push(sb, ";\n")
         oi = oi + 1
       }
@@ -754,7 +793,7 @@ export fn wit_from_program(export_stmts: Array[Stmt], effect_stmts: Array[Stmt],
     StringBuilder::push(sb, "  export ")
     StringBuilder::push(sb, wit_kebab_ident(ex_name))
     StringBuilder::push(sb, ": ")
-    StringBuilder::push(sb, wit_func_text_of(ex_param_names, ex_param_types, ex_ret, is_async))
+    StringBuilder::push(sb, wit_func_text_of(ex_param_names, ex_param_types, ex_ret, is_async, string_map_shadowed))
     StringBuilder::push(sb, ";\n")
     xo = xo + 1
   }

--- a/lib/@vibe/compiler/wit_gen.vibe
+++ b/lib/@vibe/compiler/wit_gen.vibe
@@ -3,6 +3,7 @@
 import @vibe/compiler/core {
   Expr,
   ImportItem,
+  ImportKind,
   Stmt,
   TypeExpr,
   effect_row_emitted_text,
@@ -681,7 +682,20 @@ fn wit_resolve_effect_names_into(label: String, es_names: Array[String], es_memb
 /// gives a "no WIT mapping" error rather than a silently mismatched ABI.
 fn import_item_is_typeish(item: ImportItem) -> Bool {
   match item.kind {
-    Some(_) => true,
+    // EXACT when the kind is written: only these three own a type spelling.
+    // An effect and a trait live in their own environments, so
+    // `import ./d.vibe { trait StringMap }` leaves the checker resolving
+    // `StringMap[V]` to the builtin -- and treating every `Some` as type-like
+    // failed that valid program with `no WIT mapping` (Codex round 10;
+    // measured, it did).
+    Some(k) => match k {
+      ImportType => true,
+      ImportStruct => true,
+      ImportEnum => true,
+      ImportEffect => false,
+      ImportTrait => false
+    },
+    // Only the unwritten kind needs the name-case heuristic.
     None => str_starts_upper(item.name)
   }
 }

--- a/lib/@vibe/compiler/wit_gen.vibe
+++ b/lib/@vibe/compiler/wit_gen.vibe
@@ -126,7 +126,7 @@ export fn wit_type_text(ty: TypeExpr) -> String with Exception {
         // hand a handler the request body.
         "stream<u8>"
       } else {
-        throw("wit: no WIT mapping for type '\{name}' (supported: Int, Double, Bool, String, Char, Bytes, Unit, Array, Option, Result, Map, tuples, Future[T], ByteStream, HostStream)")
+        throw("wit: no WIT mapping for type '\{name}' (supported: Int, Double, Bool, String, Char, Bytes, Unit, Array, Option, Result, Map, StringMap, tuples, Future[T], ByteStream, HostStream)")
       }
     },
     TyApp(head, args) => {
@@ -138,6 +138,8 @@ export fn wit_type_text(ty: TypeExpr) -> String with Exception {
         "result<\{wit_type_text(Array::get(args, 0))}, \{wit_type_text(Array::get(args, 1))}>"
       } else if head == "Map" && Array::length(args) == 2 {
         "list<tuple<\{wit_type_text(Array::get(args, 0))}, \{wit_type_text(Array::get(args, 1))}>>"
+      } else if head == "StringMap" && Array::length(args) == 1 {
+        "list<tuple<string, \{wit_type_text(Array::get(args, 0))}>>"
       } else if head == "Future" && Array::length(args) == 1 {
         // ADR-0089 Decision 5 (#1218): `Future[T]` projects to the P3
         // `future<T'>` payload type. Backed by a real lowering since step

--- a/lib/@vibe/compiler/wit_gen.vibe
+++ b/lib/@vibe/compiler/wit_gen.vibe
@@ -686,6 +686,13 @@ fn import_item_is_typeish(item: ImportItem) -> Bool {
     // enter the checker's TypeDef environment; traits live only in the trait
     // environment. Thus an imported effect owns the nominal spelling while
     // `import ./d.vibe { trait StringMap }` leaves the builtin visible.
+    //
+    // The premise is pinned rather than argued: `types_test.vibe` measures the
+    // resolver both ways -- `TDEffect("StringMap", ...)` in `defs` gives
+    // `CtNamed("StringMap", [Int])`, an empty `defs` gives
+    // `CtNamed("Map", [String, Int])`. Round 10 had grouped effects with
+    // traits, and while that stood an imported effect type was published with
+    // the builtin map's ABI.
     Some(k) => match k {
       ImportType => true,
       ImportStruct => true,

--- a/lib/@vibe/compiler/wit_gen.vibe
+++ b/lib/@vibe/compiler/wit_gen.vibe
@@ -736,16 +736,16 @@ fn import_items_bind_type(items: Array[ImportItem], needle: String) -> Bool {
   found
 }
 
-/// Whether a function literal binds `needle` as one of its own type
-/// parameters. Only the statement's own binder list is read -- a nested
-/// lambda's binders are not in scope for the exported signature.
-fn expr_binds_type_param(body: Expr, needle: String) -> Bool {
-  match body {
-    EFn(tparams, _, _, _, _, _) => {
+/// Whether a type annotation APPLIES `needle` to arguments anywhere inside it.
+fn type_expr_applies(ty: TypeExpr, needle: String) -> Bool {
+  match ty {
+    TyApp(head, args) => if head == needle {
+      true
+    } else {
       let mut i = 0
       let mut found = false
-      while i < Array::length(tparams) {
-        if Array::get(tparams, i) == needle {
+      while i < Array::length(args) {
+        if type_expr_applies(Array::get(args, i), needle) {
           found = true
         } else {
           ()
@@ -753,6 +753,86 @@ fn expr_binds_type_param(body: Expr, needle: String) -> Bool {
         i = i + 1
       }
       found
+    },
+    TyFn(params, ret, _) => {
+      let mut i = 0
+      let mut found = type_expr_applies(ret, needle)
+      while i < Array::length(params) {
+        if type_expr_applies(Array::get(params, i), needle) {
+          found = true
+        } else {
+          ()
+        }
+        i = i + 1
+      }
+      found
+    },
+    TyTuple(items) => {
+      let mut i = 0
+      let mut found = false
+      while i < Array::length(items) {
+        if type_expr_applies(Array::get(items, i), needle) {
+          found = true
+        } else {
+          ()
+        }
+        i = i + 1
+      }
+      found
+    },
+    _ => false
+  }
+}
+
+/// Whether this statement's own function literal binds `needle` as a type
+/// parameter AND applies it to arguments in its own signature -- the shape
+/// `export fn f[StringMap](m: StringMap[Int])`, which the checker rejects
+/// (#2268) but neither `--wit` path ever asks the checker about.
+///
+/// The application is what makes this ownership. Round 14 tested the binder
+/// ALONE and claimed a file carrying one "never compiles"; that was wrong,
+/// and Codex round 16 measured it: `fn id[StringMap](x: StringMap) ->
+/// StringMap` is a perfectly valid program, because #2268 rejects an APPLIED
+/// formal, not a declared one. Treating its binder as ownership failed
+/// `--wit` with `no WIT mapping` for an unrelated export in the same file.
+///
+/// Only the statement's own binders are read -- a nested lambda's are not in
+/// scope for the exported signature.
+fn expr_binds_applied_type_param(body: Expr, needle: String) -> Bool {
+  match body {
+    EFn(tparams, _, params, ret, _, _) => {
+      let mut i = 0
+      let mut binds = false
+      while i < Array::length(tparams) {
+        if Array::get(tparams, i) == needle {
+          binds = true
+        } else {
+          ()
+        }
+        i = i + 1
+      }
+      if binds {
+        let mut applied = match ret {
+          Some(rt) => type_expr_applies(rt, needle),
+          None => false
+        }
+        let mut pi = 0
+        while pi < Array::length(params) {
+          let (_, pty) = Array::get(params, pi)
+          match pty {
+            Some(t) => if type_expr_applies(t, needle) {
+              applied = true
+            } else {
+              ()
+            },
+            None => ()
+          }
+          pi = pi + 1
+        }
+        applied
+      } else {
+        false
+      }
     },
     _ => false
   }
@@ -806,20 +886,22 @@ fn wit_stmts_declare_type(stmts: Array[Stmt], needle: String) -> Bool {
       } else {
         ()
       },
-      // #2276 (Codex round 14): a function's own TYPE BINDER owns the name
-      // inside its signature -- `export fn f[StringMap](m: StringMap[Int])`
-      // makes `StringMap` the formal, not the builtin. The checker rejects
-      // that program (a type parameter cannot take arguments, #2268), but
-      // neither `--wit` path runs the checker, so without this arm the
+      // #2276 (Codex round 14, narrowed by round 16): a function that binds
+      // the name AND applies it owns the spelling inside its signature --
+      // `export fn f[StringMap](m: StringMap[Int])` makes `StringMap` the
+      // formal, not the builtin. The checker rejects that program (#2268),
+      // but neither `--wit` path runs the checker, so without this arm the
       // projection published the builtin's `list<tuple<string, V>>` ABI for a
       // program that does not compile.
       //
-      // The flag is program-wide rather than per-signature, so a binder in
-      // ONE function disables the builtin projection for the whole file.
-      // That over-reach cannot cost a valid program anything: a file that
-      // binds `StringMap` as a type parameter is rejected by the checker
-      // before it can be built, and failing to project is the loud direction.
-      SLet(_, _, _, _, body) => if expr_binds_type_param(body, needle) {
+      // The flag is program-wide rather than per-signature, so one such
+      // statement disables the builtin projection for the whole file. That
+      // over-reach costs no VALID program anything, because the applied
+      // formal is what #2268 rejects -- which is why the test is the
+      // application and not the binder. Round 14 tested the binder alone and
+      // justified it with the same sentence; the sentence was false there,
+      // since `fn id[StringMap](x: StringMap)` compiles fine.
+      SLet(_, _, _, _, body) => if expr_binds_applied_type_param(body, needle) {
         found = true
       } else {
         ()

--- a/lib/@vibe/compiler/wit_gen.vibe
+++ b/lib/@vibe/compiler/wit_gen.vibe
@@ -1,7 +1,14 @@
 //# Imports
 
 import @vibe/compiler/core {
-  Expr, Stmt, TypeExpr, effect_row_emitted_text, has_standard_host_provider, is_entry_runtime_managed_effect, is_exception_effect_name
+  Expr,
+  ImportItem,
+  Stmt,
+  TypeExpr,
+  effect_row_emitted_text,
+  has_standard_host_provider,
+  is_entry_runtime_managed_effect,
+  is_exception_effect_name
 }
 
 import @vibe/compiler/checker {
@@ -656,6 +663,29 @@ fn wit_resolve_effect_names_into(label: String, es_names: Array[String], es_memb
   }
 }
 
+/// Whether an import item plausibly binds a TYPE.
+///
+/// The WIT CLI parses only the entry file and never resolves imports, so this
+/// cannot be answered exactly: `{ Box as StringMap }` and
+/// `{ helper as StringMap }` both parse with `kind: None`, and only the
+/// dependency knows which is a type. Two signals are available -- an explicit
+/// `kind` (`import ./d.vibe { struct Box as StringMap }`), and the case of the
+/// SOURCE name, since a value is lower-case and a type is not.
+///
+/// #2276 (Codex rounds 5 and 9) pulled this in both directions. Treating every
+/// bound name as a type published a wrong ABI for an imported type; treating
+/// none as a type made a value import named `StringMap` fail an otherwise
+/// valid program with `no WIT mapping` -- measured, it did. The source-name
+/// case separates the two cases that actually occur, and where it is wrong it
+/// is wrong in the LOUD direction: an unconventional lower-case type name
+/// gives a "no WIT mapping" error rather than a silently mismatched ABI.
+fn import_item_is_typeish(item: ImportItem) -> Bool {
+  match item.kind {
+    Some(_) => true,
+    None => str_starts_upper(item.name)
+  }
+}
+
 fn wit_stmts_declare_type(stmts: Array[Stmt], needle: String) -> Bool {
   let mut found = false
   let mut i = 0
@@ -697,7 +727,7 @@ fn wit_stmts_declare_type(stmts: Array[Stmt], needle: String) -> Bool {
             Some(a) => a,
             None => item.name
           }
-          if bound == needle {
+          if bound == needle && import_item_is_typeish(item) {
             found = true
           } else {
             ()

--- a/lib/@vibe/compiler/wit_gen.vibe
+++ b/lib/@vibe/compiler/wit_gen.vibe
@@ -651,6 +651,30 @@ fn wit_stmts_declare_type(stmts: Array[Stmt], needle: String) -> Bool {
       } else {
         ()
       },
+      // #2276 (Codex): an IMPORT can bind the name too --
+      // `import ./dep.vibe { Box as StringMap }` makes `StringMap` a
+      // source-owned nominal type just as a local declaration does. The WIT
+      // CLI parses only the entry file and never resolves imports, so this
+      // scan is the only place that ownership can be seen; without this arm
+      // the projection published `list<tuple<string, V>>` for a user's own
+      // type -- an ABI that does not match the function's representation,
+      // and silently so.
+      SImport(_, items) => {
+        let mut ii = 0
+        while ii < Array::length(items) {
+          let item = Array::get(items, ii)
+          let bound = match item.alias {
+            Some(a) => a,
+            None => item.name
+          }
+          if bound == needle {
+            found = true
+          } else {
+            ()
+          }
+          ii = ii + 1
+        }
+      },
       _ => ()
     }
     i = i + 1

--- a/lib/@vibe/compiler/wit_gen.vibe
+++ b/lib/@vibe/compiler/wit_gen.vibe
@@ -736,6 +736,28 @@ fn import_items_bind_type(items: Array[ImportItem], needle: String) -> Bool {
   found
 }
 
+/// Whether a function literal binds `needle` as one of its own type
+/// parameters. Only the statement's own binder list is read -- a nested
+/// lambda's binders are not in scope for the exported signature.
+fn expr_binds_type_param(body: Expr, needle: String) -> Bool {
+  match body {
+    EFn(tparams, _, _, _, _, _) => {
+      let mut i = 0
+      let mut found = false
+      while i < Array::length(tparams) {
+        if Array::get(tparams, i) == needle {
+          found = true
+        } else {
+          ()
+        }
+        i = i + 1
+      }
+      found
+    },
+    _ => false
+  }
+}
+
 fn wit_stmts_declare_type(stmts: Array[Stmt], needle: String) -> Bool {
   let mut found = false
   let mut i = 0
@@ -780,6 +802,24 @@ fn wit_stmts_declare_type(stmts: Array[Stmt], needle: String) -> Bool {
       // `SImport` published the nominal parameter with the builtin's ABI,
       // which is the silent-wrong direction.
       SReExport(_, items) => if import_items_bind_type(items, needle) {
+        found = true
+      } else {
+        ()
+      },
+      // #2276 (Codex round 14): a function's own TYPE BINDER owns the name
+      // inside its signature -- `export fn f[StringMap](m: StringMap[Int])`
+      // makes `StringMap` the formal, not the builtin. The checker rejects
+      // that program (a type parameter cannot take arguments, #2268), but
+      // neither `--wit` path runs the checker, so without this arm the
+      // projection published the builtin's `list<tuple<string, V>>` ABI for a
+      // program that does not compile.
+      //
+      // The flag is program-wide rather than per-signature, so a binder in
+      // ONE function disables the builtin projection for the whole file.
+      // That over-reach cannot cost a valid program anything: a file that
+      // binds `StringMap` as a type parameter is rejected by the checker
+      // before it can be built, and failing to project is the loud direction.
+      SLet(_, _, _, _, body) => if expr_binds_type_param(body, needle) {
         found = true
       } else {
         ()

--- a/lib/@vibe/compiler/wit_gen.vibe
+++ b/lib/@vibe/compiler/wit_gen.vibe
@@ -869,6 +869,21 @@ fn wit_stmts_declare_type(stmts: Array[Stmt], needle: String) -> Bool {
       // before the builtin branch. Handling only the imported side left the
       // local one publishing a nominal effect type with the builtin map's
       // ABI, which is the silent-wrong direction.
+      // #2276 (Codex round 20): `suberror StringMap(Int)` claims a typedef
+      // slot as a `TDEnum` (`own_typedef_slot`, checker_stmt.vibe), so it owns
+      // the spelling exactly as a struct or enum does.
+      //
+      // With this arm the scan now matches the checker's own set. Verified
+      // against the two places a LOCAL declaration reaches `defs`:
+      // `own_typedef_slot` (SEnum, SSuberror, SStruct) and the direct
+      // `Array::push(defs, ...)` sites (STypeAlias, SEffectDef). `SEffectSet`
+      // is carried too -- a local one does not reach `defs`, only an imported
+      // one does, so that arm is deliberate over-reach in the LOUD direction.
+      SSuberror(_, name, _) => if name == needle {
+        found = true
+      } else {
+        ()
+      },
       SEffectDef(_, name, _, _) => if name == needle {
         found = true
       } else {


### PR DESCRIPTION
This is the cheap realization of the direction given for #2263:

> 1 でやるが、基本的には 0.1.0 リリースまでに Map は用意したい

Option 1 was "free the `Map` name so the tag is honest". A literal rename measured at 1160 `.vibe` + 109 `.vpkg` + 18 doc files plus a bootstrap bump, which is not what the direction was asking to pay. This does the same job at the surface the tag actually freezes, and leaves the door open: landing generic `Map` before the tag only relaxes a rejection, which is a compatible change.

## The problem

The builtin map is String-keyed, but its type is spelled `Map[K, V]` — the name of the generic map it is not. That made the freeze dishonest in both directions:

- the frozen surface promised `Map[K, V]`, which no implementation delivers;
- an annotation naming a concrete non-String key resolved fine and then had every operation reject its key argument, so the *type* promised something no *operation* delivers.

## What changed

**`StringMap[V]` is a compiler-known spelling** for the String-keyed map. `resolve_type_expr_core_shadowed` resolves it to the same `Map[String, V]` the operations take, so there is no second operation family and no import is needed. It is resolved there rather than declared as a prelude alias because a prelude type is not in scope without an import (measured: a bare `Byte` parameter answers "unknown type"). A user declaration of the name wins, checked against **both** the generic-binder shadow list and `defs`.

**A concrete non-String key is rejected where it is written**, with the edit that fixes it:

```
the builtin map is String-keyed, so a `Int` key has no implementation in
parameter `m` -- spell the String-keyed map `StringMap[V]`, or use
`MutMap[K, V]` from `@vibe/core` for other keys (generic `Map` keys are #2263)
```

The message names `MutMap[K, V]` because that is the real answer today, not a consolation: measured, `MutMap[Int, String]` compiles and runs end to end (`MutMap::new_int()` / `set` / `get` → `1` / `seven`). An earlier draft said "convert the key to `String`", which was worse advice than the language already supports.

A key that is a type **formal**, an inference variable, or an unresolved head is accepted untouched, so generic code over `Map[K, V]` keeps compiling — the rejection is only for a key that is concrete and not `String`.

**A structural head applied to the wrong arity is reported by its arity.** `ty_head_is_structural` exempts `Array` / `Option` / `StringMap` from the unknown-name sweep, and the resolver requires the exact arity and otherwise falls through to an unresolved `CtNamed` that `check_assignable` tolerates like a wildcard — so `fn f(m: Array[Int, String]) -> Int { m }` compiled clean and returned a non-`Int` as `Int`, and `Option[Int, String]` did the same. One rule now answers for all three heads and names the arity rather than calling a known type unknown.

`StringMap` is also wired through the structural-equality lowering and WIT projection, so the new spelling behaves like `Map[String, V]` everywhere the old one did.

## Measured

| probe | verdict |
|---|---|
| `fn f(m: StringMap[Int])` | ok |
| `fn f(m: Map[Int, String])` | reject |
| `fn f(m: Map[Foo, String])` (declared struct key) | reject |
| `fn f(m: Map[(Int, Int), String])` | reject |
| `fn f(m: Array[Map[Int, String]])` | reject |
| `type IntMap = Map[Int, String]` used as a parameter | reject (at the use) |
| `type M[K, V] = Map[K, V]` used as `M[Int, String]` | reject (args substituted) |
| `struct StringMap[T]` declared in source, then used | ok — the declaration wins, and runs |
| `fn f[K, V](m: Map[K, V])` | ok |
| `Array[Int, String]` / `Option[Int, String]` / `StringMap[Int, String]` | reject, naming the arity |
| `MutMap[Int, String]` set/get | ok, and runs |
| `let m = Map::new(); Map::set(m, 7, 1)` | still `argument type mismatch for Map::set: expected String, got Int` — the message the cheatsheet documents, unchanged |

## Freeze

`docs/spec/stable-surface.md` §2.1 lists `StringMap[V]` among the composite types, and §3's map entry freezes the six operations while declaring **`Map[K, V]`'s generality deliberately NOT frozen**, with `MutMap[K, V]` named as the generic map available today.

## Found while measuring — filed, not fixed here

- **#2274** — a builtin `Map::` op used as a bare value (`let g = Map::get`) passes the checker **silently** and then ICEs in codegen with "this is a bug in the compiler and not in your program". The silence is the interesting half: the checker answers "yes" for a name that does not resolve.
- **#2275** — `check_freeze_surface.sh` decides a frozen name exists by "the checker printed no `unknown name`", which #2274's silent arm satisfies. Six of the names it currently certifies are verified by that proxy. Its calibration cannot catch this: both calibration points sit outside the permissive arm.
- **#2279** — `resolve_type_alias_params` returns a tree whose leaves are **borrowed** from its `args` (`Array::get(args, idx)` returned directly while every other arm allocates fresh). Consuming that tree drops nodes it does not own and a later unrelated allocation traps with `memory access out of bounds at __rt_rc_alloc`. This PR routes around it rather than fixing it, because the function has other callers that want their own audit.

The `StringMap` entry is spelled around #2274 — `Map::new` and `Map::from_pairs` are marked as unable to be frozen until it lands, rather than listed as certified by a probe that cannot see them.

## A correction, recorded because it cost real time

An earlier revision of this description said the `unknown_type_name_enforced_test.vibe` trap "reproduced on the unmodified pre-change stage2" and was therefore "not attributable to this change". **Both halves were wrong**, and the misdiagnosis is #2279's real story:

- The evidence swapped `VIBE_TEST_CLI_WASM` across generations and saw the trap every time. But that test does `import @vibe/compiler/checker`, so it links the **working tree's** checker source; the variable only selects which compiler *compiles* it. Three generations were swapped and the same checker was measured three times. A worktree at `origin/main` passes. This is `CLAUDE.md`'s "which compiler answered?" trap in a second form — *the compiler that compiles a test is not the source that test links*.
- It was also called a memory ceiling, and the file was split to fit under it. That did not work: the 11-test tail still trapped, because **one** test is enough. That is what exposed the misdiagnosis. The split is reverted; all 38 tests are back in one file.

**#2278**, filed on the wrong diagnosis, is withdrawn and closed.

## Gates

- unit tests: **1021/1021**
- typecheck fixtures: ok (260 rows)
- cheatsheet doctest: 36 pass / 0 fail
- early compiler gate: ok
- freeze surface: ok (41 frozen symbols resolve; 6 explicitly not frozen)
- vibe-fmt lint: 1026 files, 0 violations
- doc path citations, book links: ok

---
_Generated by [Claude Code](https://claude.ai/code/session_012BesqGvopmB2byi8gB4HXG)_