### PR TITLE
ADR-0068 becomes opt-in; a user's own `assert_eq` wins; `vibe fmt` stops blaming the file

### DIFF
--- a/Taskfile.pkl
+++ b/Taskfile.pkl
@@ -831,6 +831,15 @@ local testUncaughtExceptionExit =
   scriptTask("test-uncaught-exception-exit", "scripts/test_uncaught_exception_exit.sh")
 local testVibeTest = scriptTask("test-vibe-test", "scripts/vibe_test_smoke.sh")
 local testVibeFmt = scriptTask("test-vibe-fmt", "scripts/vibe_fmt_smoke.sh")
+// #2271: `vibe fmt` reported a file as unformatted when the FORMATTER ENTRY
+// had failed to compile. Under `set -e` a non-zero runner abandoned
+// ensure_entry_wasm.sh one line above the check written to explain it, and
+// exit 1 with empty stderr is byte-for-byte what `--check` means by "this
+// file is not formatted", so `vibe fmt` looped forever on a file that was
+// never at fault. Pins the loud-failure path, the callers' handling of the
+// exit code, and the publish-by-rename that replaced it.
+local testEnsureEntryWasm =
+  scriptTask("test-ensure-entry-wasm", "scripts/ensure_entry_wasm_test.sh")
 local testVibeNormalizeSmoke =
   scriptTask("test-vibe-normalize-smoke", "scripts/vibe_normalize_smoke.sh")
 local testSelfhostCliSeam = scriptTask("test-cli-seam", "scripts/vibe_cli_smoke.sh")
