### PR TITLE
Relicense to Apache-2.0 before 0.1.0

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,21 +1,201 @@
-MIT License
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
 
-Copyright (c) 2026 mizchi
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+   1. Definitions.
 
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+      "Licensor" shall mean the copyright owner or entity authorized by the
+      copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and do
+          not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2026 mizchi
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/README.md
+++ b/README.md
@@ -169,4 +169,5 @@ the full CLI/task-runner reference for development live in
 
 ## License
 
-MIT
+Licensed under the [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0).
+See [LICENSE](LICENSE).

--- a/docs/issue-triage.md
+++ b/docs/issue-triage.md
@@ -1,7 +1,7 @@
 # Issue triage — deciding kind and priority mechanically
 
-Last updated: 2026-08-07 (after the first pass; four issues closed the same day
-by done-verification, and the parallel-lane section added).
+Last updated: 2026-08-25 (applied state rewritten against the open set;
+the 2026-08-07 P0/P1 lists are closed).
 
 So that "what do I do next" does not have to be re-derived every time, **each
 label means exactly one thing**. Every issue is labelled independently on three
@@ -53,48 +53,46 @@ the same shelf as a real bug.
 An `epic` is an index, so it is never itself the thing to work on (look at its
 sub-issues).
 
-## Applied state as of 2026-08-07
+## Applied state as of 2026-08-25
 
-### P0 — silently wrong (4)
+Open PRs occupy files. **Do not start a new branch on a file an open PR already
+edits.** Merge or land that PR first, then take the leftover.
 
-| # | blocker | what |
+| occupied files | PR | what it is holding |
 |---|---|---|
