### PR TITLE
Reject duplicate import value bindings (#2293)

### DIFF
--- a/fixtures/err_import_duplicate_value_binding.vibe
+++ b/fixtures/err_import_duplicate_value_binding.vibe
@@ -1,6 +1,9 @@
-// #2127 leftover: two imports binding the same local name. The second is
-// ignored, so `abs(-1)` typechecks and then dies as a top-level expression.
-import @vibe/builtin { abs }
-import @vibe/builtin { clamp as abs }
+// #2293: two imports binding the same local name is a duplicate declaration.
+import @vibe/builtin {
+  abs
+}
+import @vibe/builtin {
+  clamp as abs
+}
 
 abs(-1)

--- a/fixtures/typecheck/expected.tsv
+++ b/fixtures/typecheck/expected.tsv
@@ -467,6 +467,6 @@ map_future_key_reject	reject	the builtin map is String-keyed
 map_mutmap_key_reject	reject	the builtin map is String-keyed
 err_import_missing_symbol_ref	reject	not a valid import spec
 err_import_missing_version_ref	reject	not a valid import spec
-err_import_duplicate_value_binding	reject	top-level expressions are not allowed
+err_import_duplicate_value_binding	reject	duplicate declaration: abs
 err_type_recursive_without_return_type	reject	lambda parameter `n` needs a type
 err_type_trait_impl_func_label_mismatch	reject	expected type name after 'for'

--- a/lib/@vibe/compiler/checker/checker_stmt.vibe
+++ b/lib/@vibe/compiler/checker/checker_stmt.vibe
@@ -776,10 +776,15 @@ fn duplicate_import_value_note(seen: Array[String], item: ImportItem, errors: Ar
     ()
   } else {
     let local = import_bound_name(item)
-    if name_is_type_head(local) {
-      ()
-    } else {
-      duplicate_value_decl_note(seen, local, errors)
+    // Unaliased PascalCase is the unkinded type-head form (`import { HashMap }`).
+    // An alias is a value local even when it is PascalCase (`abs as Abs`).
+    match item.alias {
+      Some(_) => duplicate_value_decl_note(seen, local, errors),
+      None => if name_is_type_head(local) {
+        ()
+      } else {
+        duplicate_value_decl_note(seen, local, errors)
+      }
     }
   }
 }

--- a/lib/@vibe/compiler/checker/checker_stmt.vibe
+++ b/lib/@vibe/compiler/checker/checker_stmt.vibe
@@ -746,18 +746,60 @@ fn duplicate_value_decl_note(seen: Array[String], dname: String, errors: Array[S
   }
 }
 
+fn import_bound_name(item: ImportItem) -> String {
+  match item.alias {
+    Some(a) => a,
+    None => item.name
+  }
+}
+
+fn import_item_is_value_binding(item: ImportItem) -> Bool {
+  match item.kind {
+    None => true,
+    Some(_) => false
+  }
+}
+
+fn name_is_type_head(n: String) -> Bool {
+  if String::length(n) == 0 {
+    false
+  } else if String::contains(n, "::") {
+    false
+  } else {
+    let c = String::char_code_at(n, 0)
+    c >= 65 && c <= 90
+  }
+}
+
+fn duplicate_import_value_note(seen: Array[String], item: ImportItem, errors: Array[String]) -> Unit {
+  if !import_item_is_value_binding(item) {
+    ()
+  } else {
+    let local = import_bound_name(item)
+    if name_is_type_head(local) {
+      ()
+    } else {
+      duplicate_value_decl_note(seen, local, errors)
+    }
+  }
+}
+
 fn duplicate_value_decl_errors(stmts: Array[Stmt], from_idx: Int, errors: Array[String]) -> Unit {
-  let seen = array_empty()
+  let let_seen = array_empty()
+  let import_seen = array_empty()
   let mut i = from_idx
   while i < Array::length(stmts) {
     match Array::get(stmts, i) {
-      SLet(_, _, n, _, _) => duplicate_value_decl_note(seen, n, errors),
-      SLetMut(n, _, _) => duplicate_value_decl_note(seen, n, errors),
-      SExternLet(n, _) => duplicate_value_decl_note(seen, n, errors),
-      // Import/import last-win (#2127) is leftover: a same-block duplicate
-      // (`emit_arith_wrap_int` twice) and PascalCase type heads across a
-      // contract import are not the last-win hole, and mixing SImport into
-      // this set broke the compiler self-check. Track only value lets here.
+      SLet(_, _, n, _, _) => duplicate_value_decl_note(let_seen, n, errors),
+      SLetMut(n, _, _) => duplicate_value_decl_note(let_seen, n, errors),
+      SExternLet(n, _) => duplicate_value_decl_note(let_seen, n, errors),
+      SImport(_, items) => {
+        let mut j = 0
+        while j < Array::length(items) {
+          duplicate_import_value_note(import_seen, Array::get(items, j), errors)
+          j = j + 1
+        }
+      },
       _ => ()
     }
     i = i + 1

--- a/lib/@vibe/compiler/codegen/expr/compile_expr_tail.vibe
+++ b/lib/@vibe/compiler/codegen/expr/compile_expr_tail.vibe
@@ -45,7 +45,6 @@ import @vibe/compiler/codegen/common_base {
   agg_ret_lookup,
   agg_slot_lookup,
   emit_arith_wrap_int,
-  emit_arith_wrap_int,
   emit_binop_op,
   emit_heap_grow_after_heap_set,
   emit_i32_eq,

--- a/lib/@vibe/compiler/codegen/wasi/linked_compile.vibe
+++ b/lib/@vibe/compiler/codegen/wasi/linked_compile.vibe
@@ -167,7 +167,6 @@ import @vibe/compiler/codegen/common_base {
   emit_i32_ne,
   emit_i32_sub,
   emit_i64_load,
-  emit_i64_store,
   emit_rc_dup_guarded,
   emit_str_ref,
   empty_dbg_prov,

--- a/lib/@vibe/compiler/tests/import_ref_debt_test.vibe
+++ b/lib/@vibe/compiler/tests/import_ref_debt_test.vibe
@@ -47,6 +47,11 @@ test "#2293: a PascalCase type head is not a value-import duplicate" {
   assert(!String::contains(check_source_error_message(source), "duplicate declaration: HashMap"))
 }
 
+test "#2293: a PascalCase value alias is still a duplicate" {
+  let source = "import @vibe/builtin { abs as Abs }\nimport @vibe/builtin { clamp as Abs }\nAbs(-1)\n"
+  inspect(check_source_error_message(source), "duplicate declaration: Abs")
+}
+
 test "current import of ref_lib_export keeps add(value, 2) as 9" {
   inspect(add(value, 2), "9")
 }

--- a/lib/@vibe/compiler/tests/import_ref_debt_test.vibe
+++ b/lib/@vibe/compiler/tests/import_ref_debt_test.vibe
@@ -27,14 +27,24 @@ test "stale version@fixture import is rejected" {
   assert(String::contains(msg, "not a valid import spec"))
 }
 
-test "#2127 leftover: two imports binding the same name still last-win" {
+test "#2293: two imports binding the same name are a duplicate" {
   let source = "import @vibe/builtin { abs }\nimport @vibe/builtin { clamp as abs }\nabs(-1)\n"
-  assert(!String::contains(check_source_error_message(source), "duplicate declaration: abs"))
+  inspect(check_source_error_message(source), "duplicate declaration: abs")
 }
 
-test "#2127 leftover: an import and a local fn of the same name are not a duplicate" {
+test "#2293: two same-arity imports binding the same name are still a duplicate" {
+  let source = "import @vibe/builtin { abs }\nimport @vibe/builtin { abs as abs }\nfn main { abs(-1) }\n"
+  inspect(check_source_error_message(source), "duplicate declaration: abs")
+}
+
+test "#2293: an import and a local fn of the same name are not a duplicate" {
   let source = "import @vibe/core { array_empty }\nfn array_empty() -> Int { 0 }\n"
   assert(!String::contains(check_source_error_message(source), "duplicate declaration: array_empty"))
+}
+
+test "#2293: a PascalCase type head is not a value-import duplicate" {
+  let source = "import @vibe/core { type HashMap }\nimport @vibe/core { type HashMap }\nfn main { 0 }\n"
+  assert(!String::contains(check_source_error_message(source), "duplicate declaration: HashMap"))
 }
 
 test "current import of ref_lib_export keeps add(value, 2) as 9" {

--- a/lib/@vibe/compiler/tests/type_db_cross_module_test.vibe
+++ b/lib/@vibe/compiler/tests/type_db_cross_module_test.vibe
@@ -1001,26 +1001,41 @@ test "projected checker does not let builtin assert_eq claim a re-export alias" 
   inspect(String::contains(message, "unknown name: assert_eq"), "true")
 }
 
-test "projected checker root keeps path and source-order winners with cached payloads" {
+test "projected checker root keeps path with cached payloads" {
   let first_path = "workspace/first.vibe"
   let second_path = "workspace/second.vibe"
   let shared_source = "export let value = 1\nexport let other = 2"
   let first_env = env_cache(checked_test_env(shared_source))
   let second_env = env_cache(checked_test_env(shared_source))
-  let source = "import ./first.vibe { value as firstCopy, value as chosen, other as clash }\nimport ./second.vibe { value as secondCopy, value as chosen }\nimport ./first.vibe { value as clash }"
+  let source = "import ./first.vibe { value as firstCopy, other as otherCopy }\nimport ./second.vibe { value as secondCopy }"
   let checked = projected_checked_env(source, "workspace/main.vibe", [
     first_path,
-    second_path,
-    first_path
+    second_path
   ], [(first_path, first_env), (second_path, second_env)])
-  match (env_lookup(checked, "chosen"), env_lookup(checked, "clash")) {
-    (Some(CtInt), Some(CtInt)) => (),
+  match (env_lookup(checked, "firstCopy"), env_lookup(checked, "secondCopy"), env_lookup(checked, "otherCopy")) {
+    (Some(CtInt), Some(CtInt), Some(CtInt)) => (),
     _ => assert(false)
   }
   assert_module_origin(checked, "firstCopy", first_path, "value")
   assert_module_origin(checked, "secondCopy", second_path, "value")
-  assert_module_origin(checked, "chosen", second_path, "value")
-  assert_module_origin(checked, "clash", first_path, "value")
+  assert_module_origin(checked, "otherCopy", first_path, "other")
+}
+
+test "projected checker rejects two imports binding the same local" {
+  let first_path = "workspace/first.vibe"
+  let second_path = "workspace/second.vibe"
+  let shared_source = "export let value = 1"
+  let first_env = env_cache(checked_test_env(shared_source))
+  let second_env = env_cache(checked_test_env(shared_source))
+  let source = "import ./first.vibe { value as chosen }\nimport ./second.vibe { value as chosen }"
+  let message = handle {
+    let _ = projected_checked_env(source, "workspace/main.vibe", [
+      first_path,
+      second_path
+    ], [(first_path, first_env), (second_path, second_env)])
+    ""
+  } with { Exception::Throw(msg) => msg }
+  assert(String::contains(message, "duplicate declaration: chosen"))
 }
 
 test "projected checker root local hoist shadows imports while generic replay stays legacy" {


### PR DESCRIPTION
## Summary

- Count **import value** locals in their own seen-set (`duplicate_value_decl_errors`). Do not mix them with `SLet`.
- Skip kind-qualified items and PascalCase type heads.
- `import { abs }` plus `fn abs` is still not a duplicate.
- Two imports binding `abs` (`clamp as abs`) now report `duplicate declaration: abs`.

Fixes #2293.

## Why the previous attempt failed

#2291 mixed `SImport` into the let set. That flagged last-win and also `import X` + `fn X`, PascalCase type heads, and a same-list `emit_arith_wrap_int` duplicate.

## Compiler-source cleanup this check required

- `compile_expr_tail.vibe`: `emit_arith_wrap_int` listed twice in one import.
- `linked_compile.vibe`: `emit_i64_store` imported from both `common_base` and `wasm_emit` (last-win was wasm_emit; the two helpers emit the same opcode).

## Tests

`VIBE_TEST_CLI_WASM=_build/selfhost/generations/2293b/stage2.wasm bash scripts/vibe_test.sh lib/@vibe/compiler/tests/import_ref_debt_test.vibe` — 8 passed.