@@ -1615,6 +1624,7 @@ local releaseCheck = new Task {
   deps {
     selfhostOnlyGate
     checkVibeFmt
+    testEnsureEntryWasm
     checkTaskfileFmt
     // These ran ONLY from the local pre-commit hook -- CI never invoked them.
     // That made the hook the single enforcement point, so #1729 (a stale
@@ -1783,6 +1793,7 @@ tasks {
   testUncaughtExceptionExit
   testVibeTest
   testVibeFmt
+  testEnsureEntryWasm
   testVibeNormalizeSmoke
   testSelfhostCliSeam
   minifyGate

--- a/book/en/17_concurrency.vibe.md
+++ b/book/en/17_concurrency.vibe.md
@@ -11,6 +11,20 @@ checkable.
 
 The package is `@vibe/concurrent`.
 
+**This chapter is the one unstable surface in the book.** Everything here is
+ADR-0068, which is still `proposed`: `Nursery`, `Task`, `Sender`/`Receiver`,
+`TaskGroup::run` / `spawn` / `spawn_suspend`, and the compiler's `Send` rule.
+It is outside the SemVer promise and can change within a Minor release — see
+[the stable surface](../../docs/spec/stable-surface.md) §6. What it decides is
+settled enough to build on; what is not settled is the `Send`/region checking
+and which backend runs it (today's scheduler is a cooperative
+run-to-completion prototype).
+
+The `Async` effect itself is NOT in that bucket. ADR-0012 is accepted, and
+`with Async` on a row is as stable as any other effect — it appears in shipped
+builtin signatures like `StdinStream::next`. The unstable part is the
+concurrency model built on top of it, not the vocabulary.
+
 ## Spawning and joining
 
 ```vibe run

--- a/book/ja/17_concurrency.vibe.md
+++ b/book/ja/17_concurrency.vibe.md
@@ -11,6 +11,20 @@ vibe でスレッドを spawn することはありません。`TaskGroup` を�
 
 パッケージは `@vibe/concurrent`。
 
+**この章は本書で唯一の unstable な面です。** ここに出てくるものはすべて
+ADR-0068 で、状態はまだ `proposed` です — `Nursery`、`Task`、
+`Sender`/`Receiver`、`TaskGroup::run` / `spawn` / `spawn_suspend`、および
+コンパイラの `Send` 判定。SemVer の約束の外側にあり、Minor リリースの中で
+変わりえます ([stable surface](../../docs/spec/stable-surface.md) §6)。決めて
+あることは組み立てるに足りますが、決まっていないのは `Send`/region の検査と、
+どの backend が動かすかです (現行のスケジューラは cooperative
+run-to-completion のプロトタイプ)。
+
+`Async` effect 自体はこのバケツに入りません。ADR-0012 は accepted で、row 上の
+`with Async` は他の effect と同じだけ安定しています — `StdinStream::next` の
+ように出荷済み builtin の署名にも現れます。不安定なのはその上に建つ並行
+モデルであって、語彙ではありません。
+
 ## spawn して join する
 
 ```vibe run

--- a/docs/spec/stable-surface.md
+++ b/docs/spec/stable-surface.md
@@ -34,8 +34,37 @@ Trait bound compatibility follows the lock in [decisions.md](decisions.md):
 **tighter bounds = Major / looser bounds = Minor**.
 
 The **unstable surface (§6)** is outside this guarantee. Those parts can break
-within a Minor. They are reached only through `@build.unstable`, an explicit
-flag, or an ADR still marked `proposed`.
+within a Minor.
+
+**How the unstable surface is marked.** By a mechanism the compiler enforces,
+never by an ADR's status — status is bookkeeping a reader never sees, and a
+surface marked only that way compiles clean with no marker of any kind.
+
+What is enforced today, measured 2026-08-24:
+
+| surface | how it is gated |
+| --- | --- |
+| wasm-gc backend | opt-in env var (`VIBE_BACKEND=gc` and friends) |
+| `perform?` | the checker rejects it, naming the edit that fixes it |
+| SIMD | the package does not resolve |
+| **ADR-0068 concurrency** | **`import @vibe/concurrent` is rejected by `vibe check` AND by `vibe build`; `VIBE_UNSTABLE=1` allows it** |
+
+An **error**, not a warning. `vibe check` exits non-zero and `vibe build`
+emits no wasm; the diagnostic names the environment variable that opts in.
+Both verbs answer the same way on purpose — a build that accepts what the
+check rejects is the "two verbs, two answers" defect #1567 fixed for
+check/diagnostics, and it is worse here because the accepting verb is the one
+that ships.
+
+The gate reads the entry file's **parsed** imports, so whitespace does not
+cross it (`import\t@vibe/concurrent` is the same as `import @vibe/concurrent`),
+and it looks at the entry only: a dependency's own imports are its author's
+choice. Harnesses inside this repository that compile in-tree sources against
+the surface deliberately (the book's concurrency chapter, the unit-test
+batch) grant the opt-in themselves; the boundary is pinned by
+`tests/gates/late/run.sh` section 108.
+
+The rest of §6 is still a reading obligation rather than an enforced boundary.
 
 ---
 
@@ -54,8 +83,7 @@ of each item is [spec/syntax.md](syntax.md) and the
   `Char` (an `Int` alias), `Bool`, `Unit`.
 - Literals: integers (decimal / `0x` hex), floats (`1.5f` / `3.14`), strings
   (interpolation `\{expr}`), chars `'A'`, `true`/`false`, `()`.
-- Composite types: tuples `(A, B)`, `Array[T]`, `StringMap[V]` (the builtin
-  map; `Map[K, V]`'s generality is not frozen — see §3), record, struct,
+- Composite types: tuples `(A, B)`, `Array[T]`, `Map[K, V]`, record, struct,
   enum, function types `(A) -> B`, effectful `(A) -> B with E`, generics `[T]`,
   trait bounds `[T: A + B]`, and the `Option[T]` sugar `T?` (ADR-0046).
 - **Equality (`==`) — the fail-closed contract** (ADR-0097 as shipped; measured
@@ -160,35 +188,16 @@ The stable symbols listed under "Key Builtins" in the
   functions in `@vibe/builtin`, reached by
   `import @vibe/builtin { String::replace }`, and are not in the builtin
   registry.
-- **Array**: `length`, `get`, `slice`, `concat`, plus `ArrayBuilder::new/push/freeze`.
-  `map`, `filter`, `fold`, `find`, `any`, `all`, `reverse` cannot be frozen as
-  first-class values (call-only operations: `Array::map(xs, f)`, not
-  `let g = Array::map`; #2275).
-- **StringMap** — the String-keyed builtin map. Its type is spelled
-  `StringMap[V]`; the operations keep the `Map::` qualifier, so the spelling
-  is the type's, not a second operation family. Neither needs an import.
-  `Map::get`, `Map::has_key`, `Map::keys`, `Map::values`, `Map::set`, `Map::size`, `Map::new`, and `Map::from_pairs` cannot be frozen as first-class values -- they are call-only builtin operations (`Map::get(m, k)`, not `let g = Map::get`; #2274 / #2275).
-  **`Map[K, V]`'s generality is deliberately NOT frozen** (#2263): the builtin
-  is String-keyed today, and an annotation naming a concrete non-String key is
-  rejected where it is written. The name `Map` is reserved for the generic
-  type; completing it turns a rejection into an answer, which is a compatible
-  change. A key that is a type parameter is unaffected — generic code over
-  `Map[K, V]` keeps compiling.
-  **Another key type is already available today**: `MutMap[K, V]` from
-  `@vibe/core` is the generic open-addressing map, and it is what the
-  rejection points at (`MutMap::new_int()` / `new_string()`, or
-  `MutMap::new(hash_fn, eq_fn)` for any other key). It is a library type, so
-  it is frozen by §3's `@vibe/core` entry rather than by the builtin surface.
-- **Int64Array**: `make`, `get`, `set`, `length` cannot be frozen as
-  first-class values (call-only; #2275).
-- **Conversions**: `Int::to_double`, `Double::to_int`.
-  `Int::to_string` cannot be frozen as a first-class value (call-only; #2275).
+- **Array**: `length`, `get`, `slice`, `map`, `filter`, `fold`, `find`, `any`,
+  `all`, `reverse`, `concat`, plus `ArrayBuilder::new/push/freeze`.
+- **Map**: `get`, `has_key`, `keys`, `values`, `set`, `size`.
+- **Int64Array**: `make`, `get`, `set`, `length` (for 32-bit word workloads).
+- **Conversions**: `Int::to_string`, `Int::to_double`, `Double::to_int`.
 - **Iteration**: the `Iterable` trait and the `for-in` desugar (ADR-0044). The
   **combinator layer (`Iterator::map` and friends) is not frozen** — it is
   retired by ADR-0099's two-layer split and has zero rows in the registry
-  (measured: `Iterator::` 0 hits). Eager iteration is the call forms
-  `Array::map` / `Array::filter` / `Array::fold` (cannot be frozen as
-  first-class values; see Array above).
+  (measured: `Iterator::` 0 hits). Eager iteration is
+  `Array::map` / `Array::filter` / `Array::fold`.
 - **@vibe/builtin helpers**: `compose` / `identity` / `flip` (func), and the
   `let*` railway bind. `Result::and_then` **cannot be frozen** — `Result` was
   removed from the language in #1324, and `Result::` has zero registry rows.
@@ -256,12 +265,19 @@ The following is still under construction or its design is not settled. It is
 **outside** the SemVer guarantee and can break within a Minor. Use it knowing
 that.
 
-- **Async / structured concurrency / WASI 0.3** (ADR-0012, ADR-0068,
-  `proposed`): the `{Async}` effect, `Future[T]`, `Stream[T]`, `Task[T]`,
-  `for await`. Today's codegen is an eager prototype; the public semantics are
-  defined in the [structured concurrency spec](../concurrency.md). JSPI/Worker,
-  the WASI Component Model, and shared-everything threads are interchangeable
-  lowerings — the stable surface is tied to none of them.
+- **Structured concurrency / WASI 0.3** (ADR-0068, `proposed`): `Nursery[r]`,
+  `Task[r,T]`, `Sender`/`Receiver`, `TaskGroup::run` / `spawn` /
+  `spawn_suspend`, and the `Send` eligibility rule. Today's codegen is an eager
+  prototype; the public semantics are defined in the
+  [structured concurrency spec](../concurrency.md). JSPI/Worker, the WASI
+  Component Model, and shared-everything threads are interchangeable lowerings
+  — the stable surface is tied to none of them.
+
+  **The `Async` effect ROW ELEMENT is not in this bullet.** ADR-0012 is
+  `accepted`, and `Async` already appears in shipped builtin signatures a user
+  can reach (`StdinStream::next(StdinStream) -> Int with Async`), where `vibe
+  check` enforces it like any other row element. The unsettled part is the
+  concurrency model built on top of it, not the vocabulary.
 - **Component Model `#import` integration** (ADR-0021 Phase 2/3): CPS lowering
   of non-tail-resumptive handlers, capability effects.
 - **Capability authorization surface** (ADR-0088, `proposed`): the two-clause

--- a/docs/spec/stable-surface.md
+++ b/docs/spec/stable-surface.md
@@ -83,7 +83,8 @@ of each item is [spec/syntax.md](syntax.md) and the
   `Char` (an `Int` alias), `Bool`, `Unit`.
 - Literals: integers (decimal / `0x` hex), floats (`1.5f` / `3.14`), strings
   (interpolation `\{expr}`), chars `'A'`, `true`/`false`, `()`.
-- Composite types: tuples `(A, B)`, `Array[T]`, `Map[K, V]`, record, struct,
+- Composite types: tuples `(A, B)`, `Array[T]`, `StringMap[V]` (the builtin
+  map; `Map[K, V]`'s generality is not frozen — see §3), record, struct,
   enum, function types `(A) -> B`, effectful `(A) -> B with E`, generics `[T]`,
   trait bounds `[T: A + B]`, and the `Option[T]` sugar `T?` (ADR-0046).
 - **Equality (`==`) — the fail-closed contract** (ADR-0097 as shipped; measured
@@ -188,16 +189,35 @@ The stable symbols listed under "Key Builtins" in the
   functions in `@vibe/builtin`, reached by
   `import @vibe/builtin { String::replace }`, and are not in the builtin
   registry.
-- **Array**: `length`, `get`, `slice`, `map`, `filter`, `fold`, `find`, `any`,
-  `all`, `reverse`, `concat`, plus `ArrayBuilder::new/push/freeze`.
-- **Map**: `get`, `has_key`, `keys`, `values`, `set`, `size`.
-- **Int64Array**: `make`, `get`, `set`, `length` (for 32-bit word workloads).
-- **Conversions**: `Int::to_string`, `Int::to_double`, `Double::to_int`.
+- **Array**: `length`, `get`, `slice`, `concat`, plus `ArrayBuilder::new/push/freeze`.
+  `map`, `filter`, `fold`, `find`, `any`, `all`, `reverse` cannot be frozen as
+  first-class values (call-only operations: `Array::map(xs, f)`, not
+  `let g = Array::map`; #2275).
+- **StringMap** — the String-keyed builtin map. Its type is spelled
+  `StringMap[V]`; the operations keep the `Map::` qualifier, so the spelling
+  is the type's, not a second operation family. Neither needs an import.
+  `Map::get`, `Map::has_key`, `Map::keys`, `Map::values`, `Map::set`, `Map::size`, `Map::new`, and `Map::from_pairs` cannot be frozen as first-class values -- they are call-only builtin operations (`Map::get(m, k)`, not `let g = Map::get`; #2274 / #2275).
+  **`Map[K, V]`'s generality is deliberately NOT frozen** (#2263): the builtin
+  is String-keyed today, and an annotation naming a concrete non-String key is
+  rejected where it is written. The name `Map` is reserved for the generic
+  type; completing it turns a rejection into an answer, which is a compatible
+  change. A key that is a type parameter is unaffected — generic code over
+  `Map[K, V]` keeps compiling.
+  **Another key type is already available today**: `MutMap[K, V]` from
+  `@vibe/core` is the generic open-addressing map, and it is what the
+  rejection points at (`MutMap::new_int()` / `new_string()`, or
+  `MutMap::new(hash_fn, eq_fn)` for any other key). It is a library type, so
+  it is frozen by §3's `@vibe/core` entry rather than by the builtin surface.
+- **Int64Array**: `make`, `get`, `set`, `length` cannot be frozen as
+  first-class values (call-only; #2275).
+- **Conversions**: `Int::to_double`, `Double::to_int`.
+  `Int::to_string` cannot be frozen as a first-class value (call-only; #2275).
 - **Iteration**: the `Iterable` trait and the `for-in` desugar (ADR-0044). The
   **combinator layer (`Iterator::map` and friends) is not frozen** — it is
   retired by ADR-0099's two-layer split and has zero rows in the registry
-  (measured: `Iterator::` 0 hits). Eager iteration is
-  `Array::map` / `Array::filter` / `Array::fold`.
+  (measured: `Iterator::` 0 hits). Eager iteration is the call forms
+  `Array::map` / `Array::filter` / `Array::fold` (cannot be frozen as
+  first-class values; see Array above).
 - **@vibe/builtin helpers**: `compose` / `identity` / `flip` (func), and the
   `let*` railway bind. `Result::and_then` **cannot be frozen** — `Result` was
   removed from the language in #1324, and `Result::` has zero registry rows.

--- a/lib/@vibe/compiler/cli_adapter.vibe
+++ b/lib/@vibe/compiler/cli_adapter.vibe
@@ -110,12 +110,15 @@ import ./cli_support.vibe {
   check_deprecated_warnings_from_source_groups,
   check_linked_file_source_groups,
   check_redundant_import_warnings_from_source_groups,
+  check_unstable_surface_warnings_from_path,
+  check_unstable_surface_warnings_from_source_groups,
   strip_executable_wasm_env,
+  unstable_surface_diagnostics,
   verify_culprit_off_marker_fs_fail_closed
 }
 
 import @vibe/lsp {
-  lsp_diagnostics_json_string, lsp_main
+  lsp_diagnostics_json_string, lsp_diagnostics_json_string_with, lsp_main
 }
 
 import @vibe/compiler/checker {
@@ -443,6 +446,13 @@ fn adapter_split_nonempty_lines(text: String) -> Array[String] {
 
 /// #2149: does `s` end with `suffix`? Used only to spot a `.vpkg` path, whose
 /// header is not vibe syntax and so can never be parse-checked as a whole file.
+/// An empty warning list. A named function rather than a bare `[]` so the
+/// `if` arms agree on the element type without an annotation (#2248).
+fn adapter_no_warnings() -> Array[String] {
+  let out: Array[String] = []
+  out
+}
+
 fn adapter_path_has_suffix(s: String, suffix: String) -> Bool {
   let n = String::length(s)
   let m = String::length(suffix)
@@ -745,6 +755,23 @@ fn adapter_emit_wit(input_path: String, output_path: String) -> Int with Fs + En
 /// the WIT world sidecar.
 fn adapter_serve_component(input_path: String, output_path: String) -> Int with Fs + Env {
   handle {
+    // ADR-0068 gate, BEFORE any compile work -- the same gate the FS-compile
+    // branch applies, for the same reason. `vibe serve` reaches this function
+    // through its own `VIBE_SERVE_COMPONENT` branch, which returns before that
+    // one, so without this a handler importing `@vibe/concurrent` produced a
+    // DEPLOYABLE component while `vibe check` rejected the identical file
+    // (#2277 review). An artifact-producing verb that accepts what the check
+    // verb refuses is the worst direction for that disagreement to run.
+    let serve_unstable = if Env::get("VIBE_UNSTABLE") == "1" {
+      adapter_no_warnings()
+    } else {
+      check_unstable_surface_warnings_from_path(input_path)
+    }
+    if Array::length(serve_unstable) > 0 {
+      return emit_compile_diag(output_path, Array::get(serve_unstable, 0))
+    } else {
+      ()
+    }
     let entry_stmts = parse_program(lex(Fs::read_file(input_path)))
     validate_serve_handler(entry_stmts)
     // No command entry: the component surface is `handler`. `__no_entry__`
@@ -1256,6 +1283,42 @@ export fn cli_main() -> Int with Exception + Fs + Env + Stdin + Stdout {
         StringBuilder::push(out_text, "\n")
         rwi = rwi + 1
       }
+      // Unstable-surface warnings (ADR-0068). `docs/spec/stable-surface.md`
+      // section 6 used to claim this surface "is reached only through
+      // `@build.unstable`, an explicit flag, or an ADR still marked
+      // `proposed`" -- and `@build.unstable` appeared NOWHERE else in the
+      // tree, there was no such flag, and an ADR's status is bookkeeping a
+      // reader never sees. `TaskGroup::run` compiled with `vibe check` clean
+      // and no marker of any kind. This is the missing half.
+      //
+      // An ERROR, not a warning, and the escalation is deliberate: the surface
+      // has no external users yet. Measured -- exactly 14 files carry a
+      // column-1 `import @vibe/concurrent`, all of them in this repository
+      // (13 fixtures + 1 eval probe), and NONE under lib/, so the bootstrap
+      // chain never touches it. Refusing now costs 14 opt-ins; refusing after
+      // someone depends on it costs them a rewrite.
+      //
+      // The FS-compile branch carries the same gate, because a build that
+      // accepts what the check rejects is worse than either answer alone.
+      //
+      // `VIBE_UNSTABLE=1` opts in, read in EXPRESSION position like the
+      // other observation-only knobs: `check_selector_precedence.sh` derives
+      // the adapter's BRANCH order from statement-position `if Env::get(..)`,
+      // and a selector that picks no verb must not enter that order (it would
+      // then take a position in every arm's derived clear list). Read HERE and
+      // not in cli_support so the warning collectors stay pure functions of
+      // (path, sources) -- the same reason every other selector is an adapter
+      // concern.
+      let unstable_warns = if Env::get("VIBE_UNSTABLE") == "1" {
+        adapter_no_warnings()
+      } else {
+        check_unstable_surface_warnings_from_source_groups(input_path, checked_source_groups)
+      }
+      if Array::length(unstable_warns) > 0 {
+        return emit_compile_diag(output_path, Array::get(unstable_warns, 0))
+      } else {
+        ()
+      }
       StringBuilder::push(out_text, "ok\n")
       Fs::write_file(output_path, StringBuilder::freeze(out_text))
       // Publish this successful-check observation strictly after the final
@@ -1277,6 +1340,22 @@ export fn cli_main() -> Int with Exception + Fs + Env + Stdin + Stdout {
       // Request validation and stale-sidecar deletion happened before every
       // CLI early return above. This branch now only consumes the validated
       // request while preserving the ordinary compile-path selection below.
+      //
+      // ADR-0068 gate, BEFORE any compile work. `vibe check` and this branch
+      // must agree: a build that accepts what the check rejects is the same
+      // "two verbs, two answers" defect #1567 fixed for check/diagnostics, and
+      // it is worse here because the accepting verb is the one that ships.
+      // `VIBE_UNSTABLE=1` opts in.
+      let fs_unstable = if Env::get("VIBE_UNSTABLE") == "1" {
+        adapter_no_warnings()
+      } else {
+        check_unstable_surface_warnings_from_path(input_path)
+      }
+      if Array::length(fs_unstable) > 0 {
+        return emit_compile_diag(output_path, Array::get(fs_unstable, 0))
+      } else {
+        ()
+      }
       let artifact_input_trace_nonce = Env::get("VIBE_ARTIFACT_INPUT_TRACE_NONCE")
       // debugger trace (DAP P1 groundwork): `vibe run --trace` sets VIBE_DEBUG=1
       // so the user file (and its imports) is compiled with function-call
@@ -1696,10 +1775,33 @@ export fn cli_main() -> Int with Exception + Fs + Env + Stdin + Stdout {
   // diagnostic shape shared by the editor protocol and the CLI.
   if Env::get("VIBE_DIAGNOSTICS") == "1" {
     let src = Fs::read_file(input_path)
+    // ADR-0068 opt-in, in the buffer lane too. This is the mode `vibe check
+    // --single-file` and the editor use, and it does not resolve imports -- so
+    // an UNUSED `import @vibe/concurrent` analyzed clean here while `vibe check`
+    // and `vibe build` both rejected the same buffer (#2277 review). The gate is
+    // a property of the declaration, not of the imported names being reached, so
+    // it belongs in every lane that reads the file. Scanned on the buffer's own
+    // text: this lane exists for unsaved buffers, and ingestion would answer
+    // about the file on disk instead.
+    let unstable_diags = if Env::get("VIBE_UNSTABLE") == "1" {
+      adapter_no_warnings()
+    } else {
+      handle {
+        unstable_surface_diagnostics(input_path, src)
+      } with { Exception::Throw(_) => adapter_no_warnings() }
+    }
     if Env::get("VIBE_DIAGNOSTICS_JSON") == "1" {
-      Fs::write_bytes(output_path, adapter_string_to_bytes(lsp_diagnostics_json_string(src)))
+      // The JSON form is what the editor consumes; dropping the opt-in
+      // diagnostic here would make the LSP the one surface that still accepts
+      // the unstable import (#2277 review).
+      Fs::write_bytes(output_path, adapter_string_to_bytes(lsp_diagnostics_json_string_with(src, unstable_diags)))
     } else {
       let diags = collect_all_diagnostics(src)
+      let mut ui = 0
+      while ui < Array::length(unstable_diags) {
+        Array::push(diags, Array::get(unstable_diags, ui))
+        ui = ui + 1
+      }
       Fs::write_bytes(output_path, adapter_string_to_bytes(line_terminated(join_lines(diags))))
     }
     return 0
@@ -1774,6 +1876,25 @@ export fn cli_main() -> Int with Exception + Fs + Env + Stdin + Stdout {
     return adapter_serve_component(input_path, output_path)
   }
   let source = Fs::read_file(input_path)
+  // ADR-0068 gate for the SINGLE-SOURCE lane. `VIBE_TEST_BACKEND=gc` and
+  // `VIBE_BENCH_BACKEND=gc` reach compilation through here -- `runtime/vibe`
+  // clears `VIBE_FS_COMPILE` and selects the backend -- so this lane compiled
+  // and RAN a file with an unstable import while every check form rejected the
+  // same declaration (#2277 review). Measured: `vibe test` said the file was
+  // refused, `VIBE_TEST_BACKEND=gc vibe test` said `1 passed`.
+  //
+  // The entry's own bytes, with no ingestion: this lane resolves no imports, so
+  // there is no ingested text to differ from them.
+  let bare_unstable = if Env::get("VIBE_UNSTABLE") == "1" {
+    adapter_no_warnings()
+  } else {
+    unstable_surface_diagnostics(input_path, source)
+  }
+  if Array::length(bare_unstable) > 0 {
+    return emit_compile_diag(output_path, Array::get(bare_unstable, 0))
+  } else {
+    ()
+  }
   profile_memory_mark(mark_memory)
   // #594 Stage 1b: emit-module-source mode. VIBE_EMIT_MODULE_SOURCE=1 reuses the
   // same (input, output, entry) interface but, instead of compiling, writes the

--- a/lib/@vibe/compiler/cli_support.vibe
+++ b/lib/@vibe/compiler/cli_support.vibe
@@ -89,7 +89,7 @@ import @vibe/compiler/runtime {
 // is one-error-at-a-time; `vibe diagnostics` is the multi-diagnostic surface
 // — collect_all_diagnostics already uses this same recovering parser).
 import @vibe/compiler/syntax {
-  lex_with_offsets, parse_program_recovering
+  Token, lex_with_offsets, parse_program_recovering, token_to_string
 }
 
 //# Functions
@@ -600,6 +600,40 @@ fn owner_locating_source(path: String, source: String) -> Option[String] with Ex
   }
 }
 
+/// The entry's snapshot EXACTLY as the linked check consumed it -- ingested,
+/// markers and all, with no remap to the physical file. `checked_entry_source`
+/// does that remap so ordinary warnings cite lines a reader can visit; a
+/// VERDICT must not, or an inherited `.vpkg` import is invisible to it while
+/// the build rejects the same entry.
+///
+/// Unique-or-nothing, like `checked_entry_source`: describing text that was not
+/// the text checked is worse than saying nothing.
+fn checked_entry_snapshot(input_path: String, source_groups: Array[(String, Array[(String, String)])]) -> Option[String] {
+  let mut found: Option[String] = None
+  let mut count = 0
+  let mut gi = 0
+  while gi < Array::length(source_groups) {
+    let (_, sources) = Array::get(source_groups, gi)
+    let mut si = 0
+    while si < Array::length(sources) {
+      let (path, source) = Array::get(sources, si)
+      if path == input_path {
+        found = Some(source)
+        count = count + 1
+      } else {
+        ()
+      }
+      si = si + 1
+    }
+    gi = gi + 1
+  }
+  if count == 1 {
+    found
+  } else {
+    None
+  }
+}
+
 fn checked_entry_source(input_path: String, source_groups: Array[(String, Array[(String, String)])]) -> Option[String] with Exception + Fs {
   let mut found: Option[String] = None
   let mut count = 0
@@ -662,6 +696,251 @@ fn checked_warning_stmts(input_path: String, source: String) -> Option[Array[Stm
       Some(stmts)
     }
   }
+}
+
+/// UNSTABLE-surface diagnostics (ADR-0068). One line per import of a package
+/// whose design is not settled, so a reader is told at the keyboard rather
+/// than only in docs/spec/stable-surface.md section 6.
+///
+/// `@vibe/concurrent` is the whole list today: `Nursery`, `Task`,
+/// `Sender`/`Receiver`, `TaskGroup::run` / `spawn` / `spawn_suspend`, and the
+/// `Send` rule are ADR-0068, still `proposed`. The `Async` effect itself is
+/// NOT here -- ADR-0012 is accepted and `with Async` ships in builtin
+/// signatures a user can reach (`StdinStream::next`). The unstable part is
+/// the concurrency model built on top, not the row vocabulary.
+fn unstable_package_note(name: String) -> String {
+  if name == "@vibe/concurrent" || String::starts_with(name, "@vibe/concurrent/") {
+    "set VIBE_UNSTABLE=1 to build against `@vibe/concurrent`, or drop the import. It is ADR-0068, still proposed: outside the SemVer promise and able to change within a Minor release, so it is opt-in rather than silent (docs/spec/stable-surface.md section 6). The `Async` effect itself is stable and needs no opt-in -- only this package's concurrency model does."
+  } else {
+    ""
+  }
+}
+
+/// Byte offset of the `import` keyword that introduces `pkg`, or -1.
+///
+/// TOKENS, not text. Three separate review findings came from trying to
+/// recover this position by reading the source as lines, and each fix only
+/// moved the hole (#2277 review):
+///
+///   - "a line starting with `import` that contains the package name" pointed
+///     at `import @vibe/core { .. } // @vibe/concurrent`, a stable import that
+///     merely mentions it in a comment;
+///   - requiring the path to be the token right after `import` ON THAT LINE
+///     then missed `import\n  @vibe/concurrent { .. }`, valid source whose
+///     path is on the next line, and fell back to line 1 -- an unrelated
+///     declaration.
+///
+/// The lexer already answers this exactly, and `token_to_string` reaches it
+/// through the contract without needing the opaque `Token`'s constructors. A
+/// string literal cannot masquerade either: it renders as `TString("...")`,
+/// never `TIdent(...)`.
+/// `cursor` holds the token index to resume from, and is advanced past each
+/// match. Without it every `SImport` for the same package rescanned from zero
+/// and got the FIRST declaration's offset, so a file importing
+/// `@vibe/concurrent` twice with disjoint item lists reported both diagnostics
+/// at the first import's coordinates -- and the second one names a line whose
+/// text the reader would find nothing wrong with (#2277 review).
+///
+/// A single monotonic cursor is enough even across different package paths:
+/// statements are visited in source order, and each declaration's tokens
+/// appear in that same order, so nothing a later statement needs sits behind
+/// the cursor.
+fn unstable_import_offset(tokens: Array[Token], starts: Array[Int], pkg: String, cursor: Array[Int]) -> Int {
+  let want = String::concat("TIdent(", String::concat(pkg, ")"))
+  let n = Array::length(starts)
+  let mut i = Array::get(cursor, 0)
+  while i + 1 < n {
+    if token_to_string(Array::get(tokens, i)) == "TImport" && token_to_string(Array::get(tokens, i + 1)) == want {
+      Array::set(cursor, 0, i + 1)
+      return Array::get(starts, i)
+    } else {
+      ()
+    }
+    i = i + 1
+  }
+  0 - 1
+}
+
+/// 1-based line of a byte offset. Offset -1 (the token scan found nothing)
+/// falls back to line 1: a miss costs a position, never a verdict.
+/// 1-based BYTE column of an offset (ADR-0108: columns are bytes). An
+/// indented import -- inside an `SModule` block, say -- starts past the line
+/// start, and reporting a hardcoded column 1 pointed the text form, and every
+/// editor consuming the JSON/LSP form, at the indentation instead of the
+/// `import` token (#2277 review). Offset -1 (nothing found) is column 1, which
+/// pairs with the line-1 fallback.
+fn unstable_col_of_offset(source: String, off: Int) -> Int {
+  if off < 0 {
+    1
+  } else {
+    let n = String::length(source)
+    let limit = if off < n {
+      off
+    } else {
+      n
+    }
+    let mut start = 0
+    let mut i = 0
+    while i < limit {
+      if String::byte_at(source, i) == 10 {
+        start = i + 1
+      } else {
+        ()
+      }
+      i = i + 1
+    }
+    limit - start + 1
+  }
+}
+
+fn unstable_line_of_offset(source: String, off: Int) -> Int {
+  let n = String::length(source)
+  let mut line = 1
+  let mut i = 0
+  while i < off && i < n {
+    if String::byte_at(source, i) == 10 {
+      line = line + 1
+    } else {
+      ()
+    }
+    i = i + 1
+  }
+  line
+}
+
+/// One import's diagnostic, if the package it names is unstable.
+///
+/// Imports only. A re-export of a PACKAGE (`export @vibe/concurrent { .. }`)
+/// would depend on it the same way, but that syntax does not exist: the parser
+/// builds `SReExport` for `TDot`/`TDotDot` paths alone and answers a package
+/// path with "unexpected token in export" (measured). Adding an `SReExport` arm
+/// here would be a branch nothing can reach, which reads as coverage without
+/// being any. Gate 108 pins the boundary from the outside instead, so the day
+/// that syntax lands the gate fails rather than passing silently (#2277 review).
+fn unstable_decl_diagnostic(path: String, source: String, tokens: Array[Token], starts: Array[Int], out: Array[String], cursor: Array[Int]) -> Unit {
+  let note = unstable_package_note(path)
+  if note != "" {
+    let off = unstable_import_offset(tokens, starts, path, cursor)
+    let where_note = if off < 0 {
+      String::concat("this file inherits `", String::concat(path, "` from its directory's index.vpkg (it is not written here). "))
+    } else {
+      ""
+    }
+    let line = unstable_line_of_offset(source, off)
+    let col = unstable_col_of_offset(source, off)
+    // `line L:C:` -- the numeric prefix every other diagnostic in the
+    // tree uses, and the ONLY spelling `lsp_parse_diag_line` accepts. A
+    // readable `:col C:` was measured to make the JSON form fall back to
+    // column 1 (`lsp_parse_uint_or("col 3", 1)`), so the text and JSON
+    // answers disagreed about where to put the cursor (#2277 review).
+    Array::push(out, String::concat("line ", String::concat(Int::to_string(line), String::concat(":", String::concat(Int::to_string(col), String::concat(": ", String::concat(where_note, note)))))))
+  } else {
+    ()
+  }
+}
+
+fn unstable_stmt_diagnostics(stmts: Array[Stmt], source: String, tokens: Array[Token], starts: Array[Int], out: Array[String], cursor: Array[Int]) -> Unit {
+  let mut i = 0
+  while i < Array::length(stmts) {
+    match Array::get(stmts, i) {
+      SImport(path, _) => unstable_decl_diagnostic(path, source, tokens, starts, out, cursor),
+      // An import nested in a `module` block is still this file's dependency.
+      SModule(_, _, body) => unstable_stmt_diagnostics(body, source, tokens, starts, out, cursor),
+      _ => ()
+    }
+    i = i + 1
+  }
+}
+
+/// The gate itself, over ONE file's own bytes, read off the PARSED import
+/// statements rather than the line spelling.
+///
+/// The first version matched `String::starts_with(line, "import ")` and sliced
+/// a fixed 7 bytes, so `import\t@vibe/concurrent { .. }` was skipped entirely
+/// and `import  @vibe/concurrent { .. }` (two spaces) yielded an empty package
+/// name -- both valid source the lexer accepts, and both a silent bypass
+/// (#2277 review). An opt-in boundary that whitespace can cross is not one.
+///
+/// Only the ENTRY file is scanned: a transitive dependency's own imports are
+/// its author's choice, not this file's, and reporting them would be noise
+/// nobody here can act on. A source that does not parse yields nothing -- it
+/// cannot compile either, and the parse error is what the reader needs first.
+export fn unstable_surface_diagnostics(input_path: String, source: String) -> Array[String] with Exception {
+  unstable_surface_diagnostics_located(input_path, source, source)
+}
+
+/// Detection and LOCATION come from different texts on purpose.
+///
+/// `detected` is the INGESTED snapshot -- what the build compiles. `located` is
+/// the file's own bytes. They differ when a directory's `index.vpkg` declares a
+/// shared import that a sibling entry inherits without spelling it: the import
+/// is real, the build rejects it, and it appears nowhere in the file. Scanning
+/// the physical source for the VERDICT let `vibe check` call such an entry
+/// clean while the build refused it -- the two-verbs-disagree defect this gate
+/// exists to prevent (#2277 review).
+///
+/// So the verdict is the ingested text's, and the position is the physical
+/// file's when the import is physically there. When it is not, there is no
+/// honest line to give, and the note says where the import actually comes from
+/// instead of pointing at a line the reader would find nothing on (#1445).
+export fn unstable_surface_diagnostics_located(input_path: String, detected: String, located: String) -> Array[String] with Exception {
+  let out = array_empty()
+  let (tokens, starts, _ends) = lex_with_offsets(located)
+  match checked_warning_stmts(input_path, detected) {
+    Some(stmts) => unstable_stmt_diagnostics(stmts, located, tokens, starts, out, [
+      0
+    ]),
+    None => ()
+  }
+  out
+}
+
+/// The BUILD lane's entry point: one file read, no import closure. It used to
+/// call `collect_source_groups_fs`, which parses every reachable file a second
+/// time purely to find the entry again -- measured as a 1.1% self-compile heap
+/// regression that took CI's selfcompile KPI over its +10% ceiling (#2277 CI).
+/// Only the entry is scanned, so only the entry needs reading.
+/// INGESTED, not raw. The build ingests before it parses, and ingestion blanks
+/// the package header -- so a pinned `require @scope/pkg x.y.z = #pkg:sha1:...`
+/// line reaches a raw scan with a `#` in it, the lexer refuses it ("unknown #
+/// directive"), the parse yields nothing, and the gate goes SILENT while the
+/// build compiles the unstable import anyway. Measured: the same file unpinned
+/// produced the diagnostic, pinned produced none. That is the two-verbs-
+/// disagree defect this gate exists to prevent, reintroduced by reading the
+/// file a different way than the build reads it (#2277 review).
+export fn check_unstable_surface_warnings_from_path(input_path: String) -> Array[String] with Exception + Fs {
+  handle {
+    unstable_surface_diagnostics_located(input_path, ingest_source_text_fs(input_path, Fs::read_file(input_path)), Fs::read_file(input_path))
+  } with {
+  // An unreadable or uningestable entry is the compile's error to report, in
+  // its own words.
+  Exception::Throw(_) => array_empty() }
+}
+
+/// The CHECK lane's entry point: reuses the snapshot the linked check already
+/// collected, so it costs a lookup rather than a second traversal.
+export fn check_unstable_surface_warnings_from_source_groups(input_path: String, source_groups: Array[(String, Array[(String, String)])]) -> Array[String] with Exception + Fs {
+  // NOT `checked_entry_source`: that deliberately hands back the PHYSICAL file
+  // when the loader prepended inherited `.vpkg` imports, which is right for
+  // ordinary warnings and wrong for this verdict -- an inherited
+  // `@vibe/concurrent` would be invisible here and rejected by the build. The
+  // verdict comes from the same ingestion the build uses; only the position
+  // comes from the file's own bytes.
+  //
+  // And the snapshot, not a fresh read. Re-reading the entry evaluated text the
+  // check never saw: a save landing between the linked check and this call
+  // could remove the import and be reported clean, or add one the check never
+  // validated (#2277 review).
+  let detected = match checked_entry_snapshot(input_path, source_groups) {
+    Some(snapshot) => snapshot,
+    // No unique snapshot means nothing here was checked for this path. The
+    // build lane still gates it; inventing a verdict from disk would answer
+    // about text this check never consumed.
+    None => return array_empty()
+  }
+  handle {
+    unstable_surface_diagnostics_located(input_path, detected, Fs::read_file(input_path))
+  } with { Exception::Throw(_) => array_empty() }
 }
 
 /// Redundant import warnings derived from the exact source snapshot consumed

--- a/lib/@vibe/compiler/codegen/expr/compile_call.vibe
+++ b/lib/@vibe/compiler/codegen/expr/compile_call.vibe
@@ -3012,17 +3012,25 @@ fn compile_call_core(buf: Bytes, callee: Expr, args: Array[Expr], local_names: A
       // write into a region that no longer exists.
       throw("internal: `resume` reached codegen -- its handle was neither migrated (evidence dict) nor CPS-transformed (suspend class), and the replay engine was removed (ADR-0076 追記34 V2)")
     }
-    else if fname == "assert" {
-      // #1095: no `!prefer_bound_call` guard here (assert_true / assert_eq
-      // below never had one). Inside a lambda, capture analysis lists the
+    else if fname == "assert" && fn_idx_in_list < 0 {
+      // #1095: `prefer_bound_call` is the WRONG guard here (assert_true /
+      // assert_eq below had none either). Inside a lambda, capture analysis
+      // lists the
       // free name `assert` as a capture; the creation site cannot resolve it
       // and stores 0, so the "bound call" dispatched call_indirect through a
       // ZERO closure — table slot 0, i.e. an arbitrary user function. Before
       // #1107 Phase 4 that slot always happened to be populated, silently
       // NO-OPing every assert in a closure (concurrent_test's asserts never
       // actually asserted); with the minimized funcref table it surfaced as
-      // "null function" traps. Builtin statement asserts cannot be shadowed
-      // meaningfully, so always compile the builtin form.
+      // "null function" traps.
+      //
+      // #2283: the half of `prefer_bound_call` that is wrong is
+      // `local_idx_hint` -- the capture artifact. A name in the FUNCTION TABLE
+      // is a real top-level definition the reader wrote, and it must win, so
+      // these three arms test `fn_idx_in_list` alone. Without that the checker
+      // typed the call against the user's function while codegen emitted the
+      // builtin assert: `fn assert_eq(a: Int, b: Int) -> String` compiled clean
+      // and then trapped, with no diagnostic anywhere naming the conflict.
       let nl = ce(buf, Array::get(args, 0), local_names, next_local, ctx, ld)
       emit_i32_wrap_i64(buf)
       emit_if_void(buf)
@@ -3032,7 +3040,7 @@ fn compile_call_core(buf: Bytes, callee: Expr, args: Array[Expr], local_names: A
       emit_i64_const(buf, 0)
       nl
     }
-    else if fname == "assert_true" {
+    else if fname == "assert_true" && fn_idx_in_list < 0 {
       let nl = ce(buf, Array::get(args, 0), local_names, next_local, ctx, ld)
       emit_i32_wrap_i64(buf)
       emit_if_void(buf)
@@ -3042,7 +3050,7 @@ fn compile_call_core(buf: Bytes, callee: Expr, args: Array[Expr], local_names: A
       emit_i64_const(buf, 0)
       nl
     }
-    else if fname == "assert_eq" {
+    else if fname == "assert_eq" && fn_idx_in_list < 0 {
       // Fallback only. The shipped path rewrites `assert_eq` in
       // desugar_trait_dicts (expected/actual on stderr, then trap). This
       // arm stays for lanes that skip that pass (compile_module): still

--- a/lib/@vibe/compiler/index.vpkg
+++ b/lib/@vibe/compiler/index.vpkg
@@ -519,6 +519,10 @@ fn check_deprecated_warnings(input_path: String) -> Array[String] with Exception
 fn check_deprecated_warnings_from_source_groups(input_path: String, source_groups: Array[(String, Array[(String, String)])]) -> Array[String] with Exception + Fs
 fn check_redundant_import_warnings(input_path: String) -> Array[String] with Exception + Fs
 fn check_redundant_import_warnings_from_source_groups(input_path: String, source_groups: Array[(String, Array[(String, String)])]) -> Array[String] with Exception + Fs
+fn check_unstable_surface_warnings_from_path(input_path: String) -> Array[String] with Exception + Fs
+fn check_unstable_surface_warnings_from_source_groups(input_path: String, source_groups: Array[(String, Array[(String, String)])]) -> Array[String] with Exception + Fs
+fn unstable_surface_diagnostics(input_path: String, source: String) -> Array[String] with Exception
+fn unstable_surface_diagnostics_located(input_path: String, detected: String, located: String) -> Array[String] with Exception
 fn strip_executable_wasm(wasm: Bytes, entry_name: String, strip_names: Bool, filter_exports: Bool) -> Bytes
 fn strip_executable_wasm_env(wasm: Bytes, entry_name: String) -> Bytes with Env
 fn write_linked_debug_build(input_path: String, output_path: String, entry_name: String) -> Unit with Exception + Fs

--- a/lib/@vibe/compiler/normalize/desugar_trait_dict.vibe
+++ b/lib/@vibe/compiler/normalize/desugar_trait_dict.vibe
@@ -6339,11 +6339,90 @@ fn interp_take_repl(r: Option[Expr]) -> Expr {
 /// what the checker sees (effect-free); this pass rewrites it after check so
 /// a failure can print both sides without adding Stderr/Exception to the
 /// source row.
+/// A program that DEFINES `assert_eq` itself gets its own function, not this
+/// lowering. Measured before the guard: `fn assert_eq(a: Int, b: Int) -> Int {
+/// a + b }` plus `assert_eq(1, 2)` compiled clean and trapped with `assert_eq
+/// failed` instead of returning 3, with no diagnostic naming the conflict
+/// anywhere (#2283).
 fn is_assert_eq_call(callee: Expr, args: Array[Expr]) -> Bool {
   match callee {
-    EIdent(n, _) => n == "assert_eq" && Array::length(args) == 2,
+    EIdent(n, _) => n == "assert_eq" && Array::length(args) == 2 && !user_assert_eq_bound(),
     _ => false
   }
+}
+
+/// Pass state, reset at every `desugar_trait_dicts` entry like the exn-kind
+/// cell above: whether THIS program binds `assert_eq` itself.
+///
+/// The unit is the program this pass was handed, which in the FS lane is every
+/// module merged together -- so one module defining `assert_eq` stands the
+/// lowering down for all of them. Coarse, and deliberately so: the merged
+/// program is what this pass sees, and a per-module answer here would be
+/// invented.
+let dtd_user_assert_eq = [0]
+
+fn user_assert_eq_reset(stmts: Array[Stmt]) -> Unit {
+  Array::set(dtd_user_assert_eq, 0, if stmts_define_assert_eq(stmts) {
+    1
+  } else {
+    0
+  })
+}
+
+fn user_assert_eq_bound() -> Bool {
+  Array::get(dtd_user_assert_eq, 0) == 1
+}
+
+/// Whether this program DEFINES `assert_eq` at the top level -- a
+/// statement-level definition, or an import that lands under that name.
+///
+/// Top-level only, and that boundary is not arbitrary: it is exactly what the
+/// codegen guard can honor. `compile_call.vibe` decides by `fn_idx_in_list`
+/// (the function table) and deliberately ignores `local_idx_hint`, because a
+/// lambda's captured free name appears there with an unresolved slot -- the
+/// #1095 trap. Suppressing the lowering for a LOCAL binding only moves the
+/// failure: the pass stands down, codegen's own `assert_eq` arm still claims
+/// the call, and the program traps with no message at all. Measured on
+/// `match make_cmp() { assert_eq => assert_eq(1, 2) }`: the builtin assertion
+/// before, a bare `unreachable` after. Worse, not better -- so the local and
+/// pattern-bound cases keep their pre-existing behaviour (#2285).
+fn stmts_define_assert_eq(stmts: Array[Stmt]) -> Bool {
+  let mut i = 0
+  let mut found = false
+  while i < Array::length(stmts) && !found {
+    let hit = match Array::get(stmts, i) {
+      SLet(_, _, name, _, _) => name == "assert_eq",
+      SModule(_, _, body) => stmts_define_assert_eq(body),
+      SImport(_, items) => import_binds_assert_eq(items),
+      _ => false
+    }
+    if hit {
+      found = true
+    } else {
+      ()
+    }
+    i = i + 1
+  }
+  found
+}
+
+fn import_binds_assert_eq(items: Array[ImportItem]) -> Bool {
+  let mut i = 0
+  let mut found = false
+  while i < Array::length(items) && !found {
+    let item = Array::get(items, i)
+    let local = match item.alias {
+      Some(a) => a,
+      None => item.name
+    }
+    if local == "assert_eq" {
+      found = true
+    } else {
+      ()
+    }
+    i = i + 1
+  }
+  found
 }
 
 fn assert_eq_concat(a: Expr, b: Expr) -> Expr {
@@ -14876,6 +14955,9 @@ export fn desugar_trait_dicts(stmts: Array[Stmt]) -> Unit with Exception {
   // #2141: a throw mid-rewrite leaves frames on the lexical binder stack;
   // reset so a later run on another program cannot see them.
   scope_formals_reset()
+  // #2283: same discipline -- whether the assert lowering must stand down for
+  // THIS program, because the program defines the name itself.
+  user_assert_eq_reset(stmts)
   eq_tuple_uid_reset()
   eq_known_types_reset(stmts)
   desugar_derives(stmts)

--- a/lib/@vibe/compiler/normalize/desugar_trait_dict.vibe
+++ b/lib/@vibe/compiler/normalize/desugar_trait_dict.vibe
@@ -6392,7 +6392,15 @@ fn stmts_define_assert_eq(stmts: Array[Stmt]) -> Bool {
   while i < Array::length(stmts) && !found {
     let hit = match Array::get(stmts, i) {
       SLet(_, _, name, _, _) => name == "assert_eq",
-      SModule(_, _, body) => stmts_define_assert_eq(body),
+      // NO `SModule` recursion. A module member declares `M::assert_eq`, not
+      // the bare prelude name, so recursing would stand the lowering down for
+      // an unrelated top-level `assert_eq(a, b)` -- and the function table
+      // holds only the qualified definition, so codegen would then fall to a
+      // bare `unreachable`, losing the message and both operands (#2296
+      // review). Unreachable today either way: `module` blocks were removed in
+      // #728 and the parser answers this shape with "'module' blocks are
+      // removed", measured on the current tree. Left out rather than left
+      // wrong, since the arm would be a latent defect the day modules return.
       SImport(_, items) => import_binds_assert_eq(items),
       _ => false
     }

--- a/lib/@vibe/concurrent/index.vpkg
+++ b/lib/@vibe/concurrent/index.vpkg
@@ -1,6 +1,8 @@
 name = @vibe/concurrent
 version = 0.0.1
 description =
+  #|UNSTABLE (ADR-0068, proposed): outside the SemVer promise, can change
+  #|within a Minor -- see docs/spec/stable-surface.md section 6.
   #|@vibe/concurrent — ADR-0068 shared-nothing structured concurrency,
 deps = {}
 

--- a/lib/@vibe/lsp/index.vpkg
+++ b/lib/@vibe/lsp/index.vpkg
@@ -34,3 +34,4 @@ generated_hash =
 fn lsp_main() -> Int with Stdin + Stdout
 fn lsp_diagnostics_safe(source: String) -> Json
 fn lsp_diagnostics_json_string(source: String) -> String
+fn lsp_diagnostics_json_string_with(source: String, extra: Array[String]) -> String

--- a/lib/@vibe/lsp/lsp_server.vibe
+++ b/lib/@vibe/lsp/lsp_server.vibe
@@ -768,6 +768,33 @@ export fn lsp_diagnostics_json_string(source: String) -> String {
   Json::stringify(lsp_diagnostics_safe(source))
 }
 
+/// #2277: the ADR-0068 opt-in diagnostic is produced by the ADAPTER, not by
+/// `collect_all_diagnostics` -- it is a property of the import declaration
+/// rather than of single-file analysis -- so the JSON form has to be handed it
+/// or `vibe check --single-file --json` answers `[]` where the text form
+/// reports the error. Same diagnostic shape either way: the extra lines are the
+/// same `line L:C: message` strings every other consumer produces, mapped
+/// through the same parser.
+///
+/// The extra lines are appended even when `collect_all_diagnostics` throws: an
+/// internal failure in single-file analysis is not a reason to drop a verdict
+/// the caller already computed.
+export fn lsp_diagnostics_json_string_with(source: String, extra: Array[String]) -> String {
+  let msgs = handle {
+    collect_all_diagnostics(source)
+  } with { Exception::Throw(_) => array_empty() }
+  let mut i = 0
+  while i < Array::length(extra) {
+    Array::push(msgs, Array::get(extra, i))
+    i = i + 1
+  }
+  Json::stringify(handle {
+    JArr(for msg in msgs {
+      lsp_parse_diag_line(source, msg)
+    })
+  } with { Exception::Throw(_) => JArr([]) })
+}
+
 //# Completion / signature help / workspace-symbol (parity slice 2).
 //# Deliberately built on the SAME single-file compiler primitives as the
 //# rest of this server (symbol_spans / type_at_source), not on a ported

--- a/scripts/check_selector_precedence.sh
+++ b/scripts/check_selector_precedence.sh
@@ -49,11 +49,14 @@ adapter, launcher, mode, enforced = sys.argv[1], sys.argv[2], sys.argv[3], sys.a
 # read inside a branch, not a branch of its own.
 # Names that appear only in EXPRESSION position and do not pick a branch: they
 # modify observation inside whichever branch was already selected, and a caller
-# sets them deliberately (both are documented user-facing knobs). Clearing them
+# sets them deliberately (documented user-facing knobs). Clearing them
 # would break that, so they are excluded BY NAME -- and the check below fails on
 # any expression-position selector not accounted for here, so a new one cannot
 # be silently dropped the way VIBE_COVERAGE was (#2246 review).
-OBSERVATION_ONLY = {"VIBE_DIAGNOSTICS_ALL", "VIBE_PROFILE_MEMORY_MARKS"}
+# VIBE_UNSTABLE is the ADR-0068 opt-in, read inside already-selected branches
+# (`vibe check` / `vibe build` / `vibe serve`); it must not enter
+# VIBE_SELECTOR_ORDER or selector_clears_before would strip it.
+OBSERVATION_ONLY = {"VIBE_DIAGNOSTICS_ALL", "VIBE_PROFILE_MEMORY_MARKS", "VIBE_UNSTABLE"}
 
 # The order is SOURCE ORDER, and a selector counts wherever it is tested --
 # `let bytes = if Env::get("VIBE_COVERAGE") == "1" { .. } else if

--- a/scripts/check_vibe_fmt.sh
+++ b/scripts/check_vibe_fmt.sh
@@ -95,6 +95,17 @@ while IFS=$'\t' read -r status rel_path message; do
   fi
 done < <(printf '%s\n' "${files[@]}" | bash scripts/run_vibe_fmt_batch.sh check "$JOBS")
 
+# A process substitution's exit status is not this script's, so a batch that
+# died -- the formatter would not build, a shard produced no report -- fed
+# the loop zero lines and every count below stayed 0: "checked 0 file(s)",
+# exit 0, a green that inspected nothing (#2271, same family as the silent
+# rc-1 loop it fixes). Every file handed to the batch must come back.
+if [ "$checked" -ne "${#files[@]}" ]; then
+  echo "vibe-fmt lint: the batch reported on $checked of ${#files[@]} file(s); the rest were never checked" >&2
+  echo "  this is NOT a formatting verdict -- see the batch's diagnostics above" >&2
+  exit 2
+fi
+
 if [ "${#errors[@]}" -gt 0 ]; then
   echo "vibe-fmt lint: ${#errors[@]} file(s) errored while checking (not merely unformatted):" >&2
   printf '  %s\n' "${errors[@]}" >&2

--- a/scripts/ensure_entry_wasm.sh
+++ b/scripts/ensure_entry_wasm.sh
@@ -76,26 +76,120 @@ else
 fi
 
 if [ "$stale" = "1" ]; then
+  # Build to a PROCESS-UNIQUE path and publish by rename, never in place.
+  #
+  # A failed rebuild must not leave the previous artifact answering -- that is
+  # the stale-reuse the staleness rules above exist to prevent (#2271) -- but
+  # deleting it up front to achieve that opened a worse window: callers run
+  # concurrently (scripts/vibe_md.sh spawns one worker per document), two
+  # workers can both see "stale", and the slower one's `rm` then lands after
+  # the faster one has finished compiling or has already started running the
+  # wasm. The first caller is handed a path to a deleted or half-written file,
+  # which surfaces as an intermittent formatter or docs-gate failure (#2277
+  # review). Compiling to `$$`-suffixed paths and `mv`-ing on success gives
+  # both properties without ever unlinking a file another process may be
+  # running: a success replaces the artifact atomically for everyone else, and
+  # a failure retracts only the manifest, which is enough to force a rebuild.
+  build_wasm_rel="$wasm_rel.$$.tmp"
+  build_diag_rel="$build_wasm_rel.diag"
+  build_deps_rel="$deps_rel.$$.tmp"
+  # The compiler writes `<out>.funcmap` beside the wasm and the runner reads it
+  # to symbolize traps, so it has to travel WITH the wasm -- publishing one and
+  # leaving the other names the wrong functions in every later stack trace.
+  build_funcmap_rel="$build_wasm_rel.funcmap"
+  rm -f "$ROOT_DIR/$build_wasm_rel" "$ROOT_DIR/$build_diag_rel" \
+        "$ROOT_DIR/$build_deps_rel" "$ROOT_DIR/$build_funcmap_rel"
+  trap 'rm -f "$ROOT_DIR/$build_wasm_rel" "$ROOT_DIR/$build_diag_rel" "$ROOT_DIR/$build_deps_rel" "$ROOT_DIR/$build_funcmap_rel"' EXIT
+  # `|| compile_rc=$?` is load-bearing: as a bare command under `set -e` a
+  # non-zero runner abandoned the script HERE, one line above the check that
+  # was written to explain the failure, so the message below never printed
+  # and the cause stayed in the .diag sidecar that nothing reads (#2271).
+  compile_rc=0
   VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
     bash "$ROOT_DIR/scripts/run_wasm_vibe_host_runner.sh" \
-    --invoke cli_main "$seed" "$entry_src" "$wasm_rel" main >&2
-  [ -s "$ROOT_DIR/$wasm_rel" ] || { echo "ensure_entry_wasm.sh: failed to compile $entry_src" >&2; exit 1; }
+    --invoke cli_main "$seed" "$entry_src" "$build_wasm_rel" main >&2 || compile_rc=$?
+  if [ "$compile_rc" != "0" ] || [ ! -s "$ROOT_DIR/$build_wasm_rel" ]; then
+    echo "ensure_entry_wasm.sh: failed to compile $entry_src -> $wasm_rel" >&2
+    if [ -s "$ROOT_DIR/$build_diag_rel" ]; then
+      # awk, not `sed s/^/  /`: the compiler writes the sidecar with NO
+      # trailing newline, so sed ran the hint below onto the same line.
+      awk '{ printf "  %s\n", $0 }' "$ROOT_DIR/$build_diag_rel" >&2
+    else
+      echo "  the compiler wrote no diagnostics (runner exit $compile_rc)" >&2
+    fi
+    # The overwhelmingly common cause on a fresh checkout: the untracked
+    # generated artifacts are not there yet, so the compiler package's own
+    # contract has declarations with no implementation.
+    echo "  if that names a generated artifact (lib/@vibe/compiler/cache/, *_bundle.vibe), run: bash scripts/ensure_generated.sh" >&2
+    # Nothing published, so nothing to undo -- but whatever an earlier run left
+    # behind must not go on answering. Drop the MANIFEST rather than the wasm:
+    # the staleness rules read it first, so its absence forces a rebuild, and a
+    # concurrent caller that is running the previous artifact this instant keeps
+    # the bytes it was handed. This process failing says nothing about those.
+    rm -f "$ROOT_DIR/$deps_rel"
+    exit 1
+  fi
   # Capture the closure the compiler just resolved. The plan mode also
   # writes one `.N.src` sidecar per module; keep them in a scratch dir so
   # only the manifest survives. Best-effort: on failure no manifest is
   # written and the next run rebuilds again rather than reusing stale.
   plan_dir="$(mktemp -d "$ROOT_DIR/_build/ensure_entry_plan.XXXXXX")"
   plan_rel="${plan_dir#"$ROOT_DIR"/}/plan.tsv"
+  captured=0
   if VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_MODULE_PLAN=1 \
       bash "$ROOT_DIR/scripts/run_wasm_vibe_host_runner.sh" \
       --invoke cli_main "$seed" "$entry_src" "$plan_rel" "__no_entry__" >&2 \
       && [ -s "$ROOT_DIR/$plan_rel" ]; then
-    awk -F'\t' '$1 == "module" { print $4 }' "$ROOT_DIR/$plan_rel" > "$ROOT_DIR/$deps_rel"
+    awk -F'\t' '$1 == "module" { print $4 }' "$ROOT_DIR/$plan_rel" > "$ROOT_DIR/$build_deps_rel"
+    captured=1
   else
-    rm -f "$ROOT_DIR/$deps_rel"
     echo "ensure_entry_wasm.sh: could not capture the dependency closure for $entry_src; the artifact will rebuild every run until it can" >&2
   fi
   rm -rf "$plan_dir"
+
+  # Publish. The manifest goes away FIRST: between the two renames a concurrent
+  # reader would otherwise pair the new wasm with the old closure and call it
+  # fresh, where an absent manifest just makes it rebuild. Both renames are
+  # within one directory, so each is atomic for everyone else.
+  rm -f "$ROOT_DIR/$deps_rel"
+  build_inode="$(ls -i "$ROOT_DIR/$build_wasm_rel" 2>/dev/null | awk '{ print $1 }')"
+  mv -f "$ROOT_DIR/$build_wasm_rel" "$ROOT_DIR/$wasm_rel"
+  # Each rename is atomic, but the three of them are not one transaction: two
+  # builders that both saw "stale" can interleave and pair one's wasm with the
+  # other's funcmap or manifest (#2277 review). `mv` within a directory is
+  # rename(2), so the published file keeps our inode -- a DIFFERENT one means
+  # someone published over us between the rename and here.
+  #
+  # The response is fail-closed rather than a lock: drop the manifest and
+  # publish none of our sidecars, so the winner's tuple stays whole and the next
+  # run rebuilds. A lock would also have to recover from a killed holder, and
+  # stale-lock stealing is a larger hazard than the one it removes here.
+  published_inode="$(ls -i "$ROOT_DIR/$wasm_rel" 2>/dev/null | awk '{ print $1 }')"
+  if [ -n "$build_inode" ] && [ -n "$published_inode" ] && [ "$published_inode" != "$build_inode" ]; then
+    rm -f "$ROOT_DIR/$deps_rel"
+    echo "ensure_entry_wasm.sh: another build published $wasm_rel first; leaving its artifact whole and rebuilding next run" >&2
+  else
+    if [ -s "$ROOT_DIR/$build_funcmap_rel" ]; then
+      mv -f "$ROOT_DIR/$build_funcmap_rel" "$ROOT_DIR/$wasm_rel.funcmap"
+    else
+      rm -f "$ROOT_DIR/$wasm_rel.funcmap"
+    fi
+    if [ "$captured" = "1" ]; then
+      mv -f "$ROOT_DIR/$build_deps_rel" "$ROOT_DIR/$deps_rel"
+    fi
+    # Re-check AFTER the sidecars: the first comparison only catches a winner
+    # that landed before it, and a builder can still replace the wasm between
+    # that check and these renames, leaving its wasm beside our sidecars (#2277
+    # review). Dropping the manifest is what matters -- it is the first
+    # staleness test, so the next run rebuilds the whole tuple. A funcmap can
+    # stay mismatched until then, which costs symbol names in a trace, not
+    # correctness.
+    final_inode="$(ls -i "$ROOT_DIR/$wasm_rel" 2>/dev/null | awk '{ print $1 }')"
+    if [ -n "$final_inode" ] && [ "$final_inode" != "$build_inode" ]; then
+      rm -f "$ROOT_DIR/$deps_rel"
+      echo "ensure_entry_wasm.sh: $wasm_rel was replaced while its sidecars were published; rebuilding next run" >&2
+    fi
+  fi
 fi
 
 echo "$wasm_rel"

--- a/scripts/ensure_entry_wasm_test.sh
+++ b/scripts/ensure_entry_wasm_test.sh
@@ -1,0 +1,189 @@
+#!/usr/bin/env bash
+# Self-test for scripts/ensure_entry_wasm.sh's FAILURE path, and for the two
+# callers that consume its exit code (#2271).
+#
+# The bug it pins: the compile line ran as a bare command under `set -e`, so a
+# non-zero runner abandoned the script one line above the `[ -s ... ] || echo
+# ... exit 1` that existed to explain the failure. Callers got exit 1 and an
+# empty stderr -- which is exactly what `vibe fmt --check` means by "not
+# formatted" -- so `vibe fmt` looped forever on a file that was never at fault,
+# with the real cause sitting in the `<wasm>.diag` sidecar that nothing read.
+#
+# Everything here works on scratch entries under _build/, never on the real
+# formatter artifact, so it cannot leave the tree in a state another gate
+# section would trip over.
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+WORK_REL="_build/ensure_entry_wasm_test"
+WORK="$ROOT_DIR/$WORK_REL"
+rm -rf "$WORK"
+mkdir -p "$WORK"
+trap 'rm -rf "$WORK"' EXIT
+
+fail() { echo "[ensure-entry-wasm-test] FAIL: $*" >&2; exit 1; }
+
+# --- 1. a compile failure is LOUD, and names the compiler's own diagnostic ---
+printf 'fn f( -> Int {\n' > "$WORK/bad.vibe"
+rc=0
+bash scripts/ensure_entry_wasm.sh "$WORK_REL/bad.vibe" "$WORK_REL/bad.wasm" \
+  >"$WORK/bad.out" 2>"$WORK/bad.err" || rc=$?
+[ "$rc" = "1" ] || fail "unbuildable entry exited $rc, want 1"
+grep -q "failed to compile $WORK_REL/bad.vibe" "$WORK/bad.err" \
+  || fail "stderr does not name the entry it could not compile"
+# The compiler's own words, not just "it failed" -- that is the difference
+# between an actionable message and the silent exit this test exists for.
+grep -q "expected parameter name" "$WORK/bad.err" \
+  || fail "stderr does not carry the compiler's diagnostic"
+grep -q "ensure_generated.sh" "$WORK/bad.err" \
+  || fail "stderr does not point at the usual cause on a fresh checkout"
+[ ! -e "$WORK/bad.wasm" ] || fail "a failed compile left an artifact behind"
+
+# --- 2. a failed REBUILD retracts the previous build's verdict ---
+# Otherwise the caller keeps answering from a formatter built before the edit,
+# which is the stale-reuse ensure_entry_wasm.sh's staleness rules exist to
+# prevent. The bogus wasm stands in for a good build from an earlier run.
+#
+# What must go is the MANIFEST, not the wasm: an absent manifest is the first
+# staleness test, so the next run rebuilds, while the bytes stay put for a
+# concurrent caller that is running them right now (#2277 review). The check is
+# therefore behavioural -- ask again and it must still refuse to call it fresh.
+printf 'stale artifact\n' > "$WORK/stale.wasm"
+printf '%s\n' "$WORK_REL/stale.vibe" > "$WORK/stale.wasm.deps"
+printf 'fn g( -> Int {\n' > "$WORK/stale.vibe"
+# Backdate the artifact rather than trusting write order: everything here is
+# written inside one second, and the staleness tests are strict `-nt`, so
+# same-second mtimes read as fresh and nothing would rebuild at all.
+touch -t 200001010000 "$WORK/stale.wasm" "$WORK/stale.wasm.deps"
+rc=0
+bash scripts/ensure_entry_wasm.sh "$WORK_REL/stale.vibe" "$WORK_REL/stale.wasm" \
+  >/dev/null 2>"$WORK/stale.err" || rc=$?
+[ "$rc" = "1" ] || fail "failed rebuild exited $rc, want 1"
+[ ! -e "$WORK/stale.wasm.deps" ] || fail "failed rebuild kept the manifest, so the next run would reuse the old artifact"
+rc=0
+bash scripts/ensure_entry_wasm.sh "$WORK_REL/stale.vibe" "$WORK_REL/stale.wasm" \
+  >/dev/null 2>/dev/null || rc=$?
+[ "$rc" = "1" ] || fail "the run after a failed rebuild answered $rc -- it reused the stale artifact"
+
+# --- 3. the success path still works, and still prints the path ---
+printf 'fn main() -> Int {\n  0\n}\n' > "$WORK/good.vibe"
+out="$(bash scripts/ensure_entry_wasm.sh "$WORK_REL/good.vibe" "$WORK_REL/good.wasm" 2>/dev/null)"
+[ "$out" = "$WORK_REL/good.wasm" ] || fail "success printed '$out', want '$WORK_REL/good.wasm'"
+[ -s "$WORK/good.wasm" ] || fail "success produced no wasm"
+[ -s "$WORK/good.wasm.deps" ] || fail "success captured no dependency closure"
+# The funcmap sidecar has to be published with the wasm, and nothing named for
+# the temporary build path may survive -- a leaked `.tmp` sidecar is a stale
+# symbol table sitting next to a fresh artifact.
+[ -s "$WORK/good.wasm.funcmap" ] || fail "success left the funcmap sidecar unpublished"
+leftover="$(find "$WORK" -name '*.tmp*' -print -quit)"
+[ -z "$leftover" ] || fail "the build left a temporary artifact behind: $leftover"
+
+# --- 4. the callers must not swallow that exit code in a bare assignment ---
+# `var="$(bash .../ensure_...)"` under `set -e` dies with exit 1 and nothing on
+# stderr, which is indistinguishable from a formatting verdict. Each caller has
+# to handle the failure explicitly.
+assert_handles() {
+  local file="$1" ensure="$2"
+  grep -qE "^[a-z_]+=\"\\\$\(bash \"\\\$ROOT_DIR/scripts/$ensure\"\)\"\$" "$file" \
+    && return 1
+  grep -q "scripts/$ensure" "$file" || return 2
+  return 0
+}
+for pair in "scripts/vibe_fmt.sh ensure_vibe_fmt_entry.sh" \
+            "scripts/run_vibe_fmt_batch.sh ensure_vibe_fmt_batch.sh"; do
+  set -- $pair
+  case "$(assert_handles "$1" "$2" && echo 0 || echo $?)" in
+    0) ;;
+    1) fail "$1 calls $2 in a bare assignment; a build failure exits 1 with no message" ;;
+    2) fail "$1 no longer calls $2 -- update this test" ;;
+  esac
+done
+
+# --- 5. every consumer of the batch must reconcile the report COUNT ---
+# `done < <(... | run_vibe_fmt_batch.sh ...)` hides the batch's exit status, so a
+# dead batch feeds the loop zero lines and the caller reports "0 file(s)" and
+# exits 0 -- green having done nothing. check_vibe_fmt.sh was fixed for this and
+# vibe_fmt_apply.sh was missed, which is `pkf run fmt` silently rewriting
+# nothing (#2271, #2277 review). The check is lexical -- shell dataflow is not
+# decidable here -- so it requires the one structural thing that cannot be
+# faked into existence: a comparison against the input list's length.
+reconciles() {
+  grep -q 'run_vibe_fmt_batch\.sh' "$1" || return 2
+  grep -qE -- '-ne "\$\{#[a-z_]+\[@\]\}"' "$1" || return 1
+  return 0
+}
+for f in scripts/check_vibe_fmt.sh scripts/vibe_fmt_apply.sh; do
+  case "$(reconciles "$f" && echo 0 || echo $?)" in
+    0) ;;
+    1) fail "$f consumes the batch without reconciling the report count against its input" ;;
+    2) fail "$f no longer consumes run_vibe_fmt_batch.sh -- update this test" ;;
+  esac
+done
+
+# Red-test rule 5: strip the guard and it must be rejected.
+mkdir -p "$WORK/mut5"
+grep -v -E -- '-ne "\$\{#[a-z_]+\[@\]\}"' scripts/vibe_fmt_apply.sh > "$WORK/mut5/vibe_fmt_apply.sh"
+if ! grep -q 'run_vibe_fmt_batch\.sh' "$WORK/mut5/vibe_fmt_apply.sh"; then
+  fail "red-test mutation removed the batch call it needed to keep"
+fi
+if reconciles "$WORK/mut5/vibe_fmt_apply.sh"; then
+  fail "rule 5 accepts a caller with no count reconciliation"
+fi
+
+# --- 6. the rebuild must never write over the published artifact in place ---
+# Callers run concurrently (scripts/vibe_md.sh spawns one worker per document),
+# so two of them can both see "stale" at once. Compiling straight to the shared
+# path hands the other worker a half-written wasm, and deleting it first hands
+# it a missing one; both surface as an intermittent gate failure with no signal
+# in it (#2277 review). Lexical, like rules 4-5: what it pins is that the
+# compile target is a per-process path and that the publish is a rename.
+publishes_by_rename() {
+  grep -qE 'build_wasm_rel="\$wasm_rel\.\$\$' "$1" || return 1
+  grep -qE -- '--invoke cli_main "\$seed" "\$entry_src" "\$build_wasm_rel"' "$1" || return 1
+  grep -qE '^\s*mv -f "\$ROOT_DIR/\$build_wasm_rel" "\$ROOT_DIR/\$wasm_rel"$' "$1" || return 1
+  # ...and it must notice when someone published over it between that rename and
+  # the sidecars, since the three renames are not one transaction. The inode is
+  # the only evidence available without a lock: `mv` in-directory is rename(2),
+  # so the published file keeps ours unless it was replaced.
+  grep -q 'build_inode=' "$1" || return 1
+  grep -q 'published_inode=' "$1" || return 1
+  grep -qE '\[ "\$published_inode" != "\$build_inode" \]' "$1" || return 1
+  # ...and again after the sidecars, since the first check only catches a winner
+  # that landed before it.
+  grep -qE '\[ "\$final_inode" != "\$build_inode" \]' "$1" || return 1
+  return 0
+}
+publishes_by_rename scripts/ensure_entry_wasm.sh \
+  || fail "the rebuild does not compile to a per-process path and publish it by rename"
+
+# Red-test rule 6 twice: once against the compile target, once against the
+# interleave check. A mutation that matches nothing proves nothing, so each
+# `sed` is verified to have actually removed the line it targets.
+mkdir -p "$WORK/mut6"
+sed 's|"\$entry_src" "\$build_wasm_rel" main|"$entry_src" "$wasm_rel" main|' \
+  scripts/ensure_entry_wasm.sh > "$WORK/mut6/ensure_entry_wasm.sh"
+if publishes_by_rename "$WORK/mut6/ensure_entry_wasm.sh"; then
+  fail "rule 6 accepts a rebuild that compiles straight to the published path"
+fi
+grep -v 'published_inode=' scripts/ensure_entry_wasm.sh > "$WORK/mut6/no_inode.sh"
+if ! grep -q 'build_inode=' "$WORK/mut6/no_inode.sh"; then
+  fail "red-test mutation removed more than the line it targeted"
+fi
+if publishes_by_rename "$WORK/mut6/no_inode.sh"; then
+  fail "rule 6 accepts a publish that cannot notice an interleaved winner"
+fi
+
+# Red-test rule 4 against a mutated copy: a checker that cannot fail is not a
+# check. Restoring the bare form must be rejected.
+mkdir -p "$WORK/mut/scripts"
+sed 's/^entry_wasm_rel=.*$/entry_wasm_rel="$(bash "$ROOT_DIR\/scripts\/ensure_vibe_fmt_entry.sh")"/' \
+  scripts/vibe_fmt.sh > "$WORK/mut/scripts/vibe_fmt.sh"
+grep -q 'ensure_vibe_fmt_entry' "$WORK/mut/scripts/vibe_fmt.sh" \
+  || fail "red-test mutation lost the call it was supposed to reintroduce"
+if assert_handles "$WORK/mut/scripts/vibe_fmt.sh" "ensure_vibe_fmt_entry.sh"; then
+  fail "rule 4 accepts the bare assignment it exists to reject"
+fi
+
+echo "[ensure-entry-wasm-test] ok (loud failure + diagnostic + stale retraction + success path + caller exit-code handling + batch count reconciliation + atomic publish + interleave detection, red-tested)"

--- a/scripts/run_vibe_fmt_batch.sh
+++ b/scripts/run_vibe_fmt_batch.sh
@@ -27,7 +27,16 @@ case "$mode" in
   *) echo "run_vibe_fmt_batch.sh: mode must be check or write, got: $mode" >&2; exit 2 ;;
 esac
 
-batch_wasm_rel="$(bash "$ROOT_DIR/scripts/ensure_vibe_fmt_batch.sh")"
+# `|| exit 2` -- NOT a bare assignment. Under `set -e` a failed formatter
+# build killed this script with exit 1 and nothing on stderr, and the caller
+# reads this script through a process substitution whose status it never
+# sees, so the batch simply produced no report lines and the lint reported
+# "checked 0 file(s)" and exited 0 (#2271).
+batch_wasm_rel="$(bash "$ROOT_DIR/scripts/ensure_vibe_fmt_batch.sh")" || {
+  echo "run_vibe_fmt_batch.sh: could not build the batch formatter -- see the compile diagnostics above" >&2
+  echo "  no file was checked or rewritten; this is not a formatting verdict" >&2
+  exit 2
+}
 
 work="$ROOT_DIR/_build/vibe_fmt_batch"
 mkdir -p "$work"

--- a/scripts/unit_batch_compile.mjs
+++ b/scripts/unit_batch_compile.mjs
@@ -286,7 +286,18 @@ async function main() {
     `[unit-batch] ${totalMisses} of ${listed.length} files to compile (${nHits} cached) with ${JOBS} daemons`,
   );
 
-  const daemons = Array.from({ length: JOBS }, (_, i) => new Daemon(`c${i}`, { VIBE_FS_COMPILE: "1" }));
+  // VIBE_UNSTABLE: ADR-0068's `@vibe/concurrent` needs the opt-in to compile
+  // at all, and a handful of in-tree fixtures deliberately test that surface
+  // (fixtures/async_boundary_user_sleep_test.vibe). It is granted for the
+  // whole daemon, not per file, because a daemon compiles many files in one
+  // long-lived process and its env is fixed at spawn. That is acceptable
+  // here: the boundary exists for a USER's build, these are the repository's
+  // own tests, and the boundary itself is pinned by the compiler gate
+  // (tests/gates/late/run.sh section 108) rather than by this harness.
+  const daemons = Array.from(
+    { length: JOBS },
+    (_, i) => new Daemon(`c${i}`, { VIBE_FS_COMPILE: "1", VIBE_UNSTABLE: "1" }),
+  );
   const planDaemon = new Daemon("plan", { VIBE_MODULE_PLAN: "1" });
 
   // Weight >= HEAVY_MS marks the compiler-closure class: their compiles

--- a/scripts/unit_test_runner.sh
+++ b/scripts/unit_test_runner.sh
@@ -368,7 +368,10 @@ run_one_untraced() {
     attempt=$((attempt + 1))
     local out; out="$(mktemp -t vibe-unit-XXXXXX.wasm)"
     rm -f "$out" "$out.diag"
-    VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
+    # VIBE_UNSTABLE: matches what scripts/unit_batch_compile.mjs grants its
+    # daemons, so the one-shot fallback and the batch path compile the same
+    # files the same way. See that file for why it is granted wholesale.
+    VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw VIBE_UNSTABLE=1 \
       timeout 300 bash "$RUNNER" --invoke cli_main "$S2" "$f" "$out" __no_entry__ >/dev/null 2>&1 || true
     if [ -s "$out" ]; then
       # timeout: a miscompiled test that loops forever must fail the FILE,

--- a/scripts/vibe_fmt.sh
+++ b/scripts/vibe_fmt.sh
@@ -8,6 +8,12 @@
 #   bash scripts/vibe_fmt.sh --stdout <file.vibe> # print formatted result, no write
 #
 # Paths must live under the repo root (the wasm preopen dir).
+#
+# Exit codes: 0 formatted / already formatted; 1 the FILE is at fault
+# (--check found a diff, or the formatter declined to rewrite it); 2 THIS
+# SCRIPT could not answer (bad usage, or the formatter would not build).
+# 1 and 2 must stay distinct -- a caller that cannot tell them apart
+# retries an unformattable file forever (#2271).
 set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
@@ -46,7 +52,17 @@ case "$src" in
 esac
 [ -f "$ROOT_DIR/$src_rel" ] || { echo "vibe_fmt.sh: not found: $src_rel" >&2; exit 2; }
 
-entry_wasm_rel="$(bash "$ROOT_DIR/scripts/ensure_vibe_fmt_entry.sh")"
+# `|| exit 2` -- NOT the bare assignment this used to be. Under `set -e` a
+# failed formatter build killed this script with exit 1 and nothing on
+# stderr, which is byte-for-byte what `--check` means by "not formatted": a
+# caller applied, saw no change, checked again, and looped forever over a
+# file that was never the problem (#2271). "Could not answer" gets its own
+# code, the same 2 the usage errors above use.
+entry_wasm_rel="$(bash "$ROOT_DIR/scripts/ensure_vibe_fmt_entry.sh")" || {
+  echo "vibe_fmt.sh: could not build the formatter itself -- see the compile diagnostics above" >&2
+  echo "  $src_rel was NOT checked or rewritten; this says nothing about that file" >&2
+  exit 2
+}
 
 # The formatter's output path is PER PROCESS. It used to be the fixed
 # `_build/vibe_fmt/out.vibe`, which two concurrent `vibe_fmt.sh` runs would

--- a/scripts/vibe_fmt_apply.sh
+++ b/scripts/vibe_fmt_apply.sh
@@ -60,6 +60,17 @@ if [ "${#to_format[@]}" -gt 0 ]; then
       ERROR) errors+=("$rel_path: $message") ;;
     esac
   done < <(printf '%s\n' "${to_format[@]}" | bash scripts/run_vibe_fmt_batch.sh write "$JOBS")
+  # A process substitution's exit status is not this script's, so a batch that
+  # died -- the formatter would not build, a shard produced no report -- fed the
+  # loop zero lines and this printed "formatted 0 file(s)" and exited 0. That is
+  # `pkf run fmt`, the documented whole-tree command, silently rewriting nothing
+  # (#2271; the same hole was fixed in check_vibe_fmt.sh and this caller was
+  # missed). Every file handed to the batch must come back.
+  if [ "$formatted" -ne "${#to_format[@]}" ]; then
+    echo "vibe-fmt apply: the batch reported on $formatted of ${#to_format[@]} file(s); the rest were NOT formatted" >&2
+    echo "  nothing here says those files are clean -- see the batch's diagnostics above" >&2
+    exit 2
+  fi
 fi
 
 if [ "${#errors[@]}" -gt 0 ]; then

--- a/scripts/vibe_md.vibex
+++ b/scripts/vibe_md.vibex
@@ -479,6 +479,24 @@ struct BlockResult {
 // scripts/vibe_md.py's VIBE_MD_TIMEOUT, default 120): without it a hung or
 // infinite-looping tutorial block ties up sh_capture (and therefore the CI
 // job running it) with no per-block failure ever produced.
+/// Does this block import an ADR-0068 (`proposed`) package? Matched on the
+/// line's own text after leading whitespace, which is enough here: these are
+/// book blocks the repository writes, not adversarial input, and a miss costs
+/// a FAIL with the compiler's own opt-in message rather than a silent pass.
+fn block_imports_unstable(blk: Block) -> Bool {
+  let mut i = 0
+  while i < Array::length(blk.code_lines) {
+    let line = Array::get(blk.code_lines, i)
+    if String::index_of(line, "@vibe/concurrent") >= 0 && String::index_of(line, "import") >= 0 {
+      return true
+    } else {
+      ()
+    }
+    i = i + 1
+  }
+  false
+}
+
 fn md_timeout_secs() -> String with Env {
   let v = String::trim(Env::get("VIBE_MD_TIMEOUT"))
   if String::length(v) > 0 {
@@ -577,7 +595,18 @@ fn run_one_block(cwd: String, compiler: String, md_path: String, md_dir: String,
       ""
     }
     let timeout_secs = md_timeout_secs()
-    let compile_cmd = "timeout \{timeout_secs} env VIBE_PREOPEN_DIR=\{shq(cwd)} VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \{meta_env}bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main \{shq(compiler)} \{shq(src)} \{shq(out)} \{shq(entry)}"
+    // ADR-0068's `@vibe/concurrent` needs VIBE_UNSTABLE=1 to compile at all,
+    // and book/*/17_concurrency.vibe.md exists to SHOW that surface. Granted
+    // per block, only to blocks that import it, so the opt-in stays a real
+    // boundary for every other chapter instead of a blanket env var this
+    // harness sets for the whole book. Enforcement itself is pinned by the
+    // late gate (section 108), not here.
+    let unstable_env = if block_imports_unstable(blk) {
+      "VIBE_UNSTABLE=1 "
+    } else {
+      ""
+    }
+    let compile_cmd = "timeout \{timeout_secs} env VIBE_PREOPEN_DIR=\{shq(cwd)} VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \{unstable_env}\{meta_env}bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main \{shq(compiler)} \{shq(src)} \{shq(out)} \{shq(entry)}"
     let cr = sh_capture(compile_cmd)
     let compiled = cr.exit_code == 0 && file_nonempty(out)
     if !compiled {
@@ -927,7 +956,16 @@ fn compile_merged(cwd: String, compiler: String, md_dir: String, base: String) -
   let src = merge_driver_path(md_dir, base)
   let out = merge_wasm_path(md_dir, base)
   let timeout_secs = md_timeout_secs()
-  let cmd = "timeout \{timeout_secs} env VIBE_PREOPEN_DIR=\{shq(cwd)} VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main \{shq(compiler)} \{shq(src)} \{shq(out)} '__no_entry__'"
+  // Same ADR-0068 opt-in the per-block path grants, decided from the merged
+  // driver's own text. Without it the merged compile of the concurrency
+  // chapter fails and every block falls back to a standalone compile -- the
+  // right answer, reached the slow way.
+  let unstable_env = if String::index_of(Fs::read_file(src), "@vibe/concurrent") >= 0 {
+    "VIBE_UNSTABLE=1 "
+  } else {
+    ""
+  }
+  let cmd = "timeout \{timeout_secs} env VIBE_PREOPEN_DIR=\{shq(cwd)} VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \{unstable_env}bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main \{shq(compiler)} \{shq(src)} \{shq(out)} '__no_entry__'"
   let cr = sh_capture(cmd)
   cr.exit_code == 0 && file_nonempty(out)
 }

--- a/tests/gates/late/run.sh
+++ b/tests/gates/late/run.sh
@@ -6045,3 +6045,567 @@ if ! cmp -s "$fmtdir/expected.vibe" "$fmtdir/out.vibe"; then
 fi
 rm -rf "$fmtdir"
 echo "[compiler-gate] vibe fmt ok (#2149)"
+
+# 108/108. The ADR-0068 concurrency surface is opt-in (#2248).
+#      docs/spec/stable-surface.md said the unstable surface "is reached only
+#      through `@build.unstable`, an explicit flag, or an ADR still marked
+#      `proposed`" -- and `@build.unstable` appeared nowhere else in the tree,
+#      there was no such flag, and `TaskGroup::run` checked clean with no
+#      marker of any kind.
+#
+#      BOTH verbs, because a build that accepts what the check rejects is the
+#      "two verbs, two answers" defect #1567 fixed for check/diagnostics, and
+#      it is worse here: the accepting verb is the one that ships. And three
+#      directions each, since any one alone is satisfiable by the wrong thing
+#      -- silence would also pass if the gate were deleted, rejection would
+#      also pass if the opt-in did nothing, and both would pass if it rejected
+#      every file.
+echo "[compiler-gate] 108/108 the ADR-0068 concurrency surface is opt-in, in check AND build (#2248)"
+uwdir="_build/_gate_unstable_warn"
+rm -rf "$uwdir"; mkdir -p "$uwdir"
+cat > "$uwdir/uses.vibe" <<'UWEOF'
+import @vibe/concurrent { TaskGroup }
+
+fn main() -> Int with Exception {
+  TaskGroup::run((n) -> {
+    let _t = TaskGroup::spawn(n, () -> { 7 })
+    0
+  })
+}
+UWEOF
+cat > "$uwdir/plain.vibe" <<'UWEOF'
+fn main() -> Int { 1 + 1 }
+UWEOF
+# `env -u VIBE_UNSTABLE`: the no-opt-in cases must not inherit the opt-in.
+# Measured -- with VIBE_UNSTABLE=1 in the ambient environment this section
+# reported "did not reject" and would have passed vacuously had the assertion
+# been the other way round. Same defect #2252 found in five self-tests: a
+# check that measures the machine, not the property.
+uw_check() { env -u VIBE_UNSTABLE VIBE_RUNNER="$ROOT_DIR/scripts/viberun_node.sh" VIBE_CLI_WASM="$stage2_wasm" \
+  VIBE_PREOPEN_DIR="$ROOT_DIR" bash "$ROOT_DIR/runtime/vibe" check "$1" 2>&1; }
+uw_build() { # <src> <out> [extra env assignments...]
+  local src="$1" out="$2"; shift 2
+  rm -f "$out" "$out.diag"
+  env -u VIBE_UNSTABLE "$@" VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
+    bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
+    "$src" "$out" main >/dev/null 2>&1 || true
+}
+
+# check: rejected, opt-in accepted, unrelated file untouched.
+#
+# Captured into a variable, not piped: this gate runs under `set -o pipefail`,
+# and `uw_check` exits 1 on the rejection it is asserting, so `uw_check | grep`
+# fails even when grep MATCHES. Measured -- the first version reported "vibe
+# check accepted @vibe/concurrent" while the rejection it was looking for was
+# printed one line above it in the same log.
+uw_uses_out="$(uw_check "$uwdir/uses.vibe" || true)"
+if ! printf '%s\n' "$uw_uses_out" | grep -qF 'VIBE_UNSTABLE=1'; then
+  echo "[compiler-gate] FAIL: vibe check accepted @vibe/concurrent with no opt-in (#2248)" >&2
+  printf '%s\n' "$uw_uses_out" >&2
+  exit 1
+fi
+if ! VIBE_UNSTABLE=1 VIBE_RUNNER="$ROOT_DIR/scripts/viberun_node.sh" VIBE_CLI_WASM="$stage2_wasm" \
+  VIBE_PREOPEN_DIR="$ROOT_DIR" bash "$ROOT_DIR/runtime/vibe" check "$uwdir/uses.vibe" >/dev/null 2>&1; then
+  echo "[compiler-gate] FAIL: VIBE_UNSTABLE=1 did not let vibe check through (#2248)" >&2
+  exit 1
+fi
+uw_plain_out="$(uw_check "$uwdir/plain.vibe" || true)"
+if printf '%s\n' "$uw_plain_out" | grep -qF 'VIBE_UNSTABLE=1'; then
+  echo "[compiler-gate] FAIL: a file not importing @vibe/concurrent was rejected anyway (#2248)" >&2
+  printf '%s\n' "$uw_plain_out" >&2
+  exit 1
+fi
+
+# build: the same three, through the FS-compile lane.
+uw_build "$uwdir/uses.vibe" "$uwdir/uses.wasm"
+if [ -s "$uwdir/uses.wasm" ]; then
+  echo "[compiler-gate] FAIL: vibe build accepted @vibe/concurrent with no opt-in -- the build accepts what the check rejects (#2248)" >&2
+  exit 1
+fi
+if ! grep -qF 'VIBE_UNSTABLE=1' "$uwdir/uses.wasm.diag" 2>/dev/null; then
+  echo "[compiler-gate] FAIL: the build rejection did not name the opt-in (#2248)" >&2
+  cat "$uwdir/uses.wasm.diag" 2>/dev/null >&2 || true
+  exit 1
+fi
+uw_build "$uwdir/uses.vibe" "$uwdir/uses_optin.wasm" VIBE_UNSTABLE=1
+if [ ! -s "$uwdir/uses_optin.wasm" ]; then
+  echo "[compiler-gate] FAIL: VIBE_UNSTABLE=1 did not let the build through (#2248)" >&2
+  cat "$uwdir/uses_optin.wasm.diag" 2>/dev/null >&2 || true
+  exit 1
+fi
+uw_build "$uwdir/plain.vibe" "$uwdir/plain.wasm"
+if [ ! -s "$uwdir/plain.wasm" ]; then
+  echo "[compiler-gate] FAIL: a file not importing @vibe/concurrent failed to build (#2248)" >&2
+  cat "$uwdir/plain.wasm.diag" 2>/dev/null >&2 || true
+  exit 1
+fi
+
+# Whitespace must not cross the boundary (#2277 review). The first version of
+# the scan matched `String::starts_with(line, "import ")` and sliced a fixed 7
+# bytes, so a tab skipped the check outright and two spaces yielded an empty
+# package name. Both spellings are valid source the lexer accepts, so both were
+# a silent bypass; the gate now reads the PARSED import instead. Written with
+# printf rather than a heredoc so the tab survives being read back.
+printf 'import\t@vibe/concurrent { TaskGroup }\n\nfn main() -> Int with Exception {\n  TaskGroup::run((n) -> { 0 })\n}\n' > "$uwdir/tab.vibe"
+printf 'import  @vibe/concurrent { TaskGroup }\n\nfn main() -> Int with Exception {\n  TaskGroup::run((n) -> { 0 })\n}\n' > "$uwdir/spaces.vibe"
+for uw_odd in tab spaces; do
+  uw_odd_out="$(uw_check "$uwdir/$uw_odd.vibe" || true)"
+  if ! printf '%s\n' "$uw_odd_out" | grep -qF 'VIBE_UNSTABLE=1'; then
+    echo "[compiler-gate] FAIL: '$uw_odd' whitespace spelling of the import bypassed the check gate (#2277)" >&2
+    printf '%s\n' "$uw_odd_out" >&2
+    exit 1
+  fi
+  uw_build "$uwdir/$uw_odd.vibe" "$uwdir/$uw_odd.wasm"
+  if [ -s "$uwdir/$uw_odd.wasm" ]; then
+    echo "[compiler-gate] FAIL: '$uw_odd' whitespace spelling of the import bypassed the build gate (#2277)" >&2
+    exit 1
+  fi
+done
+
+# The reported line must be the OFFENDING import, not the first line that
+# mentions the package. `import @vibe/core { .. } // @vibe/concurrent` is a
+# stable import carrying the name in a comment; naming it told the reader to
+# delete a line that was not the problem, which is worse than no line at all
+# (#2277 review). The offending import is on line 3 here.
+cat > "$uwdir/comment.vibe" <<'UWEOF'
+import @vibe/core { array_empty } // @vibe/concurrent
+
+import @vibe/concurrent { TaskGroup }
+
+fn main() -> Int with Exception {
+  TaskGroup::run((n) -> { 0 })
+}
+UWEOF
+uw_build "$uwdir/comment.vibe" "$uwdir/comment.wasm"
+if ! grep -qF 'line 3:' "$uwdir/comment.wasm.diag" 2>/dev/null; then
+  echo "[compiler-gate] FAIL: the opt-in diagnostic named the wrong import line (#2277)" >&2
+  cat "$uwdir/comment.wasm.diag" 2>/dev/null >&2 || true
+  exit 1
+fi
+
+# A PINNED `require` header must not silence the gate. The build ingests before
+# it parses, and ingestion blanks that header; a scan that read the raw bytes
+# instead met the `#` in `#pkg:sha1:...`, the lexer refused it ("unknown #
+# directive"), the parse yielded nothing, and the gate went silent while the
+# build compiled the unstable import. Measured: unpinned produced the
+# diagnostic, pinned produced none (#2277 review).
+#
+# The pin here is deliberately bogus, so the build fails either way -- what is
+# asserted is WHICH diagnostic comes out. A pin error means the gate never
+# spoke.
+cat > "$uwdir/pinned.vibe" <<'UWEOF'
+require @vibe/concurrent 0.0.1 = #pkg:sha1:0123456789abcdef0123456789abcdef01234567
+
+import @vibe/concurrent { TaskGroup }
+
+fn main() -> Int with Exception {
+  TaskGroup::run((n) -> { 0 })
+}
+UWEOF
+uw_build "$uwdir/pinned.vibe" "$uwdir/pinned.wasm"
+if [ -s "$uwdir/pinned.wasm" ]; then
+  echo "[compiler-gate] FAIL: a pinned-require entry built against @vibe/concurrent with no opt-in (#2277)" >&2
+  exit 1
+fi
+if ! grep -qF 'VIBE_UNSTABLE=1' "$uwdir/pinned.wasm.diag" 2>/dev/null; then
+  echo "[compiler-gate] FAIL: a pinned require header silenced the opt-in gate (#2277)" >&2
+  cat "$uwdir/pinned.wasm.diag" 2>/dev/null >&2 || true
+  exit 1
+fi
+
+# The path may be on the NEXT line. `import\n  @vibe/concurrent { .. }` is valid
+# source; a same-line search missed it and fell back to line 1, naming an
+# unrelated declaration. The location comes from the lexer now, so this and the
+# comment case above are the same rule rather than two patches (#2277 review).
+# The import here starts on line 5.
+printf 'fn helper() -> Int {\n  1\n}\n\nimport\n  @vibe/concurrent { TaskGroup }\n\nfn main() -> Int with Exception {\n  TaskGroup::run((n) -> { 0 })\n}\n' > "$uwdir/multiline.vibe"
+uw_build "$uwdir/multiline.vibe" "$uwdir/multiline.wasm"
+if ! grep -qF 'line 5:' "$uwdir/multiline.wasm.diag" 2>/dev/null; then
+  echo "[compiler-gate] FAIL: a multiline import declaration got the wrong line (#2277)" >&2
+  cat "$uwdir/multiline.wasm.diag" 2>/dev/null >&2 || true
+  exit 1
+fi
+
+# The BUFFER lane must agree too. `vibe check --single-file` (VIBE_DIAGNOSTICS)
+# does not resolve imports, so an UNUSED `import @vibe/concurrent` analyzed
+# clean there while both other verbs rejected the same file -- an editor showing
+# nothing is the third answer to the same question (#2277 review). Unused on
+# purpose: that is the shape that slipped through.
+cat > "$uwdir/buffer.vibe" <<'UWEOF'
+import @vibe/concurrent { TaskGroup }
+
+fn main() -> Int {
+  1
+}
+UWEOF
+rm -f "$uwdir/buffer.out"
+env -u VIBE_UNSTABLE VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_IMPORT_ABI=raw VIBE_DIAGNOSTICS=1   bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm"   "$uwdir/buffer.vibe" "$uwdir/buffer.out" __no_entry__ >/dev/null 2>&1 || true
+if ! grep -qF 'VIBE_UNSTABLE=1' "$uwdir/buffer.out" 2>/dev/null; then
+  echo "[compiler-gate] FAIL: the single-file diagnostics lane accepted an unstable import (#2277)" >&2
+  cat "$uwdir/buffer.out" 2>/dev/null >&2 || true
+  exit 1
+fi
+rm -f "$uwdir/buffer.optin.out"
+VIBE_UNSTABLE=1 VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_IMPORT_ABI=raw VIBE_DIAGNOSTICS=1   bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm"   "$uwdir/buffer.vibe" "$uwdir/buffer.optin.out" __no_entry__ >/dev/null 2>&1 || true
+if grep -qF 'VIBE_UNSTABLE=1' "$uwdir/buffer.optin.out" 2>/dev/null; then
+  echo "[compiler-gate] FAIL: VIBE_UNSTABLE=1 did not clear the single-file diagnostic (#2277)" >&2
+  cat "$uwdir/buffer.optin.out" 2>/dev/null >&2 || true
+  exit 1
+fi
+# ...and the JSON form of that same buffer lane, which is what the editor
+# actually consumes. It serialized only `collect_all_diagnostics`, so it
+# answered `[]` while the text form reported the error -- the LSP would have
+# been the one surface still accepting the unstable import (#2277 review).
+rm -f "$uwdir/buffer.json"
+env -u VIBE_UNSTABLE VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_IMPORT_ABI=raw VIBE_DIAGNOSTICS=1 VIBE_DIAGNOSTICS_JSON=1 \
+  bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
+  "$uwdir/buffer.vibe" "$uwdir/buffer.json" __no_entry__ >/dev/null 2>&1 || true
+if ! grep -qF 'VIBE_UNSTABLE=1' "$uwdir/buffer.json" 2>/dev/null; then
+  echo "[compiler-gate] FAIL: the single-file JSON lane dropped the unstable diagnostic (#2277)" >&2
+  cat "$uwdir/buffer.json" 2>/dev/null >&2 || true
+  exit 1
+fi
+# The JSON form must carry the COLUMN, not just the message. `lsp_parse_diag_line`
+# accepts exactly `line L:C:`; a readable `line L:col C:` made it fall back to
+# column 1, so the editor put the cursor at character 0 while the text form
+# named the real column (#2277 review). The import is indented so the two
+# answers can differ at all.
+printf '  import @vibe/concurrent { TaskGroup }\n\nfn main() -> Int {\n  1\n}\n' > "$uwdir/indented.vibe"
+rm -f "$uwdir/indented.out" "$uwdir/indented.json"
+env -u VIBE_UNSTABLE VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_IMPORT_ABI=raw VIBE_DIAGNOSTICS=1 \
+  bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
+  "$uwdir/indented.vibe" "$uwdir/indented.out" __no_entry__ >/dev/null 2>&1 || true
+env -u VIBE_UNSTABLE VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_IMPORT_ABI=raw VIBE_DIAGNOSTICS=1 VIBE_DIAGNOSTICS_JSON=1 \
+  bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
+  "$uwdir/indented.vibe" "$uwdir/indented.json" __no_entry__ >/dev/null 2>&1 || true
+# Two lanes, one column: byte column 3 in the text form is UTF-16 character 2 in
+# the JSON form. Before the fix the JSON said 0 for this file while the text
+# form said 3, because `line L:col C:` is not a spelling `lsp_parse_diag_line`
+# can read -- it parsed "col 3" as a number, failed, and fell back to column 1.
+if ! grep -qF 'line 1:3: set VIBE_UNSTABLE=1' "$uwdir/indented.out" 2>/dev/null; then
+  echo "[compiler-gate] FAIL: the text diagnostic lost the column of an indented unstable import (#2277)" >&2
+  cat "$uwdir/indented.out" 2>/dev/null >&2 || true
+  exit 1
+fi
+if ! grep -qF '"character":2' "$uwdir/indented.json" 2>/dev/null; then
+  echo "[compiler-gate] FAIL: the JSON diagnostic lost the column the text form reported (#2277)" >&2
+  cat "$uwdir/indented.json" 2>/dev/null >&2 || true
+  exit 1
+fi
+
+# `vibe serve` is an ARTIFACT-producing verb with its own branch, taken before
+# the FS-compile gate, so the same handler that `vibe check` rejects used to
+# yield a deployable component with no opt-in (#2277 review). The handler shape
+# is the four-parameter String one `validate_serve_handler` requires; the
+# control below proves the file is otherwise servable.
+cat > "$uwdir/serve.vibe" <<'UWEOF'
+import @vibe/concurrent { TaskGroup }
+
+export fn handler(method: String, url: String, headers: String, body: String) -> String {
+  "ok"
+}
+UWEOF
+rm -f "$uwdir/serve.component.wasm" "$uwdir/serve.component.wasm.diag"
+env -u VIBE_UNSTABLE VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_IMPORT_ABI=raw VIBE_SERVE_COMPONENT=1 \
+  bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
+  "$uwdir/serve.vibe" "$uwdir/serve.component.wasm" __no_entry__ >/dev/null 2>&1 || true
+if [ -s "$uwdir/serve.component.wasm" ]; then
+  echo "[compiler-gate] FAIL: vibe serve emitted a component for an unstable import with no opt-in (#2277)" >&2
+  exit 1
+fi
+if ! grep -qF 'VIBE_UNSTABLE=1' "$uwdir/serve.component.wasm.diag" 2>/dev/null; then
+  echo "[compiler-gate] FAIL: vibe serve refused the handler for the wrong reason (#2277)" >&2
+  cat "$uwdir/serve.component.wasm.diag" 2>/dev/null >&2 || true
+  exit 1
+fi
+rm -f "$uwdir/serve.optin.wasm" "$uwdir/serve.optin.wasm.diag"
+VIBE_UNSTABLE=1 VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_IMPORT_ABI=raw VIBE_SERVE_COMPONENT=1 \
+  bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
+  "$uwdir/serve.vibe" "$uwdir/serve.optin.wasm" __no_entry__ >/dev/null 2>&1 || true
+if grep -qF 'VIBE_UNSTABLE=1' "$uwdir/serve.optin.wasm.diag" 2>/dev/null; then
+  echo "[compiler-gate] FAIL: VIBE_UNSTABLE=1 did not clear the serve gate (#2277)" >&2
+  cat "$uwdir/serve.optin.wasm.diag" 2>/dev/null >&2 || true
+  exit 1
+fi
+# `export @pkg { .. }` would depend on the package exactly as an import does and
+# then PUBLISH its surface onward. Measured: it does not parse, so nothing
+# crosses the boundary through it -- but that is a fact about the PARSER, not
+# about this gate, and it is the kind of fact that changes without anyone
+# revisiting the gate (#2277 review).
+cat > "$uwdir/reexport.vibe" <<'UWEOF'
+export @vibe/concurrent { TaskGroup }
+
+fn main() -> Int {
+  1
+}
+UWEOF
+uw_build "$uwdir/reexport.vibe" "$uwdir/reexport.wasm"
+if [ -s "$uwdir/reexport.wasm" ]; then
+  echo "[compiler-gate] FAIL: a re-export of the unstable package built with no opt-in (#2277)" >&2
+  exit 1
+fi
+# TWO acceptable refusals, and the check has to distinguish them or it passes
+# for a reason it never verified. Today the form does not parse at all -- the
+# parser builds `SReExport` for `TDot`/`TDotDot` paths only and answers a
+# package path with "unexpected token in export" -- so the gate is not what
+# stops it. If that syntax ever lands, this arm stops matching and the
+# diagnostic must be the opt-in one instead; anything else fails here.
+if grep -qF 'unexpected token in export' "$uwdir/reexport.wasm.diag" 2>/dev/null; then
+  :
+elif grep -qF 'VIBE_UNSTABLE=1' "$uwdir/reexport.wasm.diag" 2>/dev/null; then
+  :
+else
+  echo "[compiler-gate] FAIL: a package re-export was refused for an unrelated reason -- if it now parses, gate it (#2277)" >&2
+  cat "$uwdir/reexport.wasm.diag" 2>/dev/null >&2 || true
+  exit 1
+fi
+# The SINGLE-SOURCE lane is artifact-producing too. `VIBE_TEST_BACKEND=gc` and
+# `VIBE_BENCH_BACKEND=gc` reach it because `runtime/vibe` clears
+# `VIBE_FS_COMPILE` and selects the backend, so the file compiled and RAN with
+# no opt-in while every check form rejected the same declaration. Measured
+# before the fix: `vibe test` refused it, `VIBE_TEST_BACKEND=gc vibe test`
+# answered `1 passed` (#2277 review). The import is unused on purpose -- that is
+# the shape this lane accepts.
+cat > "$uwdir/bare.vibe" <<'UWEOF'
+import @vibe/concurrent { TaskGroup }
+
+test "unused unstable import" {
+  assert_true(1 + 1 == 2)
+}
+UWEOF
+rm -f "$uwdir/bare.wasm" "$uwdir/bare.wasm.diag"
+env -u VIBE_UNSTABLE -u VIBE_FS_COMPILE VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_IMPORT_ABI=raw VIBE_TEST=1 \
+  bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
+  "$uwdir/bare.vibe" "$uwdir/bare.wasm" __no_entry__ >/dev/null 2>&1 || true
+if [ -s "$uwdir/bare.wasm" ]; then
+  echo "[compiler-gate] FAIL: the single-source lane built an unstable import with no opt-in (#2277)" >&2
+  exit 1
+fi
+if ! grep -qF 'VIBE_UNSTABLE=1' "$uwdir/bare.wasm.diag" 2>/dev/null; then
+  echo "[compiler-gate] FAIL: the single-source lane refused the file for the wrong reason (#2277)" >&2
+  cat "$uwdir/bare.wasm.diag" 2>/dev/null >&2 || true
+  exit 1
+fi
+rm -f "$uwdir/bare.optin.wasm" "$uwdir/bare.optin.wasm.diag"
+env -u VIBE_FS_COMPILE VIBE_UNSTABLE=1 VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_IMPORT_ABI=raw VIBE_TEST=1 \
+  bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
+  "$uwdir/bare.vibe" "$uwdir/bare.optin.wasm" __no_entry__ >/dev/null 2>&1 || true
+if [ ! -s "$uwdir/bare.optin.wasm" ]; then
+  echo "[compiler-gate] FAIL: VIBE_UNSTABLE=1 did not clear the single-source gate (#2277)" >&2
+  cat "$uwdir/bare.optin.wasm.diag" 2>/dev/null >&2 || true
+  exit 1
+fi
+# ...and an ordinary file on that lane is untouched, so the gate is not simply
+# refusing everything.
+printf 'test "plain" {\n  assert_true(1 + 1 == 2)\n}\n' > "$uwdir/bare_plain.vibe"
+rm -f "$uwdir/bare_plain.wasm" "$uwdir/bare_plain.wasm.diag"
+env -u VIBE_UNSTABLE -u VIBE_FS_COMPILE VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_IMPORT_ABI=raw VIBE_TEST=1 \
+  bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
+  "$uwdir/bare_plain.vibe" "$uwdir/bare_plain.wasm" __no_entry__ >/dev/null 2>&1 || true
+if [ ! -s "$uwdir/bare_plain.wasm" ]; then
+  echo "[compiler-gate] FAIL: the single-source gate refused an ordinary file (#2277)" >&2
+  cat "$uwdir/bare_plain.wasm.diag" 2>/dev/null >&2 || true
+  exit 1
+fi
+# TWO imports of the same package must be located independently. The offset scan
+# restarted from token zero for each `SImport`, so both diagnostics carried the
+# FIRST declaration's coordinates -- and the second one then names a line whose
+# text the reader would find nothing wrong with (#2277 review).
+cat > "$uwdir/twice.vibe" <<'UWEOF'
+import @vibe/concurrent { TaskGroup }
+
+import @vibe/concurrent { Nursery }
+
+fn main() -> Int {
+  1
+}
+UWEOF
+rm -f "$uwdir/twice.out"
+env -u VIBE_UNSTABLE VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_IMPORT_ABI=raw VIBE_DIAGNOSTICS=1 \
+  bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
+  "$uwdir/twice.vibe" "$uwdir/twice.out" __no_entry__ >/dev/null 2>&1 || true
+if ! grep -qF 'line 1:1: set VIBE_UNSTABLE=1' "$uwdir/twice.out" 2>/dev/null; then
+  echo "[compiler-gate] FAIL: the first of two unstable imports was not reported at line 1 (#2277)" >&2
+  cat "$uwdir/twice.out" 2>/dev/null >&2 || true
+  exit 1
+fi
+if ! grep -qF 'line 3:1: set VIBE_UNSTABLE=1' "$uwdir/twice.out" 2>/dev/null; then
+  echo "[compiler-gate] FAIL: the SECOND unstable import was reported at the first one's line (#2277)" >&2
+  cat "$uwdir/twice.out" 2>/dev/null >&2 || true
+  exit 1
+fi
+rm -rf "$uwdir"
+echo "[compiler-gate] ADR-0068 opt-in gate: check + build + serve + single-source + repeated-import + package-re-export + buffer(text+json+column) + whitespace + comment + multiline + pinned-require ok (#2248, #2277)"
+fmtdir="_build/_gate_vibe_fmt"
+rm -rf "$fmtdir"; mkdir -p "$fmtdir"
+printf 'let   add=(a:Int,b:Int)->Int{a+b}\n' > "$fmtdir/messy.vibe"
+VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_IMPORT_ABI=raw VIBE_FMT=1 \
+  bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
+  "$fmtdir/messy.vibe" "$fmtdir/out.vibe" >"$fmtdir/run.log" 2>&1 || true
+if [ ! -s "$fmtdir/out.vibe" ]; then
+  echo "[compiler-gate] FAIL: VIBE_FMT produced no output -- vibe fmt is not wired into the compiler (#2149)" >&2
+  cat "$fmtdir/run.log" >&2 || true
+  exit 1
+fi
+cat > "$fmtdir/expected.vibe" <<'FMTEXP'
+let add = (a: Int, b: Int) -> Int {
+  a + b
+}
+FMTEXP
+if ! cmp -s "$fmtdir/expected.vibe" "$fmtdir/out.vibe"; then
+  echo "[compiler-gate] FAIL: VIBE_FMT did not produce the canonical layout (#2149)" >&2
+  diff -u "$fmtdir/expected.vibe" "$fmtdir/out.vibe" >&2 || true
+  exit 1
+fi
+rm -rf "$fmtdir"
+echo "[compiler-gate] vibe fmt ok (#2149)"
+
+# 109/109. A multiline closure literal in a NON-FINAL argument slot formats to
+# a fixpoint (#2271). Reported as permanently unformattable -- apply changed
+# nothing, --check kept reporting a diff. The construct was never the problem:
+# the formatter ENTRY had failed to compile (a fresh checkout has none of the
+# untracked generated artifacts), and `vibe fmt` spelled "I could not build
+# myself" with the same exit 1 it uses for "this file is not formatted", so a
+# caller looped forever. Fixed in scripts/ensure_entry_wasm.sh (the failure is
+# loud) and scripts/vibe_fmt.sh (it exits 2), pinned there by
+# scripts/ensure_entry_wasm_test.sh. This section pins the other half of the
+# report -- that the SHAPE formats, on the stage2 lane -- so the issue's claim
+# is a regression test in both directions.
+echo "[compiler-gate] 109/109 a multiline closure in a non-final argument slot formats to a fixpoint (#2271)"
+nfdir="_build/_gate_nonfinal_closure"
+rm -rf "$nfdir"; mkdir -p "$nfdir"
+cat > "$nfdir/in.vibe" <<'NFIN'
+fn collect_by(is_formal: (String) -> Bool, out: Array[String]) -> Unit {
+  ()
+}
+fn caller(shadow: Array[String], out: Array[String]) -> Unit {
+  collect_by((head) -> {
+      let mut found = false
+      if Array::length(shadow) > 0 {
+    found = true
+      } else {
+        ()
+      }
+      found
+  }, out)
+}
+NFIN
+cat > "$nfdir/expected.vibe" <<'NFEXP'
+fn collect_by(is_formal: (String) -> Bool, out: Array[String]) -> Unit {
+  ()
+}
+fn caller(shadow: Array[String], out: Array[String]) -> Unit {
+  collect_by((head) -> {
+    let mut found = false
+    if Array::length(shadow) > 0 {
+      found = true
+    } else {
+      ()
+    }
+    found
+  }, out)
+}
+NFEXP
+VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_IMPORT_ABI=raw VIBE_FMT=1 \
+  bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
+  "$nfdir/in.vibe" "$nfdir/out.vibe" >"$nfdir/run.log" 2>&1 || true
+if [ ! -s "$nfdir/out.vibe" ]; then
+  echo "[compiler-gate] FAIL: the formatter produced nothing for a non-final closure argument (#2271)" >&2
+  cat "$nfdir/run.log" >&2 || true
+  exit 1
+fi
+if ! cmp -s "$nfdir/expected.vibe" "$nfdir/out.vibe"; then
+  echo "[compiler-gate] FAIL: non-final closure argument not formatted as expected (#2271)" >&2
+  diff -u "$nfdir/expected.vibe" "$nfdir/out.vibe" >&2 || true
+  exit 1
+fi
+# The fixpoint is the half the issue said was unreachable: formatting the
+# formatted form again must change nothing, or `pkf run fmt` and CI's
+# vibe-fmt-check disagree about the file forever.
+VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_IMPORT_ABI=raw VIBE_FMT=1 \
+  bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
+  "$nfdir/expected.vibe" "$nfdir/again.vibe" >"$nfdir/again.log" 2>&1 || true
+if ! cmp -s "$nfdir/expected.vibe" "$nfdir/again.vibe"; then
+  echo "[compiler-gate] FAIL: the formatted non-final closure is not a fixpoint (#2271)" >&2
+  diff -u "$nfdir/expected.vibe" "$nfdir/again.vibe" >&2 || true
+  exit 1
+fi
+rm -rf "$nfdir"
+echo "[compiler-gate] non-final closure argument fixpoint ok (#2271)"
+
+
+# 110/110. A user's own `assert_eq` is the function that runs (#2283).
+# Measured on a stage2 predating this guard: `fn assert_eq(a: Int, b: Int) ->
+# Int { a + b }` plus `assert_eq(1, 2)` compiled clean and TRAPPED with
+# `assert_eq failed` instead of returning 3, with no diagnostic naming the
+# conflict. Two layers had to give -- the lowering, which claimed every arity-2
+# `assert_eq` by name, and codegen, which had no shadowing guard at all on
+# these three spellings (#1095 removed `prefer_bound_call`, and the half of it
+# that was wrong is `local_idx_hint`, not `fn_idx_in_list`).
+echo "[compiler-gate] 110/110 a user's own assert_eq is the function that runs (#2283)"
+asdir="_build/_gate_assert_shadow"
+rm -rf "$asdir"; mkdir -p "$asdir"
+cat > "$asdir/shadow.vibe" <<'ASEOF'
+fn assert_eq(a: Int, b: Int) -> String {
+  Int::to_string(a + b)
+}
+
+fn main() -> Unit with Stdout {
+  println(assert_eq(1, 2))
+}
+ASEOF
+rm -f "$asdir/shadow.wasm" "$asdir/shadow.wasm.diag"
+VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_IMPORT_ABI=raw \
+  bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
+  "$asdir/shadow.vibe" "$asdir/shadow.wasm" main >/dev/null 2>&1 || true
+if [ ! -s "$asdir/shadow.wasm" ]; then
+  echo "[compiler-gate] FAIL: a program defining its own assert_eq did not compile (#2283)" >&2
+  cat "$asdir/shadow.wasm.diag" 2>/dev/null >&2 || true
+  exit 1
+fi
+as_out="$(VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh --invoke _start "$asdir/shadow.wasm" 2>&1 || true)"
+if ! printf '%s\n' "$as_out" | grep -qx '3'; then
+  echo "[compiler-gate] FAIL: the user's own assert_eq was not the function that ran (#2283)" >&2
+  printf '%s\n' "$as_out" >&2
+  exit 1
+fi
+# The FS lane too. `assert_true` is the oracle so the check does not depend on
+# captured stdout: if the builtin claimed the call, `assert_eq(1, 2)` traps
+# before `assert_true` ever sees a value.
+cat > "$asdir/shadow_test.vibe" <<'ASEOF'
+fn assert_eq(a: Int, b: Int) -> Int {
+  a + b
+}
+
+test "own assert_eq" {
+  assert_true(assert_eq(1, 2) == 3)
+}
+ASEOF
+VIBE_TEST_CLI_WASM="$stage2_wasm" VIBE_TEST_QUIET_COMPILER_NOTE=1 \
+  bash scripts/vibe_test.sh "$asdir/shadow_test.vibe" >"$asdir/shadow.log" 2>&1 || true
+if grep -qF 'assert_eq failed' "$asdir/shadow.log"; then
+  echo "[compiler-gate] FAIL: the FS lane replaced the user's assert_eq with the builtin assertion (#2283)" >&2
+  cat "$asdir/shadow.log" >&2
+  exit 1
+fi
+if ! grep -qF '1 passed, 0 failed' "$asdir/shadow.log"; then
+  echo "[compiler-gate] FAIL: the user's own assert_eq did not run in the FS lane (#2283)" >&2
+  cat "$asdir/shadow.log" >&2
+  exit 1
+fi
+# ...and the BUILTIN still works where nothing shadows it, or the guard has
+# simply turned the feature off.
+cat > "$asdir/builtin_test.vibe" <<'ASEOF'
+test "builtin assert still fires" {
+  assert_eq(1, 2)
+}
+ASEOF
+VIBE_TEST_CLI_WASM="$stage2_wasm" VIBE_TEST_QUIET_COMPILER_NOTE=1 \
+  bash scripts/vibe_test.sh "$asdir/builtin_test.vibe" >"$asdir/builtin.log" 2>&1 || true
+if ! grep -qF 'assert_eq failed' "$asdir/builtin.log"; then
+  echo "[compiler-gate] FAIL: the builtin assert_eq stopped reporting failures (#2283)" >&2
+  cat "$asdir/builtin.log" >&2
+  exit 1
+fi
+rm -rf "$asdir"
+echo "[compiler-gate] user-defined assert_eq wins; builtin still fires ok (#2283)"

--- a/tests/gates/late/run.sh
+++ b/tests/gates/late/run.sh
@@ -9,6 +9,16 @@ GATES_LIB="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)/lib.sh"
 source "$GATES_LIB"
 gate_resolve_stage2
 
+# ADR-0068 (#2248): `@vibe/concurrent` needs `VIBE_UNSTABLE=1` to compile at
+# all, and a dozen fixtures in this lane exercise that surface deliberately
+# (region generativity, spawnable capture, the async boundary, the TaskGroup
+# sugar). Granted lane-wide rather than per call site: the boundary exists for
+# a USER's build, these are the repository's own fixtures, and the boundary
+# itself is pinned by section 108 -- which clears the variable with
+# `env -u VIBE_UNSTABLE` on every no-opt-in case precisely so it stays honest
+# under an ambient grant.
+export VIBE_UNSTABLE=1
+
 
 # 41. ADR-0069 Phase 1: `fn main {}` sugar + entry/top-level hardening.
 #     (a) ok_fnmain: the paren-less/annotation-less `fn main with Stdout { .. }`

--- a/tests/gates/mid/run.sh
+++ b/tests/gates/mid/run.sh
@@ -9,6 +9,16 @@ GATES_LIB="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)/lib.sh"
 source "$GATES_LIB"
 gate_resolve_stage2
 
+# ADR-0068 (#2248): `@vibe/concurrent` needs `VIBE_UNSTABLE=1` to compile at
+# all, and a dozen fixtures in this lane exercise that surface deliberately
+# (region generativity, spawnable capture, the async boundary, the TaskGroup
+# sugar). Granted lane-wide rather than per call site: the boundary exists for
+# a USER's build, these are the repository's own fixtures, and the boundary
+# itself is pinned by section 108 -- which clears the variable with
+# `env -u VIBE_UNSTABLE` on every no-opt-in case precisely so it stays honest
+# under an ambient grant.
+export VIBE_UNSTABLE=1
+
 
 # 40. V128 SIMD intrinsics (#536): the first-class V128 type + 12 wasm-SIMD
 #     intrinsics (v128_load/store/splat/eq/le_u/ge_u/and/or/not/bitmask/

--- a/tests/gates/registry.tsv
+++ b/tests/gates/registry.tsv
@@ -225,3 +225,6 @@ x-adr-0090-1937-exception-unwind-region-restore	late	ADR-0090 #1937 exception-un
 105/105	late	105/105 checker Double call-result offsets on the linear source lane (#2158)
 106/106	late	106/106 vibe fmt reaches an installed user (#2149)
 107/107	late	107/107 the host runner's crash dump is opt-in (#2199)
+108/108	late	108/108 the ADR-0068 concurrency surface is opt-in, in check AND build (#2248)
+109/109	late	109/109 a multiline closure in a non-final argument slot formats to a fixpoint (#2271)
+110/110	late	110/110 a user's own assert_eq is the function that runs (#2283)


### PR DESCRIPTION
Re-landed from the closed #2277 onto current `main`. That PR carried six areas; `main` has since implemented four of them independently (#2261 dot-call offset, #2202 `assert_eq` location via `at off=N`, the #2164 contract sentinel as `is_builtin_type_name`, and the crash-dump opt-in), so only the ones below are still novel. The #2202 collision is why the old branch could not be merged mechanically — see its closing comment.

## The ADR-0068 concurrency surface is opt-in

ADR-0012 (`Async`) is **accepted** and stays free. ADR-0068 (`@vibe/concurrent` — `Nursery` / `Task` / `Sender` / `Receiver` / `Send` / `TaskGroup`) is **proposed**: outside the SemVer promise and able to change inside a Minor release. Importing it silently was the wrong default, so it now requires `VIBE_UNSTABLE=1`.

The gate reads the entry's **parsed** `SImport` statements, from the same ingestion the build uses. A `String::starts_with(line, "import ")` version was measured to let `import@vibe/concurrent` through entirely and to yield an empty package name for `import  @vibe/concurrent` — an opt-in boundary that whitespace can cross is not one.

Every verb that can produce an artifact applies it:

| lane | how it is reached |
|---|---|
| `vibe check` | linked check, from the snapshot the check consumed |
| `vibe check --single-file` (text and JSON) | the buffer lane an editor consumes |
| `vibe build` / `vibe run` | the FS-compile branch |
| `vibe serve` | its own branch, which **returns before** the FS gate — it emitted a deployable component with no opt-in |
| `VIBE_TEST_BACKEND=gc` / `VIBE_BENCH_BACKEND=gc` | the single-source branch, reached because `runtime/vibe` clears `VIBE_FS_COMPILE` |

The diagnostic gives the import's real line **and column** in the numeric `line L:C:` form — the only spelling `lsp_parse_diag_line` accepts, so the text and JSON lanes agree on where the cursor goes — and repeated imports of the same package are located independently rather than all pointing at the first.

Two in-tree harnesses compile the surface deliberately and are granted the opt-in: the doctest driver **per block**, so every chapter but the concurrency one still meets the boundary, and the unit-test batch daemon wholesale, because a daemon's env is fixed at spawn. The `late` and `mid` gate lanes are granted it the same way — a dozen fixtures there exercise the surface on purpose — which is safe because section 108 clears the variable with `env -u VIBE_UNSTABLE` on every no-opt-in case.

**Known gap, filed not fixed:** the scan covers the entry only, so moving the import into a sibling bypasses it (#2284). Fixing only the check lane would make the build the permissive verb, and covering the build lane the obvious way costs a second full traversal — measured earlier as a 1.1% self-compile heap regression. #2284 carries the design that avoids both.

`vibe lsp`'s `publishDiagnostics` is the one surface that does not report it (#2297): `@vibe/lsp` consumes only `@vibe/compiler/runtime`'s public contract by design, and the verdict lives in `cli_support`. The fix is to move the check to where `collect_all_diagnostics` lives, which also removes the duplication that let the two paths drift.

## A user-defined `assert_eq` is the function that runs — on the linear lane (closes #2283)

Measured: `fn assert_eq(a: Int, b: Int) -> Int { a + b }` plus `assert_eq(1, 2)` compiled clean and trapped with `assert_eq failed` instead of returning 3. Neither that trap nor the equal-values type error mentions the conflict.

Two layers, and the second is not where it looks:

1. the lowering claimed every arity-2 `assert_eq` by name; it now stands down when the program defines the name;
2. **codegen had no shadowing guard at all** on `assert` / `assert_true` / `assert_eq`. Without it the checker typed the call against the user's function while codegen emitted the builtin assert — two answers to one question. The half of `prefer_bound_call` that is wrong there is `local_idx_hint` (the #1095 capture artifact); a name in the **function table** is a real definition and must win.

Scoped to top-level definitions on purpose: that is exactly what the codegen guard can honor. Suppressing for a local binding was measured to replace a legible assertion message with a bare `unreachable`, which is worse — that slice is #2285, blocked on the #1095 question.

**The wasm-gc lane is NOT fixed, and this PR leaves the two lanes disagreeing.** Measured on the same file:

| lane | result |
|---|---|
| linear | `1 passed` — the user's function runs |
| gc | `trap: unreachable` — the builtin still claims the call |

An earlier draft of this description claimed the gc lane was safe because `backend_body.vibe` rejects a user declaration of these spellings. That is wrong: `gc_direct_abi_name_has_spelling_lowering` only disables the direct-ABI reference lane for the component — it emits no diagnostic. The naive fix does not work either; applying the same `func_table_index_of` guard to `codegen/gc/backend_call.vibe` was measured to break `fixtures/gc_backend_smoke_test.vibe` outright ("expected 1 elements on the stack for fallthru, found 3"), because that lane's func table *contains* the generated builtin names and `FuncTable` carries no user-vs-generated distinction. Tracked as #2300.

This is not a regression — before this change both lanes hijacked the call. It is a partial fix that leaves the lanes inconsistent, which is stated here rather than discovered later.

This is **orthogonal to `main`'s #2202 work**: the `at off=N` location survives untouched, and gate section 110 checks that directly so the two cannot drift.

## `vibe fmt` must not blame the file when it could not build itself (closes #2271)

#2271 reported a multiline closure in a non-final argument slot as permanently unformattable. It formats to a fixpoint — and so does a three-line file with no closure in it, which is the tell.

The formatter **entry** had failed to compile. `ensure_entry_wasm.sh` never said so: its compile line was a bare command under `set -e`, so a non-zero runner abandoned the script one line above the check written to explain it. `vibe_fmt.sh` then died the same way inside a command substitution — exit 1, empty stderr, byte-for-byte what `--check` means by "not formatted", so a caller applied, saw no change, and looped forever.

- `ensure_entry_wasm.sh` surfaces the compiler's own diagnostic and **publishes by rename**. Deleting the artifact up front — the first version of this fix — opened a worse window: callers run concurrently (`vibe_md.sh` spawns one worker per document) and the slower one's `rm` landed after the faster one had started running the wasm. A failed rebuild now retracts only the manifest, and the publish revalidates the inode before and after the sidecars.
- `vibe_fmt.sh` / `run_vibe_fmt_batch.sh` return **2**, not 1: "could not answer" and "the file is at fault" must stay distinguishable.
- `check_vibe_fmt.sh` and `vibe_fmt_apply.sh` read the batch through a process substitution whose status they never saw, so a dead batch made them report "0 file(s)" and exit 0. Every file handed to the batch must now come back.

## Verification

`ensure_generated` → `generations.sh build --stage3` → `cmp stage2 stage3` (FIXPOINT) → `compiler_gate.sh`, with new late-gate sections 108 (opt-in, ten directions) and 110 (shadowing, three including that the builtin still fires). `ensure_entry_wasm_test.sh` pins six rules, each red-tested with a mutation that must be rejected, and runs from `release-check`. CI: 31/31.

Issues from this work that stay open: #2280, #2284, #2285, #2287, #2288, #2289, #2297, #2300.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GbtLER6wNT4jsZEN1Zp6xe