### PR TITLE
The ADR-0068 gate covers the resolved closure, not just the entry

### DIFF
--- a/lib/@vibe/compiler/cli_adapter.vibe
+++ b/lib/@vibe/compiler/cli_adapter.vibe
@@ -110,9 +110,10 @@ import ./cli_support.vibe {
   check_deprecated_warnings_from_source_groups,
   check_linked_file_source_groups,
   check_redundant_import_warnings_from_source_groups,
+  check_unstable_surface_warnings_from_closure,
   check_unstable_surface_warnings_from_path,
-  check_unstable_surface_warnings_from_source_groups,
   strip_executable_wasm_env,
+  unstable_closure_reset,
   unstable_surface_diagnostics,
   verify_culprit_off_marker_fs_fail_closed
 }
@@ -1245,6 +1246,9 @@ export fn cli_main() -> Int with Exception + Fs + Env + Stdin + Stdout {
       // This has no cache behavior: it only makes the successful walk carry
       // a canonical public-interface observation into the requested sidecar.
       set_incremental_interface_trace_enabled(invalidation_trace_out != "")
+      // #2284: the closure record is filled by the loader during this call,
+      // and read by the gate below. Reset first so it describes THIS check.
+      unstable_closure_reset()
       let checked_source_groups = check_linked_file_source_groups(input_path)
       if telemetry_out != "" {
         Fs::write_file(telemetry_out, incremental_typecheck_telemetry_json())
@@ -1312,7 +1316,7 @@ export fn cli_main() -> Int with Exception + Fs + Env + Stdin + Stdout {
       let unstable_warns = if Env::get("VIBE_UNSTABLE") == "1" {
         adapter_no_warnings()
       } else {
-        check_unstable_surface_warnings_from_source_groups(input_path, checked_source_groups)
+        check_unstable_surface_warnings_from_closure()
       }
       if Array::length(unstable_warns) > 0 {
         return emit_compile_diag(output_path, Array::get(unstable_warns, 0))
@@ -1346,7 +1350,11 @@ export fn cli_main() -> Int with Exception + Fs + Env + Stdin + Stdout {
       // "two verbs, two answers" defect #1567 fixed for check/diagnostics, and
       // it is worse here because the accepting verb is the one that ships.
       // `VIBE_UNSTABLE=1` opts in.
-      let fs_unstable = if Env::get("VIBE_UNSTABLE") == "1" {
+      let unstable_opt_in = Env::get("VIBE_UNSTABLE") == "1"
+      // The entry's own import, rejected before any compile work is done. The
+      // closure check below is the complete one; this one keeps the common
+      // rejection fast.
+      let fs_unstable = if unstable_opt_in {
         adapter_no_warnings()
       } else {
         check_unstable_surface_warnings_from_path(input_path)
@@ -1356,6 +1364,11 @@ export fn cli_main() -> Int with Exception + Fs + Env + Stdin + Stdout {
       } else {
         ()
       }
+      // #2284: the loader records every module of the resolved closure as it
+      // ingests it, so the complete answer is only available AFTER the compile
+      // has loaded them. Reset here so the record describes THIS compile --
+      // the unit-test batch runs many compiles in one daemon.
+      unstable_closure_reset()
       let artifact_input_trace_nonce = Env::get("VIBE_ARTIFACT_INPUT_TRACE_NONCE")
       // debugger trace (DAP P1 groundwork): `vibe run --trace` sets VIBE_DEBUG=1
       // so the user file (and its imports) is compiled with function-call
@@ -1435,6 +1448,21 @@ export fn cli_main() -> Int with Exception + Fs + Env + Stdin + Stdout {
         })
       } else {
         maybe_wrap_stdin_provider_core(core_bytes, entry_name)
+      }
+      // #2284: gate before the ARTIFACT, not before the compile. The entry
+      // pre-check above cannot see a sibling that carries the import, and the
+      // closure is only known once the loader has walked it. A rejected build
+      // wastes the compile, which is the right trade for not paying a second
+      // full traversal on every build.
+      let closure_unstable = if unstable_opt_in {
+        adapter_no_warnings()
+      } else {
+        check_unstable_surface_warnings_from_closure()
+      }
+      if Array::length(closure_unstable) > 0 {
+        return emit_compile_diag(output_path, Array::get(closure_unstable, 0))
+      } else {
+        ()
       }
       Fs::write_bytes(output_path, out_bytes)
       // #1553: this observes the executable-strip + primary-output boundary.

--- a/lib/@vibe/compiler/cli_adapter.vibe
+++ b/lib/@vibe/compiler/cli_adapter.vibe
@@ -763,7 +763,8 @@ fn adapter_serve_component(input_path: String, output_path: String) -> Int with 
     // DEPLOYABLE component while `vibe check` rejected the identical file
     // (#2277 review). An artifact-producing verb that accepts what the check
     // verb refuses is the worst direction for that disagreement to run.
-    let serve_unstable = if Env::get("VIBE_UNSTABLE") == "1" {
+    let serve_opt_in = Env::get("VIBE_UNSTABLE") == "1"
+    let serve_unstable = if serve_opt_in {
       adapter_no_warnings()
     } else {
       check_unstable_surface_warnings_from_path(input_path)
@@ -773,12 +774,34 @@ fn adapter_serve_component(input_path: String, output_path: String) -> Int with 
     } else {
       ()
     }
+    // #2284: the entry check above cannot see a MODULE the handler imports, and
+    // the closure is only known once the loader has walked it -- so reset here
+    // and re-ask below, before the component is written. `vibe serve` needs its
+    // own copy of that discipline because it returns before the FS-compile
+    // branch that carries the other one (#2302 review).
+    unstable_closure_reset()
     let entry_stmts = parse_program(lex(Fs::read_file(input_path)))
     validate_serve_handler(entry_stmts)
     // No command entry: the component surface is `handler`. `__no_entry__`
     // is the explicit sentinel — any other unknown entry name is a compile
     // error since ADR-0069.
     let core = compile_file_fs_mode(input_path, "__no_entry__", "no-dce")
+    // The complete answer, from the closure that compile actually loaded, and
+    // BEFORE the component is emitted. Placement matters: emitting first let
+    // the handler-purity check speak instead -- an unstable dependency drags
+    // in `vibe.sleep`, so the reader was told the handler is impure rather
+    // than that the dependency needs an opt-in. The gate has to win over the
+    // diagnostics that are downstream consequences of it (#2302 review).
+    let serve_closure_unstable = if serve_opt_in {
+      adapter_no_warnings()
+    } else {
+      check_unstable_surface_warnings_from_closure()
+    }
+    if Array::length(serve_closure_unstable) > 0 {
+      return emit_compile_diag(output_path, Array::get(serve_closure_unstable, 0))
+    } else {
+      ()
+    }
     // #1540 scope 4: a `body: HostStream` handler goes down the stream lane
     // (async lift + a component `stream<u8>` param) so it can read the body
     // as it arrives; everything else keeps the sync lift and the collected

--- a/lib/@vibe/compiler/cli_support.vibe
+++ b/lib/@vibe/compiler/cli_support.vibe
@@ -13,7 +13,7 @@ import @vibe/compiler/codegen/common_base {
 }
 
 import @vibe/compiler/core {
-  Stmt, is_contract_ext
+  Stmt, is_contract_ext, unstable_package_note
 }
 
 import @vibe/compiler/checker {
@@ -33,7 +33,7 @@ import @vibe/compiler/entry/compiler/file_compile {
 }
 
 import @vibe/compiler/loader {
-  collect_source_groups_fs, ingest_source_text_fs, ingestion_pipeline_telemetry_add
+  collect_source_groups_fs, ingest_source_text_fs, ingestion_pipeline_telemetry_add, unstable_candidates, unstable_candidates_reset
 }
 
 // #897: package-form import (wasi_only/ is now an index.vpkg boundary) --
@@ -708,13 +708,6 @@ fn checked_warning_stmts(input_path: String, source: String) -> Option[Array[Stm
 /// NOT here -- ADR-0012 is accepted and `with Async` ships in builtin
 /// signatures a user can reach (`StdinStream::next`). The unstable part is
 /// the concurrency model built on top, not the row vocabulary.
-fn unstable_package_note(name: String) -> String {
-  if name == "@vibe/concurrent" || String::starts_with(name, "@vibe/concurrent/") {
-    "set VIBE_UNSTABLE=1 to build against `@vibe/concurrent`, or drop the import. It is ADR-0068, still proposed: outside the SemVer promise and able to change within a Minor release, so it is opt-in rather than silent (docs/spec/stable-surface.md section 6). The `Async` effect itself is stable and needs no opt-in -- only this package's concurrency model does."
-  } else {
-    ""
-  }
-}
 
 /// Byte offset of the `import` keyword that introduces `pkg`, or -1.
 ///
@@ -908,6 +901,54 @@ export fn unstable_surface_diagnostics_located(input_path: String, detected: Str
 /// produced the diagnostic, pinned produced none. That is the two-verbs-
 /// disagree defect this gate exists to prevent, reintroduced by reading the
 /// file a different way than the build reads it (#2277 review).
+/// The CLOSURE lane: every module the compile actually loaded, not just the
+/// entry (#2284).
+///
+/// The entry-only scan let a sibling carry the import -- `main.vibe` importing
+/// `./worker.vibe`, with the concurrency in `worker.vibe`, is the normal shape
+/// of a project, so the boundary was absent for exactly the structure it most
+/// needed to cover. Measured before this: that two-file program built an
+/// artifact and checked clean with no opt-in.
+///
+/// The loader records candidates as it ingests (`unstable_candidates`), so this
+/// costs no extra traversal -- the alternative, calling `collect_source_groups_fs`
+/// a second time, was measured as a 1.1% self-compile heap regression that put
+/// the selfcompile KPI over its ceiling.
+///
+/// Each candidate is confirmed by the same token scan the entry lane uses, so a
+/// module that merely MENTIONS the package in a comment yields nothing. The
+/// diagnostic names the file that actually spells the import, which is the edit
+/// point even when that file is a dependency the reader did not write --
+/// `VIBE_UNSTABLE=1` stays the escape hatch either way.
+export fn check_unstable_surface_warnings_from_closure() -> Array[String] with Exception + Fs {
+  let out = array_empty()
+  let candidates = unstable_candidates()
+  let mut i = 0
+  while i < Array::length(candidates) {
+    let (path, ingested) = Array::get(candidates, i)
+    let located = handle {
+      Fs::read_file(path)
+    } with { Exception::Throw(_) => ingested }
+    let diags = handle {
+      unstable_surface_diagnostics_located(path, ingested, located)
+    } with { Exception::Throw(_) => array_empty() }
+    let mut j = 0
+    while j < Array::length(diags) {
+      Array::push(out, String::concat(path, String::concat(": ", Array::get(diags, j))))
+      j = j + 1
+    }
+    i = i + 1
+  }
+  out
+}
+
+/// Clear the record before a compile. The unit-test batch compiles many files
+/// in one long-lived daemon, so a record left standing would report a previous
+/// file's dependency against the next one.
+export fn unstable_closure_reset() -> Unit {
+  unstable_candidates_reset()
+}
+
 export fn check_unstable_surface_warnings_from_path(input_path: String) -> Array[String] with Exception + Fs {
   handle {
     unstable_surface_diagnostics_located(input_path, ingest_source_text_fs(input_path, Fs::read_file(input_path)), Fs::read_file(input_path))
@@ -915,32 +956,6 @@ export fn check_unstable_surface_warnings_from_path(input_path: String) -> Array
   // An unreadable or uningestable entry is the compile's error to report, in
   // its own words.
   Exception::Throw(_) => array_empty() }
-}
-
-/// The CHECK lane's entry point: reuses the snapshot the linked check already
-/// collected, so it costs a lookup rather than a second traversal.
-export fn check_unstable_surface_warnings_from_source_groups(input_path: String, source_groups: Array[(String, Array[(String, String)])]) -> Array[String] with Exception + Fs {
-  // NOT `checked_entry_source`: that deliberately hands back the PHYSICAL file
-  // when the loader prepended inherited `.vpkg` imports, which is right for
-  // ordinary warnings and wrong for this verdict -- an inherited
-  // `@vibe/concurrent` would be invisible here and rejected by the build. The
-  // verdict comes from the same ingestion the build uses; only the position
-  // comes from the file's own bytes.
-  //
-  // And the snapshot, not a fresh read. Re-reading the entry evaluated text the
-  // check never saw: a save landing between the linked check and this call
-  // could remove the import and be reported clean, or add one the check never
-  // validated (#2277 review).
-  let detected = match checked_entry_snapshot(input_path, source_groups) {
-    Some(snapshot) => snapshot,
-    // No unique snapshot means nothing here was checked for this path. The
-    // build lane still gates it; inventing a verdict from disk would answer
-    // about text this check never consumed.
-    None => return array_empty()
-  }
-  handle {
-    unstable_surface_diagnostics_located(input_path, detected, Fs::read_file(input_path))
-  } with { Exception::Throw(_) => array_empty() }
 }
 
 /// Redundant import warnings derived from the exact source snapshot consumed

--- a/lib/@vibe/compiler/compiler_sources_manifest.tsv
+++ b/lib/@vibe/compiler/compiler_sources_manifest.tsv
@@ -24,6 +24,7 @@ core	core/types.vibe
 core	core/dce.vibe
 core	core/expr_children.vibe
 core	core/exception_effect.vibe
+core	core/unstable_surface.vibe
 core	core/builtin_name.vibe
 core	core/standard_effect_policy.vibe
 core	core/sorted_index.vibe

--- a/lib/@vibe/compiler/core/core.vibe
+++ b/lib/@vibe/compiler/core/core.vibe
@@ -34,6 +34,10 @@ export ./dce.vibe {
   dce_keep_flags, dce_stmts
 }
 
+export ./unstable_surface.vibe {
+  text_mentions_unstable_package, unstable_package_name, unstable_package_note
+}
+
 export ./expr_children.vibe {
   expr_children
 }

--- a/lib/@vibe/compiler/core/index.vpkg
+++ b/lib/@vibe/compiler/core/index.vpkg
@@ -122,6 +122,11 @@ type EnvValueBinding
 // --- expr_children
 fn expr_children(expr: Expr) -> Array[Expr]
 
+// --- unstable_surface
+let unstable_package_name: String
+fn unstable_package_note(name: String) -> String
+fn text_mentions_unstable_package(text: String) -> Bool
+
 // --- builtin_name
 fn canonical_builtin_name(name: String) -> String
 fn builtin_deprecated_message(name: String) -> Option[String]

--- a/lib/@vibe/compiler/core/unstable_surface.vibe
+++ b/lib/@vibe/compiler/core/unstable_surface.vibe
@@ -1,0 +1,38 @@
+//# The ADR-0068 unstable-surface rule, in one place (#2248, #2284)
+//
+// `@vibe/concurrent` is `proposed`: outside the SemVer promise and able to
+// change inside a Minor release, so importing it requires `VIBE_UNSTABLE=1`.
+//
+// Two passes need this rule and they sit on opposite sides of the import
+// graph, which is why it lives in core rather than beside either one:
+//
+//   - `loader.vibe` needs the NAME, as a cheap substring pre-filter while it
+//     ingests each module of the resolved closure (#2284). It cannot import
+//     `cli_support.vibe`, which is above it.
+//   - `cli_support.vibe` needs the NOTE, for the diagnostic it emits after the
+//     precise token scan confirms a real `SImport`.
+//
+// One spelling. The pre-filter deliberately over-matches -- a comment
+// mentioning the package counts -- because the verdict is the token scan's,
+// never the substring's.
+
+/// The package whose surface is opt-in. Subpaths count: `@vibe/concurrent/x`
+/// is the same surface.
+export let unstable_package_name: String = "@vibe/concurrent"
+
+/// The diagnostic for an import of that package, or "" for any other name.
+/// Leads with the edit that fixes it, per the CLI policy: set the variable, or
+/// drop the import.
+export fn unstable_package_note(name: String) -> String {
+  if name == unstable_package_name || String::starts_with(name, String::concat(unstable_package_name, "/")) {
+    "set VIBE_UNSTABLE=1 to build against `@vibe/concurrent`, or drop the import. It is ADR-0068, still proposed: outside the SemVer promise and able to change within a Minor release, so it is opt-in rather than silent (docs/spec/stable-surface.md section 6). The `Async` effect itself is stable and needs no opt-in -- only this package's concurrency model does."
+  } else {
+    ""
+  }
+}
+
+/// Whether a module's text could possibly carry such an import. Cheap and
+/// deliberately loose -- the caller confirms with a token scan.
+export fn text_mentions_unstable_package(text: String) -> Bool {
+  String::index_of(text, unstable_package_name) >= 0
+}

--- a/lib/@vibe/compiler/index.vpkg
+++ b/lib/@vibe/compiler/index.vpkg
@@ -520,7 +520,8 @@ fn check_deprecated_warnings_from_source_groups(input_path: String, source_group
 fn check_redundant_import_warnings(input_path: String) -> Array[String] with Exception + Fs
 fn check_redundant_import_warnings_from_source_groups(input_path: String, source_groups: Array[(String, Array[(String, String)])]) -> Array[String] with Exception + Fs
 fn check_unstable_surface_warnings_from_path(input_path: String) -> Array[String] with Exception + Fs
-fn check_unstable_surface_warnings_from_source_groups(input_path: String, source_groups: Array[(String, Array[(String, String)])]) -> Array[String] with Exception + Fs
+fn check_unstable_surface_warnings_from_closure() -> Array[String] with Exception + Fs
+fn unstable_closure_reset() -> Unit
 fn unstable_surface_diagnostics(input_path: String, source: String) -> Array[String] with Exception
 fn unstable_surface_diagnostics_located(input_path: String, detected: String, located: String) -> Array[String] with Exception
 fn strip_executable_wasm(wasm: Bytes, entry_name: String, strip_names: Bool, filter_exports: Bool) -> Bytes

--- a/lib/@vibe/compiler/loader/index.vpkg
+++ b/lib/@vibe/compiler/loader/index.vpkg
@@ -97,6 +97,8 @@ fn ingestion_pipeline_telemetry_json(nonce: String) -> String
 
 // --- loader.vibe
 fn resolution_context_fingerprint_fs() -> String with Exception + Fs
+fn unstable_candidates_reset() -> Unit
+fn unstable_candidates() -> Array[(String, String)]
 fn ingest_source_text_fs(path: String, raw: String) -> String with Exception + Fs
 fn load_persistent_source_group_fingerprint_if_valid(entry_path: String) -> Option[String] with Exception + Fs
 // Narrow trace-only access to persistent_resolution_context_fingerprint_fs

--- a/lib/@vibe/compiler/loader/loader.vibe
+++ b/lib/@vibe/compiler/loader/loader.vibe
@@ -34,6 +34,7 @@ import @vibe/compiler/core {
   resolve_import_path,
   resolve_import_path_candidates,
   resolve_import_path_probe,
+  text_mentions_unstable_package,
   vibe_env_flag,
   vpkg_path_in_dir
 }
@@ -1289,9 +1290,43 @@ fn apply_vpkg_directory_shared_imports_fs(path: String, pin_blanked: String) -> 
   }
 }
 
+/// #2284: every on-disk module of the resolved closure passes through
+/// `ingest_source_text_fs`, so this is the one place the WHOLE closure can be
+/// observed without a second traversal. The ADR-0068 gate used to read the
+/// entry file alone, which meant moving `import @vibe/concurrent` into a
+/// sibling bypassed it -- and `main.vibe` calling `./worker.vibe` is the
+/// normal shape of a project, so the boundary was missing for exactly the
+/// structure it most needed to cover.
+///
+/// Only a cheap substring test happens here; the VERDICT is the token scan's,
+/// in `cli_support.vibe`. Over-matching is fine and expected -- roughly ten
+/// compiler files merely MENTION the package in a comment -- because a
+/// candidate that carries no real `SImport` produces no diagnostic.
+///
+/// Reset per compilation by the adapter. That matters: the unit-test batch
+/// compiles many files in one long-lived daemon, so a record left standing
+/// would report a previous file's dependency against the next one.
+let unstable_candidate_cell: Array[(String, String)] = array_empty()
+
+export fn unstable_candidates_reset() -> Unit {
+  Array::truncate(unstable_candidate_cell, 0)
+}
+
+export fn unstable_candidates() -> Array[(String, String)] {
+  unstable_candidate_cell
+}
+
+fn record_unstable_candidate(path: String, ingested: String) -> Unit {
+  if text_mentions_unstable_package(ingested) {
+    Array::push(unstable_candidate_cell, (path, ingested))
+  } else {
+    ()
+  }
+}
+
 export fn ingest_source_text_fs(path: String, raw: String) -> String with Exception + Fs {
   let (_, pin_blanked) = extract_require_pins(raw)
-  if is_contract_ext(path) {
+  let ingested = if is_contract_ext(path) {
     if String::starts_with(pin_blanked, contract_facade_marker) {
       pin_blanked
     } else {
@@ -1300,6 +1335,8 @@ export fn ingest_source_text_fs(path: String, raw: String) -> String with Except
   } else {
     apply_vpkg_directory_shared_imports_fs(path, pin_blanked)
   }
+  record_unstable_candidate(path, ingested)
+  ingested
 }
 
 /// #740: manifest source loaders (manifest_sources.vibe) read RAW disk bytes;

--- a/tests/gates/late/run.sh
+++ b/tests/gates/late/run.sh
@@ -6512,6 +6512,77 @@ if [ ! -s "$uwdir/plain2/main.wasm" ]; then
   exit 1
 fi
 
+# `vibe serve` needs its own copy of the closure gate: it returns before the
+# FS-compile branch that carries the other one, so a handler whose DEPENDENCY
+# imports the package emitted a deployable component with no opt-in (#2302
+# review).
+#
+# Placement is asserted too, not just rejection. The gate runs before the
+# component is emitted, because an unstable dependency drags in `vibe.sleep`
+# and the handler-purity check would otherwise speak first -- telling the
+# reader their handler is impure rather than that the dependency needs an
+# opt-in. A gate must win over the diagnostics that are downstream of it.
+mkdir -p "$uwdir/srv"
+cat > "$uwdir/srv/dep.vibe" <<'UWEOF'
+import @vibe/concurrent {
+  TaskGroup
+}
+
+export fn helper() -> Int with Exception {
+  TaskGroup::run((n) -> {
+    0
+  })
+}
+UWEOF
+cat > "$uwdir/srv/h.vibe" <<'UWEOF'
+import ./dep.vibe {
+  helper
+}
+
+export fn handler(method: String, url: String, headers: String, body: String) -> String {
+  "ok"
+}
+UWEOF
+rm -f "$uwdir/srv/c.wasm" "$uwdir/srv/c.wasm.diag"
+env -u VIBE_UNSTABLE VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_IMPORT_ABI=raw VIBE_SERVE_COMPONENT=1 \
+  bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
+  "$uwdir/srv/h.vibe" "$uwdir/srv/c.wasm" __no_entry__ >/dev/null 2>&1 || true
+if [ -s "$uwdir/srv/c.wasm" ]; then
+  echo "[compiler-gate] FAIL: vibe serve emitted a component whose dependency imports the unstable package (#2284)" >&2
+  exit 1
+fi
+if ! grep -qF 'VIBE_UNSTABLE=1' "$uwdir/srv/c.wasm.diag" 2>/dev/null; then
+  echo "[compiler-gate] FAIL: vibe serve refused the handler for the wrong reason -- the gate must outrank the purity check (#2302)" >&2
+  cat "$uwdir/srv/c.wasm.diag" 2>/dev/null >&2 || true
+  exit 1
+fi
+if ! grep -qF 'dep.vibe' "$uwdir/srv/c.wasm.diag" 2>/dev/null; then
+  echo "[compiler-gate] FAIL: the serve diagnostic named the handler, not the file that spells the import (#2284)" >&2
+  cat "$uwdir/srv/c.wasm.diag" 2>/dev/null >&2 || true
+  exit 1
+fi
+# With the opt-in the gate stands down -- whatever happens next is not its say.
+rm -f "$uwdir/srv/optin.wasm" "$uwdir/srv/optin.wasm.diag"
+VIBE_UNSTABLE=1 VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_IMPORT_ABI=raw VIBE_SERVE_COMPONENT=1 \
+  bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
+  "$uwdir/srv/h.vibe" "$uwdir/srv/optin.wasm" __no_entry__ >/dev/null 2>&1 || true
+if grep -qF 'VIBE_UNSTABLE=1' "$uwdir/srv/optin.wasm.diag" 2>/dev/null; then
+  echo "[compiler-gate] FAIL: VIBE_UNSTABLE=1 did not clear the serve closure gate (#2302)" >&2
+  cat "$uwdir/srv/optin.wasm.diag" 2>/dev/null >&2 || true
+  exit 1
+fi
+# ...and an ordinary handler is untouched.
+printf 'export fn handler(method: String, url: String, headers: String, body: String) -> String {\n  "ok"\n}\n' > "$uwdir/srv/plain.vibe"
+rm -f "$uwdir/srv/plain.wasm" "$uwdir/srv/plain.wasm.diag"
+env -u VIBE_UNSTABLE VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_IMPORT_ABI=raw VIBE_SERVE_COMPONENT=1 \
+  bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
+  "$uwdir/srv/plain.vibe" "$uwdir/srv/plain.wasm" __no_entry__ >/dev/null 2>&1 || true
+if [ ! -s "$uwdir/srv/plain.wasm" ]; then
+  echo "[compiler-gate] FAIL: the serve closure gate refused an ordinary handler (#2302)" >&2
+  cat "$uwdir/srv/plain.wasm.diag" 2>/dev/null >&2 || true
+  exit 1
+fi
+
 rm -rf "$uwdir"
 echo "[compiler-gate] ADR-0068 opt-in gate: check + build + serve + single-source + closure + repeated-import + package-re-export + buffer(text+json+column) + whitespace + comment + multiline + pinned-require ok (#2248, #2277)"
 fmtdir="_build/_gate_vibe_fmt"

--- a/tests/gates/late/run.sh
+++ b/tests/gates/late/run.sh
@@ -6444,8 +6444,76 @@ if ! grep -qF 'line 3:1: set VIBE_UNSTABLE=1' "$uwdir/twice.out" 2>/dev/null; th
   cat "$uwdir/twice.out" 2>/dev/null >&2 || true
   exit 1
 fi
+# The import may sit in a SIBLING, and that is the normal shape of a project --
+# `main.vibe` calling `./worker.vibe` with the concurrency in the worker. The
+# entry-only scan missed exactly that: measured before the fix, this two-file
+# program BUILT an artifact and checked clean with no opt-in (#2284).
+#
+# The diagnostic must name the file that actually spells the import, not the
+# entry -- otherwise the reader is sent to a file with nothing wrong in it.
+mkdir -p "$uwdir/sib"
+cat > "$uwdir/sib/worker.vibe" <<'UWEOF'
+import @vibe/concurrent {
+  TaskGroup
+}
+
+export fn run_all() -> Int with Exception {
+  TaskGroup::run((n) -> {
+    0
+  })
+}
+UWEOF
+cat > "$uwdir/sib/main.vibe" <<'UWEOF'
+import ./worker.vibe {
+  run_all
+}
+
+fn main() -> Int with Exception {
+  run_all()
+}
+UWEOF
+uw_build "$uwdir/sib/main.vibe" "$uwdir/sib/main.wasm"
+if [ -s "$uwdir/sib/main.wasm" ]; then
+  echo "[compiler-gate] FAIL: a sibling file carried the unstable import past the gate (#2284)" >&2
+  exit 1
+fi
+if ! grep -qF 'VIBE_UNSTABLE=1' "$uwdir/sib/main.wasm.diag" 2>/dev/null; then
+  echo "[compiler-gate] FAIL: the sibling import was refused for the wrong reason (#2284)" >&2
+  cat "$uwdir/sib/main.wasm.diag" 2>/dev/null >&2 || true
+  exit 1
+fi
+if ! grep -qF 'worker.vibe' "$uwdir/sib/main.wasm.diag" 2>/dev/null; then
+  echo "[compiler-gate] FAIL: the diagnostic named the entry, not the file that spells the import (#2284)" >&2
+  cat "$uwdir/sib/main.wasm.diag" 2>/dev/null >&2 || true
+  exit 1
+fi
+uw_build "$uwdir/sib/main.vibe" "$uwdir/sib/optin.wasm" VIBE_UNSTABLE=1
+if [ ! -s "$uwdir/sib/optin.wasm" ]; then
+  echo "[compiler-gate] FAIL: VIBE_UNSTABLE=1 did not let the sibling case build (#2284)" >&2
+  cat "$uwdir/sib/optin.wasm.diag" 2>/dev/null >&2 || true
+  exit 1
+fi
+# `vibe check` must agree -- the whole point is that the two verbs answer alike.
+uw_sib_out="$(uw_check "$uwdir/sib/main.vibe" || true)"
+if ! printf '%s\n' "$uw_sib_out" | grep -qF 'VIBE_UNSTABLE=1'; then
+  echo "[compiler-gate] FAIL: vibe check accepted a sibling-carried unstable import (#2284)" >&2
+  printf '%s\n' "$uw_sib_out" >&2
+  exit 1
+fi
+# ...and an ordinary two-file program is untouched, or the closure scan is
+# simply refusing everything with a dependency.
+mkdir -p "$uwdir/plain2"
+printf 'export fn helper() -> Int {\n  7\n}\n' > "$uwdir/plain2/dep.vibe"
+printf 'import ./dep.vibe {\n  helper\n}\n\nfn main() -> Int {\n  helper()\n}\n' > "$uwdir/plain2/main.vibe"
+uw_build "$uwdir/plain2/main.vibe" "$uwdir/plain2/main.wasm"
+if [ ! -s "$uwdir/plain2/main.wasm" ]; then
+  echo "[compiler-gate] FAIL: the closure scan refused an ordinary two-file program (#2284)" >&2
+  cat "$uwdir/plain2/main.wasm.diag" 2>/dev/null >&2 || true
+  exit 1
+fi
+
 rm -rf "$uwdir"
-echo "[compiler-gate] ADR-0068 opt-in gate: check + build + serve + single-source + repeated-import + package-re-export + buffer(text+json+column) + whitespace + comment + multiline + pinned-require ok (#2248, #2277)"
+echo "[compiler-gate] ADR-0068 opt-in gate: check + build + serve + single-source + closure + repeated-import + package-re-export + buffer(text+json+column) + whitespace + comment + multiline + pinned-require ok (#2248, #2277)"
 fmtdir="_build/_gate_vibe_fmt"
 rm -rf "$fmtdir"; mkdir -p "$fmtdir"
 printf 'let   add=(a:Int,b:Int)->Int{a+b}\n' > "$fmtdir/messy.vibe"


### PR DESCRIPTION
Closes #2284.

## The bypass

The ADR-0068 gate read the **entry file alone**, so moving the import one file over went straight past it:

```
main.vibe    -> import ./worker.vibe { run_all }
worker.vibe  -> import @vibe/concurrent { TaskGroup }   // uses it
```

Measured before this change, on a stage2 from `ce51c49a`: that program **built an artifact and checked clean** with no opt-in, while the same import written in the entry was rejected.

This is not an adversarial shape. Putting the concurrency in `worker.vibe` and calling it from `main.vibe` is what anyone would write, so the boundary was absent for exactly the structure it most needed to cover.

## Why it was entry-only, and why the obvious fixes are wrong

Fixing only the check lane would make the **build** the permissive verb — the worse direction of the same "two verbs, two answers" defect the gate exists to prevent. And covering the build lane by calling `collect_source_groups_fs` a second time is what an earlier round of #2277 already tried: it parses every reachable file again, measured as a **1.1% self-compile heap regression** that put the selfcompile KPI over its +10% ceiling.

## Fused into the load instead

- **`loader.vibe`** records `(path, ingested)` for any module whose ingested text mentions the package, inside `ingest_source_text_fs` — the single funnel all four collection branches already converge on. A substring test per module, **no extra traversal**. Deliberately loose: about ten compiler files merely *mention* the package in a comment, and they cost nothing because the verdict is the token scan's.
- **`cli_support.vibe`** confirms each candidate with the same parsed-`SImport` scan the entry lane uses, and the diagnostic names **the file that actually spells the import** rather than the entry — otherwise the reader is sent to a file with nothing wrong in it.
- **the adapter** resets the record before each load and consults it before writing the artifact. That inverts "gate before any compile work" into "gate before any **artifact**": a rejected build wastes the compile, which is the right trade for not paying a second traversal on every build. The entry pre-check stays, so the common rejection is still early.

The reset is load-bearing, not hygiene: the unit-test batch compiles many files in one long-lived daemon, and a record left standing would report a previous file's dependency against the next one.

The rule itself moves to `core/unstable_surface.vibe` — the loader needs the package **name** and cannot import `cli_support`, which sits above it. One spelling for both.

## Measured after, all through the same stage2

| case | result |
|---|---|
| build, sibling import, no opt-in | rejected, naming `worker.vibe:1:1` |
| build, sibling import, `VIBE_UNSTABLE=1` | builds |
| check, sibling import, no opt-in | rejects |
| check, sibling import, `VIBE_UNSTABLE=1` | clean |
| build, ordinary two-file program | builds |

Gate 108 pins all five, including that the diagnostic names `worker.vibe` and not the entry.

## Scope decision

A dependency's own use of the package gates the consumer too. The alternative — only gating relative imports the author owns — leaves a real bypass through any wrapper package, and the diagnostic stays actionable either way because it names the offending file and `VIBE_UNSTABLE=1` is always the escape hatch.

## Verification

`ensure_generated` → `generations.sh build --stage3` → `cmp stage2 stage3` → **`FIXPOINT_OK`**; `compiler_gate.sh` running with the new gate cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GbtLER6wNT4jsZEN1Zp6xe

---
_Generated by [Claude Code](https://claude.ai/code/session_01GbtLER6wNT4jsZEN1Zp6xe)_