-| #1526 | | `==` gives three different answers for an Array (bare = reference / inside a struct or enum = structural / inside a tuple = reference). **The semantics are decided: unify on structural equality (ADR-0097)** — only the implementation is left |
-| #1527 | | a `Bool` returned from a function interpolates as `1` / `0` |
-| #1529 | | a bounded call `B::method(x)` breaks unless the struct the impl targets is first in the file |
-| #1533 | ✔ | importing a non-exported name passes the checker. A prerequisite for the import-mandatory phase of ADR-0096 (#1455) |
+| `checker/checker_stmt.vibe` | [#2294](https://github.com/mizchi/vibe-lang/pull/2294) | #2290 / #2292. After merge: #2293 |
+| `normalize/desugar_trait_dict.vibe`, `codegen/expr/compile_call.vibe`, `cli_adapter.vibe`, `cli_support.vibe`, `lsp/lsp_server.vibe`, fmt scripts | [#2296](https://github.com/mizchi/vibe-lang/pull/2296) | #2283, ADR-0068 opt-in, `vibe fmt` self-blame. CI is red (freeze-surface `Map::*` + `VIBE_UNSTABLE` selector). After merge: **P0 #2281**, then #2284 / #2285 / #2297 / #2280 |
 
-(#1525, the local-enum miscompile, was resolved by the parser rejection in
-`ab031d2` and is closed.)
+Independent of both PRs: Apache-2.0 relicense (this file's companion change),
+#2287 (re-export alias merge).
+
+### P0 — silently wrong (1)
+
+| # | wait for | what |
+|---|---|---|
+| #2281 | #2296 (`desugar_trait_dict.vibe`) | a parameterized alias wrapping a structural container (`type AL[V] = Array[V]`) loses structural `==` and answers by identity |
 
 ### P1 — crashes, or cannot be written (7)
 
-| # | blocker | what |
+| # | wait for | what |
 |---|---|---|
-| #1536 | ✔ | see-through in the suspend CPS split. Row-free closure param flow, eager `Stream::next` retarget, and direct if-condition / match-scrutinee are done. Remaining: row-variable callee, residual literal-param flow, compound selection input |
-| #1511 | | `handle`'s eligibility constraint slips past the type checker. (c) the error text is done; (b) is the same mechanism as a slice of #1536 |
-| #1520 | | validating the builtin registry. Proposal 1 is done; remaining: a bulk tidy of 85 double declarations plus proposal 3's positive-example corpus |
-| #1508 | | a test / bench that runs `Http`. The row syntax is done; remaining: `Http::*` lowering on the test/bench path |
-| #1514 | | diagnostic positions come in three tiers (C is done, the rest is not) |
-| #1446 | | accepting an abortive effect in a guard's else as divergence |
-| #1553 | | 2.6 GiB guest heap on a cold cache. Decided: set no target figure yet; per-phase measurement plus a 3.5 GiB watch comes first |
-
-(#1500 optional arguments and #1503 trait-instance resolution are implemented
-and closed; #1547 finalizers was settled as "not now" and closed.)
+| #2283 | in #2296 | a user-defined `assert_eq/2` is claimed by the builtin lowering |
+| #2284 | after #2296 | ADR-0068 opt-in scans only the entry; a sibling import bypasses it |
+| #2287 | free | `export ./dep.vibe { cmp as compare }` dies at codegen |
+| #2280 | after #2296 (`cli_adapter`) | `vibe check` cannot parse a `.vpkg` |
+| #2293 | after #2294 | two imports binding the same local name still last-win |
+| #2164 | after #2294 if it touches checker type names | contract transparent types have no provenance for typos |
+| #2199 | rides #1987 | OOB abort names operation/index/length; source provenance and the `[crash debug]` dump remain |
 
 ### P2 carrying blocker (the entrance to a subtree)
 
 | # | what it is holding up |
 |---|---|
-| #1541 | wasm-gc Phase C (#1542) / Phase D (#1543) |
-| #1548 | incremental P0-3 (#1550) |
-| #1549 | incremental P0-3 (#1550) |
-| #1550 | incremental P3 codegen reuse (#1552) |
+| #1959 | persist semantic module / SCC reuse (#1960) |
 
 ### epics (indexes, not things to work on)
 
-#1230 async / #1238 formal / #1262 RC and region / #1331 wasm-gc /
-#1341 ADR-0089 D3 / #1379 incremental
+#2002 docs audience / #2001 scripts layer / #2269 HKT / #1379 incremental
 
 ## How to use sub-issues
 
@@ -130,11 +128,11 @@ serially. Running across lanes is free.**
 
 | lane | file area | issues | notes |
 |---|---|---|---|
-| **A. checker/parser** | `lib/@vibe/compiler/checker/`, `parser/` | #1533; the check-phase detection of #1536(c) + #1511(b); #1520 proposal 3 | |
-| **B. codegen (linear)** | `codegen/expr/compile_call.vibe`, `builtin_bodies/` | #1527, #1529, #1526 (ADR-0097 decided), #1538-1 | compile_call is a shared point, so serialize within the lane |
-| **C. wasm-gc** | `codegen/gc/` | #1541 → #1542 | ADR-0095 structurally guarantees no conflict with linear |
-| **D. incremental/cache** | `runtime/typecheck_fs.vibe`, `cache/` | #1548 → #1549 → #1550 | |
-| **F. runtime/host** | `scripts/wasm_vibe_host_runner.js`, `runtime/viberun` | the measurement in #1553, #1540 | |
+| **A. checker type-env** | `checker/checker_stmt.vibe` | #2294, then #2293 / #2164 | serialize on `checker_stmt` |
+| **B. eq-shape / call / cli** | `normalize/desugar_trait_dict.vibe`, `codegen/expr/compile_call.vibe`, `cli_*.vibe` | #2296, then **#2281**, then #2284 / #2285 / #2297 / #2280 | P0 #2281 lives in `ty_to_eq_shape`; do not fork this file while #2296 is open |
+| **C. re-export merge** | `core/import_alias_rewrite.vibe`, merge | #2287 | independent of A and B |
+| **D. incremental/cache** | `runtime/typecheck_fs.vibe`, `cache/` | #1959 → #1960 | |
+| **F. runtime/host** | `runtime/viberun`, abort provenance | #2199 (rides #1987) | |
 
 Within a lane the order is blocker first, then by priority. An entry added to a
 gate script must always be **appended at the end** — inserting into the middle of

--- a/docs/issue-triage.md
+++ b/docs/issue-triage.md
@@ -61,10 +61,7 @@ edits.** Merge or land that PR first, then take the leftover.
 | occupied files | PR | what it is holding |
 |---|---|---|
 | `checker/checker_stmt.vibe` | [#2294](https://github.com/mizchi/vibe-lang/pull/2294) | #2290 / #2292. After merge: #2293 |
-| `normalize/desugar_trait_dict.vibe`, `codegen/expr/compile_call.vibe`, `cli_adapter.vibe`, `cli_support.vibe`, `lsp/lsp_server.vibe`, fmt scripts | [#2296](https://github.com/mizchi/vibe-lang/pull/2296) | #2283, ADR-0068 opt-in, `vibe fmt` self-blame. CI is red (freeze-surface `Map::*` + `VIBE_UNSTABLE` selector). After merge: **P0 #2281**, then #2284 / #2285 / #2297 / #2280 |
-
-Independent of both PRs: Apache-2.0 relicense (this file's companion change),
-#2287 (re-export alias merge).
+| `normalize/desugar_trait_dict.vibe`, `codegen/expr/compile_call.vibe`, `cli_adapter.vibe`, `cli_support.vibe`, `lsp/lsp_server.vibe`, `entry/source_compile/wasi_only/merge_sources.vibe`, fmt scripts | [#2296](https://github.com/mizchi/vibe-lang/pull/2296) | #2283, ADR-0068 opt-in, `vibe fmt` self-blame. CI is red (freeze-surface `Map::*` + `VIBE_UNSTABLE` selector). After merge: **P0 #2281**, then #2284 / #2285 / #2287 / #2297 / #2280 |
 
 ### P0 — silently wrong (1)
 
@@ -78,7 +75,7 @@ Independent of both PRs: Apache-2.0 relicense (this file's companion change),
 |---|---|---|
 | #2283 | in #2296 | a user-defined `assert_eq/2` is claimed by the builtin lowering |
 | #2284 | after #2296 | ADR-0068 opt-in scans only the entry; a sibling import bypasses it |
-| #2287 | free | `export ./dep.vibe { cmp as compare }` dies at codegen |
+| #2287 | after #2296 (`merge_sources.vibe`) | `export ./dep.vibe { cmp as compare }` dies at codegen |
 | #2280 | after #2296 (`cli_adapter`) | `vibe check` cannot parse a `.vpkg` |
 | #2293 | after #2294 | two imports binding the same local name still last-win |
 | #2164 | after #2294 if it touches checker type names | contract transparent types have no provenance for typos |
@@ -129,8 +126,7 @@ serially. Running across lanes is free.**
 | lane | file area | issues | notes |
 |---|---|---|---|
 | **A. checker type-env** | `checker/checker_stmt.vibe` | #2294, then #2293 / #2164 | serialize on `checker_stmt` |
-| **B. eq-shape / call / cli** | `normalize/desugar_trait_dict.vibe`, `codegen/expr/compile_call.vibe`, `cli_*.vibe` | #2296, then **#2281**, then #2284 / #2285 / #2297 / #2280 | P0 #2281 lives in `ty_to_eq_shape`; do not fork this file while #2296 is open |
-| **C. re-export merge** | `core/import_alias_rewrite.vibe`, merge | #2287 | independent of A and B |
+| **B. eq-shape / call / cli / merge** | `normalize/desugar_trait_dict.vibe`, `codegen/expr/compile_call.vibe`, `cli_*.vibe`, `merge_sources.vibe` | #2296, then **#2281**, then #2284 / #2285 / #2287 / #2297 / #2280 | P0 #2281 lives in `ty_to_eq_shape`; do not fork these files while #2296 is open |
 | **D. incremental/cache** | `runtime/typecheck_fs.vibe`, `cache/` | #1959 → #1960 | |
 | **F. runtime/host** | `runtime/viberun`, abort provenance | #2199 (rides #1987) | |
 

--- a/docs/release-notes-0.1.0.md
+++ b/docs/release-notes-0.1.0.md
@@ -126,6 +126,7 @@ the edit that fixes them rather than an internal pass name.
   SemVer stability for, and `pkf run check-freeze-surface` derives the symbol
   list from that document and probes each name against the compiler — a name it
   promises cannot quietly stop existing.
+- The project is licensed under Apache License 2.0.
 
 ## Known gaps
 
@@ -149,4 +150,5 @@ the edit that fixes them rather than an internal pass name.
 - [ ] `VIBE_VERSION` bumped from `0.1.0-dev` to `0.1.0`
       (`scripts/build_release_assets.sh` fails the build if it does not match
       the tag)
+- [ ] LICENSE is Apache-2.0 (not MIT)
 - [ ] `pkf run release-check` green on the tagged commit

--- a/docs/release-roadmap.md
+++ b/docs/release-roadmap.md
@@ -49,6 +49,8 @@ someone else's first hour, not about compiler internals:
    compiler (`pkf run check-freeze-surface`).
 5. **Editor integration** — `vibe lsp` plus the query primitives
    (`vibe check` / `symbols` / `type-at` / `binding-at` / `deps` / `grep`).
+6. **Apache License 2.0.** The `0.1.0` tag is the first release usable by
+   anyone but the author; it does not ship under MIT.
 
 ### What 0.2.0 holds
 

--- a/integrations/treesitter-vibe/package.json
+++ b/integrations/treesitter-vibe/package.json
@@ -2,7 +2,7 @@
   "name": "tree-sitter-vibe",
   "version": "0.1.0",
   "description": "Tree-sitter grammar for the Vibe programming language",
-  "license": "MIT",
+  "license": "Apache-2.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/mizchi/vibe-lang"

--- a/integrations/treesitter-vibe/tree-sitter.json
+++ b/integrations/treesitter-vibe/tree-sitter.json
@@ -11,7 +11,7 @@
   ],
   "metadata": {
     "version": "0.1.0",
-    "license": "MIT",
+    "license": "Apache-2.0",
     "description": "Tree-sitter grammar for the Vibe programming language",
     "authors": [
       {

--- a/integrations/vscode-vibe/package.json
+++ b/integrations/vscode-vibe/package.json
@@ -4,7 +4,7 @@
   "description": "Syntax highlighting and language support for the Vibe programming language",
   "version": "0.1.0",
   "publisher": "mizchi",
-  "license": "MIT",
+  "license": "Apache-2.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/mizchi/vibe-lang"


### PR DESCRIPTION
## Summary

- Replace the MIT `LICENSE` with Apache License 2.0 (copyright 2026 mizchi).
- Match reader-facing metadata: README, VS Code extension, tree-sitter grammar.
- Record Apache-2.0 on the 0.1.0 checklist and release roadmap.
- Rewrite `docs/issue-triage.md` applied state against the current open set so leftover work does not collide with #2294 / #2296.

The `0.1.0` tag is the first release usable by anyone but the author. It should not ship under MIT.

## Work order this pins (do not collide)

| lane | occupied by | next |
|---|---|---|
| `checker_stmt.vibe` | #2294 | #2293 |
| `desugar_trait_dict.vibe` / `compile_call.vibe` / CLI / `merge_sources.vibe` | #2296 (CI red) | **P0 #2281**, then #2284 / #2285 / #2287 / #2297 / #2280 |
| this PR | LICENSE / README / integrations / issue-triage | merge anytime |

P0 #2281 waits for #2296 because both edit `normalize/desugar_trait_dict.vibe`.
#2287 waits for #2296 because both edit `merge_sources.vibe`.