### PR TITLE
WIT: a LOCAL effectset does not own the StringMap spelling

### DIFF
--- a/lib/@vibe/compiler/tests/types_test.vibe
+++ b/lib/@vibe/compiler/tests/types_test.vibe
@@ -63,9 +63,10 @@ test "#2276 round 18: a TDEffect named StringMap also shadows the builtin" {
 }
 
 test "#2276 round 19: a TDEffectSet named StringMap also shadows the builtin" {
-  // The arm next to `TDEffect` in `core/types.vibe` resolves an effectset the
-  // same nominal way, so a local `effectset StringMap = ...` owns the
-  // spelling too. Round 19 named only the effect; this pins the neighbour.
+  // True for an IMPORTED effectset, which `seed_imported_type_defs` puts into
+  // `defs`. A LOCAL `effectset` declaration does NOT reach `defs` -- nothing
+  // pushes a `TDEffectSet` for one -- so it resolves to the builtin instead;
+  // that asymmetry is why `wit_stmts_declare_type` has no `SEffectSet` arm.
   let defs = [TDEffectSet("StringMap", array_empty())]
   let resolved = resolve_type_expr_core_shadowed(TyApp("StringMap", [
     TyName("Int")

--- a/lib/@vibe/compiler/tests/wit_gen_test.vibe
+++ b/lib/@vibe/compiler/tests/wit_gen_test.vibe
@@ -275,21 +275,21 @@ test "wit_from_program: a LOCAL effect named StringMap shadows the builtin" {
   assert(String::contains(message, "no WIT mapping"))
 }
 
-test "wit_from_program: a LOCAL effectset named StringMap shadows the builtin" {
-  // The neighbour round 19 did not name: an effectset lands in `defs` as
-  // `TDEffectSet` and resolves nominally too, so the same hole sat one
-  // declaration keyword away.
+test "wit_from_program: a LOCAL effectset named StringMap does NOT shadow the builtin" {
+  // Correcting round 19: `TDEffectSet` reaches `defs` only through
+  // `seed_imported_type_defs`, so a LOCAL effectset leaves the checker
+  // resolving `StringMap[Int]` as the builtin map. Measured on the equality
+  // lowering, which asks the same question: the effect form emits 1174 bytes
+  // (nominal), the effectset form 4413 (the generated map comparator).
+  // Treating it as ownership failed `--wit` for a valid program.
   let stmts = [
     SEffectSet(false, "StringMap", array_empty()),
     SLet(true, false, "read", Some(TyFn([TyApp("StringMap", [TyName("Int")])], TyName("Int"), None)), efn_of_string_params([
       "m"
     ]))
   ]
-  let message = handle {
-    let _ = wit_from_program(stmts, stmts, "localeffectset")
-    ""
-  } with { Exception::Throw(m) => m }
-  assert(String::contains(message, "no WIT mapping"))
+  let wit = wit_from_program(stmts, stmts, "localeffectset")
+  assert(String::contains(wit, "list<tuple<string, s64>>"))
 }
 
 test "wit_from_program: a TRAIT import named StringMap does not shadow the builtin" {

--- a/lib/@vibe/compiler/wit_gen.vibe
+++ b/lib/@vibe/compiler/wit_gen.vibe
@@ -889,15 +889,17 @@ fn wit_stmts_declare_type(stmts: Array[Stmt], needle: String) -> Bool {
       } else {
         ()
       },
-      // An effectset lands in `defs` as `TDEffectSet` and resolves the same
-      // nominal way (`core/types.vibe`, the arm next to `TDEffect`). Round 19
-      // named only `SEffectDef`; leaving this one out would have left the
-      // identical hole one declaration keyword away, so both are pinned.
-      SEffectSet(_, name, _) => if name == needle {
-        found = true
-      } else {
-        ()
-      },
+      // A LOCAL effectset is deliberately NOT here, correcting round 19.
+      // `TDEffectSet` reaches `defs` only through `seed_imported_type_defs`;
+      // no local declaration pushes one, so the checker resolves a locally
+      // declared `effectset StringMap`'s `StringMap[Int]` as the BUILTIN map.
+      // Measured on the equality lowering, which asks the same ownership
+      // question: `effect StringMap[T]` emits 1174 bytes (nominal) while
+      // `effectset StringMap = { Stdout }` emits 4413 -- the generated map
+      // comparator, i.e. the builtin. Claiming ownership here made `--wit`
+      // answer `no WIT mapping` for a program the checker accepts, which is
+      // round 9's complaint in a new spot. An IMPORTED effectset still
+      // shadows: it carries no `ImportKind`, so the unkinded arm fails closed.
       SModule(_, _, body) => if wit_stmts_declare_type(body, needle) {
         found = true
       } else {


### PR DESCRIPTION
Follow-up to #2276, which merged as `98b510f` a few minutes before this correction landed. Three defects went in with it, all mine.

## The bug

`wit_stmts_declare_type` has an `SEffectSet` arm I added in review round 19 by symmetry with `SEffectDef`, and defended on the PR as "deliberate over-reach in the loud direction". Measurement says it is simply wrong: a **local** effectset does not own the spelling, so the arm makes `vibe compile --wit` answer `no WIT mapping` for a program the checker accepts — which is review round 9's complaint reappearing in a new spot.

`TDEffectSet` reaches `defs` only through `seed_imported_type_defs`; no local declaration pushes one. The evidence is the equality lowering, which asks the same ownership question and whose answer is visible in the emitted code:

| declaration | emitted wasm | means |
|---|---:|---|
| `effect StringMap[T] { ... }` | 1174 B | nominal |
| `effectset StringMap = { Stdout }` | 4413 B | the generated map comparator |

4413 is the builtin-map comparator — `Map::size` / `Map::keys` / `Map::get` — so the checker types that annotation as the builtin. `2eabbab` registers `SSuberror` and `SEffectDef` as equality type-owners and deliberately **not** `SEffectSet`; this makes the WIT scan agree with it.

## Why it happened

The mistake was the reasoning, not the code. "Complete the enumeration" is not a substitute for asking whether each member actually holds. I had a version of `2eabbab` in flight that **did** add `SEffectSet` to the equality owners — that would have made equality nominal for a type the checker treats as a map, a divergence in the **silent** direction rather than the loud one this removes.

## Also fixed

- The round 19 `wit_gen` test asserted the wrong behaviour. It now asserts the builtin projection survives a local effectset.
- The `types_test` row for `TDEffectSet` keeps its assertion — true for an **imported** effectset — with its comment corrected. It claimed "a local `effectset StringMap = ...` owns the spelling too", which is exactly the false statement this PR removes from the code. @mizchi independently flagged that comment as overstating the local case while reviewing #2276.

An imported effectset still shadows: it carries no `ImportKind`, so the unkinded arm fails closed.

## Verification

Red → Green: restoring the `SEffectSet` arm makes the flipped test fail and name itself.

- 37 `wit_gen` tests, 35 `types` tests
- typecheck fixtures ok (284 rows)
- early compiler gate ok
- vibe-fmt lint 1026 files, 0 violations

Full unit suite is running; I will report it on this PR.

Refs #2263, #2276

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012BesqGvopmB2byi8gB4HXG


---
_Generated by [Claude Code](https://claude.ai/code/session_012BesqGvopmB2byi8gB4HXG)_