### PR TITLE
Expand aliases before structural `==` (#2281)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,8 +31,9 @@ but not yet implemented** (do not confuse them with today's behavior):
 structural `==` in every context (ADR-0097, #1526 — **measured 2026-08-19,
 no silent reference equality is left**. Bare, through a name, inside a tuple,
 inside a struct, nested arrays, `Array[String]` / `Array[(Int, Int)]` /
-`Array[Struct]`, through a function's return value, and empty-literal bindings
-are all structural, and a difference in length or in elements is `false`.
+`Array[Struct]`, through a function's return value, empty-literal bindings,
+and through a parameterized type alias (`type AL[V] = Array[V]` as `AL[Int]`,
+#2281) are all structural, and a difference in length or in elements is `false`.
 **An unannotated `let xs = []` is structural when the pushed value describes
 itself** (#2157, narrowed by #2192): the element type comes from the
 `Array::push(xs, v)` calls in the binding's own scope, and `v` is read from its

--- a/bench/perf/heap_baseline.txt
+++ b/bench/perf/heap_baseline.txt
@@ -213,4 +213,13 @@
 # analysis is intentional; copy CI's heap_ptr_bytes so the gate tracks the
 # new compiler rather than blocking a 0.06% miss. A later follow-up can
 # ratchet down if the walk is slimmed further.
-1165371696
+#
+# 2026-08-25 rebaseline (1165371696 -> 1282251440, +10.03%) on #2299:
+# the preceding PR commit already measured 1281905728 in the same CI gate,
+# only 3137 bytes below the old +10% ceiling, so nearly all growth is
+# pre-existing drift accumulated since #2076. The final fix adds 345712 bytes
+# (+0.027%) of compiled checker code to seed structural equality shapes for
+# nullary alias parameter annotations. This copies CI's byte-deterministic
+# measurement exactly; the functional change is covered by the 43-case
+# structural equality fixture.
+1282251440

--- a/docs/issue-triage.md
+++ b/docs/issue-triage.md
@@ -61,13 +61,14 @@ edits.** Merge or land that PR first, then take the leftover.
 | occupied files | PR | what it is holding |
 |---|---|---|
 | `checker/checker_stmt.vibe` | [#2294](https://github.com/mizchi/vibe-lang/pull/2294) | #2290 / #2292. After merge: #2293 |
-| `normalize/desugar_trait_dict.vibe`, `codegen/expr/compile_call.vibe`, `cli_adapter.vibe`, `cli_support.vibe`, `lsp/lsp_server.vibe`, `entry/source_compile/wasi_only/merge_sources.vibe`, fmt scripts | [#2296](https://github.com/mizchi/vibe-lang/pull/2296) | #2283, ADR-0068 opt-in, `vibe fmt` self-blame. CI is red (freeze-surface `Map::*` + `VIBE_UNSTABLE` selector). After merge: **P0 #2281**, then #2284 / #2285 / #2287 / #2297 / #2280 |
+| `normalize/desugar_trait_dict.vibe`, `codegen/expr/compile_call.vibe`, `cli_adapter.vibe`, `cli_support.vibe`, `lsp/lsp_server.vibe`, `entry/source_compile/wasi_only/merge_sources.vibe`, fmt scripts | [#2296](https://github.com/mizchi/vibe-lang/pull/2296) | #2283, ADR-0068 opt-in, `vibe fmt` self-blame. After merge: #2284 / #2285 / #2287 / #2297 / #2280 |
+| `ty_to_eq_shape` in `desugar_trait_dict.vibe` | [#2299](https://github.com/mizchi/vibe-lang/pull/2299) | P0 #2281. Does not conflict with #2296 (different region of the same file) |
 
 ### P0 — silently wrong (1)
 
 | # | wait for | what |
 |---|---|---|
-| #2281 | #2296 (`desugar_trait_dict.vibe`) | a parameterized alias wrapping a structural container (`type AL[V] = Array[V]`) loses structural `==` and answers by identity |
+| #2281 | in [#2299](https://github.com/mizchi/vibe-lang/pull/2299) | a parameterized alias wrapping a structural container (`type AL[V] = Array[V]`) loses structural `==` and answers by identity |
 
 ### P1 — crashes, or cannot be written (7)
 
@@ -126,7 +127,7 @@ serially. Running across lanes is free.**
 | lane | file area | issues | notes |
 |---|---|---|---|
 | **A. checker type-env** | `checker/checker_stmt.vibe` | #2294, then #2293 / #2164 | serialize on `checker_stmt` |
-| **B. eq-shape / call / cli / merge** | `normalize/desugar_trait_dict.vibe`, `codegen/expr/compile_call.vibe`, `cli_*.vibe`, `merge_sources.vibe` | #2296, then **#2281**, then #2284 / #2285 / #2287 / #2297 / #2280 | P0 #2281 lives in `ty_to_eq_shape`; do not fork these files while #2296 is open |
+| **B. eq-shape / call / cli / merge** | `normalize/desugar_trait_dict.vibe`, `codegen/expr/compile_call.vibe`, `cli_*.vibe`, `merge_sources.vibe` | #2299 (#2281, `ty_to_eq_shape`) and #2296 (assert_eq / opt-in / merge). Then #2284 / #2285 / #2287 / #2297 / #2280 | same file, different regions; merge-tree is clean |
 | **D. incremental/cache** | `runtime/typecheck_fs.vibe`, `cache/` | #1959 → #1960 | |
 | **F. runtime/host** | `runtime/viberun`, abort provenance | #2199 (rides #1987) | |
 

--- a/fixtures/structural_eq_contexts_test.vibe
+++ b/fixtures/structural_eq_contexts_test.vibe
@@ -50,6 +50,12 @@ enum AliasBox {
   Wrap(AL[Int])
 } derive (Eq)
 
+type FnInt = (Int) -> Int
+
+struct Cell[FnInt] {
+  value: FnInt
+} derive (Eq)
+
 fn make_array() -> Array[Int] {
   [1, 2]
 }
@@ -725,4 +731,20 @@ test "a struct field of a non-parameterized Array alias compares structurally" {
 test "an enum payload of a parameterized Array alias compares structurally" {
   assert(eq_ctx_wrap([1, 2, 3]) == eq_ctx_wrap([1, 2, 3]))
   assert(eq_ctx_wrap([1, 2, 3]) != eq_ctx_wrap([1, 2, 9]))
+}
+
+test "a generic parameter is not an incomparable alias of the same spelling" {
+  let xs = []
+  let ys = []
+  Array::push(xs, Cell[Int]::{
+    value: 1
+  })
+  Array::push(ys, Cell[Int]::{
+    value: 1
+  })
+  assert(xs == ys)
+  Array::push(ys, Cell[Int]::{
+    value: 2
+  })
+  assert(xs != ys)
 }

--- a/fixtures/structural_eq_contexts_test.vibe
+++ b/fixtures/structural_eq_contexts_test.vibe
@@ -32,6 +32,12 @@ enum Boxed {
   BoxedPoint(Point)
 } derive (Eq)
 
+// #2281: a parameterized alias wrapping a structural container used to keep
+// the alias head (`TyApp("AL", ...)`), so `==` fell back to identity.
+type AL[V] = Array[V]
+type SM[V] = StringMap[V]
+type A2 = Array[Int]
+
 fn make_array() -> Array[Int] {
   [1, 2]
 }
@@ -648,4 +654,32 @@ test "a declared name containing an underscore does not collide with an applicat
   let s2 = eq_ctx_named(5)
   assert(s1 == s2)
   assert(s1 != eq_ctx_named(9))
+}
+
+fn eq_ctx_al(xs: Array[Int]) -> AL[Int] {
+  xs
+}
+
+fn eq_ctx_sm(a: Int, b: Int) -> SM[Int] {
+  Map::from_pairs([("a", a), ("b", b)])
+}
+
+fn eq_ctx_a2(xs: Array[Int]) -> A2 {
+  xs
+}
+
+test "a parameterized alias around Array compares structurally" {
+  // #2281: `type AL[V] = Array[V]` used as `AL[Int]` must not identity-compare.
+  assert(eq_ctx_al([1, 2, 3]) == eq_ctx_al([1, 2, 3]))
+  assert(eq_ctx_al([1, 2, 3]) != eq_ctx_al([1, 2, 9]))
+}
+
+test "a parameterized alias around StringMap compares structurally" {
+  assert(eq_ctx_sm(1, 2) == eq_ctx_sm(1, 2))
+  assert(eq_ctx_sm(1, 2) != eq_ctx_sm(1, 9))
+}
+
+test "a non-parameterized alias around Array compares structurally" {
+  assert(eq_ctx_a2([1, 2]) == eq_ctx_a2([1, 2]))
+  assert(eq_ctx_a2([1, 2]) != eq_ctx_a2([1, 9]))
 }

--- a/fixtures/structural_eq_contexts_test.vibe
+++ b/fixtures/structural_eq_contexts_test.vibe
@@ -37,6 +37,7 @@ enum Boxed {
 type AL[V] = Array[V]
 type SM[V] = StringMap[V]
 type A2 = Array[Int]
+type SM2 = StringMap[Int]
 
 struct AliasHolder {
   xs: AL[Int]
@@ -686,20 +687,43 @@ fn eq_ctx_a2(xs: Array[Int]) -> A2 {
   xs
 }
 
+fn eq_ctx_same_a2(left: A2, right: A2) -> Bool {
+  left == right
+}
+
+fn eq_ctx_same_sm2(left: SM2, right: SM2) -> Bool {
+  left == right
+}
+
+fn eq_ctx_equality_snapshot(value: Bool) -> String {
+  if value {
+    "true"
+  } else {
+    "false"
+  }
+}
+
 test "a parameterized alias around Array compares structurally" {
   // #2281: `type AL[V] = Array[V]` used as `AL[Int]` must not identity-compare.
-  assert(eq_ctx_al([1, 2, 3]) == eq_ctx_al([1, 2, 3]))
-  assert(eq_ctx_al([1, 2, 3]) != eq_ctx_al([1, 2, 9]))
+  inspect(eq_ctx_equality_snapshot(eq_ctx_al([1, 2, 3]) == eq_ctx_al([1, 2, 3])), "true")
+  inspect(eq_ctx_equality_snapshot(eq_ctx_al([1, 2, 3]) != eq_ctx_al([1, 2, 9])), "true")
 }
 
 test "a parameterized alias around StringMap compares structurally" {
-  assert(eq_ctx_sm(1, 2) == eq_ctx_sm(1, 2))
-  assert(eq_ctx_sm(1, 2) != eq_ctx_sm(1, 9))
+  inspect(eq_ctx_equality_snapshot(eq_ctx_sm(1, 2) == eq_ctx_sm(1, 2)), "true")
+  inspect(eq_ctx_equality_snapshot(eq_ctx_sm(1, 2) != eq_ctx_sm(1, 9)), "true")
 }
 
 test "a non-parameterized alias around Array compares structurally" {
-  assert(eq_ctx_a2([1, 2]) == eq_ctx_a2([1, 2]))
-  assert(eq_ctx_a2([1, 2]) != eq_ctx_a2([1, 9]))
+  inspect(eq_ctx_equality_snapshot(eq_ctx_a2([1, 2]) == eq_ctx_a2([1, 2])), "true")
+  inspect(eq_ctx_equality_snapshot(eq_ctx_a2([1, 2]) != eq_ctx_a2([1, 9])), "true")
+}
+
+test "non-parameterized structural aliases on parameters compare structurally" {
+  inspect(eq_ctx_equality_snapshot(eq_ctx_same_a2([1, 2], [1, 2])), "true")
+  inspect(eq_ctx_equality_snapshot(eq_ctx_same_a2([1, 2], [1, 9])), "false")
+  inspect(eq_ctx_equality_snapshot(eq_ctx_same_sm2(eq_ctx_string_map(1, 2), eq_ctx_string_map(1, 2))), "true")
+  inspect(eq_ctx_equality_snapshot(eq_ctx_same_sm2(eq_ctx_string_map(1, 2), eq_ctx_string_map(1, 9))), "false")
 }
 
 fn eq_ctx_holder(xs: Array[Int]) -> AliasHolder {
@@ -719,18 +743,40 @@ fn eq_ctx_wrap(xs: Array[Int]) -> AliasBox {
 }
 
 test "a struct field of a parameterized Array alias compares structurally" {
-  assert(eq_ctx_holder([1, 2, 3]) == eq_ctx_holder([1, 2, 3]))
-  assert(eq_ctx_holder([1, 2, 3]) != eq_ctx_holder([1, 2, 9]))
+  inspect(eq_ctx_equality_snapshot(eq_ctx_holder([1, 2, 3]) == eq_ctx_holder([
+    1,
+    2,
+    3
+  ])), "true")
+  inspect(eq_ctx_equality_snapshot(eq_ctx_holder([1, 2, 3]) != eq_ctx_holder([
+    1,
+    2,
+    9
+  ])), "true")
 }
 
 test "a struct field of a non-parameterized Array alias compares structurally" {
-  assert(eq_ctx_holder_a2([1, 2]) == eq_ctx_holder_a2([1, 2]))
-  assert(eq_ctx_holder_a2([1, 2]) != eq_ctx_holder_a2([1, 9]))
+  inspect(eq_ctx_equality_snapshot(eq_ctx_holder_a2([1, 2]) == eq_ctx_holder_a2([
+    1,
+    2
+  ])), "true")
+  inspect(eq_ctx_equality_snapshot(eq_ctx_holder_a2([1, 2]) != eq_ctx_holder_a2([
+    1,
+    9
+  ])), "true")
 }
 
 test "an enum payload of a parameterized Array alias compares structurally" {
-  assert(eq_ctx_wrap([1, 2, 3]) == eq_ctx_wrap([1, 2, 3]))
-  assert(eq_ctx_wrap([1, 2, 3]) != eq_ctx_wrap([1, 2, 9]))
+  inspect(eq_ctx_equality_snapshot(eq_ctx_wrap([1, 2, 3]) == eq_ctx_wrap([
+    1,
+    2,
+    3
+  ])), "true")
+  inspect(eq_ctx_equality_snapshot(eq_ctx_wrap([1, 2, 3]) != eq_ctx_wrap([
+    1,
+    2,
+    9
+  ])), "true")
 }
 
 test "a generic parameter is not an incomparable alias of the same spelling" {
@@ -742,9 +788,9 @@ test "a generic parameter is not an incomparable alias of the same spelling" {
   Array::push(ys, Cell[Int]::{
     value: 1
   })
-  assert(xs == ys)
+  inspect(eq_ctx_equality_snapshot(xs == ys), "true")
   Array::push(ys, Cell[Int]::{
     value: 2
   })
-  assert(xs != ys)
+  inspect(eq_ctx_equality_snapshot(xs != ys), "true")
 }

--- a/fixtures/structural_eq_contexts_test.vibe
+++ b/fixtures/structural_eq_contexts_test.vibe
@@ -38,6 +38,18 @@ type AL[V] = Array[V]
 type SM[V] = StringMap[V]
 type A2 = Array[Int]
 
+struct AliasHolder {
+  xs: AL[Int]
+} derive (Eq)
+
+struct AliasHolderA2 {
+  xs: A2
+} derive (Eq)
+
+enum AliasBox {
+  Wrap(AL[Int])
+} derive (Eq)
+
 fn make_array() -> Array[Int] {
   [1, 2]
 }
@@ -682,4 +694,35 @@ test "a parameterized alias around StringMap compares structurally" {
 test "a non-parameterized alias around Array compares structurally" {
   assert(eq_ctx_a2([1, 2]) == eq_ctx_a2([1, 2]))
   assert(eq_ctx_a2([1, 2]) != eq_ctx_a2([1, 9]))
+}
+
+fn eq_ctx_holder(xs: Array[Int]) -> AliasHolder {
+  AliasHolder::{
+    xs: xs
+  }
+}
+
+fn eq_ctx_holder_a2(xs: Array[Int]) -> AliasHolderA2 {
+  AliasHolderA2::{
+    xs: xs
+  }
+}
+
+fn eq_ctx_wrap(xs: Array[Int]) -> AliasBox {
+  AliasBox::Wrap(xs)
+}
+
+test "a struct field of a parameterized Array alias compares structurally" {
+  assert(eq_ctx_holder([1, 2, 3]) == eq_ctx_holder([1, 2, 3]))
+  assert(eq_ctx_holder([1, 2, 3]) != eq_ctx_holder([1, 2, 9]))
+}
+
+test "a struct field of a non-parameterized Array alias compares structurally" {
+  assert(eq_ctx_holder_a2([1, 2]) == eq_ctx_holder_a2([1, 2]))
+  assert(eq_ctx_holder_a2([1, 2]) != eq_ctx_holder_a2([1, 9]))
+}
+
+test "an enum payload of a parameterized Array alias compares structurally" {
+  assert(eq_ctx_wrap([1, 2, 3]) == eq_ctx_wrap([1, 2, 3]))
+  assert(eq_ctx_wrap([1, 2, 3]) != eq_ctx_wrap([1, 2, 9]))
 }

--- a/lib/@vibe/compiler/normalize/desugar_trait_dict.vibe
+++ b/lib/@vibe/compiler/normalize/desugar_trait_dict.vibe
@@ -4251,7 +4251,22 @@ fn seed_var_types(params: Array[(String, Option[TypeExpr])], tparams: Array[Stri
   while i < Array::length(params) {
     let (pname, ann) = Array::get(params, i)
     match ann {
-      Some(TyName(tn)) => Array::push(out, (pname, tn)),
+      Some(TyName(tn)) => {
+        Array::push(out, (pname, tn))
+        // A nullary alias can hide a structural parameter type just as a
+        // TyApp annotation can. Preserve a same-spelled in-scope formal before
+        // expanding through the global alias table.
+        if !ty_mentions_name_in(TyName(tn), tparams) {
+          let esh = ty_to_eq_shape(TyName(tn))
+          if shape_is_composite(esh) {
+            Array::push(out, (eq_shape_key(pname), esh))
+          } else {
+            ()
+          }
+        } else {
+          ()
+        }
+      },
       // A generic struct annotation `x: LazyIter[T]` -> track the head name so
       // `for x in <param>` over a generic iterator type resolves (#636).
       // #1199 bug 1: for `x: Array[T]` specifically, ALSO record T under the

--- a/lib/@vibe/compiler/normalize/desugar_trait_dict.vibe
+++ b/lib/@vibe/compiler/normalize/desugar_trait_dict.vibe
@@ -8390,7 +8390,7 @@ fn eq_unsafe_types_fill(stmts: Array[Stmt]) -> Unit {
 /// a `Map` arm. It is admitted here for the same reason `Array` is: there is
 /// now a generated comparator that descends into it.
 fn eq_ty_field_is_content_comparable(t: TypeExpr, tparams: Array[String]) -> Bool {
-  match t {
+  match eq_expand_alias_ty(t) {
     TyName(n) => if str_array_contains(tparams, n) {
       // The owner's own type parameter is resolved by the concrete specialized
       // comparator, so it is not a declaration-level failure.
@@ -8847,7 +8847,7 @@ fn eq_for_typed(fty0: TypeExpr, lhs: Expr, rhs: Expr, known_types: Array[String]
   // seed_var_types / collect_fn_eq_return_shape), so today this subsumes the
   // Array-arm re-spelling; at generation time the scope stack is empty and
   // this is the identity.
-  let fty = subst_scope_formals_ty(fty0)
+  let fty = eq_expand_alias_ty(subst_scope_formals_ty(fty0))
   match fty {
     TyName(n) => if n == "__EqAliasCycle" {
       ESeq(ECall(EIdent("assert_true", -1), Array::slice([EBool(false)], 0, 1), -1), EBool(false))
@@ -9712,9 +9712,7 @@ fn ty_mentions_name_in(t: TypeExpr, names: Array[String]) -> Bool {
 /// (`shape_key`'s: Name / `(s1,..)` / `[s]` / "" unknown). Only shapes this
 /// pass can compare are produced; anything else collapses to "" (unknown).
 fn ty_to_eq_shape(t: TypeExpr) -> String {
-  // #2281: classify the alias body, not the alias head. `type AL[V] = Array[V]`
-  // used as `AL[Int]` is `TyApp("AL", ...)` and matched no structural arm, so
-  // `==` stayed raw identity. Expand first; a non-alias is a no-op.
+  // #2281: classify the alias body so AL[Int] is Array, not TyApp("AL", ...)
   match eq_expand_alias_ty(t) {
     TyName(n) => n,
     TyUnit => "{u}",

--- a/lib/@vibe/compiler/normalize/desugar_trait_dict.vibe
+++ b/lib/@vibe/compiler/normalize/desugar_trait_dict.vibe
@@ -9712,7 +9712,10 @@ fn ty_mentions_name_in(t: TypeExpr, names: Array[String]) -> Bool {
 /// (`shape_key`'s: Name / `(s1,..)` / `[s]` / "" unknown). Only shapes this
 /// pass can compare are produced; anything else collapses to "" (unknown).
 fn ty_to_eq_shape(t: TypeExpr) -> String {
-  match t {
+  // #2281: classify the alias body, not the alias head. `type AL[V] = Array[V]`
+  // used as `AL[Int]` is `TyApp("AL", ...)` and matched no structural arm, so
+  // `==` stayed raw identity. Expand first; a non-alias is a no-op.
+  match eq_expand_alias_ty(t) {
     TyName(n) => n,
     TyUnit => "{u}",
     TyTuple(ts) => if Array::length(ts) == 0 {
@@ -9841,7 +9844,7 @@ fn shape_to_eq_ty(sh: String) -> TypeExpr {
 /// two original heads for one release too long and said something false about
 /// the third; it is spelled by intent now.
 fn ty_needs_typed_eq(t: TypeExpr) -> Bool {
-  match t {
+  match eq_expand_alias_ty(t) {
     TyName(n) => n == "Bytes",
     TyApp(n, args) => if n == "Array" || n == "Map" || builtin_string_map_applied(n, args) || generic_eq_struct_declared(n) {
       true

--- a/lib/@vibe/compiler/normalize/desugar_trait_dict.vibe
+++ b/lib/@vibe/compiler/normalize/desugar_trait_dict.vibe
@@ -8390,7 +8390,20 @@ fn eq_unsafe_types_fill(stmts: Array[Stmt]) -> Unit {
 /// a `Map` arm. It is admitted here for the same reason `Array` is: there is
 /// now a generated comparator that descends into it.
 fn eq_ty_field_is_content_comparable(t: TypeExpr, tparams: Array[String]) -> Bool {
-  match eq_expand_alias_ty(t) {
+  // A field written as the owner's own parameter is not the same-spelled
+  // alias, even when one exists in the program (#2281).
+  match t {
+    TyName(n) => if str_array_contains(tparams, n) {
+      true
+    } else {
+      eq_ty_field_is_content_comparable_expanded(eq_expand_alias_ty(t), tparams)
+    },
+    _ => eq_ty_field_is_content_comparable_expanded(eq_expand_alias_ty(t), tparams)
+  }
+}
+
+fn eq_ty_field_is_content_comparable_expanded(t: TypeExpr, tparams: Array[String]) -> Bool {
+  match t {
     TyName(n) => if str_array_contains(tparams, n) {
       // The owner's own type parameter is resolved by the concrete specialized
       // comparator, so it is not a declaration-level failure.
@@ -9712,8 +9725,7 @@ fn ty_mentions_name_in(t: TypeExpr, names: Array[String]) -> Bool {
 /// (`shape_key`'s: Name / `(s1,..)` / `[s]` / "" unknown). Only shapes this
 /// pass can compare are produced; anything else collapses to "" (unknown).
 fn ty_to_eq_shape(t: TypeExpr) -> String {
-  // #2281: classify the alias body so AL[Int] is Array, not TyApp("AL", ...)
-  match eq_expand_alias_ty(t) {
+  match eq_expand_alias_ty(subst_scope_formals_ty(t)) {
     TyName(n) => n,
     TyUnit => "{u}",
     TyTuple(ts) => if Array::length(ts) == 0 {
@@ -9842,7 +9854,7 @@ fn shape_to_eq_ty(sh: String) -> TypeExpr {
 /// two original heads for one release too long and said something false about
 /// the third; it is spelled by intent now.
 fn ty_needs_typed_eq(t: TypeExpr) -> Bool {
-  match eq_expand_alias_ty(t) {
+  match eq_expand_alias_ty(subst_scope_formals_ty(t)) {
     TyName(n) => n == "Bytes",
     TyApp(n, args) => if n == "Array" || n == "Map" || builtin_string_map_applied(n, args) || generic_eq_struct_declared(n) {
       true

--- a/lib/@vibe/compiler/normalize/desugar_trait_dict.vibe
+++ b/lib/@vibe/compiler/normalize/desugar_trait_dict.vibe
@@ -7547,6 +7547,14 @@ fn is_marked_formal_name(n: String) -> Bool {
 /// with a declaration's own tparams at the derive-generation sites (where the
 /// declaration IS the scope).
 fn subst_formals_ty(ty: TypeExpr, formals: Array[String]) -> TypeExpr {
+  if Array::length(formals) == 0 {
+    ty
+  } else {
+    subst_formals_ty_body(ty, formals)
+  }
+}
+
+fn subst_formals_ty_body(ty: TypeExpr, formals: Array[String]) -> TypeExpr {
   match ty {
     TyName(n) => if str_array_contains(formals, n) {
       TyName(mark_formal_name(n))
@@ -9098,8 +9106,60 @@ fn eq_subst_ty(ty: TypeExpr, params: Array[String], args: Array[TypeExpr]) -> Ty
   }
 }
 
+fn eq_alias_name_exists(name: String) -> Bool {
+  let mut i = 0
+  let mut found = false
+  while i < Array::length(dtd_eq_type_aliases) {
+    if Array::get(dtd_eq_type_aliases, i).0 == name {
+      found = true
+    } else {
+      ()
+    }
+    i = i + 1
+  }
+  found
+}
+
+fn eq_ty_mentions_alias(ty: TypeExpr) -> Bool {
+  match ty {
+    TyName(name) => eq_alias_name_exists(name),
+    TyApp(head, args) => if eq_alias_name_exists(head) {
+      true
+    } else {
+      eq_tys_mention_alias(args)
+    },
+    TyFn(params, result, _) => if eq_tys_mention_alias(params) {
+      true
+    } else {
+      eq_ty_mentions_alias(result)
+    },
+    TyTuple(items) => eq_tys_mention_alias(items),
+    TyUnit => false
+  }
+}
+
+fn eq_tys_mention_alias(ts: Array[TypeExpr]) -> Bool {
+  let mut i = 0
+  let mut found = false
+  while i < Array::length(ts) {
+    if eq_ty_mentions_alias(Array::get(ts, i)) {
+      found = true
+    } else {
+      ()
+    }
+    i = i + 1
+  }
+  found
+}
+
 fn eq_expand_alias_ty(ty: TypeExpr) -> TypeExpr {
-  eq_expand_alias_ty_seen(ty, array_empty())
+  if Array::length(dtd_eq_type_aliases) == 0 {
+    ty
+  } else if !eq_ty_mentions_alias(ty) {
+    ty
+  } else {
+    eq_expand_alias_ty_seen(ty, array_empty())
+  }
 }
 
 fn eq_expand_alias_ty_seen(ty: TypeExpr, seen: Array[String]) -> TypeExpr {
@@ -9725,7 +9785,11 @@ fn ty_mentions_name_in(t: TypeExpr, names: Array[String]) -> Bool {
 /// (`shape_key`'s: Name / `(s1,..)` / `[s]` / "" unknown). Only shapes this
 /// pass can compare are produced; anything else collapses to "" (unknown).
 fn ty_to_eq_shape(t: TypeExpr) -> String {
-  match eq_expand_alias_ty(subst_scope_formals_ty(t)) {
+  ty_to_eq_shape_expanded(eq_expand_alias_ty(subst_scope_formals_ty(t)))
+}
+
+fn ty_to_eq_shape_expanded(t: TypeExpr) -> String {
+  match t {
     TyName(n) => n,
     TyUnit => "{u}",
     TyTuple(ts) => if Array::length(ts) == 0 {
@@ -9734,7 +9798,7 @@ fn ty_to_eq_shape(t: TypeExpr) -> String {
       let mut acc = "("
       let mut i = 0
       while i < Array::length(ts) {
-        let sub = ty_to_eq_shape(Array::get(ts, i))
+        let sub = ty_to_eq_shape_expanded(Array::get(ts, i))
         acc = if i == 0 {
           String::concat(acc, sub)
         } else {
@@ -9745,24 +9809,24 @@ fn ty_to_eq_shape(t: TypeExpr) -> String {
       String::concat(acc, ")")
     },
     TyApp(n, args) => if n == "Array" && Array::length(args) == 1 {
-      String::concat("[", String::concat(ty_to_eq_shape(Array::get(args, 0)), "]"))
+      String::concat("[", String::concat(ty_to_eq_shape_expanded(Array::get(args, 0)), "]"))
     } else if n == "Option" && Array::length(args) == 1 {
-      String::concat("{o:", String::concat(ty_to_eq_shape(Array::get(args, 0)), "}"))
+      String::concat("{o:", String::concat(ty_to_eq_shape_expanded(Array::get(args, 0)), "}"))
     } else if n == "Result" && Array::length(args) == 2 {
-      String::concat("{r:", String::concat(ty_to_eq_shape(Array::get(args, 0)), String::concat(",", String::concat(ty_to_eq_shape(Array::get(args, 1)), "}"))))
+      String::concat("{r:", String::concat(ty_to_eq_shape_expanded(Array::get(args, 0)), String::concat(",", String::concat(ty_to_eq_shape_expanded(Array::get(args, 1)), "}"))))
     } else if builtin_string_map_applied(n, args) {
-      String::concat("{m:String,", String::concat(ty_to_eq_shape(Array::get(args, 0)), "}"))
+      String::concat("{m:String,", String::concat(ty_to_eq_shape_expanded(Array::get(args, 0)), "}"))
     } else if n == "Map" && Array::length(args) == 2 {
       // #2218: a Map shape, so an ANNOTATED binding (`let m: Map[String, Int]`)
       // or a typed parameter reaches `eq_for_typed`'s Map arm the same way an
       // `Array[T]` one reaches its Array arm. Without this the type is known
       // and the answer still came from the raw `==`.
-      String::concat("{m:", String::concat(ty_to_eq_shape(Array::get(args, 0)), String::concat(",", String::concat(ty_to_eq_shape(Array::get(args, 1)), "}"))))
+      String::concat("{m:", String::concat(ty_to_eq_shape_expanded(Array::get(args, 0)), String::concat(",", String::concat(ty_to_eq_shape_expanded(Array::get(args, 1)), "}"))))
     } else if Array::length(args) > 0 {
       let mut acc = String::concat("{g:", n)
       let mut i = 0
       while i < Array::length(args) {
-        acc = String::concat(acc, String::concat(",", ty_to_eq_shape(Array::get(args, i))))
+        acc = String::concat(acc, String::concat(",", ty_to_eq_shape_expanded(Array::get(args, i))))
         i = i + 1
       }
       String::concat(acc, "}")
@@ -9854,7 +9918,11 @@ fn shape_to_eq_ty(sh: String) -> TypeExpr {
 /// two original heads for one release too long and said something false about
 /// the third; it is spelled by intent now.
 fn ty_needs_typed_eq(t: TypeExpr) -> Bool {
-  match eq_expand_alias_ty(subst_scope_formals_ty(t)) {
+  ty_needs_typed_eq_expanded(eq_expand_alias_ty(subst_scope_formals_ty(t)))
+}
+
+fn ty_needs_typed_eq_expanded(t: TypeExpr) -> Bool {
+  match t {
     TyName(n) => n == "Bytes",
     TyApp(n, args) => if n == "Array" || n == "Map" || builtin_string_map_applied(n, args) || generic_eq_struct_declared(n) {
       true
@@ -9862,7 +9930,7 @@ fn ty_needs_typed_eq(t: TypeExpr) -> Bool {
       let mut i = 0
       let mut found = false
       while i < Array::length(args) {
-        if ty_needs_typed_eq(Array::get(args, i)) {
+        if ty_needs_typed_eq_expanded(Array::get(args, i)) {
           found = true
         } else {
           ()
@@ -9875,7 +9943,7 @@ fn ty_needs_typed_eq(t: TypeExpr) -> Bool {
       let mut i = 0
       let mut found = false
       while i < Array::length(ts) {
-        if ty_needs_typed_eq(Array::get(ts, i)) {
+        if ty_needs_typed_eq_expanded(Array::get(ts, i)) {
           found = true
         } else {
           ()


### PR DESCRIPTION
## Summary

- expand alias bodies before structural equality classification
- preserve in-scope type formals before alias expansion
- seed equality shapes for nullary structural aliases used as parameter types
- cover parameterized and nullary Array/StringMap aliases, derived fields, enum payloads, and same-spelled formals with inspect snapshots

Fixes #2281.

## Why P0

The program runs and answers. An alias-wrapped structural container compared by identity while the direct container spelling compared by content.

## Validation

- Red: nullary alias parameters compared equal arrays as false
- Green: structural_eq_contexts_test.vibe 43/43 with a fresh stage2
- changed-file formatter checks
- review-regressions AST lint
- selfcompile heap: 1281905728 before the final fix -> 1282251440 (+345712, +0.027%); baseline updated because the branch was already 3137 bytes below the old +10% ceiling

## Collision

#2296 also edits desugar_trait_dict.vibe, but only the assert_eq lowering. This change is in equality-shape classification and parameter seeding; git merge-tree reports no conflict.