### PR TITLE
The ADR-0068 surface becomes opt-in; `vibe fmt` stops blaming the file when it could not build itself

### DIFF
--- a/Taskfile.pkl
+++ b/Taskfile.pkl
@@ -831,6 +831,12 @@ local testUncaughtExceptionExit =
   scriptTask("test-uncaught-exception-exit", "scripts/test_uncaught_exception_exit.sh")
 local testVibeTest = scriptTask("test-vibe-test", "scripts/vibe_test_smoke.sh")
 local testVibeFmt = scriptTask("test-vibe-fmt", "scripts/vibe_fmt_smoke.sh")
+// #2271: a formatter that would not BUILD reported the same exit 1 that
+// means "this file is not formatted", so `vibe fmt` looped forever on a
+// file that was never at fault. Pins the loud-failure path and the two
+// callers' handling of the exit code.
+local testEnsureEntryWasm =
+  scriptTask("test-ensure-entry-wasm", "scripts/ensure_entry_wasm_test.sh")
 local testVibeNormalizeSmoke =
   scriptTask("test-vibe-normalize-smoke", "scripts/vibe_normalize_smoke.sh")
 local testSelfhostCliSeam = scriptTask("test-cli-seam", "scripts/vibe_cli_smoke.sh")
@@ -1615,6 +1621,7 @@ local releaseCheck = new Task {
   deps {
     selfhostOnlyGate
     checkVibeFmt
+    testEnsureEntryWasm
     checkTaskfileFmt
     // These ran ONLY from the local pre-commit hook -- CI never invoked them.
     // That made the hook the single enforcement point, so #1729 (a stale
@@ -1783,6 +1790,7 @@ tasks {
   testUncaughtExceptionExit
   testVibeTest
   testVibeFmt
+  testEnsureEntryWasm
   testVibeNormalizeSmoke
   testSelfhostCliSeam
   minifyGate

--- a/book/en/12_tests.vibe.md
+++ b/book/en/12_tests.vibe.md
@@ -44,14 +44,14 @@ both sides, and stops:
 $ vibe test demo_test.vibe
 FAIL demo_test.vibe
        failing test: double works
-       assert_eq failed
+       assert_eq failed at demo_test.vibe:6
          expected: 43
          actual:   42
 [vibe-test] 0 passed, 1 failed (1 files, 1 tests)
 ```
 
-The report does not yet carry a line number, so two asserts with the
-same expected value in one test are indistinguishable (#2202).
+The report names the line the failing assert is on, so a test with
+several asserts sharing an expected value still says which one fired.
 
 `assert_eq(actual, expected)` works for any type that can be compared,
 and compares strings by content — so you can assert directly on a

--- a/book/en/17_concurrency.vibe.md
+++ b/book/en/17_concurrency.vibe.md
@@ -11,6 +11,20 @@ checkable.
 
 The package is `@vibe/concurrent`.
 
+**This chapter is the one unstable surface in the book.** Everything here is
+ADR-0068, which is still `proposed`: `Nursery`, `Task`, `Sender`/`Receiver`,
+`TaskGroup::run` / `spawn` / `spawn_suspend`, and the compiler's `Send` rule.
+It is outside the SemVer promise and can change within a Minor release — see
+[the stable surface](../../docs/spec/stable-surface.md) §6. What it decides is
+settled enough to build on; what is not settled is the `Send`/region checking
+and which backend runs it (today's scheduler is a cooperative
+run-to-completion prototype).
+
+The `Async` effect itself is NOT in that bucket. ADR-0012 is accepted, and
+`with Async` on a row is as stable as any other effect — it appears in shipped
+builtin signatures like `StdinStream::next`. The unstable part is the
+concurrency model built on top of it, not the vocabulary.
+
 ## Spawning and joining
 
 ```vibe run

--- a/book/ja/12_tests.vibe.md
+++ b/book/ja/12_tests.vibe.md
@@ -43,14 +43,14 @@ ok   demo_test.vibe
 $ vibe test demo_test.vibe
 FAIL demo_test.vibe
        failing test: double works
-       assert_eq failed
+       assert_eq failed at demo_test.vibe:6
          expected: 43
          actual:   42
 [vibe-test] 0 passed, 1 failed (1 files, 1 tests)
 ```
 
-レポートにはまだ行番号が付かないので、同じ期待値の assert が1つの
-テストに2つあると区別できません (#2202)。
+レポートは失敗した assert の行を示すので、同じ期待値の assert が
+1つのテストに複数あっても、どれが落ちたかが分かります。
 
 `assert_eq(actual, expected)` は比較可能な任意の型で使え、文字列は内容で
 比較します — なので連結の結果や関数の戻り値に対して、何も変換せずそのまま

--- a/book/ja/17_concurrency.vibe.md
+++ b/book/ja/17_concurrency.vibe.md
@@ -11,6 +11,20 @@ vibe でスレッドを spawn することはありません。`TaskGroup` を�
 
 パッケージは `@vibe/concurrent`。
 
+**この章は本書で唯一の unstable な面です。** ここに出てくるものはすべて
+ADR-0068 で、状態はまだ `proposed` です — `Nursery`、`Task`、
+`Sender`/`Receiver`、`TaskGroup::run` / `spawn` / `spawn_suspend`、および
+コンパイラの `Send` 判定。SemVer の約束の外側にあり、Minor リリースの中で
+変わりえます ([stable surface](../../docs/spec/stable-surface.md) §6)。決めて
+あることは組み立てるに足りますが、決まっていないのは `Send`/region の検査と、
+どの backend が動かすかです (現行のスケジューラは cooperative
+run-to-completion のプロトタイプ)。
+
+`Async` effect 自体はこのバケツに入りません。ADR-0012 は accepted で、row 上の
+`with Async` は他の effect と同じだけ安定しています — `StdinStream::next` の
+ように出荷済み builtin の署名にも現れます。不安定なのはその上に建つ並行
+モデルであって、語彙ではありません。
+
 ## spawn して join する
 
 ```vibe run

--- a/docs/spec/stable-surface.md
+++ b/docs/spec/stable-surface.md
@@ -36,17 +36,27 @@ Trait bound compatibility follows the lock in [decisions.md](decisions.md):
 The **unstable surface (§6)** is outside this guarantee. Those parts can break
 within a Minor.
 
-**There is no opt-in gate today, and this document used to claim there was.**
-It said those parts "are reached only through `@build.unstable`, an explicit
-flag, or an ADR still marked `proposed`" — but `@build.unstable` appears
-nowhere else in the tree, and there is no `--unstable` or `--experimental`
-flag. An ADR's status is bookkeeping, invisible to someone writing code. What
-is actually gated, measured 2026-08-24: the wasm-gc backend (an env var),
-`perform?` (the checker rejects it, naming the edit), and SIMD (the package
-does not resolve). What is NOT gated: `TaskGroup::run` and everything else in
-ADR-0068's model — `vibe check` returns clean, with no marker of any kind.
-Closing that gap is tracked separately; until it does, §6 is a reading
-obligation rather than an enforced boundary.
+**How the unstable surface is marked.** This document used to claim those
+parts "are reached only through `@build.unstable`, an explicit flag, or an ADR
+still marked `proposed`". None of that was true: `@build.unstable` appeared
+nowhere else in the tree, there was no such flag, and an ADR's status is
+bookkeeping a reader never sees. `TaskGroup::run` compiled with `vibe check`
+clean and no marker of any kind.
+
+What is enforced today, measured 2026-08-24:
+
+| surface | how it is gated |
+| --- | --- |
+| wasm-gc backend | opt-in env var (`VIBE_BACKEND=gc` and friends) |
+| `perform?` | the checker rejects it, naming the edit that fixes it |
+| SIMD | the package does not resolve |
+| **ADR-0068 concurrency** | **`vibe check` warns on `import @vibe/concurrent`; `VIBE_UNSTABLE=1` silences it** |
+
+A warning rather than an error, because the surface has no external users yet
+— every one of the 31 files using `TaskGroup::` is inside this repository. It
+escalates to an error before that stops being true, not after.
+
+The rest of §6 is still a reading obligation rather than an enforced boundary.
 
 ---
 

--- a/docs/spec/stable-surface.md
+++ b/docs/spec/stable-surface.md
@@ -50,11 +50,22 @@ What is enforced today, measured 2026-08-24:
 | wasm-gc backend | opt-in env var (`VIBE_BACKEND=gc` and friends) |
 | `perform?` | the checker rejects it, naming the edit that fixes it |
 | SIMD | the package does not resolve |
-| **ADR-0068 concurrency** | **`vibe check` warns on `import @vibe/concurrent`; `VIBE_UNSTABLE=1` silences it** |
+| **ADR-0068 concurrency** | **`import @vibe/concurrent` is rejected by `vibe check` AND by `vibe build`; `VIBE_UNSTABLE=1` allows it** |
 
-A warning rather than an error, because the surface has no external users yet
-— every one of the 31 files using `TaskGroup::` is inside this repository. It
-escalates to an error before that stops being true, not after.
+An **error**, not a warning. `vibe check` exits non-zero and `vibe build`
+emits no wasm; the diagnostic names the environment variable that opts in.
+Both verbs answer the same way on purpose — a build that accepts what the
+check rejects is the "two verbs, two answers" defect #1567 fixed for
+check/diagnostics, and it is worse here because the accepting verb is the one
+that ships.
+
+The gate reads the entry file's **parsed** imports, so whitespace does not
+cross it (`import\t@vibe/concurrent` is the same as `import @vibe/concurrent`),
+and it looks at the entry only: a dependency's own imports are its author's
+choice. Harnesses inside this repository that compile in-tree sources against
+the surface deliberately (the book's concurrency chapter, the unit-test
+batch) grant the opt-in themselves; the boundary is pinned by
+`tests/gates/late/run.sh` section 108.
 
 The rest of §6 is still a reading obligation rather than an enforced boundary.
 

--- a/docs/spec/stable-surface.md
+++ b/docs/spec/stable-surface.md
@@ -34,8 +34,19 @@ Trait bound compatibility follows the lock in [decisions.md](decisions.md):
 **tighter bounds = Major / looser bounds = Minor**.
 
 The **unstable surface (§6)** is outside this guarantee. Those parts can break
-within a Minor. They are reached only through `@build.unstable`, an explicit
-flag, or an ADR still marked `proposed`.
+within a Minor.
+
+**There is no opt-in gate today, and this document used to claim there was.**
+It said those parts "are reached only through `@build.unstable`, an explicit
+flag, or an ADR still marked `proposed`" — but `@build.unstable` appears
+nowhere else in the tree, and there is no `--unstable` or `--experimental`
+flag. An ADR's status is bookkeeping, invisible to someone writing code. What
+is actually gated, measured 2026-08-24: the wasm-gc backend (an env var),
+`perform?` (the checker rejects it, naming the edit), and SIMD (the package
+does not resolve). What is NOT gated: `TaskGroup::run` and everything else in
+ADR-0068's model — `vibe check` returns clean, with no marker of any kind.
+Closing that gap is tracked separately; until it does, §6 is a reading
+obligation rather than an enforced boundary.
 
 ---
 
@@ -236,12 +247,22 @@ The following is still under construction or its design is not settled. It is
 **outside** the SemVer guarantee and can break within a Minor. Use it knowing
 that.
 
-- **Async / structured concurrency / WASI 0.3** (ADR-0012, ADR-0068,
-  `proposed`): the `{Async}` effect, `Future[T]`, `Stream[T]`, `Task[T]`,
-  `for await`. Today's codegen is an eager prototype; the public semantics are
-  defined in the [structured concurrency spec](../concurrency.md). JSPI/Worker,
-  the WASI Component Model, and shared-everything threads are interchangeable
-  lowerings — the stable surface is tied to none of them.
+- **Structured concurrency / WASI 0.3** (ADR-0068, `proposed`): `Nursery[r]`,
+  `Task[r,T]`, `Sender`/`Receiver`, `TaskGroup::run` / `spawn` /
+  `spawn_suspend`, and the `Send` eligibility rule. Today's codegen is an eager
+  prototype; the public semantics are defined in the
+  [structured concurrency spec](../concurrency.md). JSPI/Worker, the WASI
+  Component Model, and shared-everything threads are interchangeable lowerings
+  — the stable surface is tied to none of them.
+
+  **The `Async` effect ROW ELEMENT is not in this bullet.** ADR-0012 is
+  `accepted`, and `Async` already appears in shipped builtin signatures a user
+  can reach (`StdinStream::next(StdinStream) -> Int with Async`), where `vibe
+  check` enforces it like any other row element. The unsettled part is the
+  concurrency model built on top of it, not the vocabulary. This bullet used to
+  name ADR-0012 alongside ADR-0068 and mark both `proposed`, which was wrong
+  about ADR-0012's status and put a shipped, checked surface on the unstable
+  list. It also listed `for await`, retired in #1350.
 - **Component Model `#import` integration** (ADR-0021 Phase 2/3): CPS lowering
   of non-tail-resumptive handlers, capability effects.
 - **Capability authorization surface** (ADR-0088, `proposed`): the two-clause

--- a/docs/spec/stable-surface.md
+++ b/docs/spec/stable-surface.md
@@ -36,12 +36,9 @@ Trait bound compatibility follows the lock in [decisions.md](decisions.md):
 The **unstable surface (§6)** is outside this guarantee. Those parts can break
 within a Minor.
 
-**How the unstable surface is marked.** This document used to claim those
-parts "are reached only through `@build.unstable`, an explicit flag, or an ADR
-still marked `proposed`". None of that was true: `@build.unstable` appeared
-nowhere else in the tree, there was no such flag, and an ADR's status is
-bookkeeping a reader never sees. `TaskGroup::run` compiled with `vibe check`
-clean and no marker of any kind.
+**How the unstable surface is marked.** By a mechanism the compiler enforces,
+never by an ADR's status — status is bookkeeping a reader never sees, and a
+surface marked only that way compiles clean with no marker of any kind.
 
 What is enforced today, measured 2026-08-24:
 
@@ -280,10 +277,7 @@ that.
   `accepted`, and `Async` already appears in shipped builtin signatures a user
   can reach (`StdinStream::next(StdinStream) -> Int with Async`), where `vibe
   check` enforces it like any other row element. The unsettled part is the
-  concurrency model built on top of it, not the vocabulary. This bullet used to
-  name ADR-0012 alongside ADR-0068 and mark both `proposed`, which was wrong
-  about ADR-0012's status and put a shipped, checked surface on the unstable
-  list. It also listed `for await`, retired in #1350.
+  concurrency model built on top of it, not the vocabulary.
 - **Component Model `#import` integration** (ADR-0021 Phase 2/3): CPS lowering
   of non-tail-resumptive handlers, capability effects.
 - **Capability authorization surface** (ADR-0088, `proposed`): the two-clause

--- a/lib/@vibe/compiler/checker/checker_resolve.vibe
+++ b/lib/@vibe/compiler/checker/checker_resolve.vibe
@@ -1,7 +1,14 @@
 //# Imports
 
 import @vibe/compiler/core {
-  Type, TypeDef, TypeExpr, find_typedef, resolve_builtin, resolve_type_alias_params, resolve_type_expr_core_shadowed
+  Type,
+  TypeDef,
+  TypeExpr,
+  find_typedef,
+  is_wellknown_nominal_head,
+  resolve_builtin,
+  resolve_type_alias_params,
+  resolve_type_expr_core_shadowed
 }
 
 import @vibe/core {
@@ -50,39 +57,14 @@ export fn resolve_type_expr_shadowed(te: TypeExpr, defs: Array[TypeDef], shadow:
   resolve_type_expr_core_shadowed(te, defs, shadow)
 }
 
-/// #2125: nominal heads the compiler owns itself. They resolve to
-/// `CtNamed(name, args)` with no `TypeDef` behind them and no entry in
-/// `resolve_builtin`, so they are indistinguishable from a typo by lookup
-/// alone and have to be named.
-///
-/// This list is EMPIRICAL, not a design: it is what Red runs of
-/// `collect_unknown_type_names` over `lib/**` and `fixtures/**` reported as
-/// unresolved while the tree compiled clean. Adding a compiler-owned type
-/// without adding it here makes every annotation that mentions it an error,
-/// which is a loud failure, not a silent one -- `PromptText` joined the list
-/// that way (`declare PromptText::new(String) -> PromptText`,
-/// builtins/declarations.vibe, names a type `resolve_builtin` does not carry).
-fn is_wellknown_nominal_head(name: String) -> Bool {
-  name == "Future"
-  || name == "ByteStream"
-  || name == "HostStream"
-  || name == "Task"
-  || name == "TaskHandle"
-  || name == "TaskGroup"
-  || name == "Sender"
-  || name == "Receiver"
-  || name == "Map"
-  || name == "MapBuilder"
-  || name == "MutList"
-  || name == "MutBytes"
-  || name == "MutMap"
-  || name == "ArrayBuilder"
-  || name == "StringBuilder"
-  || name == "FrozenArray"
-  || name == "FixedArray"
-  || name == "Attempt"
-  || name == "PromptText"
-}
+/// #2125's list of compiler-owned nominal heads lives in
+/// `@vibe/compiler/core` (builtin_name.vibe) as `is_wellknown_nominal_head`.
+/// It moved there because the contract types-module sentinel needs the SAME
+/// answer (#2164): it asked `resolve_builtin` -- which answers for builtin
+/// VALUES -- plus a hardcoded `Array`/`Option`, a set narrower than the
+/// language. Every contract mentioning `Map` therefore had its transparent
+/// types exempted from checking. Two hand-maintained lists that have to agree
+/// is exactly the shape that produced that hole; there is one list now.
 // `Self` is deliberately NOT in the list (Codex round 4 on #2147): it is a
 // type only inside a trait declaration's method signatures, and those are
 // resolved by the trait machinery, never by `report_unknown_type_names`'s

--- a/lib/@vibe/compiler/cli_adapter.vibe
+++ b/lib/@vibe/compiler/cli_adapter.vibe
@@ -118,7 +118,7 @@ import ./cli_support.vibe {
 }
 
 import @vibe/lsp {
-  lsp_diagnostics_json_string, lsp_main
+  lsp_diagnostics_json_string, lsp_diagnostics_json_string_with, lsp_main
 }
 
 import @vibe/compiler/checker {
@@ -1774,7 +1774,10 @@ export fn cli_main() -> Int with Exception + Fs + Env + Stdin + Stdout {
       } with { Exception::Throw(_) => adapter_no_warnings() }
     }
     if Env::get("VIBE_DIAGNOSTICS_JSON") == "1" {
-      Fs::write_bytes(output_path, adapter_string_to_bytes(lsp_diagnostics_json_string(src)))
+      // The JSON form is what the editor consumes; dropping the opt-in
+      // diagnostic here would make the LSP the one surface that still accepts
+      // the unstable import (#2277 review).
+      Fs::write_bytes(output_path, adapter_string_to_bytes(lsp_diagnostics_json_string_with(src, unstable_diags)))
     } else {
       let diags = collect_all_diagnostics(src)
       let mut ui = 0

--- a/lib/@vibe/compiler/cli_adapter.vibe
+++ b/lib/@vibe/compiler/cli_adapter.vibe
@@ -110,6 +110,7 @@ import ./cli_support.vibe {
   check_deprecated_warnings_from_source_groups,
   check_linked_file_source_groups,
   check_redundant_import_warnings_from_source_groups,
+  check_unstable_surface_warnings_from_source_groups,
   strip_executable_wasm_env,
   verify_culprit_off_marker_fs_fail_closed
 }
@@ -443,6 +444,13 @@ fn adapter_split_nonempty_lines(text: String) -> Array[String] {
 
 /// #2149: does `s` end with `suffix`? Used only to spot a `.vpkg` path, whose
 /// header is not vibe syntax and so can never be parse-checked as a whole file.
+/// An empty warning list. A named function rather than a bare `[]` so the
+/// `if` arms agree on the element type without an annotation (#2248).
+fn adapter_no_warnings() -> Array[String] {
+  let out: Array[String] = []
+  out
+}
+
 fn adapter_path_has_suffix(s: String, suffix: String) -> Bool {
   let n = String::length(s)
   let m = String::length(suffix)
@@ -1255,6 +1263,39 @@ export fn cli_main() -> Int with Exception + Fs + Env + Stdin + Stdout {
         StringBuilder::push(out_text, Array::get(redundant_import_warns, rwi))
         StringBuilder::push(out_text, "\n")
         rwi = rwi + 1
+      }
+      // Unstable-surface warnings (ADR-0068). `docs/spec/stable-surface.md`
+      // section 6 used to claim this surface "is reached only through
+      // `@build.unstable`, an explicit flag, or an ADR still marked
+      // `proposed`" -- and `@build.unstable` appeared NOWHERE else in the
+      // tree, there was no such flag, and an ADR's status is bookkeeping a
+      // reader never sees. `TaskGroup::run` compiled with `vibe check` clean
+      // and no marker of any kind. This is the missing half.
+      //
+      // A warning, not an error: the surface has no external users yet (all
+      // 31 `TaskGroup::` files are in-repo, measured), so nothing is broken by
+      // saying so, and an error would need the opt-in threaded through every
+      // gate lane before it could land. Escalating to an error is the next
+      // step, taken before external users appear rather than after.
+      //
+      // `VIBE_UNSTABLE=1` silences it, read in EXPRESSION position like the
+      // other observation-only knobs: `check_selector_precedence.sh` derives
+      // the adapter's BRANCH order from statement-position `if Env::get(..)`,
+      // and a selector that picks no verb must not enter that order (it would
+      // then take a position in every arm's derived clear list). Read HERE and
+      // not in cli_support so the warning collectors stay pure functions of
+      // (path, sources) -- the same reason every other selector is an adapter
+      // concern.
+      let unstable_warns = if Env::get("VIBE_UNSTABLE") == "1" {
+        adapter_no_warnings()
+      } else {
+        check_unstable_surface_warnings_from_source_groups(input_path, checked_source_groups)
+      }
+      let mut uwi = 0
+      while uwi < Array::length(unstable_warns) {
+        StringBuilder::push(out_text, Array::get(unstable_warns, uwi))
+        StringBuilder::push(out_text, "\n")
+        uwi = uwi + 1
       }
       StringBuilder::push(out_text, "ok\n")
       Fs::write_file(output_path, StringBuilder::freeze(out_text))

--- a/lib/@vibe/compiler/cli_adapter.vibe
+++ b/lib/@vibe/compiler/cli_adapter.vibe
@@ -1272,13 +1272,17 @@ export fn cli_main() -> Int with Exception + Fs + Env + Stdin + Stdout {
       // reader never sees. `TaskGroup::run` compiled with `vibe check` clean
       // and no marker of any kind. This is the missing half.
       //
-      // A warning, not an error: the surface has no external users yet (all
-      // 31 `TaskGroup::` files are in-repo, measured), so nothing is broken by
-      // saying so, and an error would need the opt-in threaded through every
-      // gate lane before it could land. Escalating to an error is the next
-      // step, taken before external users appear rather than after.
+      // An ERROR, not a warning, and the escalation is deliberate: the surface
+      // has no external users yet. Measured -- exactly 14 files carry a
+      // column-1 `import @vibe/concurrent`, all of them in this repository
+      // (13 fixtures + 1 eval probe), and NONE under lib/, so the bootstrap
+      // chain never touches it. Refusing now costs 14 opt-ins; refusing after
+      // someone depends on it costs them a rewrite.
       //
-      // `VIBE_UNSTABLE=1` silences it, read in EXPRESSION position like the
+      // The FS-compile branch carries the same gate, because a build that
+      // accepts what the check rejects is worse than either answer alone.
+      //
+      // `VIBE_UNSTABLE=1` opts in, read in EXPRESSION position like the
       // other observation-only knobs: `check_selector_precedence.sh` derives
       // the adapter's BRANCH order from statement-position `if Env::get(..)`,
       // and a selector that picks no verb must not enter that order (it would
@@ -1291,11 +1295,10 @@ export fn cli_main() -> Int with Exception + Fs + Env + Stdin + Stdout {
       } else {
         check_unstable_surface_warnings_from_source_groups(input_path, checked_source_groups)
       }
-      let mut uwi = 0
-      while uwi < Array::length(unstable_warns) {
-        StringBuilder::push(out_text, Array::get(unstable_warns, uwi))
-        StringBuilder::push(out_text, "\n")
-        uwi = uwi + 1
+      if Array::length(unstable_warns) > 0 {
+        return emit_compile_diag(output_path, Array::get(unstable_warns, 0))
+      } else {
+        ()
       }
       StringBuilder::push(out_text, "ok\n")
       Fs::write_file(output_path, StringBuilder::freeze(out_text))
@@ -1318,6 +1321,22 @@ export fn cli_main() -> Int with Exception + Fs + Env + Stdin + Stdout {
       // Request validation and stale-sidecar deletion happened before every
       // CLI early return above. This branch now only consumes the validated
       // request while preserving the ordinary compile-path selection below.
+      //
+      // ADR-0068 gate, BEFORE any compile work. `vibe check` and this branch
+      // must agree: a build that accepts what the check rejects is the same
+      // "two verbs, two answers" defect #1567 fixed for check/diagnostics, and
+      // it is worse here because the accepting verb is the one that ships.
+      // `VIBE_UNSTABLE=1` opts in.
+      let fs_unstable = if Env::get("VIBE_UNSTABLE") == "1" {
+        adapter_no_warnings()
+      } else {
+        check_unstable_surface_warnings_from_source_groups(input_path, collect_source_groups_fs(input_path))
+      }
+      if Array::length(fs_unstable) > 0 {
+        return emit_compile_diag(output_path, Array::get(fs_unstable, 0))
+      } else {
+        ()
+      }
       let artifact_input_trace_nonce = Env::get("VIBE_ARTIFACT_INPUT_TRACE_NONCE")
       // debugger trace (DAP P1 groundwork): `vibe run --trace` sets VIBE_DEBUG=1
       // so the user file (and its imports) is compiled with function-call

--- a/lib/@vibe/compiler/cli_adapter.vibe
+++ b/lib/@vibe/compiler/cli_adapter.vibe
@@ -1876,6 +1876,25 @@ export fn cli_main() -> Int with Exception + Fs + Env + Stdin + Stdout {
     return adapter_serve_component(input_path, output_path)
   }
   let source = Fs::read_file(input_path)
+  // ADR-0068 gate for the SINGLE-SOURCE lane. `VIBE_TEST_BACKEND=gc` and
+  // `VIBE_BENCH_BACKEND=gc` reach compilation through here -- `runtime/vibe`
+  // clears `VIBE_FS_COMPILE` and selects the backend -- so this lane compiled
+  // and RAN a file with an unstable import while every check form rejected the
+  // same declaration (#2277 review). Measured: `vibe test` said the file was
+  // refused, `VIBE_TEST_BACKEND=gc vibe test` said `1 passed`.
+  //
+  // The entry's own bytes, with no ingestion: this lane resolves no imports, so
+  // there is no ingested text to differ from them.
+  let bare_unstable = if Env::get("VIBE_UNSTABLE") == "1" {
+    adapter_no_warnings()
+  } else {
+    unstable_surface_diagnostics(input_path, source)
+  }
+  if Array::length(bare_unstable) > 0 {
+    return emit_compile_diag(output_path, Array::get(bare_unstable, 0))
+  } else {
+    ()
+  }
   profile_memory_mark(mark_memory)
   // #594 Stage 1b: emit-module-source mode. VIBE_EMIT_MODULE_SOURCE=1 reuses the
   // same (input, output, entry) interface but, instead of compiling, writes the

--- a/lib/@vibe/compiler/cli_adapter.vibe
+++ b/lib/@vibe/compiler/cli_adapter.vibe
@@ -110,6 +110,7 @@ import ./cli_support.vibe {
   check_deprecated_warnings_from_source_groups,
   check_linked_file_source_groups,
   check_redundant_import_warnings_from_source_groups,
+  check_unstable_surface_warnings_from_path,
   check_unstable_surface_warnings_from_source_groups,
   strip_executable_wasm_env,
   verify_culprit_off_marker_fs_fail_closed
@@ -1330,7 +1331,7 @@ export fn cli_main() -> Int with Exception + Fs + Env + Stdin + Stdout {
       let fs_unstable = if Env::get("VIBE_UNSTABLE") == "1" {
         adapter_no_warnings()
       } else {
-        check_unstable_surface_warnings_from_source_groups(input_path, collect_source_groups_fs(input_path))
+        check_unstable_surface_warnings_from_path(input_path)
       }
       if Array::length(fs_unstable) > 0 {
         return emit_compile_diag(output_path, Array::get(fs_unstable, 0))

--- a/lib/@vibe/compiler/cli_adapter.vibe
+++ b/lib/@vibe/compiler/cli_adapter.vibe
@@ -113,6 +113,7 @@ import ./cli_support.vibe {
   check_unstable_surface_warnings_from_path,
   check_unstable_surface_warnings_from_source_groups,
   strip_executable_wasm_env,
+  unstable_surface_diagnostics,
   verify_culprit_off_marker_fs_fail_closed
 }
 
@@ -1757,10 +1758,30 @@ export fn cli_main() -> Int with Exception + Fs + Env + Stdin + Stdout {
   // diagnostic shape shared by the editor protocol and the CLI.
   if Env::get("VIBE_DIAGNOSTICS") == "1" {
     let src = Fs::read_file(input_path)
+    // ADR-0068 opt-in, in the buffer lane too. This is the mode `vibe check
+    // --single-file` and the editor use, and it does not resolve imports -- so
+    // an UNUSED `import @vibe/concurrent` analyzed clean here while `vibe check`
+    // and `vibe build` both rejected the same buffer (#2277 review). The gate is
+    // a property of the declaration, not of the imported names being reached, so
+    // it belongs in every lane that reads the file. Scanned on the buffer's own
+    // text: this lane exists for unsaved buffers, and ingestion would answer
+    // about the file on disk instead.
+    let unstable_diags = if Env::get("VIBE_UNSTABLE") == "1" {
+      adapter_no_warnings()
+    } else {
+      handle {
+        unstable_surface_diagnostics(input_path, src)
+      } with { Exception::Throw(_) => adapter_no_warnings() }
+    }
     if Env::get("VIBE_DIAGNOSTICS_JSON") == "1" {
       Fs::write_bytes(output_path, adapter_string_to_bytes(lsp_diagnostics_json_string(src)))
     } else {
       let diags = collect_all_diagnostics(src)
+      let mut ui = 0
+      while ui < Array::length(unstable_diags) {
+        Array::push(diags, Array::get(unstable_diags, ui))
+        ui = ui + 1
+      }
       Fs::write_bytes(output_path, adapter_string_to_bytes(line_terminated(join_lines(diags))))
     }
     return 0

--- a/lib/@vibe/compiler/cli_adapter.vibe
+++ b/lib/@vibe/compiler/cli_adapter.vibe
@@ -755,6 +755,23 @@ fn adapter_emit_wit(input_path: String, output_path: String) -> Int with Fs + En
 /// the WIT world sidecar.
 fn adapter_serve_component(input_path: String, output_path: String) -> Int with Fs + Env {
   handle {
+    // ADR-0068 gate, BEFORE any compile work -- the same gate the FS-compile
+    // branch applies, for the same reason. `vibe serve` reaches this function
+    // through its own `VIBE_SERVE_COMPONENT` branch, which returns before that
+    // one, so without this a handler importing `@vibe/concurrent` produced a
+    // DEPLOYABLE component while `vibe check` rejected the identical file
+    // (#2277 review). An artifact-producing verb that accepts what the check
+    // verb refuses is the worst direction for that disagreement to run.
+    let serve_unstable = if Env::get("VIBE_UNSTABLE") == "1" {
+      adapter_no_warnings()
+    } else {
+      check_unstable_surface_warnings_from_path(input_path)
+    }
+    if Array::length(serve_unstable) > 0 {
+      return emit_compile_diag(output_path, Array::get(serve_unstable, 0))
+    } else {
+      ()
+    }
     let entry_stmts = parse_program(lex(Fs::read_file(input_path)))
     validate_serve_handler(entry_stmts)
     // No command entry: the component surface is `handler`. `__no_entry__`

--- a/lib/@vibe/compiler/cli_support.vibe
+++ b/lib/@vibe/compiler/cli_support.vibe
@@ -739,8 +739,14 @@ fn unstable_stmt_diagnostics(stmts: Array[Stmt], source: String, tokens: Array[T
       SImport(path, _) => {
         let note = unstable_package_note(path)
         if note != "" {
-          let line = unstable_line_of_offset(source, unstable_import_offset(tokens, starts, path))
-          Array::push(out, String::concat("line ", String::concat(Int::to_string(line), String::concat(":col 1: ", note))))
+          let off = unstable_import_offset(tokens, starts, path)
+          let where_note = if off < 0 {
+            String::concat("this file inherits `", String::concat(path, "` from its directory's index.vpkg (it is not written here). "))
+          } else {
+            ""
+          }
+          let line = unstable_line_of_offset(source, off)
+          Array::push(out, String::concat("line ", String::concat(Int::to_string(line), String::concat(":col 1: ", String::concat(where_note, note)))))
         } else {
           ()
         }
@@ -767,10 +773,28 @@ fn unstable_stmt_diagnostics(stmts: Array[Stmt], source: String, tokens: Array[T
 /// nobody here can act on. A source that does not parse yields nothing -- it
 /// cannot compile either, and the parse error is what the reader needs first.
 export fn unstable_surface_diagnostics(input_path: String, source: String) -> Array[String] with Exception {
+  unstable_surface_diagnostics_located(input_path, source, source)
+}
+
+/// Detection and LOCATION come from different texts on purpose.
+///
+/// `detected` is the INGESTED snapshot -- what the build compiles. `located` is
+/// the file's own bytes. They differ when a directory's `index.vpkg` declares a
+/// shared import that a sibling entry inherits without spelling it: the import
+/// is real, the build rejects it, and it appears nowhere in the file. Scanning
+/// the physical source for the VERDICT let `vibe check` call such an entry
+/// clean while the build refused it -- the two-verbs-disagree defect this gate
+/// exists to prevent (#2277 review).
+///
+/// So the verdict is the ingested text's, and the position is the physical
+/// file's when the import is physically there. When it is not, there is no
+/// honest line to give, and the note says where the import actually comes from
+/// instead of pointing at a line the reader would find nothing on (#1445).
+export fn unstable_surface_diagnostics_located(input_path: String, detected: String, located: String) -> Array[String] with Exception {
   let out = array_empty()
-  let (tokens, starts, _ends) = lex_with_offsets(source)
-  match checked_warning_stmts(input_path, source) {
-    Some(stmts) => unstable_stmt_diagnostics(stmts, source, tokens, starts, out),
+  let (tokens, starts, _ends) = lex_with_offsets(located)
+  match checked_warning_stmts(input_path, detected) {
+    Some(stmts) => unstable_stmt_diagnostics(stmts, located, tokens, starts, out),
     None => ()
   }
   out
@@ -791,7 +815,7 @@ export fn unstable_surface_diagnostics(input_path: String, source: String) -> Ar
 /// file a different way than the build reads it (#2277 review).
 export fn check_unstable_surface_warnings_from_path(input_path: String) -> Array[String] with Exception + Fs {
   handle {
-    unstable_surface_diagnostics(input_path, ingest_source_text_fs(input_path, Fs::read_file(input_path)))
+    unstable_surface_diagnostics_located(input_path, ingest_source_text_fs(input_path, Fs::read_file(input_path)), Fs::read_file(input_path))
   } with {
   // An unreadable or uningestable entry is the compile's error to report, in
   // its own words.
@@ -801,11 +825,15 @@ export fn check_unstable_surface_warnings_from_path(input_path: String) -> Array
 /// The CHECK lane's entry point: reuses the snapshot the linked check already
 /// collected, so it costs a lookup rather than a second traversal.
 export fn check_unstable_surface_warnings_from_source_groups(input_path: String, source_groups: Array[(String, Array[(String, String)])]) -> Array[String] with Exception + Fs {
-  let source = match checked_entry_source(input_path, source_groups) {
-    Some(snapshot) => snapshot,
-    None => return array_empty()
-  }
-  unstable_surface_diagnostics(input_path, source)
+  // NOT `checked_entry_source`: that deliberately hands back the PHYSICAL file
+  // when the loader prepended inherited `.vpkg` imports, which is right for
+  // ordinary warnings and wrong for this verdict -- an inherited
+  // `@vibe/concurrent` would be invisible here and rejected by the build. The
+  // verdict comes from the same ingestion the build uses; only the position
+  // comes from the file's own bytes.
+  handle {
+    unstable_surface_diagnostics_located(input_path, ingest_source_text_fs(input_path, Fs::read_file(input_path)), Fs::read_file(input_path))
+  } with { Exception::Throw(_) => array_empty() }
 }
 
 /// Redundant import warnings derived from the exact source snapshot consumed

--- a/lib/@vibe/compiler/cli_support.vibe
+++ b/lib/@vibe/compiler/cli_support.vibe
@@ -664,6 +664,87 @@ fn checked_warning_stmts(input_path: String, source: String) -> Option[Array[Stm
   }
 }
 
+/// UNSTABLE-surface warnings (ADR-0068). One line per import of a package
+/// whose design is not settled, so a reader is told at the keyboard rather
+/// than only in docs/spec/stable-surface.md section 6.
+///
+/// The scan is TEXTUAL on the entry source, for the same reason
+/// `deprecated_scan` is token-level: it needs no name resolution and it
+/// reports where the reader actually wrote the dependency. Only the ENTRY
+/// file warns -- a transitive dependency's own imports are its author's
+/// choice, not this file's, and warning about them would be noise nobody
+/// here can act on.
+///
+/// `@vibe/concurrent` is the whole list today: `Nursery`, `Task`,
+/// `Sender`/`Receiver`, `TaskGroup::run` / `spawn` / `spawn_suspend`, and the
+/// `Send` rule are ADR-0068, still `proposed`. The `Async` effect itself is
+/// NOT here -- ADR-0012 is accepted and `with Async` ships in builtin
+/// signatures a user can reach (`StdinStream::next`). The unstable part is
+/// the concurrency model built on top, not the row vocabulary.
+
+/// The first whitespace-delimited token. `import @vibe/concurrent { X }` ->
+/// `@vibe/concurrent`. A `{` with no space before it also ends the token, so
+/// `import @vibe/concurrent{X}` is read the same way.
+fn str_take_until_space(s: String) -> String {
+  let n = String::length(s)
+  let mut cut = n
+  let mut i = 0
+  while i < n {
+    let c = String::char_code_at(s, i)
+    if (c == 32 || c == 9 || c == 123) && cut == n {
+      cut = i
+    } else {
+      ()
+    }
+    i = i + 1
+  }
+  String::substring(s, 0, cut)
+}
+
+fn unstable_package_note(name: String) -> String {
+  if name == "@vibe/concurrent" {
+    "`@vibe/concurrent` is UNSTABLE (ADR-0068, still proposed): it is outside the SemVer promise and can change within a Minor release -- see docs/spec/stable-surface.md section 6. Set VIBE_UNSTABLE=1 to silence this."
+  } else {
+    ""
+  }
+}
+
+export fn check_unstable_surface_warnings_from_source_groups(input_path: String, source_groups: Array[(String, Array[(String, String)])]) -> Array[String] with Exception + Fs {
+  let source = match checked_entry_source(input_path, source_groups) {
+    Some(snapshot) => snapshot,
+    None => return array_empty()
+  }
+  let out = array_empty()
+  let lines = String::split(source, "\n")
+  let mut i = 0
+  while i < Array::length(lines) {
+    let line = Array::get(lines, i)
+    // Column 1, no trimming: an `import` is a top-level declaration and the
+    // formatter puts it there, so a leading-whitespace form is not a thing
+    // this has to read. It also keeps the scan off `String::trim_start`,
+    // which docs/cheatsheet.md lists but the compiler's own surface does not
+    // have -- measured here, and worth its own issue.
+    if String::starts_with(line, "import ") {
+      let pkg = str_take_until_space(String::substring(line, 7, String::length(line)))
+      let note = unstable_package_note(pkg)
+      if note != "" {
+        // `warning: line N:col 1: ...`, the spelling deprecated_scan uses.
+        // The launcher's check arm forwards ONLY lines matching `^warning: `
+        // (runtime/vibe), so a `path:line:col: warning:` form -- which is what
+        // `vibe diagnostics` emits -- is silently dropped here. Measured: the
+        // first version of this used that form and printed nothing.
+        Array::push(out, String::concat("warning: line ", String::concat(Int::to_string(i + 1), String::concat(":col 1: ", note))))
+      } else {
+        ()
+      }
+    } else {
+      ()
+    }
+    i = i + 1
+  }
+  out
+}
+
 /// Redundant import warnings derived from the exact source snapshot consumed
 /// by the successful linked check. Missing or duplicate entry identity is
 /// fail-closed: no warning is safer than describing unchecked contents.

--- a/lib/@vibe/compiler/cli_support.vibe
+++ b/lib/@vibe/compiler/cli_support.vibe
@@ -664,16 +664,9 @@ fn checked_warning_stmts(input_path: String, source: String) -> Option[Array[Stm
   }
 }
 
-/// UNSTABLE-surface warnings (ADR-0068). One line per import of a package
+/// UNSTABLE-surface diagnostics (ADR-0068). One line per import of a package
 /// whose design is not settled, so a reader is told at the keyboard rather
 /// than only in docs/spec/stable-surface.md section 6.
-///
-/// The scan is TEXTUAL on the entry source, for the same reason
-/// `deprecated_scan` is token-level: it needs no name resolution and it
-/// reports where the reader actually wrote the dependency. Only the ENTRY
-/// file warns -- a transitive dependency's own imports are its author's
-/// choice, not this file's, and warning about them would be noise nobody
-/// here can act on.
 ///
 /// `@vibe/concurrent` is the whole list today: `Nursery`, `Task`,
 /// `Sender`/`Receiver`, `TaskGroup::run` / `spawn` / `spawn_suspend`, and the
@@ -681,74 +674,111 @@ fn checked_warning_stmts(input_path: String, source: String) -> Option[Array[Stm
 /// NOT here -- ADR-0012 is accepted and `with Async` ships in builtin
 /// signatures a user can reach (`StdinStream::next`). The unstable part is
 /// the concurrency model built on top, not the row vocabulary.
-
-/// The first whitespace-delimited token. `import @vibe/concurrent { X }` ->
-/// `@vibe/concurrent`. A `{` with no space before it also ends the token, so
-/// `import @vibe/concurrent{X}` is read the same way.
-fn str_take_until_space(s: String) -> String {
-  let n = String::length(s)
-  let mut cut = n
-  let mut i = 0
-  while i < n {
-    let c = String::char_code_at(s, i)
-    if (c == 32 || c == 9 || c == 123) && cut == n {
-      cut = i
-    } else {
-      ()
-    }
-    i = i + 1
-  }
-  String::substring(s, 0, cut)
-}
-
 fn unstable_package_note(name: String) -> String {
-  if name == "@vibe/concurrent" {
+  if name == "@vibe/concurrent" || String::starts_with(name, "@vibe/concurrent/") {
     "set VIBE_UNSTABLE=1 to build against `@vibe/concurrent`, or drop the import. It is ADR-0068, still proposed: outside the SemVer promise and able to change within a Minor release, so it is opt-in rather than silent (docs/spec/stable-surface.md section 6). The `Async` effect itself is stable and needs no opt-in -- only this package's concurrency model does."
   } else {
     ""
   }
 }
 
-export fn check_unstable_surface_warnings_from_source_groups(input_path: String, source_groups: Array[(String, Array[(String, String)])]) -> Array[String] with Exception + Fs {
-  let source = match checked_entry_source(input_path, source_groups) {
-    Some(snapshot) => snapshot,
-    None => return array_empty()
+/// Byte offset of the first character that is not a space or a tab.
+fn unstable_first_nonspace(line: String) -> Int {
+  let n = String::length(line)
+  let mut i = 0
+  while i < n {
+    let c = String::char_code_at(line, i)
+    if c == 32 || c == 9 {
+      i = i + 1
+    } else {
+      return i
+    }
   }
-  let out = array_empty()
+  n
+}
+
+/// Which line the reader has to edit. DETECTION is structural (below); this is
+/// presentation only, so a miss costs a position and never a verdict -- hence
+/// the fallback to line 1 rather than a second parse.
+fn unstable_import_line(source: String, pkg: String) -> Int {
   let lines = String::split(source, "\n")
   let mut i = 0
   while i < Array::length(lines) {
     let line = Array::get(lines, i)
-    // Column 1, no trimming: an `import` is a top-level declaration and the
-    // formatter puts it there, so a leading-whitespace form is not a thing
-    // this has to read.
-    //
-    // It also needs no `String::trim_start`, which is a LIBRARY function
-    // rather than a builtin -- reaching it here would mean adding an
-    // `@vibe/builtin` import to this file. docs/cheatsheet.md says so
-    // explicitly ("These are not builtins ... calling one without its import
-    // is `unknown name`", the #2124 fix); the first version of this scan used
-    // it, read the resulting `unknown name` as the cheatsheet being wrong,
-    // and was wrong itself.
-    if String::starts_with(line, "import ") {
-      let pkg = str_take_until_space(String::substring(line, 7, String::length(line)))
-      let note = unstable_package_note(pkg)
-      if note != "" {
-        // `line N:col 1: ...`, the located-diagnostic spelling. This started
-        // as a `warning: ` line, which the launcher's check arm forwards to
-        // stderr; it is now an ERROR routed through emit_compile_diag, and
-        // that channel is the one both `vibe check` and `vibe build` already
-        // read, so the two verbs cannot disagree.
-        Array::push(out, String::concat("line ", String::concat(Int::to_string(i + 1), String::concat(":col 1: ", note))))
-      } else {
-        ()
-      }
+    let trimmed = String::substring(line, unstable_first_nonspace(line), String::length(line))
+    if String::starts_with(trimmed, "import") && String::index_of(line, pkg) >= 0 {
+      return i + 1
     } else {
       ()
     }
     i = i + 1
   }
+  1
+}
+
+fn unstable_stmt_diagnostics(stmts: Array[Stmt], source: String, out: Array[String]) -> Unit {
+  let mut i = 0
+  while i < Array::length(stmts) {
+    match Array::get(stmts, i) {
+      SImport(path, _) => {
+        let note = unstable_package_note(path)
+        if note != "" {
+          Array::push(out, String::concat("line ", String::concat(Int::to_string(unstable_import_line(source, path)), String::concat(":col 1: ", note))))
+        } else {
+          ()
+        }
+      },
+      // An import nested in a `module` block is still this file's dependency.
+      SModule(_, _, body) => unstable_stmt_diagnostics(body, source, out),
+      _ => ()
+    }
+    i = i + 1
+  }
+}
+
+/// The gate itself, over ONE file's own bytes, read off the PARSED import
+/// statements rather than the line spelling.
+///
+/// The first version matched `String::starts_with(line, "import ")` and sliced
+/// a fixed 7 bytes, so `import\t@vibe/concurrent { .. }` was skipped entirely
+/// and `import  @vibe/concurrent { .. }` (two spaces) yielded an empty package
+/// name -- both valid source the lexer accepts, and both a silent bypass
+/// (#2277 review). An opt-in boundary that whitespace can cross is not one.
+///
+/// Only the ENTRY file is scanned: a transitive dependency's own imports are
+/// its author's choice, not this file's, and reporting them would be noise
+/// nobody here can act on. A source that does not parse yields nothing -- it
+/// cannot compile either, and the parse error is what the reader needs first.
+export fn unstable_surface_diagnostics(input_path: String, source: String) -> Array[String] with Exception {
+  let out = array_empty()
+  match checked_warning_stmts(input_path, source) {
+    Some(stmts) => unstable_stmt_diagnostics(stmts, source, out),
+    None => ()
+  }
   out
+}
+
+/// The BUILD lane's entry point: one file read, no import closure. It used to
+/// call `collect_source_groups_fs`, which parses every reachable file a second
+/// time purely to find the entry again -- measured as a 1.1% self-compile heap
+/// regression that took CI's selfcompile KPI over its +10% ceiling (#2277 CI).
+/// Only the entry is scanned, so only the entry needs reading.
+export fn check_unstable_surface_warnings_from_path(input_path: String) -> Array[String] with Exception + Fs {
+  handle {
+    unstable_surface_diagnostics(input_path, Fs::read_file(input_path))
+  } with {
+  // An unreadable entry is the compile's error to report, in its own words.
+  Exception::Throw(_) => array_empty() }
+}
+
+/// The CHECK lane's entry point: reuses the snapshot the linked check already
+/// collected, so it costs a lookup rather than a second traversal.
+export fn check_unstable_surface_warnings_from_source_groups(input_path: String, source_groups: Array[(String, Array[(String, String)])]) -> Array[String] with Exception + Fs {
+  let source = match checked_entry_source(input_path, source_groups) {
+    Some(snapshot) => snapshot,
+    None => return array_empty()
+  }
+  unstable_surface_diagnostics(input_path, source)
 }
 
 /// Redundant import warnings derived from the exact source snapshot consumed

--- a/lib/@vibe/compiler/cli_support.vibe
+++ b/lib/@vibe/compiler/cli_support.vibe
@@ -796,31 +796,42 @@ fn unstable_line_of_offset(source: String, off: Int) -> Int {
   line
 }
 
+/// One import's diagnostic, if the package it names is unstable.
+///
+/// Imports only. A re-export of a PACKAGE (`export @vibe/concurrent { .. }`)
+/// would depend on it the same way, but that syntax does not exist: the parser
+/// builds `SReExport` for `TDot`/`TDotDot` paths alone and answers a package
+/// path with "unexpected token in export" (measured). Adding an `SReExport` arm
+/// here would be a branch nothing can reach, which reads as coverage without
+/// being any. Gate 108 pins the boundary from the outside instead, so the day
+/// that syntax lands the gate fails rather than passing silently (#2277 review).
+fn unstable_decl_diagnostic(path: String, source: String, tokens: Array[Token], starts: Array[Int], out: Array[String]) -> Unit {
+  let note = unstable_package_note(path)
+  if note != "" {
+    let off = unstable_import_offset(tokens, starts, path)
+    let where_note = if off < 0 {
+      String::concat("this file inherits `", String::concat(path, "` from its directory's index.vpkg (it is not written here). "))
+    } else {
+      ""
+    }
+    let line = unstable_line_of_offset(source, off)
+    let col = unstable_col_of_offset(source, off)
+    // `line L:C:` -- the numeric prefix every other diagnostic in the
+    // tree uses, and the ONLY spelling `lsp_parse_diag_line` accepts. A
+    // readable `:col C:` was measured to make the JSON form fall back to
+    // column 1 (`lsp_parse_uint_or("col 3", 1)`), so the text and JSON
+    // answers disagreed about where to put the cursor (#2277 review).
+    Array::push(out, String::concat("line ", String::concat(Int::to_string(line), String::concat(":", String::concat(Int::to_string(col), String::concat(": ", String::concat(where_note, note)))))))
+  } else {
+    ()
+  }
+}
+
 fn unstable_stmt_diagnostics(stmts: Array[Stmt], source: String, tokens: Array[Token], starts: Array[Int], out: Array[String]) -> Unit {
   let mut i = 0
   while i < Array::length(stmts) {
     match Array::get(stmts, i) {
-      SImport(path, _) => {
-        let note = unstable_package_note(path)
-        if note != "" {
-          let off = unstable_import_offset(tokens, starts, path)
-          let where_note = if off < 0 {
-            String::concat("this file inherits `", String::concat(path, "` from its directory's index.vpkg (it is not written here). "))
-          } else {
-            ""
-          }
-          let line = unstable_line_of_offset(source, off)
-          let col = unstable_col_of_offset(source, off)
-          // `line L:C:` -- the numeric prefix every other diagnostic in the
-          // tree uses, and the ONLY spelling `lsp_parse_diag_line` accepts. A
-          // readable `:col C:` was measured to make the JSON form fall back to
-          // column 1 (`lsp_parse_uint_or("col 3", 1)`), so the text and JSON
-          // answers disagreed about where to put the cursor (#2277 review).
-          Array::push(out, String::concat("line ", String::concat(Int::to_string(line), String::concat(":", String::concat(Int::to_string(col), String::concat(": ", String::concat(where_note, note)))))))
-        } else {
-          ()
-        }
-      },
+      SImport(path, _) => unstable_decl_diagnostic(path, source, tokens, starts, out),
       // An import nested in a `module` block is still this file's dependency.
       SModule(_, _, body) => unstable_stmt_diagnostics(body, source, tokens, starts, out),
       _ => ()

--- a/lib/@vibe/compiler/cli_support.vibe
+++ b/lib/@vibe/compiler/cli_support.vibe
@@ -697,17 +697,42 @@ fn unstable_first_nonspace(line: String) -> Int {
   n
 }
 
-/// Which line the reader has to edit. DETECTION is structural (below); this is
-/// presentation only, so a miss costs a position and never a verdict -- hence
-/// the fallback to line 1 rather than a second parse.
+/// The character after the package path has to END the token -- end of line,
+/// whitespace, or `{` -- so `@vibe/concurrentx` is not read as
+/// `@vibe/concurrent`.
+fn unstable_path_token_ends(rest: String, n: Int) -> Bool {
+  if String::length(rest) == n {
+    true
+  } else {
+    let c = String::char_code_at(rest, n)
+    c == 32 || c == 9 || c == 123
+  }
+}
+
+/// Which line the reader has to edit. DETECTION is structural (the parsed
+/// `SImport` above); this is presentation only, so a miss costs a position and
+/// never a verdict -- hence the fallback to line 1 rather than a second parse.
+///
+/// The path is the token immediately after `import`, not any occurrence of the
+/// text on the line. `import @vibe/core { array_empty } // @vibe/concurrent` is
+/// a stable import that merely MENTIONS the package; naming it told the reader
+/// to delete a line that was not the problem, which is worse than giving no
+/// line at all (#2277 review).
 fn unstable_import_line(source: String, pkg: String) -> Int {
   let lines = String::split(source, "\n")
   let mut i = 0
   while i < Array::length(lines) {
     let line = Array::get(lines, i)
     let trimmed = String::substring(line, unstable_first_nonspace(line), String::length(line))
-    if String::starts_with(trimmed, "import") && String::index_of(line, pkg) >= 0 {
-      return i + 1
+    if String::starts_with(trimmed, "import") {
+      let after = String::substring(trimmed, 6, String::length(trimmed))
+      let path_start = unstable_first_nonspace(after)
+      let rest = String::substring(after, path_start, String::length(after))
+      if path_start > 0 && String::starts_with(rest, pkg) && unstable_path_token_ends(rest, String::length(pkg)) {
+        return i + 1
+      } else {
+        ()
+      }
     } else {
       ()
     }

--- a/lib/@vibe/compiler/cli_support.vibe
+++ b/lib/@vibe/compiler/cli_support.vibe
@@ -703,7 +703,7 @@ fn str_take_until_space(s: String) -> String {
 
 fn unstable_package_note(name: String) -> String {
   if name == "@vibe/concurrent" {
-    "`@vibe/concurrent` is UNSTABLE (ADR-0068, still proposed): it is outside the SemVer promise and can change within a Minor release -- see docs/spec/stable-surface.md section 6. Set VIBE_UNSTABLE=1 to silence this."
+    "set VIBE_UNSTABLE=1 to build against `@vibe/concurrent`, or drop the import. It is ADR-0068, still proposed: outside the SemVer promise and able to change within a Minor release, so it is opt-in rather than silent (docs/spec/stable-surface.md section 6). The `Async` effect itself is stable and needs no opt-in -- only this package's concurrency model does."
   } else {
     ""
   }
@@ -721,19 +721,25 @@ export fn check_unstable_surface_warnings_from_source_groups(input_path: String,
     let line = Array::get(lines, i)
     // Column 1, no trimming: an `import` is a top-level declaration and the
     // formatter puts it there, so a leading-whitespace form is not a thing
-    // this has to read. It also keeps the scan off `String::trim_start`,
-    // which docs/cheatsheet.md lists but the compiler's own surface does not
-    // have -- measured here, and worth its own issue.
+    // this has to read.
+    //
+    // It also needs no `String::trim_start`, which is a LIBRARY function
+    // rather than a builtin -- reaching it here would mean adding an
+    // `@vibe/builtin` import to this file. docs/cheatsheet.md says so
+    // explicitly ("These are not builtins ... calling one without its import
+    // is `unknown name`", the #2124 fix); the first version of this scan used
+    // it, read the resulting `unknown name` as the cheatsheet being wrong,
+    // and was wrong itself.
     if String::starts_with(line, "import ") {
       let pkg = str_take_until_space(String::substring(line, 7, String::length(line)))
       let note = unstable_package_note(pkg)
       if note != "" {
-        // `warning: line N:col 1: ...`, the spelling deprecated_scan uses.
-        // The launcher's check arm forwards ONLY lines matching `^warning: `
-        // (runtime/vibe), so a `path:line:col: warning:` form -- which is what
-        // `vibe diagnostics` emits -- is silently dropped here. Measured: the
-        // first version of this used that form and printed nothing.
-        Array::push(out, String::concat("warning: line ", String::concat(Int::to_string(i + 1), String::concat(":col 1: ", note))))
+        // `line N:col 1: ...`, the located-diagnostic spelling. This started
+        // as a `warning: ` line, which the launcher's check arm forwards to
+        // stderr; it is now an ERROR routed through emit_compile_diag, and
+        // that channel is the one both `vibe check` and `vibe build` already
+        // read, so the two verbs cannot disagree.
+        Array::push(out, String::concat("line ", String::concat(Int::to_string(i + 1), String::concat(":col 1: ", note))))
       } else {
         ()
       }

--- a/lib/@vibe/compiler/cli_support.vibe
+++ b/lib/@vibe/compiler/cli_support.vibe
@@ -788,11 +788,20 @@ export fn unstable_surface_diagnostics(input_path: String, source: String) -> Ar
 /// time purely to find the entry again -- measured as a 1.1% self-compile heap
 /// regression that took CI's selfcompile KPI over its +10% ceiling (#2277 CI).
 /// Only the entry is scanned, so only the entry needs reading.
+/// INGESTED, not raw. The build ingests before it parses, and ingestion blanks
+/// the package header -- so a pinned `require @scope/pkg x.y.z = #pkg:sha1:...`
+/// line reaches a raw scan with a `#` in it, the lexer refuses it ("unknown #
+/// directive"), the parse yields nothing, and the gate goes SILENT while the
+/// build compiles the unstable import anyway. Measured: the same file unpinned
+/// produced the diagnostic, pinned produced none. That is the two-verbs-
+/// disagree defect this gate exists to prevent, reintroduced by reading the
+/// file a different way than the build reads it (#2277 review).
 export fn check_unstable_surface_warnings_from_path(input_path: String) -> Array[String] with Exception + Fs {
   handle {
-    unstable_surface_diagnostics(input_path, Fs::read_file(input_path))
+    unstable_surface_diagnostics(input_path, ingest_source_text_fs(input_path, Fs::read_file(input_path)))
   } with {
-  // An unreadable entry is the compile's error to report, in its own words.
+  // An unreadable or uningestable entry is the compile's error to report, in
+  // its own words.
   Exception::Throw(_) => array_empty() }
 }
 

--- a/lib/@vibe/compiler/cli_support.vibe
+++ b/lib/@vibe/compiler/cli_support.vibe
@@ -600,6 +600,40 @@ fn owner_locating_source(path: String, source: String) -> Option[String] with Ex
   }
 }
 
+/// The entry's snapshot EXACTLY as the linked check consumed it -- ingested,
+/// markers and all, with no remap to the physical file. `checked_entry_source`
+/// does that remap so ordinary warnings cite lines a reader can visit; a
+/// VERDICT must not, or an inherited `.vpkg` import is invisible to it while
+/// the build rejects the same entry.
+///
+/// Unique-or-nothing, like `checked_entry_source`: describing text that was not
+/// the text checked is worse than saying nothing.
+fn checked_entry_snapshot(input_path: String, source_groups: Array[(String, Array[(String, String)])]) -> Option[String] {
+  let mut found: Option[String] = None
+  let mut count = 0
+  let mut gi = 0
+  while gi < Array::length(source_groups) {
+    let (_, sources) = Array::get(source_groups, gi)
+    let mut si = 0
+    while si < Array::length(sources) {
+      let (path, source) = Array::get(sources, si)
+      if path == input_path {
+        found = Some(source)
+        count = count + 1
+      } else {
+        ()
+      }
+      si = si + 1
+    }
+    gi = gi + 1
+  }
+  if count == 1 {
+    found
+  } else {
+    None
+  }
+}
+
 fn checked_entry_source(input_path: String, source_groups: Array[(String, Array[(String, String)])]) -> Option[String] with Exception + Fs {
   let mut found: Option[String] = None
   let mut count = 0
@@ -831,8 +865,20 @@ export fn check_unstable_surface_warnings_from_source_groups(input_path: String,
   // `@vibe/concurrent` would be invisible here and rejected by the build. The
   // verdict comes from the same ingestion the build uses; only the position
   // comes from the file's own bytes.
+  //
+  // And the snapshot, not a fresh read. Re-reading the entry evaluated text the
+  // check never saw: a save landing between the linked check and this call
+  // could remove the import and be reported clean, or add one the check never
+  // validated (#2277 review).
+  let detected = match checked_entry_snapshot(input_path, source_groups) {
+    Some(snapshot) => snapshot,
+    // No unique snapshot means nothing here was checked for this path. The
+    // build lane still gates it; inventing a verdict from disk would answer
+    // about text this check never consumed.
+    None => return array_empty()
+  }
   handle {
-    unstable_surface_diagnostics_located(input_path, ingest_source_text_fs(input_path, Fs::read_file(input_path)), Fs::read_file(input_path))
+    unstable_surface_diagnostics_located(input_path, detected, Fs::read_file(input_path))
   } with { Exception::Throw(_) => array_empty() }
 }
 

--- a/lib/@vibe/compiler/cli_support.vibe
+++ b/lib/@vibe/compiler/cli_support.vibe
@@ -722,7 +722,7 @@ fn unstable_line_of_offset(source: String, off: Int) -> Int {
   let mut line = 1
   let mut i = 0
   while i < off && i < n {
-    if String::char_code_at(source, i) == 10 {
+    if String::byte_at(source, i) == 10 {
       line = line + 1
     } else {
       ()

--- a/lib/@vibe/compiler/cli_support.vibe
+++ b/lib/@vibe/compiler/cli_support.vibe
@@ -811,7 +811,12 @@ fn unstable_stmt_diagnostics(stmts: Array[Stmt], source: String, tokens: Array[T
           }
           let line = unstable_line_of_offset(source, off)
           let col = unstable_col_of_offset(source, off)
-          Array::push(out, String::concat("line ", String::concat(Int::to_string(line), String::concat(":col ", String::concat(Int::to_string(col), String::concat(": ", String::concat(where_note, note)))))))
+          // `line L:C:` -- the numeric prefix every other diagnostic in the
+          // tree uses, and the ONLY spelling `lsp_parse_diag_line` accepts. A
+          // readable `:col C:` was measured to make the JSON form fall back to
+          // column 1 (`lsp_parse_uint_or("col 3", 1)`), so the text and JSON
+          // answers disagreed about where to put the cursor (#2277 review).
+          Array::push(out, String::concat("line ", String::concat(Int::to_string(line), String::concat(":", String::concat(Int::to_string(col), String::concat(": ", String::concat(where_note, note)))))))
         } else {
           ()
         }

--- a/lib/@vibe/compiler/cli_support.vibe
+++ b/lib/@vibe/compiler/cli_support.vibe
@@ -89,7 +89,7 @@ import @vibe/compiler/runtime {
 // is one-error-at-a-time; `vibe diagnostics` is the multi-diagnostic surface
 // — collect_all_diagnostics already uses this same recovering parser).
 import @vibe/compiler/syntax {
-  lex_with_offsets, parse_program_recovering
+  Token, lex_with_offsets, parse_program_recovering, token_to_string
 }
 
 //# Functions
@@ -682,79 +682,71 @@ fn unstable_package_note(name: String) -> String {
   }
 }
 
-/// Byte offset of the first character that is not a space or a tab.
-fn unstable_first_nonspace(line: String) -> Int {
-  let n = String::length(line)
-  let mut i = 0
-  while i < n {
-    let c = String::char_code_at(line, i)
-    if c == 32 || c == 9 {
-      i = i + 1
-    } else {
-      return i
-    }
-  }
-  n
-}
-
-/// The character after the package path has to END the token -- end of line,
-/// whitespace, or `{` -- so `@vibe/concurrentx` is not read as
-/// `@vibe/concurrent`.
-fn unstable_path_token_ends(rest: String, n: Int) -> Bool {
-  if String::length(rest) == n {
-    true
-  } else {
-    let c = String::char_code_at(rest, n)
-    c == 32 || c == 9 || c == 123
-  }
-}
-
-/// Which line the reader has to edit. DETECTION is structural (the parsed
-/// `SImport` above); this is presentation only, so a miss costs a position and
-/// never a verdict -- hence the fallback to line 1 rather than a second parse.
+/// Byte offset of the `import` keyword that introduces `pkg`, or -1.
 ///
-/// The path is the token immediately after `import`, not any occurrence of the
-/// text on the line. `import @vibe/core { array_empty } // @vibe/concurrent` is
-/// a stable import that merely MENTIONS the package; naming it told the reader
-/// to delete a line that was not the problem, which is worse than giving no
-/// line at all (#2277 review).
-fn unstable_import_line(source: String, pkg: String) -> Int {
-  let lines = String::split(source, "\n")
+/// TOKENS, not text. Three separate review findings came from trying to
+/// recover this position by reading the source as lines, and each fix only
+/// moved the hole (#2277 review):
+///
+///   - "a line starting with `import` that contains the package name" pointed
+///     at `import @vibe/core { .. } // @vibe/concurrent`, a stable import that
+///     merely mentions it in a comment;
+///   - requiring the path to be the token right after `import` ON THAT LINE
+///     then missed `import\n  @vibe/concurrent { .. }`, valid source whose
+///     path is on the next line, and fell back to line 1 -- an unrelated
+///     declaration.
+///
+/// The lexer already answers this exactly, and `token_to_string` reaches it
+/// through the contract without needing the opaque `Token`'s constructors. A
+/// string literal cannot masquerade either: it renders as `TString("...")`,
+/// never `TIdent(...)`.
+fn unstable_import_offset(tokens: Array[Token], starts: Array[Int], pkg: String) -> Int {
+  let want = String::concat("TIdent(", String::concat(pkg, ")"))
+  let n = Array::length(starts)
   let mut i = 0
-  while i < Array::length(lines) {
-    let line = Array::get(lines, i)
-    let trimmed = String::substring(line, unstable_first_nonspace(line), String::length(line))
-    if String::starts_with(trimmed, "import") {
-      let after = String::substring(trimmed, 6, String::length(trimmed))
-      let path_start = unstable_first_nonspace(after)
-      let rest = String::substring(after, path_start, String::length(after))
-      if path_start > 0 && String::starts_with(rest, pkg) && unstable_path_token_ends(rest, String::length(pkg)) {
-        return i + 1
-      } else {
-        ()
-      }
+  while i + 1 < n {
+    if token_to_string(Array::get(tokens, i)) == "TImport" && token_to_string(Array::get(tokens, i + 1)) == want {
+      return Array::get(starts, i)
     } else {
       ()
     }
     i = i + 1
   }
-  1
+  0 - 1
 }
 
-fn unstable_stmt_diagnostics(stmts: Array[Stmt], source: String, out: Array[String]) -> Unit {
+/// 1-based line of a byte offset. Offset -1 (the token scan found nothing)
+/// falls back to line 1: a miss costs a position, never a verdict.
+fn unstable_line_of_offset(source: String, off: Int) -> Int {
+  let n = String::length(source)
+  let mut line = 1
+  let mut i = 0
+  while i < off && i < n {
+    if String::char_code_at(source, i) == 10 {
+      line = line + 1
+    } else {
+      ()
+    }
+    i = i + 1
+  }
+  line
+}
+
+fn unstable_stmt_diagnostics(stmts: Array[Stmt], source: String, tokens: Array[Token], starts: Array[Int], out: Array[String]) -> Unit {
   let mut i = 0
   while i < Array::length(stmts) {
     match Array::get(stmts, i) {
       SImport(path, _) => {
         let note = unstable_package_note(path)
         if note != "" {
-          Array::push(out, String::concat("line ", String::concat(Int::to_string(unstable_import_line(source, path)), String::concat(":col 1: ", note))))
+          let line = unstable_line_of_offset(source, unstable_import_offset(tokens, starts, path))
+          Array::push(out, String::concat("line ", String::concat(Int::to_string(line), String::concat(":col 1: ", note))))
         } else {
           ()
         }
       },
       // An import nested in a `module` block is still this file's dependency.
-      SModule(_, _, body) => unstable_stmt_diagnostics(body, source, out),
+      SModule(_, _, body) => unstable_stmt_diagnostics(body, source, tokens, starts, out),
       _ => ()
     }
     i = i + 1
@@ -776,8 +768,9 @@ fn unstable_stmt_diagnostics(stmts: Array[Stmt], source: String, out: Array[Stri
 /// cannot compile either, and the parse error is what the reader needs first.
 export fn unstable_surface_diagnostics(input_path: String, source: String) -> Array[String] with Exception {
   let out = array_empty()
+  let (tokens, starts, _ends) = lex_with_offsets(source)
   match checked_warning_stmts(input_path, source) {
-    Some(stmts) => unstable_stmt_diagnostics(stmts, source, out),
+    Some(stmts) => unstable_stmt_diagnostics(stmts, source, tokens, starts, out),
     None => ()
   }
   out

--- a/lib/@vibe/compiler/cli_support.vibe
+++ b/lib/@vibe/compiler/cli_support.vibe
@@ -751,6 +751,36 @@ fn unstable_import_offset(tokens: Array[Token], starts: Array[Int], pkg: String)
 
 /// 1-based line of a byte offset. Offset -1 (the token scan found nothing)
 /// falls back to line 1: a miss costs a position, never a verdict.
+/// 1-based BYTE column of an offset (ADR-0108: columns are bytes). An
+/// indented import -- inside an `SModule` block, say -- starts past the line
+/// start, and reporting a hardcoded column 1 pointed the text form, and every
+/// editor consuming the JSON/LSP form, at the indentation instead of the
+/// `import` token (#2277 review). Offset -1 (nothing found) is column 1, which
+/// pairs with the line-1 fallback.
+fn unstable_col_of_offset(source: String, off: Int) -> Int {
+  if off < 0 {
+    1
+  } else {
+    let n = String::length(source)
+    let limit = if off < n {
+      off
+    } else {
+      n
+    }
+    let mut start = 0
+    let mut i = 0
+    while i < limit {
+      if String::byte_at(source, i) == 10 {
+        start = i + 1
+      } else {
+        ()
+      }
+      i = i + 1
+    }
+    limit - start + 1
+  }
+}
+
 fn unstable_line_of_offset(source: String, off: Int) -> Int {
   let n = String::length(source)
   let mut line = 1
@@ -780,7 +810,8 @@ fn unstable_stmt_diagnostics(stmts: Array[Stmt], source: String, tokens: Array[T
             ""
           }
           let line = unstable_line_of_offset(source, off)
-          Array::push(out, String::concat("line ", String::concat(Int::to_string(line), String::concat(":col 1: ", String::concat(where_note, note)))))
+          let col = unstable_col_of_offset(source, off)
+          Array::push(out, String::concat("line ", String::concat(Int::to_string(line), String::concat(":col ", String::concat(Int::to_string(col), String::concat(": ", String::concat(where_note, note)))))))
         } else {
           ()
         }

--- a/lib/@vibe/compiler/cli_support.vibe
+++ b/lib/@vibe/compiler/cli_support.vibe
@@ -734,12 +734,24 @@ fn unstable_package_note(name: String) -> String {
 /// through the contract without needing the opaque `Token`'s constructors. A
 /// string literal cannot masquerade either: it renders as `TString("...")`,
 /// never `TIdent(...)`.
-fn unstable_import_offset(tokens: Array[Token], starts: Array[Int], pkg: String) -> Int {
+/// `cursor` holds the token index to resume from, and is advanced past each
+/// match. Without it every `SImport` for the same package rescanned from zero
+/// and got the FIRST declaration's offset, so a file importing
+/// `@vibe/concurrent` twice with disjoint item lists reported both diagnostics
+/// at the first import's coordinates -- and the second one names a line whose
+/// text the reader would find nothing wrong with (#2277 review).
+///
+/// A single monotonic cursor is enough even across different package paths:
+/// statements are visited in source order, and each declaration's tokens
+/// appear in that same order, so nothing a later statement needs sits behind
+/// the cursor.
+fn unstable_import_offset(tokens: Array[Token], starts: Array[Int], pkg: String, cursor: Array[Int]) -> Int {
   let want = String::concat("TIdent(", String::concat(pkg, ")"))
   let n = Array::length(starts)
-  let mut i = 0
+  let mut i = Array::get(cursor, 0)
   while i + 1 < n {
     if token_to_string(Array::get(tokens, i)) == "TImport" && token_to_string(Array::get(tokens, i + 1)) == want {
+      Array::set(cursor, 0, i + 1)
       return Array::get(starts, i)
     } else {
       ()
@@ -805,10 +817,10 @@ fn unstable_line_of_offset(source: String, off: Int) -> Int {
 /// here would be a branch nothing can reach, which reads as coverage without
 /// being any. Gate 108 pins the boundary from the outside instead, so the day
 /// that syntax lands the gate fails rather than passing silently (#2277 review).
-fn unstable_decl_diagnostic(path: String, source: String, tokens: Array[Token], starts: Array[Int], out: Array[String]) -> Unit {
+fn unstable_decl_diagnostic(path: String, source: String, tokens: Array[Token], starts: Array[Int], out: Array[String], cursor: Array[Int]) -> Unit {
   let note = unstable_package_note(path)
   if note != "" {
-    let off = unstable_import_offset(tokens, starts, path)
+    let off = unstable_import_offset(tokens, starts, path, cursor)
     let where_note = if off < 0 {
       String::concat("this file inherits `", String::concat(path, "` from its directory's index.vpkg (it is not written here). "))
     } else {
@@ -827,13 +839,13 @@ fn unstable_decl_diagnostic(path: String, source: String, tokens: Array[Token], 
   }
 }
 
-fn unstable_stmt_diagnostics(stmts: Array[Stmt], source: String, tokens: Array[Token], starts: Array[Int], out: Array[String]) -> Unit {
+fn unstable_stmt_diagnostics(stmts: Array[Stmt], source: String, tokens: Array[Token], starts: Array[Int], out: Array[String], cursor: Array[Int]) -> Unit {
   let mut i = 0
   while i < Array::length(stmts) {
     match Array::get(stmts, i) {
-      SImport(path, _) => unstable_decl_diagnostic(path, source, tokens, starts, out),
+      SImport(path, _) => unstable_decl_diagnostic(path, source, tokens, starts, out, cursor),
       // An import nested in a `module` block is still this file's dependency.
-      SModule(_, _, body) => unstable_stmt_diagnostics(body, source, tokens, starts, out),
+      SModule(_, _, body) => unstable_stmt_diagnostics(body, source, tokens, starts, out, cursor),
       _ => ()
     }
     i = i + 1
@@ -875,7 +887,9 @@ export fn unstable_surface_diagnostics_located(input_path: String, detected: Str
   let out = array_empty()
   let (tokens, starts, _ends) = lex_with_offsets(located)
   match checked_warning_stmts(input_path, detected) {
-    Some(stmts) => unstable_stmt_diagnostics(stmts, located, tokens, starts, out),
+    Some(stmts) => unstable_stmt_diagnostics(stmts, located, tokens, starts, out, [
+      0
+    ]),
     None => ()
   }
   out

--- a/lib/@vibe/compiler/codegen/expr/compile_call.vibe
+++ b/lib/@vibe/compiler/codegen/expr/compile_call.vibe
@@ -3012,17 +3012,25 @@ fn compile_call_core(buf: Bytes, callee: Expr, args: Array[Expr], local_names: A
       // write into a region that no longer exists.
       throw("internal: `resume` reached codegen -- its handle was neither migrated (evidence dict) nor CPS-transformed (suspend class), and the replay engine was removed (ADR-0076 追記34 V2)")
     }
-    else if fname == "assert" {
-      // #1095: no `!prefer_bound_call` guard here (assert_true / assert_eq
-      // below never had one). Inside a lambda, capture analysis lists the
+    else if fname == "assert" && fn_idx_in_list < 0 {
+      // #1095: `prefer_bound_call` is the WRONG guard here (assert_true /
+      // assert_eq below had none either). Inside a lambda, capture analysis
+      // lists the
       // free name `assert` as a capture; the creation site cannot resolve it
       // and stores 0, so the "bound call" dispatched call_indirect through a
       // ZERO closure — table slot 0, i.e. an arbitrary user function. Before
       // #1107 Phase 4 that slot always happened to be populated, silently
       // NO-OPing every assert in a closure (concurrent_test's asserts never
       // actually asserted); with the minimized funcref table it surfaced as
-      // "null function" traps. Builtin statement asserts cannot be shadowed
-      // meaningfully, so always compile the builtin form.
+      // "null function" traps.
+      //
+      // #2283: the half of `prefer_bound_call` that was wrong is
+      // `local_idx_hint` -- the capture artifact. A name in the FUNCTION TABLE
+      // is a real top-level definition the reader wrote, and it must win, so
+      // these three arms test `fn_idx_in_list` alone. Without that the checker
+      // typed the call against the user's function while codegen emitted the
+      // builtin assert: `fn assert_eq(a: Int, b: Int) -> String` compiled clean
+      // and then trapped, with no diagnostic anywhere naming the conflict.
       let nl = ce(buf, Array::get(args, 0), local_names, next_local, ctx, ld)
       emit_i32_wrap_i64(buf)
       emit_if_void(buf)
@@ -3032,7 +3040,7 @@ fn compile_call_core(buf: Bytes, callee: Expr, args: Array[Expr], local_names: A
       emit_i64_const(buf, 0)
       nl
     }
-    else if fname == "assert_true" {
+    else if fname == "assert_true" && fn_idx_in_list < 0 {
       let nl = ce(buf, Array::get(args, 0), local_names, next_local, ctx, ld)
       emit_i32_wrap_i64(buf)
       emit_if_void(buf)
@@ -3042,7 +3050,7 @@ fn compile_call_core(buf: Bytes, callee: Expr, args: Array[Expr], local_names: A
       emit_i64_const(buf, 0)
       nl
     }
-    else if fname == "assert_eq" {
+    else if fname == "assert_eq" && fn_idx_in_list < 0 {
       // Fallback only. The shipped path rewrites `assert_eq` in
       // desugar_trait_dicts (expected/actual on stderr, then trap). This
       // arm stays for lanes that skip that pass (compile_module): still

--- a/lib/@vibe/compiler/codegen/gc/backend_call.vibe
+++ b/lib/@vibe/compiler/codegen/gc/backend_call.vibe
@@ -3023,12 +3023,18 @@ fn compile_call_gc(buf: Bytes, callee: Expr, args: Array[Expr], local_names: Arr
         emit_i64_const(buf, 0)
         nl
       }
-      else if (fname == "assert" || fname == "assert_true") && func_table_index_of(ctx.func_table, fname) < 0 {
+      else if fname == "assert" || fname == "assert_true" {
         // Trap (unreachable) on a false condition, like the linear backend.
-        // #2283: and, like the linear backend, stand down when the program
-        // defines a function of that name. The test is the FUNCTION TABLE, not
-        // `source_is_bound` -- a local of the same name is the #1095 capture
-        // artifact, which is what these arms deliberately ignore.
+        //
+        // #2283: NO shadowing guard here, unlike the linear arms. This lane
+        // already refuses the shadow one step earlier -- these three spellings
+        // are direct-ABI names (backend_direct_abi_names.vibe) and
+        // `backend_body.vibe` rejects a user declaration of any of them, which
+        // is a diagnostic rather than the silent substitution #2283 is about.
+        // Adding a `func_table_index_of` guard here was measured to break
+        // fixtures/gc_backend_smoke_test.vibe outright ("expected 1 elements on
+        // the stack for fallthru, found 3"): on this lane the direct-ABI names
+        // are IN the func table, so the guard fired for every ordinary call.
         let nl = ce(buf, Array::get(args, 0), local_names, next_local, ld)
         emit_i64_eqz(buf)
         emit_if_void(buf)
@@ -3037,7 +3043,7 @@ fn compile_call_gc(buf: Bytes, callee: Expr, args: Array[Expr], local_names: Arr
         emit_i64_const(buf, 0)
         nl
       }
-      else if fname == "assert_eq" && func_table_index_of(ctx.func_table, fname) < 0 {
+      else if fname == "assert_eq" {
         // Fallback only. The shipped path rewrites `assert_eq` in
         // desugar_trait_dicts. Keep parity with the linear fallback:
         // synthesized `==` uses the backend's value-aware equality path.

--- a/lib/@vibe/compiler/codegen/gc/backend_call.vibe
+++ b/lib/@vibe/compiler/codegen/gc/backend_call.vibe
@@ -3023,8 +3023,12 @@ fn compile_call_gc(buf: Bytes, callee: Expr, args: Array[Expr], local_names: Arr
         emit_i64_const(buf, 0)
         nl
       }
-      else if fname == "assert" || fname == "assert_true" {
+      else if (fname == "assert" || fname == "assert_true") && func_table_index_of(ctx.func_table, fname) < 0 {
         // Trap (unreachable) on a false condition, like the linear backend.
+        // #2283: and, like the linear backend, stand down when the program
+        // defines a function of that name. The test is the FUNCTION TABLE, not
+        // `source_is_bound` -- a local of the same name is the #1095 capture
+        // artifact, which is what these arms deliberately ignore.
         let nl = ce(buf, Array::get(args, 0), local_names, next_local, ld)
         emit_i64_eqz(buf)
         emit_if_void(buf)
@@ -3033,7 +3037,7 @@ fn compile_call_gc(buf: Bytes, callee: Expr, args: Array[Expr], local_names: Arr
         emit_i64_const(buf, 0)
         nl
       }
-      else if fname == "assert_eq" {
+      else if fname == "assert_eq" && func_table_index_of(ctx.func_table, fname) < 0 {
         // Fallback only. The shipped path rewrites `assert_eq` in
         // desugar_trait_dicts. Keep parity with the linear fallback:
         // synthesized `==` uses the backend's value-aware equality path.

--- a/lib/@vibe/compiler/compiler_sources_manifest.tsv
+++ b/lib/@vibe/compiler/compiler_sources_manifest.tsv
@@ -23,6 +23,7 @@ core	core/ast.vibe
 core	core/types.vibe
 core	core/dce.vibe
 core	core/expr_children.vibe
+core	core/assert_stamp.vibe
 core	core/exception_effect.vibe
 core	core/builtin_name.vibe
 core	core/standard_effect_policy.vibe

--- a/lib/@vibe/compiler/contract/contract.vibe
+++ b/lib/@vibe/compiler/contract/contract.vibe
@@ -835,7 +835,17 @@ export fn contract_declared_foreign_names(opaques: Array[(String, Int)], stmts: 
       SImport(raw_path, items) => if contract_is_provenance_import(raw_path, items) {
         let mut j = 0
         while j < Array::length(items) {
-          Array::push(out, Array::get(items, j).name)
+          let item = Array::get(items, j)
+          // The LOCAL binding, which is the alias when there is one: a
+          // transparent type referring to `Env` after
+          // `import @pkg { TypeEnv as Env }` mentions `Env`, so recording
+          // `TypeEnv` would leave the name the contract actually uses
+          // undeclared -- reported as unknown in the generated types module
+          // (#2277 review).
+          match item.alias {
+            Some(local) => Array::push(out, local),
+            None => Array::push(out, item.name)
+          }
           j = j + 1
         }
       } else {

--- a/lib/@vibe/compiler/contract/contract.vibe
+++ b/lib/@vibe/compiler/contract/contract.vibe
@@ -800,6 +800,54 @@ export fn check_contract(decls: Array[(String, String)], opaque_names: Array[(St
   errors
 }
 
+/// A contract import that states WHERE a foreign type name comes from, as
+/// opposed to the implementation-file wiring `import ./impl.vibe {}`. Package
+/// rooted (`@scope/pkg`) and naming at least one item.
+export fn contract_is_provenance_import(raw_path: String, items: Array[ImportItem]) -> Bool {
+  String::starts_with(raw_path, "@") && Array::length(items) > 0
+}
+
+/// The type names a contract declares WITHOUT defining -- everything it may
+/// legitimately mention in a transparent struct/enum that its own types module
+/// cannot resolve (#2164). Two spellings, because they state two different
+/// facts:
+///
+///   - `import @scope/pkg { TypeEnv }` -- ANOTHER package owns the name. The
+///     contract says which, so the reference is traceable.
+///   - `opaque type MutSet` -- a sibling implementation of THIS package owns
+///     it. There is deliberately no import: the materialized types module
+///     importing its own package's impl is the `types -> impl` cycle the
+///     module exists to avoid, so existence is all a contract can state here.
+///
+/// Anything a contract references and does NOT declare this way is a typo, and
+/// stops being exempted from checking -- which is the whole point of the pair.
+export fn contract_declared_foreign_names(opaques: Array[(String, Int)], stmts: Array[Stmt]) -> Array[String] {
+  let out = array_empty()
+  let mut oi = 0
+  while oi < Array::length(opaques) {
+    let (oname, _) = Array::get(opaques, oi)
+    Array::push(out, oname)
+    oi = oi + 1
+  }
+  let mut i = 0
+  while i < Array::length(stmts) {
+    match Array::get(stmts, i) {
+      SImport(raw_path, items) => if contract_is_provenance_import(raw_path, items) {
+        let mut j = 0
+        while j < Array::length(items) {
+          Array::push(out, Array::get(items, j).name)
+          j = j + 1
+        }
+      } else {
+        ()
+      },
+      _ => ()
+    }
+    i = i + 1
+  }
+  out
+}
+
 /// Classify a contract's non-declaration statements: implementation-file
 /// imports (`import ./impl.vibe {}`) and transparent type definitions
 /// (struct / enum / type alias — the definition IS the contract, so it lives
@@ -811,7 +859,16 @@ export fn classify_contract_stmts(stmts: Array[Stmt]) -> (Array[String], Array[S
   let mut i = 0
   while i < Array::length(stmts) {
     match Array::get(stmts, i) {
-      SImport(raw_path, _) => Array::push(raws, raw_path),
+      // A `@scope/pkg { Name }` import is PROVENANCE for a foreign type name
+      // (#2164), not implementation-file wiring. Only a relative path names an
+      // implementation of this package, so package-rooted imports stay out of
+      // `raws` -- treating one as an impl file would try to load another
+      // package as this contract's implementation.
+      SImport(raw_path, items) => if contract_is_provenance_import(raw_path, items) {
+        ()
+      } else {
+        Array::push(raws, raw_path)
+      },
       SStruct(_, name, fields, derives, mut_names, tparams) => Array::push(type_defs, SStruct(true, name, fields, derives, mut_names, tparams)),
       SEnum(_, name, tparams, ctors, derives) => Array::push(type_defs, SEnum(true, name, tparams, ctors, derives)),
       STypeAlias(_, name, tparams, ty) => Array::push(type_defs, STypeAlias(true, name, tparams, ty)),
@@ -898,7 +955,7 @@ export let vpkg_types_module_marker: String = "// vibe: vpkg contract types modu
 /// #2162: a module-wide `declared` let `struct Box[Counter]`'s binder hide
 /// `struct Holder`'s reference to the contract-`opaque` `Counter`, dropping
 /// it from the sentinel and rejecting a valid contract).
-fn ctm_deferred_type_names(tds: Array[Stmt]) -> (Array[String], Array[String]) {
+fn ctm_deferred_type_names(tds: Array[Stmt], declared_foreign: Array[String]) -> (Array[String], Array[String]) {
   let declared = array_empty()
   let referenced = array_empty()
   let mut i = 0
@@ -980,10 +1037,20 @@ fn ctm_deferred_type_names(tds: Array[Stmt]) -> (Array[String], Array[String]) {
       Some(_) => true,
       None => n == "Array" || n == "Option"
     }
+    // #2164: only a name the contract DECLARED as foreign is exempted -- an
+    // `import @scope/pkg { N }` or an `opaque type N`. Before this, every
+    // referenced-but-undeclared head was deferred, which is why a typo inside
+    // a contract's transparent type kept its pre-enforcement wildcard
+    // behavior: it was textually indistinguishable from a legitimate foreign
+    // reference, because the contract had no way to say which it was. It has
+    // one now, so an undeclared name falls out of the sentinel and the checker
+    // reports it like every other position.
     if is_builtin || ctm_str_list_has(declared, n) || ctm_str_list_has(out, n) {
       ()
-    } else {
+    } else if ctm_str_list_has(declared_foreign, n) {
       Array::push(out, n)
+    } else {
+      ()
     }
     ri = ri + 1
   }
@@ -1050,10 +1117,10 @@ export let vpkg_deferred_type_names_prefix: String = "__vpkg_deferred_type_names
 /// names at field/payload positions without any process-lifetime registry.
 /// `uniq` keeps the binding name collision-free when several contracts'
 /// modules meet in one merge.
-export fn contract_types_module_text(tds: Array[Stmt], uniq: String) -> String {
+export fn contract_types_module_text(tds: Array[Stmt], uniq: String, declared_foreign: Array[String]) -> String {
   let lines = array_empty()
   Array::push(lines, vpkg_types_module_marker)
-  let (decl_names, deferred) = ctm_deferred_type_names(tds)
+  let (decl_names, deferred) = ctm_deferred_type_names(tds, declared_foreign)
   if Array::length(deferred) == 0 {
     ()
   } else {

--- a/lib/@vibe/compiler/contract/contract.vibe
+++ b/lib/@vibe/compiler/contract/contract.vibe
@@ -1,7 +1,7 @@
 //# Imports
 
 import @vibe/compiler/core {
-  Expr, ImportItem, Stmt, TypeExpr, lookup_registry_builtin, resolve_builtin
+  Expr, ImportItem, Stmt, TypeExpr, is_wellknown_nominal_head, lookup_registry_builtin, resolve_builtin
 }
 
 import @vibe/compiler/syntax {
@@ -965,7 +965,18 @@ fn ctm_deferred_type_names(tds: Array[Stmt]) -> (Array[String], Array[String]) {
   let mut ri = 0
   while ri < Array::length(referenced) {
     let n = Array::get(referenced, ri)
-    let is_builtin = match resolve_builtin(n) {
+    // `resolve_builtin` answers for builtin VALUES, so alone this test was
+    // narrower than the language: every compiler-owned TYPE head with no value
+    // behind it -- `Map`, `MutMap`, `Future`, `TaskGroup`, ... -- fell through
+    // and got deferred, which exempted that contract's whole transparent type
+    // set from checking. Five contract types were exempt this way
+    // (`HttpRequest`, `HttpResponse`, `Request`, `Response`, `Handler`),
+    // reachable with no typo at all (#2164).
+    //
+    // `is_wellknown_nominal_head` is the checker's OWN list, moved into core so
+    // both ask one question. A second hand-maintained list here is what
+    // produced the hole.
+    let is_builtin = is_wellknown_nominal_head(n) || match resolve_builtin(n) {
       Some(_) => true,
       None => n == "Array" || n == "Option"
     }

--- a/lib/@vibe/compiler/contract/contract.vibe
+++ b/lib/@vibe/compiler/contract/contract.vibe
@@ -800,64 +800,6 @@ export fn check_contract(decls: Array[(String, String)], opaque_names: Array[(St
   errors
 }
 
-/// A contract import that states WHERE a foreign type name comes from, as
-/// opposed to the implementation-file wiring `import ./impl.vibe {}`. Package
-/// rooted (`@scope/pkg`) and naming at least one item.
-export fn contract_is_provenance_import(raw_path: String, items: Array[ImportItem]) -> Bool {
-  String::starts_with(raw_path, "@") && Array::length(items) > 0
-}
-
-/// The type names a contract declares WITHOUT defining -- everything it may
-/// legitimately mention in a transparent struct/enum that its own types module
-/// cannot resolve (#2164). Two spellings, because they state two different
-/// facts:
-///
-///   - `import @scope/pkg { TypeEnv }` -- ANOTHER package owns the name. The
-///     contract says which, so the reference is traceable.
-///   - `opaque type MutSet` -- a sibling implementation of THIS package owns
-///     it. There is deliberately no import: the materialized types module
-///     importing its own package's impl is the `types -> impl` cycle the
-///     module exists to avoid, so existence is all a contract can state here.
-///
-/// Anything a contract references and does NOT declare this way is a typo, and
-/// stops being exempted from checking -- which is the whole point of the pair.
-export fn contract_declared_foreign_names(opaques: Array[(String, Int)], stmts: Array[Stmt]) -> Array[String] {
-  let out = array_empty()
-  let mut oi = 0
-  while oi < Array::length(opaques) {
-    let (oname, _) = Array::get(opaques, oi)
-    Array::push(out, oname)
-    oi = oi + 1
-  }
-  let mut i = 0
-  while i < Array::length(stmts) {
-    match Array::get(stmts, i) {
-      SImport(raw_path, items) => if contract_is_provenance_import(raw_path, items) {
-        let mut j = 0
-        while j < Array::length(items) {
-          let item = Array::get(items, j)
-          // The LOCAL binding, which is the alias when there is one: a
-          // transparent type referring to `Env` after
-          // `import @pkg { TypeEnv as Env }` mentions `Env`, so recording
-          // `TypeEnv` would leave the name the contract actually uses
-          // undeclared -- reported as unknown in the generated types module
-          // (#2277 review).
-          match item.alias {
-            Some(local) => Array::push(out, local),
-            None => Array::push(out, item.name)
-          }
-          j = j + 1
-        }
-      } else {
-        ()
-      },
-      _ => ()
-    }
-    i = i + 1
-  }
-  out
-}
-
 /// Classify a contract's non-declaration statements: implementation-file
 /// imports (`import ./impl.vibe {}`) and transparent type definitions
 /// (struct / enum / type alias — the definition IS the contract, so it lives
@@ -869,16 +811,7 @@ export fn classify_contract_stmts(stmts: Array[Stmt]) -> (Array[String], Array[S
   let mut i = 0
   while i < Array::length(stmts) {
     match Array::get(stmts, i) {
-      // A `@scope/pkg { Name }` import is PROVENANCE for a foreign type name
-      // (#2164), not implementation-file wiring. Only a relative path names an
-      // implementation of this package, so package-rooted imports stay out of
-      // `raws` -- treating one as an impl file would try to load another
-      // package as this contract's implementation.
-      SImport(raw_path, items) => if contract_is_provenance_import(raw_path, items) {
-        ()
-      } else {
-        Array::push(raws, raw_path)
-      },
+      SImport(raw_path, _) => Array::push(raws, raw_path),
       SStruct(_, name, fields, derives, mut_names, tparams) => Array::push(type_defs, SStruct(true, name, fields, derives, mut_names, tparams)),
       SEnum(_, name, tparams, ctors, derives) => Array::push(type_defs, SEnum(true, name, tparams, ctors, derives)),
       STypeAlias(_, name, tparams, ty) => Array::push(type_defs, STypeAlias(true, name, tparams, ty)),
@@ -965,7 +898,7 @@ export let vpkg_types_module_marker: String = "// vibe: vpkg contract types modu
 /// #2162: a module-wide `declared` let `struct Box[Counter]`'s binder hide
 /// `struct Holder`'s reference to the contract-`opaque` `Counter`, dropping
 /// it from the sentinel and rejecting a valid contract).
-fn ctm_deferred_type_names(tds: Array[Stmt], declared_foreign: Array[String]) -> (Array[String], Array[String]) {
+fn ctm_deferred_type_names(tds: Array[Stmt]) -> (Array[String], Array[String]) {
   let declared = array_empty()
   let referenced = array_empty()
   let mut i = 0
@@ -1047,20 +980,10 @@ fn ctm_deferred_type_names(tds: Array[Stmt], declared_foreign: Array[String]) ->
       Some(_) => true,
       None => n == "Array" || n == "Option"
     }
-    // #2164: only a name the contract DECLARED as foreign is exempted -- an
-    // `import @scope/pkg { N }` or an `opaque type N`. Before this, every
-    // referenced-but-undeclared head was deferred, which is why a typo inside
-    // a contract's transparent type kept its pre-enforcement wildcard
-    // behavior: it was textually indistinguishable from a legitimate foreign
-    // reference, because the contract had no way to say which it was. It has
-    // one now, so an undeclared name falls out of the sentinel and the checker
-    // reports it like every other position.
     if is_builtin || ctm_str_list_has(declared, n) || ctm_str_list_has(out, n) {
       ()
-    } else if ctm_str_list_has(declared_foreign, n) {
-      Array::push(out, n)
     } else {
-      ()
+      Array::push(out, n)
     }
     ri = ri + 1
   }
@@ -1127,10 +1050,10 @@ export let vpkg_deferred_type_names_prefix: String = "__vpkg_deferred_type_names
 /// names at field/payload positions without any process-lifetime registry.
 /// `uniq` keeps the binding name collision-free when several contracts'
 /// modules meet in one merge.
-export fn contract_types_module_text(tds: Array[Stmt], uniq: String, declared_foreign: Array[String]) -> String {
+export fn contract_types_module_text(tds: Array[Stmt], uniq: String) -> String {
   let lines = array_empty()
   Array::push(lines, vpkg_types_module_marker)
-  let (decl_names, deferred) = ctm_deferred_type_names(tds, declared_foreign)
+  let (decl_names, deferred) = ctm_deferred_type_names(tds)
   if Array::length(deferred) == 0 {
     ()
   } else {

--- a/lib/@vibe/compiler/contract/index.vpkg
+++ b/lib/@vibe/compiler/contract/index.vpkg
@@ -55,9 +55,7 @@ fn contract_facade_source(decls: Array[(String, String)], opaque_names: Array[(S
 
 // --- materialized types module (#1840)
 fn contract_type_family_defs(type_defs: Array[Stmt]) -> Array[Stmt]
-fn contract_declared_foreign_names(opaques: Array[(String, Int)], stmts: Array[Stmt]) -> Array[String]
-fn contract_is_provenance_import(raw_path: String, items: Array[ImportItem]) -> Bool
-fn contract_types_module_text(tds: Array[Stmt], uniq: String, declared_foreign: Array[String]) -> String
+fn contract_types_module_text(tds: Array[Stmt], uniq: String) -> String
 let vpkg_deferred_type_names_prefix: String
 fn contract_types_item_names(tds: Array[Stmt]) -> Array[String]
 fn contract_types_module_line(keyword: String, types_path: String, tds: Array[Stmt]) -> String

--- a/lib/@vibe/compiler/contract/index.vpkg
+++ b/lib/@vibe/compiler/contract/index.vpkg
@@ -55,7 +55,9 @@ fn contract_facade_source(decls: Array[(String, String)], opaque_names: Array[(S
 
 // --- materialized types module (#1840)
 fn contract_type_family_defs(type_defs: Array[Stmt]) -> Array[Stmt]
-fn contract_types_module_text(tds: Array[Stmt], uniq: String) -> String
+fn contract_declared_foreign_names(opaques: Array[(String, Int)], stmts: Array[Stmt]) -> Array[String]
+fn contract_is_provenance_import(raw_path: String, items: Array[ImportItem]) -> Bool
+fn contract_types_module_text(tds: Array[Stmt], uniq: String, declared_foreign: Array[String]) -> String
 let vpkg_deferred_type_names_prefix: String
 fn contract_types_item_names(tds: Array[Stmt]) -> Array[String]
 fn contract_types_module_line(keyword: String, types_path: String, tds: Array[Stmt]) -> String

--- a/lib/@vibe/compiler/core/assert_stamp.vibe
+++ b/lib/@vibe/compiler/core/assert_stamp.vibe
@@ -1,0 +1,133 @@
+//# `assert_eq` source locations (#2202)
+//
+// An `assert_eq` failure named the test and both operands but not the line, so
+// a test with several asserts sharing an expected value could not say which one
+// fired. The reason is structural: the compile lanes MERGE every module into one
+// program, and an offset is a PER-MODULE space -- a merged program cannot say
+// which module one of its offsets belongs to. `cli_support.vibe` documents that
+// hazard, and #1445 settles that a plausible-but-wrong position is worse than
+// none.
+//
+// So the location is taken while the module's OWN source is still in hand, in
+// the merge, and attached to the call as a third argument -- `assert_eq(a, b,
+// "path:line")` -- so it travels with the node. A side table keyed by statement
+// index would not survive: `desugar_trait_dicts` hoists lambdas and inlines
+// wrappers into new top-level definitions before the assert lowering runs, so
+// indices shift under it.
+//
+// Degradation is always toward NO line, never a wrong one: a statement parsed
+// without offsets carries -1 and is left alone, and the walk descends only the
+// expression forms that CARRY statements, so an `assert_eq` buried in (say) a
+// tuple loses its line rather than borrowing someone else's.
+
+import @vibe/core {
+  array_empty
+}
+
+import ./ast.vibe {
+  Expr, Pat, Stmt
+}
+
+/// `path:line`, 1-based, counted in the module's own text.
+fn assert_loc_string(path: String, source: String, off: Int) -> String {
+  let n = String::length(source)
+  let mut line = 1
+  let mut i = 0
+  while i < off && i < n {
+    if String::char_code_at(source, i) == 10 {
+      line = line + 1
+    } else {
+      ()
+    }
+    i = i + 1
+  }
+  String::concat(path, String::concat(":", Int::to_string(line)))
+}
+
+fn is_two_arg_assert_eq(callee: Expr, args: Array[Expr], off: Int) -> Bool {
+  if off < 0 || Array::length(args) != 2 {
+    false
+  } else {
+    match callee {
+      EIdent(name, _) => name == "assert_eq",
+      _ => false
+    }
+  }
+}
+
+fn stamp_assert_exprs(exprs: Array[Expr], path: String, source: String) -> Array[Expr] {
+  let out = array_empty()
+  let mut i = 0
+  while i < Array::length(exprs) {
+    Array::push(out, stamp_assert_expr(Array::get(exprs, i), path, source))
+    i = i + 1
+  }
+  out
+}
+
+fn stamp_assert_arms(arms: Array[(Pat, Expr)], path: String, source: String) -> Array[(Pat, Expr)] {
+  let out = array_empty()
+  let mut i = 0
+  while i < Array::length(arms) {
+    let (pat, body) = Array::get(arms, i)
+    Array::push(out, (pat, stamp_assert_expr(body, path, source)))
+    i = i + 1
+  }
+  out
+}
+
+fn stamp_assert_expr(e: Expr, path: String, source: String) -> Expr {
+  match e {
+    ECall(callee, args, off) => {
+      let stamped_args = stamp_assert_exprs(args, path, source)
+      if is_two_arg_assert_eq(callee, args, off) {
+        Array::push(stamped_args, EString(assert_loc_string(path, source, off)))
+        ECall(callee, stamped_args, off)
+      } else {
+        ECall(stamp_assert_expr(callee, path, source), stamped_args, off)
+      }
+    },
+    ESeq(a, b) => ESeq(stamp_assert_expr(a, path, source), stamp_assert_expr(b, path, source)),
+    EIf(c, t, f) => EIf(stamp_assert_expr(c, path, source), stamp_assert_expr(t, path, source), stamp_assert_expr(f, path, source)),
+    EWhile(c, b) => EWhile(stamp_assert_expr(c, path, source), stamp_assert_expr(b, path, source)),
+    EForIn(v, k, it, b) => EForIn(v, k, stamp_assert_expr(it, path, source), stamp_assert_expr(b, path, source)),
+    ELoop(inits, b) => ELoop(inits, stamp_assert_expr(b, path, source)),
+    ELet(n, v, b, off) => ELet(n, stamp_assert_expr(v, path, source), stamp_assert_expr(b, path, source), off),
+    ELetMut(n, v, b, off) => ELetMut(n, stamp_assert_expr(v, path, source), stamp_assert_expr(b, path, source), off),
+    ELetRec(n, v, b) => ELetRec(n, stamp_assert_expr(v, path, source), stamp_assert_expr(b, path, source)),
+    EMatch(scrutinee, arms) => EMatch(stamp_assert_expr(scrutinee, path, source), stamp_assert_arms(arms, path, source)),
+    EHandle(body, arms) => EHandle(stamp_assert_expr(body, path, source), stamp_assert_arms(arms, path, source)),
+    EFn(gens, bounds, params, ret, row, body) => EFn(gens, bounds, params, ret, row, stamp_assert_expr(body, path, source)),
+    EReturn(inner) => EReturn(stamp_assert_expr(inner, path, source)),
+    _ => e
+  }
+}
+
+/// One module's statements with every locatable two-argument `assert_eq` given
+/// its own `path:line`. Pure: a new spine is returned and nothing the caller
+/// handed in is mutated, which matters because the FS lane's parse is memoized
+/// and its nodes are shared between callers.
+export fn stamp_assert_stmts(stmts: Array[Stmt], path: String, source: String) -> Array[Stmt] {
+  let out = array_empty()
+  let mut i = 0
+  while i < Array::length(stmts) {
+    let stamped = match Array::get(stmts, i) {
+      SLet(exp, is_rec, name, ann, expr) => SLet(exp, is_rec, name, ann, stamp_assert_expr(expr, path, source)),
+      STest(name, expr) => STest(name, stamp_assert_expr(expr, path, source)),
+      SBench(name, expr) => SBench(name, stamp_assert_expr(expr, path, source)),
+      SExample(name, expr) => SExample(name, stamp_assert_expr(expr, path, source)),
+      SExpr(expr) => SExpr(stamp_assert_expr(expr, path, source)),
+      SModule(exp, name, body) => SModule(exp, name, stamp_assert_stmts(body, path, source)),
+      other => other
+    }
+    Array::push(out, stamped)
+    i = i + 1
+  }
+  out
+}
+
+/// Whether a module can produce an assert failure at all. Callers use it to keep
+/// the walk off the files that cannot, which is nearly all of them.
+export fn source_has_assert_eq(source: String) -> Bool {
+  String::index_of(source, "assert_eq") >= 0
+}

--- a/lib/@vibe/compiler/core/assert_stamp.vibe
+++ b/lib/@vibe/compiler/core/assert_stamp.vibe
@@ -57,7 +57,7 @@ fn assert_loc_string(path: String, source: String, off: Int) -> String {
   let mut line = 1
   let mut i = 0
   while i < off && i < n {
-    if String::char_code_at(source, i) == 10 {
+    if String::byte_at(source, i) == 10 {
       line = line + 1
     } else {
       ()

--- a/lib/@vibe/compiler/core/assert_stamp.vibe
+++ b/lib/@vibe/compiler/core/assert_stamp.vibe
@@ -156,6 +156,20 @@ export fn stmts_bind_assert_eq(stmts: Array[Stmt]) -> Bool {
       SLet(_, _, name, _, _) => name == "assert_eq",
       SModule(_, _, body) => stmts_bind_assert_eq(body),
       SImport(_, items) => import_binds_assert_eq(items),
+      // `export ./dep.vibe { cmp as assert_eq }` binds the name in this module
+      // exactly as an import does -- `checker_stmt.vibe` routes both through
+      // the same `bind_stmt_imports`.
+      //
+      // Standing down here does NOT make that program work: re-export ALIASES
+      // are broken independently of the asserts (#2287 -- the merge inlines the
+      // dependency under its original name and drops the alias, so the call
+      // site reaches codegen unresolved). What it does is stop the lowering
+      // from MASKING that: `cmp as assert_eq` is the one alias spelling that
+      // did not crash, because the builtin claimed the call and ran an
+      // assertion instead. A loud unresolved-name failure is the better of the
+      // two, and it is the order the design policy sets -- never be silently
+      // wrong outranks crashing (#2277 review).
+      SReExport(_, items) => import_binds_assert_eq(items),
       _ => false
     }
     if hit {

--- a/lib/@vibe/compiler/core/assert_stamp.vibe
+++ b/lib/@vibe/compiler/core/assert_stamp.vibe
@@ -118,6 +118,13 @@ fn stamp_assert_expr(e: Expr, path: String, source: String) -> Expr {
     ELet(n, v, b, off) => ELet(n, stamp_assert_expr(v, path, source), stamp_assert_expr(b, path, source), off),
     ELetMut(n, v, b, off) => ELetMut(n, stamp_assert_expr(v, path, source), stamp_assert_expr(b, path, source), off),
     ELetRec(n, v, b) => ELetRec(n, stamp_assert_expr(v, path, source), stamp_assert_expr(b, path, source)),
+    // `x = e` and `x += e` carry the REST OF THE BLOCK in their last field,
+    // exactly like `ELet` -- they are not leaves. Treating them as leaves meant
+    // every assert after a mutation in a test body silently lost its line,
+    // which is a common shape and precisely the one #2202 is about
+    // (#2277 review).
+    EAssign(n, v, b) => EAssign(n, stamp_assert_expr(v, path, source), stamp_assert_expr(b, path, source)),
+    EAssignOp(op, n, v, b) => EAssignOp(op, n, stamp_assert_expr(v, path, source), stamp_assert_expr(b, path, source)),
     EMatch(scrutinee, arms) => EMatch(stamp_assert_expr(scrutinee, path, source), stamp_assert_arms(arms, path, source)),
     EHandle(body, arms) => EHandle(stamp_assert_expr(body, path, source), stamp_assert_arms(arms, path, source)),
     EFn(gens, bounds, params, ret, row, body) => EFn(gens, bounds, params, ret, row, stamp_assert_expr(body, path, source)),

--- a/lib/@vibe/compiler/core/assert_stamp.vibe
+++ b/lib/@vibe/compiler/core/assert_stamp.vibe
@@ -25,11 +25,7 @@ import @vibe/core {
 }
 
 import ./ast.vibe {
-  Expr, ImportItem, Pat, Stmt, TypeExpr
-}
-
-import ./expr_children.vibe {
-  expr_children
+  Expr, ImportItem, Pat, Stmt
 }
 
 /// The internal callee a stamped `assert_eq` is rewritten to. Read by the
@@ -137,77 +133,27 @@ fn stamp_assert_expr(e: Expr, path: String, source: String) -> Expr {
   }
 }
 
-/// Whether one expression node binds the name at ITS OWN level. Recursion is
-/// the caller's job; this answers only "does this node introduce the name".
-fn expr_node_binds(e: Expr, name: String) -> Bool {
-  match e {
-    ELet(n, _, _, _) => n == name,
-    ELetMut(n, _, _, _) => n == name,
-    ELetRec(n, _, _) => n == name,
-    EFn(_, _, params, _, _, _) => params_bind(params, name),
-    _ => false
-  }
-}
-
-fn params_bind(params: Array[(String, Option[TypeExpr])], name: String) -> Bool {
-  let mut i = 0
-  let mut found = false
-  while i < Array::length(params) && !found {
-    let (p, _) = Array::get(params, i)
-    if p == name {
-      found = true
-    } else {
-      ()
-    }
-    i = i + 1
-  }
-  found
-}
-
-/// The same question over a whole expression tree. `expr_children` supplies the
-/// structural recursion, so a new `Expr` variant cannot quietly fall out of this
-/// scan the way it would out of a hand-written match.
-fn expr_binds(e: Expr, name: String) -> Bool {
-  if expr_node_binds(e, name) {
-    true
-  } else {
-    let kids = expr_children(e)
-    let mut i = 0
-    let mut found = false
-    while i < Array::length(kids) && !found {
-      if expr_binds(Array::get(kids, i), name) {
-        found = true
-      } else {
-        ()
-      }
-      i = i + 1
-    }
-    found
-  }
-}
-
-/// Whether this module binds the name `assert_eq` itself -- a definition, an
-/// import that lands under that name, or a `let`/parameter inside any body.
-/// Such a module is left alone entirely: neither the stamp here nor the
-/// lowering that consumes it (normalize/desugar_trait_dict.vibe) touches a call
-/// the reader wrote, so their own function is the one that runs (#2283).
+/// Whether this module DEFINES `assert_eq` at the top level -- a statement-level
+/// definition, or an import that lands under that name.
 ///
-/// Whole-module rather than per-scope, deliberately. The lowering runs BEFORE
-/// `check_program` in the single-file lane, so a rewrite it makes is never
-/// reviewed by name resolution -- the only safe reading of "this file has its
-/// own assert_eq" is the conservative one. A module that binds the name locally
-/// and also wants the builtin elsewhere now gets an unknown-name error, which
-/// the reader can act on, instead of the silent substitution this replaces.
+/// Top-level only, and that boundary is not arbitrary: it is exactly what the
+/// codegen guard can honor. `compile_call.vibe` decides by `fn_idx_in_list` (the
+/// function table) and deliberately ignores `local_idx_hint`, because a lambda's
+/// captured free name appears there with an unresolved slot -- the #1095 trap.
+/// So suppressing the lowering for a LOCAL binding only moves the failure: the
+/// pass stands down, codegen's own `assert_eq` arm still claims the call, and
+/// the program traps with no message at all. Measured on
+/// `match make_cmp() { assert_eq => assert_eq(1, 2) }`: builtin assertion before,
+/// bare `unreachable` after. Worse, not better.
+///
+/// The local and pattern-bound cases therefore keep their pre-existing
+/// behaviour, and moving them needs the #1095 question answered first.
 export fn stmts_bind_assert_eq(stmts: Array[Stmt]) -> Bool {
   let mut i = 0
   let mut found = false
   while i < Array::length(stmts) && !found {
     let hit = match Array::get(stmts, i) {
-      SLet(_, _, name, _, expr) => name == "assert_eq" || expr_binds(expr, "assert_eq"),
-      STest(_, expr) => expr_binds(expr, "assert_eq"),
-      SBench(_, expr) => expr_binds(expr, "assert_eq"),
-      SExample(_, expr) => expr_binds(expr, "assert_eq"),
-      SExpr(expr) => expr_binds(expr, "assert_eq"),
+      SLet(_, _, name, _, _) => name == "assert_eq",
       SModule(_, _, body) => stmts_bind_assert_eq(body),
       SImport(_, items) => import_binds_assert_eq(items),
       _ => false

--- a/lib/@vibe/compiler/core/assert_stamp.vibe
+++ b/lib/@vibe/compiler/core/assert_stamp.vibe
@@ -124,7 +124,7 @@ fn stamp_assert_expr(e: Expr, path: String, source: String) -> Expr {
     // which is a common shape and precisely the one #2202 is about
     // (#2277 review).
     EAssign(n, v, b) => EAssign(n, stamp_assert_expr(v, path, source), stamp_assert_expr(b, path, source)),
-    EAssignOp(op, n, v, b) => EAssignOp(op, n, stamp_assert_expr(v, path, source), stamp_assert_expr(b, path, source)),
+    EAssignOp(n, op, v, b) => EAssignOp(n, op, stamp_assert_expr(v, path, source), stamp_assert_expr(b, path, source)),
     EMatch(scrutinee, arms) => EMatch(stamp_assert_expr(scrutinee, path, source), stamp_assert_arms(arms, path, source)),
     EHandle(body, arms) => EHandle(stamp_assert_expr(body, path, source), stamp_assert_arms(arms, path, source)),
     EFn(gens, bounds, params, ret, row, body) => EFn(gens, bounds, params, ret, row, stamp_assert_expr(body, path, source)),

--- a/lib/@vibe/compiler/core/assert_stamp.vibe
+++ b/lib/@vibe/compiler/core/assert_stamp.vibe
@@ -67,8 +67,8 @@ fn assert_loc_string(path: String, source: String, off: Int) -> String {
   String::concat(path, String::concat(":", Int::to_string(line)))
 }
 
-fn is_two_arg_assert_eq(callee: Expr, args: Array[Expr], off: Int) -> Bool {
-  if off < 0 || Array::length(args) != 2 {
+fn is_two_arg_assert_eq(callee: Expr, args: Array[Expr], off: Int, locate: Bool) -> Bool {
+  if (off < 0 && locate) || Array::length(args) != 2 {
     false
   } else {
     match callee {
@@ -78,57 +78,65 @@ fn is_two_arg_assert_eq(callee: Expr, args: Array[Expr], off: Int) -> Bool {
   }
 }
 
-fn stamp_assert_exprs(exprs: Array[Expr], path: String, source: String) -> Array[Expr] {
+fn stamp_assert_exprs(exprs: Array[Expr], path: String, source: String, locate: Bool) -> Array[Expr] {
   let out = array_empty()
   let mut i = 0
   while i < Array::length(exprs) {
-    Array::push(out, stamp_assert_expr(Array::get(exprs, i), path, source))
+    Array::push(out, stamp_assert_expr(Array::get(exprs, i), path, source, locate))
     i = i + 1
   }
   out
 }
 
-fn stamp_assert_arms(arms: Array[(Pat, Expr)], path: String, source: String) -> Array[(Pat, Expr)] {
+fn stamp_assert_arms(arms: Array[(Pat, Expr)], path: String, source: String, locate: Bool) -> Array[(Pat, Expr)] {
   let out = array_empty()
   let mut i = 0
   while i < Array::length(arms) {
     let (pat, body) = Array::get(arms, i)
-    Array::push(out, (pat, stamp_assert_expr(body, path, source)))
+    Array::push(out, (pat, stamp_assert_expr(body, path, source, locate)))
     i = i + 1
   }
   out
 }
 
-fn stamp_assert_expr(e: Expr, path: String, source: String) -> Expr {
+fn stamp_assert_expr(e: Expr, path: String, source: String, locate: Bool) -> Expr {
   match e {
     ECall(callee, args, off) => {
-      let stamped_args = stamp_assert_exprs(args, path, source)
-      if is_two_arg_assert_eq(callee, args, off) {
-        Array::push(stamped_args, EString(assert_loc_string(path, source, off)))
+      let stamped_args = stamp_assert_exprs(args, path, source, locate)
+      if is_two_arg_assert_eq(callee, args, off, locate) {
+        // An unlocated stamp still says "this call resolved to the BUILTIN in
+        // its own module", which is the fact the merge would otherwise lose.
+        // The empty string is the location the lowering already knows how to
+        // print without one.
+        Array::push(stamped_args, EString(if locate {
+          assert_loc_string(path, source, off)
+        } else {
+          ""
+        }))
         ECall(EIdent(assert_eq_located_callee, -1), stamped_args, off)
       } else {
-        ECall(stamp_assert_expr(callee, path, source), stamped_args, off)
+        ECall(stamp_assert_expr(callee, path, source, locate), stamped_args, off)
       }
     },
-    ESeq(a, b) => ESeq(stamp_assert_expr(a, path, source), stamp_assert_expr(b, path, source)),
-    EIf(c, t, f) => EIf(stamp_assert_expr(c, path, source), stamp_assert_expr(t, path, source), stamp_assert_expr(f, path, source)),
-    EWhile(c, b) => EWhile(stamp_assert_expr(c, path, source), stamp_assert_expr(b, path, source)),
-    EForIn(v, k, it, b) => EForIn(v, k, stamp_assert_expr(it, path, source), stamp_assert_expr(b, path, source)),
-    ELoop(inits, b) => ELoop(inits, stamp_assert_expr(b, path, source)),
-    ELet(n, v, b, off) => ELet(n, stamp_assert_expr(v, path, source), stamp_assert_expr(b, path, source), off),
-    ELetMut(n, v, b, off) => ELetMut(n, stamp_assert_expr(v, path, source), stamp_assert_expr(b, path, source), off),
-    ELetRec(n, v, b) => ELetRec(n, stamp_assert_expr(v, path, source), stamp_assert_expr(b, path, source)),
+    ESeq(a, b) => ESeq(stamp_assert_expr(a, path, source, locate), stamp_assert_expr(b, path, source, locate)),
+    EIf(c, t, f) => EIf(stamp_assert_expr(c, path, source, locate), stamp_assert_expr(t, path, source, locate), stamp_assert_expr(f, path, source, locate)),
+    EWhile(c, b) => EWhile(stamp_assert_expr(c, path, source, locate), stamp_assert_expr(b, path, source, locate)),
+    EForIn(v, k, it, b) => EForIn(v, k, stamp_assert_expr(it, path, source, locate), stamp_assert_expr(b, path, source, locate)),
+    ELoop(inits, b) => ELoop(inits, stamp_assert_expr(b, path, source, locate)),
+    ELet(n, v, b, off) => ELet(n, stamp_assert_expr(v, path, source, locate), stamp_assert_expr(b, path, source, locate), off),
+    ELetMut(n, v, b, off) => ELetMut(n, stamp_assert_expr(v, path, source, locate), stamp_assert_expr(b, path, source, locate), off),
+    ELetRec(n, v, b) => ELetRec(n, stamp_assert_expr(v, path, source, locate), stamp_assert_expr(b, path, source, locate)),
     // `x = e` and `x += e` carry the REST OF THE BLOCK in their last field,
     // exactly like `ELet` -- they are not leaves. Treating them as leaves meant
     // every assert after a mutation in a test body silently lost its line,
     // which is a common shape and precisely the one #2202 is about
     // (#2277 review).
-    EAssign(n, v, b) => EAssign(n, stamp_assert_expr(v, path, source), stamp_assert_expr(b, path, source)),
-    EAssignOp(n, op, v, b) => EAssignOp(n, op, stamp_assert_expr(v, path, source), stamp_assert_expr(b, path, source)),
-    EMatch(scrutinee, arms) => EMatch(stamp_assert_expr(scrutinee, path, source), stamp_assert_arms(arms, path, source)),
-    EHandle(body, arms) => EHandle(stamp_assert_expr(body, path, source), stamp_assert_arms(arms, path, source)),
-    EFn(gens, bounds, params, ret, row, body) => EFn(gens, bounds, params, ret, row, stamp_assert_expr(body, path, source)),
-    EReturn(inner) => EReturn(stamp_assert_expr(inner, path, source)),
+    EAssign(n, v, b) => EAssign(n, stamp_assert_expr(v, path, source, locate), stamp_assert_expr(b, path, source, locate)),
+    EAssignOp(n, op, v, b) => EAssignOp(n, op, stamp_assert_expr(v, path, source, locate), stamp_assert_expr(b, path, source, locate)),
+    EMatch(scrutinee, arms) => EMatch(stamp_assert_expr(scrutinee, path, source, locate), stamp_assert_arms(arms, path, source, locate)),
+    EHandle(body, arms) => EHandle(stamp_assert_expr(body, path, source, locate), stamp_assert_arms(arms, path, source, locate)),
+    EFn(gens, bounds, params, ret, row, body) => EFn(gens, bounds, params, ret, row, stamp_assert_expr(body, path, source, locate)),
+    EReturn(inner) => EReturn(stamp_assert_expr(inner, path, source, locate)),
     _ => e
   }
 }
@@ -209,21 +217,40 @@ export fn stamp_assert_stmts(stmts: Array[Stmt], path: String, source: String) -
   if stmts_bind_assert_eq(stmts) {
     stmts
   } else {
-    stamp_assert_walk(stmts, path, source)
+    stamp_assert_walk(stmts, path, source, true)
   }
 }
 
-fn stamp_assert_walk(stmts: Array[Stmt], path: String, source: String) -> Array[Stmt] {
+/// The same rewrite with NO location, for text whose line numbers are not the
+/// file's (the loader prepends a directory's inherited `.vpkg` imports, and
+/// replaces a contract with its facade). Those modules used to be left alone
+/// entirely, which lost more than the line: a BARE `assert_eq` call carries no
+/// evidence that it meant the builtin, so if any OTHER merged module defines a
+/// top-level `assert_eq`, the program-wide suppression stands the lowering down
+/// and codegen's func-table dispatch sends this module's call to that unrelated
+/// function -- silently, with the checker still having typed it as the builtin
+/// (#2277 review). The marker preserves the per-module fact; the empty location
+/// is the one the lowering already prints without (#1445: no line beats a wrong
+/// line).
+export fn stamp_assert_stmts_unlocated(stmts: Array[Stmt]) -> Array[Stmt] {
+  if stmts_bind_assert_eq(stmts) {
+    stmts
+  } else {
+    stamp_assert_walk(stmts, "", "", false)
+  }
+}
+
+fn stamp_assert_walk(stmts: Array[Stmt], path: String, source: String, locate: Bool) -> Array[Stmt] {
   let out = array_empty()
   let mut i = 0
   while i < Array::length(stmts) {
     let stamped = match Array::get(stmts, i) {
-      SLet(exp, is_rec, name, ann, expr) => SLet(exp, is_rec, name, ann, stamp_assert_expr(expr, path, source)),
-      STest(name, expr) => STest(name, stamp_assert_expr(expr, path, source)),
-      SBench(name, expr) => SBench(name, stamp_assert_expr(expr, path, source)),
-      SExample(name, expr) => SExample(name, stamp_assert_expr(expr, path, source)),
-      SExpr(expr) => SExpr(stamp_assert_expr(expr, path, source)),
-      SModule(exp, name, body) => SModule(exp, name, stamp_assert_walk(body, path, source)),
+      SLet(exp, is_rec, name, ann, expr) => SLet(exp, is_rec, name, ann, stamp_assert_expr(expr, path, source, locate)),
+      STest(name, expr) => STest(name, stamp_assert_expr(expr, path, source, locate)),
+      SBench(name, expr) => SBench(name, stamp_assert_expr(expr, path, source, locate)),
+      SExample(name, expr) => SExample(name, stamp_assert_expr(expr, path, source, locate)),
+      SExpr(expr) => SExpr(stamp_assert_expr(expr, path, source, locate)),
+      SModule(exp, name, body) => SModule(exp, name, stamp_assert_walk(body, path, source, locate)),
       other => other
     }
     Array::push(out, stamped)

--- a/lib/@vibe/compiler/core/assert_stamp.vibe
+++ b/lib/@vibe/compiler/core/assert_stamp.vibe
@@ -28,13 +28,28 @@ import ./ast.vibe {
   Expr, Pat, Stmt
 }
 
-/// The internal callee a stamped `assert_eq` is rewritten to. Deliberately NOT
-/// `assert_eq` at arity 3: the single-source lane lowers before it checks, so a
-/// three-argument `assert_eq` recognized by shape would let a user-written
-/// `assert_eq(1, 2, "user")` through as a located call instead of the arity
-/// error (measured; Codex review on #2277). Read by the lowering in
-/// normalize/desugar_trait_dict.vibe, which is the only thing that consumes it.
-export let assert_eq_located_callee: String = "__assert_eq_at"
+/// The internal callee a stamped `assert_eq` is rewritten to. Read by the
+/// lowering in normalize/desugar_trait_dict.vibe, the only thing that consumes
+/// it.
+///
+/// The LEADING `#` is the whole point, and it took two tries to get here. Both
+/// earlier spellings were reachable from source, and in the single-source lane
+/// the lowering runs before `check_program`, so anything it recognizes bypasses
+/// name and arity checking entirely:
+///
+///   - `assert_eq` at arity 3 with a literal string third operand -- exactly
+///     what a user types as `assert_eq(1, 2, "user")`. Measured: compiled and
+///     printed `assert_eq failed at user` instead of the arity error.
+///   - `__assert_eq_at` -- an ordinary identifier. Measured: user source
+///     calling it compiled and ran as an assert, and a user DECLARING that name
+///     would have had their own calls rewritten out from under them.
+///
+/// `#` is not an identifier character: `#assert_eq_at(1, 2, "x")` in source is
+/// rejected by the lexer ("unknown # directive: assert_eq_at"), so this node
+/// cannot be constructed from any input. Same convention as the `#region_`
+/// skolems the checker already relies on. A marker source cannot spell beats a
+/// marker source is unlikely to spell (Codex review on #2277).
+export let assert_eq_located_callee: String = "#assert_eq_at"
 
 /// `path:line`, 1-based, counted in the module's own text.
 fn assert_loc_string(path: String, source: String, off: Int) -> String {

--- a/lib/@vibe/compiler/core/assert_stamp.vibe
+++ b/lib/@vibe/compiler/core/assert_stamp.vibe
@@ -16,9 +16,14 @@
 // indices shift under it.
 //
 // Degradation is always toward NO line, never a wrong one: a statement parsed
-// without offsets carries -1 and is left alone, and the walk descends only the
-// expression forms that CARRY statements, so an `assert_eq` buried in (say) a
-// tuple loses its line rather than borrowing someone else's.
+// without offsets carries -1 and is left alone.
+//
+// The walk descends only the expression forms that CARRY statements, so an
+// `assert_eq` buried in (say) a tuple element or an operand loses its line.
+// That is a COVERAGE limit, not a safety one -- this comment used to justify it
+// as "rather than borrowing someone else's line", which is wrong: a nested
+// `ECall` has its own offset, so there is nothing to borrow. Widening the walk
+// to rebuild every container form is mechanical and safe, and is #2288.
 
 import @vibe/core {
   array_empty
@@ -164,20 +169,15 @@ export fn stmts_bind_assert_eq(stmts: Array[Stmt]) -> Bool {
       SLet(_, _, name, _, _) => name == "assert_eq",
       SModule(_, _, body) => stmts_bind_assert_eq(body),
       SImport(_, items) => import_binds_assert_eq(items),
-      // `export ./dep.vibe { cmp as assert_eq }` binds the name in this module
-      // exactly as an import does -- `checker_stmt.vibe` routes both through
-      // the same `bind_stmt_imports`.
-      //
-      // Standing down here does NOT make that program work: re-export ALIASES
-      // are broken independently of the asserts (#2287 -- the merge inlines the
-      // dependency under its original name and drops the alias, so the call
-      // site reaches codegen unresolved). What it does is stop the lowering
-      // from MASKING that: `cmp as assert_eq` is the one alias spelling that
-      // did not crash, because the builtin claimed the call and ran an
-      // assertion instead. A loud unresolved-name failure is the better of the
-      // two, and it is the order the design policy sets -- never be silently
-      // wrong outranks crashing (#2277 review).
-      SReExport(_, items) => import_binds_assert_eq(items),
+      // NO `SReExport` arm, and that is measured rather than assumed.
+      // `export ./dep.vibe { cmp as assert_eq }` does bind the name here, but
+      // standing down cannot help: this scan runs per module, the merge then
+      // DROPS the re-export (the dependency arrives under its own name), and
+      // the lowering -- which sees only the merged program -- claims the bare
+      // call regardless. Adding the arm changed no observed behaviour. The
+      // masking it would have removed belongs to #2287, and fixing that removes
+      // it for free: once the alias rewrites the call site, the name at the
+      // call is no longer `assert_eq` (#2277 review).
       _ => false
     }
     if hit {

--- a/lib/@vibe/compiler/core/assert_stamp.vibe
+++ b/lib/@vibe/compiler/core/assert_stamp.vibe
@@ -25,7 +25,11 @@ import @vibe/core {
 }
 
 import ./ast.vibe {
-  Expr, Pat, Stmt
+  Expr, ImportItem, Pat, Stmt, TypeExpr
+}
+
+import ./expr_children.vibe {
+  expr_children
 }
 
 /// The internal callee a stamped `assert_eq` is rewritten to. Read by the
@@ -133,11 +137,123 @@ fn stamp_assert_expr(e: Expr, path: String, source: String) -> Expr {
   }
 }
 
+/// Whether one expression node binds the name at ITS OWN level. Recursion is
+/// the caller's job; this answers only "does this node introduce the name".
+fn expr_node_binds(e: Expr, name: String) -> Bool {
+  match e {
+    ELet(n, _, _, _) => n == name,
+    ELetMut(n, _, _, _) => n == name,
+    ELetRec(n, _, _) => n == name,
+    EFn(_, _, params, _, _, _) => params_bind(params, name),
+    _ => false
+  }
+}
+
+fn params_bind(params: Array[(String, Option[TypeExpr])], name: String) -> Bool {
+  let mut i = 0
+  let mut found = false
+  while i < Array::length(params) && !found {
+    let (p, _) = Array::get(params, i)
+    if p == name {
+      found = true
+    } else {
+      ()
+    }
+    i = i + 1
+  }
+  found
+}
+
+/// The same question over a whole expression tree. `expr_children` supplies the
+/// structural recursion, so a new `Expr` variant cannot quietly fall out of this
+/// scan the way it would out of a hand-written match.
+fn expr_binds(e: Expr, name: String) -> Bool {
+  if expr_node_binds(e, name) {
+    true
+  } else {
+    let kids = expr_children(e)
+    let mut i = 0
+    let mut found = false
+    while i < Array::length(kids) && !found {
+      if expr_binds(Array::get(kids, i), name) {
+        found = true
+      } else {
+        ()
+      }
+      i = i + 1
+    }
+    found
+  }
+}
+
+/// Whether this module binds the name `assert_eq` itself -- a definition, an
+/// import that lands under that name, or a `let`/parameter inside any body.
+/// Such a module is left alone entirely: neither the stamp here nor the
+/// lowering that consumes it (normalize/desugar_trait_dict.vibe) touches a call
+/// the reader wrote, so their own function is the one that runs (#2283).
+///
+/// Whole-module rather than per-scope, deliberately. The lowering runs BEFORE
+/// `check_program` in the single-file lane, so a rewrite it makes is never
+/// reviewed by name resolution -- the only safe reading of "this file has its
+/// own assert_eq" is the conservative one. A module that binds the name locally
+/// and also wants the builtin elsewhere now gets an unknown-name error, which
+/// the reader can act on, instead of the silent substitution this replaces.
+export fn stmts_bind_assert_eq(stmts: Array[Stmt]) -> Bool {
+  let mut i = 0
+  let mut found = false
+  while i < Array::length(stmts) && !found {
+    let hit = match Array::get(stmts, i) {
+      SLet(_, _, name, _, expr) => name == "assert_eq" || expr_binds(expr, "assert_eq"),
+      STest(_, expr) => expr_binds(expr, "assert_eq"),
+      SBench(_, expr) => expr_binds(expr, "assert_eq"),
+      SExample(_, expr) => expr_binds(expr, "assert_eq"),
+      SExpr(expr) => expr_binds(expr, "assert_eq"),
+      SModule(_, _, body) => stmts_bind_assert_eq(body),
+      SImport(_, items) => import_binds_assert_eq(items),
+      _ => false
+    }
+    if hit {
+      found = true
+    } else {
+      ()
+    }
+    i = i + 1
+  }
+  found
+}
+
+fn import_binds_assert_eq(items: Array[ImportItem]) -> Bool {
+  let mut i = 0
+  let mut found = false
+  while i < Array::length(items) && !found {
+    let item = Array::get(items, i)
+    let local = match item.alias {
+      Some(a) => a,
+      None => item.name
+    }
+    if local == "assert_eq" {
+      found = true
+    } else {
+      ()
+    }
+    i = i + 1
+  }
+  found
+}
+
 /// One module's statements with every locatable two-argument `assert_eq` given
 /// its own `path:line`. Pure: a new spine is returned and nothing the caller
 /// handed in is mutated, which matters because the FS lane's parse is memoized
 /// and its nodes are shared between callers.
 export fn stamp_assert_stmts(stmts: Array[Stmt], path: String, source: String) -> Array[Stmt] {
+  if stmts_bind_assert_eq(stmts) {
+    stmts
+  } else {
+    stamp_assert_walk(stmts, path, source)
+  }
+}
+
+fn stamp_assert_walk(stmts: Array[Stmt], path: String, source: String) -> Array[Stmt] {
   let out = array_empty()
   let mut i = 0
   while i < Array::length(stmts) {
@@ -147,7 +263,7 @@ export fn stamp_assert_stmts(stmts: Array[Stmt], path: String, source: String) -
       SBench(name, expr) => SBench(name, stamp_assert_expr(expr, path, source)),
       SExample(name, expr) => SExample(name, stamp_assert_expr(expr, path, source)),
       SExpr(expr) => SExpr(stamp_assert_expr(expr, path, source)),
-      SModule(exp, name, body) => SModule(exp, name, stamp_assert_stmts(body, path, source)),
+      SModule(exp, name, body) => SModule(exp, name, stamp_assert_walk(body, path, source)),
       other => other
     }
     Array::push(out, stamped)

--- a/lib/@vibe/compiler/core/assert_stamp.vibe
+++ b/lib/@vibe/compiler/core/assert_stamp.vibe
@@ -28,6 +28,14 @@ import ./ast.vibe {
   Expr, Pat, Stmt
 }
 
+/// The internal callee a stamped `assert_eq` is rewritten to. Deliberately NOT
+/// `assert_eq` at arity 3: the single-source lane lowers before it checks, so a
+/// three-argument `assert_eq` recognized by shape would let a user-written
+/// `assert_eq(1, 2, "user")` through as a located call instead of the arity
+/// error (measured; Codex review on #2277). Read by the lowering in
+/// normalize/desugar_trait_dict.vibe, which is the only thing that consumes it.
+export let assert_eq_located_callee: String = "__assert_eq_at"
+
 /// `path:line`, 1-based, counted in the module's own text.
 fn assert_loc_string(path: String, source: String, off: Int) -> String {
   let n = String::length(source)
@@ -82,7 +90,7 @@ fn stamp_assert_expr(e: Expr, path: String, source: String) -> Expr {
       let stamped_args = stamp_assert_exprs(args, path, source)
       if is_two_arg_assert_eq(callee, args, off) {
         Array::push(stamped_args, EString(assert_loc_string(path, source, off)))
-        ECall(callee, stamped_args, off)
+        ECall(EIdent(assert_eq_located_callee, -1), stamped_args, off)
       } else {
         ECall(stamp_assert_expr(callee, path, source), stamped_args, off)
       }

--- a/lib/@vibe/compiler/core/builtin_name.vibe
+++ b/lib/@vibe/compiler/core/builtin_name.vibe
@@ -1,5 +1,39 @@
 //# Functions
 
+/// #2125: nominal heads the compiler owns itself. They resolve to
+/// `CtNamed(name, args)` with no `TypeDef` behind them and no entry in
+/// `resolve_builtin`, so they are indistinguishable from a typo by lookup
+/// alone and have to be named.
+///
+/// This list is EMPIRICAL, not a design: it is what Red runs of
+/// `collect_unknown_type_names` over `lib/**` and `fixtures/**` reported as
+/// unresolved while the tree compiled clean. Adding a compiler-owned type
+/// without adding it here makes every annotation that mentions it an error,
+/// which is a loud failure, not a silent one -- `PromptText` joined the list
+/// that way (`declare PromptText::new(String) -> PromptText`,
+/// builtins/declarations.vibe, names a type `resolve_builtin` does not carry).
+export fn is_wellknown_nominal_head(name: String) -> Bool {
+  name == "Future"
+  || name == "ByteStream"
+  || name == "HostStream"
+  || name == "Task"
+  || name == "TaskHandle"
+  || name == "TaskGroup"
+  || name == "Sender"
+  || name == "Receiver"
+  || name == "Map"
+  || name == "MapBuilder"
+  || name == "MutList"
+  || name == "MutBytes"
+  || name == "MutMap"
+  || name == "ArrayBuilder"
+  || name == "StringBuilder"
+  || name == "FrozenArray"
+  || name == "FixedArray"
+  || name == "Attempt"
+  || name == "PromptText"
+}
+
 export fn canonical_builtin_name(name: String) -> String {
   match name {
     "Fs::ReadFile" => "Fs::read_file",

--- a/lib/@vibe/compiler/core/core.vibe
+++ b/lib/@vibe/compiler/core/core.vibe
@@ -38,6 +38,10 @@ export ./assert_stamp.vibe {
   assert_eq_located_callee, source_has_assert_eq, stamp_assert_stmts
 }
 
+export ./builtin_name.vibe {
+  is_wellknown_nominal_head
+}
+
 export ./expr_children.vibe {
   expr_children
 }

--- a/lib/@vibe/compiler/core/core.vibe
+++ b/lib/@vibe/compiler/core/core.vibe
@@ -34,6 +34,10 @@ export ./dce.vibe {
   dce_keep_flags, dce_stmts
 }
 
+export ./assert_stamp.vibe {
+  source_has_assert_eq, stamp_assert_stmts
+}
+
 export ./expr_children.vibe {
   expr_children
 }

--- a/lib/@vibe/compiler/core/core.vibe
+++ b/lib/@vibe/compiler/core/core.vibe
@@ -35,7 +35,7 @@ export ./dce.vibe {
 }
 
 export ./assert_stamp.vibe {
-  source_has_assert_eq, stamp_assert_stmts
+  assert_eq_located_callee, source_has_assert_eq, stamp_assert_stmts
 }
 
 export ./expr_children.vibe {

--- a/lib/@vibe/compiler/core/core.vibe
+++ b/lib/@vibe/compiler/core/core.vibe
@@ -35,7 +35,7 @@ export ./dce.vibe {
 }
 
 export ./assert_stamp.vibe {
-  assert_eq_located_callee, source_has_assert_eq, stamp_assert_stmts
+  assert_eq_located_callee, source_has_assert_eq, stamp_assert_stmts, stmts_bind_assert_eq
 }
 
 export ./builtin_name.vibe {

--- a/lib/@vibe/compiler/core/index.vpkg
+++ b/lib/@vibe/compiler/core/index.vpkg
@@ -124,6 +124,7 @@ let assert_eq_located_callee: String
 fn source_has_assert_eq(source: String) -> Bool
 fn stmts_bind_assert_eq(stmts: Array[Stmt]) -> Bool
 fn stamp_assert_stmts(stmts: Array[Stmt], path: String, source: String) -> Array[Stmt]
+fn stamp_assert_stmts_unlocated(stmts: Array[Stmt]) -> Array[Stmt]
 
 // --- builtin_name
 fn is_wellknown_nominal_head(name: String) -> Bool

--- a/lib/@vibe/compiler/core/index.vpkg
+++ b/lib/@vibe/compiler/core/index.vpkg
@@ -122,6 +122,7 @@ type EnvValueBinding
 // --- assert_stamp
 let assert_eq_located_callee: String
 fn source_has_assert_eq(source: String) -> Bool
+fn stmts_bind_assert_eq(stmts: Array[Stmt]) -> Bool
 fn stamp_assert_stmts(stmts: Array[Stmt], path: String, source: String) -> Array[Stmt]
 
 // --- builtin_name

--- a/lib/@vibe/compiler/core/index.vpkg
+++ b/lib/@vibe/compiler/core/index.vpkg
@@ -124,6 +124,9 @@ let assert_eq_located_callee: String
 fn source_has_assert_eq(source: String) -> Bool
 fn stamp_assert_stmts(stmts: Array[Stmt], path: String, source: String) -> Array[Stmt]
 
+// --- builtin_name
+fn is_wellknown_nominal_head(name: String) -> Bool
+
 // --- expr_children
 fn expr_children(expr: Expr) -> Array[Expr]
 

--- a/lib/@vibe/compiler/core/index.vpkg
+++ b/lib/@vibe/compiler/core/index.vpkg
@@ -119,6 +119,10 @@ type EnvValueBinding
 
 // --- core (facade)
 
+// --- assert_stamp
+fn source_has_assert_eq(source: String) -> Bool
+fn stamp_assert_stmts(stmts: Array[Stmt], path: String, source: String) -> Array[Stmt]
+
 // --- expr_children
 fn expr_children(expr: Expr) -> Array[Expr]
 

--- a/lib/@vibe/compiler/core/index.vpkg
+++ b/lib/@vibe/compiler/core/index.vpkg
@@ -120,6 +120,7 @@ type EnvValueBinding
 // --- core (facade)
 
 // --- assert_stamp
+let assert_eq_located_callee: String
 fn source_has_assert_eq(source: String) -> Bool
 fn stamp_assert_stmts(stmts: Array[Stmt], path: String, source: String) -> Array[Stmt]
 

--- a/lib/@vibe/compiler/entry/compiler/file_compile/file_compile.vibe
+++ b/lib/@vibe/compiler/entry/compiler/file_compile/file_compile.vibe
@@ -39,6 +39,7 @@ import @vibe/compiler/core {
   rewrite_imported_value_stmt_to_local,
   source_has_assert_eq,
   stamp_assert_stmts,
+  stamp_assert_stmts_unlocated,
   stmts_have_import_deep
 }
 
@@ -228,14 +229,22 @@ fn parse_program_for_path(path: String, source: String) -> Array[Stmt] with Exce
   // reach a generated bundle and thus never reaches the committed seed, which
   // knows only the two-argument form.
   let stmts = parse_program_with_path(path, source)
-  // Only stamp when THIS text's line numbers are the FILE's. The loader
+  // Locate only when THIS text's line numbers are the FILE's. The loader
   // prepends a directory's inherited `.vpkg` imports, and replaces a contract
-  // with its generated facade -- both shift every line after them, so stamping
-  // that text would print the physical path beside a line the reader cannot
-  // find (#2277 review). No line beats a wrong line (#1445), which is the whole
-  // rule this stamping is built on.
-  if source_has_assert_eq(source) && !String::starts_with(source, vpkg_shared_import_marker) && !String::starts_with(source, contract_facade_marker) {
-    stamp_assert_stmts(stmts, path, source)
+  // with its generated facade -- both shift every line after them, so a
+  // location taken from that text would print the physical path beside a line
+  // the reader cannot find (#2277 review). No line beats a wrong line (#1445).
+  //
+  // But such a module is still STAMPED, without a location. Leaving its calls
+  // bare loses more than the line: nothing then records that they meant the
+  // BUILTIN, so another merged module's top-level `assert_eq` would capture
+  // them through the func table (#2277 review).
+  if source_has_assert_eq(source) {
+    if !String::starts_with(source, vpkg_shared_import_marker) && !String::starts_with(source, contract_facade_marker) {
+      stamp_assert_stmts(stmts, path, source)
+    } else {
+      stamp_assert_stmts_unlocated(stmts)
+    }
   } else {
     stmts
   }

--- a/lib/@vibe/compiler/entry/compiler/file_compile/file_compile.vibe
+++ b/lib/@vibe/compiler/entry/compiler/file_compile/file_compile.vibe
@@ -37,6 +37,8 @@ import @vibe/compiler/core {
   resolution_env_seed,
   resolve_import_path,
   rewrite_imported_value_stmt_to_local,
+  source_has_assert_eq,
+  stamp_assert_stmts,
   stmts_have_import_deep
 }
 
@@ -209,7 +211,24 @@ fn lookup_source_by_path(sources: Array[(String, String)], target_path: String) 
 /// require. Interior-line breakpoints (span-arc step5) still get their real
 /// EIdent char-offsets: the memoized parse is the same located one.
 fn parse_program_for_path(path: String, source: String) -> Array[Stmt] with Exception {
-  parse_program_with_path(path, source)
+  // #2202: give every locatable two-argument `assert_eq` its own
+  // `path:line` HERE, while this module's own source is still in hand. After
+  // the merge it is impossible: an offset is a per-module space and a merged
+  // program cannot say which module one belongs to, so a location recovered
+  // downstream would be plausible and wrong (#1445). The memoized parse above
+  // is already the located one, so this costs a walk and no second parse --
+  // and only for the files whose text contains the call at all.
+  //
+  // Unconditional in this lane, unlike the wasi_only merge's cell: nothing
+  // here PRINTS the merged program, so a three-argument `assert_eq` cannot
+  // reach a generated bundle and thus never reaches the committed seed, which
+  // knows only the two-argument form.
+  let stmts = parse_program_with_path(path, source)
+  if source_has_assert_eq(source) {
+    stamp_assert_stmts(stmts, path, source)
+  } else {
+    stmts
+  }
 }
 
 /// #716: collision-def fallback (see merge_sources.vibe). `excluded_locals`

--- a/lib/@vibe/compiler/entry/compiler/file_compile/file_compile.vibe
+++ b/lib/@vibe/compiler/entry/compiler/file_compile/file_compile.vibe
@@ -60,6 +60,10 @@ import @vibe/compiler/codegen/wasi {
   compile_wasi_module_impl, compile_wasi_module_no_dce_impl, effect_lowering_prelude
 }
 
+import @vibe/compiler/contract {
+  contract_facade_marker, vpkg_shared_import_marker
+}
+
 import @vibe/compiler/loader {
   artifact_input_trace_resolution_context_fingerprint_fs, collect_source_groups_fs, load_persistent_source_group_fingerprint_if_valid
 }
@@ -224,7 +228,13 @@ fn parse_program_for_path(path: String, source: String) -> Array[Stmt] with Exce
   // reach a generated bundle and thus never reaches the committed seed, which
   // knows only the two-argument form.
   let stmts = parse_program_with_path(path, source)
-  if source_has_assert_eq(source) {
+  // Only stamp when THIS text's line numbers are the FILE's. The loader
+  // prepends a directory's inherited `.vpkg` imports, and replaces a contract
+  // with its generated facade -- both shift every line after them, so stamping
+  // that text would print the physical path beside a line the reader cannot
+  // find (#2277 review). No line beats a wrong line (#1445), which is the whole
+  // rule this stamping is built on.
+  if source_has_assert_eq(source) && !String::starts_with(source, vpkg_shared_import_marker) && !String::starts_with(source, contract_facade_marker) {
     stamp_assert_stmts(stmts, path, source)
   } else {
     stmts

--- a/lib/@vibe/compiler/entry/compiler/file_compile/index.vpkg
+++ b/lib/@vibe/compiler/entry/compiler/file_compile/index.vpkg
@@ -8,6 +8,7 @@ deps = {
   @vibe/compiler/codegen : 0.0.1
   @vibe/compiler/codegen/common_base : 0.0.1
   @vibe/compiler/codegen/wasi : 0.0.1
+  @vibe/compiler/contract : 0.0.1
   @vibe/compiler/core : 0.0.1
   @vibe/compiler/loader : 0.0.1
   @vibe/compiler/runtime : 0.0.1

--- a/lib/@vibe/compiler/entry/source_compile/wasi_only/index.vpkg
+++ b/lib/@vibe/compiler/entry/source_compile/wasi_only/index.vpkg
@@ -8,6 +8,7 @@ deps = {
   @vibe/compiler/codegen/common_base : 0.0.1
   @vibe/compiler/codegen/wasi : 0.0.1
   @vibe/compiler/codegen/wasm_emit : 0.0.1
+  @vibe/compiler/contract : 0.0.1
   @vibe/compiler/core : 0.0.1
   @vibe/compiler/loader : 0.0.1
   @vibe/compiler/syntax : 0.0.1

--- a/lib/@vibe/compiler/entry/source_compile/wasi_only/merge_sources.vibe
+++ b/lib/@vibe/compiler/entry/source_compile/wasi_only/merge_sources.vibe
@@ -42,6 +42,7 @@ import @vibe/compiler/core {
   rewrite_imported_value_stmt_to_local,
   source_has_assert_eq,
   stamp_assert_stmts,
+  stamp_assert_stmts_unlocated,
   stmts_have_import_deep
 }
 
@@ -99,9 +100,16 @@ fn parse_module_stmts(path: String, source: String) -> Array[Stmt] with Exceptio
   // that text prints the physical path beside a line the reader cannot find.
   // No line beats a wrong line (#1445).
   let one_to_one = !String::starts_with(source, vpkg_shared_import_marker) && !String::starts_with(source, contract_facade_marker)
-  if assert_stamp_on() && one_to_one && source_has_assert_eq(source) {
-    let (tokens, starts, _ends) = lex_with_offsets(source)
-    stamp_assert_stmts(parse_program_located(tokens, starts, source), path, source)
+  if assert_stamp_on() && source_has_assert_eq(source) {
+    if one_to_one {
+      let (tokens, starts, _ends) = lex_with_offsets(source)
+      stamp_assert_stmts(parse_program_located(tokens, starts, source), path, source)
+    } else {
+      // Stamped without a location: the line numbers are not this file's, but
+      // the marker still has to record that these calls meant the builtin --
+      // see file_compile.vibe's copy of this decision.
+      stamp_assert_stmts_unlocated(parse_program(lex(source)))
+    }
   } else {
     parse_program(lex(source))
   }

--- a/lib/@vibe/compiler/entry/source_compile/wasi_only/merge_sources.vibe
+++ b/lib/@vibe/compiler/entry/source_compile/wasi_only/merge_sources.vibe
@@ -53,6 +53,10 @@ import ./preprocess.vibe {
   expand_interp_stmts, strip_generic_type_params
 }
 
+import @vibe/compiler/contract {
+  contract_facade_marker, vpkg_shared_import_marker
+}
+
 import @vibe/compiler/loader {
   ingest_source_text_fs
 }
@@ -88,7 +92,14 @@ fn assert_stamp_on() -> Bool {
 /// extra `lex_with_offsets` + located parse + walk is confined to the files
 /// that can actually produce an assert failure.
 fn parse_module_stmts(path: String, source: String) -> Array[Stmt] with Exception {
-  if assert_stamp_on() && source_has_assert_eq(source) {
+  // The marker guard the FS lane has, because this lane needs it for the same
+  // reason and did not get it in the same commit (#2277 review). The loader
+  // prepends a directory's inherited `.vpkg` imports and replaces a contract
+  // with its generated facade; both shift every line after them, so stamping
+  // that text prints the physical path beside a line the reader cannot find.
+  // No line beats a wrong line (#1445).
+  let one_to_one = !String::starts_with(source, vpkg_shared_import_marker) && !String::starts_with(source, contract_facade_marker)
+  if assert_stamp_on() && one_to_one && source_has_assert_eq(source) {
     let (tokens, starts, _ends) = lex_with_offsets(source)
     stamp_assert_stmts(parse_program_located(tokens, starts, source), path, source)
   } else {

--- a/lib/@vibe/compiler/entry/source_compile/wasi_only/merge_sources.vibe
+++ b/lib/@vibe/compiler/entry/source_compile/wasi_only/merge_sources.vibe
@@ -13,7 +13,7 @@ import @vibe/compiler/codegen/wasi {
 }
 
 import @vibe/compiler/syntax {
-  lex, parse_program, print_program
+  lex, lex_with_offsets, parse_program, parse_program_located, print_program
 }
 
 import @vibe/compiler/core {
@@ -40,6 +40,8 @@ import @vibe/compiler/core {
   resolve_import_path_candidates,
   resolve_import_path_probe,
   rewrite_imported_value_stmt_to_local,
+  source_has_assert_eq,
+  stamp_assert_stmts,
   stmts_have_import_deep
 }
 
@@ -56,6 +58,43 @@ import @vibe/compiler/loader {
 }
 
 //# Functions
+
+//# assert_eq source locations (#2202)
+
+/// The walk itself lives in `@vibe/compiler/core` so this merge and the FS
+/// lane's merge (entry/compiler/file_compile) stamp identically. What is local
+/// here is WHEN: this lane also has callers that PRINT the merged program as
+/// source, and a printed three-argument `assert_eq` would land in the generated
+/// bundles, which the committed seed compiles -- and the seed knows only the
+/// two-argument form. So the compile entry turns stamping on and every printing
+/// entry turns it off, explicitly, per invocation.
+let assert_stamp_cell = array_empty()
+
+fn assert_stamp_set(on: Bool) -> Unit {
+  Array::truncate(assert_stamp_cell, 0)
+  Array::push(assert_stamp_cell, on)
+}
+
+fn assert_stamp_on() -> Bool {
+  if Array::length(assert_stamp_cell) > 0 {
+    Array::get(assert_stamp_cell, 0)
+  } else {
+    false
+  }
+}
+
+/// One module's statements, located only when it can pay for itself: a module
+/// with no `assert_eq` in its text gets the ordinary unlocated parse, so the
+/// extra `lex_with_offsets` + located parse + walk is confined to the files
+/// that can actually produce an assert failure.
+fn parse_module_stmts(path: String, source: String) -> Array[Stmt] with Exception {
+  if assert_stamp_on() && source_has_assert_eq(source) {
+    let (tokens, starts, _ends) = lex_with_offsets(source)
+    stamp_assert_stmts(parse_program_located(tokens, starts, source), path, source)
+  } else {
+    parse_program(lex(source))
+  }
+}
 
 fn string_array_contains_local(items: Array[String], target: String) -> Bool {
   let mut i = 0
@@ -150,7 +189,7 @@ fn collect_parsed_sources_recursive(path: String, file_paths: Array[String], fil
     // in THIS lane too, so a contract package in the graph resolves to its
     // conformance-checked facade instead of a parse error on bodyless decls.
     let source = ingest_source_text_fs(path, Fs::read_file(path))
-    let stmts = parse_program(lex(source))
+    let stmts = parse_module_stmts(path, source)
     let base_dir = dir_of_path(path)
     let mut i = 0
     while i < Array::length(stmts) {
@@ -516,6 +555,8 @@ fn append_coverage_driver_stmts(entry_path: String, driver_path: String, driver_
 /// names produced by the ordinary export/private namespacing pipeline; no
 /// guessed mangling or visibility broadening is involved.
 export fn coverage_driver_program_source_fs(entry_path: String, driver_path: String) -> String with Exception + Fs {
+  // OFF: this lane prints the merged program as source (see compile_file_wasi_only).
+  assert_stamp_set(false)
   let file_paths = array_empty()
   let file_stmts = array_empty()
   let visited = path_set_new()
@@ -541,6 +582,8 @@ export fn coverage_driver_program_source_fs(entry_path: String, driver_path: Str
 export fn merged_program_source_fs(entry_path: String) -> String with Exception + Fs {
   // #2205: the rename table describes ONE merged program.
   namespace_rename_originals_reset()
+  // OFF: this lane prints the merged program as source (see compile_file_wasi_only).
+  assert_stamp_set(false)
   let stmts = empty_stmt_array()
   let visited = path_set_new()
   collect_merged_stmts_recursive(entry_path, stmts, visited)
@@ -550,6 +593,11 @@ export fn merged_program_source_fs(entry_path: String) -> String with Exception 
 export fn compile_file_wasi_only(entry_path: String, entry_name: String) -> Bytes with Exception + Fs {
   // #2205: the rename table describes ONE merged program.
   namespace_rename_originals_reset()
+  // #2202: stamp `assert_eq` call sites with their own module's `path:line`.
+  // ON here and OFF in every lane that PRINTS the merged program: a printed
+  // three-argument `assert_eq` would land in the generated bundles, which the
+  // committed seed compiles, and the seed knows only the two-argument form.
+  assert_stamp_set(true)
   let stmts = empty_stmt_array()
   let visited = path_set_new()
   collect_merged_stmts_recursive(entry_path, stmts, visited)

--- a/lib/@vibe/compiler/index.vpkg
+++ b/lib/@vibe/compiler/index.vpkg
@@ -518,7 +518,9 @@ fn check_deprecated_warnings(input_path: String) -> Array[String] with Exception
 fn check_deprecated_warnings_from_source_groups(input_path: String, source_groups: Array[(String, Array[(String, String)])]) -> Array[String] with Exception + Fs
 fn check_redundant_import_warnings(input_path: String) -> Array[String] with Exception + Fs
 fn check_redundant_import_warnings_from_source_groups(input_path: String, source_groups: Array[(String, Array[(String, String)])]) -> Array[String] with Exception + Fs
+fn check_unstable_surface_warnings_from_path(input_path: String) -> Array[String] with Exception + Fs
 fn check_unstable_surface_warnings_from_source_groups(input_path: String, source_groups: Array[(String, Array[(String, String)])]) -> Array[String] with Exception + Fs
+fn unstable_surface_diagnostics(input_path: String, source: String) -> Array[String] with Exception
 fn strip_executable_wasm(wasm: Bytes, entry_name: String, strip_names: Bool, filter_exports: Bool) -> Bytes
 fn strip_executable_wasm_env(wasm: Bytes, entry_name: String) -> Bytes with Env
 fn write_linked_debug_build(input_path: String, output_path: String, entry_name: String) -> Unit with Exception + Fs

--- a/lib/@vibe/compiler/index.vpkg
+++ b/lib/@vibe/compiler/index.vpkg
@@ -518,6 +518,7 @@ fn check_deprecated_warnings(input_path: String) -> Array[String] with Exception
 fn check_deprecated_warnings_from_source_groups(input_path: String, source_groups: Array[(String, Array[(String, String)])]) -> Array[String] with Exception + Fs
 fn check_redundant_import_warnings(input_path: String) -> Array[String] with Exception + Fs
 fn check_redundant_import_warnings_from_source_groups(input_path: String, source_groups: Array[(String, Array[(String, String)])]) -> Array[String] with Exception + Fs
+fn check_unstable_surface_warnings_from_source_groups(input_path: String, source_groups: Array[(String, Array[(String, String)])]) -> Array[String] with Exception + Fs
 fn strip_executable_wasm(wasm: Bytes, entry_name: String, strip_names: Bool, filter_exports: Bool) -> Bytes
 fn strip_executable_wasm_env(wasm: Bytes, entry_name: String) -> Bytes with Env
 fn write_linked_debug_build(input_path: String, output_path: String, entry_name: String) -> Unit with Exception + Fs

--- a/lib/@vibe/compiler/index.vpkg
+++ b/lib/@vibe/compiler/index.vpkg
@@ -521,6 +521,7 @@ fn check_redundant_import_warnings_from_source_groups(input_path: String, source
 fn check_unstable_surface_warnings_from_path(input_path: String) -> Array[String] with Exception + Fs
 fn check_unstable_surface_warnings_from_source_groups(input_path: String, source_groups: Array[(String, Array[(String, String)])]) -> Array[String] with Exception + Fs
 fn unstable_surface_diagnostics(input_path: String, source: String) -> Array[String] with Exception
+fn unstable_surface_diagnostics_located(input_path: String, detected: String, located: String) -> Array[String] with Exception
 fn strip_executable_wasm(wasm: Bytes, entry_name: String, strip_names: Bool, filter_exports: Bool) -> Bytes
 fn strip_executable_wasm_env(wasm: Bytes, entry_name: String) -> Bytes with Env
 fn write_linked_debug_build(input_path: String, output_path: String, entry_name: String) -> Unit with Exception + Fs

--- a/lib/@vibe/compiler/loader/loader.vibe
+++ b/lib/@vibe/compiler/loader/loader.vibe
@@ -72,7 +72,8 @@ import @vibe/compiler/contract {
   replace_generated_hash_directive,
   semver_parts,
   verify_publish_bump,
-  vpkg_shared_import_marker
+  vpkg_shared_import_marker,
+  contract_declared_foreign_names
 }
 
 import ./ingestion_pipeline_telemetry.vibe {
@@ -1085,7 +1086,7 @@ let vpkg_types_registry_contracts: Array[String] = [] let vpkg_types_registry_pa
 /// the package lives outside the repo-relative tree (an absolute VIBE_LIB
 /// external root — the relative import spelling below cannot reach _build
 /// from there, so those packages keep the verbatim-facade behavior).
-fn ensure_vpkg_types_module_fs(vpkg_path: String, extra: Array[Stmt]) -> String with Exception + Fs {
+fn ensure_vpkg_types_module_fs(vpkg_path: String, extra: Array[Stmt], declared_foreign: Array[String]) -> String with Exception + Fs {
   if String::starts_with(vpkg_path, "/") {
     return ""
   } else {
@@ -1115,7 +1116,7 @@ fn ensure_vpkg_types_module_fs(vpkg_path: String, extra: Array[Stmt]) -> String 
       }
       uci = uci + 1
     }
-    let text = contract_types_module_text(tds, StringBuilder::freeze(uniq_sb))
+    let text = contract_types_module_text(tds, StringBuilder::freeze(uniq_sb), declared_foreign)
     let raw_key = compact_string_fingerprint(String::concat(vpkg_path, String::concat("|", text)))
     // Identifier-safe basename: the import-path grammar (parser_base.vibe's
     // collect_import_path) lexes path segments as identifier/keyword tokens,
@@ -1251,13 +1252,13 @@ fn vpkg_directory_shared_import_prefix_fs(path: String) -> String with Exception
       } else {
         let vpkg_raw = Fs::read_file(vpkg_path)
         let (_, vpkg_pin_blanked) = extract_require_pins(vpkg_raw)
-        let (_, _, vpkg_extra) = parse_contract_program(lex(vpkg_pin_blanked))
+        let (_, vpkg_opaques, vpkg_extra) = parse_contract_program(lex(vpkg_pin_blanked))
         let shared_text = contract_directory_shared_import_prefix_text(vpkg_extra)
         // #1840: siblings import the contract's type family from the
         // materialized types module — this is what gives enum constructors
         // real value bindings inside impl units (the facade cannot be
         // imported from a sibling: facade → impl is already an edge).
-        let types_path = ensure_vpkg_types_module_fs(vpkg_path, vpkg_extra)
+        let types_path = ensure_vpkg_types_module_fs(vpkg_path, vpkg_extra, contract_declared_foreign_names(vpkg_opaques, vpkg_extra))
         let prefix_text = if types_path == "" {
           shared_text
         } else {
@@ -2112,7 +2113,7 @@ fn desugar_contract_source_fs(path: String, source: String) -> String with Excep
   // text needs the package-dir-RELATIVE spelling (the export grammar rejects
   // a bare root-relative head token); the cache row below keeps the
   // canonical root-relative path for its existence re-check.
-  let facade_types_path = ensure_vpkg_types_module_fs(path, extra)
+  let facade_types_path = ensure_vpkg_types_module_fs(path, extra, contract_declared_foreign_names(opaque_names, extra))
   let facade_types_rel = if facade_types_path == "" {
     ""
   } else {

--- a/lib/@vibe/compiler/loader/loader.vibe
+++ b/lib/@vibe/compiler/loader/loader.vibe
@@ -72,8 +72,7 @@ import @vibe/compiler/contract {
   replace_generated_hash_directive,
   semver_parts,
   verify_publish_bump,
-  vpkg_shared_import_marker,
-  contract_declared_foreign_names
+  vpkg_shared_import_marker
 }
 
 import ./ingestion_pipeline_telemetry.vibe {
@@ -1086,7 +1085,7 @@ let vpkg_types_registry_contracts: Array[String] = [] let vpkg_types_registry_pa
 /// the package lives outside the repo-relative tree (an absolute VIBE_LIB
 /// external root — the relative import spelling below cannot reach _build
 /// from there, so those packages keep the verbatim-facade behavior).
-fn ensure_vpkg_types_module_fs(vpkg_path: String, extra: Array[Stmt], declared_foreign: Array[String]) -> String with Exception + Fs {
+fn ensure_vpkg_types_module_fs(vpkg_path: String, extra: Array[Stmt]) -> String with Exception + Fs {
   if String::starts_with(vpkg_path, "/") {
     return ""
   } else {
@@ -1116,7 +1115,7 @@ fn ensure_vpkg_types_module_fs(vpkg_path: String, extra: Array[Stmt], declared_f
       }
       uci = uci + 1
     }
-    let text = contract_types_module_text(tds, StringBuilder::freeze(uniq_sb), declared_foreign)
+    let text = contract_types_module_text(tds, StringBuilder::freeze(uniq_sb))
     let raw_key = compact_string_fingerprint(String::concat(vpkg_path, String::concat("|", text)))
     // Identifier-safe basename: the import-path grammar (parser_base.vibe's
     // collect_import_path) lexes path segments as identifier/keyword tokens,
@@ -1252,13 +1251,13 @@ fn vpkg_directory_shared_import_prefix_fs(path: String) -> String with Exception
       } else {
         let vpkg_raw = Fs::read_file(vpkg_path)
         let (_, vpkg_pin_blanked) = extract_require_pins(vpkg_raw)
-        let (_, vpkg_opaques, vpkg_extra) = parse_contract_program(lex(vpkg_pin_blanked))
+        let (_, _, vpkg_extra) = parse_contract_program(lex(vpkg_pin_blanked))
         let shared_text = contract_directory_shared_import_prefix_text(vpkg_extra)
         // #1840: siblings import the contract's type family from the
         // materialized types module — this is what gives enum constructors
         // real value bindings inside impl units (the facade cannot be
         // imported from a sibling: facade → impl is already an edge).
-        let types_path = ensure_vpkg_types_module_fs(vpkg_path, vpkg_extra, contract_declared_foreign_names(vpkg_opaques, vpkg_extra))
+        let types_path = ensure_vpkg_types_module_fs(vpkg_path, vpkg_extra)
         let prefix_text = if types_path == "" {
           shared_text
         } else {
@@ -2113,7 +2112,7 @@ fn desugar_contract_source_fs(path: String, source: String) -> String with Excep
   // text needs the package-dir-RELATIVE spelling (the export grammar rejects
   // a bare root-relative head token); the cache row below keeps the
   // canonical root-relative path for its existence re-check.
-  let facade_types_path = ensure_vpkg_types_module_fs(path, extra, contract_declared_foreign_names(opaque_names, extra))
+  let facade_types_path = ensure_vpkg_types_module_fs(path, extra)
   let facade_types_rel = if facade_types_path == "" {
     ""
   } else {

--- a/lib/@vibe/compiler/normalize/desugar_trait_dict.vibe
+++ b/lib/@vibe/compiler/normalize/desugar_trait_dict.vibe
@@ -7,6 +7,7 @@ import @vibe/compiler/core {
   Stmt,
   TypeEnv,
   TypeExpr,
+  assert_eq_located_callee,
   expr_children,
   is_exception_effect_name,
   is_exception_throw_operation,
@@ -6331,29 +6332,28 @@ fn interp_take_repl(r: Option[Expr]) -> Expr {
 /// what the checker sees (effect-free); this pass rewrites it after check so
 /// a failure can print both sides without adding Stderr/Exception to the
 /// source row.
-/// Arity 2 is what the user writes. Arity 3 is the same call after the merge
-/// stamped it with `"path:line"` from its own module's source (#2202) -- that
-/// form exists only between the merge and this lowering, and this lowering
-/// removes it, so neither the checker nor either backend ever sees it.
+/// `assert_eq` is the user's spelling and takes exactly two arguments.
+/// `__assert_eq_at` is the SAME call after the merge stamped it with
+/// `"path:line"` from its own module's source (#2202); it exists only between
+/// the merge and this lowering, which removes it, so neither the checker nor
+/// either backend sees it.
+///
+/// A separate callee, NOT `assert_eq` at arity 3. Recognizing a three-argument
+/// `assert_eq` whose third operand is a literal string made a user-written
+/// `assert_eq(1, 2, "user")` indistinguishable from a stamped call -- and in
+/// the single-source lane `expand_interp_stmts` runs BEFORE `check_program`,
+/// so that call compiled and reported `assert_eq failed at user` instead of
+/// the arity error. Measured, and exactly the silent-wrong the guard was meant
+/// to prevent (Codex review on #2277).
 fn is_assert_eq_call(callee: Expr, args: Array[Expr]) -> Bool {
   match callee {
-    EIdent(n, _) => n == "assert_eq" && (Array::length(args) == 2 || (Array::length(args) == 3 && assert_eq_stamp_is_string(args))),
+    EIdent(n, _) => (n == "assert_eq" && Array::length(args) == 2) || (n == assert_eq_located_callee && Array::length(args) == 3),
     _ => false
   }
 }
 
-/// A third argument counts only when it is a literal string, so a user's
-/// `assert_eq(a, b, c)` still fails on arity as it always did rather than
-/// silently dropping its third operand.
-fn assert_eq_stamp_is_string(args: Array[Expr]) -> Bool {
-  match Array::get(args, 2) {
-    EString(_) => true,
-    _ => false
-  }
-}
-
-/// The stamped location, or "" when the call was never stamped -- an unlocated
-/// parse, a lane that does not stamp, or an `assert_eq` in an expression
+/// The stamped location, or "" when the call was never stamped -- a lane that
+/// does not stamp, an unlocated parse, or an `assert_eq` in an expression
 /// position the stamping walk does not descend into. No line is the designed
 /// degradation; a wrong line would be worse than none (#1445).
 fn assert_eq_location(args: Array[Expr]) -> String {

--- a/lib/@vibe/compiler/normalize/desugar_trait_dict.vibe
+++ b/lib/@vibe/compiler/normalize/desugar_trait_dict.vibe
@@ -6355,13 +6355,22 @@ fn interp_take_repl(r: Option[Expr]) -> Expr {
 /// cannot arise there either -- this arm is the backstop for the lanes that do
 /// not stamp at all.
 fn is_assert_eq_call(callee: Expr, args: Array[Expr]) -> Bool {
-  if user_assert_eq_bound() {
-    false
-  } else {
-    match callee {
-      EIdent(n, _) => (n == "assert_eq" && Array::length(args) == 2) || (n == assert_eq_located_callee && Array::length(args) == 3),
-      _ => false
-    }
+  match callee {
+    EIdent(n, _) => if n == "assert_eq" {
+      // The BARE spelling is the only one a user binding competes with, so it
+      // is the only one the suppression applies to.
+      Array::length(args) == 2 && !user_assert_eq_bound()
+    } else {
+      // The stamped marker is ALWAYS consumed. It cannot come from source (`#`
+      // is not an identifier character), so it exists only because the stamp
+      // put it there -- and the stamp is per MODULE while the flag above is
+      // per merged program. Suppressing it too meant one dependency binding
+      // `assert_eq` locally left ANOTHER module's already-stamped calls
+      // unlowered, and `#assert_eq_at` then reached codegen as an unresolved
+      // function, breaking an otherwise valid multi-file build (#2277 review).
+      n == assert_eq_located_callee && Array::length(args) == 3
+    },
+    _ => false
   }
 }
 

--- a/lib/@vibe/compiler/normalize/desugar_trait_dict.vibe
+++ b/lib/@vibe/compiler/normalize/desugar_trait_dict.vibe
@@ -6331,10 +6331,39 @@ fn interp_take_repl(r: Option[Expr]) -> Expr {
 /// what the checker sees (effect-free); this pass rewrites it after check so
 /// a failure can print both sides without adding Stderr/Exception to the
 /// source row.
+/// Arity 2 is what the user writes. Arity 3 is the same call after the merge
+/// stamped it with `"path:line"` from its own module's source (#2202) -- that
+/// form exists only between the merge and this lowering, and this lowering
+/// removes it, so neither the checker nor either backend ever sees it.
 fn is_assert_eq_call(callee: Expr, args: Array[Expr]) -> Bool {
   match callee {
-    EIdent(n, _) => n == "assert_eq" && Array::length(args) == 2,
+    EIdent(n, _) => n == "assert_eq" && (Array::length(args) == 2 || (Array::length(args) == 3 && assert_eq_stamp_is_string(args))),
     _ => false
+  }
+}
+
+/// A third argument counts only when it is a literal string, so a user's
+/// `assert_eq(a, b, c)` still fails on arity as it always did rather than
+/// silently dropping its third operand.
+fn assert_eq_stamp_is_string(args: Array[Expr]) -> Bool {
+  match Array::get(args, 2) {
+    EString(_) => true,
+    _ => false
+  }
+}
+
+/// The stamped location, or "" when the call was never stamped -- an unlocated
+/// parse, a lane that does not stamp, or an `assert_eq` in an expression
+/// position the stamping walk does not descend into. No line is the designed
+/// degradation; a wrong line would be worse than none (#1445).
+fn assert_eq_location(args: Array[Expr]) -> String {
+  if Array::length(args) < 3 {
+    ""
+  } else {
+    match Array::get(args, 2) {
+      EString(loc) => loc,
+      _ => ""
+    }
   }
 }
 
@@ -6399,7 +6428,13 @@ fn lower_assert_eq(args: Array[Expr], gens: Array[(String, Array[(String, String
   // block, so the block text alone cannot identify the abort. The
   // condensers hide the line; in a plain `vibe run` it reads as ordinary
   // diagnostic prose rather than harness protocol.
-  let msg = assert_eq_concat(EString("assert_eq failed\n  expected: "), assert_eq_concat(expected_s, assert_eq_concat(EString("\n  actual:   "), assert_eq_concat(actual_s, EString("\nassert failed: aborting")))))
+  let located = assert_eq_location(args)
+  let head = if located == "" {
+    "assert_eq failed\n  expected: "
+  } else {
+    String::concat("assert_eq failed at ", String::concat(located, "\n  expected: "))
+  }
+  let msg = assert_eq_concat(EString(head), assert_eq_concat(expected_s, assert_eq_concat(EString("\n  actual:   "), assert_eq_concat(actual_s, EString("\nassert failed: aborting")))))
   // stdout, not Stderr::write_stream: the gc lane only reserves host
   // imports when the source already used one, and flipping that on a
   // SIMD-only file shifts every generated-body index (gc-gate

--- a/lib/@vibe/compiler/normalize/desugar_trait_dict.vibe
+++ b/lib/@vibe/compiler/normalize/desugar_trait_dict.vibe
@@ -14,6 +14,7 @@ import @vibe/compiler/core {
   namespace_rename_original,
   namespace_rename_originals_reset,
   sort_perm_by_names,
+  stmts_bind_assert_eq,
   str_lt,
   trait_method_sig_binders_deep
 }
@@ -6345,11 +6346,46 @@ fn interp_take_repl(r: Option[Expr]) -> Expr {
 /// so that call compiled and reported `assert_eq failed at user` instead of
 /// the arity error. Measured, and exactly the silent-wrong the guard was meant
 /// to prevent (Codex review on #2277).
+/// A program that binds `assert_eq` itself gets NEITHER form. The lowering runs
+/// before `check_program` in the single-file lane, so it used to replace the
+/// reader's own function with assertion behavior and nothing downstream could
+/// notice: `fn assert_eq(a: Int, b: Int) -> Int { a + b }` plus `assert_eq(1, 2)`
+/// compiled clean and trapped with `assert_eq failed` instead of returning 3
+/// (#2283). The stamp is suppressed for the same modules, so the located form
+/// cannot arise there either -- this arm is the backstop for the lanes that do
+/// not stamp at all.
 fn is_assert_eq_call(callee: Expr, args: Array[Expr]) -> Bool {
-  match callee {
-    EIdent(n, _) => (n == "assert_eq" && Array::length(args) == 2) || (n == assert_eq_located_callee && Array::length(args) == 3),
-    _ => false
+  if user_assert_eq_bound() {
+    false
+  } else {
+    match callee {
+      EIdent(n, _) => (n == "assert_eq" && Array::length(args) == 2) || (n == assert_eq_located_callee && Array::length(args) == 3),
+      _ => false
+    }
   }
+}
+
+/// Pass state, reset at every `desugar_trait_dicts` entry like the exn-kind
+/// cell above: whether THIS program binds `assert_eq` itself.
+///
+/// The unit is the program this pass was handed, which in the FS lane is every
+/// module merged together -- so one module defining `assert_eq` stands the
+/// lowering down for all of them. Coarse, and deliberately so: a merged offset
+/// cannot say which module it came from, so a per-module answer here would be
+/// invented. The stamp upstream IS per module (it still has each module's own
+/// text), and it is the half that decides what a failure prints.
+let dtd_user_assert_eq = [0]
+
+fn user_assert_eq_reset(stmts: Array[Stmt]) -> Unit {
+  Array::set(dtd_user_assert_eq, 0, if stmts_bind_assert_eq(stmts) {
+    1
+  } else {
+    0
+  })
+}
+
+fn user_assert_eq_bound() -> Bool {
+  Array::get(dtd_user_assert_eq, 0) == 1
 }
 
 /// The stamped location, or "" when the call was never stamped -- a lane that
@@ -14867,6 +14903,9 @@ export fn desugar_trait_dicts(stmts: Array[Stmt]) -> Unit with Exception {
   // #2141: a throw mid-rewrite leaves frames on the lexical binder stack;
   // reset so a later run on another program cannot see them.
   scope_formals_reset()
+  // #2283: same discipline -- whether the assert lowering must stand down for
+  // THIS program, because the program binds the name itself.
+  user_assert_eq_reset(stmts)
   eq_tuple_uid_reset()
   eq_known_types_reset(stmts)
   desugar_derives(stmts)

--- a/lib/@vibe/compiler/perceus/index.vpkg
+++ b/lib/@vibe/compiler/perceus/index.vpkg
@@ -10,6 +10,9 @@ deps = {
 
 generated_hash =
 
+// #2164: defined by a sibling implementation of this package.
+opaque type PerceusActionKind
+
 // @vibe/compiler/perceus — the RC backend's Perceus dup/drop planner
 // (count + emit passes over a function body), the program-wide
 // borrow-return / scalar-return / heap-return name scans, and the

--- a/lib/@vibe/compiler/perceus/index.vpkg
+++ b/lib/@vibe/compiler/perceus/index.vpkg
@@ -10,9 +10,6 @@ deps = {
 
 generated_hash =
 
-// #2164: defined by a sibling implementation of this package.
-opaque type PerceusActionKind
-
 // @vibe/compiler/perceus — the RC backend's Perceus dup/drop planner
 // (count + emit passes over a function body), the program-wide
 // borrow-return / scalar-return / heap-return name scans, and the

--- a/lib/@vibe/compiler/runtime/index.vpkg
+++ b/lib/@vibe/compiler/runtime/index.vpkg
@@ -23,11 +23,6 @@ deps = {
 
 generated_hash =
 
-// #2164: `ModuleJob` names a type another package owns. The import states
-// which, so the reference is traceable and an undeclared name next to it is
-// a typo rather than an unverifiable wildcard.
-import @vibe/compiler/core { TypeEnv }
-
 // @vibe/compiler/runtime — ADR-0070 / #897 compiler-internal contract,
 // compiler-internal batch 8. Directory-shared-scope package (originally 7
 // impl files, ~4275 lines; doc_at.vibe added under #854): the incremental

--- a/lib/@vibe/compiler/runtime/index.vpkg
+++ b/lib/@vibe/compiler/runtime/index.vpkg
@@ -23,6 +23,11 @@ deps = {
 
 generated_hash =
 
+// #2164: `ModuleJob` names a type another package owns. The import states
+// which, so the reference is traceable and an undeclared name next to it is
+// a typo rather than an unverifiable wildcard.
+import @vibe/compiler/core { TypeEnv }
+
 // @vibe/compiler/runtime — ADR-0070 / #897 compiler-internal contract,
 // compiler-internal batch 8. Directory-shared-scope package (originally 7
 // impl files, ~4275 lines; doc_at.vibe added under #854): the incremental

--- a/lib/@vibe/concurrent/index.vpkg
+++ b/lib/@vibe/concurrent/index.vpkg
@@ -1,6 +1,8 @@
 name = @vibe/concurrent
 version = 0.0.1
 description =
+  #|UNSTABLE (ADR-0068, proposed): outside the SemVer promise, can change
+  #|within a Minor -- see docs/spec/stable-surface.md section 6.
   #|@vibe/concurrent — ADR-0068 shared-nothing structured concurrency,
 deps = {}
 

--- a/lib/@vibe/core/index.vpkg
+++ b/lib/@vibe/core/index.vpkg
@@ -6,14 +6,6 @@ deps = {}
 
 generated_hash =
 
-// #2164: defined by sibling implementations of THIS package (hashset.vibe,
-// sortedmap.vibe, sortedset.vibe). Declared, not imported: the materialized
-// types module importing its own package's impl is the `types -> impl` cycle
-// that module exists to avoid.
-opaque type MutSet
-opaque type MutSortedMap
-opaque type MutSortedSet
-
 // @vibe/core — vibe standard core library (ADR-0063 contract package).
 // Modeled on moonbitlang/core's per-domain organization. The top level of
 // this contract IS the public API: transparent type definitions + fn

--- a/lib/@vibe/core/index.vpkg
+++ b/lib/@vibe/core/index.vpkg
@@ -6,6 +6,14 @@ deps = {}
 
 generated_hash =
 
+// #2164: defined by sibling implementations of THIS package (hashset.vibe,
+// sortedmap.vibe, sortedset.vibe). Declared, not imported: the materialized
+// types module importing its own package's impl is the `types -> impl` cycle
+// that module exists to avoid.
+opaque type MutSet
+opaque type MutSortedMap
+opaque type MutSortedSet
+
 // @vibe/core — vibe standard core library (ADR-0063 contract package).
 // Modeled on moonbitlang/core's per-domain organization. The top level of
 // this contract IS the public API: transparent type definitions + fn

--- a/lib/@vibe/lsp/index.vpkg
+++ b/lib/@vibe/lsp/index.vpkg
@@ -34,3 +34,4 @@ generated_hash =
 fn lsp_main() -> Int with Stdin + Stdout
 fn lsp_diagnostics_safe(source: String) -> Json
 fn lsp_diagnostics_json_string(source: String) -> String
+fn lsp_diagnostics_json_string_with(source: String, extra: Array[String]) -> String

--- a/lib/@vibe/lsp/lsp_server.vibe
+++ b/lib/@vibe/lsp/lsp_server.vibe
@@ -768,6 +768,33 @@ export fn lsp_diagnostics_json_string(source: String) -> String {
   Json::stringify(lsp_diagnostics_safe(source))
 }
 
+/// #2277: the ADR-0068 opt-in diagnostic is produced by the ADAPTER, not by
+/// `collect_all_diagnostics` -- it is a property of the import declaration
+/// rather than of single-file analysis -- so the JSON form has to be handed it
+/// or `vibe check --single-file --json` answers `[]` where the text form
+/// reports the error. Same diagnostic shape either way: the extra lines are the
+/// same `line L:C: message` strings every other consumer produces, mapped
+/// through the same parser.
+///
+/// The extra lines are appended even when `collect_all_diagnostics` throws: an
+/// internal failure in single-file analysis is not a reason to drop a verdict
+/// the caller already computed.
+export fn lsp_diagnostics_json_string_with(source: String, extra: Array[String]) -> String {
+  let msgs = handle {
+    collect_all_diagnostics(source)
+  } with { Exception::Throw(_) => array_empty() }
+  let mut i = 0
+  while i < Array::length(extra) {
+    Array::push(msgs, Array::get(extra, i))
+    i = i + 1
+  }
+  Json::stringify(handle {
+    JArr(for msg in msgs {
+      lsp_parse_diag_line(source, msg)
+    })
+  } with { Exception::Throw(_) => JArr([]) })
+}
+
 //# Completion / signature help / workspace-symbol (parity slice 2).
 //# Deliberately built on the SAME single-file compiler primitives as the
 //# rest of this server (symbol_spans / type_at_source), not on a ported

--- a/lib/@vibe/parser/parser_expr_core.vibe
+++ b/lib/@vibe/parser/parser_expr_core.vibe
@@ -445,6 +445,15 @@ fn map_from_pairs_fields(args: Array[Expr], pos: Int) -> Array[(String, Expr)] w
   }
 }
 
+/// Is this callee a dot expression? Its offset belongs to the receiver, not
+/// to the call (#2261).
+fn is_dot_callee(e: Expr) -> Bool {
+  match e {
+    EDot(_, _, _, _) => true,
+    _ => false
+  }
+}
+
 /// Does this callee expression root at a CALL?
 ///
 /// #2231: the answer decides whether the callee's offset belongs to the callee
@@ -470,7 +479,18 @@ fn callee_roots_at_call(e: Expr) -> Bool {
 /// diagnostic position moves: only a callee that roots at a call is given a
 /// different offset -- the field name for a dot-call, the `(` otherwise.
 fn call_site_offset(callee: Expr, lparen_off: Int) -> Int {
-  if callee_roots_at_call(callee) {
+  // A DOT callee never owns its offset either. `EDot`'s own offset is its
+  // receiver's root (parser_expr_core's TDot arm passes `callee_offset(expr)`),
+  // so `b.get()` gave the outer call the offset of the identifier `b` -- and
+  // `type_at`'s table is last-wins, so hovering `b` answered `Double`, the
+  // CALL's result, instead of `Box` (#2261). #1941 solved the same collision
+  // for a NAMED callee with `CalleeHit`; that escape resolves through the
+  // top-level env and so cannot answer for a local receiver.
+  //
+  // #2231 moved only the call-ROOTED case off the callee's offset, because
+  // that was the case its symptom could show. The rule is the same one:
+  // a call node's offset must identify that call node.
+  if callee_roots_at_call(callee) || is_dot_callee(callee) {
     // The `(` that opens the argument list, which belongs to no other node.
     //
     // Using the dot's FIELD-NAME offset here was wrong in a way the #2231

--- a/lib/@vibex/immut/index.vpkg
+++ b/lib/@vibex/immut/index.vpkg
@@ -6,6 +6,9 @@ deps = {}
 
 generated_hash =
 
+// #2164: defined by the sibling implementation immut_map.vibe.
+opaque type MapHamt
+
 // @vibex/immut — persistent (immutable) collections (#841 C 群、ADR-0065
 // 実験 scope)。0.4.0 並行モデル (ADR-0068) の sendable データの布石:
 // 更新は常に新しい値を返し、旧版は構造共有のまま不変。

--- a/lib/@vibex/immut/index.vpkg
+++ b/lib/@vibex/immut/index.vpkg
@@ -6,9 +6,6 @@ deps = {}
 
 generated_hash =
 
-// #2164: defined by the sibling implementation immut_map.vibe.
-opaque type MapHamt
-
 // @vibex/immut — persistent (immutable) collections (#841 C 群、ADR-0065
 // 実験 scope)。0.4.0 並行モデル (ADR-0068) の sendable データの布石:
 // 更新は常に新しい値を返し、旧版は構造共有のまま不変。

--- a/runtime/vibe
+++ b/runtime/vibe
@@ -750,7 +750,14 @@ condense_test_trap() {
     # with only crash-debug / blank lines between (keep in lockstep with
     # scripts/vibe_test.sh vt_fail_detail).
     { __blk = 0 }
-    $0 == "assert_eq failed" {
+    # Anchored, and now with the optional location the merge stamps onto the
+    # call (#2202): `assert_eq failed at path:line`. Still a full-line match
+    # ending in `:<digits>`, so ordinary program output cannot masquerade as
+    # the head of an assert block -- the property the exact-match spelling was
+    # there for. An exact match alone silently DROPPED the located line from
+    # the condensed report, which is how the located build first looked like it
+    # had changed nothing.
+    $0 ~ /^assert_eq failed( at .+:[0-9]+)?$/ {
       __blk = 1
       ablk = 1
       ndiag++

--- a/scripts/check_gate_portability.sh
+++ b/scripts/check_gate_portability.sh
@@ -79,13 +79,25 @@ findings="$(
       next
     }
 
-    # 3. `sed -i` with no suffix. GNU takes an optional one, BSD/macOS REQUIRES
-    #    one, so the bare form aborts there. Lexical, and a real instance:
-    #    check_book_console_test.sh -- a release-check dependency -- used it,
-    #    so the default gate could not run on the environment this file exists
-    #    to protect (#2248 review). `sed -i.bak` and `sed -i ''` both pass.
-    /(^|[^A-Za-z0-9_.-])sed[[:space:]]+(-[A-Za-z]+[[:space:]]+)*-i([[:space:]]|$)/ {
-      printf "  %s:%d: `sed -i` with no suffix; BSD/macOS requires one -- use a temp file, or `sed -i.bak` and remove it\n", rel, FNR
+    # 3. In-place `sed` with no suffix. GNU takes an optional one, BSD/macOS
+    #    REQUIRES it, so every no-suffix spelling aborts there. Lexical, and a
+    #    real instance: check_book_console_test.sh -- a release-check
+    #    dependency -- used it, so the default gate could not run on the
+    #    environment this file exists to protect (#2248 review).
+    #
+    #    THREE spellings, not one. The first version matched only a standalone
+    #    `-i` and accepted `sed --in-place` and `sed -Ei` (measured, both
+    #    printed ok). The option word is matched as: a short cluster ending in
+    #    `i` (`-i`, `-Ei`, `-ni`) or the long form with no `=SUFFIX`. Anything
+    #    after the `i` is a suffix, so `-i.bak` and `--in-place=.bak` pass, as
+    #    does a temp-file edit -- pinned by a green guard, because a rule that
+    #    rejected every `sed` would satisfy the red cases and be useless.
+    #
+    #    The leading `(-[^[:space:]]+[[:space:]]+)*` requires every word
+    #    between `sed` and the offender to be an option, so `sed 's/x/y/' f |
+    #    grep -i foo` is not mistaken for one.
+    /(^|[^A-Za-z0-9_.-])sed[[:space:]]+(-[^[:space:]]+[[:space:]]+)*(-[A-Za-z]*i|--in-place)([[:space:]]|$)/ {
+      printf "  %s:%d: in-place `sed` with no suffix; BSD/macOS requires one -- use a temp file, or `sed -i.bak` and remove it\n", rel, FNR
       next
     }
 
@@ -118,4 +130,4 @@ if [ -n "$findings" ]; then
   exit 1
 fi
 
-echo "[gate-portability] ok (no ripgrep dependency; no bare sed -i; no uninterpreted \\t in grep patterns)"
+echo "[gate-portability] ok (no ripgrep dependency; no no-suffix in-place sed; no uninterpreted \\t in grep patterns)"

--- a/scripts/check_gate_portability_test.sh
+++ b/scripts/check_gate_portability_test.sh
@@ -67,13 +67,31 @@ run && { cat "$TMP_ROOT/out" >&2; fail "a bare sed -i was accepted"; }
 grep -qF 'BSD/macOS requires one' "$TMP_ROOT/out" || fail "sed -i finding did not name the reason"
 ok "a bare sed -i is rejected"
 
-# --- green guard for 1c: both portable spellings must still pass, or the rule
-# could be satisfied by rejecting every sed.
+# --- red 1c2/1c3: the OTHER no-suffix spellings. Matching only a standalone
+# `-i` accepted `sed --in-place` and `sed -Ei`, which are the same GNU-only
+# behaviour one keystroke away (#2248 review).
+reset_tree
+printf '%s\n' 'sed --in-place "s/a/b/" "$1"' >> "$TMP_ROOT/scripts/clean.sh"
+grep -qF 'sed --in-place' "$TMP_ROOT/scripts/clean.sh" || fail "fixture 1c2 did not land"
+run && { cat "$TMP_ROOT/out" >&2; fail "sed --in-place was accepted"; }
+ok "sed --in-place (long form, no suffix) is rejected"
+
+reset_tree
+printf '%s\n' 'sed -Ei "s/a/b/" "$1"' >> "$TMP_ROOT/scripts/clean.sh"
+grep -qF 'sed -Ei' "$TMP_ROOT/scripts/clean.sh" || fail "fixture 1c3 did not land"
+run && { cat "$TMP_ROOT/out" >&2; fail "a clustered -Ei was accepted"; }
+ok "a clustered short option ending in i (-Ei) is rejected"
+
+# --- green guard for 1c: every portable spelling must still pass, or the rule
+# could be satisfied by rejecting every sed. The last one is the false positive
+# the option-run anchor exists to prevent: a `grep -i` AFTER a sed pipeline.
 reset_tree
 printf '%s\n' 'sed -i.bak "s/a/b/" "$1"' >> "$TMP_ROOT/scripts/clean.sh"
+printf '%s\n' 'sed --in-place=.bak "s/a/b/" "$1"' >> "$TMP_ROOT/scripts/clean.sh"
 printf '%s\n' 'sed "s/a/b/" "$1" > "$1.tmp" && mv "$1.tmp" "$1"' >> "$TMP_ROOT/scripts/clean.sh"
+printf '%s\n' "sed 's/x/y/' \"\$1\" | grep -i foo" >> "$TMP_ROOT/scripts/clean.sh"
 run || { cat "$TMP_ROOT/out" >&2; fail "a portable sed spelling was rejected"; }
-ok "sed -i.bak and a temp-file edit still pass"
+ok "sed -i.bak, --in-place=.bak, a temp-file edit and a piped grep -i still pass"
 
 # --- red 2: ripgrep behind a pipe.
 reset_tree

--- a/scripts/check_selector_precedence.sh
+++ b/scripts/check_selector_precedence.sh
@@ -53,7 +53,12 @@ adapter, launcher, mode, enforced = sys.argv[1], sys.argv[2], sys.argv[3], sys.a
 # would break that, so they are excluded BY NAME -- and the check below fails on
 # any expression-position selector not accounted for here, so a new one cannot
 # be silently dropped the way VIBE_COVERAGE was (#2246 review).
-OBSERVATION_ONLY = {"VIBE_DIAGNOSTICS_ALL", "VIBE_PROFILE_MEMORY_MARKS"}
+# VIBE_UNSTABLE joins them: it is read INSIDE the already-selected VIBE_CHECK
+# branch and only decides whether ADR-0068 warning lines are appended. It picks
+# no branch, so it cannot hijack a verb -- and clearing it would silence a
+# caller who set it deliberately, which is the same reason the other two are
+# here.
+OBSERVATION_ONLY = {"VIBE_DIAGNOSTICS_ALL", "VIBE_PROFILE_MEMORY_MARKS", "VIBE_UNSTABLE"}
 
 # The order is SOURCE ORDER, and a selector counts wherever it is tested --
 # `let bytes = if Env::get("VIBE_COVERAGE") == "1" { .. } else if

--- a/scripts/check_selector_precedence.sh
+++ b/scripts/check_selector_precedence.sh
@@ -160,20 +160,30 @@ for m in re.finditer(r'\benv\b((?:[^\n]*\\\n)*[^\n]*)', src):
     # question is changed rather than answered: no variables, and the check
     # becomes "is the call spelled here", which a scanner CAN decide.
     #
-    # Searched with single-quoted spans REMOVED first. The shell does not
-    # expand `$( ... )` inside single quotes, so `env 'X=$(selector_clears_
-    # before VIBE_BACKEND)' ...` passes a literal string and clears nothing --
-    # and matching the helper's TEXT anywhere in the block credited exactly
-    # that (#2248 review). Same defect as every earlier round: the check read
-    # a proxy (the characters are present) for the property (the shell runs
-    # it). A single-quoted span cannot execute anything, so deleting those
-    # spans before looking is the whole fix.
+    # Searched with QUOTED spans removed first -- both kinds. The clears must
+    # reach `env` as separate words, and only a bare, unquoted command
+    # substitution does that.
     #
-    # Double quotes are left alone on purpose: `"$(selector_clears_before X)"`
-    # DOES expand -- though it would then be one argument rather than the word
-    # list `env` needs, which is a different bug and one the runner would
-    # surface immediately.
+    #   'X=$(selector_clears_before VIBE_BACKEND)'  never expands at all
+    #   "X=$(selector_clears_before VIBE_BACKEND)"  expands, then collapses to
+    #                                               ONE `X=...` assignment
+    #
+    # Neither passes a single `-u` to `env`, and the block still reads as
+    # though it clears everything. Both were measured reporting `ok` on a
+    # hijackable tree (#2248 review, two separate rounds).
+    #
+    # The second round is the one worth recording, because I argued myself out
+    # of it: the previous version stripped only single quotes, on the reasoning
+    # that the double-quoted form "DOES expand -- though it would then be one
+    # argument rather than the word list `env` needs, which is a different bug
+    # and one the runner would surface immediately". It does not surface. `env`
+    # accepts `X=...` as a perfectly valid assignment and runs the command with
+    # no clears at all. Same defect as every earlier round -- the check read a
+    # proxy (the characters are present) for the property (the shell passes
+    # them as words) -- and this time the proxy was in my justification for
+    # leaving the hole open.
     executable = re.sub(r"'[^']*'", "", block)
+    executable = re.sub(r'"[^"]*"', "", executable)
     inline = re.findall(r'\$\(selector_clears_before (VIBE_[A-Z_]+)\)', executable)
     covered = inline
 

--- a/scripts/check_selector_precedence_test.sh
+++ b/scripts/check_selector_precedence_test.sh
@@ -123,6 +123,15 @@ red "the helper is spelled inside single quotes" \
     "unresolved expansion" \
     "out = s.replace('env \$(selector_clears_before VIBE_BACKEND)', chr(101)+chr(110)+chr(118)+chr(32)+chr(39)+'X=\$(selector_clears_before VIBE_BACKEND)'+chr(39), 1)"
 
+# ...and in DOUBLE quotes, which is the sharper of the two. The helper really
+# does run; its whole output then becomes one `X=...` argument, which `env`
+# accepts as a valid assignment and which passes no `-u` at all. I left this
+# open deliberately in the previous round, arguing the runner would surface it.
+# It does not (#2248 review).
+red "the helper is spelled inside double quotes" \
+    "unresolved expansion" \
+    "out = s.replace('env \$(selector_clears_before VIBE_BACKEND)', chr(101)+chr(110)+chr(118)+chr(32)+chr(34)+'X=\$(selector_clears_before VIBE_BACKEND)'+chr(34), 1)"
+
 # Five cases used to live here, all mutating the variable that carried the
 # clears (an uncovered path, an underived narrowing, an assignment behind
 # `&&`, one after `;`, a deleted declaration). Routing them through a variable

--- a/scripts/check_vibe_fmt.sh
+++ b/scripts/check_vibe_fmt.sh
@@ -95,6 +95,17 @@ while IFS=$'\t' read -r status rel_path message; do
   fi
 done < <(printf '%s\n' "${files[@]}" | bash scripts/run_vibe_fmt_batch.sh check "$JOBS")
 
+# A process substitution's exit status is not this script's, so a batch that
+# died -- the formatter would not build, a shard produced no report -- fed
+# the loop zero lines and every count below stayed 0: "checked 0 file(s)",
+# exit 0, a green that inspected nothing (#2271, same family as the silent
+# rc-1 loop it fixes). Every file handed to the batch must come back.
+if [ "$checked" -ne "${#files[@]}" ]; then
+  echo "vibe-fmt lint: the batch reported on $checked of ${#files[@]} file(s); the rest were never checked" >&2
+  echo "  this is NOT a formatting verdict -- see the batch's diagnostics above" >&2
+  exit 2
+fi
+
 if [ "${#errors[@]}" -gt 0 ]; then
   echo "vibe-fmt lint: ${#errors[@]} file(s) errored while checking (not merely unformatted):" >&2
   printf '  %s\n' "${errors[@]}" >&2

--- a/scripts/ensure_entry_wasm.sh
+++ b/scripts/ensure_entry_wasm.sh
@@ -177,6 +177,18 @@ if [ "$stale" = "1" ]; then
     if [ "$captured" = "1" ]; then
       mv -f "$ROOT_DIR/$build_deps_rel" "$ROOT_DIR/$deps_rel"
     fi
+    # Re-check AFTER the sidecars: the first comparison only catches a winner
+    # that landed before it, and a builder can still replace the wasm between
+    # that check and these renames, leaving its wasm beside our sidecars (#2277
+    # review). Dropping the manifest is what matters -- it is the first
+    # staleness test, so the next run rebuilds the whole tuple. A funcmap can
+    # stay mismatched until then, which costs symbol names in a trace, not
+    # correctness.
+    final_inode="$(ls -i "$ROOT_DIR/$wasm_rel" 2>/dev/null | awk '{ print $1 }')"
+    if [ -n "$final_inode" ] && [ "$final_inode" != "$build_inode" ]; then
+      rm -f "$ROOT_DIR/$deps_rel"
+      echo "ensure_entry_wasm.sh: $wasm_rel was replaced while its sidecars were published; rebuilding next run" >&2
+    fi
   fi
 fi
 

--- a/scripts/ensure_entry_wasm.sh
+++ b/scripts/ensure_entry_wasm.sh
@@ -76,10 +76,33 @@ else
 fi
 
 if [ "$stale" = "1" ]; then
+  # Remove the previous artifact FIRST. A failed rebuild used to leave it in
+  # place, so the caller kept answering with the old formatter -- the exact
+  # stale-reuse the staleness rules above exist to prevent (#2271).
+  rm -f "$ROOT_DIR/$wasm_rel" "$ROOT_DIR/$deps_rel" "$ROOT_DIR/$wasm_rel.diag"
+  # `|| compile_rc=$?` is load-bearing: as a bare command under `set -e` a
+  # non-zero runner abandoned the script HERE, one line above the check that
+  # was written to explain the failure, so the message below never printed
+  # and the cause stayed in the .diag sidecar that nothing reads (#2271).
+  compile_rc=0
   VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
     bash "$ROOT_DIR/scripts/run_wasm_vibe_host_runner.sh" \
-    --invoke cli_main "$seed" "$entry_src" "$wasm_rel" main >&2
-  [ -s "$ROOT_DIR/$wasm_rel" ] || { echo "ensure_entry_wasm.sh: failed to compile $entry_src" >&2; exit 1; }
+    --invoke cli_main "$seed" "$entry_src" "$wasm_rel" main >&2 || compile_rc=$?
+  if [ "$compile_rc" != "0" ] || [ ! -s "$ROOT_DIR/$wasm_rel" ]; then
+    echo "ensure_entry_wasm.sh: failed to compile $entry_src -> $wasm_rel" >&2
+    if [ -s "$ROOT_DIR/$wasm_rel.diag" ]; then
+      # awk, not `sed s/^/  /`: the compiler writes the sidecar with NO
+      # trailing newline, so sed ran the hint below onto the same line.
+      awk '{ printf "  %s\n", $0 }' "$ROOT_DIR/$wasm_rel.diag" >&2
+    else
+      echo "  the compiler wrote no diagnostics (runner exit $compile_rc)" >&2
+    fi
+    # The overwhelmingly common cause on a fresh checkout: the untracked
+    # generated artifacts are not there yet, so the compiler package's own
+    # contract has declarations with no implementation.
+    echo "  if that names a generated artifact (lib/@vibe/compiler/cache/, *_bundle.vibe), run: bash scripts/ensure_generated.sh" >&2
+    exit 1
+  fi
   # Capture the closure the compiler just resolved. The plan mode also
   # writes one `.N.src` sidecar per module; keep them in a scratch dir so
   # only the manifest survives. Best-effort: on failure no manifest is

--- a/scripts/ensure_entry_wasm.sh
+++ b/scripts/ensure_entry_wasm.sh
@@ -76,10 +76,30 @@ else
 fi
 
 if [ "$stale" = "1" ]; then
-  # Remove the previous artifact FIRST. A failed rebuild used to leave it in
-  # place, so the caller kept answering with the old formatter -- the exact
-  # stale-reuse the staleness rules above exist to prevent (#2271).
-  rm -f "$ROOT_DIR/$wasm_rel" "$ROOT_DIR/$deps_rel" "$ROOT_DIR/$wasm_rel.diag"
+  # Build to a PROCESS-UNIQUE path and publish by rename, never in place.
+  #
+  # A failed rebuild must not leave the previous artifact answering -- that is
+  # the stale-reuse the staleness rules above exist to prevent (#2271) -- but
+  # deleting it up front to achieve that opened a worse window: callers run
+  # concurrently (scripts/vibe_md.sh spawns one worker per document), two
+  # workers can both see "stale", and the slower one's `rm` then lands after
+  # the faster one has finished compiling or has already started running the
+  # wasm. The first caller is handed a path to a deleted or half-written file,
+  # which surfaces as an intermittent formatter or docs-gate failure (#2277
+  # review). Compiling to `$$`-suffixed paths and `mv`-ing on success gives
+  # both properties without ever unlinking a file another process may be
+  # running: a success replaces the artifact atomically for everyone else, and
+  # a failure retracts only the manifest, which is enough to force a rebuild.
+  build_wasm_rel="$wasm_rel.$$.tmp"
+  build_diag_rel="$build_wasm_rel.diag"
+  build_deps_rel="$deps_rel.$$.tmp"
+  # The compiler writes `<out>.funcmap` beside the wasm and the runner reads it
+  # to symbolize traps, so it has to travel WITH the wasm -- publishing one and
+  # leaving the other names the wrong functions in every later stack trace.
+  build_funcmap_rel="$build_wasm_rel.funcmap"
+  rm -f "$ROOT_DIR/$build_wasm_rel" "$ROOT_DIR/$build_diag_rel" \
+        "$ROOT_DIR/$build_deps_rel" "$ROOT_DIR/$build_funcmap_rel"
+  trap 'rm -f "$ROOT_DIR/$build_wasm_rel" "$ROOT_DIR/$build_diag_rel" "$ROOT_DIR/$build_deps_rel" "$ROOT_DIR/$build_funcmap_rel"' EXIT
   # `|| compile_rc=$?` is load-bearing: as a bare command under `set -e` a
   # non-zero runner abandoned the script HERE, one line above the check that
   # was written to explain the failure, so the message below never printed
@@ -87,13 +107,13 @@ if [ "$stale" = "1" ]; then
   compile_rc=0
   VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
     bash "$ROOT_DIR/scripts/run_wasm_vibe_host_runner.sh" \
-    --invoke cli_main "$seed" "$entry_src" "$wasm_rel" main >&2 || compile_rc=$?
-  if [ "$compile_rc" != "0" ] || [ ! -s "$ROOT_DIR/$wasm_rel" ]; then
+    --invoke cli_main "$seed" "$entry_src" "$build_wasm_rel" main >&2 || compile_rc=$?
+  if [ "$compile_rc" != "0" ] || [ ! -s "$ROOT_DIR/$build_wasm_rel" ]; then
     echo "ensure_entry_wasm.sh: failed to compile $entry_src -> $wasm_rel" >&2
-    if [ -s "$ROOT_DIR/$wasm_rel.diag" ]; then
+    if [ -s "$ROOT_DIR/$build_diag_rel" ]; then
       # awk, not `sed s/^/  /`: the compiler writes the sidecar with NO
       # trailing newline, so sed ran the hint below onto the same line.
-      awk '{ printf "  %s\n", $0 }' "$ROOT_DIR/$wasm_rel.diag" >&2
+      awk '{ printf "  %s\n", $0 }' "$ROOT_DIR/$build_diag_rel" >&2
     else
       echo "  the compiler wrote no diagnostics (runner exit $compile_rc)" >&2
     fi
@@ -101,6 +121,12 @@ if [ "$stale" = "1" ]; then
     # generated artifacts are not there yet, so the compiler package's own
     # contract has declarations with no implementation.
     echo "  if that names a generated artifact (lib/@vibe/compiler/cache/, *_bundle.vibe), run: bash scripts/ensure_generated.sh" >&2
+    # Nothing published, so nothing to undo -- but whatever an earlier run left
+    # behind must not go on answering. Drop the MANIFEST rather than the wasm:
+    # the staleness rules read it first, so its absence forces a rebuild, and a
+    # concurrent caller that is running the previous artifact this instant keeps
+    # the bytes it was handed. This process failing says nothing about those.
+    rm -f "$ROOT_DIR/$deps_rel"
     exit 1
   fi
   # Capture the closure the compiler just resolved. The plan mode also
@@ -109,16 +135,32 @@ if [ "$stale" = "1" ]; then
   # written and the next run rebuilds again rather than reusing stale.
   plan_dir="$(mktemp -d "$ROOT_DIR/_build/ensure_entry_plan.XXXXXX")"
   plan_rel="${plan_dir#"$ROOT_DIR"/}/plan.tsv"
+  captured=0
   if VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_MODULE_PLAN=1 \
       bash "$ROOT_DIR/scripts/run_wasm_vibe_host_runner.sh" \
       --invoke cli_main "$seed" "$entry_src" "$plan_rel" "__no_entry__" >&2 \
       && [ -s "$ROOT_DIR/$plan_rel" ]; then
-    awk -F'\t' '$1 == "module" { print $4 }' "$ROOT_DIR/$plan_rel" > "$ROOT_DIR/$deps_rel"
+    awk -F'\t' '$1 == "module" { print $4 }' "$ROOT_DIR/$plan_rel" > "$ROOT_DIR/$build_deps_rel"
+    captured=1
   else
-    rm -f "$ROOT_DIR/$deps_rel"
     echo "ensure_entry_wasm.sh: could not capture the dependency closure for $entry_src; the artifact will rebuild every run until it can" >&2
   fi
   rm -rf "$plan_dir"
+
+  # Publish. The manifest goes away FIRST: between the two renames a concurrent
+  # reader would otherwise pair the new wasm with the old closure and call it
+  # fresh, where an absent manifest just makes it rebuild. Both renames are
+  # within one directory, so each is atomic for everyone else.
+  rm -f "$ROOT_DIR/$deps_rel"
+  mv -f "$ROOT_DIR/$build_wasm_rel" "$ROOT_DIR/$wasm_rel"
+  if [ -s "$ROOT_DIR/$build_funcmap_rel" ]; then
+    mv -f "$ROOT_DIR/$build_funcmap_rel" "$ROOT_DIR/$wasm_rel.funcmap"
+  else
+    rm -f "$ROOT_DIR/$wasm_rel.funcmap"
+  fi
+  if [ "$captured" = "1" ]; then
+    mv -f "$ROOT_DIR/$build_deps_rel" "$ROOT_DIR/$deps_rel"
+  fi
 fi
 
 echo "$wasm_rel"

--- a/scripts/ensure_entry_wasm.sh
+++ b/scripts/ensure_entry_wasm.sh
@@ -152,14 +152,31 @@ if [ "$stale" = "1" ]; then
   # fresh, where an absent manifest just makes it rebuild. Both renames are
   # within one directory, so each is atomic for everyone else.
   rm -f "$ROOT_DIR/$deps_rel"
+  build_inode="$(ls -i "$ROOT_DIR/$build_wasm_rel" 2>/dev/null | awk '{ print $1 }')"
   mv -f "$ROOT_DIR/$build_wasm_rel" "$ROOT_DIR/$wasm_rel"
-  if [ -s "$ROOT_DIR/$build_funcmap_rel" ]; then
-    mv -f "$ROOT_DIR/$build_funcmap_rel" "$ROOT_DIR/$wasm_rel.funcmap"
+  # Each rename is atomic, but the three of them are not one transaction: two
+  # builders that both saw "stale" can interleave and pair one's wasm with the
+  # other's funcmap or manifest (#2277 review). `mv` within a directory is
+  # rename(2), so the published file keeps our inode -- a DIFFERENT one means
+  # someone published over us between the rename and here.
+  #
+  # The response is fail-closed rather than a lock: drop the manifest and
+  # publish none of our sidecars, so the winner's tuple stays whole and the next
+  # run rebuilds. A lock would also have to recover from a killed holder, and
+  # stale-lock stealing is a larger hazard than the one it removes here.
+  published_inode="$(ls -i "$ROOT_DIR/$wasm_rel" 2>/dev/null | awk '{ print $1 }')"
+  if [ -n "$build_inode" ] && [ -n "$published_inode" ] && [ "$published_inode" != "$build_inode" ]; then
+    rm -f "$ROOT_DIR/$deps_rel"
+    echo "ensure_entry_wasm.sh: another build published $wasm_rel first; leaving its artifact whole and rebuilding next run" >&2
   else
-    rm -f "$ROOT_DIR/$wasm_rel.funcmap"
-  fi
-  if [ "$captured" = "1" ]; then
-    mv -f "$ROOT_DIR/$build_deps_rel" "$ROOT_DIR/$deps_rel"
+    if [ -s "$ROOT_DIR/$build_funcmap_rel" ]; then
+      mv -f "$ROOT_DIR/$build_funcmap_rel" "$ROOT_DIR/$wasm_rel.funcmap"
+    else
+      rm -f "$ROOT_DIR/$wasm_rel.funcmap"
+    fi
+    if [ "$captured" = "1" ]; then
+      mv -f "$ROOT_DIR/$build_deps_rel" "$ROOT_DIR/$deps_rel"
+    fi
   fi
 fi
 

--- a/scripts/ensure_entry_wasm_test.sh
+++ b/scripts/ensure_entry_wasm_test.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+# Self-test for scripts/ensure_entry_wasm.sh's FAILURE path, and for the two
+# callers that consume its exit code (#2271).
+#
+# The bug it pins: the compile line ran as a bare command under `set -e`, so a
+# non-zero runner abandoned the script one line above the `[ -s ... ] || echo
+# ... exit 1` that existed to explain the failure. Callers got exit 1 and an
+# empty stderr -- which is exactly what `vibe fmt --check` means by "not
+# formatted" -- so `vibe fmt` looped forever on a file that was never at fault,
+# with the real cause sitting in the `<wasm>.diag` sidecar that nothing read.
+#
+# Everything here works on scratch entries under _build/, never on the real
+# formatter artifact, so it cannot leave the tree in a state another gate
+# section would trip over.
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+WORK_REL="_build/ensure_entry_wasm_test"
+WORK="$ROOT_DIR/$WORK_REL"
+rm -rf "$WORK"
+mkdir -p "$WORK"
+trap 'rm -rf "$WORK"' EXIT
+
+fail() { echo "[ensure-entry-wasm-test] FAIL: $*" >&2; exit 1; }
+
+# --- 1. a compile failure is LOUD, and names the compiler's own diagnostic ---
+printf 'fn f( -> Int {\n' > "$WORK/bad.vibe"
+rc=0
+bash scripts/ensure_entry_wasm.sh "$WORK_REL/bad.vibe" "$WORK_REL/bad.wasm" \
+  >"$WORK/bad.out" 2>"$WORK/bad.err" || rc=$?
+[ "$rc" = "1" ] || fail "unbuildable entry exited $rc, want 1"
+grep -q "failed to compile $WORK_REL/bad.vibe" "$WORK/bad.err" \
+  || fail "stderr does not name the entry it could not compile"
+# The compiler's own words, not just "it failed" -- that is the difference
+# between an actionable message and the silent exit this test exists for.
+grep -q "expected parameter name" "$WORK/bad.err" \
+  || fail "stderr does not carry the compiler's diagnostic"
+grep -q "ensure_generated.sh" "$WORK/bad.err" \
+  || fail "stderr does not point at the usual cause on a fresh checkout"
+[ ! -e "$WORK/bad.wasm" ] || fail "a failed compile left an artifact behind"
+
+# --- 2. a failed REBUILD removes the previous artifact ---
+# Otherwise the caller keeps answering from a formatter built before the edit,
+# which is the stale-reuse ensure_entry_wasm.sh's staleness rules exist to
+# prevent. The bogus wasm stands in for a good build from an earlier run.
+printf 'stale artifact\n' > "$WORK/stale.wasm"
+printf '%s\n' "$WORK_REL/stale.vibe" > "$WORK/stale.wasm.deps"
+printf 'fn g( -> Int {\n' > "$WORK/stale.vibe"
+# Backdate the artifact rather than trusting write order: everything here is
+# written inside one second, and the staleness tests are strict `-nt`, so
+# same-second mtimes read as fresh and nothing would rebuild at all.
+touch -t 200001010000 "$WORK/stale.wasm" "$WORK/stale.wasm.deps"
+rc=0
+bash scripts/ensure_entry_wasm.sh "$WORK_REL/stale.vibe" "$WORK_REL/stale.wasm" \
+  >/dev/null 2>"$WORK/stale.err" || rc=$?
+[ "$rc" = "1" ] || fail "failed rebuild exited $rc, want 1"
+[ ! -e "$WORK/stale.wasm" ] || fail "failed rebuild left the previous artifact in place"
+
+# --- 3. the success path still works, and still prints the path ---
+printf 'fn main() -> Int {\n  0\n}\n' > "$WORK/good.vibe"
+out="$(bash scripts/ensure_entry_wasm.sh "$WORK_REL/good.vibe" "$WORK_REL/good.wasm" 2>/dev/null)"
+[ "$out" = "$WORK_REL/good.wasm" ] || fail "success printed '$out', want '$WORK_REL/good.wasm'"
+[ -s "$WORK/good.wasm" ] || fail "success produced no wasm"
+[ -s "$WORK/good.wasm.deps" ] || fail "success captured no dependency closure"
+
+# --- 4. the callers must not swallow that exit code in a bare assignment ---
+# `var="$(bash .../ensure_...)"` under `set -e` dies with exit 1 and nothing on
+# stderr, which is indistinguishable from a formatting verdict. Each caller has
+# to handle the failure explicitly.
+assert_handles() {
+  local file="$1" ensure="$2"
+  grep -qE "^[a-z_]+=\"\\\$\(bash \"\\\$ROOT_DIR/scripts/$ensure\"\)\"\$" "$file" \
+    && return 1
+  grep -q "scripts/$ensure" "$file" || return 2
+  return 0
+}
+for pair in "scripts/vibe_fmt.sh ensure_vibe_fmt_entry.sh" \
+            "scripts/run_vibe_fmt_batch.sh ensure_vibe_fmt_batch.sh"; do
+  set -- $pair
+  case "$(assert_handles "$1" "$2" && echo 0 || echo $?)" in
+    0) ;;
+    1) fail "$1 calls $2 in a bare assignment; a build failure exits 1 with no message" ;;
+    2) fail "$1 no longer calls $2 -- update this test" ;;
+  esac
+done
+
+# Red-test rule 4 against a mutated copy: a checker that cannot fail is not a
+# check. Restoring the bare form must be rejected.
+mkdir -p "$WORK/mut/scripts"
+sed 's/^entry_wasm_rel=.*$/entry_wasm_rel="$(bash "$ROOT_DIR\/scripts\/ensure_vibe_fmt_entry.sh")"/' \
+  scripts/vibe_fmt.sh > "$WORK/mut/scripts/vibe_fmt.sh"
+grep -q 'ensure_vibe_fmt_entry' "$WORK/mut/scripts/vibe_fmt.sh" \
+  || fail "red-test mutation lost the call it was supposed to reintroduce"
+if assert_handles "$WORK/mut/scripts/vibe_fmt.sh" "ensure_vibe_fmt_entry.sh"; then
+  fail "rule 4 accepts the bare assignment it exists to reject"
+fi
+
+echo "[ensure-entry-wasm-test] ok (loud failure + diagnostic + stale removal + success path + caller exit-code handling, red-tested)"

--- a/scripts/ensure_entry_wasm_test.sh
+++ b/scripts/ensure_entry_wasm_test.sh
@@ -143,17 +143,33 @@ publishes_by_rename() {
   grep -qE 'build_wasm_rel="\$wasm_rel\.\$\$' "$1" || return 1
   grep -qE -- '--invoke cli_main "\$seed" "\$entry_src" "\$build_wasm_rel"' "$1" || return 1
   grep -qE '^\s*mv -f "\$ROOT_DIR/\$build_wasm_rel" "\$ROOT_DIR/\$wasm_rel"$' "$1" || return 1
+  # ...and it must notice when someone published over it between that rename and
+  # the sidecars, since the three renames are not one transaction. The inode is
+  # the only evidence available without a lock: `mv` in-directory is rename(2),
+  # so the published file keeps ours unless it was replaced.
+  grep -q 'build_inode=' "$1" || return 1
+  grep -q 'published_inode=' "$1" || return 1
+  grep -qE '\[ "\$published_inode" != "\$build_inode" \]' "$1" || return 1
   return 0
 }
 publishes_by_rename scripts/ensure_entry_wasm.sh \
   || fail "the rebuild does not compile to a per-process path and publish it by rename"
 
-# Red-test rule 6: point the compile back at the shared path and it must fail.
+# Red-test rule 6 twice: once against the compile target, once against the
+# interleave check. A mutation that matches nothing proves nothing, so each
+# `sed` is verified to have actually removed the line it targets.
 mkdir -p "$WORK/mut6"
 sed 's|"\$entry_src" "\$build_wasm_rel" main|"$entry_src" "$wasm_rel" main|' \
   scripts/ensure_entry_wasm.sh > "$WORK/mut6/ensure_entry_wasm.sh"
 if publishes_by_rename "$WORK/mut6/ensure_entry_wasm.sh"; then
   fail "rule 6 accepts a rebuild that compiles straight to the published path"
+fi
+grep -v 'published_inode=' scripts/ensure_entry_wasm.sh > "$WORK/mut6/no_inode.sh"
+if ! grep -q 'build_inode=' "$WORK/mut6/no_inode.sh"; then
+  fail "red-test mutation removed more than the line it targeted"
+fi
+if publishes_by_rename "$WORK/mut6/no_inode.sh"; then
+  fail "rule 6 accepts a publish that cannot notice an interleaved winner"
 fi
 
 # Red-test rule 4 against a mutated copy: a checker that cannot fail is not a
@@ -167,4 +183,4 @@ if assert_handles "$WORK/mut/scripts/vibe_fmt.sh" "ensure_vibe_fmt_entry.sh"; th
   fail "rule 4 accepts the bare assignment it exists to reject"
 fi
 
-echo "[ensure-entry-wasm-test] ok (loud failure + diagnostic + stale retraction + success path + caller exit-code handling + batch count reconciliation + atomic publish, red-tested)"
+echo "[ensure-entry-wasm-test] ok (loud failure + diagnostic + stale retraction + success path + caller exit-code handling + batch count reconciliation + atomic publish + interleave detection, red-tested)"

--- a/scripts/ensure_entry_wasm_test.sh
+++ b/scripts/ensure_entry_wasm_test.sh
@@ -41,10 +41,15 @@ grep -q "ensure_generated.sh" "$WORK/bad.err" \
   || fail "stderr does not point at the usual cause on a fresh checkout"
 [ ! -e "$WORK/bad.wasm" ] || fail "a failed compile left an artifact behind"
 
-# --- 2. a failed REBUILD removes the previous artifact ---
+# --- 2. a failed REBUILD retracts the previous build's verdict ---
 # Otherwise the caller keeps answering from a formatter built before the edit,
 # which is the stale-reuse ensure_entry_wasm.sh's staleness rules exist to
 # prevent. The bogus wasm stands in for a good build from an earlier run.
+#
+# What must go is the MANIFEST, not the wasm: an absent manifest is the first
+# staleness test, so the next run rebuilds, while the bytes stay put for a
+# concurrent caller that is running them right now (#2277 review). The check is
+# therefore behavioural -- ask again and it must still refuse to call it fresh.
 printf 'stale artifact\n' > "$WORK/stale.wasm"
 printf '%s\n' "$WORK_REL/stale.vibe" > "$WORK/stale.wasm.deps"
 printf 'fn g( -> Int {\n' > "$WORK/stale.vibe"
@@ -56,7 +61,11 @@ rc=0
 bash scripts/ensure_entry_wasm.sh "$WORK_REL/stale.vibe" "$WORK_REL/stale.wasm" \
   >/dev/null 2>"$WORK/stale.err" || rc=$?
 [ "$rc" = "1" ] || fail "failed rebuild exited $rc, want 1"
-[ ! -e "$WORK/stale.wasm" ] || fail "failed rebuild left the previous artifact in place"
+[ ! -e "$WORK/stale.wasm.deps" ] || fail "failed rebuild kept the manifest, so the next run would reuse the old artifact"
+rc=0
+bash scripts/ensure_entry_wasm.sh "$WORK_REL/stale.vibe" "$WORK_REL/stale.wasm" \
+  >/dev/null 2>/dev/null || rc=$?
+[ "$rc" = "1" ] || fail "the run after a failed rebuild answered $rc -- it reused the stale artifact"
 
 # --- 3. the success path still works, and still prints the path ---
 printf 'fn main() -> Int {\n  0\n}\n' > "$WORK/good.vibe"
@@ -64,6 +73,12 @@ out="$(bash scripts/ensure_entry_wasm.sh "$WORK_REL/good.vibe" "$WORK_REL/good.w
 [ "$out" = "$WORK_REL/good.wasm" ] || fail "success printed '$out', want '$WORK_REL/good.wasm'"
 [ -s "$WORK/good.wasm" ] || fail "success produced no wasm"
 [ -s "$WORK/good.wasm.deps" ] || fail "success captured no dependency closure"
+# The funcmap sidecar has to be published with the wasm, and nothing named for
+# the temporary build path may survive -- a leaked `.tmp` sidecar is a stale
+# symbol table sitting next to a fresh artifact.
+[ -s "$WORK/good.wasm.funcmap" ] || fail "success left the funcmap sidecar unpublished"
+leftover="$(find "$WORK" -name '*.tmp*' -print -quit)"
+[ -z "$leftover" ] || fail "the build left a temporary artifact behind: $leftover"
 
 # --- 4. the callers must not swallow that exit code in a bare assignment ---
 # `var="$(bash .../ensure_...)"` under `set -e` dies with exit 1 and nothing on
@@ -117,6 +132,30 @@ if reconciles "$WORK/mut5/vibe_fmt_apply.sh"; then
   fail "rule 5 accepts a caller with no count reconciliation"
 fi
 
+# --- 6. the rebuild must never write over the published artifact in place ---
+# Callers run concurrently (scripts/vibe_md.sh spawns one worker per document),
+# so two of them can both see "stale" at once. Compiling straight to the shared
+# path hands the other worker a half-written wasm, and deleting it first hands
+# it a missing one; both surface as an intermittent gate failure with no signal
+# in it (#2277 review). Lexical, like rules 4-5: what it pins is that the
+# compile target is a per-process path and that the publish is a rename.
+publishes_by_rename() {
+  grep -qE 'build_wasm_rel="\$wasm_rel\.\$\$' "$1" || return 1
+  grep -qE -- '--invoke cli_main "\$seed" "\$entry_src" "\$build_wasm_rel"' "$1" || return 1
+  grep -qE '^\s*mv -f "\$ROOT_DIR/\$build_wasm_rel" "\$ROOT_DIR/\$wasm_rel"$' "$1" || return 1
+  return 0
+}
+publishes_by_rename scripts/ensure_entry_wasm.sh \
+  || fail "the rebuild does not compile to a per-process path and publish it by rename"
+
+# Red-test rule 6: point the compile back at the shared path and it must fail.
+mkdir -p "$WORK/mut6"
+sed 's|"\$entry_src" "\$build_wasm_rel" main|"$entry_src" "$wasm_rel" main|' \
+  scripts/ensure_entry_wasm.sh > "$WORK/mut6/ensure_entry_wasm.sh"
+if publishes_by_rename "$WORK/mut6/ensure_entry_wasm.sh"; then
+  fail "rule 6 accepts a rebuild that compiles straight to the published path"
+fi
+
 # Red-test rule 4 against a mutated copy: a checker that cannot fail is not a
 # check. Restoring the bare form must be rejected.
 mkdir -p "$WORK/mut/scripts"
@@ -128,4 +167,4 @@ if assert_handles "$WORK/mut/scripts/vibe_fmt.sh" "ensure_vibe_fmt_entry.sh"; th
   fail "rule 4 accepts the bare assignment it exists to reject"
 fi
 
-echo "[ensure-entry-wasm-test] ok (loud failure + diagnostic + stale removal + success path + caller exit-code handling + batch count reconciliation, red-tested)"
+echo "[ensure-entry-wasm-test] ok (loud failure + diagnostic + stale retraction + success path + caller exit-code handling + batch count reconciliation + atomic publish, red-tested)"

--- a/scripts/ensure_entry_wasm_test.sh
+++ b/scripts/ensure_entry_wasm_test.sh
@@ -150,6 +150,9 @@ publishes_by_rename() {
   grep -q 'build_inode=' "$1" || return 1
   grep -q 'published_inode=' "$1" || return 1
   grep -qE '\[ "\$published_inode" != "\$build_inode" \]' "$1" || return 1
+  # ...and again after the sidecars, since the first check only catches a winner
+  # that landed before it.
+  grep -qE '\[ "\$final_inode" != "\$build_inode" \]' "$1" || return 1
   return 0
 }
 publishes_by_rename scripts/ensure_entry_wasm.sh \

--- a/scripts/ensure_entry_wasm_test.sh
+++ b/scripts/ensure_entry_wasm_test.sh
@@ -86,6 +86,37 @@ for pair in "scripts/vibe_fmt.sh ensure_vibe_fmt_entry.sh" \
   esac
 done
 
+# --- 5. every consumer of the batch must reconcile the report COUNT ---
+# `done < <(... | run_vibe_fmt_batch.sh ...)` hides the batch's exit status, so a
+# dead batch feeds the loop zero lines and the caller reports "0 file(s)" and
+# exits 0 -- green having done nothing. check_vibe_fmt.sh was fixed for this and
+# vibe_fmt_apply.sh was missed, which is `pkf run fmt` silently rewriting
+# nothing (#2271, #2277 review). The check is lexical -- shell dataflow is not
+# decidable here -- so it requires the one structural thing that cannot be
+# faked into existence: a comparison against the input list's length.
+reconciles() {
+  grep -q 'run_vibe_fmt_batch\.sh' "$1" || return 2
+  grep -qE -- '-ne "\$\{#[a-z_]+\[@\]\}"' "$1" || return 1
+  return 0
+}
+for f in scripts/check_vibe_fmt.sh scripts/vibe_fmt_apply.sh; do
+  case "$(reconciles "$f" && echo 0 || echo $?)" in
+    0) ;;
+    1) fail "$f consumes the batch without reconciling the report count against its input" ;;
+    2) fail "$f no longer consumes run_vibe_fmt_batch.sh -- update this test" ;;
+  esac
+done
+
+# Red-test rule 5: strip the guard and it must be rejected.
+mkdir -p "$WORK/mut5"
+grep -v -E -- '-ne "\$\{#[a-z_]+\[@\]\}"' scripts/vibe_fmt_apply.sh > "$WORK/mut5/vibe_fmt_apply.sh"
+if ! grep -q 'run_vibe_fmt_batch\.sh' "$WORK/mut5/vibe_fmt_apply.sh"; then
+  fail "red-test mutation removed the batch call it needed to keep"
+fi
+if reconciles "$WORK/mut5/vibe_fmt_apply.sh"; then
+  fail "rule 5 accepts a caller with no count reconciliation"
+fi
+
 # Red-test rule 4 against a mutated copy: a checker that cannot fail is not a
 # check. Restoring the bare form must be rejected.
 mkdir -p "$WORK/mut/scripts"
@@ -97,4 +128,4 @@ if assert_handles "$WORK/mut/scripts/vibe_fmt.sh" "ensure_vibe_fmt_entry.sh"; th
   fail "rule 4 accepts the bare assignment it exists to reject"
 fi
 
-echo "[ensure-entry-wasm-test] ok (loud failure + diagnostic + stale removal + success path + caller exit-code handling, red-tested)"
+echo "[ensure-entry-wasm-test] ok (loud failure + diagnostic + stale removal + success path + caller exit-code handling + batch count reconciliation, red-tested)"

--- a/scripts/run_vibe_fmt_batch.sh
+++ b/scripts/run_vibe_fmt_batch.sh
@@ -27,7 +27,16 @@ case "$mode" in
   *) echo "run_vibe_fmt_batch.sh: mode must be check or write, got: $mode" >&2; exit 2 ;;
 esac
 
-batch_wasm_rel="$(bash "$ROOT_DIR/scripts/ensure_vibe_fmt_batch.sh")"
+# `|| exit 2` -- NOT a bare assignment. Under `set -e` a failed formatter
+# build killed this script with exit 1 and nothing on stderr, and the caller
+# reads this script through a process substitution whose status it never
+# sees, so the batch simply produced no report lines and the lint reported
+# "checked 0 file(s)" and exited 0 (#2271).
+batch_wasm_rel="$(bash "$ROOT_DIR/scripts/ensure_vibe_fmt_batch.sh")" || {
+  echo "run_vibe_fmt_batch.sh: could not build the batch formatter -- see the compile diagnostics above" >&2
+  echo "  no file was checked or rewritten; this is not a formatting verdict" >&2
+  exit 2
+}
 
 work="$ROOT_DIR/_build/vibe_fmt_batch"
 mkdir -p "$work"

--- a/scripts/unit_batch_compile.mjs
+++ b/scripts/unit_batch_compile.mjs
@@ -286,7 +286,18 @@ async function main() {
     `[unit-batch] ${totalMisses} of ${listed.length} files to compile (${nHits} cached) with ${JOBS} daemons`,
   );
 
-  const daemons = Array.from({ length: JOBS }, (_, i) => new Daemon(`c${i}`, { VIBE_FS_COMPILE: "1" }));
+  // VIBE_UNSTABLE: ADR-0068's `@vibe/concurrent` needs the opt-in to compile
+  // at all, and a handful of in-tree fixtures deliberately test that surface
+  // (fixtures/async_boundary_user_sleep_test.vibe). It is granted for the
+  // whole daemon, not per file, because a daemon compiles many files in one
+  // long-lived process and its env is fixed at spawn. That is acceptable
+  // here: the boundary exists for a USER's build, these are the repository's
+  // own tests, and the boundary itself is pinned by the compiler gate
+  // (tests/gates/late/run.sh section 108) rather than by this harness.
+  const daemons = Array.from(
+    { length: JOBS },
+    (_, i) => new Daemon(`c${i}`, { VIBE_FS_COMPILE: "1", VIBE_UNSTABLE: "1" }),
+  );
   const planDaemon = new Daemon("plan", { VIBE_MODULE_PLAN: "1" });
 
   // Weight >= HEAVY_MS marks the compiler-closure class: their compiles

--- a/scripts/unit_test_runner.sh
+++ b/scripts/unit_test_runner.sh
@@ -368,7 +368,10 @@ run_one_untraced() {
     attempt=$((attempt + 1))
     local out; out="$(mktemp -t vibe-unit-XXXXXX.wasm)"
     rm -f "$out" "$out.diag"
-    VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
+    # VIBE_UNSTABLE: matches what scripts/unit_batch_compile.mjs grants its
+    # daemons, so the one-shot fallback and the batch path compile the same
+    # files the same way. See that file for why it is granted wholesale.
+    VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw VIBE_UNSTABLE=1 \
       timeout 300 bash "$RUNNER" --invoke cli_main "$S2" "$f" "$out" __no_entry__ >/dev/null 2>&1 || true
     if [ -s "$out" ]; then
       # timeout: a miscompiled test that loops forever must fail the FILE,

--- a/scripts/vibe_fmt.sh
+++ b/scripts/vibe_fmt.sh
@@ -8,6 +8,12 @@
 #   bash scripts/vibe_fmt.sh --stdout <file.vibe> # print formatted result, no write
 #
 # Paths must live under the repo root (the wasm preopen dir).
+#
+# Exit codes: 0 formatted / already formatted; 1 the FILE is at fault
+# (--check found a diff, or the formatter declined to rewrite it); 2 THIS
+# SCRIPT could not answer (bad usage, or the formatter would not build).
+# 1 and 2 must stay distinct -- a caller that cannot tell them apart
+# retries an unformattable file forever (#2271).
 set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
@@ -46,7 +52,17 @@ case "$src" in
 esac
 [ -f "$ROOT_DIR/$src_rel" ] || { echo "vibe_fmt.sh: not found: $src_rel" >&2; exit 2; }
 
-entry_wasm_rel="$(bash "$ROOT_DIR/scripts/ensure_vibe_fmt_entry.sh")"
+# `|| exit 2` -- NOT the bare assignment this used to be. Under `set -e` a
+# failed formatter build killed this script with exit 1 and nothing on
+# stderr, which is byte-for-byte what `--check` means by "not formatted": a
+# caller applied, saw no change, checked again, and looped forever over a
+# file that was never the problem (#2271). "Could not answer" gets its own
+# code, the same 2 the usage errors above use.
+entry_wasm_rel="$(bash "$ROOT_DIR/scripts/ensure_vibe_fmt_entry.sh")" || {
+  echo "vibe_fmt.sh: could not build the formatter itself -- see the compile diagnostics above" >&2
+  echo "  $src_rel was NOT checked or rewritten; this says nothing about that file" >&2
+  exit 2
+}
 
 # The formatter's output path is PER PROCESS. It used to be the fixed
 # `_build/vibe_fmt/out.vibe`, which two concurrent `vibe_fmt.sh` runs would

--- a/scripts/vibe_fmt_apply.sh
+++ b/scripts/vibe_fmt_apply.sh
@@ -60,6 +60,17 @@ if [ "${#to_format[@]}" -gt 0 ]; then
       ERROR) errors+=("$rel_path: $message") ;;
     esac
   done < <(printf '%s\n' "${to_format[@]}" | bash scripts/run_vibe_fmt_batch.sh write "$JOBS")
+  # A process substitution's exit status is not this script's, so a batch that
+  # died -- the formatter would not build, a shard produced no report -- fed the
+  # loop zero lines and this printed "formatted 0 file(s)" and exited 0. That is
+  # `pkf run fmt`, the documented whole-tree command, silently rewriting nothing
+  # (#2271; the same hole was fixed in check_vibe_fmt.sh and this caller was
+  # missed). Every file handed to the batch must come back.
+  if [ "$formatted" -ne "${#to_format[@]}" ]; then
+    echo "vibe-fmt apply: the batch reported on $formatted of ${#to_format[@]} file(s); the rest were NOT formatted" >&2
+    echo "  nothing here says those files are clean -- see the batch's diagnostics above" >&2
+    exit 2
+  fi
 fi
 
 if [ "${#errors[@]}" -gt 0 ]; then

--- a/scripts/vibe_fmt_smoke.sh
+++ b/scripts/vibe_fmt_smoke.sh
@@ -319,4 +319,54 @@ if ! cmp -s "$WORK/as_only.expected.vibe" "$WORK/as_only.got.vibe"; then
   exit 1
 fi
 
-echo "[vibe-fmt-smoke] ok (canonical + idempotent + --check + paths #628 + import sort/wrap + enum/struct guard + nested-call block newlines + from-identifier guard + is-ctor guard + return-handle guard + as-only guard)"
+# A multiline closure literal in a NON-FINAL argument slot (#2271). Reported
+# as unformattable -- apply changed nothing, --check kept reporting a diff,
+# forever. It was never this construct: the formatter entry had failed to
+# compile, and `vibe fmt` spelled that with the same exit 1 it uses for "not
+# formatted" (fixed in scripts/ensure_entry_wasm.sh + scripts/vibe_fmt.sh).
+# Pinned here so the claim in the issue is a regression test either way.
+cat > "$WORK/nonfinal_closure.in.vibe" <<'EOF'
+fn collect_by(is_formal: (String) -> Bool, out: Array[String]) -> Unit {
+  ()
+}
+fn caller(shadow: Array[String], out: Array[String]) -> Unit {
+  collect_by((head) -> {
+      let mut found = false
+      if Array::length(shadow) > 0 {
+    found = true
+      } else {
+        ()
+      }
+      found
+  }, out)
+}
+EOF
+cat > "$WORK/nonfinal_closure.expected.vibe" <<'EOF'
+fn collect_by(is_formal: (String) -> Bool, out: Array[String]) -> Unit {
+  ()
+}
+fn caller(shadow: Array[String], out: Array[String]) -> Unit {
+  collect_by((head) -> {
+    let mut found = false
+    if Array::length(shadow) > 0 {
+      found = true
+    } else {
+      ()
+    }
+    found
+  }, out)
+}
+EOF
+bash "$ROOT_DIR/scripts/vibe_fmt.sh" --stdout "$WORK/nonfinal_closure.in.vibe" > "$WORK/nonfinal_closure.got.vibe" 2>/dev/null
+if ! cmp -s "$WORK/nonfinal_closure.expected.vibe" "$WORK/nonfinal_closure.got.vibe"; then
+  echo "[vibe-fmt-smoke] FAIL: multiline closure in a non-final argument slot not formatted" >&2
+  diff "$WORK/nonfinal_closure.expected.vibe" "$WORK/nonfinal_closure.got.vibe" >&2 || true
+  exit 1
+fi
+# The fixpoint is the half the issue said was unreachable: --check must
+# accept the formatted form, so `pkf run fmt` and CI cannot disagree forever.
+if ! bash "$ROOT_DIR/scripts/vibe_fmt.sh" --check "$WORK/nonfinal_closure.expected.vibe" >/dev/null 2>&1; then
+  echo "[vibe-fmt-smoke] FAIL: formatted non-final closure is not a fixpoint" >&2; exit 1
+fi
+
+echo "[vibe-fmt-smoke] ok (canonical + idempotent + --check + paths #628 + import sort/wrap + enum/struct guard + nested-call block newlines + from-identifier guard + is-ctor guard + return-handle guard + as-only guard + non-final closure arg #2271)"

--- a/scripts/vibe_md.vibex
+++ b/scripts/vibe_md.vibex
@@ -479,6 +479,24 @@ struct BlockResult {
 // scripts/vibe_md.py's VIBE_MD_TIMEOUT, default 120): without it a hung or
 // infinite-looping tutorial block ties up sh_capture (and therefore the CI
 // job running it) with no per-block failure ever produced.
+/// Does this block import an ADR-0068 (`proposed`) package? Matched on the
+/// line's own text after leading whitespace, which is enough here: these are
+/// book blocks the repository writes, not adversarial input, and a miss costs
+/// a FAIL with the compiler's own opt-in message rather than a silent pass.
+fn block_imports_unstable(blk: Block) -> Bool {
+  let mut i = 0
+  while i < Array::length(blk.code_lines) {
+    let line = Array::get(blk.code_lines, i)
+    if String::index_of(line, "@vibe/concurrent") >= 0 && String::index_of(line, "import") >= 0 {
+      return true
+    } else {
+      ()
+    }
+    i = i + 1
+  }
+  false
+}
+
 fn md_timeout_secs() -> String with Env {
   let v = String::trim(Env::get("VIBE_MD_TIMEOUT"))
   if String::length(v) > 0 {
@@ -577,7 +595,18 @@ fn run_one_block(cwd: String, compiler: String, md_path: String, md_dir: String,
       ""
     }
     let timeout_secs = md_timeout_secs()
-    let compile_cmd = "timeout \{timeout_secs} env VIBE_PREOPEN_DIR=\{shq(cwd)} VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \{meta_env}bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main \{shq(compiler)} \{shq(src)} \{shq(out)} \{shq(entry)}"
+    // ADR-0068's `@vibe/concurrent` needs VIBE_UNSTABLE=1 to compile at all,
+    // and book/*/17_concurrency.vibe.md exists to SHOW that surface. Granted
+    // per block, only to blocks that import it, so the opt-in stays a real
+    // boundary for every other chapter instead of a blanket env var this
+    // harness sets for the whole book. Enforcement itself is pinned by the
+    // late gate (section 108), not here.
+    let unstable_env = if block_imports_unstable(blk) {
+      "VIBE_UNSTABLE=1 "
+    } else {
+      ""
+    }
+    let compile_cmd = "timeout \{timeout_secs} env VIBE_PREOPEN_DIR=\{shq(cwd)} VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \{unstable_env}\{meta_env}bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main \{shq(compiler)} \{shq(src)} \{shq(out)} \{shq(entry)}"
     let cr = sh_capture(compile_cmd)
     let compiled = cr.exit_code == 0 && file_nonempty(out)
     if !compiled {
@@ -927,7 +956,16 @@ fn compile_merged(cwd: String, compiler: String, md_dir: String, base: String) -
   let src = merge_driver_path(md_dir, base)
   let out = merge_wasm_path(md_dir, base)
   let timeout_secs = md_timeout_secs()
-  let cmd = "timeout \{timeout_secs} env VIBE_PREOPEN_DIR=\{shq(cwd)} VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main \{shq(compiler)} \{shq(src)} \{shq(out)} '__no_entry__'"
+  // Same ADR-0068 opt-in the per-block path grants, decided from the merged
+  // driver's own text. Without it the merged compile of the concurrency
+  // chapter fails and every block falls back to a standalone compile -- the
+  // right answer, reached the slow way.
+  let unstable_env = if String::index_of(Fs::read_file(src), "@vibe/concurrent") >= 0 {
+    "VIBE_UNSTABLE=1 "
+  } else {
+    ""
+  }
+  let cmd = "timeout \{timeout_secs} env VIBE_PREOPEN_DIR=\{shq(cwd)} VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \{unstable_env}bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main \{shq(compiler)} \{shq(src)} \{shq(out)} '__no_entry__'"
   let cr = sh_capture(cmd)
   cr.exit_code == 0 && file_nonempty(out)
 }

--- a/scripts/vibe_test.sh
+++ b/scripts/vibe_test.sh
@@ -314,7 +314,14 @@ vt_fail_detail() {
     # reason with only the host crash-debug dump or blank lines in between --
     # the exact shape the generated assert_eq abort produces.
     { __blk = 0 }
-    $0 == "assert_eq failed" {
+    # Anchored, and now with the optional location the merge stamps onto the
+    # call (#2202): `assert_eq failed at path:line`. Still a full-line match
+    # ending in `:<digits>`, so ordinary program output cannot masquerade as
+    # the head of an assert block -- the property the exact-match spelling was
+    # there for. An exact match alone silently DROPPED the located line from
+    # the condensed report, which is how the located build first looked like it
+    # had changed nothing.
+    $0 ~ /^assert_eq failed( at .+:[0-9]+)?$/ {
       __blk = 1
       ablk = 1
       ndiag++

--- a/tests/gates/late/run.sh
+++ b/tests/gates/late/run.sh
@@ -6331,8 +6331,40 @@ if grep -qF 'VIBE_UNSTABLE=1' "$uwdir/serve.optin.wasm.diag" 2>/dev/null; then
   cat "$uwdir/serve.optin.wasm.diag" 2>/dev/null >&2 || true
   exit 1
 fi
+# `export @pkg { .. }` would depend on the package exactly as an import does and
+# then PUBLISH its surface onward. Measured: it does not parse, so nothing
+# crosses the boundary through it -- but that is a fact about the PARSER, not
+# about this gate, and it is the kind of fact that changes without anyone
+# revisiting the gate (#2277 review).
+cat > "$uwdir/reexport.vibe" <<'UWEOF'
+export @vibe/concurrent { TaskGroup }
+
+fn main() -> Int {
+  1
+}
+UWEOF
+uw_build "$uwdir/reexport.vibe" "$uwdir/reexport.wasm"
+if [ -s "$uwdir/reexport.wasm" ]; then
+  echo "[compiler-gate] FAIL: a re-export of the unstable package built with no opt-in (#2277)" >&2
+  exit 1
+fi
+# TWO acceptable refusals, and the check has to distinguish them or it passes
+# for a reason it never verified. Today the form does not parse at all -- the
+# parser builds `SReExport` for `TDot`/`TDotDot` paths only and answers a
+# package path with "unexpected token in export" -- so the gate is not what
+# stops it. If that syntax ever lands, this arm stops matching and the
+# diagnostic must be the opt-in one instead; anything else fails here.
+if grep -qF 'unexpected token in export' "$uwdir/reexport.wasm.diag" 2>/dev/null; then
+  :
+elif grep -qF 'VIBE_UNSTABLE=1' "$uwdir/reexport.wasm.diag" 2>/dev/null; then
+  :
+else
+  echo "[compiler-gate] FAIL: a package re-export was refused for an unrelated reason -- if it now parses, gate it (#2277)" >&2
+  cat "$uwdir/reexport.wasm.diag" 2>/dev/null >&2 || true
+  exit 1
+fi
 rm -rf "$uwdir"
-echo "[compiler-gate] ADR-0068 opt-in gate: check + build + serve + buffer(text+json+column) + whitespace + comment + multiline + pinned-require ok (#2248, #2277)"
+echo "[compiler-gate] ADR-0068 opt-in gate: check + build + serve + package-re-export + buffer(text+json+column) + whitespace + comment + multiline + pinned-require ok (#2248, #2277)"
 fmtdir="_build/_gate_vibe_fmt"
 rm -rf "$fmtdir"; mkdir -p "$fmtdir"
 printf 'let   add=(a:Int,b:Int)->Int{a+b}\n' > "$fmtdir/messy.vibe"
@@ -6616,5 +6648,33 @@ if ! grep -qF '1 passed, 0 failed' "$aldir/shadow.log"; then
   cat "$aldir/shadow.log" >&2
   exit 1
 fi
+# A LOCAL binding of the name is deliberately NOT covered, and this pins the
+# boundary so the omission stays a decision rather than a gap someone rediscovers.
+# Suppressing the lowering for a local only moves the failure: the codegen guard
+# tests the function table and ignores locals (the #1095 capture trap), so the
+# pass stands down and codegen's own `assert_eq` arm claims the call anyway --
+# measured as a bare `unreachable` with no message, which is worse than the
+# builtin assertion it replaced. What the gate requires is that the failure stay
+# the LEGIBLE one until #1095 is answered (#2277 review, #2285).
+cat > "$aldir/pat_shadow_test.vibe" <<'ALEOF'
+fn make_cmp() -> (Int, Int) -> Int {
+  (a, b) -> {
+    a + b
+  }
+}
+
+test "pattern-bound assert_eq" {
+  match make_cmp() {
+    assert_eq => assert_true(assert_eq(1, 2) == 3)
+  }
+}
+ALEOF
+VIBE_TEST_CLI_WASM="$stage2_wasm" VIBE_TEST_QUIET_COMPILER_NOTE=1 \
+  bash scripts/vibe_test.sh "$aldir/pat_shadow_test.vibe" >"$aldir/pat.log" 2>&1 || true
+if ! grep -qF 'assert_eq failed' "$aldir/pat.log"; then
+  echo "[compiler-gate] FAIL: a pattern-bound assert_eq now fails without a message -- the local case must keep the legible failure (#2285)" >&2
+  cat "$aldir/pat.log" >&2
+  exit 1
+fi
 rm -rf "$aldir"
-echo "[compiler-gate] assert_eq location + after-assignment + 3-arg + unspellable-marker + user-shadowing ok (#2202, #2283)"
+echo "[compiler-gate] assert_eq location + after-assignment + 3-arg + unspellable-marker + top-level shadowing ok (#2202, #2283)"

--- a/tests/gates/late/run.sh
+++ b/tests/gates/late/run.sh
@@ -6191,3 +6191,75 @@ fi
 rm -rf "$fmtdir"
 echo "[compiler-gate] vibe fmt ok (#2149)"
 
+# 109/109. A multiline closure literal in a NON-FINAL argument slot formats to
+# a fixpoint (#2271). Reported as permanently unformattable -- apply changed
+# nothing, --check kept reporting a diff. The construct was never the problem:
+# the formatter ENTRY had failed to compile (a fresh checkout has none of the
+# untracked generated artifacts), and `vibe fmt` spelled "I could not build
+# myself" with the same exit 1 it uses for "this file is not formatted", so a
+# caller looped forever. Fixed in scripts/ensure_entry_wasm.sh (the failure is
+# loud) and scripts/vibe_fmt.sh (it exits 2), pinned there by
+# scripts/ensure_entry_wasm_test.sh. This section pins the other half of the
+# report -- that the SHAPE formats, on the stage2 lane -- so the issue's claim
+# is a regression test in both directions.
+echo "[compiler-gate] 109/109 a multiline closure in a non-final argument slot formats to a fixpoint (#2271)"
+nfdir="_build/_gate_nonfinal_closure"
+rm -rf "$nfdir"; mkdir -p "$nfdir"
+cat > "$nfdir/in.vibe" <<'NFIN'
+fn collect_by(is_formal: (String) -> Bool, out: Array[String]) -> Unit {
+  ()
+}
+fn caller(shadow: Array[String], out: Array[String]) -> Unit {
+  collect_by((head) -> {
+      let mut found = false
+      if Array::length(shadow) > 0 {
+    found = true
+      } else {
+        ()
+      }
+      found
+  }, out)
+}
+NFIN
+cat > "$nfdir/expected.vibe" <<'NFEXP'
+fn collect_by(is_formal: (String) -> Bool, out: Array[String]) -> Unit {
+  ()
+}
+fn caller(shadow: Array[String], out: Array[String]) -> Unit {
+  collect_by((head) -> {
+    let mut found = false
+    if Array::length(shadow) > 0 {
+      found = true
+    } else {
+      ()
+    }
+    found
+  }, out)
+}
+NFEXP
+VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_IMPORT_ABI=raw VIBE_FMT=1 \
+  bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
+  "$nfdir/in.vibe" "$nfdir/out.vibe" >"$nfdir/run.log" 2>&1 || true
+if [ ! -s "$nfdir/out.vibe" ]; then
+  echo "[compiler-gate] FAIL: the formatter produced nothing for a non-final closure argument (#2271)" >&2
+  cat "$nfdir/run.log" >&2 || true
+  exit 1
+fi
+if ! cmp -s "$nfdir/expected.vibe" "$nfdir/out.vibe"; then
+  echo "[compiler-gate] FAIL: non-final closure argument not formatted as expected (#2271)" >&2
+  diff -u "$nfdir/expected.vibe" "$nfdir/out.vibe" >&2 || true
+  exit 1
+fi
+# The fixpoint is the half the issue said was unreachable: formatting the
+# formatted form again must change nothing, or `pkf run fmt` and CI's
+# vibe-fmt-check disagree about the file forever.
+VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_IMPORT_ABI=raw VIBE_FMT=1 \
+  bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
+  "$nfdir/expected.vibe" "$nfdir/again.vibe" >"$nfdir/again.log" 2>&1 || true
+if ! cmp -s "$nfdir/expected.vibe" "$nfdir/again.vibe"; then
+  echo "[compiler-gate] FAIL: the formatted non-final closure is not a fixpoint (#2271)" >&2
+  diff -u "$nfdir/expected.vibe" "$nfdir/again.vibe" >&2 || true
+  exit 1
+fi
+rm -rf "$nfdir"
+echo "[compiler-gate] non-final closure argument fixpoint ok (#2271)"

--- a/tests/gates/late/run.sh
+++ b/tests/gates/late/run.sh
@@ -6676,5 +6676,32 @@ if ! grep -qF 'assert_eq failed' "$aldir/pat.log"; then
   cat "$aldir/pat.log" >&2
   exit 1
 fi
+# A re-exported binding of the name must not be claimed by the builtin either.
+# This does NOT assert the program works -- re-export aliases are broken on
+# their own (#2287: the merge inlines the dependency under its original name and
+# drops the alias, so the call reaches codegen unresolved). `cmp as assert_eq`
+# was the one alias spelling that did not crash, because the lowering claimed
+# the call and ran an assertion instead, which is how #2287 stayed hidden. What
+# the gate requires is that the masking stay gone: whatever this program does,
+# it must not silently be an assertion. It will pass unchanged once #2287 lands.
+cat > "$aldir/redep.vibe" <<'ALEOF'
+export fn cmp(a: Int, b: Int) -> Int {
+  a + b
+}
+ALEOF
+cat > "$aldir/reexport_test.vibe" <<'ALEOF'
+export ./redep.vibe { cmp as assert_eq }
+
+test "re-exported binding" {
+  assert_true(assert_eq(1, 2) == 3)
+}
+ALEOF
+VIBE_TEST_CLI_WASM="$stage2_wasm" VIBE_TEST_QUIET_COMPILER_NOTE=1 \
+  bash scripts/vibe_test.sh "$aldir/reexport_test.vibe" >"$aldir/re.log" 2>&1 || true
+if grep -qF 'assert_eq failed' "$aldir/re.log"; then
+  echo "[compiler-gate] FAIL: a re-exported assert_eq was claimed by the builtin assertion, masking #2287" >&2
+  cat "$aldir/re.log" >&2
+  exit 1
+fi
 rm -rf "$aldir"
-echo "[compiler-gate] assert_eq location + after-assignment + 3-arg + unspellable-marker + top-level shadowing ok (#2202, #2283)"
+echo "[compiler-gate] assert_eq location + after-assignment + 3-arg + unspellable-marker + top-level shadowing (definition + re-export) ok (#2202, #2283)"

--- a/tests/gates/late/run.sh
+++ b/tests/gates/late/run.sh
@@ -6308,5 +6308,38 @@ if ! grep -qF 'expected: 5' "$aldir/out.log" || ! grep -qF 'actual:   4' "$aldir
   cat "$aldir/out.log" >&2
   exit 1
 fi
+
+# A USER-written three-argument `assert_eq` must still be an arity error, in
+# BOTH lanes. The first version of the stamp reused `assert_eq` at arity 3 and
+# recognized it by "third operand is a literal string", which made
+# `assert_eq(1, 2, "user")` indistinguishable from a stamped call -- and the
+# single-source lane lowers BEFORE it checks, so that call compiled and
+# reported `assert_eq failed at user` instead of an arity error (#2277 review).
+# The stamp is a separate internal callee now. Both lanes are checked because
+# the FS lane happened to reject it anyway, by typechecking the unstamped
+# module -- so testing only that lane proves nothing about this.
+cat > "$aldir/user_three_arg.vibe" <<'ALEOF'
+test "user three arg" {
+  assert_eq(1, 2, "user")
+}
+ALEOF
+al_fs_out="$(VIBE_TEST_CLI_WASM="$stage2_wasm" VIBE_TEST_QUIET_COMPILER_NOTE=1   bash scripts/vibe_test.sh "$aldir/user_three_arg.vibe" 2>&1 || true)"
+if ! printf '%s\n' "$al_fs_out" | grep -qF 'arity mismatch for assert_eq'; then
+  echo "[compiler-gate] FAIL: a user-written 3-arg assert_eq was accepted by the FS lane (#2202)" >&2
+  printf '%s\n' "$al_fs_out" >&2
+  exit 1
+fi
+rm -f "$aldir/user.wasm" "$aldir/user.wasm.diag"
+VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_IMPORT_ABI=raw VIBE_TEST=1   bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm"   "$aldir/user_three_arg.vibe" "$aldir/user.wasm" __no_entry__ >/dev/null 2>&1 || true
+if [ -s "$aldir/user.wasm" ]; then
+  echo "[compiler-gate] FAIL: a user-written 3-arg assert_eq COMPILED on the single-source lane -- it was lowered as a stamped call (#2202)" >&2
+  VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh --invoke _start "$aldir/user.wasm" >&2 2>&1 || true
+  exit 1
+fi
+if ! grep -qF 'arity mismatch for assert_eq' "$aldir/user.wasm.diag" 2>/dev/null; then
+  echo "[compiler-gate] FAIL: the single-source lane rejected the 3-arg assert_eq for the wrong reason (#2202)" >&2
+  cat "$aldir/user.wasm.diag" 2>/dev/null >&2 || true
+  exit 1
+fi
 rm -rf "$aldir"
-echo "[compiler-gate] assert_eq failure location ok (#2202)"
+echo "[compiler-gate] assert_eq failure location ok, user 3-arg still rejected in both lanes (#2202)"

--- a/tests/gates/late/run.sh
+++ b/tests/gates/late/run.sh
@@ -6342,4 +6342,4 @@ if ! grep -qF 'arity mismatch for assert_eq' "$aldir/user.wasm.diag" 2>/dev/null
   exit 1
 fi
 rm -rf "$aldir"
-echo "[compiler-gate] assert_eq failure location ok, user 3-arg still rejected in both lanes (#2202)"
+echo "[compiler-gate] assert_eq location + user 3-arg rejection ok (#2202)"

--- a/tests/gates/late/run.sh
+++ b/tests/gates/late/run.sh
@@ -6256,8 +6256,21 @@ if grep -qF 'VIBE_UNSTABLE=1' "$uwdir/buffer.optin.out" 2>/dev/null; then
   cat "$uwdir/buffer.optin.out" 2>/dev/null >&2 || true
   exit 1
 fi
+# ...and the JSON form of that same buffer lane, which is what the editor
+# actually consumes. It serialized only `collect_all_diagnostics`, so it
+# answered `[]` while the text form reported the error -- the LSP would have
+# been the one surface still accepting the unstable import (#2277 review).
+rm -f "$uwdir/buffer.json"
+env -u VIBE_UNSTABLE VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_IMPORT_ABI=raw VIBE_DIAGNOSTICS=1 VIBE_DIAGNOSTICS_JSON=1 \
+  bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
+  "$uwdir/buffer.vibe" "$uwdir/buffer.json" __no_entry__ >/dev/null 2>&1 || true
+if ! grep -qF 'VIBE_UNSTABLE=1' "$uwdir/buffer.json" 2>/dev/null; then
+  echo "[compiler-gate] FAIL: the single-file JSON lane dropped the unstable diagnostic (#2277)" >&2
+  cat "$uwdir/buffer.json" 2>/dev/null >&2 || true
+  exit 1
+fi
 rm -rf "$uwdir"
-echo "[compiler-gate] ADR-0068 opt-in gate: check + build + buffer + whitespace + comment + multiline + pinned-require ok (#2248, #2277)"
+echo "[compiler-gate] ADR-0068 opt-in gate: check + build + buffer(text+json) + whitespace + comment + multiline + pinned-require ok (#2248, #2277)"
 fmtdir="_build/_gate_vibe_fmt"
 rm -rf "$fmtdir"; mkdir -p "$fmtdir"
 printf 'let   add=(a:Int,b:Int)->Int{a+b}\n' > "$fmtdir/messy.vibe"

--- a/tests/gates/late/run.sh
+++ b/tests/gates/late/run.sh
@@ -6411,8 +6411,35 @@ if [ ! -s "$uwdir/bare_plain.wasm" ]; then
   cat "$uwdir/bare_plain.wasm.diag" 2>/dev/null >&2 || true
   exit 1
 fi
+# TWO imports of the same package must be located independently. The offset scan
+# restarted from token zero for each `SImport`, so both diagnostics carried the
+# FIRST declaration's coordinates -- and the second one then names a line whose
+# text the reader would find nothing wrong with (#2277 review).
+cat > "$uwdir/twice.vibe" <<'UWEOF'
+import @vibe/concurrent { TaskGroup }
+
+import @vibe/concurrent { Nursery }
+
+fn main() -> Int {
+  1
+}
+UWEOF
+rm -f "$uwdir/twice.out"
+env -u VIBE_UNSTABLE VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_IMPORT_ABI=raw VIBE_DIAGNOSTICS=1 \
+  bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
+  "$uwdir/twice.vibe" "$uwdir/twice.out" __no_entry__ >/dev/null 2>&1 || true
+if ! grep -qF 'line 1:1: set VIBE_UNSTABLE=1' "$uwdir/twice.out" 2>/dev/null; then
+  echo "[compiler-gate] FAIL: the first of two unstable imports was not reported at line 1 (#2277)" >&2
+  cat "$uwdir/twice.out" 2>/dev/null >&2 || true
+  exit 1
+fi
+if ! grep -qF 'line 3:1: set VIBE_UNSTABLE=1' "$uwdir/twice.out" 2>/dev/null; then
+  echo "[compiler-gate] FAIL: the SECOND unstable import was reported at the first one's line (#2277)" >&2
+  cat "$uwdir/twice.out" 2>/dev/null >&2 || true
+  exit 1
+fi
 rm -rf "$uwdir"
-echo "[compiler-gate] ADR-0068 opt-in gate: check + build + serve + single-source + package-re-export + buffer(text+json+column) + whitespace + comment + multiline + pinned-require ok (#2248, #2277)"
+echo "[compiler-gate] ADR-0068 opt-in gate: check + build + serve + single-source + repeated-import + package-re-export + buffer(text+json+column) + whitespace + comment + multiline + pinned-require ok (#2248, #2277)"
 fmtdir="_build/_gate_vibe_fmt"
 rm -rf "$fmtdir"; mkdir -p "$fmtdir"
 printf 'let   add=(a:Int,b:Int)->Int{a+b}\n' > "$fmtdir/messy.vibe"

--- a/tests/gates/late/run.sh
+++ b/tests/gates/late/run.sh
@@ -6269,8 +6269,70 @@ if ! grep -qF 'VIBE_UNSTABLE=1' "$uwdir/buffer.json" 2>/dev/null; then
   cat "$uwdir/buffer.json" 2>/dev/null >&2 || true
   exit 1
 fi
+# The JSON form must carry the COLUMN, not just the message. `lsp_parse_diag_line`
+# accepts exactly `line L:C:`; a readable `line L:col C:` made it fall back to
+# column 1, so the editor put the cursor at character 0 while the text form
+# named the real column (#2277 review). The import is indented so the two
+# answers can differ at all.
+printf '  import @vibe/concurrent { TaskGroup }\n\nfn main() -> Int {\n  1\n}\n' > "$uwdir/indented.vibe"
+rm -f "$uwdir/indented.out" "$uwdir/indented.json"
+env -u VIBE_UNSTABLE VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_IMPORT_ABI=raw VIBE_DIAGNOSTICS=1 \
+  bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
+  "$uwdir/indented.vibe" "$uwdir/indented.out" __no_entry__ >/dev/null 2>&1 || true
+env -u VIBE_UNSTABLE VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_IMPORT_ABI=raw VIBE_DIAGNOSTICS=1 VIBE_DIAGNOSTICS_JSON=1 \
+  bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
+  "$uwdir/indented.vibe" "$uwdir/indented.json" __no_entry__ >/dev/null 2>&1 || true
+# Two lanes, one column: byte column 3 in the text form is UTF-16 character 2 in
+# the JSON form. Before the fix the JSON said 0 for this file while the text
+# form said 3, because `line L:col C:` is not a spelling `lsp_parse_diag_line`
+# can read -- it parsed "col 3" as a number, failed, and fell back to column 1.
+if ! grep -qF 'line 1:3: set VIBE_UNSTABLE=1' "$uwdir/indented.out" 2>/dev/null; then
+  echo "[compiler-gate] FAIL: the text diagnostic lost the column of an indented unstable import (#2277)" >&2
+  cat "$uwdir/indented.out" 2>/dev/null >&2 || true
+  exit 1
+fi
+if ! grep -qF '"character":2' "$uwdir/indented.json" 2>/dev/null; then
+  echo "[compiler-gate] FAIL: the JSON diagnostic lost the column the text form reported (#2277)" >&2
+  cat "$uwdir/indented.json" 2>/dev/null >&2 || true
+  exit 1
+fi
+
+# `vibe serve` is an ARTIFACT-producing verb with its own branch, taken before
+# the FS-compile gate, so the same handler that `vibe check` rejects used to
+# yield a deployable component with no opt-in (#2277 review). The handler shape
+# is the four-parameter String one `validate_serve_handler` requires; the
+# control below proves the file is otherwise servable.
+cat > "$uwdir/serve.vibe" <<'UWEOF'
+import @vibe/concurrent { TaskGroup }
+
+export fn handler(method: String, url: String, headers: String, body: String) -> String {
+  "ok"
+}
+UWEOF
+rm -f "$uwdir/serve.component.wasm" "$uwdir/serve.component.wasm.diag"
+env -u VIBE_UNSTABLE VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_IMPORT_ABI=raw VIBE_SERVE_COMPONENT=1 \
+  bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
+  "$uwdir/serve.vibe" "$uwdir/serve.component.wasm" __no_entry__ >/dev/null 2>&1 || true
+if [ -s "$uwdir/serve.component.wasm" ]; then
+  echo "[compiler-gate] FAIL: vibe serve emitted a component for an unstable import with no opt-in (#2277)" >&2
+  exit 1
+fi
+if ! grep -qF 'VIBE_UNSTABLE=1' "$uwdir/serve.component.wasm.diag" 2>/dev/null; then
+  echo "[compiler-gate] FAIL: vibe serve refused the handler for the wrong reason (#2277)" >&2
+  cat "$uwdir/serve.component.wasm.diag" 2>/dev/null >&2 || true
+  exit 1
+fi
+rm -f "$uwdir/serve.optin.wasm" "$uwdir/serve.optin.wasm.diag"
+VIBE_UNSTABLE=1 VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_IMPORT_ABI=raw VIBE_SERVE_COMPONENT=1 \
+  bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
+  "$uwdir/serve.vibe" "$uwdir/serve.optin.wasm" __no_entry__ >/dev/null 2>&1 || true
+if grep -qF 'VIBE_UNSTABLE=1' "$uwdir/serve.optin.wasm.diag" 2>/dev/null; then
+  echo "[compiler-gate] FAIL: VIBE_UNSTABLE=1 did not clear the serve gate (#2277)" >&2
+  cat "$uwdir/serve.optin.wasm.diag" 2>/dev/null >&2 || true
+  exit 1
+fi
 rm -rf "$uwdir"
-echo "[compiler-gate] ADR-0068 opt-in gate: check + build + buffer(text+json) + whitespace + comment + multiline + pinned-require ok (#2248, #2277)"
+echo "[compiler-gate] ADR-0068 opt-in gate: check + build + serve + buffer(text+json+column) + whitespace + comment + multiline + pinned-require ok (#2248, #2277)"
 fmtdir="_build/_gate_vibe_fmt"
 rm -rf "$fmtdir"; mkdir -p "$fmtdir"
 printf 'let   add=(a:Int,b:Int)->Int{a+b}\n' > "$fmtdir/messy.vibe"

--- a/tests/gates/late/run.sh
+++ b/tests/gates/late/run.sh
@@ -6165,8 +6165,29 @@ for uw_odd in tab spaces; do
     exit 1
   fi
 done
+
+# The reported line must be the OFFENDING import, not the first line that
+# mentions the package. `import @vibe/core { .. } // @vibe/concurrent` is a
+# stable import carrying the name in a comment; naming it told the reader to
+# delete a line that was not the problem, which is worse than no line at all
+# (#2277 review). The offending import is on line 3 here.
+cat > "$uwdir/comment.vibe" <<'UWEOF'
+import @vibe/core { array_empty } // @vibe/concurrent
+
+import @vibe/concurrent { TaskGroup }
+
+fn main() -> Int with Exception {
+  TaskGroup::run((n) -> { 0 })
+}
+UWEOF
+uw_build "$uwdir/comment.vibe" "$uwdir/comment.wasm"
+if ! grep -qF 'line 3:' "$uwdir/comment.wasm.diag" 2>/dev/null; then
+  echo "[compiler-gate] FAIL: the opt-in diagnostic named the wrong import line (#2277)" >&2
+  cat "$uwdir/comment.wasm.diag" 2>/dev/null >&2 || true
+  exit 1
+fi
 rm -rf "$uwdir"
-echo "[compiler-gate] ADR-0068 opt-in gate: check + build + whitespace spellings ok (#2248, #2277)"
+echo "[compiler-gate] ADR-0068 opt-in gate: check + build + whitespace + comment-line ok (#2248, #2277)"
 fmtdir="_build/_gate_vibe_fmt"
 rm -rf "$fmtdir"; mkdir -p "$fmtdir"
 printf 'let   add=(a:Int,b:Int)->Int{a+b}\n' > "$fmtdir/messy.vibe"

--- a/tests/gates/late/run.sh
+++ b/tests/gates/late/run.sh
@@ -6186,8 +6186,38 @@ if ! grep -qF 'line 3:' "$uwdir/comment.wasm.diag" 2>/dev/null; then
   cat "$uwdir/comment.wasm.diag" 2>/dev/null >&2 || true
   exit 1
 fi
+
+# A PINNED `require` header must not silence the gate. The build ingests before
+# it parses, and ingestion blanks that header; a scan that read the raw bytes
+# instead met the `#` in `#pkg:sha1:...`, the lexer refused it ("unknown #
+# directive"), the parse yielded nothing, and the gate went silent while the
+# build compiled the unstable import. Measured: unpinned produced the
+# diagnostic, pinned produced none (#2277 review).
+#
+# The pin here is deliberately bogus, so the build fails either way -- what is
+# asserted is WHICH diagnostic comes out. A pin error means the gate never
+# spoke.
+cat > "$uwdir/pinned.vibe" <<'UWEOF'
+require @vibe/concurrent 0.0.1 = #pkg:sha1:0123456789abcdef0123456789abcdef01234567
+
+import @vibe/concurrent { TaskGroup }
+
+fn main() -> Int with Exception {
+  TaskGroup::run((n) -> { 0 })
+}
+UWEOF
+uw_build "$uwdir/pinned.vibe" "$uwdir/pinned.wasm"
+if [ -s "$uwdir/pinned.wasm" ]; then
+  echo "[compiler-gate] FAIL: a pinned-require entry built against @vibe/concurrent with no opt-in (#2277)" >&2
+  exit 1
+fi
+if ! grep -qF 'VIBE_UNSTABLE=1' "$uwdir/pinned.wasm.diag" 2>/dev/null; then
+  echo "[compiler-gate] FAIL: a pinned require header silenced the opt-in gate (#2277)" >&2
+  cat "$uwdir/pinned.wasm.diag" 2>/dev/null >&2 || true
+  exit 1
+fi
 rm -rf "$uwdir"
-echo "[compiler-gate] ADR-0068 opt-in gate: check + build + whitespace + comment-line ok (#2248, #2277)"
+echo "[compiler-gate] ADR-0068 opt-in gate: check + build + whitespace + comment-line + pinned-require ok (#2248, #2277)"
 fmtdir="_build/_gate_vibe_fmt"
 rm -rf "$fmtdir"; mkdir -p "$fmtdir"
 printf 'let   add=(a:Int,b:Int)->Int{a+b}\n' > "$fmtdir/messy.vibe"

--- a/tests/gates/late/run.sh
+++ b/tests/gates/late/run.sh
@@ -6363,8 +6363,56 @@ else
   cat "$uwdir/reexport.wasm.diag" 2>/dev/null >&2 || true
   exit 1
 fi
+# The SINGLE-SOURCE lane is artifact-producing too. `VIBE_TEST_BACKEND=gc` and
+# `VIBE_BENCH_BACKEND=gc` reach it because `runtime/vibe` clears
+# `VIBE_FS_COMPILE` and selects the backend, so the file compiled and RAN with
+# no opt-in while every check form rejected the same declaration. Measured
+# before the fix: `vibe test` refused it, `VIBE_TEST_BACKEND=gc vibe test`
+# answered `1 passed` (#2277 review). The import is unused on purpose -- that is
+# the shape this lane accepts.
+cat > "$uwdir/bare.vibe" <<'UWEOF'
+import @vibe/concurrent { TaskGroup }
+
+test "unused unstable import" {
+  assert_true(1 + 1 == 2)
+}
+UWEOF
+rm -f "$uwdir/bare.wasm" "$uwdir/bare.wasm.diag"
+env -u VIBE_UNSTABLE -u VIBE_FS_COMPILE VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_IMPORT_ABI=raw VIBE_TEST=1 \
+  bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
+  "$uwdir/bare.vibe" "$uwdir/bare.wasm" __no_entry__ >/dev/null 2>&1 || true
+if [ -s "$uwdir/bare.wasm" ]; then
+  echo "[compiler-gate] FAIL: the single-source lane built an unstable import with no opt-in (#2277)" >&2
+  exit 1
+fi
+if ! grep -qF 'VIBE_UNSTABLE=1' "$uwdir/bare.wasm.diag" 2>/dev/null; then
+  echo "[compiler-gate] FAIL: the single-source lane refused the file for the wrong reason (#2277)" >&2
+  cat "$uwdir/bare.wasm.diag" 2>/dev/null >&2 || true
+  exit 1
+fi
+rm -f "$uwdir/bare.optin.wasm" "$uwdir/bare.optin.wasm.diag"
+env -u VIBE_FS_COMPILE VIBE_UNSTABLE=1 VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_IMPORT_ABI=raw VIBE_TEST=1 \
+  bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
+  "$uwdir/bare.vibe" "$uwdir/bare.optin.wasm" __no_entry__ >/dev/null 2>&1 || true
+if [ ! -s "$uwdir/bare.optin.wasm" ]; then
+  echo "[compiler-gate] FAIL: VIBE_UNSTABLE=1 did not clear the single-source gate (#2277)" >&2
+  cat "$uwdir/bare.optin.wasm.diag" 2>/dev/null >&2 || true
+  exit 1
+fi
+# ...and an ordinary file on that lane is untouched, so the gate is not simply
+# refusing everything.
+printf 'test "plain" {\n  assert_true(1 + 1 == 2)\n}\n' > "$uwdir/bare_plain.vibe"
+rm -f "$uwdir/bare_plain.wasm" "$uwdir/bare_plain.wasm.diag"
+env -u VIBE_UNSTABLE -u VIBE_FS_COMPILE VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_IMPORT_ABI=raw VIBE_TEST=1 \
+  bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
+  "$uwdir/bare_plain.vibe" "$uwdir/bare_plain.wasm" __no_entry__ >/dev/null 2>&1 || true
+if [ ! -s "$uwdir/bare_plain.wasm" ]; then
+  echo "[compiler-gate] FAIL: the single-source gate refused an ordinary file (#2277)" >&2
+  cat "$uwdir/bare_plain.wasm.diag" 2>/dev/null >&2 || true
+  exit 1
+fi
 rm -rf "$uwdir"
-echo "[compiler-gate] ADR-0068 opt-in gate: check + build + serve + package-re-export + buffer(text+json+column) + whitespace + comment + multiline + pinned-require ok (#2248, #2277)"
+echo "[compiler-gate] ADR-0068 opt-in gate: check + build + serve + single-source + package-re-export + buffer(text+json+column) + whitespace + comment + multiline + pinned-require ok (#2248, #2277)"
 fmtdir="_build/_gate_vibe_fmt"
 rm -rf "$fmtdir"; mkdir -p "$fmtdir"
 printf 'let   add=(a:Int,b:Int)->Int{a+b}\n' > "$fmtdir/messy.vibe"
@@ -6676,33 +6724,6 @@ if ! grep -qF 'assert_eq failed' "$aldir/pat.log"; then
   cat "$aldir/pat.log" >&2
   exit 1
 fi
-# A re-exported binding of the name must not be claimed by the builtin either.
-# This does NOT assert the program works -- re-export aliases are broken on
-# their own (#2287: the merge inlines the dependency under its original name and
-# drops the alias, so the call reaches codegen unresolved). `cmp as assert_eq`
-# was the one alias spelling that did not crash, because the lowering claimed
-# the call and ran an assertion instead, which is how #2287 stayed hidden. What
-# the gate requires is that the masking stay gone: whatever this program does,
-# it must not silently be an assertion. It will pass unchanged once #2287 lands.
-cat > "$aldir/redep.vibe" <<'ALEOF'
-export fn cmp(a: Int, b: Int) -> Int {
-  a + b
-}
-ALEOF
-cat > "$aldir/reexport_test.vibe" <<'ALEOF'
-export ./redep.vibe { cmp as assert_eq }
-
-test "re-exported binding" {
-  assert_true(assert_eq(1, 2) == 3)
-}
-ALEOF
-VIBE_TEST_CLI_WASM="$stage2_wasm" VIBE_TEST_QUIET_COMPILER_NOTE=1 \
-  bash scripts/vibe_test.sh "$aldir/reexport_test.vibe" >"$aldir/re.log" 2>&1 || true
-if grep -qF 'assert_eq failed' "$aldir/re.log"; then
-  echo "[compiler-gate] FAIL: a re-exported assert_eq was claimed by the builtin assertion, masking #2287" >&2
-  cat "$aldir/re.log" >&2
-  exit 1
-fi
 # A module whose line numbers are NOT its own is still stamped -- without a
 # location. Leaving those calls bare lost more than the line: nothing recorded
 # that they meant the BUILTIN, so a top-level `assert_eq` in ANY other merged
@@ -6767,4 +6788,4 @@ if printf '%s\n' "$al_marker_out" | grep -qE 'assert_eq failed at '; then
   exit 1
 fi
 rm -rf "$aldir"
-echo "[compiler-gate] assert_eq location + after-assignment + 3-arg + unspellable-marker + top-level shadowing (definition + re-export) + inherited-import capture ok (#2202, #2283)"
+echo "[compiler-gate] assert_eq location + after-assignment + 3-arg + unspellable-marker + top-level shadowing (definition) + inherited-import capture ok (#2202, #2283)"

--- a/tests/gates/late/run.sh
+++ b/tests/gates/late/run.sh
@@ -6475,5 +6475,29 @@ if [ -s "$aldir/hash.wasm" ]; then
   echo "[compiler-gate] FAIL: a '#'-prefixed callee was accepted from source -- the marker is spellable (#2202)" >&2
   exit 1
 fi
+
+# An assert AFTER a mutation must still get its line. `x = e` / `x += e` carry
+# the rest of the block in their last field like `ELet` does; treating them as
+# leaves lost the stamp for every assert that follows one, which is the common
+# mutable-state test shape (#2277 review). The failing assert is on line 9.
+cat > "$aldir/after_assign_test.vibe" <<'ALEOF'
+fn double(n: Int) -> Int {
+  n * 2
+}
+
+test "after assignment" {
+  let mut acc = 0
+  acc = double(2)
+  acc += 1
+  assert_eq(acc, 99)
+}
+ALEOF
+VIBE_TEST_CLI_WASM="$stage2_wasm" VIBE_TEST_QUIET_COMPILER_NOTE=1 \
+  bash scripts/vibe_test.sh "$aldir/after_assign_test.vibe" >"$aldir/assign.log" 2>&1 || true
+if ! grep -qF 'after_assign_test.vibe:9' "$aldir/assign.log"; then
+  echo "[compiler-gate] FAIL: an assert following an assignment lost its line (#2202)" >&2
+  cat "$aldir/assign.log" >&2
+  exit 1
+fi
 rm -rf "$aldir"
-echo "[compiler-gate] assert_eq location + 3-arg + unspellable-marker rejection ok (#2202)"
+echo "[compiler-gate] assert_eq location + after-assignment + 3-arg + unspellable-marker rejection ok (#2202)"

--- a/tests/gates/late/run.sh
+++ b/tests/gates/late/run.sh
@@ -6143,8 +6143,30 @@ if [ ! -s "$uwdir/plain.wasm" ]; then
   cat "$uwdir/plain.wasm.diag" 2>/dev/null >&2 || true
   exit 1
 fi
+
+# Whitespace must not cross the boundary (#2277 review). The first version of
+# the scan matched `String::starts_with(line, "import ")` and sliced a fixed 7
+# bytes, so a tab skipped the check outright and two spaces yielded an empty
+# package name. Both spellings are valid source the lexer accepts, so both were
+# a silent bypass; the gate now reads the PARSED import instead. Written with
+# printf rather than a heredoc so the tab survives being read back.
+printf 'import\t@vibe/concurrent { TaskGroup }\n\nfn main() -> Int with Exception {\n  TaskGroup::run((n) -> { 0 })\n}\n' > "$uwdir/tab.vibe"
+printf 'import  @vibe/concurrent { TaskGroup }\n\nfn main() -> Int with Exception {\n  TaskGroup::run((n) -> { 0 })\n}\n' > "$uwdir/spaces.vibe"
+for uw_odd in tab spaces; do
+  uw_odd_out="$(uw_check "$uwdir/$uw_odd.vibe" || true)"
+  if ! printf '%s\n' "$uw_odd_out" | grep -qF 'VIBE_UNSTABLE=1'; then
+    echo "[compiler-gate] FAIL: '$uw_odd' whitespace spelling of the import bypassed the check gate (#2277)" >&2
+    printf '%s\n' "$uw_odd_out" >&2
+    exit 1
+  fi
+  uw_build "$uwdir/$uw_odd.vibe" "$uwdir/$uw_odd.wasm"
+  if [ -s "$uwdir/$uw_odd.wasm" ]; then
+    echo "[compiler-gate] FAIL: '$uw_odd' whitespace spelling of the import bypassed the build gate (#2277)" >&2
+    exit 1
+  fi
+done
 rm -rf "$uwdir"
-echo "[compiler-gate] ADR-0068 opt-in gate: check + build ok (#2248)"
+echo "[compiler-gate] ADR-0068 opt-in gate: check + build + whitespace spellings ok (#2248, #2277)"
 fmtdir="_build/_gate_vibe_fmt"
 rm -rf "$fmtdir"; mkdir -p "$fmtdir"
 printf 'let   add=(a:Int,b:Int)->Int{a+b}\n' > "$fmtdir/messy.vibe"
@@ -6168,3 +6190,4 @@ if ! cmp -s "$fmtdir/expected.vibe" "$fmtdir/out.vibe"; then
 fi
 rm -rf "$fmtdir"
 echo "[compiler-gate] vibe fmt ok (#2149)"
+

--- a/tests/gates/late/run.sh
+++ b/tests/gates/late/run.sh
@@ -6499,5 +6499,60 @@ if ! grep -qF 'after_assign_test.vibe:9' "$aldir/assign.log"; then
   cat "$aldir/assign.log" >&2
   exit 1
 fi
+# A program that binds `assert_eq` ITSELF must get its own function, in both
+# lanes. The lowering claimed every arity-2 `assert_eq` by name alone, so a
+# user's definition was accepted and then ignored: the call trapped with
+# `assert_eq failed` instead of returning, with no diagnostic naming the
+# conflict anywhere (#2283). Measured on a compiler predating #2202, so this is
+# not a stamping regression -- but the stamp would have rewritten the same call,
+# which is why both the stamp and the lowering stand down together.
+cat > "$aldir/shadow.vibe" <<'ALEOF'
+fn assert_eq(a: Int, b: Int) -> String {
+  Int::to_string(a + b)
+}
+
+fn main() -> Unit with Stdout {
+  println(assert_eq(1, 2))
+}
+ALEOF
+rm -f "$aldir/shadow.wasm" "$aldir/shadow.wasm.diag"
+VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_IMPORT_ABI=raw   bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm"   "$aldir/shadow.vibe" "$aldir/shadow.wasm" main >/dev/null 2>&1 || true
+if [ ! -s "$aldir/shadow.wasm" ]; then
+  echo "[compiler-gate] FAIL: a program defining its own assert_eq did not compile (#2283)" >&2
+  cat "$aldir/shadow.wasm.diag" 2>/dev/null >&2 || true
+  exit 1
+fi
+al_shadow_out="$(VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh --invoke _start "$aldir/shadow.wasm" 2>&1 || true)"
+if ! printf '%s\n' "$al_shadow_out" | grep -qx '3'; then
+  echo "[compiler-gate] FAIL: the user's own assert_eq was not the function that ran (#2283)" >&2
+  printf '%s\n' "$al_shadow_out" >&2
+  exit 1
+fi
+# The FS lane too, through the stamp. `assert_true` is the oracle here so the
+# check does not depend on captured stdout: if the builtin claimed the call,
+# `assert_eq(1, 2)` traps before `assert_true` ever sees a value. Measured on
+# the pre-fix compiler, this exact file reports `assert_eq failed / expected: 2
+# / actual: 1`.
+cat > "$aldir/shadow_test.vibe" <<'ALEOF'
+fn assert_eq(a: Int, b: Int) -> Int {
+  a + b
+}
+
+test "own assert_eq" {
+  assert_true(assert_eq(1, 2) == 3)
+}
+ALEOF
+VIBE_TEST_CLI_WASM="$stage2_wasm" VIBE_TEST_QUIET_COMPILER_NOTE=1 \
+  bash scripts/vibe_test.sh "$aldir/shadow_test.vibe" >"$aldir/shadow.log" 2>&1 || true
+if grep -qF 'assert_eq failed' "$aldir/shadow.log"; then
+  echo "[compiler-gate] FAIL: the FS lane replaced the user's assert_eq with the builtin assertion (#2283)" >&2
+  cat "$aldir/shadow.log" >&2
+  exit 1
+fi
+if ! grep -qF '1 passed, 0 failed' "$aldir/shadow.log"; then
+  echo "[compiler-gate] FAIL: the user's own assert_eq did not run in the FS lane (#2283)" >&2
+  cat "$aldir/shadow.log" >&2
+  exit 1
+fi
 rm -rf "$aldir"
-echo "[compiler-gate] assert_eq location + after-assignment + 3-arg + unspellable-marker rejection ok (#2202)"
+echo "[compiler-gate] assert_eq location + after-assignment + 3-arg + unspellable-marker + user-shadowing ok (#2202, #2283)"

--- a/tests/gates/late/run.sh
+++ b/tests/gates/late/run.sh
@@ -1819,7 +1819,7 @@ rm -rf "$regiondir"; mkdir -p "$regiondir"
 # #1571: the expected value lives in the fixture now (an `inspect` test
 # block declaring the entry's own row, #1508), so this compiles it AS-IS --
 # no `__DATA__` strip, no temp copy, and no expected value in shell.
-VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
+VIBE_UNSTABLE=1 VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
   fixtures/region_ok_basic.vibe "$regiondir/pos.wasm" __no_entry__ >/dev/null 2>&1 || true
 if [ ! -s "$regiondir/pos.wasm" ]; then
@@ -1835,7 +1835,7 @@ fi
 # #1571: the expectation for this rejection is the diagnostic grep below,
 # so the fixture no longer carries an unread `__DATA__` error_contains copy
 # and is compiled AS-IS -- no `sed` strip, no temp copy.
-VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
+VIBE_UNSTABLE=1 VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
   fixtures/err_region_escape_return.vibe "$regiondir/neg.wasm" main >/dev/null 2>&1 || true
 if [ -s "$regiondir/neg.wasm" ]; then
@@ -1892,7 +1892,7 @@ rm -rf "$spawnabledir"; mkdir -p "$spawnabledir"
 # #1571: the expected value lives in the fixture now (an `inspect` test
 # block declaring the entry's own row, #1508), so this compiles it AS-IS --
 # no `__DATA__` strip, no temp copy, and no expected value in shell.
-VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
+VIBE_UNSTABLE=1 VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
   fixtures/region_ok_spawnable_capture.vibe "$spawnabledir/pos.wasm" __no_entry__ >/dev/null 2>&1 || true
 if [ ! -s "$spawnabledir/pos.wasm" ]; then
@@ -1908,7 +1908,7 @@ fi
 # #1571: the expectation for this rejection is the diagnostic grep below,
 # so the fixture no longer carries an unread `__DATA__` error_contains copy
 # and is compiled AS-IS -- no `sed` strip, no temp copy.
-VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
+VIBE_UNSTABLE=1 VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
   fixtures/err_spawnable_capture_array.vibe "$spawnabledir/neg_array.wasm" main >/dev/null 2>&1 || true
 if [ -s "$spawnabledir/neg_array.wasm" ]; then
@@ -1923,7 +1923,7 @@ fi
 # #1571: the expectation for this rejection is the diagnostic grep below,
 # so the fixture no longer carries an unread `__DATA__` error_contains copy
 # and is compiled AS-IS -- no `sed` strip, no temp copy.
-VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
+VIBE_UNSTABLE=1 VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
   fixtures/err_spawnable_capture_cross_region.vibe "$spawnabledir/neg_cross.wasm" main >/dev/null 2>&1 || true
 if [ -s "$spawnabledir/neg_cross.wasm" ]; then
@@ -1938,7 +1938,7 @@ fi
 # #1571: the expectation for this rejection is the diagnostic grep below,
 # so the fixture no longer carries an unread `__DATA__` error_contains copy
 # and is compiled AS-IS -- no `sed` strip, no temp copy.
-VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
+VIBE_UNSTABLE=1 VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
   fixtures/err_spawnable_capture_letmut.vibe "$spawnabledir/neg_letmut.wasm" main >/dev/null 2>&1 || true
 if [ -s "$spawnabledir/neg_letmut.wasm" ]; then
@@ -1953,7 +1953,7 @@ fi
 # #1571: the expectation for this rejection is the diagnostic grep below,
 # so the fixture no longer carries an unread `__DATA__` error_contains copy
 # and is compiled AS-IS -- no `sed` strip, no temp copy.
-VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
+VIBE_UNSTABLE=1 VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
   fixtures/err_spawnable_capture_letmut_outer_scope.vibe "$spawnabledir/neg_letmut_outer.wasm" main >/dev/null 2>&1 || true
 if [ -s "$spawnabledir/neg_letmut_outer.wasm" ]; then
@@ -1974,7 +1974,7 @@ fi
 # #1571: the expected value lives in the fixture now (an `inspect` test
 # block declaring the entry's own row, #1508), so this compiles it AS-IS --
 # no `__DATA__` strip, no temp copy, and no expected value in shell.
-VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
+VIBE_UNSTABLE=1 VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
   fixtures/region_ok_spawnable_capture_shadowed_letmut.vibe "$spawnabledir/pos_shadow.wasm" __no_entry__ >/dev/null 2>&1 || true
 if [ ! -s "$spawnabledir/pos_shadow.wasm" ]; then
@@ -2016,7 +2016,7 @@ rm -rf "$taskgroupdir"; mkdir -p "$taskgroupdir"
 # #1571: the expected value lives in the fixture now (an `inspect` test
 # block declaring the entry's own row, #1508), so this compiles it AS-IS --
 # no `__DATA__` strip, no temp copy, and no expected value in shell.
-VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
+VIBE_UNSTABLE=1 VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
   fixtures/region_ok_taskgroup_sugar.vibe "$taskgroupdir/pos.wasm" __no_entry__ >/dev/null 2>&1 || true
 if [ ! -s "$taskgroupdir/pos.wasm" ]; then
@@ -2032,7 +2032,7 @@ fi
 # #1571: the expectation for this rejection is the diagnostic grep below,
 # so the fixture no longer carries an unread `__DATA__` error_contains copy
 # and is compiled AS-IS -- no `sed` strip, no temp copy.
-VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
+VIBE_UNSTABLE=1 VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
   fixtures/err_taskgroup_sugar_region_escape.vibe "$taskgroupdir/neg.wasm" main >/dev/null 2>&1 || true
 if [ -s "$taskgroupdir/neg.wasm" ]; then
@@ -2122,7 +2122,7 @@ fi
 # #1571: the expected value lives in the fixture now (an `inspect` test
 # block declaring the entry's own row, #1508), so this compiles it AS-IS --
 # no `__DATA__` strip, no temp copy, and no expected value in shell.
-VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
+VIBE_UNSTABLE=1 VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
   fixtures/region_ok_frozen_array_taskgroup_capture.vibe "$frozenarrdir/capture.wasm" __no_entry__ >/dev/null 2>&1 || true
 if [ ! -s "$frozenarrdir/capture.wasm" ]; then
@@ -3322,7 +3322,7 @@ if [ "$asb89_pos_out" != "42" ]; then
   exit 1
 fi
 cp fixtures/err_async_boundary_mixed_convention.vibe "$asb89dir/neg.vibe"
-VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
+VIBE_UNSTABLE=1 VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
   "$asb89dir/neg.vibe" "$asb89dir/neg.wasm" main >/dev/null 2>&1 || true
 if [ -s "$asb89dir/neg.wasm" ]; then
@@ -3361,7 +3361,7 @@ if ! grep -qF 'mixing the step convention' "$asb89dir/negop.wasm.diag" 2>/dev/nu
   exit 1
 fi
 cp fixtures/async_boundary_user_sleep_test.vibe "$asb89dir/usersleep.vibe"
-VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
+VIBE_UNSTABLE=1 VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
   "$asb89dir/usersleep.vibe" "$asb89dir/usersleep.wasm" main >/dev/null 2>&1 || true
 if [ ! -s "$asb89dir/usersleep.wasm" ]; then
@@ -6050,16 +6050,21 @@ fi
 rm -rf "$cdbg"
 echo "[compiler-gate] crash dump opt-in ok (#2199)"
 
-# 108/108. The ADR-0068 concurrency surface is MARKED unstable (#2248).
+# 108/108. The ADR-0068 concurrency surface is opt-in (#2248).
 #      docs/spec/stable-surface.md said the unstable surface "is reached only
 #      through `@build.unstable`, an explicit flag, or an ADR still marked
 #      `proposed`" -- and `@build.unstable` appeared nowhere else in the tree,
 #      there was no such flag, and `TaskGroup::run` checked clean with no
-#      marker of any kind. Three directions, because each alone is satisfiable
-#      by the wrong thing: silence would also pass if the warning were deleted,
-#      the warning alone would pass if the opt-in did nothing, and both would
-#      pass if it warned on every file.
-echo "[compiler-gate] 108/108 the ADR-0068 concurrency surface warns unless opted in (#2248)"
+#      marker of any kind.
+#
+#      BOTH verbs, because a build that accepts what the check rejects is the
+#      "two verbs, two answers" defect #1567 fixed for check/diagnostics, and
+#      it is worse here: the accepting verb is the one that ships. And three
+#      directions each, since any one alone is satisfiable by the wrong thing
+#      -- silence would also pass if the gate were deleted, rejection would
+#      also pass if the opt-in did nothing, and both would pass if it rejected
+#      every file.
+echo "[compiler-gate] 108/108 the ADR-0068 concurrency surface is opt-in, in check AND build (#2248)"
 uwdir="_build/_gate_unstable_warn"
 rm -rf "$uwdir"; mkdir -p "$uwdir"
 cat > "$uwdir/uses.vibe" <<'UWEOF'
@@ -6077,31 +6082,69 @@ fn main() -> Int { 1 + 1 }
 UWEOF
 # `env -u VIBE_UNSTABLE`: the no-opt-in cases must not inherit the opt-in.
 # Measured -- with VIBE_UNSTABLE=1 in the ambient environment this section
-# reported "importing @vibe/concurrent did not warn" and would have passed
-# vacuously had the assertion been the other way round. Same defect #2252
-# found in five self-tests: a check that measures the machine, not the
-# property.
+# reported "did not reject" and would have passed vacuously had the assertion
+# been the other way round. Same defect #2252 found in five self-tests: a
+# check that measures the machine, not the property.
 uw_check() { env -u VIBE_UNSTABLE VIBE_RUNNER="$ROOT_DIR/scripts/viberun_node.sh" VIBE_CLI_WASM="$stage2_wasm" \
   VIBE_PREOPEN_DIR="$ROOT_DIR" bash "$ROOT_DIR/runtime/vibe" check "$1" 2>&1; }
-uw_warned="$(uw_check "$uwdir/uses.vibe" | grep -c 'is UNSTABLE (ADR-0068' || true)"
-uw_optin="$(VIBE_UNSTABLE=1 VIBE_RUNNER="$ROOT_DIR/scripts/viberun_node.sh" VIBE_CLI_WASM="$stage2_wasm" \
-  VIBE_PREOPEN_DIR="$ROOT_DIR" bash "$ROOT_DIR/runtime/vibe" check "$uwdir/uses.vibe" 2>&1 | grep -c 'is UNSTABLE (ADR-0068' || true)"
-uw_plain="$(uw_check "$uwdir/plain.vibe" | grep -c 'is UNSTABLE (ADR-0068' || true)"
-if [ "$uw_warned" -lt 1 ]; then
-  echo "[compiler-gate] FAIL: importing @vibe/concurrent did not warn (#2248)" >&2
-  uw_check "$uwdir/uses.vibe" >&2
+uw_build() { # <src> <out> [extra env assignments...]
+  local src="$1" out="$2"; shift 2
+  rm -f "$out" "$out.diag"
+  env -u VIBE_UNSTABLE "$@" VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
+    bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
+    "$src" "$out" main >/dev/null 2>&1 || true
+}
+
+# check: rejected, opt-in accepted, unrelated file untouched.
+#
+# Captured into a variable, not piped: this gate runs under `set -o pipefail`,
+# and `uw_check` exits 1 on the rejection it is asserting, so `uw_check | grep`
+# fails even when grep MATCHES. Measured -- the first version reported "vibe
+# check accepted @vibe/concurrent" while the rejection it was looking for was
+# printed one line above it in the same log.
+uw_uses_out="$(uw_check "$uwdir/uses.vibe" || true)"
+if ! printf '%s\n' "$uw_uses_out" | grep -qF 'VIBE_UNSTABLE=1'; then
+  echo "[compiler-gate] FAIL: vibe check accepted @vibe/concurrent with no opt-in (#2248)" >&2
+  printf '%s\n' "$uw_uses_out" >&2
   exit 1
 fi
-if [ "$uw_optin" -ne 0 ]; then
-  echo "[compiler-gate] FAIL: VIBE_UNSTABLE=1 did not silence the ADR-0068 warning (#2248)" >&2
+if ! VIBE_UNSTABLE=1 VIBE_RUNNER="$ROOT_DIR/scripts/viberun_node.sh" VIBE_CLI_WASM="$stage2_wasm" \
+  VIBE_PREOPEN_DIR="$ROOT_DIR" bash "$ROOT_DIR/runtime/vibe" check "$uwdir/uses.vibe" >/dev/null 2>&1; then
+  echo "[compiler-gate] FAIL: VIBE_UNSTABLE=1 did not let vibe check through (#2248)" >&2
   exit 1
 fi
-if [ "$uw_plain" -ne 0 ]; then
-  echo "[compiler-gate] FAIL: a file not touching @vibe/concurrent warned anyway (#2248)" >&2
+uw_plain_out="$(uw_check "$uwdir/plain.vibe" || true)"
+if printf '%s\n' "$uw_plain_out" | grep -qF 'VIBE_UNSTABLE=1'; then
+  echo "[compiler-gate] FAIL: a file not importing @vibe/concurrent was rejected anyway (#2248)" >&2
+  printf '%s\n' "$uw_plain_out" >&2
+  exit 1
+fi
+
+# build: the same three, through the FS-compile lane.
+uw_build "$uwdir/uses.vibe" "$uwdir/uses.wasm"
+if [ -s "$uwdir/uses.wasm" ]; then
+  echo "[compiler-gate] FAIL: vibe build accepted @vibe/concurrent with no opt-in -- the build accepts what the check rejects (#2248)" >&2
+  exit 1
+fi
+if ! grep -qF 'VIBE_UNSTABLE=1' "$uwdir/uses.wasm.diag" 2>/dev/null; then
+  echo "[compiler-gate] FAIL: the build rejection did not name the opt-in (#2248)" >&2
+  cat "$uwdir/uses.wasm.diag" 2>/dev/null >&2 || true
+  exit 1
+fi
+uw_build "$uwdir/uses.vibe" "$uwdir/uses_optin.wasm" VIBE_UNSTABLE=1
+if [ ! -s "$uwdir/uses_optin.wasm" ]; then
+  echo "[compiler-gate] FAIL: VIBE_UNSTABLE=1 did not let the build through (#2248)" >&2
+  cat "$uwdir/uses_optin.wasm.diag" 2>/dev/null >&2 || true
+  exit 1
+fi
+uw_build "$uwdir/plain.vibe" "$uwdir/plain.wasm"
+if [ ! -s "$uwdir/plain.wasm" ]; then
+  echo "[compiler-gate] FAIL: a file not importing @vibe/concurrent failed to build (#2248)" >&2
+  cat "$uwdir/plain.wasm.diag" 2>/dev/null >&2 || true
   exit 1
 fi
 rm -rf "$uwdir"
-echo "[compiler-gate] ADR-0068 unstable-surface warning ok (#2248)"
+echo "[compiler-gate] ADR-0068 opt-in gate: check + build ok (#2248)"
 fmtdir="_build/_gate_vibe_fmt"
 rm -rf "$fmtdir"; mkdir -p "$fmtdir"
 printf 'let   add=(a:Int,b:Int)->Int{a+b}\n' > "$fmtdir/messy.vibe"

--- a/tests/gates/late/run.sh
+++ b/tests/gates/late/run.sh
@@ -6216,8 +6216,21 @@ if ! grep -qF 'VIBE_UNSTABLE=1' "$uwdir/pinned.wasm.diag" 2>/dev/null; then
   cat "$uwdir/pinned.wasm.diag" 2>/dev/null >&2 || true
   exit 1
 fi
+
+# The path may be on the NEXT line. `import\n  @vibe/concurrent { .. }` is valid
+# source; a same-line search missed it and fell back to line 1, naming an
+# unrelated declaration. The location comes from the lexer now, so this and the
+# comment case above are the same rule rather than two patches (#2277 review).
+# The import here starts on line 5.
+printf 'fn helper() -> Int {\n  1\n}\n\nimport\n  @vibe/concurrent { TaskGroup }\n\nfn main() -> Int with Exception {\n  TaskGroup::run((n) -> { 0 })\n}\n' > "$uwdir/multiline.vibe"
+uw_build "$uwdir/multiline.vibe" "$uwdir/multiline.wasm"
+if ! grep -qF 'line 5:' "$uwdir/multiline.wasm.diag" 2>/dev/null; then
+  echo "[compiler-gate] FAIL: a multiline import declaration got the wrong line (#2277)" >&2
+  cat "$uwdir/multiline.wasm.diag" 2>/dev/null >&2 || true
+  exit 1
+fi
 rm -rf "$uwdir"
-echo "[compiler-gate] ADR-0068 opt-in gate: check + build + whitespace + comment-line + pinned-require ok (#2248, #2277)"
+echo "[compiler-gate] ADR-0068 opt-in gate: check + build + whitespace + comment + multiline + pinned-require ok (#2248, #2277)"
 fmtdir="_build/_gate_vibe_fmt"
 rm -rf "$fmtdir"; mkdir -p "$fmtdir"
 printf 'let   add=(a:Int,b:Int)->Int{a+b}\n' > "$fmtdir/messy.vibe"

--- a/tests/gates/late/run.sh
+++ b/tests/gates/late/run.sh
@@ -6341,5 +6341,35 @@ if ! grep -qF 'arity mismatch for assert_eq' "$aldir/user.wasm.diag" 2>/dev/null
   cat "$aldir/user.wasm.diag" 2>/dev/null >&2 || true
   exit 1
 fi
+
+# The stamped callee must be UNSPELLABLE, not merely obscure. Two earlier
+# spellings were reachable from source, and in the single-source lane the
+# lowering runs before `check_program`, so anything it recognizes bypasses name
+# and arity checking: `assert_eq` at arity 3 with a string, then the ordinary
+# identifier `__assert_eq_at`. Both compiled and ran as asserts; the second
+# would also have let a user DECLARING that name have their calls rewritten out
+# from under them. `#` is not an identifier character, so the marker cannot be
+# constructed from any input (#2277 review).
+printf 'test "hijack" {\n  __assert_eq_at(1, 2, "user")\n}\n' > "$aldir/hijack.vibe"
+rm -f "$aldir/hijack.wasm" "$aldir/hijack.wasm.diag"
+VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_IMPORT_ABI=raw VIBE_TEST=1 \
+  bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
+  "$aldir/hijack.vibe" "$aldir/hijack.wasm" __no_entry__ >/dev/null 2>&1 || true
+if [ -s "$aldir/hijack.wasm" ]; then
+  echo "[compiler-gate] FAIL: user source spelling the stamped callee was lowered as an assert (#2202)" >&2
+  VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh --invoke _start "$aldir/hijack.wasm" >&2 2>&1 || true
+  exit 1
+fi
+# The `#` spelling is not an identifier at all -- the lexer refuses it, which is
+# what makes the marker unspellable rather than merely unlikely.
+printf 'test "hash" {\n  #assert_eq_at(1, 2, "user")\n}\n' > "$aldir/hash.vibe"
+rm -f "$aldir/hash.wasm" "$aldir/hash.wasm.diag"
+VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_IMPORT_ABI=raw VIBE_TEST=1 \
+  bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
+  "$aldir/hash.vibe" "$aldir/hash.wasm" __no_entry__ >/dev/null 2>&1 || true
+if [ -s "$aldir/hash.wasm" ]; then
+  echo "[compiler-gate] FAIL: a '#'-prefixed callee was accepted from source -- the marker is spellable (#2202)" >&2
+  exit 1
+fi
 rm -rf "$aldir"
-echo "[compiler-gate] assert_eq location + user 3-arg rejection ok (#2202)"
+echo "[compiler-gate] assert_eq location + 3-arg + unspellable-marker rejection ok (#2202)"

--- a/tests/gates/late/run.sh
+++ b/tests/gates/late/run.sh
@@ -6049,6 +6049,59 @@ if ! grep -qF '[crash debug]' "$cdbg/loud.log"; then
 fi
 rm -rf "$cdbg"
 echo "[compiler-gate] crash dump opt-in ok (#2199)"
+
+# 108/108. The ADR-0068 concurrency surface is MARKED unstable (#2248).
+#      docs/spec/stable-surface.md said the unstable surface "is reached only
+#      through `@build.unstable`, an explicit flag, or an ADR still marked
+#      `proposed`" -- and `@build.unstable` appeared nowhere else in the tree,
+#      there was no such flag, and `TaskGroup::run` checked clean with no
+#      marker of any kind. Three directions, because each alone is satisfiable
+#      by the wrong thing: silence would also pass if the warning were deleted,
+#      the warning alone would pass if the opt-in did nothing, and both would
+#      pass if it warned on every file.
+echo "[compiler-gate] 108/108 the ADR-0068 concurrency surface warns unless opted in (#2248)"
+uwdir="_build/_gate_unstable_warn"
+rm -rf "$uwdir"; mkdir -p "$uwdir"
+cat > "$uwdir/uses.vibe" <<'UWEOF'
+import @vibe/concurrent { TaskGroup }
+
+fn main() -> Int with Exception {
+  TaskGroup::run((n) -> {
+    let _t = TaskGroup::spawn(n, () -> { 7 })
+    0
+  })
+}
+UWEOF
+cat > "$uwdir/plain.vibe" <<'UWEOF'
+fn main() -> Int { 1 + 1 }
+UWEOF
+# `env -u VIBE_UNSTABLE`: the no-opt-in cases must not inherit the opt-in.
+# Measured -- with VIBE_UNSTABLE=1 in the ambient environment this section
+# reported "importing @vibe/concurrent did not warn" and would have passed
+# vacuously had the assertion been the other way round. Same defect #2252
+# found in five self-tests: a check that measures the machine, not the
+# property.
+uw_check() { env -u VIBE_UNSTABLE VIBE_RUNNER="$ROOT_DIR/scripts/viberun_node.sh" VIBE_CLI_WASM="$stage2_wasm" \
+  VIBE_PREOPEN_DIR="$ROOT_DIR" bash "$ROOT_DIR/runtime/vibe" check "$1" 2>&1; }
+uw_warned="$(uw_check "$uwdir/uses.vibe" | grep -c 'is UNSTABLE (ADR-0068' || true)"
+uw_optin="$(VIBE_UNSTABLE=1 VIBE_RUNNER="$ROOT_DIR/scripts/viberun_node.sh" VIBE_CLI_WASM="$stage2_wasm" \
+  VIBE_PREOPEN_DIR="$ROOT_DIR" bash "$ROOT_DIR/runtime/vibe" check "$uwdir/uses.vibe" 2>&1 | grep -c 'is UNSTABLE (ADR-0068' || true)"
+uw_plain="$(uw_check "$uwdir/plain.vibe" | grep -c 'is UNSTABLE (ADR-0068' || true)"
+if [ "$uw_warned" -lt 1 ]; then
+  echo "[compiler-gate] FAIL: importing @vibe/concurrent did not warn (#2248)" >&2
+  uw_check "$uwdir/uses.vibe" >&2
+  exit 1
+fi
+if [ "$uw_optin" -ne 0 ]; then
+  echo "[compiler-gate] FAIL: VIBE_UNSTABLE=1 did not silence the ADR-0068 warning (#2248)" >&2
+  exit 1
+fi
+if [ "$uw_plain" -ne 0 ]; then
+  echo "[compiler-gate] FAIL: a file not touching @vibe/concurrent warned anyway (#2248)" >&2
+  exit 1
+fi
+rm -rf "$uwdir"
+echo "[compiler-gate] ADR-0068 unstable-surface warning ok (#2248)"
 fmtdir="_build/_gate_vibe_fmt"
 rm -rf "$fmtdir"; mkdir -p "$fmtdir"
 printf 'let   add=(a:Int,b:Int)->Int{a+b}\n' > "$fmtdir/messy.vibe"

--- a/tests/gates/late/run.sh
+++ b/tests/gates/late/run.sh
@@ -6229,8 +6229,35 @@ if ! grep -qF 'line 5:' "$uwdir/multiline.wasm.diag" 2>/dev/null; then
   cat "$uwdir/multiline.wasm.diag" 2>/dev/null >&2 || true
   exit 1
 fi
+
+# The BUFFER lane must agree too. `vibe check --single-file` (VIBE_DIAGNOSTICS)
+# does not resolve imports, so an UNUSED `import @vibe/concurrent` analyzed
+# clean there while both other verbs rejected the same file -- an editor showing
+# nothing is the third answer to the same question (#2277 review). Unused on
+# purpose: that is the shape that slipped through.
+cat > "$uwdir/buffer.vibe" <<'UWEOF'
+import @vibe/concurrent { TaskGroup }
+
+fn main() -> Int {
+  1
+}
+UWEOF
+rm -f "$uwdir/buffer.out"
+env -u VIBE_UNSTABLE VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_IMPORT_ABI=raw VIBE_DIAGNOSTICS=1   bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm"   "$uwdir/buffer.vibe" "$uwdir/buffer.out" __no_entry__ >/dev/null 2>&1 || true
+if ! grep -qF 'VIBE_UNSTABLE=1' "$uwdir/buffer.out" 2>/dev/null; then
+  echo "[compiler-gate] FAIL: the single-file diagnostics lane accepted an unstable import (#2277)" >&2
+  cat "$uwdir/buffer.out" 2>/dev/null >&2 || true
+  exit 1
+fi
+rm -f "$uwdir/buffer.optin.out"
+VIBE_UNSTABLE=1 VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_IMPORT_ABI=raw VIBE_DIAGNOSTICS=1   bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm"   "$uwdir/buffer.vibe" "$uwdir/buffer.optin.out" __no_entry__ >/dev/null 2>&1 || true
+if grep -qF 'VIBE_UNSTABLE=1' "$uwdir/buffer.optin.out" 2>/dev/null; then
+  echo "[compiler-gate] FAIL: VIBE_UNSTABLE=1 did not clear the single-file diagnostic (#2277)" >&2
+  cat "$uwdir/buffer.optin.out" 2>/dev/null >&2 || true
+  exit 1
+fi
 rm -rf "$uwdir"
-echo "[compiler-gate] ADR-0068 opt-in gate: check + build + whitespace + comment + multiline + pinned-require ok (#2248, #2277)"
+echo "[compiler-gate] ADR-0068 opt-in gate: check + build + buffer + whitespace + comment + multiline + pinned-require ok (#2248, #2277)"
 fmtdir="_build/_gate_vibe_fmt"
 rm -rf "$fmtdir"; mkdir -p "$fmtdir"
 printf 'let   add=(a:Int,b:Int)->Int{a+b}\n' > "$fmtdir/messy.vibe"

--- a/tests/gates/late/run.sh
+++ b/tests/gates/late/run.sh
@@ -5934,6 +5934,33 @@ if [ "$ta_out" != "() -> Box" ]; then
   echo "[compiler-gate] FAIL: type-at on \`mk_box\` in a call-rooted dot-call reports '$ta_out', not '() -> Box' -- the call-site offset is stealing an identifier token (#2231/#2248)" >&2
   exit 1
 fi
+
+# #2261: the same collision for an IDENT-rooted dot-call. `b.get()` gave the
+# outer call the offset of the identifier `b`, and type-at's table is
+# last-wins, so hovering `b` answered `Double` -- the CALL's result -- instead
+# of `Box`. #1941 solved this for a NAMED callee via `CalleeHit`, but that
+# escape resolves through the top-level env and cannot answer for a local
+# receiver. Three positions, because a fix that answered "" everywhere would
+# also stop reporting Double.
+cat > "$tadir/ta2.vibe" <<'TAEOF2'
+struct Box { get: () -> Double }
+fn mk_box() -> Box { Box::{ get: () -> { 2.5 } } }
+fn main() -> Int {
+  let b = mk_box()
+  let w = b.get()
+  let z = b
+  0
+}
+TAEOF2
+ta_q() { VIBE_RUNNER="$ROOT_DIR/scripts/viberun_node.sh" VIBE_CLI_WASM="$stage2_wasm" \
+  VIBE_PREOPEN_DIR="$ROOT_DIR" bash "$ROOT_DIR/runtime/vibe" type-at "$tadir/ta2.vibe" "$1" "$2" 2>/dev/null | head -1; }
+ta_recv="$(ta_q 5 11)"
+ta_plain="$(ta_q 6 11)"
+ta_fn="$(ta_q 4 11)"
+if [ "$ta_recv" != "Box" ] || [ "$ta_plain" != "Box" ] || [ "$ta_fn" != "() -> Box" ]; then
+  echo "[compiler-gate] FAIL: type-at on a dot-call receiver (#2261): recv='$ta_recv' plain='$ta_plain' fn='$ta_fn'; wanted Box / Box / () -> Box" >&2
+  exit 1
+fi
 rm -rf "$tadir"
 echo "[compiler-gate] call-site offset does not steal an identifier token ok (#2231)"
 

--- a/tests/gates/late/run.sh
+++ b/tests/gates/late/run.sh
@@ -6263,3 +6263,50 @@ if ! cmp -s "$nfdir/expected.vibe" "$nfdir/again.vibe"; then
 fi
 rm -rf "$nfdir"
 echo "[compiler-gate] non-final closure argument fixpoint ok (#2271)"
+
+# 110/110. An `assert_eq` failure names the line it fired on (#2202).
+# The report gave the test name and both sides but no location, so a test with
+# several asserts sharing an expected value could not say which one failed --
+# and the book's chapter 12 reproduces that output shape verbatim, documenting
+# the gap without naming it.
+#
+# Two directions, because either alone is satisfiable by the wrong thing: the
+# SECOND assert's line must appear (not merely "a line"), and the first
+# assert's line must NOT, or the stamp is attached to the test rather than to
+# the call. `vibe test` compiles through VIBE_FS_COMPILE, which is the lane
+# that merges modules and therefore the lane where offsets are per-module.
+echo "[compiler-gate] 110/110 an assert_eq failure names its own line (#2202)"
+aldir="_build/_gate_assert_line"
+rm -rf "$aldir"; mkdir -p "$aldir"
+cat > "$aldir/two_asserts_test.vibe" <<'ALEOF'
+fn double(n: Int) -> Int {
+  n * 2
+}
+
+test "which assert fired" {
+  assert_eq(double(21), 42)
+  assert_eq(double(2), 5)
+}
+ALEOF
+VIBE_TEST_CLI_WASM="$stage2_wasm" VIBE_TEST_QUIET_COMPILER_NOTE=1 \
+  bash scripts/vibe_test.sh "$aldir/two_asserts_test.vibe" >"$aldir/out.log" 2>&1 || true
+# The failing assert is on line 7; the passing one is on line 6.
+if ! grep -qF 'two_asserts_test.vibe:7' "$aldir/out.log"; then
+  echo "[compiler-gate] FAIL: the assert_eq failure did not name the line it fired on (#2202)" >&2
+  cat "$aldir/out.log" >&2
+  exit 1
+fi
+if grep -qF 'two_asserts_test.vibe:6' "$aldir/out.log"; then
+  echo "[compiler-gate] FAIL: the report named the PASSING assert's line -- the stamp is not per call (#2202)" >&2
+  cat "$aldir/out.log" >&2
+  exit 1
+fi
+# The values still have to be there: a location that replaced the diagnostic
+# would pass the two checks above and be a regression.
+if ! grep -qF 'expected: 5' "$aldir/out.log" || ! grep -qF 'actual:   4' "$aldir/out.log"; then
+  echo "[compiler-gate] FAIL: the assert_eq report lost its operands (#2202)" >&2
+  cat "$aldir/out.log" >&2
+  exit 1
+fi
+rm -rf "$aldir"
+echo "[compiler-gate] assert_eq failure location ok (#2202)"

--- a/tests/gates/late/run.sh
+++ b/tests/gates/late/run.sh
@@ -6703,5 +6703,68 @@ if grep -qF 'assert_eq failed' "$aldir/re.log"; then
   cat "$aldir/re.log" >&2
   exit 1
 fi
+# A module whose line numbers are NOT its own is still stamped -- without a
+# location. Leaving those calls bare lost more than the line: nothing recorded
+# that they meant the BUILTIN, so a top-level `assert_eq` in ANY other merged
+# module suppressed the lowering program-wide and codegen's func-table dispatch
+# sent them to that unrelated function. Measured before the fix: `probe()`
+# returned 7 with no assertion and no diagnostic -- silently the wrong function
+# (#2277 review). The sibling below inherits `index.vpkg`'s shared import, which
+# is what makes its ingested text non-1:1.
+mkdir -p "$aldir/pkg"
+cat > "$aldir/pkg/index.vpkg" <<'ALEOF'
+name = @scratch/assertmarker
+version = 0.0.1
+description =
+  #|assert marker probe
+deps = {
+  @vibe/core : 0.2.0
+}
+
+generated_hash =
+
+import @vibe/core { array_empty }
+
+fn probe() -> Int
+ALEOF
+cat > "$aldir/pkg/main_impl.vibe" <<'ALEOF'
+export fn probe() -> Int {
+  let _unused = array_empty()
+  assert_eq(1, 2)
+  7
+}
+ALEOF
+cat > "$aldir/marker_use.vibe" <<'ALEOF'
+import ./pkg { probe }
+
+fn assert_eq(a: Int, b: Int) -> Int {
+  a + b
+}
+
+fn main() -> Int {
+  probe()
+}
+ALEOF
+rm -f "$aldir/marker.wasm" "$aldir/marker.wasm.diag"
+VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
+  bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
+  "$aldir/marker_use.vibe" "$aldir/marker.wasm" main >/dev/null 2>&1 || true
+if [ ! -s "$aldir/marker.wasm" ]; then
+  echo "[compiler-gate] FAIL: the vpkg-inheriting assert probe did not compile (#2277 review)" >&2
+  cat "$aldir/marker.wasm.diag" 2>/dev/null >&2 || true
+  exit 1
+fi
+al_marker_out="$(VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh --invoke _start "$aldir/marker.wasm" 2>&1 || true)"
+if ! printf '%s\n' "$al_marker_out" | grep -qF 'assert_eq failed'; then
+  echo "[compiler-gate] FAIL: an inherited-import module's builtin assert was captured by another module's assert_eq (#2277 review)" >&2
+  printf '%s\n' "$al_marker_out" >&2
+  exit 1
+fi
+# ...and unlocated, not with a line borrowed from the shifted text (#1445).
+if printf '%s\n' "$al_marker_out" | grep -qE 'assert_eq failed at '; then
+  echo "[compiler-gate] FAIL: a module whose lines are not its own reported a location anyway (#1445)" >&2
+  printf '%s\n' "$al_marker_out" >&2
+  exit 1
+fi
 rm -rf "$aldir"
-echo "[compiler-gate] assert_eq location + after-assignment + 3-arg + unspellable-marker + top-level shadowing (definition + re-export) ok (#2202, #2283)"
+echo "[compiler-gate] assert_eq location + after-assignment + 3-arg + unspellable-marker + top-level shadowing (definition + re-export) + inherited-import capture ok (#2202, #2283)"

--- a/tests/gates/registry.tsv
+++ b/tests/gates/registry.tsv
@@ -225,4 +225,4 @@ x-adr-0090-1937-exception-unwind-region-restore	late	ADR-0090 #1937 exception-un
 105/105	late	105/105 checker Double call-result offsets on the linear source lane (#2158)
 106/106	late	106/106 vibe fmt reaches an installed user (#2149)
 107/107	late	107/107 the host runner's crash dump is opt-in (#2199)
-108/108	late	108/108 the ADR-0068 concurrency surface warns unless opted in (#2248)
+108/108	late	108/108 the ADR-0068 concurrency surface is opt-in, in check AND build (#2248)

--- a/tests/gates/registry.tsv
+++ b/tests/gates/registry.tsv
@@ -226,3 +226,4 @@ x-adr-0090-1937-exception-unwind-region-restore	late	ADR-0090 #1937 exception-un
 106/106	late	106/106 vibe fmt reaches an installed user (#2149)
 107/107	late	107/107 the host runner's crash dump is opt-in (#2199)
 108/108	late	108/108 the ADR-0068 concurrency surface is opt-in, in check AND build (#2248)
+109/109	late	109/109 a multiline closure in a non-final argument slot formats to a fixpoint (#2271)

--- a/tests/gates/registry.tsv
+++ b/tests/gates/registry.tsv
@@ -227,3 +227,4 @@ x-adr-0090-1937-exception-unwind-region-restore	late	ADR-0090 #1937 exception-un
 107/107	late	107/107 the host runner's crash dump is opt-in (#2199)
 108/108	late	108/108 the ADR-0068 concurrency surface is opt-in, in check AND build (#2248)
 109/109	late	109/109 a multiline closure in a non-final argument slot formats to a fixpoint (#2271)
+110/110	late	110/110 an assert_eq failure names its own line (#2202)

--- a/tests/gates/registry.tsv
+++ b/tests/gates/registry.tsv
@@ -225,3 +225,4 @@ x-adr-0090-1937-exception-unwind-region-restore	late	ADR-0090 #1937 exception-un
 105/105	late	105/105 checker Double call-result offsets on the linear source lane (#2158)
 106/106	late	106/106 vibe fmt reaches an installed user (#2149)
 107/107	late	107/107 the host runner's crash dump is opt-in (#2199)
+108/108	late	108/108 the ADR-0068 concurrency surface warns unless opted in (#2248)


### PR DESCRIPTION
Closes #2261. Closes #2271. Closes #2202. Closes #2283.

Follow-up to #2248 (merged); the first five commits were rebased onto `main` and could not ride the merged PR.

## What changes

### A dot-call must not take its receiver's offset either (closes #2261)

`vibe type-at` on the receiver of `b.get()` answered `Double` — the **call's result type** — instead of `Box`. `EDot`'s own offset is its receiver's root, so the outer `ECall` filed a `CallResult` entry at the identifier `b`'s offset, and `type_at`'s table is last-wins. Same collision #2231 fixed, one token over.

`call_site_offset` now falls back to the `(` offset when the callee is a dot access, or roots at a call. Measured before/after on the same file:

| | before | after |
|---|---|---|
| `b` as a dot-call receiver | `Double` | `Box` |
| `b` as a plain reference | `Box` | `Box` |
| `mk_box` | `() -> Box` | `() -> Box` |

Not a regression — a stage2 from `04c9bcd0` (predating all the #2231 work) answers identically to the pre-fix build.

### The ADR-0068 concurrency surface is now opt-in

ADR-0012 (`Async`) is **accepted** and stays free. ADR-0068 (`Nursery` / `Task` / `Sender` / `Receiver` / `Send` / `TaskGroup`, i.e. `@vibe/concurrent`) is **proposed** — outside the SemVer promise and able to change inside a Minor release. Importing it silently was the wrong default, so it now requires `VIBE_UNSTABLE=1`.

The gate reads the entry file's **parsed** `SImport` statements, from the same ingestion the build uses. Every verb that can produce an artifact applies it, which took several rounds to get complete:

| lane | how it is reached |
|---|---|
| `vibe check` | linked check, from the snapshot the check consumed |
| `vibe check --single-file` (text and JSON) | buffer lane, which an editor consumes |
| `vibe build` / `vibe run` | FS-compile branch |
| `vibe serve` | its own `VIBE_SERVE_COMPONENT` branch, which returns *before* the FS gate — it produced a deployable component with no opt-in |
| `VIBE_TEST_BACKEND=gc` / `VIBE_BENCH_BACKEND=gc` | the single-source branch, reached because `runtime/vibe` clears `VIBE_FS_COMPILE` |

Two in-tree harnesses compile sources that use the surface deliberately and are granted the opt-in — the doctest driver **per block**, so every chapter other than the concurrency one still meets the boundary, and the unit-test batch daemon wholesale, because a daemon's env is fixed at spawn.

The diagnostic reports the import's real line **and column**, in the numeric `line L:C:` form — the only spelling `lsp_parse_diag_line` accepts, so the text and JSON lanes agree on where the cursor goes. Repeated imports of the same package are located independently rather than all pointing at the first.

`docs/spec/stable-surface.md` §1 is rewritten as a table of what is *enforced*, with no narration of the abandoned `@build.unstable` route.

**Known gap, filed not fixed:** the scan covers the entry only, so moving the import into a sibling file bypasses it (#2284). Fixing only the check lane would make the build the permissive verb, and covering the build lane the obvious way is the `collect_source_groups_fs` call that measured as a 1.1% self-compile heap regression earlier in this PR. #2284 carries the design that avoids both.

### `vibe fmt` must not say "not formatted" when it could not build itself (closes #2271)

#2271 reported a multiline closure literal in a non-final argument slot as permanently unformattable. The construct formats to a fixpoint — and so does a three-line file with no closure in it, which is the tell.

The formatter **entry** had failed to compile (a fresh checkout has none of the untracked generated artifacts). `ensure_entry_wasm.sh` never said so: its compile line was a bare command under `set -e`, so a non-zero runner abandoned the script one line above the `[ -s ... ] || echo ... exit 1` written to explain exactly this. `vibe_fmt.sh` then died the same way inside a command substitution — exit 1, empty stderr, byte-for-byte what `--check` means by "not formatted", so a caller applied, saw no change, and looped forever.

- `ensure_entry_wasm.sh` captures the runner's status, prints the compiler's own diagnostic, and points at `ensure_generated.sh`. It builds to a `$$`-suffixed path and **publishes by rename** — wasm and `.funcmap` together, manifest retracted first. Deleting the previous artifact up front (the first version of this fix) opened a worse window: callers run concurrently, and the slower one's `rm` landed after the faster one had already started running the wasm. A failed rebuild now retracts only the manifest, which forces a rebuild while leaving the bytes for a caller mid-run, and the publish revalidates the inode before and after the sidecars so an interleaved winner's tuple stays whole.
- `vibe_fmt.sh` and `run_vibe_fmt_batch.sh` return **2**, not 1. "Could not answer" and "the file is at fault" must stay distinguishable.
- `check_vibe_fmt.sh` and `vibe_fmt_apply.sh` read the batch through a process substitution whose status they never saw, so a dead batch fed them zero lines and they reported "0 file(s)" and exited 0 — green having done nothing. Every file handed to the batch must now come back.

### An `assert_eq` failure names the line it fired on (closes #2202)

```
failing test: which assert fired          failing test: which assert fired
assert_eq failed                    ->    assert_eq failed at probe.vibe:7
  expected: 5                               expected: 5
  actual:   4                               actual:   4
```

The compile lanes merge every module into one program, and an offset is a **per-module** space — a merged program cannot say which module one of its offsets belongs to. So the location is taken while the module's own source is still in hand, during the merge, and attached to the call as a third argument so it travels with the node. A side table keyed by statement index would not have survived: `desugar_trait_dicts` hoists lambdas and inlines wrappers into new top-level definitions before the assert lowering runs.

The stamped callee is `#assert_eq_at`. The leading `#` is load-bearing: it is not an identifier character, so the marker cannot be constructed from any source. Two earlier spellings were reachable, and in the single-source lane the lowering runs before `check_program`, so anything it recognizes bypasses name and arity checking entirely.

A module whose ingested text is **not 1:1** with its file — the loader prepends inherited `.vpkg` imports, or replaces a contract with its facade — is stamped with an *empty* location rather than skipped. Skipping lost more than the line: a bare call carries no evidence that it meant the builtin, so one top-level `assert_eq` anywhere in the merged program captured it through the func table. Measured: a `.vpkg`-inheriting sibling's assert silently became a call to an unrelated function and the program returned 7.

Two corrections that only measurement produced:

- **The lane was not the obvious one.** `vibe test` compiles through the FS lane (`entry/compiler/file_compile`), which has its own merge and already parses located (#1100). Instrumenting only `compile_file_wasi_only` reached a fixpoint and changed the report not at all — a green build that proved nothing.
- **The condensers hid the fix.** `scripts/vibe_test.sh` and `runtime/vibe` matched the head line exactly, so the located line was produced and then silently dropped.

Degradation is always toward no line, never a wrong one (#1445). Pinned by late-gate 110. Container-expression coverage is #2288.

### A user's own `assert_eq` is the function that runs (closes #2283)

Measured on a stage2 predating all of the above: `fn assert_eq(a: Int, b: Int) -> Int { a + b }` plus `assert_eq(1, 2)` compiled clean and trapped with `assert_eq failed` instead of returning 3. Pre-existing, not a regression from the location work — but that work would have stamped the same call.

Two layers had to give, and the second is not where it looks:

1. **The lowering** claimed every arity-2 `assert_eq` by name; it now stands down when the program defines the name.
2. **Codegen had no shadowing guard at all** on `assert` / `assert_true` / `assert_eq`. Without this, the checker typed the call against the user's function while codegen emitted the builtin assert — two answers to the same question, with no diagnostic naming the conflict. The half of `prefer_bound_call` that is wrong there is `local_idx_hint` (the #1095 capture artifact); a name in the *function table* is a real definition and must win.

The gc lane is deliberately excluded: those spellings are direct-ABI names and `backend_body.vibe` already rejects a user declaration of them, which is a diagnostic rather than a substitution. Adding the guard there was measured to break `fixtures/gc_backend_smoke_test.vibe` outright, because that lane's func table *contains* the builtin names.

Local bindings keep their pre-existing behaviour (#2285) — suppressing for them moves the failure from a legible assertion message to a bare `unreachable`, and fixing it needs the #1095 question answered first.

### The crash dump is opt-in (#2199 ask 2)

`wasm_vibe_host_runner.js` dumped linear memory on every uncaught error; now only under `VIBE_CRASH_DEBUG=1` / `VIBE_DEBUG=1` / `VIBE_DEBUG708_MEMDUMP`. `tests/gates/early/run.sh` 4c asserted the *absence* of `[crash debug]`, which this change would have made vacuously true — that probe now runs with `VIBE_CRASH_DEBUG=1`, and new late-gate 107 pins the default-off direction.

### One list of compiler-owned nominal heads

Merging `main` conflicted in `checker/checker_resolve.vibe`, and both sides were right about the same thing. #2273 grew the list into `compiler_owned_type_arity`, adding each head's arity; this branch had moved `is_wellknown_nominal_head` to `@vibe/compiler/core`, because the contract types-module sentinel needs the same answer and had been asking a narrower one (#2164) — every contract mentioning `Map` had its transparent types exempted from checking.

Taking either side whole loses the other's point, so the arity table itself moved to `core/builtin_name.vibe` and the boolean derives from it. One list, both consumers.

### Review fixes carried over from #2248

- `check_gate_portability.sh` — path-qualified `rg`, suffix-less `sed -i` (BSD/macOS), and `grep` with a `\t` / `\d` escape in a quoted pattern are all rejected. The last exists because a mechanical `rg -q '^x\t'` → `grep -qE` rewrite produced `^xt`, which silently never matched.
- `check_selector_precedence.sh` — the coverage scan stripped single-quoted text but not double-quoted, so `"$(selector_clears_before X)"` counted as coverage while `env` accepted it as a plain assignment and passed no `-u`. I argued in review that the double-quoted form was safe; it is not.
- `lint_tracked_experiment_names.sh` — keeps `main`'s wider scope, drops the dead `src/` and `vibe/` paths, asks git whether it is in a work tree.
- `check_book_console_test.sh` — conditional `timeout`, temp-file edit instead of in-place `sed`.

## Filed rather than folded in

| issue | why it is separate |
|---|---|
| #2280 | `vibe check` cannot check a `.vpkg` at all — pre-existing, unrelated to this PR |
| #2284 | the opt-in scan covers the entry only; both lanes must move together |
| #2285 | a local binding of `assert_eq`; blocked on #1095 |
| #2287 | re-export **aliases** die at codegen — the assert lowering was masking it for exactly one name |
| #2288 | the stamp walk does not descend container expressions |
| #2289 | an inherited import consumes the sibling's physical offset |

## Verification

`ensure_generated` → `generations.sh build --stage3` → `cmp stage2 stage3` (FIXPOINT) → `compiler_gate.sh`, green on the final tree, with late-gate sections 107/108/109/110 all firing. Four script self-tests (`check_gate_portability_test.sh`, `check_selector_precedence_test.sh`, `check_book_console_test.sh`, and the new `ensure_entry_wasm_test.sh`) each Red-tested with a probe that must fail; the last is wired into `release-check`.

Perf against `main`: selfcompile heap +0.73% (ceiling +10%), stage2 bytes +0.77%, every bench B/op and every execution scenario ±0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GbtLER6wNT4jsZEN1Zp6xe