### PR TITLE
Keep re-export aliases out of local scope

### DIFF
--- a/lib/@vibe/ast/ast_eq_test.vibe
+++ b/lib/@vibe/ast/ast_eq_test.vibe
@@ -371,7 +371,7 @@ fn stmt_tag(v: Stmt) -> Int {
     SExport(_) => 14,
     SReExport(_, _) => 15,
     SAliasDecl(_, _) => 16,
-    SReExportAliasBlockers(_) => 17,
+    SReExportLocalBlockers(_) => 17,
     SQualifiedPatternRefs(_) => 18,
     STestEffectRows(_) => 19,
     SLetPat(_, _) => 20,
@@ -409,7 +409,7 @@ fn every_stmt() -> Array[Stmt] {
       ImportItem::{ kind: Some(ImportStruct), name: "n", alias: Some("a") }
     ]),
     SAliasDecl("s", "s"),
-    SReExportAliasBlockers(["s"]),
+    SReExportLocalBlockers(["s"]),
     SQualifiedPatternRefs([("a", "b")]),
     STestEffectRows([("a", "b")]),
     SLetPat(PWild, EUnit),
@@ -453,7 +453,7 @@ fn every_stmt_same() -> Array[Stmt] {
       ImportItem::{ kind: Some(ImportStruct), name: "n", alias: Some("a") }
     ]),
     SAliasDecl("s", "s"),
-    SReExportAliasBlockers(["s"]),
+    SReExportLocalBlockers(["s"]),
     SQualifiedPatternRefs([("a", "b")]),
     STestEffectRows([("a", "b")]),
     SLetPat(PWild, EUnit),
@@ -494,7 +494,7 @@ fn every_stmt_alt() -> Array[Stmt] {
       ImportItem::{ kind: Some(ImportEnum), name: "o", alias: Some("b") }
     ]),
     SAliasDecl("t", "t"),
-    SReExportAliasBlockers(["t"]),
+    SReExportLocalBlockers(["t"]),
     SQualifiedPatternRefs([("c", "d")]),
     STestEffectRows([("c", "d")]),
     SLetPat(PBind("z"), EInt(9)),

--- a/lib/@vibe/ast/ast_eq_test.vibe
+++ b/lib/@vibe/ast/ast_eq_test.vibe
@@ -371,7 +371,7 @@ fn stmt_tag(v: Stmt) -> Int {
     SExport(_) => 14,
     SReExport(_, _) => 15,
     SAliasDecl(_, _) => 16,
-    SReExportLocalBlockers(_) => 17,
+    SReExportSourceBoundary(_, _) => 17,
     SQualifiedPatternRefs(_) => 18,
     STestEffectRows(_) => 19,
     SLetPat(_, _) => 20,
@@ -409,7 +409,7 @@ fn every_stmt() -> Array[Stmt] {
       ImportItem::{ kind: Some(ImportStruct), name: "n", alias: Some("a") }
     ]),
     SAliasDecl("s", "s"),
-    SReExportLocalBlockers(["s"]),
+    SReExportSourceBoundary(["s"], ["a"]),
     SQualifiedPatternRefs([("a", "b")]),
     STestEffectRows([("a", "b")]),
     SLetPat(PWild, EUnit),
@@ -453,7 +453,7 @@ fn every_stmt_same() -> Array[Stmt] {
       ImportItem::{ kind: Some(ImportStruct), name: "n", alias: Some("a") }
     ]),
     SAliasDecl("s", "s"),
-    SReExportLocalBlockers(["s"]),
+    SReExportSourceBoundary(["s"], ["a"]),
     SQualifiedPatternRefs([("a", "b")]),
     STestEffectRows([("a", "b")]),
     SLetPat(PWild, EUnit),
@@ -494,7 +494,7 @@ fn every_stmt_alt() -> Array[Stmt] {
       ImportItem::{ kind: Some(ImportEnum), name: "o", alias: Some("b") }
     ]),
     SAliasDecl("t", "t"),
-    SReExportLocalBlockers(["t"]),
+    SReExportSourceBoundary(["t"], ["b"]),
     SQualifiedPatternRefs([("c", "d")]),
     STestEffectRows([("c", "d")]),
     SLetPat(PBind("z"), EInt(9)),

--- a/lib/@vibe/ast/ast_eq_test.vibe
+++ b/lib/@vibe/ast/ast_eq_test.vibe
@@ -371,14 +371,15 @@ fn stmt_tag(v: Stmt) -> Int {
     SExport(_) => 14,
     SReExport(_, _) => 15,
     SAliasDecl(_, _) => 16,
-    SQualifiedPatternRefs(_) => 17,
-    STestEffectRows(_) => 18,
-    SLetPat(_, _) => 19,
-    SModule(_, _, _) => 20,
-    SEffectDef(_, _, _, _) => 21,
-    SEffectSet(_, _, _) => 22,
-    SResource(_, _) => 23,
-    SFnDecl(_, _, _, _, _) => 24
+    SReExportAliasBlockers(_) => 17,
+    SQualifiedPatternRefs(_) => 18,
+    STestEffectRows(_) => 19,
+    SLetPat(_, _) => 20,
+    SModule(_, _, _) => 21,
+    SEffectDef(_, _, _, _) => 22,
+    SEffectSet(_, _, _) => 23,
+    SResource(_, _) => 24,
+    SFnDecl(_, _, _, _, _) => 25
   }
 }
 
@@ -408,6 +409,7 @@ fn every_stmt() -> Array[Stmt] {
       ImportItem::{ kind: Some(ImportStruct), name: "n", alias: Some("a") }
     ]),
     SAliasDecl("s", "s"),
+    SReExportAliasBlockers(["s"]),
     SQualifiedPatternRefs([("a", "b")]),
     STestEffectRows([("a", "b")]),
     SLetPat(PWild, EUnit),
@@ -451,6 +453,7 @@ fn every_stmt_same() -> Array[Stmt] {
       ImportItem::{ kind: Some(ImportStruct), name: "n", alias: Some("a") }
     ]),
     SAliasDecl("s", "s"),
+    SReExportAliasBlockers(["s"]),
     SQualifiedPatternRefs([("a", "b")]),
     STestEffectRows([("a", "b")]),
     SLetPat(PWild, EUnit),
@@ -491,6 +494,7 @@ fn every_stmt_alt() -> Array[Stmt] {
       ImportItem::{ kind: Some(ImportEnum), name: "o", alias: Some("b") }
     ]),
     SAliasDecl("t", "t"),
+    SReExportAliasBlockers(["t"]),
     SQualifiedPatternRefs([("c", "d")]),
     STestEffectRows([("c", "d")]),
     SLetPat(PBind("z"), EInt(9)),
@@ -889,7 +893,7 @@ test "Stmt ==: every variant is structurally equal to itself" {
     }
     i = i + 1
   }
-  inspect(same, "25")
+  inspect(same, "26")
 }
 
 test "Stmt ==: distinct variants are never equal" {
@@ -912,7 +916,7 @@ test "Stmt ==: distinct variants are never equal" {
     }
     i = i + 1
   }
-  inspect(differ, "25")
+  inspect(differ, "26")
 }
 
 test "Stmt ==: structurally equal but distinct values are equal" {
@@ -933,7 +937,7 @@ test "Stmt ==: structurally equal but distinct values are equal" {
   }
   // Every variant, including the ones carrying arrays and nested values. A
   // regression from structural to reference comparison drops this below n.
-  inspect(equal, "25")
+  inspect(equal, "26")
 }
 
 test "Stmt: every represented variant is the declared one, in order" {
@@ -970,7 +974,8 @@ test "Stmt: every represented variant is the declared one, in order" {
     21,
     22,
     23,
-    24
+    24,
+    25
   ]
   let vs = every_stmt()
   let n = Array::length(vs)
@@ -985,8 +990,8 @@ test "Stmt: every represented variant is the declared one, in order" {
     }
     i = i + 1
   }
-  inspect(Array::length(want), "25")
-  inspect(in_order, "25")
+  inspect(Array::length(want), "26")
+  inspect(in_order, "26")
 }
 
 test "Stmt ==: same variant with different payloads is not equal" {
@@ -1008,6 +1013,6 @@ test "Stmt ==: same variant with different payloads is not equal" {
   // Exactly the variants that CARRY a payload must differ; the nullary ones
   // rebuild identically and must still compare equal. A derive that compared
   // tags only would report 0 here.
-  inspect(Array::length(alt), "25")
-  inspect(differ, "25")
+  inspect(Array::length(alt), "26")
+  inspect(differ, "26")
 }

--- a/lib/@vibe/ast/index.vpkg
+++ b/lib/@vibe/ast/index.vpkg
@@ -130,11 +130,12 @@ export enum Stmt {
   SExport(Array[String]);
   SReExport(String, Array[ImportItem]);
   SAliasDecl(String, String);
-  // #2287: source-local value names contributed only by re-exports.
+  // #2287: source-local value names contributed by re-exports. The first array
+  // carries every locally visible spelling for builtin exclusion; the second
+  // carries aliased, publication-only spellings that must block local lookup.
   // The FS merge drops SReExport after projecting its public surface, so this
-  // marker preserves each source unit's name-resolution boundary. It carries
-  // no executable declaration; the checker and builtin desugars consume it.
-  SReExportLocalBlockers(Array[String]);
+  // marker preserves each source unit's name-resolution boundary.
+  SReExportSourceBoundary(Array[String], Array[String]);
   // #1455 step 3: every `Enum::Variant` the parser saw in PATTERN position,
   // as `(qualifier, variant)`. `parse_pattern` lowers `Color::Red` to the same
   // `PCtor("Red", ..)` the bare spelling produces, so the qualifier has

--- a/lib/@vibe/ast/index.vpkg
+++ b/lib/@vibe/ast/index.vpkg
@@ -130,11 +130,11 @@ export enum Stmt {
   SExport(Array[String]);
   SReExport(String, Array[ImportItem]);
   SAliasDecl(String, String);
-  // #2287: source-local value names contributed only by aliased re-exports.
+  // #2287: source-local value names contributed only by re-exports.
   // The FS merge drops SReExport after projecting its public surface, so this
   // marker preserves each source unit's name-resolution boundary. It carries
   // no executable declaration; the checker and builtin desugars consume it.
-  SReExportAliasBlockers(Array[String]);
+  SReExportLocalBlockers(Array[String]);
   // #1455 step 3: every `Enum::Variant` the parser saw in PATTERN position,
   // as `(qualifier, variant)`. `parse_pattern` lowers `Color::Red` to the same
   // `PCtor("Red", ..)` the bare spelling produces, so the qualifier has

--- a/lib/@vibe/ast/index.vpkg
+++ b/lib/@vibe/ast/index.vpkg
@@ -130,6 +130,11 @@ export enum Stmt {
   SExport(Array[String]);
   SReExport(String, Array[ImportItem]);
   SAliasDecl(String, String);
+  // #2287: source-local value names contributed only by aliased re-exports.
+  // The FS merge drops SReExport after projecting its public surface, so this
+  // marker preserves each source unit's name-resolution boundary. It carries
+  // no executable declaration; the checker and builtin desugars consume it.
+  SReExportAliasBlockers(Array[String]);
   // #1455 step 3: every `Enum::Variant` the parser saw in PATTERN position,
   // as `(qualifier, variant)`. `parse_pattern` lowers `Color::Red` to the same
   // `PCtor("Red", ..)` the bare spelling produces, so the qualifier has

--- a/lib/@vibe/compiler/checker/artifacts/checked_implementation_body_artifact.vibe
+++ b/lib/@vibe/compiler/checker/artifacts/checked_implementation_body_artifact.vibe
@@ -2118,6 +2118,9 @@ fn normalized_binding_origin_bytes(origin: BindingOrigin) -> String {
     BindingOriginUnavailable => "u",
     BindingOriginModuleExport(module_name, export_name) => {
       let out = StringBuilder::new(); StringBuilder::push(out, "m"); body_push_piece(out, module_name); body_push_piece(out, export_name); StringBuilder::freeze(out)
+    },
+    BindingOriginReExportSurface(module_name, export_name) => {
+      let out = StringBuilder::new(); StringBuilder::push(out, "r"); body_push_piece(out, module_name); body_push_piece(out, export_name); StringBuilder::freeze(out)
     }
   }
 }
@@ -2125,7 +2128,7 @@ fn normalized_binding_origin_bytes(origin: BindingOrigin) -> String {
 fn normalized_binding_origin_valid(text: String) -> Bool {
   if text == "u" {
     true
-  } else if String::starts_with(text, "m") {
+  } else if String::starts_with(text, "m") || String::starts_with(text, "r") {
     match body_piece(text, 1) {
       Some((module_name, p)) => match body_piece(text, p) {
         Some((export_name, end)) => String::length(module_name) > 0 && String::length(export_name) > 0 && end == String::length(text),

--- a/lib/@vibe/compiler/checker/checker.vibe
+++ b/lib/@vibe/compiler/checker/checker.vibe
@@ -14,6 +14,7 @@ import @vibe/compiler/core {
   env_bind,
   env_bind_mut,
   env_cache_binding,
+  env_has_reexport_surface_binding,
   env_lookup,
   exception_effect_kind,
   exception_effect_labels_equal,
@@ -4131,7 +4132,22 @@ fn direct_builtin_return(name: String) -> Option[Type] {
 fn direct_call_return(env: TypeEnv, name: String) -> Option[Type] {
   match env_lookup(env, name) {
     Some(_) => None,
-    None => direct_builtin_return(canonical_builtin_name(name))
+    None => if env_has_reexport_surface_binding(env, name) {
+      None
+    } else {
+      direct_builtin_return(canonical_builtin_name(name))
+    }
+  }
+}
+
+/// A surface-only re-export alias is not a local value, but it is still a
+/// source spelling claimed by this module. Do not let a same-named builtin
+/// turn that invalid local use into different executable behavior (#2287).
+fn lookup_builtin_in_env(env: TypeEnv, name: String) -> Option[Type] {
+  if env_has_reexport_surface_binding(env, name) {
+    None
+  } else {
+    lookup_builtin(name)
   }
 }
 
@@ -6504,7 +6520,7 @@ fn check_expr_capture_impl(expr: Expr, env: TypeEnv, defs: Array[TypeDef], s: Su
         }
         (ti, s1, c1)
       },
-      None => match lookup_builtin(railway_ident_lookup_name(name)) {
+      None => match lookup_builtin_in_env(env, railway_ident_lookup_name(name)) {
         Some(t) => if builtin_is_first_class_value(railway_ident_lookup_name(name)) || !String::contains(name, "::") {
           // Bare names (`None`) keep the historical lookup: nullary
           // constructors are values, and rejecting every non-table builtin
@@ -7946,7 +7962,7 @@ fn check_expr_capture_impl(expr: Expr, env: TypeEnv, defs: Array[TypeDef], s: Su
               let method_form = if String::index_of(name, "::") < 0 && Array::length(args) >= 1 {
                 match env_lookup(env, name) {
                   Some(_) => false,
-                  None => match lookup_builtin(name) {
+                  None => match lookup_builtin_in_env(env, name) {
                     Some(_) => false,
                     None => true
                   }
@@ -7960,7 +7976,7 @@ fn check_expr_capture_impl(expr: Expr, env: TypeEnv, defs: Array[TypeDef], s: Su
                 let qual = String::concat(type_name_prefix(recv_ty), String::concat("::", name))
                 let has_qual = match env_lookup(env, qual) {
                   Some(_) => true,
-                  None => match lookup_builtin(qual) {
+                  None => match lookup_builtin_in_env(env, qual) {
                     Some(_) => true,
                     None => false
                   }
@@ -8010,7 +8026,7 @@ fn check_expr_capture_impl(expr: Expr, env: TypeEnv, defs: Array[TypeDef], s: Su
                       }
                       (ti, sbound, nc)
                     },
-                    None => match lookup_builtin(lookup_name) {
+                    None => match lookup_builtin_in_env(env, lookup_name) {
                       Some(t) => (t, s, c),
                       None => check_expr_capture(EIdent(name, callee_off), env, defs, s, c, errors, tytab, capture, lane)
                     }
@@ -8139,7 +8155,7 @@ fn check_expr_capture_impl(expr: Expr, env: TypeEnv, defs: Array[TypeDef], s: Su
             // `a.set(0, "bad")`). Reject these HERE instead of silently
             // accepting a call that can never compile.
             if !has_real_fn_binding && is_known_builtin_receiver_prefix(type_prefix) {
-              match lookup_builtin(qualified) {
+              match lookup_builtin_in_env(env, qualified) {
                 Some(_) => {
                   Array::push(errors, String::concat("dot-call syntax is not supported for the builtin method `", String::concat(qualified, String::concat("` -- call it as `", String::concat(qualified, String::concat("(...)`", off_marker_len(qcall_field_off, String::length(method))))))))
                   (tab_call_ty(tytab, call_off, CtUnknown, capture, lane), s1, c1)
@@ -8160,7 +8176,7 @@ fn check_expr_capture_impl(expr: Expr, env: TypeEnv, defs: Array[TypeDef], s: Su
                   let (ti, c2, _) = instantiate(t, c1)
                   (ti, s1, c2)
                 },
-                None => match lookup_builtin(qualified) {
+                None => match lookup_builtin_in_env(env, qualified) {
                   Some(t) => (t, s1, c1),
                   None => (CtUnknown, s1, c1)
                 }
@@ -8260,7 +8276,7 @@ fn check_expr_capture_impl(expr: Expr, env: TypeEnv, defs: Array[TypeDef], s: Su
                         }
                         let has_method_binding = match env_lookup(env, qualified) {
                           Some(_) => true,
-                          None => match lookup_builtin(qualified) {
+                          None => match lookup_builtin_in_env(env, qualified) {
                             Some(_) => true,
                             None => false
                           }

--- a/lib/@vibe/compiler/checker/checker_stmt.vibe
+++ b/lib/@vibe/compiler/checker/checker_stmt.vibe
@@ -41,6 +41,7 @@ import @vibe/compiler/core {
   env_selectable_type_defs,
   env_type_defs,
   env_value_binding_with_origin,
+  env_with_reexport_alias_blockers,
   expr_children,
   find_enum_typedef,
   find_typedef,
@@ -2619,6 +2620,7 @@ fn check_stmts_with_binders(raw_stmts: Array[Stmt], i: Int, env: TypeEnv, defs: 
       } else {
         (bind_stmt_imports(env, names), s, c)
       },
+      SReExportAliasBlockers(names) => (env_with_reexport_alias_blockers(env, names), s, c),
       SAliasDecl(_, _) => (env, s, c)
       ,
       STrait(_, name, supers, methods, method_gens, tparams) => {

--- a/lib/@vibe/compiler/checker/checker_stmt.vibe
+++ b/lib/@vibe/compiler/checker/checker_stmt.vibe
@@ -41,7 +41,7 @@ import @vibe/compiler/core {
   env_selectable_type_defs,
   env_type_defs,
   env_value_binding_with_origin,
-  env_with_reexport_local_blockers,
+  env_with_reexport_surface_blockers,
   expr_children,
   find_enum_typedef,
   find_typedef,
@@ -1797,7 +1797,7 @@ fn hoisted_binding_type(annotation: Option[TypeExpr], defs: Array[TypeDef]) -> T
 fn hoist_merged_source_values(stmts: Array[Stmt], start: Int, env: TypeEnv, defs: Array[TypeDef]) -> TypeEnv {
   let mut out = env
   let mut i = start
-  while i < Array::length(stmts) && !(Array::get(stmts, i) is SReExportLocalBlockers(_)) {
+  while i < Array::length(stmts) && !(Array::get(stmts, i) is SReExportSourceBoundary(_, _)) {
     match Array::get(stmts, i) {
       SLet(_, _, name, annotation, _) => {
         let ty = hoisted_binding_type(annotation, defs)
@@ -2644,8 +2644,8 @@ fn check_stmts_with_binders(raw_stmts: Array[Stmt], i: Int, env: TypeEnv, defs: 
       } else {
         (bind_stmt_imports(env, names), s, c)
       },
-      SReExportLocalBlockers(names) => {
-        let blocked = env_with_reexport_local_blockers(env, names)
+      SReExportSourceBoundary(_, surface_only_names) => {
+        let blocked = env_with_reexport_surface_blockers(env, surface_only_names)
         (hoist_merged_source_values(stmts, idx + 1, blocked, defs), s, c)
       },
       SAliasDecl(_, _) => (env, s, c)

--- a/lib/@vibe/compiler/checker/checker_stmt.vibe
+++ b/lib/@vibe/compiler/checker/checker_stmt.vibe
@@ -41,7 +41,7 @@ import @vibe/compiler/core {
   env_selectable_type_defs,
   env_type_defs,
   env_value_binding_with_origin,
-  env_with_reexport_alias_blockers,
+  env_with_reexport_local_blockers,
   expr_children,
   find_enum_typedef,
   find_typedef,
@@ -1783,6 +1783,33 @@ fn reorder_type_decls_first(stmts: Array[Stmt], start: Int) -> Array[Stmt] {
   out
 }
 
+/// Re-hoist the value declarations owned by one FS-merged source after its
+/// re-export lookup barriers. The ordinary list-wide hoist sits below those
+/// barriers, so without this pass a legitimate same-source declaration named
+/// like a re-export would be hidden together with dependency definitions.
+fn hoisted_binding_type(annotation: Option[TypeExpr], defs: Array[TypeDef]) -> Type {
+  match annotation {
+    Some(type_expr) => resolve_type_expr(type_expr, defs),
+    None => CtUnknown
+  }
+}
+
+fn hoist_merged_source_values(stmts: Array[Stmt], start: Int, env: TypeEnv, defs: Array[TypeDef]) -> TypeEnv {
+  let mut out = env
+  let mut i = start
+  while i < Array::length(stmts) && !(Array::get(stmts, i) is SReExportLocalBlockers(_)) {
+    match Array::get(stmts, i) {
+      SLet(_, _, name, annotation, _) => {
+        let ty = hoisted_binding_type(annotation, defs)
+        out = env_bind(out, name, ty)
+      },
+      _ => ()
+    }
+    i = i + 1
+  }
+  out
+}
+
 /// Map the stable type-declaration schedule back to the retained statement
 /// coordinates. `checked_stmts` stays in source/post-desugar order even though
 /// declaration checking is scheduled type-first.
@@ -1881,10 +1908,7 @@ fn check_stmts_with_binders(raw_stmts: Array[Stmt], i: Int, env: TypeEnv, defs: 
   while hoist_i < Array::length(stmts) {
     match Array::get(stmts, hoist_i) {
       SLet(_, _, hname, hann, _) => {
-        let ht = match hann {
-          Some(hte) => resolve_type_expr(hte, defs),
-          None => CtUnknown
-        }
+        let ht = hoisted_binding_type(hann, defs)
         cur_env = env_bind(cur_env, hname, ht)
       },
       _ => ()
@@ -2620,7 +2644,10 @@ fn check_stmts_with_binders(raw_stmts: Array[Stmt], i: Int, env: TypeEnv, defs: 
       } else {
         (bind_stmt_imports(env, names), s, c)
       },
-      SReExportAliasBlockers(names) => (env_with_reexport_alias_blockers(env, names), s, c),
+      SReExportLocalBlockers(names) => {
+        let blocked = env_with_reexport_local_blockers(env, names)
+        (hoist_merged_source_values(stmts, idx + 1, blocked, defs), s, c)
+      },
       SAliasDecl(_, _) => (env, s, c)
       ,
       STrait(_, name, supers, methods, method_gens, tparams) => {

--- a/lib/@vibe/compiler/checker/checker_stmt.vibe
+++ b/lib/@vibe/compiler/checker/checker_stmt.vibe
@@ -1961,11 +1961,10 @@ fn check_stmts_with_binders(raw_stmts: Array[Stmt], i: Int, env: TypeEnv, defs: 
           let item = Array::get(rstnames, rn_i)
           let rn_name = item.name
           let rn_alias = item.alias
-          let rn_bound = match rn_alias {
-            Some(a) => a,
-            None => rn_name
-          }
-          if rn_bound == "resume" {
+          // A plain re-export can resolve to the dependency's merged
+          // definition. An alias is publication-only and introduces no local
+          // binder, so it must not shadow the special `resume` call (#2287).
+          if rn_name == "resume" && rn_alias == None {
             resume_shadowed_top = true
           } else {
             ()

--- a/lib/@vibe/compiler/codegen/common_base/double_parse_expr.vibe
+++ b/lib/@vibe/compiler/codegen/common_base/double_parse_expr.vibe
@@ -72,7 +72,13 @@ export fn double_parse_expr(arg: Expr) -> Expr {
   let is_digit_ch = EBinOp("&&", EBinOp(">=", ch, EInt(48)), EBinOp("<=", ch, EInt(57)))
   let is_dot_ch = EBinOp("&&", EBinOp("==", ch, EInt(46)), EBinOp("==", seen_dot, EBool(false)))
   let digit_accum = ESeq(EAssign("__dp_mantissa", EBinOp("+", EBinOp("*", mantissa, EFloat(10.0)), digit), EUnit), ESeq(EIf(seen_dot, EAssign("__dp_frac_digits", EBinOp("+", frac_digits, EInt(1)), EUnit), EUnit), EAssign("__dp_seen_digit", EBool(true), EUnit)))
-  let would_overflow = EBinOp(">", mantissa, EBinOp("/", EBinOp("-", EFloat(2305843009213693951.0), digit), EFloat(10.0)))
+  // Keep the boundary out of an EFloat literal. Merged-source normalization
+  // serializes compiler AST constructors before reparsing them, and the
+  // compiler-side large-Double formatter can classify this rounded 2^61 value
+  // as infinity after that rewrite. Int::to_double(Int::max) is the same
+  // representable Double and survives the round trip without special printing.
+  let safe_magnitude = c1("Int::to_double", EInt(2305843009213693951))
+  let would_overflow = EBinOp(">", mantissa, EBinOp("/", EBinOp("-", safe_magnitude, digit), EFloat(10.0)))
   let digit_step = ELet("__dp_digit", c1("Int::to_double", EBinOp("-", ch, EInt(48))), EIf(would_overflow, EAssign("__dp_ok", EBool(false), EUnit), digit_accum), -1)
   let scan_step = EIf(is_digit_ch, digit_step, EIf(is_dot_ch, EAssign("__dp_seen_dot", EBool(true), EUnit), EAssign("__dp_ok", EBool(false), EUnit)))
   let loop_body = ELet("__dp_ch", c2("String::char_code_at", s, i), ESeq(scan_step, EAssign("__dp_i", EBinOp("+", i, EInt(1)), EUnit)), -1)

--- a/lib/@vibe/compiler/core/import_alias_rewrite.vibe
+++ b/lib/@vibe/compiler/core/import_alias_rewrite.vibe
@@ -2129,15 +2129,21 @@ fn append_import_value_renames(plan: ExportRenamePlan, target: String, items: Ar
     } else {
       true
     }
-    if locally_visible && String::index_of(original, "::") < 0 && !string_array_contains(locals_seen, local) {
+    if String::index_of(original, "::") < 0 && !string_array_contains(locals_seen, local) {
       // Walk bindings newest-first. Even a target that stays bare claims the
       // spelling and prevents an older import from supplying a stale rename.
+      // Publication-only aliases claim their local spelling too: they emit no
+      // rewrite, but still override an earlier import with the same local name.
       Array::push(locals_seen, local)
-      match MutMap::get(plan.rename_idx, plan_rename_key(target, original)) {
-        Some(mangled) => {
-          Array::push(out, (local, mangled))
-        },
-        None => ()
+      if locally_visible {
+        match MutMap::get(plan.rename_idx, plan_rename_key(target, original)) {
+          Some(mangled) => {
+            Array::push(out, (local, mangled))
+          },
+          None => ()
+        }
+      } else {
+        ()
       }
     } else {
       ()

--- a/lib/@vibe/compiler/core/import_alias_rewrite.vibe
+++ b/lib/@vibe/compiler/core/import_alias_rewrite.vibe
@@ -847,6 +847,7 @@ export fn stmts_have_import_deep(stmts: Array[Stmt]) -> Bool {
   let rec stmt_has_import_deep: (Stmt) -> Bool = (stmt) -> {
     match stmt {
       SImport(_, _) => true,
+      SReExport(_, _) => true,
       SModule(_, _, inner_stmts) => stmts_have_import_deep(inner_stmts),
       _ => false
     }
@@ -2110,8 +2111,42 @@ export fn export_plan_fingerprint_text(plan: ExportRenamePlan) -> String {
   StringBuilder::freeze(buf)
 }
 
+fn append_import_value_renames(plan: ExportRenamePlan, target: String, items: Array[ImportItem], plain_reexports_only: Bool, out: Array[(String, String)], locals_seen: Array[String]) -> Unit {
+  let mut j = 0
+  while j < Array::length(items) {
+    let item = Array::get(items, j)
+    let original = item.name
+    let alias_opt = item.alias
+    let local = match alias_opt {
+      Some(alias) => alias,
+      None => original
+    }
+    let locally_visible = if plain_reexports_only {
+      match alias_opt {
+        Some(_) => false,
+        None => true
+      }
+    } else {
+      true
+    }
+    if locally_visible && String::index_of(original, "::") < 0 && !string_array_contains(locals_seen, local) {
+      match MutMap::get(plan.rename_idx, plan_rename_key(target, original)) {
+        Some(mangled) => {
+          Array::push(out, (local, mangled))
+          Array::push(locals_seen, local)
+        },
+        None => ()
+      }
+    } else {
+      ()
+    }
+    j = j + 1
+  }
+}
+
 /// (local -> mangled) reference renames for one importing file, derived from
-/// its `import` statements against the plan.
+/// ordinary imports and locally visible plain re-exports. Aliased re-exports
+/// remain publication-only and deliberately contribute no local rewrite.
 export fn collect_import_value_renames(plan: ExportRenamePlan, path: String, stmts: Array[Stmt]) -> Array[(String, String)] {
   let out = empty_aliases()
   let locals_seen = empty_strings()
@@ -2127,28 +2162,11 @@ export fn collect_import_value_renames(plan: ExportRenamePlan, path: String, stm
       match Array::get(stmts, i) {
         SImport(raw_path, items) => {
           let target = resolve_known_import_path(plan.plan_paths, base_dir, raw_path, path)
-          let mut j = 0
-          while j < Array::length(items) {
-            let item = Array::get(items, j)
-            let original = item.name
-            let alias_opt = item.alias
-            let local = match alias_opt {
-              Some(alias) => alias,
-              None => original
-            }
-            if String::index_of(original, "::") < 0 && !string_array_contains(locals_seen, local) {
-              match MutMap::get(plan.rename_idx, plan_rename_key(target, original)) {
-                Some(mangled) => {
-                  Array::push(out, (local, mangled))
-                  Array::push(locals_seen, local)
-                },
-                None => ()
-              }
-            } else {
-              ()
-            }
-            j = j + 1
-          }
+          append_import_value_renames(plan, target, items, false, out, locals_seen)
+        },
+        SReExport(raw_path, items) => {
+          let target = resolve_known_import_path(plan.plan_paths, base_dir, raw_path, path)
+          append_import_value_renames(plan, target, items, true, out, locals_seen)
         },
         _ => ()
       }

--- a/lib/@vibe/compiler/core/import_alias_rewrite.vibe
+++ b/lib/@vibe/compiler/core/import_alias_rewrite.vibe
@@ -2112,8 +2112,8 @@ export fn export_plan_fingerprint_text(plan: ExportRenamePlan) -> String {
 }
 
 fn append_import_value_renames(plan: ExportRenamePlan, target: String, items: Array[ImportItem], plain_reexports_only: Bool, out: Array[(String, String)], locals_seen: Array[String]) -> Unit {
-  let mut j = 0
-  while j < Array::length(items) {
+  let mut j = Array::length(items) - 1
+  while j >= 0 {
     let item = Array::get(items, j)
     let original = item.name
     let alias_opt = item.alias
@@ -2130,17 +2130,19 @@ fn append_import_value_renames(plan: ExportRenamePlan, target: String, items: Ar
       true
     }
     if locally_visible && String::index_of(original, "::") < 0 && !string_array_contains(locals_seen, local) {
+      // Walk bindings newest-first. Even a target that stays bare claims the
+      // spelling and prevents an older import from supplying a stale rename.
+      Array::push(locals_seen, local)
       match MutMap::get(plan.rename_idx, plan_rename_key(target, original)) {
         Some(mangled) => {
           Array::push(out, (local, mangled))
-          Array::push(locals_seen, local)
         },
         None => ()
       }
     } else {
       ()
     }
-    j = j + 1
+    j = j - 1
   }
 }
 
@@ -2157,8 +2159,11 @@ export fn collect_import_value_renames(plan: ExportRenamePlan, path: String, stm
     out
   } else {
     let base_dir = dir_of_path(path)
-    let mut i = 0
-    while i < Array::length(stmts) {
+    // `build_import_env_collecting` prepends bindings as it walks source
+    // order, so the last statement wins. Visit in reverse and retain only the
+    // first occurrence of each local spelling to match that environment.
+    let mut i = Array::length(stmts) - 1
+    while i >= 0 {
       match Array::get(stmts, i) {
         SImport(raw_path, items) => {
           let target = resolve_known_import_path(plan.plan_paths, base_dir, raw_path, path)
@@ -2170,7 +2175,7 @@ export fn collect_import_value_renames(plan: ExportRenamePlan, path: String, stm
         },
         _ => ()
       }
-      i = i + 1
+      i = i - 1
     }
     out
   }

--- a/lib/@vibe/compiler/core/index.vpkg
+++ b/lib/@vibe/compiler/core/index.vpkg
@@ -217,7 +217,7 @@ fn fresh_var(c: Int) -> (Type, Int)
 fn occurs_in(id: Int, ty: Type) -> Bool
 fn env_lookup(env: TypeEnv, name: String) -> Option[Type]
 fn env_has_reexport_surface_binding(env: TypeEnv, name: String) -> Bool
-fn env_with_reexport_alias_blockers(env: TypeEnv, names: Array[String]) -> TypeEnv
+fn env_with_reexport_local_blockers(env: TypeEnv, names: Array[String]) -> TypeEnv
 fn env_lookup_binding(env: TypeEnv, name: String) -> Option[EnvValueBinding]
 fn env_bind_all(env: TypeEnv, bindings: Array[(String, Type)]) -> TypeEnv
 fn find_typedef(defs: Array[TypeDef], name: String) -> Option[TypeDef]

--- a/lib/@vibe/compiler/core/index.vpkg
+++ b/lib/@vibe/compiler/core/index.vpkg
@@ -216,6 +216,7 @@ fn env_cache(env: TypeEnv) -> TypeEnv
 fn fresh_var(c: Int) -> (Type, Int)
 fn occurs_in(id: Int, ty: Type) -> Bool
 fn env_lookup(env: TypeEnv, name: String) -> Option[Type]
+fn env_has_reexport_surface_binding(env: TypeEnv, name: String) -> Bool
 fn env_lookup_binding(env: TypeEnv, name: String) -> Option[EnvValueBinding]
 fn env_bind_all(env: TypeEnv, bindings: Array[(String, Type)]) -> TypeEnv
 fn find_typedef(defs: Array[TypeDef], name: String) -> Option[TypeDef]

--- a/lib/@vibe/compiler/core/index.vpkg
+++ b/lib/@vibe/compiler/core/index.vpkg
@@ -217,7 +217,7 @@ fn fresh_var(c: Int) -> (Type, Int)
 fn occurs_in(id: Int, ty: Type) -> Bool
 fn env_lookup(env: TypeEnv, name: String) -> Option[Type]
 fn env_has_reexport_surface_binding(env: TypeEnv, name: String) -> Bool
-fn env_with_reexport_local_blockers(env: TypeEnv, names: Array[String]) -> TypeEnv
+fn env_with_reexport_surface_blockers(env: TypeEnv, names: Array[String]) -> TypeEnv
 fn env_lookup_binding(env: TypeEnv, name: String) -> Option[EnvValueBinding]
 fn env_bind_all(env: TypeEnv, bindings: Array[(String, Type)]) -> TypeEnv
 fn find_typedef(defs: Array[TypeDef], name: String) -> Option[TypeDef]

--- a/lib/@vibe/compiler/core/index.vpkg
+++ b/lib/@vibe/compiler/core/index.vpkg
@@ -217,6 +217,7 @@ fn fresh_var(c: Int) -> (Type, Int)
 fn occurs_in(id: Int, ty: Type) -> Bool
 fn env_lookup(env: TypeEnv, name: String) -> Option[Type]
 fn env_has_reexport_surface_binding(env: TypeEnv, name: String) -> Bool
+fn env_with_reexport_alias_blockers(env: TypeEnv, names: Array[String]) -> TypeEnv
 fn env_lookup_binding(env: TypeEnv, name: String) -> Option[EnvValueBinding]
 fn env_bind_all(env: TypeEnv, bindings: Array[(String, Type)]) -> TypeEnv
 fn find_typedef(defs: Array[TypeDef], name: String) -> Option[TypeDef]

--- a/lib/@vibe/compiler/core/types.vibe
+++ b/lib/@vibe/compiler/core/types.vibe
@@ -353,7 +353,14 @@ export fn env_cache(env: TypeEnv) -> TypeEnv {
           done = true
         },
         EnvBind(n, binding, rest) => match binding.origin {
-          BindingOriginReExportSurface(_, _) => {
+          BindingOriginReExportSurface(module_name, _) => if module_name == "" {
+            // The empty module name marks an FS-merge source-boundary blocker,
+            // not a published dependency surface. Retain it in the index so a
+            // same-named definition from an earlier source cannot leak through.
+            ArrayBuilder::push(names, n)
+            ArrayBuilder::push(types, binding)
+            cur = rest
+          } else {
             // Surface-only names stay in the authoritative chain for
             // publication, but must not enter the local lookup index.
             cur = rest
@@ -384,7 +391,12 @@ export fn env_cache(env: TypeEnv) -> TypeEnv {
           while j < Array::length(bindings) {
             let (n, binding) = Array::get(bindings, j)
             match binding.origin {
-              BindingOriginReExportSurface(_, _) => (),
+              BindingOriginReExportSurface(module_name, _) => if module_name == "" {
+                ArrayBuilder::push(names, n)
+                ArrayBuilder::push(types, binding)
+              } else {
+                ()
+              },
               _ => {
                 ArrayBuilder::push(names, n)
                 ArrayBuilder::push(types, binding)
@@ -599,10 +611,11 @@ fn env_without_reexport_surface_bindings(env: TypeEnv) -> TypeEnv {
   }
 }
 
-/// Replace the transient aliased-re-export blockers for the next source unit
-/// in an FS-merged program. These names participate in builtin exclusion but
-/// remain absent from ordinary local lookup (#2287).
-export fn env_with_reexport_alias_blockers(env: TypeEnv, names: Array[String]) -> TypeEnv {
+/// Replace the transient re-export blockers for the next source unit in an
+/// FS-merged program. The empty origin path is a lookup barrier: it keeps a
+/// same-named definition flattened from an earlier source out of local scope
+/// while still participating in builtin exclusion (#2287).
+export fn env_with_reexport_local_blockers(env: TypeEnv, names: Array[String]) -> TypeEnv {
   let mut out = env_without_reexport_surface_bindings(env)
   let mut i = 0
   while i < Array::length(names) {
@@ -624,7 +637,11 @@ export fn env_lookup_binding(env: TypeEnv, name: String) -> Option[EnvValueBindi
       },
       EnvBind(n, binding, rest) => if String::equals(n, name) {
         match binding.origin {
-          BindingOriginReExportSurface(_, _) => {
+          BindingOriginReExportSurface(module_name, _) => if module_name == "" {
+            // A source-boundary blocker is authoritative: do not reveal a
+            // same-named binding flattened from an earlier source.
+            done = true
+          } else {
             cur = rest
           },
           _ => {
@@ -656,7 +673,9 @@ export fn env_lookup_binding(env: TypeEnv, name: String) -> Option[EnvValueBindi
           let (n, binding) = Array::get(bindings, j)
           if String::equals(n, name) {
             match binding.origin {
-              BindingOriginReExportSurface(_, _) => {
+              BindingOriginReExportSurface(module_name, _) => if module_name == "" {
+                done = true
+              } else {
                 j = j + 1
               },
               _ => {
@@ -677,7 +696,9 @@ export fn env_lookup_binding(env: TypeEnv, name: String) -> Option[EnvValueBindi
         if slot >= 0 {
           let binding = Array::get(types_sorted, slot)
           match binding.origin {
-            BindingOriginReExportSurface(_, _) => {
+            BindingOriginReExportSurface(module_name, _) => if module_name == "" {
+              done = true
+            } else {
               // Old/injected caches may still contain this origin. Fall back
               // to the authoritative chain, which skips it and can reveal a
               // real same-named local binding underneath.

--- a/lib/@vibe/compiler/core/types.vibe
+++ b/lib/@vibe/compiler/core/types.vibe
@@ -67,7 +67,10 @@ export enum TypeDef {
 /// Persistent/public TypeEnv transport intentionally drops this payload.
 export enum BindingOrigin {
   BindingOriginUnavailable;
-  BindingOriginModuleExport(String, String)
+  BindingOriginModuleExport(String, String);
+  /// A re-export contributes to this module's published surface, but the
+  /// re-export statement does not introduce a local binder (#2287).
+  BindingOriginReExportSurface(String, String)
 }
 
 export struct EnvValueBinding {
@@ -349,10 +352,17 @@ export fn env_cache(env: TypeEnv) -> TypeEnv {
         EnvEmpty => {
           done = true
         },
-        EnvBind(n, binding, rest) => {
-          ArrayBuilder::push(names, n)
-          ArrayBuilder::push(types, binding)
-          cur = rest
+        EnvBind(n, binding, rest) => match binding.origin {
+          BindingOriginReExportSurface(_, _) => {
+            // Surface-only names stay in the authoritative chain for
+            // publication, but must not enter the local lookup index.
+            cur = rest
+          },
+          _ => {
+            ArrayBuilder::push(names, n)
+            ArrayBuilder::push(types, binding)
+            cur = rest
+          }
         },
         EnvTraitDef(_, _, _, _, rest, _, _) => {
           cur = rest
@@ -373,8 +383,13 @@ export fn env_cache(env: TypeEnv) -> TypeEnv {
           let mut j = 0
           while j < Array::length(bindings) {
             let (n, binding) = Array::get(bindings, j)
-            ArrayBuilder::push(names, n)
-            ArrayBuilder::push(types, binding)
+            match binding.origin {
+              BindingOriginReExportSurface(_, _) => (),
+              _ => {
+                ArrayBuilder::push(names, n)
+                ArrayBuilder::push(types, binding)
+              }
+            }
             j = j + 1
           }
           done = true
@@ -465,6 +480,80 @@ export fn env_lookup(env: TypeEnv, name: String) -> Option[Type] {
   }
 }
 
+/// Whether `name` is present only to publish an aliased re-export. This is
+/// deliberately separate from `env_lookup`: the alias is not a local value,
+/// but its spelling must still block a same-named builtin from silently
+/// claiming the source call (#2287).
+export fn env_has_reexport_surface_binding(env: TypeEnv, name: String) -> Bool {
+  let mut cur = env
+  let mut found = false
+  let mut done = false
+  while !done {
+    match cur {
+      EnvEmpty => {
+        done = true
+      },
+      EnvBind(n, binding, rest) => {
+        if String::equals(n, name) {
+          match binding.origin {
+            BindingOriginReExportSurface(_, _) => {
+              found = true
+              done = true
+            },
+            _ => ()
+          }
+        } else {
+          ()
+        }
+        if !done {
+          cur = rest
+        } else {
+          ()
+        }
+      },
+      EnvTraitDef(_, _, _, _, rest, _, _) => {
+        cur = rest
+      },
+      EnvTraitImpl(_, _, rest) => {
+        cur = rest
+      },
+      EnvMutCell(_, _, rest) => {
+        cur = rest
+      },
+      EnvTraitImplGen(_, _, _, _, rest) => {
+        cur = rest
+      },
+      EnvTypeDefs(_, _, rest) => {
+        cur = rest
+      },
+      EnvFlat(bindings) => {
+        let mut i = 0
+        while i < Array::length(bindings) && !found {
+          let (n, binding) = Array::get(bindings, i)
+          if String::equals(n, name) {
+            match binding.origin {
+              BindingOriginReExportSurface(_, _) => {
+                found = true
+              },
+              _ => ()
+            }
+          } else {
+            ()
+          }
+          i = i + 1
+        }
+        done = true
+      },
+      EnvCached(_, _, rest) => {
+        // The authoritative chain retains surface-only entries even though
+        // the acceleration arrays intentionally omit them.
+        cur = rest
+      }
+    }
+  }
+  found
+}
+
 export fn env_lookup_binding(env: TypeEnv, name: String) -> Option[EnvValueBinding] {
   let mut cur = env
   let mut result = None
@@ -475,8 +564,15 @@ export fn env_lookup_binding(env: TypeEnv, name: String) -> Option[EnvValueBindi
         done = true
       },
       EnvBind(n, binding, rest) => if String::equals(n, name) {
-        result = Some(binding)
-        done = true
+        match binding.origin {
+          BindingOriginReExportSurface(_, _) => {
+            cur = rest
+          },
+          _ => {
+            result = Some(binding)
+            done = true
+          }
+        }
       } else {
         cur = rest
       },
@@ -500,8 +596,15 @@ export fn env_lookup_binding(env: TypeEnv, name: String) -> Option[EnvValueBindi
         while j < Array::length(bindings) && !done {
           let (n, binding) = Array::get(bindings, j)
           if String::equals(n, name) {
-            result = Some(binding)
-            done = true
+            match binding.origin {
+              BindingOriginReExportSurface(_, _) => {
+                j = j + 1
+              },
+              _ => {
+                result = Some(binding)
+                done = true
+              }
+            }
           } else {
             j = j + 1
           }
@@ -513,8 +616,19 @@ export fn env_lookup_binding(env: TypeEnv, name: String) -> Option[EnvValueBindi
       EnvCached(names_sorted, types_sorted, rest) => {
         let slot = bsearch_leftmost(names_sorted, name)
         if slot >= 0 {
-          result = Some(Array::get(types_sorted, slot))
-          done = true
+          let binding = Array::get(types_sorted, slot)
+          match binding.origin {
+            BindingOriginReExportSurface(_, _) => {
+              // Old/injected caches may still contain this origin. Fall back
+              // to the authoritative chain, which skips it and can reveal a
+              // real same-named local binding underneath.
+              cur = rest
+            },
+            _ => {
+              result = Some(binding)
+              done = true
+            }
+          }
         } else {
           cur = rest
         }

--- a/lib/@vibe/compiler/core/types.vibe
+++ b/lib/@vibe/compiler/core/types.vibe
@@ -554,6 +554,65 @@ export fn env_has_reexport_surface_binding(env: TypeEnv, name: String) -> Bool {
   found
 }
 
+fn env_without_reexport_surface_bindings(env: TypeEnv) -> TypeEnv {
+  match env {
+    EnvEmpty => EnvEmpty,
+    EnvBind(name, binding, rest) => match binding.origin {
+      BindingOriginReExportSurface(_, _) => env_without_reexport_surface_bindings(rest),
+      _ => EnvBind(name, binding, env_without_reexport_surface_bindings(rest))
+    },
+    EnvTraitDef(name, supers, marker, methods, rest, params, method_gens) => EnvTraitDef(name, supers, marker, methods, env_without_reexport_surface_bindings(rest), params, method_gens),
+    EnvTraitImpl(name, target, rest) => EnvTraitImpl(name, target, env_without_reexport_surface_bindings(rest)),
+    EnvTraitImplGen(name, params, bounds, target, rest) => EnvTraitImplGen(name, params, bounds, target, env_without_reexport_surface_bindings(rest)),
+    EnvTypeDefs(defs, selectable, rest) => EnvTypeDefs(defs, selectable, env_without_reexport_surface_bindings(rest)),
+    EnvMutCell(name, escapes, rest) => EnvMutCell(name, escapes, env_without_reexport_surface_bindings(rest)),
+    EnvFlat(bindings) => {
+      let kept = array_empty()
+      let mut i = 0
+      while i < Array::length(bindings) {
+        let pair = Array::get(bindings, i)
+        match pair.1.origin {
+          BindingOriginReExportSurface(_, _) => (),
+          _ => Array::push(kept, pair)
+        }
+        i = i + 1
+      }
+      EnvFlat(kept)
+    },
+    EnvCached(names, bindings, rest) => {
+      let kept_names = array_empty()
+      let kept_bindings = array_empty()
+      let mut i = 0
+      while i < Array::length(names) {
+        let binding = Array::get(bindings, i)
+        match binding.origin {
+          BindingOriginReExportSurface(_, _) => (),
+          _ => {
+            Array::push(kept_names, Array::get(names, i))
+            Array::push(kept_bindings, binding)
+          }
+        }
+        i = i + 1
+      }
+      EnvCached(kept_names, kept_bindings, env_without_reexport_surface_bindings(rest))
+    }
+  }
+}
+
+/// Replace the transient aliased-re-export blockers for the next source unit
+/// in an FS-merged program. These names participate in builtin exclusion but
+/// remain absent from ordinary local lookup (#2287).
+export fn env_with_reexport_alias_blockers(env: TypeEnv, names: Array[String]) -> TypeEnv {
+  let mut out = env_without_reexport_surface_bindings(env)
+  let mut i = 0
+  while i < Array::length(names) {
+    let name = Array::get(names, i)
+    out = env_bind_with_origin(out, name, CtUnknown, BindingOriginReExportSurface("", name))
+    i = i + 1
+  }
+  out
+}
+
 export fn env_lookup_binding(env: TypeEnv, name: String) -> Option[EnvValueBinding] {
   let mut cur = env
   let mut result = None

--- a/lib/@vibe/compiler/core/types.vibe
+++ b/lib/@vibe/compiler/core/types.vibe
@@ -353,16 +353,12 @@ export fn env_cache(env: TypeEnv) -> TypeEnv {
           done = true
         },
         EnvBind(n, binding, rest) => match binding.origin {
-          BindingOriginReExportSurface(module_name, _) => if module_name == "" {
-            // The empty module name marks an FS-merge source-boundary blocker,
-            // not a published dependency surface. Retain it in the index so a
-            // same-named definition from an earlier source cannot leak through.
+          BindingOriginReExportSurface(_, _) => {
+            // Surface-only entries are lookup barriers, not local values. They
+            // still belong in the acceleration index so an older same-named
+            // real binding cannot win before the authoritative chain is read.
             ArrayBuilder::push(names, n)
             ArrayBuilder::push(types, binding)
-            cur = rest
-          } else {
-            // Surface-only names stay in the authoritative chain for
-            // publication, but must not enter the local lookup index.
             cur = rest
           },
           _ => {
@@ -390,18 +386,8 @@ export fn env_cache(env: TypeEnv) -> TypeEnv {
           let mut j = 0
           while j < Array::length(bindings) {
             let (n, binding) = Array::get(bindings, j)
-            match binding.origin {
-              BindingOriginReExportSurface(module_name, _) => if module_name == "" {
-                ArrayBuilder::push(names, n)
-                ArrayBuilder::push(types, binding)
-              } else {
-                ()
-              },
-              _ => {
-                ArrayBuilder::push(names, n)
-                ArrayBuilder::push(types, binding)
-              }
-            }
+            ArrayBuilder::push(names, n)
+            ArrayBuilder::push(types, binding)
             j = j + 1
           }
           done = true
@@ -637,12 +623,12 @@ export fn env_lookup_binding(env: TypeEnv, name: String) -> Option[EnvValueBindi
       },
       EnvBind(n, binding, rest) => if String::equals(n, name) {
         match binding.origin {
-          BindingOriginReExportSurface(module_name, _) => if module_name == "" {
-            // A source-boundary blocker is authoritative: do not reveal a
-            // same-named binding flattened from an earlier source.
+          BindingOriginReExportSurface(_, _) => {
+            // A surface-only binding is authoritative at its position in the
+            // chain. A later real binding is already nearer the head; when the
+            // surface entry itself is reached, do not reveal an older plain
+            // import or re-export with the same spelling.
             done = true
-          } else {
-            cur = rest
           },
           _ => {
             result = Some(binding)
@@ -673,10 +659,8 @@ export fn env_lookup_binding(env: TypeEnv, name: String) -> Option[EnvValueBindi
           let (n, binding) = Array::get(bindings, j)
           if String::equals(n, name) {
             match binding.origin {
-              BindingOriginReExportSurface(module_name, _) => if module_name == "" {
+              BindingOriginReExportSurface(_, _) => {
                 done = true
-              } else {
-                j = j + 1
               },
               _ => {
                 result = Some(binding)
@@ -696,13 +680,8 @@ export fn env_lookup_binding(env: TypeEnv, name: String) -> Option[EnvValueBindi
         if slot >= 0 {
           let binding = Array::get(types_sorted, slot)
           match binding.origin {
-            BindingOriginReExportSurface(module_name, _) => if module_name == "" {
+            BindingOriginReExportSurface(_, _) => {
               done = true
-            } else {
-              // Old/injected caches may still contain this origin. Fall back
-              // to the authoritative chain, which skips it and can reveal a
-              // real same-named local binding underneath.
-              cur = rest
             },
             _ => {
               result = Some(binding)

--- a/lib/@vibe/compiler/core/types.vibe
+++ b/lib/@vibe/compiler/core/types.vibe
@@ -615,7 +615,7 @@ fn env_without_reexport_surface_bindings(env: TypeEnv) -> TypeEnv {
 /// FS-merged program. The empty origin path is a lookup barrier: it keeps a
 /// same-named definition flattened from an earlier source out of local scope
 /// while still participating in builtin exclusion (#2287).
-export fn env_with_reexport_local_blockers(env: TypeEnv, names: Array[String]) -> TypeEnv {
+export fn env_with_reexport_surface_blockers(env: TypeEnv, names: Array[String]) -> TypeEnv {
   let mut out = env_without_reexport_surface_bindings(env)
   let mut i = 0
   while i < Array::length(names) {

--- a/lib/@vibe/compiler/desugar.vibe
+++ b/lib/@vibe/compiler/desugar.vibe
@@ -245,6 +245,7 @@ export fn desugar_stmt(stmt: Stmt) -> Stmt {
     SExport(_) => stmt,
     SReExport(_, _) => stmt,
     SAliasDecl(_, _) => stmt,
+    SReExportAliasBlockers(_) => stmt,
     SLetPat(pat, expr) => SLetPat(pat, desugar_expr(expr)),
     // ADR-0075 Phase 2 (#1343): a resource declaration has no expression to
     // desugar. This match has no catch-all, so the arm is required.

--- a/lib/@vibe/compiler/desugar.vibe
+++ b/lib/@vibe/compiler/desugar.vibe
@@ -245,7 +245,7 @@ export fn desugar_stmt(stmt: Stmt) -> Stmt {
     SExport(_) => stmt,
     SReExport(_, _) => stmt,
     SAliasDecl(_, _) => stmt,
-    SReExportLocalBlockers(_) => stmt,
+    SReExportSourceBoundary(_, _) => stmt,
     SLetPat(pat, expr) => SLetPat(pat, desugar_expr(expr)),
     // ADR-0075 Phase 2 (#1343): a resource declaration has no expression to
     // desugar. This match has no catch-all, so the arm is required.

--- a/lib/@vibe/compiler/desugar.vibe
+++ b/lib/@vibe/compiler/desugar.vibe
@@ -245,7 +245,7 @@ export fn desugar_stmt(stmt: Stmt) -> Stmt {
     SExport(_) => stmt,
     SReExport(_, _) => stmt,
     SAliasDecl(_, _) => stmt,
-    SReExportAliasBlockers(_) => stmt,
+    SReExportLocalBlockers(_) => stmt,
     SLetPat(pat, expr) => SLetPat(pat, desugar_expr(expr)),
     // ADR-0075 Phase 2 (#1343): a resource declaration has no expression to
     // desugar. This match has no catch-all, so the arm is required.

--- a/lib/@vibe/compiler/entry/source_compile/wasi_only/index.vpkg
+++ b/lib/@vibe/compiler/entry/source_compile/wasi_only/index.vpkg
@@ -10,6 +10,7 @@ deps = {
   @vibe/compiler/codegen/wasm_emit : 0.0.1
   @vibe/compiler/core : 0.0.1
   @vibe/compiler/loader : 0.0.1
+  @vibe/compiler/normalize : 0.0.1
   @vibe/compiler/syntax : 0.0.1
   @vibe/core : 0.2.0
 }

--- a/lib/@vibe/compiler/entry/source_compile/wasi_only/merge_sources.vibe
+++ b/lib/@vibe/compiler/entry/source_compile/wasi_only/merge_sources.vibe
@@ -31,6 +31,7 @@ import @vibe/compiler/core {
   build_export_rename_plan,
   collect_import_alias_collision_locals,
   collect_import_alias_collision_refs,
+  collect_import_aliases,
   collect_import_value_renames,
   dir_of_path,
   export_plan_renames_for,
@@ -95,32 +96,117 @@ fn resolve_existing_import_path(base_dir: String, raw_path: String, self_path: S
 /// would double-bind the local. The copy gets the target file's export renames
 /// applied first, so its body's references to renamed sibling exports stay
 /// consistent with the merged program.
+fn append_fs_import_local_def(merged: Array[Stmt], current_path: String, raw_path: String, original: String, local: String, plan: ExportRenamePlan) -> Bool with Exception + Fs {
+  let resolved = resolve_existing_import_path(dir_of_path(current_path), raw_path, current_path)
+  // Builtin read + ingest, same as collect_parsed_sources_recursive
+  // (flatten-lane wiring constraint / #741).
+  let source = ingest_source_text_fs(resolved, Fs::read_file(resolved))
+  let source_stmts = namespace_private_value_stmts(resolved, apply_export_renames_stmts(parse_program(lex(source)), export_plan_renames_for(plan, resolved)))
+  let mut i = 0
+  let mut done = false
+  while i < Array::length(source_stmts) && !done {
+    match rewrite_imported_value_stmt_to_local(Array::get(source_stmts, i), original, local) {
+      Some(local_stmt) => {
+        Array::push(merged, local_stmt)
+        done = true
+      },
+      None => ()
+    }
+    i = i + 1
+  }
+  done
+}
+
 fn append_fs_import_alias_collision_defs(merged: Array[Stmt], current_path: String, stmts: Array[Stmt], plan: ExportRenamePlan, excluded_locals: Array[String]) -> Unit with Exception + Fs {
   let refs = collect_import_alias_collision_refs(stmts)
   let emitted = array_empty()
-  let base_dir = dir_of_path(current_path)
   let mut i = 0
   while i < Array::length(refs) {
     let (raw_path, original, local) = Array::get(refs, i)
     if !string_array_contains_local(emitted, local) && !string_array_contains_local(excluded_locals, local) {
-      let resolved = resolve_existing_import_path(base_dir, raw_path, current_path)
-      // Builtin read + ingest, same as collect_parsed_sources_recursive
-      // (flatten-lane wiring constraint / #741).
-      let source = ingest_source_text_fs(resolved, Fs::read_file(resolved))
-      let source_stmts = namespace_private_value_stmts(resolved, apply_export_renames_stmts(parse_program(lex(source)), export_plan_renames_for(plan, resolved)))
-      let mut j = 0
-      let mut done = false
-      while j < Array::length(source_stmts) && !done {
-        match rewrite_imported_value_stmt_to_local(Array::get(source_stmts, j), original, local) {
-          Some(local_stmt) => {
-            Array::push(merged, local_stmt)
-            Array::push(emitted, local)
-            done = true
-          },
-          None => ()
-        }
-        j = j + 1
+      if append_fs_import_local_def(merged, current_path, raw_path, original, local, plan) {
+        Array::push(emitted, local)
+      } else {
+        ()
       }
+    }
+    i = i + 1
+  }
+}
+
+/// Inline a real import under its local spelling when its ordinary rewrite
+/// target is also claimed by a publication-only re-export alias. A bare target
+/// name cannot carry both authorities through the merged AST; retaining the
+/// import's distinct local binding keeps the two source meanings separate.
+fn append_fs_selected_import_defs(merged: Array[Stmt], current_path: String, stmts: Array[Stmt], plan: ExportRenamePlan, selected_locals: Array[String]) -> Unit with Exception + Fs {
+  let emitted = array_empty()
+  let mut i = 0
+  while i < Array::length(stmts) {
+    match Array::get(stmts, i) {
+      SImport(raw_path, items) => {
+        let mut j = 0
+        while j < Array::length(items) {
+          let item = Array::get(items, j)
+          let local = match item.alias {
+            Some(alias) => alias,
+            None => item.name
+          }
+          if string_array_contains_local(selected_locals, local) && !string_array_contains_local(emitted, local) {
+            if append_fs_import_local_def(merged, current_path, raw_path, item.name, local, plan) {
+              Array::push(emitted, local)
+            } else {
+              throw(String::concat("cannot preserve imported value through re-export alias collision: ", local))
+            }
+          } else {
+            ()
+          }
+          j = j + 1
+        }
+      },
+      _ => ()
+    }
+    i = i + 1
+  }
+}
+
+fn import_rename_locals_targeting(renames: Array[(String, String)], names: Array[String]) -> Array[String] {
+  let out = array_empty()
+  let mut i = 0
+  while i < Array::length(renames) {
+    let (local, target) = Array::get(renames, i)
+    if string_array_contains_local(names, target) && !string_array_contains_local(out, local) {
+      Array::push(out, local)
+    } else {
+      ()
+    }
+    i = i + 1
+  }
+  out
+}
+
+fn import_renames_without_locals(renames: Array[(String, String)], omitted_locals: Array[String]) -> Array[(String, String)] {
+  let out = array_empty()
+  let mut i = 0
+  while i < Array::length(renames) {
+    let rename = Array::get(renames, i)
+    if !string_array_contains_local(omitted_locals, rename.0) {
+      Array::push(out, rename)
+    } else {
+      ()
+    }
+    i = i + 1
+  }
+  out
+}
+
+fn append_unique_strings(target: Array[String], source: Array[String]) -> Unit {
+  let mut i = 0
+  while i < Array::length(source) {
+    let item = Array::get(source, i)
+    if !string_array_contains_local(target, item) {
+      Array::push(target, item)
+    } else {
+      ()
     }
     i = i + 1
   }
@@ -276,9 +362,16 @@ fn append_parsed_merged_stmts(entry_path: String, file_paths: Array[String], fil
     Array::push(merged, SReExportSourceBoundary(reexport_locals, reexport_surface_only))
     if stmts_have_import_deep(stmts) {
       let import_renames = collect_import_value_renames(plan, path, stmts)
+      let retained_collision_locals = import_rename_locals_targeting(collect_import_aliases(stmts), reexport_surface_only)
+      append_unique_strings(retained_collision_locals, import_rename_locals_targeting(import_renames, reexport_surface_only))
+      let active_import_renames = import_renames_without_locals(import_renames, retained_collision_locals)
       let skipped_locals = collect_import_alias_collision_locals(stmts)
-      append_fs_import_alias_collision_defs(merged, path, stmts, plan, import_value_rename_locals(import_renames))
-      append_import_alias_rewritten_non_import_stmts_with_renames(merged, namespaced_stmts, skipped_locals, import_renames)
+      append_unique_strings(skipped_locals, retained_collision_locals)
+      let inline_exclusions = import_value_rename_locals(active_import_renames)
+      append_unique_strings(inline_exclusions, retained_collision_locals)
+      append_fs_import_alias_collision_defs(merged, path, stmts, plan, inline_exclusions)
+      append_fs_selected_import_defs(merged, path, stmts, plan, retained_collision_locals)
+      append_import_alias_rewritten_non_import_stmts_with_renames(merged, namespaced_stmts, skipped_locals, active_import_renames)
     } else {
       append_non_import_stmts_without_alias_rewrite(merged, namespaced_stmts)
     }

--- a/lib/@vibe/compiler/entry/source_compile/wasi_only/merge_sources.vibe
+++ b/lib/@vibe/compiler/entry/source_compile/wasi_only/merge_sources.vibe
@@ -185,8 +185,9 @@ fn transformed_file_stmts(entry_path: String, path: String, stmts: Array[Stmt], 
   }
 }
 
-fn reexport_local_blockers(stmts: Array[Stmt]) -> Array[String] {
-  let out = array_empty()
+fn reexport_source_boundary(stmts: Array[Stmt]) -> (Array[String], Array[String]) {
+  let locals = array_empty()
+  let surface_only = array_empty()
   let mut i = 0
   while i < Array::length(stmts) {
     match Array::get(stmts, i) {
@@ -198,10 +199,18 @@ fn reexport_local_blockers(stmts: Array[Stmt]) -> Array[String] {
             Some(alias) => alias,
             None => item.name
           }
-          if string_array_contains_local(out, local) {
+          if string_array_contains_local(locals, local) {
             ()
           } else {
-            Array::push(out, local)
+            Array::push(locals, local)
+          }
+          match item.alias {
+            Some(alias) => if string_array_contains_local(surface_only, alias) {
+              ()
+            } else {
+              Array::push(surface_only, alias)
+            },
+            None => ()
           }
           j = j + 1
         }
@@ -210,7 +219,7 @@ fn reexport_local_blockers(stmts: Array[Stmt]) -> Array[String] {
     }
     i = i + 1
   }
-  out
+  (locals, surface_only)
 }
 
 fn append_parsed_merged_stmts(entry_path: String, file_paths: Array[String], file_stmts: Array[Array[Stmt]], merged: Array[Stmt]) -> ExportRenamePlan with Exception + Fs {
@@ -220,10 +229,11 @@ fn append_parsed_merged_stmts(entry_path: String, file_paths: Array[String], fil
     let path = Array::get(file_paths, fi)
     let stmts = Array::get(file_stmts, fi)
     let namespaced_stmts = transformed_file_stmts(entry_path, path, stmts, plan)
-    // Imports and re-exports disappear from the executable merged AST. Keep a
-    // source-boundary marker so every re-export remains publication-only
-    // for this unit without blocking builtins in the next unit (#2287).
-    Array::push(merged, SReExportLocalBlockers(reexport_local_blockers(stmts)))
+    // Imports and re-exports disappear from the executable merged AST. Keep
+    // each source's locally visible names separate from aliased surface-only
+    // names, without blocking builtins in the next unit (#2287).
+    let (reexport_locals, reexport_surface_only) = reexport_source_boundary(stmts)
+    Array::push(merged, SReExportSourceBoundary(reexport_locals, reexport_surface_only))
     if stmts_have_import_deep(stmts) {
       let import_renames = collect_import_value_renames(plan, path, stmts)
       let skipped_locals = collect_import_alias_collision_locals(stmts)

--- a/lib/@vibe/compiler/entry/source_compile/wasi_only/merge_sources.vibe
+++ b/lib/@vibe/compiler/entry/source_compile/wasi_only/merge_sources.vibe
@@ -192,36 +192,37 @@ fn transformed_file_stmts(entry_path: String, path: String, stmts: Array[Stmt], 
 fn reexport_source_boundary(stmts: Array[Stmt]) -> (Array[String], Array[String]) {
   let locals = array_empty()
   let surface_only = array_empty()
-  let mut i = 0
-  while i < Array::length(stmts) {
+  let decided = array_empty()
+  // Re-export projection is last-binding-wins. Scan backwards so a later
+  // plain re-export cancels an earlier publication-only alias blocker, while
+  // a later alias still hides an earlier plain binding.
+  let mut i = Array::length(stmts) - 1
+  while i >= 0 {
     match Array::get(stmts, i) {
       SReExport(_, items) => {
-        let mut j = 0
-        while j < Array::length(items) {
+        let mut j = Array::length(items) - 1
+        while j >= 0 {
           let item = Array::get(items, j)
           let local = match item.alias {
             Some(alias) => alias,
             None => item.name
           }
-          if string_array_contains_local(locals, local) {
+          if string_array_contains_local(decided, local) {
             ()
           } else {
+            Array::push(decided, local)
             Array::push(locals, local)
+            match item.alias {
+              Some(alias) => Array::push(surface_only, alias),
+              None => ()
+            }
           }
-          match item.alias {
-            Some(alias) => if string_array_contains_local(surface_only, alias) {
-              ()
-            } else {
-              Array::push(surface_only, alias)
-            },
-            None => ()
-          }
-          j = j + 1
+          j = j - 1
         }
       },
       _ => ()
     }
-    i = i + 1
+    i = i - 1
   }
   (locals, surface_only)
 }

--- a/lib/@vibe/compiler/entry/source_compile/wasi_only/merge_sources.vibe
+++ b/lib/@vibe/compiler/entry/source_compile/wasi_only/merge_sources.vibe
@@ -189,9 +189,10 @@ fn transformed_file_stmts(entry_path: String, path: String, stmts: Array[Stmt], 
   }
 }
 
-fn reexport_source_boundary(stmts: Array[Stmt], retain_entry_originals: Bool) -> (Array[String], Array[String]) {
+fn reexport_source_boundary(stmts: Array[Stmt], retain_entry_originals: Bool) -> (Array[String], Array[String], Array[String]) {
   let locals = array_empty()
   let surface_only = array_empty()
+  let retained_originals = array_empty()
   let decided = array_empty()
   // Re-export projection is last-binding-wins. Scan backwards so a later
   // plain re-export cancels an earlier publication-only alias blocker, while
@@ -218,15 +219,14 @@ fn reexport_source_boundary(stmts: Array[Stmt], retain_entry_originals: Bool) ->
             }
           }
           // Entry re-exports retain the dependency definition under its
-          // original ABI spelling. That implementation detail must not make
-          // the source name locally visible when the source published only an
-          // alias. Treat it as another publication-only name unless a later
-          // re-export already decided that spelling.
+          // original ABI spelling. Record that spelling for validation before
+          // import rewriting: a raw source reference is invalid, while a real
+          // imported alias may legitimately rewrite to the same retained name.
           match item.alias {
             Some(_) => if retain_entry_originals && !string_array_contains_local(decided, item.name) {
               Array::push(decided, item.name)
               Array::push(locals, item.name)
-              Array::push(surface_only, item.name)
+              Array::push(retained_originals, item.name)
             } else {
               ()
             },
@@ -239,7 +239,26 @@ fn reexport_source_boundary(stmts: Array[Stmt], retain_entry_originals: Bool) ->
     }
     i = i - 1
   }
-  (locals, surface_only)
+  (locals, surface_only, retained_originals)
+}
+
+/// Reject direct uses of an entry re-export's retained implementation name
+/// before import aliases are rewritten. The merged AST may contain that name
+/// afterward as the valid target of a real import, so it cannot remain a
+/// checker lookup blocker in the transformed source.
+fn validate_retained_entry_source_names(stmts: Array[Stmt], retained_originals: Array[String]) -> Unit with Exception {
+  if Array::length(retained_originals) > 0 {
+    let source_unit = empty_stmt_array()
+    Array::push(source_unit, SReExportSourceBoundary(array_empty(), retained_originals))
+    let mut i = 0
+    while i < Array::length(stmts) {
+      Array::push(source_unit, Array::get(stmts, i))
+      i = i + 1
+    }
+    validate_serializable_reexport_references(source_unit)
+  } else {
+    ()
+  }
 }
 
 fn append_parsed_merged_stmts(entry_path: String, file_paths: Array[String], file_stmts: Array[Array[Stmt]], merged: Array[Stmt]) -> ExportRenamePlan with Exception + Fs {
@@ -252,7 +271,8 @@ fn append_parsed_merged_stmts(entry_path: String, file_paths: Array[String], fil
     // Imports and re-exports disappear from the executable merged AST. Keep
     // each source's locally visible names separate from aliased surface-only
     // names, without blocking builtins in the next unit (#2287).
-    let (reexport_locals, reexport_surface_only) = reexport_source_boundary(stmts, path == entry_path)
+    let (reexport_locals, reexport_surface_only, retained_originals) = reexport_source_boundary(stmts, path == entry_path)
+    validate_retained_entry_source_names(stmts, retained_originals)
     Array::push(merged, SReExportSourceBoundary(reexport_locals, reexport_surface_only))
     if stmts_have_import_deep(stmts) {
       let import_renames = collect_import_value_renames(plan, path, stmts)

--- a/lib/@vibe/compiler/entry/source_compile/wasi_only/merge_sources.vibe
+++ b/lib/@vibe/compiler/entry/source_compile/wasi_only/merge_sources.vibe
@@ -140,12 +140,14 @@ fn append_fs_import_alias_collision_defs(merged: Array[Stmt], current_path: Stri
 /// import's distinct local binding keeps the two source meanings separate.
 fn append_fs_selected_import_defs(merged: Array[Stmt], current_path: String, stmts: Array[Stmt], plan: ExportRenamePlan, selected_locals: Array[String]) -> Unit with Exception + Fs {
   let emitted = array_empty()
-  let mut i = 0
-  while i < Array::length(stmts) {
+  // Import lookup is last-binding-wins. Preserve the same winner when more
+  // than one import uses the selected local spelling.
+  let mut i = Array::length(stmts) - 1
+  while i >= 0 {
     match Array::get(stmts, i) {
       SImport(raw_path, items) => {
-        let mut j = 0
-        while j < Array::length(items) {
+        let mut j = Array::length(items) - 1
+        while j >= 0 {
           let item = Array::get(items, j)
           let local = match item.alias {
             Some(alias) => alias,
@@ -160,12 +162,12 @@ fn append_fs_selected_import_defs(merged: Array[Stmt], current_path: String, stm
           } else {
             ()
           }
-          j = j + 1
+          j = j - 1
         }
       },
       _ => ()
     }
-    i = i + 1
+    i = i - 1
   }
 }
 
@@ -175,6 +177,21 @@ fn import_rename_locals_targeting(renames: Array[(String, String)], names: Array
   while i < Array::length(renames) {
     let (local, target) = Array::get(renames, i)
     if string_array_contains_local(names, target) && !string_array_contains_local(out, local) {
+      Array::push(out, local)
+    } else {
+      ()
+    }
+    i = i + 1
+  }
+  out
+}
+
+fn import_rename_locals_named(renames: Array[(String, String)], names: Array[String]) -> Array[String] {
+  let out = array_empty()
+  let mut i = 0
+  while i < Array::length(renames) {
+    let (local, _) = Array::get(renames, i)
+    if string_array_contains_local(names, local) && !string_array_contains_local(out, local) {
       Array::push(out, local)
     } else {
       ()
@@ -366,6 +383,7 @@ fn append_parsed_merged_stmts(entry_path: String, file_paths: Array[String], fil
       append_unique_strings(retained_collision_locals, import_rename_locals_targeting(import_renames, reexport_surface_only))
       let active_import_renames = import_renames_without_locals(import_renames, retained_collision_locals)
       let skipped_locals = collect_import_alias_collision_locals(stmts)
+      append_unique_strings(skipped_locals, import_rename_locals_named(collect_import_aliases(stmts), reexport_surface_only))
       append_unique_strings(skipped_locals, retained_collision_locals)
       let inline_exclusions = import_value_rename_locals(active_import_renames)
       append_unique_strings(inline_exclusions, retained_collision_locals)

--- a/lib/@vibe/compiler/entry/source_compile/wasi_only/merge_sources.vibe
+++ b/lib/@vibe/compiler/entry/source_compile/wasi_only/merge_sources.vibe
@@ -12,6 +12,10 @@ import @vibe/compiler/codegen/wasi {
   compile_wasi_module_impl
 }
 
+import @vibe/compiler/normalize {
+  desugar_inspect_calls, validate_serializable_reexport_special_calls
+}
+
 import @vibe/compiler/syntax {
   lex, parse_program, print_program
 }
@@ -566,7 +570,13 @@ export fn coverage_driver_program_source_fs(entry_path: String, driver_path: Str
   let plan = append_parsed_merged_stmts(entry_path, file_paths, file_stmts, merged)
   let driver_source = ingest_source_text_fs(driver_path, Fs::read_file(driver_path))
   let driver_stmts = parse_program(lex(driver_source))
+  // The driver is a separate source unit from the compiler entry that precedes
+  // it, so source-scoped builtin classification must start a fresh range.
+  Array::push(merged, SReExportSourceBoundary(array_empty(), array_empty()))
   append_coverage_driver_stmts(entry_path, driver_path, driver_stmts, file_paths, file_stmts, plan, merged)
+  validate_serializable_reexport_special_calls(merged)
+  desugar_inspect_calls(merged)
+  expand_interp_stmts(merged)
   print_program(merged)
 }
 
@@ -586,6 +596,12 @@ export fn merged_program_source_fs(entry_path: String) -> String with Exception 
   let stmts = empty_stmt_array()
   let visited = path_set_new()
   collect_merged_stmts_recursive(entry_path, stmts, visited)
+  // Complete source-scoped special-call rewrites while the in-memory boundary
+  // metadata still exists. The printed program needs no sentinel syntax and
+  // can be reparsed as ordinary user source without a lexer/parser exception.
+  validate_serializable_reexport_special_calls(stmts)
+  desugar_inspect_calls(stmts)
+  expand_interp_stmts(stmts)
   print_program(stmts)
 }
 

--- a/lib/@vibe/compiler/entry/source_compile/wasi_only/merge_sources.vibe
+++ b/lib/@vibe/compiler/entry/source_compile/wasi_only/merge_sources.vibe
@@ -185,7 +185,7 @@ fn transformed_file_stmts(entry_path: String, path: String, stmts: Array[Stmt], 
   }
 }
 
-fn reexport_alias_blockers(stmts: Array[Stmt]) -> Array[String] {
+fn reexport_local_blockers(stmts: Array[Stmt]) -> Array[String] {
   let out = array_empty()
   let mut i = 0
   while i < Array::length(stmts) {
@@ -193,13 +193,15 @@ fn reexport_alias_blockers(stmts: Array[Stmt]) -> Array[String] {
       SReExport(_, items) => {
         let mut j = 0
         while j < Array::length(items) {
-          match Array::get(items, j).alias {
-            Some(alias) => if string_array_contains_local(out, alias) {
-              ()
-            } else {
-              Array::push(out, alias)
-            },
-            None => ()
+          let item = Array::get(items, j)
+          let local = match item.alias {
+            Some(alias) => alias,
+            None => item.name
+          }
+          if string_array_contains_local(out, local) {
+            ()
+          } else {
+            Array::push(out, local)
           }
           j = j + 1
         }
@@ -219,9 +221,9 @@ fn append_parsed_merged_stmts(entry_path: String, file_paths: Array[String], fil
     let stmts = Array::get(file_stmts, fi)
     let namespaced_stmts = transformed_file_stmts(entry_path, path, stmts, plan)
     // Imports and re-exports disappear from the executable merged AST. Keep a
-    // source-boundary marker so an aliased re-export remains publication-only
+    // source-boundary marker so every re-export remains publication-only
     // for this unit without blocking builtins in the next unit (#2287).
-    Array::push(merged, SReExportAliasBlockers(reexport_alias_blockers(stmts)))
+    Array::push(merged, SReExportLocalBlockers(reexport_local_blockers(stmts)))
     if stmts_have_import_deep(stmts) {
       let import_renames = collect_import_value_renames(plan, path, stmts)
       let skipped_locals = collect_import_alias_collision_locals(stmts)

--- a/lib/@vibe/compiler/entry/source_compile/wasi_only/merge_sources.vibe
+++ b/lib/@vibe/compiler/entry/source_compile/wasi_only/merge_sources.vibe
@@ -185,6 +185,32 @@ fn transformed_file_stmts(entry_path: String, path: String, stmts: Array[Stmt], 
   }
 }
 
+fn reexport_alias_blockers(stmts: Array[Stmt]) -> Array[String] {
+  let out = array_empty()
+  let mut i = 0
+  while i < Array::length(stmts) {
+    match Array::get(stmts, i) {
+      SReExport(_, items) => {
+        let mut j = 0
+        while j < Array::length(items) {
+          match Array::get(items, j).alias {
+            Some(alias) => if string_array_contains_local(out, alias) {
+              ()
+            } else {
+              Array::push(out, alias)
+            },
+            None => ()
+          }
+          j = j + 1
+        }
+      },
+      _ => ()
+    }
+    i = i + 1
+  }
+  out
+}
+
 fn append_parsed_merged_stmts(entry_path: String, file_paths: Array[String], file_stmts: Array[Array[Stmt]], merged: Array[Stmt]) -> ExportRenamePlan with Exception + Fs {
   let plan = build_export_rename_plan(file_paths, file_stmts, entry_path)
   let mut fi = 0
@@ -192,6 +218,10 @@ fn append_parsed_merged_stmts(entry_path: String, file_paths: Array[String], fil
     let path = Array::get(file_paths, fi)
     let stmts = Array::get(file_stmts, fi)
     let namespaced_stmts = transformed_file_stmts(entry_path, path, stmts, plan)
+    // Imports and re-exports disappear from the executable merged AST. Keep a
+    // source-boundary marker so an aliased re-export remains publication-only
+    // for this unit without blocking builtins in the next unit (#2287).
+    Array::push(merged, SReExportAliasBlockers(reexport_alias_blockers(stmts)))
     if stmts_have_import_deep(stmts) {
       let import_renames = collect_import_value_renames(plan, path, stmts)
       let skipped_locals = collect_import_alias_collision_locals(stmts)

--- a/lib/@vibe/compiler/entry/source_compile/wasi_only/merge_sources.vibe
+++ b/lib/@vibe/compiler/entry/source_compile/wasi_only/merge_sources.vibe
@@ -13,7 +13,7 @@ import @vibe/compiler/codegen/wasi {
 }
 
 import @vibe/compiler/normalize {
-  desugar_inspect_calls, validate_serializable_reexport_special_calls
+  desugar_inspect_calls, validate_serializable_reexport_special_references
 }
 
 import @vibe/compiler/syntax {
@@ -575,7 +575,7 @@ export fn coverage_driver_program_source_fs(entry_path: String, driver_path: Str
   // it, so source-scoped builtin classification must start a fresh range.
   Array::push(merged, SReExportSourceBoundary(array_empty(), array_empty()))
   append_coverage_driver_stmts(entry_path, driver_path, driver_stmts, file_paths, file_stmts, plan, merged)
-  validate_serializable_reexport_special_calls(merged)
+  validate_serializable_reexport_special_references(merged)
   desugar_inspect_calls(merged)
   expand_interp_stmts(merged)
   print_program(merged)
@@ -600,7 +600,7 @@ export fn merged_program_source_fs(entry_path: String) -> String with Exception 
   // Complete source-scoped special-call rewrites while the in-memory boundary
   // metadata still exists. The printed program needs no sentinel syntax and
   // can be reparsed as ordinary user source without a lexer/parser exception.
-  validate_serializable_reexport_special_calls(stmts)
+  validate_serializable_reexport_special_references(stmts)
   desugar_inspect_calls(stmts)
   expand_interp_stmts(stmts)
   print_program(stmts)

--- a/lib/@vibe/compiler/entry/source_compile/wasi_only/merge_sources.vibe
+++ b/lib/@vibe/compiler/entry/source_compile/wasi_only/merge_sources.vibe
@@ -13,7 +13,7 @@ import @vibe/compiler/codegen/wasi {
 }
 
 import @vibe/compiler/normalize {
-  desugar_inspect_calls, validate_serializable_reexport_special_references
+  desugar_inspect_calls, validate_serializable_reexport_references
 }
 
 import @vibe/compiler/syntax {
@@ -575,7 +575,7 @@ export fn coverage_driver_program_source_fs(entry_path: String, driver_path: Str
   // it, so source-scoped builtin classification must start a fresh range.
   Array::push(merged, SReExportSourceBoundary(array_empty(), array_empty()))
   append_coverage_driver_stmts(entry_path, driver_path, driver_stmts, file_paths, file_stmts, plan, merged)
-  validate_serializable_reexport_special_references(merged)
+  validate_serializable_reexport_references(merged)
   desugar_inspect_calls(merged)
   expand_interp_stmts(merged)
   print_program(merged)
@@ -600,7 +600,7 @@ export fn merged_program_source_fs(entry_path: String) -> String with Exception 
   // Complete source-scoped special-call rewrites while the in-memory boundary
   // metadata still exists. The printed program needs no sentinel syntax and
   // can be reparsed as ordinary user source without a lexer/parser exception.
-  validate_serializable_reexport_special_references(stmts)
+  validate_serializable_reexport_references(stmts)
   desugar_inspect_calls(stmts)
   expand_interp_stmts(stmts)
   print_program(stmts)

--- a/lib/@vibe/compiler/entry/source_compile/wasi_only/merge_sources.vibe
+++ b/lib/@vibe/compiler/entry/source_compile/wasi_only/merge_sources.vibe
@@ -189,7 +189,7 @@ fn transformed_file_stmts(entry_path: String, path: String, stmts: Array[Stmt], 
   }
 }
 
-fn reexport_source_boundary(stmts: Array[Stmt]) -> (Array[String], Array[String]) {
+fn reexport_source_boundary(stmts: Array[Stmt], retain_entry_originals: Bool) -> (Array[String], Array[String]) {
   let locals = array_empty()
   let surface_only = array_empty()
   let decided = array_empty()
@@ -217,6 +217,21 @@ fn reexport_source_boundary(stmts: Array[Stmt]) -> (Array[String], Array[String]
               None => ()
             }
           }
+          // Entry re-exports retain the dependency definition under its
+          // original ABI spelling. That implementation detail must not make
+          // the source name locally visible when the source published only an
+          // alias. Treat it as another publication-only name unless a later
+          // re-export already decided that spelling.
+          match item.alias {
+            Some(_) => if retain_entry_originals && !string_array_contains_local(decided, item.name) {
+              Array::push(decided, item.name)
+              Array::push(locals, item.name)
+              Array::push(surface_only, item.name)
+            } else {
+              ()
+            },
+            None => ()
+          }
           j = j - 1
         }
       },
@@ -237,7 +252,7 @@ fn append_parsed_merged_stmts(entry_path: String, file_paths: Array[String], fil
     // Imports and re-exports disappear from the executable merged AST. Keep
     // each source's locally visible names separate from aliased surface-only
     // names, without blocking builtins in the next unit (#2287).
-    let (reexport_locals, reexport_surface_only) = reexport_source_boundary(stmts)
+    let (reexport_locals, reexport_surface_only) = reexport_source_boundary(stmts, path == entry_path)
     Array::push(merged, SReExportSourceBoundary(reexport_locals, reexport_surface_only))
     if stmts_have_import_deep(stmts) {
       let import_renames = collect_import_value_renames(plan, path, stmts)

--- a/lib/@vibe/compiler/normalize/desugar_trait_dict.vibe
+++ b/lib/@vibe/compiler/normalize/desugar_trait_dict.vibe
@@ -6370,7 +6370,7 @@ fn is_assert_eq_call(callee: Expr, args: Array[Expr]) -> Bool {
 /// cell above: whether THIS program binds `assert_eq` itself.
 ///
 /// For an ordinary source array this is program-wide. The FS merge inserts an
-/// `SReExportAliasBlockers` marker before each source unit; the final rewrite
+/// `SReExportLocalBlockers` marker before each source unit; the final rewrite
 /// loop resets the cached answer and active range at every marker, so a
 /// dependency's blocker cannot suppress an unrelated entry builtin (#2287).
 ///
@@ -6453,7 +6453,7 @@ fn user_assert_eq_bound() -> Bool {
 /// UNSCOPED within one source unit: one binder anywhere in that unit stands
 /// the lowering down even for call sites the binder does not reach. A scoped
 /// answer would have to thread a binder set through `rewrite_expr`, which
-/// carries nine parameters already. `SReExportAliasBlockers` still separates
+/// carries nine parameters already. `SReExportLocalBlockers` still separates
 /// FS-merged units, so this conservative answer does not leak across modules.
 fn stmts_define_assert_eq(stmts: Array[Stmt]) -> Bool {
   stmts_range_define_assert_eq(stmts, 0, Array::length(stmts))
@@ -6628,7 +6628,7 @@ fn stmt_binds_assert_eq(stmt: Stmt) -> Bool {
     // bare prelude name; see the #2296 review measurement above.
     SImport(_, items) => import_binds_assert_eq(items),
     // Direct/single-source checking still sees the original re-export. The FS
-    // merge carries aliases separately in SReExportAliasBlockers (#2287).
+    // merge carries re-export locals separately in SReExportLocalBlockers (#2287).
     SReExport(_, items) => import_binds_assert_eq(items),
     _ => false
   }
@@ -6656,7 +6656,7 @@ fn reexport_blockers_bind_assert_eq(names: Array[String]) -> Bool {
 
 fn merged_source_range_end(stmts: Array[Stmt], start: Int) -> Int {
   let mut end = start
-  while end < Array::length(stmts) && !(Array::get(stmts, end) is SReExportAliasBlockers(_)) {
+  while end < Array::length(stmts) && !(Array::get(stmts, end) is SReExportLocalBlockers(_)) {
     end = end + 1
   }
   end
@@ -14610,11 +14610,11 @@ fn dinsp_rewrite_range(stmts: Array[Stmt], start: Int, end: Int) -> Bool {
   changed
 }
 
-fn dinsp_has_reexport_alias_boundaries(stmts: Array[Stmt]) -> Bool {
+fn dinsp_has_reexport_local_boundaries(stmts: Array[Stmt]) -> Bool {
   let mut i = 0
   let mut found = false
   while !found && i < Array::length(stmts) {
-    found = Array::get(stmts, i) is SReExportAliasBlockers(_)
+    found = Array::get(stmts, i) is SReExportLocalBlockers(_)
     i = i + 1
   }
   found
@@ -14625,10 +14625,10 @@ fn dinsp_rewrite_merged_source_ranges(stmts: Array[Stmt]) -> Bool {
   let mut i = 0
   while i < Array::length(stmts) {
     match Array::get(stmts, i) {
-      SReExportAliasBlockers(names) => {
+      SReExportLocalBlockers(names) => {
         let start = i + 1
         let mut end = start
-        while end < Array::length(stmts) && !(Array::get(stmts, end) is SReExportAliasBlockers(_)) {
+        while end < Array::length(stmts) && !(Array::get(stmts, end) is SReExportLocalBlockers(_)) {
           end = end + 1
         }
         if !dinsp_blocker_names_inspect(names) && !dinsp_range_binds_inspect(stmts, start, end) {
@@ -14701,7 +14701,7 @@ fn dinsp_mentions_binder(expr: Expr) -> Bool {
 /// see dinsp_uses for why that guard is load-bearing rather than cosmetic.
 export fn desugar_inspect_calls_reporting_change(stmts: Array[Stmt]) -> Bool {
   let mut changed = false
-  if dinsp_has_reexport_alias_boundaries(stmts) {
+  if dinsp_has_reexport_local_boundaries(stmts) {
     changed = dinsp_rewrite_merged_source_ranges(stmts)
   } else if dinsp_binds_inspect(stmts) {
     ()
@@ -15408,7 +15408,7 @@ export fn desugar_trait_dicts(stmts: Array[Stmt]) -> Unit with Exception {
   let mut i = 0
   while i < Array::length(stmts) {
     match Array::get(stmts, i) {
-      SReExportAliasBlockers(names) => user_assert_eq_set_merged_source(stmts, i + 1, names),
+      SReExportLocalBlockers(names) => user_assert_eq_set_merged_source(stmts, i + 1, names),
       stmt => Array::set(stmts, i, rewrite_stmt(stmt, gens, traits, struct_sets, fn_returns, toplevel_vars))
     }
     i = i + 1

--- a/lib/@vibe/compiler/normalize/desugar_trait_dict.vibe
+++ b/lib/@vibe/compiler/normalize/desugar_trait_dict.vibe
@@ -36,7 +36,8 @@ import @vibe/parser {
   binder_authority_slot_role,
   detach_stmts,
   located_program_binder_authority_nodes,
-  located_program_binder_authority_program
+  located_program_binder_authority_program,
+  resolve_interp_expr
 }
 
 //# Functions
@@ -14539,54 +14540,195 @@ fn dinsp_stmt_uses(stmt: Stmt) -> Bool {
   }
 }
 
-fn stmt_mentions_name(stmt: Stmt, name: String) -> Bool {
-  match stmt {
-    SModule(_, _, body) => range_mentions_name(body, 0, Array::length(body), name),
-    _ => {
-      let body = match stmt {
-        SLet(_, _, _, _, expr) => Some(expr),
-        SLetMut(_, _, expr) => Some(expr),
-        SLetPat(_, expr) => Some(expr),
-        STest(_, expr) => Some(expr),
-        SBench(_, expr) => Some(expr),
-        SExample(_, expr) => Some(expr),
-        SExpr(expr) => Some(expr),
-        SFnDecl(_, _, expr, _, _) => Some(expr),
-        _ => None
-      }
-      match body {
-        Some(expr) => dinsp_scan(expr, 2, name),
-        None => false
-      }
-    }
-  }
-}
-
-fn range_mentions_name(stmts: Array[Stmt], start: Int, end: Int, name: String) -> Bool {
-  let mut i = start
+fn import_items_bind_name(items: Array[ImportItem], name: String) -> Bool {
+  let mut i = 0
   let mut found = false
-  while !found && i < end {
-    found = stmt_mentions_name(Array::get(stmts, i), name)
+  while i < Array::length(items) && !found {
+    let item = Array::get(items, i)
+    let local = match item.alias {
+      Some(alias) => alias,
+      None => item.name
+    }
+    found = local == name
     i = i + 1
   }
   found
 }
 
-/// Reject a reference to a surface-only re-export alias whose spelling would
-/// be reclassified as a compiler builtin after source-boundary metadata is
-/// removed. A real same-source binding survives serialization and remains
-/// authoritative.
-export fn validate_serializable_reexport_special_references(stmts: Array[Stmt]) -> Unit with Exception {
+/// A declaration that gives `name` real source-local meaning. Top-level value
+/// declarations are preclaimed by the checker, so their order within the
+/// source unit does not change this answer. An aliased re-export is omitted on
+/// purpose: its alias is publication-only and is exactly what this validation
+/// protects from becoming a local after serialization.
+fn stmt_top_level_binds_name(stmt: Stmt, name: String) -> Bool {
+  match stmt {
+    SLet(_, _, local, _, _) => local == name,
+    SLetMut(local, _, _) => local == name,
+    SLetPat(pat, _) => pat_binds_name(pat, name),
+    SFnDecl(_, local, _, _, _) => local == name,
+    SExternLet(local, _) => local == name,
+    SImport(_, items) => import_items_bind_name(items, name),
+    SReExport(_, items) => plain_reexport_binds(items, name),
+    _ => false
+  }
+}
+
+fn range_top_level_binds_name(stmts: Array[Stmt], start: Int, end: Int, name: String) -> Bool {
+  let mut i = start
+  let mut found = false
+  while i < end && !found {
+    found = stmt_top_level_binds_name(Array::get(stmts, i), name)
+    i = i + 1
+  }
+  found
+}
+
+fn expr_list_has_free_name(items: Array[Expr], name: String) -> Bool with Exception {
+  let mut i = 0
+  let mut found = false
+  while i < Array::length(items) && !found {
+    found = expr_has_free_name(Array::get(items, i), name)
+    i = i + 1
+  }
+  found
+}
+
+fn arm_list_has_free_name(arms: Array[(Pat, Expr)], name: String) -> Bool with Exception {
+  let mut i = 0
+  let mut found = false
+  while i < Array::length(arms) && !found {
+    let (pat, body) = Array::get(arms, i)
+    if !pat_binds_name(pat, name) {
+      found = expr_has_free_name(body, name)
+    } else {
+      ()
+    }
+    i = i + 1
+  }
+  found
+}
+
+/// Whether `name` occurs free in this expression. Binding forms stop only the
+/// body region they govern; a same-spelled parameter in one nested function
+/// must not hide an unrelated reference elsewhere in the source unit.
+fn expr_has_free_name(expr: Expr, name: String) -> Bool with Exception {
+  match expr {
+    EIdent(local, _) => local == name,
+    EStringInterp(_) => expr_has_free_name(resolve_interp_expr(expr), name),
+    ELet(local, value, body, _) => expr_has_free_name(value, name) || if local == name {
+      false
+    } else {
+      expr_has_free_name(body, name)
+    },
+    ELetRec(local, value, body) => if local == name {
+      false
+    } else {
+      expr_has_free_name(value, name) || expr_has_free_name(body, name)
+    },
+    ELetMut(local, value, body, _) => expr_has_free_name(value, name) || if local == name {
+      false
+    } else {
+      expr_has_free_name(body, name)
+    },
+    EAssign(local, value, body) => local == name || expr_has_free_name(value, name) || expr_has_free_name(body, name),
+    EAssignOp(local, _, value, body) => local == name || expr_has_free_name(value, name) || expr_has_free_name(body, name),
+    EForIn(value_name, key_name, iter, body) => expr_has_free_name(iter, name) || if value_name == name || match key_name {
+      Some(key) => key == name,
+      None => false
+    } {
+      false
+    } else {
+      expr_has_free_name(body, name)
+    },
+    EFn(_, _, params, _, _, body) => if params_bind_name(params, name) {
+      false
+    } else {
+      expr_has_free_name(body, name)
+    },
+    ELoop(params, body) => {
+      let mut i = 0
+      let mut found = false
+      let mut shadowed = false
+      while i < Array::length(params) {
+        let (local, initial) = Array::get(params, i)
+        if !found {
+          found = expr_has_free_name(initial, name)
+        } else {
+          ()
+        }
+        if local == name {
+          shadowed = true
+        } else {
+          ()
+        }
+        i = i + 1
+      }
+      found || if shadowed {
+        false
+      } else {
+        expr_has_free_name(body, name)
+      }
+    },
+    EMatch(scrutinee, arms) => expr_has_free_name(scrutinee, name) || arm_list_has_free_name(arms, name),
+    EHandle(body, arms) => expr_has_free_name(body, name) || arm_list_has_free_name(arms, name),
+    _ => expr_list_has_free_name(expr_children(expr), name)
+  }
+}
+
+fn stmt_has_free_name(stmt: Stmt, name: String) -> Bool with Exception {
+  match stmt {
+    SLet(_, _, _, _, expr) => expr_has_free_name(expr, name),
+    SLetMut(_, _, expr) => expr_has_free_name(expr, name),
+    SLetPat(_, expr) => expr_has_free_name(expr, name),
+    STest(_, expr) => expr_has_free_name(expr, name),
+    SBench(_, expr) => expr_has_free_name(expr, name),
+    SExample(_, expr) => expr_has_free_name(expr, name),
+    SExpr(expr) => expr_has_free_name(expr, name),
+    SFnDecl(_, _, expr, requires, ensures) => expr_has_free_name(expr, name) || expr_list_has_free_name(requires, name) || expr_list_has_free_name(ensures, name),
+    SModule(_, _, body) => range_has_free_name(body, 0, Array::length(body), name),
+    _ => false
+  }
+}
+
+fn range_has_free_name(stmts: Array[Stmt], start: Int, end: Int, name: String) -> Bool with Exception {
+  if range_top_level_binds_name(stmts, start, end, name) {
+    false
+  } else {
+    let mut i = start
+    let mut found = false
+    while i < end && !found {
+      found = stmt_has_free_name(Array::get(stmts, i), name)
+      i = i + 1
+    }
+    found
+  }
+}
+
+/// Reject every free reference to a publication-only re-export alias before
+/// source-boundary metadata is removed. Without this check, reparsing the
+/// printed program can silently reinterpret names such as `println`,
+/// `assert_eq`, or `inspect` as compiler builtins. A real top-level binding or
+/// a lexical binding that governs the particular reference remains valid.
+export fn validate_serializable_reexport_references(stmts: Array[Stmt]) -> Unit with Exception {
   let mut i = 0
   while i < Array::length(stmts) {
     match Array::get(stmts, i) {
       SReExportSourceBoundary(_, surface_only_names) => {
         let start = i + 1
         let end = merged_source_range_end(stmts, start)
-        if reexport_blockers_bind_assert_eq(surface_only_names) && !stmts_range_define_assert_eq(stmts, start, end) && range_mentions_name(stmts, start, end, "assert_eq") {
-          throw("unknown name: assert_eq")
-        } else if dinsp_blocker_names_inspect(surface_only_names) && !dinsp_range_binds_inspect(stmts, start, end) && range_mentions_name(stmts, start, end, "inspect") {
-          throw("unknown name: inspect")
+        let mut n = 0
+        let mut invalid = ""
+        while n < Array::length(surface_only_names) && String::length(invalid) == 0 {
+          let name = Array::get(surface_only_names, n)
+          if range_has_free_name(stmts, start, end, name) {
+            invalid = name
+          } else {
+            ()
+          }
+          n = n + 1
+        }
+        if String::length(invalid) > 0 {
+          throw(String::concat("unknown name: ", invalid))
         } else {
           ()
         }

--- a/lib/@vibe/compiler/normalize/desugar_trait_dict.vibe
+++ b/lib/@vibe/compiler/normalize/desugar_trait_dict.vibe
@@ -6370,7 +6370,7 @@ fn is_assert_eq_call(callee: Expr, args: Array[Expr]) -> Bool {
 /// cell above: whether THIS program binds `assert_eq` itself.
 ///
 /// For an ordinary source array this is program-wide. The FS merge inserts an
-/// `SReExportLocalBlockers` marker before each source unit; the final rewrite
+/// `SReExportSourceBoundary` marker before each source unit; the final rewrite
 /// loop resets the cached answer and active range at every marker, so a
 /// dependency's blocker cannot suppress an unrelated entry builtin (#2287).
 ///
@@ -6453,7 +6453,7 @@ fn user_assert_eq_bound() -> Bool {
 /// UNSCOPED within one source unit: one binder anywhere in that unit stands
 /// the lowering down even for call sites the binder does not reach. A scoped
 /// answer would have to thread a binder set through `rewrite_expr`, which
-/// carries nine parameters already. `SReExportLocalBlockers` still separates
+/// carries nine parameters already. `SReExportSourceBoundary` still separates
 /// FS-merged units, so this conservative answer does not leak across modules.
 fn stmts_define_assert_eq(stmts: Array[Stmt]) -> Bool {
   stmts_range_define_assert_eq(stmts, 0, Array::length(stmts))
@@ -6628,7 +6628,7 @@ fn stmt_binds_assert_eq(stmt: Stmt) -> Bool {
     // bare prelude name; see the #2296 review measurement above.
     SImport(_, items) => import_binds_assert_eq(items),
     // Direct/single-source checking still sees the original re-export. The FS
-    // merge carries re-export locals separately in SReExportLocalBlockers (#2287).
+    // merge carries re-export locals separately in SReExportSourceBoundary (#2287).
     SReExport(_, items) => import_binds_assert_eq(items),
     _ => false
   }
@@ -6656,7 +6656,7 @@ fn reexport_blockers_bind_assert_eq(names: Array[String]) -> Bool {
 
 fn merged_source_range_end(stmts: Array[Stmt], start: Int) -> Int {
   let mut end = start
-  while end < Array::length(stmts) && !(Array::get(stmts, end) is SReExportLocalBlockers(_)) {
+  while end < Array::length(stmts) && !(Array::get(stmts, end) is SReExportSourceBoundary(_, _)) {
     end = end + 1
   }
   end
@@ -14610,11 +14610,11 @@ fn dinsp_rewrite_range(stmts: Array[Stmt], start: Int, end: Int) -> Bool {
   changed
 }
 
-fn dinsp_has_reexport_local_boundaries(stmts: Array[Stmt]) -> Bool {
+fn dinsp_has_reexport_source_boundaries(stmts: Array[Stmt]) -> Bool {
   let mut i = 0
   let mut found = false
   while !found && i < Array::length(stmts) {
-    found = Array::get(stmts, i) is SReExportLocalBlockers(_)
+    found = Array::get(stmts, i) is SReExportSourceBoundary(_, _)
     i = i + 1
   }
   found
@@ -14625,13 +14625,13 @@ fn dinsp_rewrite_merged_source_ranges(stmts: Array[Stmt]) -> Bool {
   let mut i = 0
   while i < Array::length(stmts) {
     match Array::get(stmts, i) {
-      SReExportLocalBlockers(names) => {
+      SReExportSourceBoundary(local_names, _) => {
         let start = i + 1
         let mut end = start
-        while end < Array::length(stmts) && !(Array::get(stmts, end) is SReExportLocalBlockers(_)) {
+        while end < Array::length(stmts) && !(Array::get(stmts, end) is SReExportSourceBoundary(_, _)) {
           end = end + 1
         }
-        if !dinsp_blocker_names_inspect(names) && !dinsp_range_binds_inspect(stmts, start, end) {
+        if !dinsp_blocker_names_inspect(local_names) && !dinsp_range_binds_inspect(stmts, start, end) {
           if dinsp_rewrite_range(stmts, start, end) {
             changed = true
           } else {
@@ -14701,7 +14701,7 @@ fn dinsp_mentions_binder(expr: Expr) -> Bool {
 /// see dinsp_uses for why that guard is load-bearing rather than cosmetic.
 export fn desugar_inspect_calls_reporting_change(stmts: Array[Stmt]) -> Bool {
   let mut changed = false
-  if dinsp_has_reexport_local_boundaries(stmts) {
+  if dinsp_has_reexport_source_boundaries(stmts) {
     changed = dinsp_rewrite_merged_source_ranges(stmts)
   } else if dinsp_binds_inspect(stmts) {
     ()
@@ -15408,7 +15408,7 @@ export fn desugar_trait_dicts(stmts: Array[Stmt]) -> Unit with Exception {
   let mut i = 0
   while i < Array::length(stmts) {
     match Array::get(stmts, i) {
-      SReExportLocalBlockers(names) => user_assert_eq_set_merged_source(stmts, i + 1, names),
+      SReExportSourceBoundary(local_names, _) => user_assert_eq_set_merged_source(stmts, i + 1, local_names),
       stmt => Array::set(stmts, i, rewrite_stmt(stmt, gens, traits, struct_sets, fn_returns, toplevel_vars))
     }
     i = i + 1

--- a/lib/@vibe/compiler/normalize/desugar_trait_dict.vibe
+++ b/lib/@vibe/compiler/normalize/desugar_trait_dict.vibe
@@ -14110,14 +14110,6 @@ fn dinsp_scan(expr: Expr, mode: Int, name: String) -> Bool {
       },
       _ => false
     }
-  } else if mode == 6 {
-    match expr {
-      ECall(callee, args, _) => match callee {
-        EIdent(n, _) => n == name && Array::length(args) == 2,
-        _ => false
-      },
-      _ => false
-    }
   } else if mode == 1 {
     match expr {
       ELet(n, _, _, _) => n == "inspect",
@@ -14547,9 +14539,9 @@ fn dinsp_stmt_uses(stmt: Stmt) -> Bool {
   }
 }
 
-fn stmt_uses_two_arg_call(stmt: Stmt, name: String) -> Bool {
+fn stmt_mentions_name(stmt: Stmt, name: String) -> Bool {
   match stmt {
-    SModule(_, _, body) => range_uses_two_arg_call(body, 0, Array::length(body), name),
+    SModule(_, _, body) => range_mentions_name(body, 0, Array::length(body), name),
     _ => {
       let body = match stmt {
         SLet(_, _, _, _, expr) => Some(expr),
@@ -14563,36 +14555,37 @@ fn stmt_uses_two_arg_call(stmt: Stmt, name: String) -> Bool {
         _ => None
       }
       match body {
-        Some(expr) => dinsp_scan(expr, 6, name),
+        Some(expr) => dinsp_scan(expr, 2, name),
         None => false
       }
     }
   }
 }
 
-fn range_uses_two_arg_call(stmts: Array[Stmt], start: Int, end: Int, name: String) -> Bool {
+fn range_mentions_name(stmts: Array[Stmt], start: Int, end: Int, name: String) -> Bool {
   let mut i = start
   let mut found = false
   while !found && i < end {
-    found = stmt_uses_two_arg_call(Array::get(stmts, i), name)
+    found = stmt_mentions_name(Array::get(stmts, i), name)
     i = i + 1
   }
   found
 }
 
-/// Reject a surface-only re-export alias whose spelling would be reclassified
-/// as a compiler builtin after source-boundary metadata is removed. A real
-/// same-source binding survives serialization and remains authoritative.
-export fn validate_serializable_reexport_special_calls(stmts: Array[Stmt]) -> Unit with Exception {
+/// Reject a reference to a surface-only re-export alias whose spelling would
+/// be reclassified as a compiler builtin after source-boundary metadata is
+/// removed. A real same-source binding survives serialization and remains
+/// authoritative.
+export fn validate_serializable_reexport_special_references(stmts: Array[Stmt]) -> Unit with Exception {
   let mut i = 0
   while i < Array::length(stmts) {
     match Array::get(stmts, i) {
       SReExportSourceBoundary(_, surface_only_names) => {
         let start = i + 1
         let end = merged_source_range_end(stmts, start)
-        if reexport_blockers_bind_assert_eq(surface_only_names) && !stmts_range_define_assert_eq(stmts, start, end) && range_uses_two_arg_call(stmts, start, end, "assert_eq") {
+        if reexport_blockers_bind_assert_eq(surface_only_names) && !stmts_range_define_assert_eq(stmts, start, end) && range_mentions_name(stmts, start, end, "assert_eq") {
           throw("unknown name: assert_eq")
-        } else if dinsp_blocker_names_inspect(surface_only_names) && !dinsp_range_binds_inspect(stmts, start, end) && range_uses_two_arg_call(stmts, start, end, "inspect") {
+        } else if dinsp_blocker_names_inspect(surface_only_names) && !dinsp_range_binds_inspect(stmts, start, end) && range_mentions_name(stmts, start, end, "inspect") {
           throw("unknown name: inspect")
         } else {
           ()

--- a/lib/@vibe/compiler/normalize/desugar_trait_dict.vibe
+++ b/lib/@vibe/compiler/normalize/desugar_trait_dict.vibe
@@ -6464,11 +6464,10 @@ fn stmts_define_assert_eq(stmts: Array[Stmt]) -> Bool {
       // removed", measured on the current tree. Left out rather than left
       // wrong, since the arm would be a latent defect the day modules return.
       SImport(_, items) => import_binds_assert_eq(items),
-      // Only a plain re-export can resolve to the dependency's merged
-      // `assert_eq` definition. An alias is publication-only and contributes
-      // no local/function-table binding, so it must not disable builtin
-      // lowering for unrelated modules in this merged program (#2287).
-      SReExport(_, items) => plain_reexport_binds(items, "assert_eq"),
+      // This scan runs on one source unit before the linked merge. An alias
+      // targeting `assert_eq` must preserve the local name-resolution blocker;
+      // unrelated modules run their own scan and keep builtin lowering (#2287).
+      SReExport(_, items) => import_binds_assert_eq(items),
       _ => false
     }
     if hit {
@@ -14556,7 +14555,10 @@ fn dinsp_import_binds(items: Array[ImportItem]) -> Bool {
 fn dinsp_stmt_binds(stmt: Stmt) -> Bool {
   match stmt {
     SImport(_, items) => dinsp_import_binds(items),
-    SReExport(_, items) => plain_reexport_binds(items, "inspect"),
+    // `inspect` is desugared before checking, per source unit. Preserve an
+    // alias target as a local blocker so name resolution can reject it; an
+    // unrelated module is processed independently and keeps its builtin.
+    SReExport(_, items) => dinsp_import_binds(items),
     SLet(_, _, name, _, body) => name == "inspect" || dinsp_mentions_binder(body),
     SLetMut(name, _, body) => name == "inspect" || dinsp_mentions_binder(body),
     SLetPat(pat, body) => dinsp_pat_binds(pat, "inspect") || dinsp_mentions_binder(body),

--- a/lib/@vibe/compiler/normalize/desugar_trait_dict.vibe
+++ b/lib/@vibe/compiler/normalize/desugar_trait_dict.vibe
@@ -14110,6 +14110,14 @@ fn dinsp_scan(expr: Expr, mode: Int, name: String) -> Bool {
       },
       _ => false
     }
+  } else if mode == 6 {
+    match expr {
+      ECall(callee, args, _) => match callee {
+        EIdent(n, _) => n == name && Array::length(args) == 2,
+        _ => false
+      },
+      _ => false
+    }
   } else if mode == 1 {
     match expr {
       ELet(n, _, _, _) => n == "inspect",
@@ -14536,6 +14544,65 @@ fn dinsp_stmt_uses(stmt: Stmt) -> Bool {
     SFnDecl(_, _, body, _, _) => dinsp_uses(body),
     SModule(_, _, body) => dinsp_stmts_use(body),
     _ => false
+  }
+}
+
+fn stmt_uses_two_arg_call(stmt: Stmt, name: String) -> Bool {
+  match stmt {
+    SModule(_, _, body) => range_uses_two_arg_call(body, 0, Array::length(body), name),
+    _ => {
+      let body = match stmt {
+        SLet(_, _, _, _, expr) => Some(expr),
+        SLetMut(_, _, expr) => Some(expr),
+        SLetPat(_, expr) => Some(expr),
+        STest(_, expr) => Some(expr),
+        SBench(_, expr) => Some(expr),
+        SExample(_, expr) => Some(expr),
+        SExpr(expr) => Some(expr),
+        SFnDecl(_, _, expr, _, _) => Some(expr),
+        _ => None
+      }
+      match body {
+        Some(expr) => dinsp_scan(expr, 6, name),
+        None => false
+      }
+    }
+  }
+}
+
+fn range_uses_two_arg_call(stmts: Array[Stmt], start: Int, end: Int, name: String) -> Bool {
+  let mut i = start
+  let mut found = false
+  while !found && i < end {
+    found = stmt_uses_two_arg_call(Array::get(stmts, i), name)
+    i = i + 1
+  }
+  found
+}
+
+/// Reject a surface-only re-export alias whose spelling would be reclassified
+/// as a compiler builtin after source-boundary metadata is removed. A real
+/// same-source binding survives serialization and remains authoritative.
+export fn validate_serializable_reexport_special_calls(stmts: Array[Stmt]) -> Unit with Exception {
+  let mut i = 0
+  while i < Array::length(stmts) {
+    match Array::get(stmts, i) {
+      SReExportSourceBoundary(_, surface_only_names) => {
+        let start = i + 1
+        let end = merged_source_range_end(stmts, start)
+        if reexport_blockers_bind_assert_eq(surface_only_names) && !stmts_range_define_assert_eq(stmts, start, end) && range_uses_two_arg_call(stmts, start, end, "assert_eq") {
+          throw("unknown name: assert_eq")
+        } else if dinsp_blocker_names_inspect(surface_only_names) && !dinsp_range_binds_inspect(stmts, start, end) && range_uses_two_arg_call(stmts, start, end, "inspect") {
+          throw("unknown name: inspect")
+        } else {
+          ()
+        }
+        i = end
+      },
+      _ => {
+        i = i + 1
+      }
+    }
   }
 }
 

--- a/lib/@vibe/compiler/normalize/desugar_trait_dict.vibe
+++ b/lib/@vibe/compiler/normalize/desugar_trait_dict.vibe
@@ -6468,7 +6468,7 @@ fn stmts_define_assert_eq(stmts: Array[Stmt]) -> Bool {
       // `assert_eq` definition. An alias is publication-only and contributes
       // no local/function-table binding, so it must not disable builtin
       // lowering for unrelated modules in this merged program (#2287).
-      SReExport(_, items) => reexport_binds_assert_eq(items),
+      SReExport(_, items) => plain_reexport_binds(items, "assert_eq"),
       _ => false
     }
     if hit {
@@ -6621,12 +6621,12 @@ fn arms_bind_assert_eq(arms: Array[(Pat, Expr)]) -> Bool {
   found
 }
 
-fn reexport_binds_assert_eq(items: Array[ImportItem]) -> Bool {
+fn plain_reexport_binds(items: Array[ImportItem], wanted: String) -> Bool {
   let mut i = 0
   let mut found = false
   while i < Array::length(items) && !found {
     let item = Array::get(items, i)
-    if item.name == "assert_eq" && item.alias == None {
+    if item.name == wanted && item.alias == None {
       found = true
     } else {
       ()
@@ -14556,7 +14556,7 @@ fn dinsp_import_binds(items: Array[ImportItem]) -> Bool {
 fn dinsp_stmt_binds(stmt: Stmt) -> Bool {
   match stmt {
     SImport(_, items) => dinsp_import_binds(items),
-    SReExport(_, items) => dinsp_import_binds(items),
+    SReExport(_, items) => plain_reexport_binds(items, "inspect"),
     SLet(_, _, name, _, body) => name == "inspect" || dinsp_mentions_binder(body),
     SLetMut(name, _, body) => name == "inspect" || dinsp_mentions_binder(body),
     SLetPat(pat, body) => dinsp_pat_binds(pat, "inspect") || dinsp_mentions_binder(body),

--- a/lib/@vibe/compiler/normalize/desugar_trait_dict.vibe
+++ b/lib/@vibe/compiler/normalize/desugar_trait_dict.vibe
@@ -6369,11 +6369,10 @@ fn is_assert_eq_call(callee: Expr, args: Array[Expr]) -> Bool {
 /// Pass state, reset at every `desugar_trait_dicts` entry like the exn-kind
 /// cell above: whether THIS program binds `assert_eq` itself.
 ///
-/// The unit is the program this pass was handed, which in the FS lane is every
-/// module merged together -- so one module binding `assert_eq` stands the
-/// lowering down for all of them. Coarse, and deliberately so: the merged
-/// program is what this pass sees, and a per-module answer here would be
-/// invented.
+/// For an ordinary source array this is program-wide. The FS merge inserts an
+/// `SReExportAliasBlockers` marker before each source unit; the final rewrite
+/// loop resets the cached answer and active range at every marker, so a
+/// dependency's blocker cannot suppress an unrelated entry builtin (#2287).
 ///
 /// COMPUTED LAZILY (#2285). The scan now descends into every expression, and
 /// paying for a whole-program AST walk on every compile is not free -- an
@@ -6392,8 +6391,19 @@ let dtd_user_assert_eq = [-1]
 /// (a throw mid-rewrite) unable to leave a previous program behind.
 let dtd_user_assert_eq_program: Array[Array[Stmt]] = array_empty()
 
+/// Half-open source-unit range within the retained program. `end < 0` means
+/// the entire array (the ordinary non-merged path).
+let dtd_user_assert_eq_range = [0, -1]
+
+/// Whether the current FS source boundary carries an aliased re-export named
+/// `assert_eq`. Kept separate so the expensive expression walk stays lazy.
+let dtd_user_assert_eq_alias_blocker = [0]
+
 fn user_assert_eq_reset(stmts: Array[Stmt]) -> Unit {
   Array::set(dtd_user_assert_eq, 0, -1)
+  Array::set(dtd_user_assert_eq_range, 0, 0)
+  Array::set(dtd_user_assert_eq_range, 1, -1)
+  Array::set(dtd_user_assert_eq_alias_blocker, 0, 0)
   Array::truncate(dtd_user_assert_eq_program, 0)
   Array::push(dtd_user_assert_eq_program, stmts)
 }
@@ -6407,7 +6417,13 @@ fn user_assert_eq_bound() -> Bool {
     // lowering -- the same thing a caller that never reset would have got.
     false
   } else {
-    let answer = stmts_define_assert_eq(Array::get(dtd_user_assert_eq_program, 0))
+    let program = Array::get(dtd_user_assert_eq_program, 0)
+    let range_end = Array::get(dtd_user_assert_eq_range, 1)
+    let answer = Array::get(dtd_user_assert_eq_alias_blocker, 0) == 1 || if range_end < 0 {
+      stmts_define_assert_eq(program)
+    } else {
+      stmts_range_define_assert_eq(program, Array::get(dtd_user_assert_eq_range, 0), range_end)
+    }
     Array::set(dtd_user_assert_eq, 0, if answer {
       1
     } else {
@@ -6434,50 +6450,13 @@ fn user_assert_eq_bound() -> Bool {
 /// a free use inside a lambda is no longer recorded as the #1095 capture
 /// artifact that made `local_idx_hint` unreadable.
 ///
-/// UNSCOPED, like the top-level half: one binder anywhere stands the lowering
-/// down for the whole merged program, even for call sites the binder does not
-/// reach. A scoped answer would have to thread a binder set through
-/// `rewrite_expr`, which carries nine parameters already. The coarseness errs
-/// in the safe direction -- standing down loses the expected/actual message,
-/// it never runs the wrong function -- and it costs nothing today: no file
-/// under `lib/`, `fixtures/`, or `examples/` binds the name locally.
+/// UNSCOPED within one source unit: one binder anywhere in that unit stands
+/// the lowering down even for call sites the binder does not reach. A scoped
+/// answer would have to thread a binder set through `rewrite_expr`, which
+/// carries nine parameters already. `SReExportAliasBlockers` still separates
+/// FS-merged units, so this conservative answer does not leak across modules.
 fn stmts_define_assert_eq(stmts: Array[Stmt]) -> Bool {
-  let mut i = 0
-  let mut found = false
-  while i < Array::length(stmts) && !found {
-    let hit = match Array::get(stmts, i) {
-      SLet(_, _, name, _, value) => name == "assert_eq" || expr_binds_assert_eq(value),
-      SLetMut(name, _, value) => name == "assert_eq" || expr_binds_assert_eq(value),
-      SLetPat(pat, value) => pat_binds_assert_eq(pat) || expr_binds_assert_eq(value),
-      SExpr(e) => expr_binds_assert_eq(e),
-      STest(_, e) => expr_binds_assert_eq(e),
-      SBench(_, e) => expr_binds_assert_eq(e),
-      SExample(_, e) => expr_binds_assert_eq(e),
-      SFnDecl(_, name, e, _, _) => name == "assert_eq" || expr_binds_assert_eq(e),
-      // NO `SModule` recursion. A module member declares `M::assert_eq`, not
-      // the bare prelude name, so recursing would stand the lowering down for
-      // an unrelated top-level `assert_eq(a, b)` -- and the function table
-      // holds only the qualified definition, so codegen would then fall to a
-      // bare `unreachable`, losing the message and both operands (#2296
-      // review). Unreachable today either way: `module` blocks were removed in
-      // #728 and the parser answers this shape with "'module' blocks are
-      // removed", measured on the current tree. Left out rather than left
-      // wrong, since the arm would be a latent defect the day modules return.
-      SImport(_, items) => import_binds_assert_eq(items),
-      // This scan runs on one source unit before the linked merge. An alias
-      // targeting `assert_eq` must preserve the local name-resolution blocker;
-      // unrelated modules run their own scan and keep builtin lowering (#2287).
-      SReExport(_, items) => import_binds_assert_eq(items),
-      _ => false
-    }
-    if hit {
-      found = true
-    } else {
-      ()
-    }
-    i = i + 1
-  }
-  found
+  stmts_range_define_assert_eq(stmts, 0, Array::length(stmts))
 }
 
 fn import_binds_assert_eq(items: Array[ImportItem]) -> Bool {
@@ -6633,6 +6612,65 @@ fn plain_reexport_binds(items: Array[ImportItem], wanted: String) -> Bool {
     i = i + 1
   }
   found
+}
+
+fn stmt_binds_assert_eq(stmt: Stmt) -> Bool {
+  match stmt {
+    SLet(_, _, name, _, value) => name == "assert_eq" || expr_binds_assert_eq(value),
+    SLetMut(name, _, value) => name == "assert_eq" || expr_binds_assert_eq(value),
+    SLetPat(pat, value) => pat_binds_assert_eq(pat) || expr_binds_assert_eq(value),
+    SExpr(e) => expr_binds_assert_eq(e),
+    STest(_, e) => expr_binds_assert_eq(e),
+    SBench(_, e) => expr_binds_assert_eq(e),
+    SExample(_, e) => expr_binds_assert_eq(e),
+    SFnDecl(_, name, e, _, _) => name == "assert_eq" || expr_binds_assert_eq(e),
+    // NO `SModule` recursion. A member would declare `M::assert_eq`, not the
+    // bare prelude name; see the #2296 review measurement above.
+    SImport(_, items) => import_binds_assert_eq(items),
+    // Direct/single-source checking still sees the original re-export. The FS
+    // merge carries aliases separately in SReExportAliasBlockers (#2287).
+    SReExport(_, items) => import_binds_assert_eq(items),
+    _ => false
+  }
+}
+
+fn stmts_range_define_assert_eq(stmts: Array[Stmt], start: Int, end: Int) -> Bool {
+  let mut i = start
+  let mut found = false
+  while !found && i < end {
+    found = stmt_binds_assert_eq(Array::get(stmts, i))
+    i = i + 1
+  }
+  found
+}
+
+fn reexport_blockers_bind_assert_eq(names: Array[String]) -> Bool {
+  let mut i = 0
+  let mut found = false
+  while !found && i < Array::length(names) {
+    found = Array::get(names, i) == "assert_eq"
+    i = i + 1
+  }
+  found
+}
+
+fn merged_source_range_end(stmts: Array[Stmt], start: Int) -> Int {
+  let mut end = start
+  while end < Array::length(stmts) && !(Array::get(stmts, end) is SReExportAliasBlockers(_)) {
+    end = end + 1
+  }
+  end
+}
+
+fn user_assert_eq_set_merged_source(stmts: Array[Stmt], start: Int, names: Array[String]) -> Unit {
+  Array::set(dtd_user_assert_eq, 0, -1)
+  Array::set(dtd_user_assert_eq_range, 0, start)
+  Array::set(dtd_user_assert_eq_range, 1, merged_source_range_end(stmts, start))
+  Array::set(dtd_user_assert_eq_alias_blocker, 0, if reexport_blockers_bind_assert_eq(names) {
+    1
+  } else {
+    0
+  })
 }
 
 fn assert_eq_concat(a: Expr, b: Expr) -> Expr {
@@ -14536,6 +14574,82 @@ fn dinsp_binds_inspect(stmts: Array[Stmt]) -> Bool {
   found
 }
 
+fn dinsp_blocker_names_inspect(names: Array[String]) -> Bool {
+  let mut i = 0
+  let mut found = false
+  while !found && i < Array::length(names) {
+    found = Array::get(names, i) == "inspect"
+    i = i + 1
+  }
+  found
+}
+
+fn dinsp_range_binds_inspect(stmts: Array[Stmt], start: Int, end: Int) -> Bool {
+  let mut i = start
+  let mut found = false
+  while !found && i < end {
+    found = dinsp_stmt_binds(Array::get(stmts, i))
+    i = i + 1
+  }
+  found
+}
+
+fn dinsp_rewrite_range(stmts: Array[Stmt], start: Int, end: Int) -> Bool {
+  let mut changed = false
+  let mut i = start
+  while i < end {
+    let stmt = Array::get(stmts, i)
+    if dinsp_stmt_uses(stmt) {
+      Array::set(stmts, i, dinsp_stmt(stmt))
+      changed = true
+    } else {
+      ()
+    }
+    i = i + 1
+  }
+  changed
+}
+
+fn dinsp_has_reexport_alias_boundaries(stmts: Array[Stmt]) -> Bool {
+  let mut i = 0
+  let mut found = false
+  while !found && i < Array::length(stmts) {
+    found = Array::get(stmts, i) is SReExportAliasBlockers(_)
+    i = i + 1
+  }
+  found
+}
+
+fn dinsp_rewrite_merged_source_ranges(stmts: Array[Stmt]) -> Bool {
+  let mut changed = false
+  let mut i = 0
+  while i < Array::length(stmts) {
+    match Array::get(stmts, i) {
+      SReExportAliasBlockers(names) => {
+        let start = i + 1
+        let mut end = start
+        while end < Array::length(stmts) && !(Array::get(stmts, end) is SReExportAliasBlockers(_)) {
+          end = end + 1
+        }
+        if !dinsp_blocker_names_inspect(names) && !dinsp_range_binds_inspect(stmts, start, end) {
+          if dinsp_rewrite_range(stmts, start, end) {
+            changed = true
+          } else {
+            ()
+          }
+        } else {
+          ()
+        }
+        i = end
+      },
+      _ => {
+        i = i + 1
+      }
+    }
+  }
+  changed
+}
+
 fn dinsp_import_binds(items: Array[ImportItem]) -> Bool {
   let mut i = 0
   let mut found = false
@@ -14555,9 +14669,9 @@ fn dinsp_import_binds(items: Array[ImportItem]) -> Bool {
 fn dinsp_stmt_binds(stmt: Stmt) -> Bool {
   match stmt {
     SImport(_, items) => dinsp_import_binds(items),
-    // `inspect` is desugared before checking, per source unit. Preserve an
-    // alias target as a local blocker so name resolution can reject it; an
-    // unrelated module is processed independently and keeps its builtin.
+    // Direct/single-source checking sees the original re-export. The FS merge
+    // replaces it with a source-boundary marker consumed by the range-aware
+    // path above, so unrelated modules keep their builtin (#2287).
     SReExport(_, items) => dinsp_import_binds(items),
     SLet(_, _, name, _, body) => name == "inspect" || dinsp_mentions_binder(body),
     SLetMut(name, _, body) => name == "inspect" || dinsp_mentions_binder(body),
@@ -14587,20 +14701,12 @@ fn dinsp_mentions_binder(expr: Expr) -> Bool {
 /// see dinsp_uses for why that guard is load-bearing rather than cosmetic.
 export fn desugar_inspect_calls_reporting_change(stmts: Array[Stmt]) -> Bool {
   let mut changed = false
-  if dinsp_binds_inspect(stmts) {
+  if dinsp_has_reexport_alias_boundaries(stmts) {
+    changed = dinsp_rewrite_merged_source_ranges(stmts)
+  } else if dinsp_binds_inspect(stmts) {
     ()
   } else {
-    let mut i = 0
-    while i < Array::length(stmts) {
-      let stmt = Array::get(stmts, i)
-      if dinsp_stmt_uses(stmt) {
-        Array::set(stmts, i, dinsp_stmt(stmt))
-        changed = true
-      } else {
-        ()
-      }
-      i = i + 1
-    }
+    changed = dinsp_rewrite_range(stmts, 0, Array::length(stmts))
   }
   changed
 }
@@ -15301,7 +15407,10 @@ export fn desugar_trait_dicts(stmts: Array[Stmt]) -> Unit with Exception {
   Array::set(dtd_exn_kind_state, 2, 0)
   let mut i = 0
   while i < Array::length(stmts) {
-    Array::set(stmts, i, rewrite_stmt(Array::get(stmts, i), gens, traits, struct_sets, fn_returns, toplevel_vars))
+    match Array::get(stmts, i) {
+      SReExportAliasBlockers(names) => user_assert_eq_set_merged_source(stmts, i + 1, names),
+      stmt => Array::set(stmts, i, rewrite_stmt(stmt, gens, traits, struct_sets, fn_returns, toplevel_vars))
+    }
     i = i + 1
   }
   // #1526: the rewrite above is what emits `__arr_equals__<key>` calls, so it

--- a/lib/@vibe/compiler/normalize/desugar_trait_dict.vibe
+++ b/lib/@vibe/compiler/normalize/desugar_trait_dict.vibe
@@ -6464,6 +6464,11 @@ fn stmts_define_assert_eq(stmts: Array[Stmt]) -> Bool {
       // removed", measured on the current tree. Left out rather than left
       // wrong, since the arm would be a latent defect the day modules return.
       SImport(_, items) => import_binds_assert_eq(items),
+      // A plain re-export can resolve to the dependency's merged definition;
+      // an aliased re-export is surface-only and the checker rejects a local
+      // use. In both cases builtin lowering must stand down instead of
+      // silently claiming the selected source spelling (#2287).
+      SReExport(_, items) => import_binds_assert_eq(items),
       _ => false
     }
     if hit {

--- a/lib/@vibe/compiler/normalize/desugar_trait_dict.vibe
+++ b/lib/@vibe/compiler/normalize/desugar_trait_dict.vibe
@@ -6464,11 +6464,11 @@ fn stmts_define_assert_eq(stmts: Array[Stmt]) -> Bool {
       // removed", measured on the current tree. Left out rather than left
       // wrong, since the arm would be a latent defect the day modules return.
       SImport(_, items) => import_binds_assert_eq(items),
-      // A plain re-export can resolve to the dependency's merged definition;
-      // an aliased re-export is surface-only and the checker rejects a local
-      // use. In both cases builtin lowering must stand down instead of
-      // silently claiming the selected source spelling (#2287).
-      SReExport(_, items) => import_binds_assert_eq(items),
+      // Only a plain re-export can resolve to the dependency's merged
+      // `assert_eq` definition. An alias is publication-only and contributes
+      // no local/function-table binding, so it must not disable builtin
+      // lowering for unrelated modules in this merged program (#2287).
+      SReExport(_, items) => reexport_binds_assert_eq(items),
       _ => false
     }
     if hit {
@@ -6612,6 +6612,21 @@ fn arms_bind_assert_eq(arms: Array[(Pat, Expr)]) -> Bool {
   while i < Array::length(arms) && !found {
     let (pat, _) = Array::get(arms, i)
     if pat_binds_assert_eq(pat) {
+      found = true
+    } else {
+      ()
+    }
+    i = i + 1
+  }
+  found
+}
+
+fn reexport_binds_assert_eq(items: Array[ImportItem]) -> Bool {
+  let mut i = 0
+  let mut found = false
+  while i < Array::length(items) && !found {
+    let item = Array::get(items, i)
+    if item.name == "assert_eq" && item.alias == None {
       found = true
     } else {
       ()

--- a/lib/@vibe/compiler/normalize/index.vpkg
+++ b/lib/@vibe/compiler/normalize/index.vpkg
@@ -82,7 +82,7 @@ fn normalized_program_binder_authority_nodes(authority: NormalizedProgramBinderA
 // import and every pre-codegen scan sees ordinary calls.
 fn desugar_inspect_calls(stmts: Array[Stmt]) -> Unit
 fn desugar_inspect_calls_reporting_change(stmts: Array[Stmt]) -> Bool
-fn validate_serializable_reexport_special_calls(stmts: Array[Stmt]) -> Unit with Exception
+fn validate_serializable_reexport_special_references(stmts: Array[Stmt]) -> Unit with Exception
 fn desugar_array_spread(stmts: Array[Stmt]) -> Unit
 fn desugar_trait_dicts(stmts: Array[Stmt]) -> Unit with Exception
 

--- a/lib/@vibe/compiler/normalize/index.vpkg
+++ b/lib/@vibe/compiler/normalize/index.vpkg
@@ -82,7 +82,7 @@ fn normalized_program_binder_authority_nodes(authority: NormalizedProgramBinderA
 // import and every pre-codegen scan sees ordinary calls.
 fn desugar_inspect_calls(stmts: Array[Stmt]) -> Unit
 fn desugar_inspect_calls_reporting_change(stmts: Array[Stmt]) -> Bool
-fn validate_serializable_reexport_special_references(stmts: Array[Stmt]) -> Unit with Exception
+fn validate_serializable_reexport_references(stmts: Array[Stmt]) -> Unit with Exception
 fn desugar_array_spread(stmts: Array[Stmt]) -> Unit
 fn desugar_trait_dicts(stmts: Array[Stmt]) -> Unit with Exception
 

--- a/lib/@vibe/compiler/normalize/index.vpkg
+++ b/lib/@vibe/compiler/normalize/index.vpkg
@@ -82,6 +82,7 @@ fn normalized_program_binder_authority_nodes(authority: NormalizedProgramBinderA
 // import and every pre-codegen scan sees ordinary calls.
 fn desugar_inspect_calls(stmts: Array[Stmt]) -> Unit
 fn desugar_inspect_calls_reporting_change(stmts: Array[Stmt]) -> Bool
+fn validate_serializable_reexport_special_calls(stmts: Array[Stmt]) -> Unit with Exception
 fn desugar_array_spread(stmts: Array[Stmt]) -> Unit
 fn desugar_trait_dicts(stmts: Array[Stmt]) -> Unit with Exception
 

--- a/lib/@vibe/compiler/runtime/typecheck_fs.vibe
+++ b/lib/@vibe/compiler/runtime/typecheck_fs.vibe
@@ -255,7 +255,15 @@ fn is_selected_type_companion(name: String, ty: Type, type_surface: Array[String
 /// coincidence) but "unknown name: Json::string" for the other 8 of the
 /// 11 documented accessors. The bundle-merge lane resolves these by name
 /// against the merged unit and never had the gap; only this FS lane did.
-fn bind_enum_constructor_companions(acc: TypeEnv, resolved: String, dep_bindings: Array[(String, Type)], enum_name: String, trait_mappings: Array[(String, String)]) -> TypeEnv {
+fn selected_module_binding_origin(resolved: String, source_name: String, reexport_surface_only: Bool) -> BindingOrigin {
+  if reexport_surface_only {
+    BindingOriginReExportSurface(resolved, source_name)
+  } else {
+    BindingOriginModuleExport(resolved, source_name)
+  }
+}
+
+fn bind_enum_constructor_companions(acc: TypeEnv, resolved: String, dep_bindings: Array[(String, Type)], enum_name: String, trait_mappings: Array[(String, String)], reexport_surface_only: Bool) -> TypeEnv {
   let qual_prefix = String::concat(enum_name, "::")
   let mut out = acc
   // #1908: the dep's flat bindings can carry a name twice — the authoritative
@@ -278,7 +286,7 @@ fn bind_enum_constructor_companions(acc: TypeEnv, resolved: String, dep_bindings
         ()
       } else {
         Array::push(seen, candidate_name)
-        out = env_bind_with_origin(out, candidate_name, trait_projection_map_type_bounds(candidate_ty, trait_mappings), BindingOriginModuleExport(resolved, candidate_name))
+        out = env_bind_with_origin(out, candidate_name, trait_projection_map_type_bounds(candidate_ty, trait_mappings), selected_module_binding_origin(resolved, candidate_name, reexport_surface_only))
       }
     }
     i = i + 1
@@ -1094,7 +1102,7 @@ fn prepend_dependency_trait_nodes(dep_env: TypeEnv, mappings: Array[(String, Str
   out
 }
 
-fn bind_import_names_from_cache_collecting(acc: TypeEnv, resolved: String, raw_path: String, names: Array[ImportItem], cache: Array[(String, TypeEnv)], unresolved: Array[String], trait_claims: Array[(String, String, Bool, String)]) -> TypeEnv {
+fn bind_import_names_from_cache_collecting(acc: TypeEnv, resolved: String, raw_path: String, names: Array[ImportItem], cache: Array[(String, TypeEnv)], unresolved: Array[String], trait_claims: Array[(String, String, Bool, String)], reexport_surface_only: Bool) -> TypeEnv {
   let cached = lookup_env_cache(cache, resolved)
   let dep_env = match cached {
     Some(e) => e,
@@ -1148,6 +1156,11 @@ fn bind_import_names_from_cache_collecting(acc: TypeEnv, resolved: String, raw_p
         Some(a) => a,
         None => name
       }
+      // A plain re-export's original name is also present in the merged
+      // program and remains locally resolvable for compatibility. Only an
+      // alias is surface-only: the merge emits no binding under that spelling
+      // and the parser records no local binder for it (#2287).
+      let surface_only_item = reexport_surface_only && alias != None
       let imported_ty = env_lookup_flat(dep_bindings, name)
       let ty = match imported_ty {
         Some(t) => trait_projection_map_type_bounds(t, trait_mappings),
@@ -1164,13 +1177,13 @@ fn bind_import_names_from_cache_collecting(acc: TypeEnv, resolved: String, raw_p
         }
       }
       let with_name = match imported_ty {
-        Some(_) => env_bind_with_origin(nacc, bound_name, ty, BindingOriginModuleExport(resolved, name)),
+        Some(_) => env_bind_with_origin(nacc, bound_name, ty, selected_module_binding_origin(resolved, name, surface_only_item)),
         None => env_bind(nacc, bound_name, ty)
       }
       let with_companions = match ty {
-        CtEnum(enum_name) => bind_enum_constructor_companions(with_name, resolved, dep_bindings, enum_name, trait_mappings),
+        CtEnum(enum_name) => bind_enum_constructor_companions(with_name, resolved, dep_bindings, enum_name, trait_mappings, surface_only_item),
         _ => if starts_with_upper(name) {
-          bind_enum_constructor_companions(with_name, resolved, dep_bindings, name, trait_mappings)
+          bind_enum_constructor_companions(with_name, resolved, dep_bindings, name, trait_mappings, surface_only_item)
         } else {
           with_name
         }
@@ -1211,11 +1224,11 @@ fn build_import_env_collecting(stmts: Array[Stmt], base_dir: String, cache: Arra
       let next = match Array::get(stmts, i) {
         SImport(raw_path, names) => {
           let resolved = resolve_cached_import_path(base_dir, raw_path, cache)
-          bind_import_names_from_cache_collecting(acc, resolved, raw_path, names, cache, unresolved, trait_claims)
+          bind_import_names_from_cache_collecting(acc, resolved, raw_path, names, cache, unresolved, trait_claims, false)
         },
         SReExport(raw_path, names) => {
           let resolved = resolve_cached_import_path(base_dir, raw_path, cache)
-          bind_import_names_from_cache_collecting(acc, resolved, raw_path, names, cache, unresolved, trait_claims)
+          bind_import_names_from_cache_collecting(acc, resolved, raw_path, names, cache, unresolved, trait_claims, true)
         },
         _ => acc
       }

--- a/lib/@vibe/compiler/tests/assert_eq_failure_test.vibe
+++ b/lib/@vibe/compiler/tests/assert_eq_failure_test.vibe
@@ -112,9 +112,9 @@ test "assert_eq lowering still compiles on the gc lane" {
   assert(Bytes::length(bytes) > 8)
 }
 
-test "#2287 review: a surface-only re-export alias does not suppress builtin assert_eq lowering" {
+test "#2287 review: a surface-only re-export alias preserves the local assert_eq blocker" {
   let out = desugared_assert_eq_source("export ./dep.vibe { cmp as assert_eq }\nfn valid() -> Unit { assert_eq(1, 2) }\n")
-  inspect(String::contains(out, "assert_eq failed"), content = "true")
+  inspect(String::contains(out, "assert_eq failed"), content = "false")
 }
 
 test "#2287 review: a plain assert_eq re-export still suppresses builtin lowering" {

--- a/lib/@vibe/compiler/tests/assert_eq_failure_test.vibe
+++ b/lib/@vibe/compiler/tests/assert_eq_failure_test.vibe
@@ -16,6 +16,14 @@ import @vibe/compiler/entry/source_compile/gc_only {
   compile_source_gc_only
 }
 
+import @vibe/compiler/normalize {
+  desugar_trait_dicts
+}
+
+import @vibe/compiler/syntax {
+  lex, parse_program, print_program
+}
+
 //# Helpers
 
 fn bytes_contains(hay: Bytes, needle: String) -> Bool {
@@ -62,6 +70,12 @@ fn capture_failing_assert_eq(body: String) -> String with Exception + Fs + Proce
   Fs::read_file("_build/vibe_test/assert_eq_fail_probe.err")
 }
 
+fn desugared_assert_eq_source(source: String) -> String with Exception {
+  let stmts = parse_program(lex(source))
+  desugar_trait_dicts(stmts)
+  print_program(stmts)
+}
+
 //# Tests
 
 /// Drive the shipped compile path (`compile_source_wasi` ->
@@ -96,6 +110,16 @@ test "assert_eq failure compiles a fallback for an unrenderable value" {
 test "assert_eq lowering still compiles on the gc lane" {
   let bytes = compile_source_gc_only("let main: () -> Int with Stdout = () -> {\n  assert_eq(1, 1)\n  0\n}", "main")
   assert(Bytes::length(bytes) > 8)
+}
+
+test "#2287 review: a surface-only re-export alias does not suppress builtin assert_eq lowering" {
+  let out = desugared_assert_eq_source("export ./dep.vibe { cmp as assert_eq }\nfn valid() -> Unit { assert_eq(1, 2) }\n")
+  inspect(String::contains(out, "assert_eq failed"), content = "true")
+}
+
+test "#2287 review: a plain assert_eq re-export still suppresses builtin lowering" {
+  let out = desugared_assert_eq_source("export ./dep.vibe { assert_eq }\nfn valid() -> Unit { assert_eq(1, 2) }\n")
+  inspect(String::contains(out, "assert_eq failed"), content = "false")
 }
 
 test "assert_eq failure prints expected and actual on stderr" {

--- a/lib/@vibe/compiler/tests/checked_implementation_body_artifact_test.vibe
+++ b/lib/@vibe/compiler/tests/checked_implementation_body_artifact_test.vibe
@@ -362,6 +362,18 @@ test "#1958: value TypeEnv preserves order duplicates and binding origin" {
   }
 }
 
+test "#2287: value TypeEnv accepts a re-export surface origin" {
+  let surface = EnvValueBinding::{
+    ty: CtString,
+    origin: BindingOriginReExportSurface("dep", "source_value")
+  }
+  let valid = match value_env_bytes(EnvFlat([("forwarded", surface)])) {
+    Some(bytes) => decode_normalized_value_type_env_artifact_v1(bytes) != None,
+    None => false
+  }
+  inspect(valid, "true")
+}
+
 test "#1958: cached value TypeEnv preserves exact index and rejects mismatch" {
   let local = EnvValueBinding::{
     ty: CtString,

--- a/lib/@vibe/compiler/tests/checker_resume_misuse_test.vibe
+++ b/lib/@vibe/compiler/tests/checker_resume_misuse_test.vibe
@@ -46,6 +46,12 @@ test "resume at a fn's tail but outside any handle is rejected" {
   assert(String::contains(msg, "only valid inside a handler arm"))
 }
 
+test "#2287 review: a surface-only re-export alias does not shadow special resume" {
+  let src = "export ./dep.vibe { f as resume }\nfn main() -> Int { resume(1) }\n"
+  let msg = first_check_error(src)
+  assert(String::contains(msg, "only valid inside a handler arm"))
+}
+
 test "resume in the handled body (not in an arm) is rejected" {
   let src = "effect Ask { Get() -> Int }\nfn main() -> Int { handle { resume(1) } with { Ask::Get() => resume(2) } }\n"
   let msg = first_check_error(src)

--- a/lib/@vibe/compiler/tests/cli_support_test.vibe
+++ b/lib/@vibe/compiler/tests/cli_support_test.vibe
@@ -123,6 +123,22 @@ test "check_linked_file: a genuine type error still throws, located" {
   assert(String::contains(msg, "line 1:"))
 }
 
+test "check_linked_file: later re-export alias blocks an earlier plain re-export" {
+  let base_dir = "/tmp/vibe_check_reexport_later_alias_v2"
+  let a_path = String::concat(base_dir, "/a.vibe")
+  let b_path = String::concat(base_dir, "/b.vibe")
+  let main_path = String::concat(base_dir, "/main.vibe")
+  Fs::mkdir_p(base_dir)
+  Fs::write_bytes(a_path, string_to_bytes("export fn foo() -> Int { 1 }\n"))
+  Fs::write_bytes(b_path, string_to_bytes("export fn f() -> Int { 2 }\n"))
+  Fs::write_bytes(main_path, string_to_bytes("export ./a.vibe { foo }\nexport ./b.vibe { f as foo }\nexport fn answer() -> Int { foo() }\n"))
+  let msg = handle {
+    let _ = check_linked_file(main_path)
+    ""
+  } with { Exception::Throw(m) => m }
+  assert(String::contains(msg, "unknown name: foo"))
+}
+
 /// #946 P1 (Codex, PR #1006): check_linked_file's dep-collection
 /// (collect_linked_dep_inputs_for_stmts) exists to feed the wasm import-
 /// linking codegen boundary -- it copies a dependency's SEnum/struct decls

--- a/lib/@vibe/compiler/tests/compiler_fs_test.vibe
+++ b/lib/@vibe/compiler/tests/compiler_fs_test.vibe
@@ -141,6 +141,20 @@ test "collect_linked_compile_inputs: resolves an aliased re-export the entry imp
   assert(func_name == "bar")
 }
 
+test "re-export aliases in a dependency do not suppress entry builtins" {
+  let base_dir = "/tmp/vibe_compiler_reexport_alias_builtin_scope"
+  let inner_path = String::concat(base_dir, "/inner.vibe")
+  let facade_path = String::concat(base_dir, "/facade.vibe")
+  let main_path = String::concat(base_dir, "/main.vibe")
+  Fs::mkdir_p(base_dir)
+  Fs::write_bytes(inner_path, string_to_bytes("export fn cmp(a: Int, b: Int) -> Int { a + b }\nexport fn view(a: Int, b: Int) -> Int { a + b }\n"))
+  Fs::write_bytes(facade_path, string_to_bytes("export ./inner.vibe { cmp as assert_eq, view as inspect }\n"))
+  Fs::write_bytes(main_path, string_to_bytes("import ./facade.vibe { assert_eq as forwarded_assert, inspect as forwarded_inspect }\nexport let answer: () -> Int with Stdout = () -> {\n  let _ = forwarded_assert(1, 2)\n  let _ = forwarded_inspect(1, 2)\n  inspect(1, \"1\")\n  assert_eq(1, 2)\n  0\n}\n"))
+  let bytes = compile_file_wasi_only(main_path, "answer")
+  assert_wasm_magic(bytes)
+  assert(bytes_contains_ascii(bytes, "assert_eq failed"))
+}
+
 test "compile_file_wasi_only: simple file produces valid WASM" {
   let base_dir = "/tmp/vibe_compiler_wasi_only"
   let main_path = String::concat(base_dir, "/main.vibe")

--- a/lib/@vibe/compiler/tests/compiler_fs_test.vibe
+++ b/lib/@vibe/compiler/tests/compiler_fs_test.vibe
@@ -170,6 +170,9 @@ test "same-source imported assert_eq is not lowered as the builtin through FS me
   let bytes = compile_file_wasi_only(main_path, "answer")
   assert_wasm_magic(bytes)
   inspect(bytes_contains_ascii(bytes, "assert_eq failed"), content = "false")
+  let merged_bytes = compile_source_wasi_only(merged_program_source_fs(main_path), "answer")
+  assert_wasm_magic(merged_bytes)
+  inspect(bytes_contains_ascii(merged_bytes, "assert_eq failed"), content = "false")
 }
 
 test "same-source import aliased as assert_eq is not lowered as the builtin through FS merge" {
@@ -275,24 +278,30 @@ test "same-source ordinary re-export alias remains unknown through FS merge" {
   inspect(String::contains(compile_file_error(main_path, "answer"), "unknown name: forwarded"), content = "true")
 }
 
-test "same-source plain assert_eq re-export remains unknown through FS merge" {
+test "same-source plain assert_eq re-export remains callable through FS merge" {
   let base_dir = "/tmp/vibe_compiler_reexport_plain_assert_eq_blocker"
   let dep_path = String::concat(base_dir, "/dep.vibe")
   let main_path = String::concat(base_dir, "/main.vibe")
   Fs::mkdir_p(base_dir)
   Fs::write_bytes(dep_path, string_to_bytes("export fn assert_eq(a: Int, b: Int) -> Int { a + b }\n"))
   Fs::write_bytes(main_path, string_to_bytes("export ./dep.vibe { assert_eq }\nexport fn answer() -> Int { assert_eq(1, 2) }\n"))
-  inspect(String::contains(compile_file_error(main_path, "answer"), "unknown name: assert_eq"), content = "true")
+  let bytes = compile_file_wasi_only(main_path, "answer")
+  assert_wasm_magic(bytes)
+  inspect(bytes_contains_ascii(bytes, "assert_eq failed"), content = "false")
+  let merged_bytes = compile_source_wasi_only(merged_program_source_fs(main_path), "answer")
+  assert_wasm_magic(merged_bytes)
+  inspect(bytes_contains_ascii(merged_bytes, "assert_eq failed"), content = "false")
 }
 
-test "same-source plain inspect re-export remains unknown through FS merge" {
+test "same-source plain inspect re-export remains callable through FS merge" {
   let base_dir = "/tmp/vibe_compiler_reexport_plain_inspect_blocker"
   let dep_path = String::concat(base_dir, "/dep.vibe")
   let main_path = String::concat(base_dir, "/main.vibe")
   Fs::mkdir_p(base_dir)
   Fs::write_bytes(dep_path, string_to_bytes("export fn inspect(a: Int, _expected: String) -> Int { a + 1 }\n"))
   Fs::write_bytes(main_path, string_to_bytes("export ./dep.vibe { inspect }\nexport fn answer() -> Int { inspect(1, \"ignored\") }\n"))
-  inspect(String::contains(compile_file_error(main_path, "answer"), "unknown name: inspect"), content = "true")
+  let bytes = compile_file_wasi_only(main_path, "answer")
+  assert_wasm_magic(bytes)
 }
 
 test "compile_file_wasi_only: simple file produces valid WASM" {

--- a/lib/@vibe/compiler/tests/compiler_fs_test.vibe
+++ b/lib/@vibe/compiler/tests/compiler_fs_test.vibe
@@ -288,6 +288,36 @@ test "same-source inspect re-export alias value remains unknown before serializa
   inspect(String::contains(merged_source_error(main_path), "unknown name: inspect"), content = "true")
 }
 
+test "same-source builtin-named re-export alias remains unknown before serialization" {
+  let base_dir = "/tmp/vibe_compiler_reexport_alias_println_blocker"
+  let dep_path = String::concat(base_dir, "/dep.vibe")
+  let main_path = String::concat(base_dir, "/main.vibe")
+  Fs::mkdir_p(base_dir)
+  Fs::write_bytes(dep_path, string_to_bytes("export fn emit(message: String) -> Unit { () }\n"))
+  Fs::write_bytes(main_path, string_to_bytes("export ./dep.vibe { emit as println }\nexport fn answer() -> Unit with Stdout { println(\"x\") }\n"))
+  inspect(String::contains(merged_source_error(main_path), "unknown name: println"), content = "true")
+}
+
+test "nested alias shadow does not hide an unbound re-export alias reference" {
+  let base_dir = "/tmp/vibe_compiler_reexport_alias_lexical_blocker"
+  let dep_path = String::concat(base_dir, "/dep.vibe")
+  let main_path = String::concat(base_dir, "/main.vibe")
+  Fs::mkdir_p(base_dir)
+  Fs::write_bytes(dep_path, string_to_bytes("export fn cmp(a: Int, b: Int) -> Int { a + b }\n"))
+  Fs::write_bytes(main_path, string_to_bytes("export ./dep.vibe { cmp as assert_eq }\nexport fn shadow(assert_eq: (Int, Int) -> Int) -> Int { assert_eq(1, 2) }\nexport fn answer() -> Int { let f = assert_eq; f(1, 2) }\n"))
+  inspect(String::contains(merged_source_error(main_path), "unknown name: assert_eq"), content = "true")
+}
+
+test "lexically shadowed re-export alias reference remains valid" {
+  let base_dir = "/tmp/vibe_compiler_reexport_alias_lexical_shadow"
+  let dep_path = String::concat(base_dir, "/dep.vibe")
+  let main_path = String::concat(base_dir, "/main.vibe")
+  Fs::mkdir_p(base_dir)
+  Fs::write_bytes(dep_path, string_to_bytes("export fn emit(message: String) -> Unit { () }\n"))
+  Fs::write_bytes(main_path, string_to_bytes("export ./dep.vibe { emit as println }\nexport fn answer() -> Unit { let println = (_message: String) -> (); println(\"x\") }\n"))
+  inspect(merged_source_error(main_path), content = "")
+}
+
 test "same-source ordinary re-export alias remains unknown through FS merge" {
   let base_dir = "/tmp/vibe_compiler_reexport_alias_value_blocker"
   let dep_path = String::concat(base_dir, "/dep.vibe")
@@ -296,6 +326,7 @@ test "same-source ordinary re-export alias remains unknown through FS merge" {
   Fs::write_bytes(dep_path, string_to_bytes("export fn source_value() -> Int { 7 }\n"))
   Fs::write_bytes(main_path, string_to_bytes("export ./dep.vibe { source_value as forwarded }\nexport fn answer() -> Int { forwarded() }\n"))
   inspect(String::contains(compile_file_error(main_path, "answer"), "unknown name: forwarded"), content = "true")
+  inspect(String::contains(merged_source_error(main_path), "unknown name: forwarded"), content = "true")
 }
 
 test "same-source plain assert_eq re-export remains callable through FS merge" {

--- a/lib/@vibe/compiler/tests/compiler_fs_test.vibe
+++ b/lib/@vibe/compiler/tests/compiler_fs_test.vibe
@@ -317,6 +317,19 @@ test "non-entry facade can call its plain re-export after FS namespacing" {
   assert_wasm_magic(compile_source_wasi_only(merged_program_source_fs(main_path), "answer"))
 }
 
+test "later plain re-export cancels an earlier same-name alias blocker" {
+  let base_dir = "/tmp/vibe_compiler_reexport_plain_cancels_alias"
+  let a_path = String::concat(base_dir, "/a.vibe")
+  let b_path = String::concat(base_dir, "/b.vibe")
+  let main_path = String::concat(base_dir, "/main.vibe")
+  Fs::mkdir_p(base_dir)
+  Fs::write_bytes(a_path, string_to_bytes("export fn f() -> Int { 1 }\n"))
+  Fs::write_bytes(b_path, string_to_bytes("export fn foo() -> Int { 2 }\n"))
+  Fs::write_bytes(main_path, string_to_bytes("export ./a.vibe { f as foo }\nexport ./b.vibe { foo }\nexport fn answer() -> Int { foo() }\n"))
+  assert_wasm_magic(compile_file_wasi_only(main_path, "answer"))
+  assert_wasm_magic(compile_source_wasi_only(merged_program_source_fs(main_path), "answer"))
+}
+
 test "compile_file_wasi_only: simple file produces valid WASM" {
   let base_dir = "/tmp/vibe_compiler_wasi_only"
   let main_path = String::concat(base_dir, "/main.vibe")

--- a/lib/@vibe/compiler/tests/compiler_fs_test.vibe
+++ b/lib/@vibe/compiler/tests/compiler_fs_test.vibe
@@ -257,6 +257,16 @@ test "same-source assert_eq re-export alias remains unknown through FS merge" {
   inspect(String::contains(compile_file_error(main_path, "answer"), "unknown name: assert_eq"), content = "true")
 }
 
+test "same-source assert_eq re-export alias value remains unknown before serialization" {
+  let base_dir = "/tmp/vibe_compiler_reexport_alias_assert_eq_value_blocker"
+  let dep_path = String::concat(base_dir, "/dep.vibe")
+  let main_path = String::concat(base_dir, "/main.vibe")
+  Fs::mkdir_p(base_dir)
+  Fs::write_bytes(dep_path, string_to_bytes("export fn cmp(a: Int, b: Int) -> Int { a + b }\n"))
+  Fs::write_bytes(main_path, string_to_bytes("export ./dep.vibe { cmp as assert_eq }\nexport fn answer() -> Int { let f = assert_eq; f(1, 2) }\n"))
+  inspect(String::contains(merged_source_error(main_path), "unknown name: assert_eq"), content = "true")
+}
+
 test "same-source inspect re-export alias remains unknown through FS merge" {
   let base_dir = "/tmp/vibe_compiler_reexport_alias_inspect_blocker"
   let dep_path = String::concat(base_dir, "/dep.vibe")
@@ -265,6 +275,16 @@ test "same-source inspect re-export alias remains unknown through FS merge" {
   Fs::write_bytes(dep_path, string_to_bytes("export fn view(a: Int, b: Int) -> Int { a + b }\n"))
   Fs::write_bytes(main_path, string_to_bytes("export ./dep.vibe { view as inspect }\nexport let answer: () -> Int with Stdout = () -> { inspect(1, \"1\"); 0 }\n"))
   inspect(String::contains(compile_file_error(main_path, "answer"), "unknown name: inspect"), content = "true")
+  inspect(String::contains(merged_source_error(main_path), "unknown name: inspect"), content = "true")
+}
+
+test "same-source inspect re-export alias value remains unknown before serialization" {
+  let base_dir = "/tmp/vibe_compiler_reexport_alias_inspect_value_blocker"
+  let dep_path = String::concat(base_dir, "/dep.vibe")
+  let main_path = String::concat(base_dir, "/main.vibe")
+  Fs::mkdir_p(base_dir)
+  Fs::write_bytes(dep_path, string_to_bytes("export fn view(a: Int, b: Int) -> Int { a + b }\n"))
+  Fs::write_bytes(main_path, string_to_bytes("export ./dep.vibe { view as inspect }\nexport fn answer() -> Int { let f = inspect; f(1, 2) }\n"))
   inspect(String::contains(merged_source_error(main_path), "unknown name: inspect"), content = "true")
 }
 

--- a/lib/@vibe/compiler/tests/compiler_fs_test.vibe
+++ b/lib/@vibe/compiler/tests/compiler_fs_test.vibe
@@ -340,6 +340,19 @@ test "entry re-export source name remains inaccessible through FS merge" {
   inspect(String::contains(merged_source_error(main_path), "unknown name: source_value"), content = "true")
 }
 
+test "entry import rewrite may use a retained re-export source name" {
+  let base_dir = "/tmp/vibe_compiler_reexport_alias_retained_import"
+  let dep_path = String::concat(base_dir, "/dep.vibe")
+  let main_path = String::concat(base_dir, "/main.vibe")
+  Fs::mkdir_p(base_dir)
+  Fs::write_bytes(dep_path, string_to_bytes("export fn source_value() -> Int { 7 }\n"))
+  Fs::write_bytes(main_path, string_to_bytes("import ./dep.vibe { source_value as local_value }\nexport ./dep.vibe { source_value as public_value }\nexport fn answer() -> Int { local_value() }\n"))
+  let bytes = compile_file_wasi_only(main_path, "answer")
+  assert_wasm_magic(bytes)
+  let merged_bytes = compile_source_wasi_only(merged_program_source_fs(main_path), "answer")
+  assert_wasm_magic(merged_bytes)
+}
+
 test "same-source plain assert_eq re-export remains callable through FS merge" {
   let base_dir = "/tmp/vibe_compiler_reexport_plain_assert_eq_blocker"
   let dep_path = String::concat(base_dir, "/dep.vibe")

--- a/lib/@vibe/compiler/tests/compiler_fs_test.vibe
+++ b/lib/@vibe/compiler/tests/compiler_fs_test.vibe
@@ -8,7 +8,12 @@ import @vibe/core {
 // collect_linked_compile_inputs used to arrive via a separate leaf import of
 // linked_artifacts.vibe, now merged into this one package-form import.
 import @vibe/compiler/entry/source_compile/wasi_only {
-  collect_linked_compile_inputs, compile_file_wasi_library, compile_file_wasi_linked_artifacts, compile_file_wasi_only
+  collect_linked_compile_inputs,
+  compile_file_wasi_library,
+  compile_file_wasi_linked_artifacts,
+  compile_file_wasi_only,
+  compile_source_wasi_only,
+  merged_program_source_fs
 }
 
 //# Functions
@@ -155,11 +160,89 @@ test "re-export aliases in a dependency do not suppress entry builtins" {
   assert(bytes_contains_ascii(bytes, "assert_eq failed"))
 }
 
+test "same-source imported assert_eq is not lowered as the builtin through FS merge" {
+  let base_dir = "/tmp/vibe_compiler_imported_assert_eq_blocker"
+  let dep_path = String::concat(base_dir, "/dep.vibe")
+  let main_path = String::concat(base_dir, "/main.vibe")
+  Fs::mkdir_p(base_dir)
+  Fs::write_bytes(dep_path, string_to_bytes("export fn assert_eq(a: Int, b: Int) -> Int { a + b }\n"))
+  Fs::write_bytes(main_path, string_to_bytes("import ./dep.vibe { assert_eq }\nexport fn answer() -> Int { assert_eq(1, 2) }\n"))
+  let bytes = compile_file_wasi_only(main_path, "answer")
+  assert_wasm_magic(bytes)
+  inspect(bytes_contains_ascii(bytes, "assert_eq failed"), content = "false")
+}
+
+test "same-source import aliased as assert_eq is not lowered as the builtin through FS merge" {
+  let base_dir = "/tmp/vibe_compiler_import_alias_assert_eq_blocker"
+  let dep_path = String::concat(base_dir, "/dep.vibe")
+  let main_path = String::concat(base_dir, "/main.vibe")
+  Fs::mkdir_p(base_dir)
+  Fs::write_bytes(dep_path, string_to_bytes("export fn cmp(a: Int, b: Int) -> Int { a + b }\n"))
+  Fs::write_bytes(main_path, string_to_bytes("import ./dep.vibe { cmp as assert_eq }\nexport fn answer() -> Int { assert_eq(1, 2) }\n"))
+  let bytes = compile_file_wasi_only(main_path, "answer")
+  assert_wasm_magic(bytes)
+  inspect(bytes_contains_ascii(bytes, "assert_eq failed"), content = "false")
+}
+
+test "same-source imported inspect is not lowered as the builtin through FS merge" {
+  let base_dir = "/tmp/vibe_compiler_imported_inspect_blocker"
+  let dep_path = String::concat(base_dir, "/dep.vibe")
+  let main_path = String::concat(base_dir, "/main.vibe")
+  Fs::mkdir_p(base_dir)
+  Fs::write_bytes(dep_path, string_to_bytes("export fn inspect(a: Int, _expected: String) -> Int { a + 1 }\n"))
+  Fs::write_bytes(main_path, string_to_bytes("import ./dep.vibe { inspect }\nexport fn answer() -> Int { inspect(1, \"ignored\") }\n"))
+  let bytes = compile_file_wasi_only(main_path, "answer")
+  assert_wasm_magic(bytes)
+}
+
+test "same-source import aliased as inspect is not lowered as the builtin through FS merge" {
+  let base_dir = "/tmp/vibe_compiler_import_alias_inspect_blocker"
+  let dep_path = String::concat(base_dir, "/dep.vibe")
+  let main_path = String::concat(base_dir, "/main.vibe")
+  Fs::mkdir_p(base_dir)
+  Fs::write_bytes(dep_path, string_to_bytes("export fn view(a: Int, _expected: String) -> Int { a + 1 }\n"))
+  Fs::write_bytes(main_path, string_to_bytes("import ./dep.vibe { view as inspect }\nexport fn answer() -> Int { inspect(1, \"ignored\") }\n"))
+  let bytes = compile_file_wasi_only(main_path, "answer")
+  assert_wasm_magic(bytes)
+}
+
 fn compile_file_error(path: String, entry: String) -> String with Fs + Exception {
   handle {
     let _ = compile_file_wasi_only(path, entry)
     ""
   } with { Exception::Throw(msg) => msg }
+}
+
+fn compile_source_error(source: String, entry: String) -> String with Exception {
+  handle {
+    let _ = compile_source_wasi_only(source, entry)
+    ""
+  } with { Exception::Throw(msg) => msg }
+}
+
+test "merged source preserves a same-source re-export alias blocker" {
+  let base_dir = "/tmp/vibe_compiler_merged_source_reexport_alias_blocker"
+  let dep_path = String::concat(base_dir, "/dep.vibe")
+  let main_path = String::concat(base_dir, "/main.vibe")
+  Fs::mkdir_p(base_dir)
+  Fs::write_bytes(dep_path, string_to_bytes("export fn cmp(a: Int, b: Int) -> Int { a + b }\n"))
+  Fs::write_bytes(main_path, string_to_bytes("export ./dep.vibe { cmp as assert_eq }\nexport fn answer() -> Int { assert_eq(1, 2) }\n"))
+  let merged = merged_program_source_fs(main_path)
+  inspect(String::contains(compile_source_error(merged, "answer"), "unknown name: assert_eq"), content = "true")
+}
+
+test "merged source keeps a dependency re-export from suppressing an entry builtin" {
+  let base_dir = "/tmp/vibe_compiler_merged_source_entry_builtin_scope"
+  let inner_path = String::concat(base_dir, "/inner.vibe")
+  let facade_path = String::concat(base_dir, "/facade.vibe")
+  let main_path = String::concat(base_dir, "/main.vibe")
+  Fs::mkdir_p(base_dir)
+  Fs::write_bytes(inner_path, string_to_bytes("export fn cmp(a: Int, b: Int) -> Int { a + b }\n"))
+  Fs::write_bytes(facade_path, string_to_bytes("export ./inner.vibe { cmp as assert_eq }\n"))
+  Fs::write_bytes(main_path, string_to_bytes("import ./facade.vibe { assert_eq as forwarded_assert }\nexport fn answer() -> Int with Stdout {\n  let _ = forwarded_assert(1, 2)\n  assert_eq(1, 2)\n  0\n}\n"))
+  let bytes = compile_source_wasi_only(merged_program_source_fs(main_path), "answer")
+  assert_wasm_magic(bytes)
+  inspect(bytes_contains_ascii(bytes, "assert_eq failed"), content = "true")
 }
 
 test "same-source assert_eq re-export alias remains unknown through FS merge" {
@@ -190,6 +273,26 @@ test "same-source ordinary re-export alias remains unknown through FS merge" {
   Fs::write_bytes(dep_path, string_to_bytes("export fn source_value() -> Int { 7 }\n"))
   Fs::write_bytes(main_path, string_to_bytes("export ./dep.vibe { source_value as forwarded }\nexport fn answer() -> Int { forwarded() }\n"))
   inspect(String::contains(compile_file_error(main_path, "answer"), "unknown name: forwarded"), content = "true")
+}
+
+test "same-source plain assert_eq re-export remains unknown through FS merge" {
+  let base_dir = "/tmp/vibe_compiler_reexport_plain_assert_eq_blocker"
+  let dep_path = String::concat(base_dir, "/dep.vibe")
+  let main_path = String::concat(base_dir, "/main.vibe")
+  Fs::mkdir_p(base_dir)
+  Fs::write_bytes(dep_path, string_to_bytes("export fn assert_eq(a: Int, b: Int) -> Int { a + b }\n"))
+  Fs::write_bytes(main_path, string_to_bytes("export ./dep.vibe { assert_eq }\nexport fn answer() -> Int { assert_eq(1, 2) }\n"))
+  inspect(String::contains(compile_file_error(main_path, "answer"), "unknown name: assert_eq"), content = "true")
+}
+
+test "same-source plain inspect re-export remains unknown through FS merge" {
+  let base_dir = "/tmp/vibe_compiler_reexport_plain_inspect_blocker"
+  let dep_path = String::concat(base_dir, "/dep.vibe")
+  let main_path = String::concat(base_dir, "/main.vibe")
+  Fs::mkdir_p(base_dir)
+  Fs::write_bytes(dep_path, string_to_bytes("export fn inspect(a: Int, _expected: String) -> Int { a + 1 }\n"))
+  Fs::write_bytes(main_path, string_to_bytes("export ./dep.vibe { inspect }\nexport fn answer() -> Int { inspect(1, \"ignored\") }\n"))
+  inspect(String::contains(compile_file_error(main_path, "answer"), "unknown name: inspect"), content = "true")
 }
 
 test "compile_file_wasi_only: simple file produces valid WASM" {

--- a/lib/@vibe/compiler/tests/compiler_fs_test.vibe
+++ b/lib/@vibe/compiler/tests/compiler_fs_test.vibe
@@ -353,6 +353,21 @@ test "entry import rewrite may use a retained re-export source name" {
   assert_wasm_magic(merged_bytes)
 }
 
+test "retained import survives a colliding re-export alias" {
+  let base_dir = "/tmp/vibe_compiler_retained_import_alias_collision"
+  let a_path = String::concat(base_dir, "/a.vibe")
+  let b_path = String::concat(base_dir, "/b.vibe")
+  let main_path = String::concat(base_dir, "/main.vibe")
+  Fs::mkdir_p(base_dir)
+  Fs::write_bytes(a_path, string_to_bytes("export fn f() -> Int { 7 }\n"))
+  Fs::write_bytes(b_path, string_to_bytes("export fn h() -> Int { 8 }\n"))
+  Fs::write_bytes(main_path, string_to_bytes("import ./a.vibe { f as local_value }\nexport ./a.vibe { f as public_a }\nexport ./b.vibe { h as f }\nexport fn answer() -> Int { local_value() }\n"))
+  let bytes = compile_file_wasi_only(main_path, "answer")
+  assert_wasm_magic(bytes)
+  let merged_bytes = compile_source_wasi_only(merged_program_source_fs(main_path), "answer")
+  assert_wasm_magic(merged_bytes)
+}
+
 test "same-source plain assert_eq re-export remains callable through FS merge" {
   let base_dir = "/tmp/vibe_compiler_reexport_plain_assert_eq_blocker"
   let dep_path = String::concat(base_dir, "/dep.vibe")

--- a/lib/@vibe/compiler/tests/compiler_fs_test.vibe
+++ b/lib/@vibe/compiler/tests/compiler_fs_test.vibe
@@ -329,6 +329,17 @@ test "same-source ordinary re-export alias remains unknown through FS merge" {
   inspect(String::contains(merged_source_error(main_path), "unknown name: forwarded"), content = "true")
 }
 
+test "entry re-export source name remains inaccessible through FS merge" {
+  let base_dir = "/tmp/vibe_compiler_reexport_alias_source_name_blocker"
+  let dep_path = String::concat(base_dir, "/dep.vibe")
+  let main_path = String::concat(base_dir, "/main.vibe")
+  Fs::mkdir_p(base_dir)
+  Fs::write_bytes(dep_path, string_to_bytes("export fn source_value() -> Int { 7 }\n"))
+  Fs::write_bytes(main_path, string_to_bytes("export ./dep.vibe { source_value as forwarded }\nexport fn answer() -> Int { source_value() }\n"))
+  inspect(String::contains(compile_file_error(main_path, "answer"), "unknown name: source_value"), content = "true")
+  inspect(String::contains(merged_source_error(main_path), "unknown name: source_value"), content = "true")
+}
+
 test "same-source plain assert_eq re-export remains callable through FS merge" {
   let base_dir = "/tmp/vibe_compiler_reexport_plain_assert_eq_blocker"
   let dep_path = String::concat(base_dir, "/dep.vibe")

--- a/lib/@vibe/compiler/tests/compiler_fs_test.vibe
+++ b/lib/@vibe/compiler/tests/compiler_fs_test.vibe
@@ -155,6 +155,43 @@ test "re-export aliases in a dependency do not suppress entry builtins" {
   assert(bytes_contains_ascii(bytes, "assert_eq failed"))
 }
 
+fn compile_file_error(path: String, entry: String) -> String with Fs + Exception {
+  handle {
+    let _ = compile_file_wasi_only(path, entry)
+    ""
+  } with { Exception::Throw(msg) => msg }
+}
+
+test "same-source assert_eq re-export alias remains unknown through FS merge" {
+  let base_dir = "/tmp/vibe_compiler_reexport_alias_assert_eq_blocker"
+  let dep_path = String::concat(base_dir, "/dep.vibe")
+  let main_path = String::concat(base_dir, "/main.vibe")
+  Fs::mkdir_p(base_dir)
+  Fs::write_bytes(dep_path, string_to_bytes("export fn cmp(a: Int, b: Int) -> Int { a + b }\n"))
+  Fs::write_bytes(main_path, string_to_bytes("export ./dep.vibe { cmp as assert_eq }\nexport let answer: () -> Int with Stdout = () -> { assert_eq(1, 2); 0 }\n"))
+  inspect(String::contains(compile_file_error(main_path, "answer"), "unknown name: assert_eq"), content = "true")
+}
+
+test "same-source inspect re-export alias remains unknown through FS merge" {
+  let base_dir = "/tmp/vibe_compiler_reexport_alias_inspect_blocker"
+  let dep_path = String::concat(base_dir, "/dep.vibe")
+  let main_path = String::concat(base_dir, "/main.vibe")
+  Fs::mkdir_p(base_dir)
+  Fs::write_bytes(dep_path, string_to_bytes("export fn view(a: Int, b: Int) -> Int { a + b }\n"))
+  Fs::write_bytes(main_path, string_to_bytes("export ./dep.vibe { view as inspect }\nexport let answer: () -> Int with Stdout = () -> { inspect(1, \"1\"); 0 }\n"))
+  inspect(String::contains(compile_file_error(main_path, "answer"), "unknown name: inspect"), content = "true")
+}
+
+test "same-source ordinary re-export alias remains unknown through FS merge" {
+  let base_dir = "/tmp/vibe_compiler_reexport_alias_value_blocker"
+  let dep_path = String::concat(base_dir, "/dep.vibe")
+  let main_path = String::concat(base_dir, "/main.vibe")
+  Fs::mkdir_p(base_dir)
+  Fs::write_bytes(dep_path, string_to_bytes("export fn source_value() -> Int { 7 }\n"))
+  Fs::write_bytes(main_path, string_to_bytes("export ./dep.vibe { source_value as forwarded }\nexport fn answer() -> Int { forwarded() }\n"))
+  inspect(String::contains(compile_file_error(main_path, "answer"), "unknown name: forwarded"), content = "true")
+}
+
 test "compile_file_wasi_only: simple file produces valid WASM" {
   let base_dir = "/tmp/vibe_compiler_wasi_only"
   let main_path = String::concat(base_dir, "/main.vibe")

--- a/lib/@vibe/compiler/tests/compiler_fs_test.vibe
+++ b/lib/@vibe/compiler/tests/compiler_fs_test.vibe
@@ -368,6 +368,37 @@ test "retained import survives a colliding re-export alias" {
   assert_wasm_magic(merged_bytes)
 }
 
+test "later re-export alias blocks an earlier import rewrite through FS merge" {
+  let base_dir = "/tmp/vibe_compiler_later_alias_blocks_import"
+  let a_path = String::concat(base_dir, "/a.vibe")
+  let b_path = String::concat(base_dir, "/b.vibe")
+  let main_path = String::concat(base_dir, "/main.vibe")
+  Fs::mkdir_p(base_dir)
+  Fs::write_bytes(a_path, string_to_bytes("export fn old() -> Int { 1 }\n"))
+  Fs::write_bytes(b_path, string_to_bytes("export fn new() -> Int { 2 }\n"))
+  Fs::write_bytes(main_path, string_to_bytes("import ./a.vibe { old as foo }\nexport ./b.vibe { new as foo }\nexport fn answer() -> Int { foo() }\n"))
+  inspect(String::contains(compile_file_error(main_path, "answer"), "unknown name: foo"), content = "true")
+  inspect(String::contains(merged_source_error(main_path), "unknown name: foo"), content = "true")
+}
+
+test "collision preservation selects the latest same-local import" {
+  let base_dir = "/tmp/vibe_compiler_collision_latest_import"
+  let a_path = String::concat(base_dir, "/a.vibe")
+  let b_path = String::concat(base_dir, "/b.vibe")
+  let c_path = String::concat(base_dir, "/c.vibe")
+  let main_path = String::concat(base_dir, "/main.vibe")
+  Fs::mkdir_p(base_dir)
+  Fs::write_bytes(a_path, string_to_bytes("export fn first() -> Int { 11 }\n"))
+  Fs::write_bytes(b_path, string_to_bytes("export fn second() -> Int { 22 }\n"))
+  Fs::write_bytes(c_path, string_to_bytes("export fn blocker() -> Int { 33 }\n"))
+  Fs::write_bytes(main_path, string_to_bytes("import ./a.vibe { first as local }\nimport ./b.vibe { second as local }\nexport ./b.vibe { second as public_b }\nexport ./c.vibe { blocker as second }\nexport fn answer() -> Int { local() }\n"))
+  let merged = merged_program_source_fs(main_path)
+  assert(String::contains(merged, "let rec local = () -> Int { 22 }"))
+  assert(!String::contains(merged, "let rec local = () -> Int { 11 }"))
+  assert_wasm_magic(compile_file_wasi_only(main_path, "answer"))
+  assert_wasm_magic(compile_source_wasi_only(merged, "answer"))
+}
+
 test "same-source plain assert_eq re-export remains callable through FS merge" {
   let base_dir = "/tmp/vibe_compiler_reexport_plain_assert_eq_blocker"
   let dep_path = String::concat(base_dir, "/dep.vibe")

--- a/lib/@vibe/compiler/tests/compiler_fs_test.vibe
+++ b/lib/@vibe/compiler/tests/compiler_fs_test.vibe
@@ -216,9 +216,9 @@ fn compile_file_error(path: String, entry: String) -> String with Fs + Exception
   } with { Exception::Throw(msg) => msg }
 }
 
-fn compile_source_error(source: String, entry: String) -> String with Exception {
+fn merged_source_error(path: String) -> String with Fs + Exception {
   handle {
-    let _ = compile_source_wasi_only(source, entry)
+    let _ = merged_program_source_fs(path)
     ""
   } with { Exception::Throw(msg) => msg }
 }
@@ -230,8 +230,7 @@ test "merged source preserves a same-source re-export alias blocker" {
   Fs::mkdir_p(base_dir)
   Fs::write_bytes(dep_path, string_to_bytes("export fn cmp(a: Int, b: Int) -> Int { a + b }\n"))
   Fs::write_bytes(main_path, string_to_bytes("export ./dep.vibe { cmp as assert_eq }\nexport fn answer() -> Int { assert_eq(1, 2) }\n"))
-  let merged = merged_program_source_fs(main_path)
-  inspect(String::contains(compile_source_error(merged, "answer"), "unknown name: assert_eq"), content = "true")
+  inspect(String::contains(merged_source_error(main_path), "unknown name: assert_eq"), content = "true")
 }
 
 test "merged source keeps a dependency re-export from suppressing an entry builtin" {
@@ -266,6 +265,7 @@ test "same-source inspect re-export alias remains unknown through FS merge" {
   Fs::write_bytes(dep_path, string_to_bytes("export fn view(a: Int, b: Int) -> Int { a + b }\n"))
   Fs::write_bytes(main_path, string_to_bytes("export ./dep.vibe { view as inspect }\nexport let answer: () -> Int with Stdout = () -> { inspect(1, \"1\"); 0 }\n"))
   inspect(String::contains(compile_file_error(main_path, "answer"), "unknown name: inspect"), content = "true")
+  inspect(String::contains(merged_source_error(main_path), "unknown name: inspect"), content = "true")
 }
 
 test "same-source ordinary re-export alias remains unknown through FS merge" {
@@ -302,6 +302,19 @@ test "same-source plain inspect re-export remains callable through FS merge" {
   Fs::write_bytes(main_path, string_to_bytes("export ./dep.vibe { inspect }\nexport fn answer() -> Int { inspect(1, \"ignored\") }\n"))
   let bytes = compile_file_wasi_only(main_path, "answer")
   assert_wasm_magic(bytes)
+}
+
+test "non-entry facade can call its plain re-export after FS namespacing" {
+  let base_dir = "/tmp/vibe_compiler_non_entry_plain_reexport_call"
+  let dep_path = String::concat(base_dir, "/dep.vibe")
+  let facade_path = String::concat(base_dir, "/facade.vibe")
+  let main_path = String::concat(base_dir, "/main.vibe")
+  Fs::mkdir_p(base_dir)
+  Fs::write_bytes(dep_path, string_to_bytes("export fn foo() -> Int { 41 }\n"))
+  Fs::write_bytes(facade_path, string_to_bytes("export ./dep.vibe { foo }\nexport fn bar() -> Int { foo() + 1 }\n"))
+  Fs::write_bytes(main_path, string_to_bytes("import ./facade.vibe { bar }\nexport fn answer() -> Int { bar() }\n"))
+  assert_wasm_magic(compile_file_wasi_only(main_path, "answer"))
+  assert_wasm_magic(compile_source_wasi_only(merged_program_source_fs(main_path), "answer"))
 }
 
 test "compile_file_wasi_only: simple file produces valid WASM" {

--- a/lib/@vibe/compiler/tests/import_alias_rewrite_test.vibe
+++ b/lib/@vibe/compiler/tests/import_alias_rewrite_test.vibe
@@ -1,7 +1,7 @@
 //# Imports
 
 import @vibe/compiler/core {
-  append_import_alias_rewritten_non_import_stmts
+  append_import_alias_rewritten_non_import_stmts, build_export_rename_plan, collect_import_value_renames, namespace_exported_name
 }
 
 import @vibe/compiler/syntax {
@@ -27,4 +27,27 @@ test "imported type aliases rewrite fn annotations but not type formals" {
   assert(String::contains(printed, "StdinStream"))
   assert(!String::contains(printed, "(stream: S)"))
   assert(String::contains(printed, "(value: S)"))
+}
+
+test "later plain re-export wins over an earlier import reference rename" {
+  let a_path = "/virtual/a.vibe"
+  let b_path = "/virtual/b.vibe"
+  let facade_path = "/virtual/facade.vibe"
+  let main_path = "/virtual/main.vibe"
+  let a_stmts = parse_program(lex("export fn foo() -> Int { 1 }"))
+  let b_stmts = parse_program(lex("export fn foo() -> Int { 2 }"))
+  let facade_stmts = parse_program(lex("import ./a.vibe { foo }\nexport ./b.vibe { foo }\nexport fn bar() -> Int { foo() }"))
+  let main_stmts = parse_program(lex("import ./facade.vibe { bar }\nexport fn answer() -> Int { bar() }"))
+  let paths = [a_path, b_path, facade_path, main_path]
+  let plan = build_export_rename_plan(paths, [
+    a_stmts,
+    b_stmts,
+    facade_stmts,
+    main_stmts
+  ], main_path)
+  let renames = collect_import_value_renames(plan, facade_path, facade_stmts)
+  assert(Array::length(renames) == 1)
+  let (local, target) = Array::get(renames, 0)
+  assert(local == "foo")
+  assert(target == namespace_exported_name(b_path, "foo"))
 }

--- a/lib/@vibe/compiler/tests/import_alias_rewrite_test.vibe
+++ b/lib/@vibe/compiler/tests/import_alias_rewrite_test.vibe
@@ -51,3 +51,22 @@ test "later plain re-export wins over an earlier import reference rename" {
   assert(local == "foo")
   assert(target == namespace_exported_name(b_path, "foo"))
 }
+
+test "later aliased re-export blocks an earlier import reference rename" {
+  let a_path = "/virtual/a.vibe"
+  let b_path = "/virtual/b.vibe"
+  let facade_path = "/virtual/facade.vibe"
+  let main_path = "/virtual/main.vibe"
+  let a_stmts = parse_program(lex("export fn old() -> Int { 1 }"))
+  let b_stmts = parse_program(lex("export fn new() -> Int { 2 }"))
+  let facade_stmts = parse_program(lex("import ./a.vibe { old as foo }\nexport ./b.vibe { new as foo }\nexport fn bar() -> Int { foo() }"))
+  let main_stmts = parse_program(lex("import ./facade.vibe { bar }\nexport fn answer() -> Int { bar() }"))
+  let plan = build_export_rename_plan([a_path, b_path, facade_path, main_path], [
+    a_stmts,
+    b_stmts,
+    facade_stmts,
+    main_stmts
+  ], main_path)
+  let renames = collect_import_value_renames(plan, facade_path, facade_stmts)
+  assert(Array::length(renames) == 0)
+}

--- a/lib/@vibe/compiler/tests/normalize_transform_change_status_test.vibe
+++ b/lib/@vibe/compiler/tests/normalize_transform_change_status_test.vibe
@@ -221,6 +221,16 @@ test "bound inspect remains inert and reports unchanged" {
   inspect(desugar_inspect_calls_reporting_change(stmts), "false")
 }
 
+test "#2287 review: a surface-only re-export alias does not suppress inspect lowering" {
+  let stmts = parse("export ./dep.vibe { f as inspect }; let main = () -> { inspect(1, \"1\") }")
+  inspect(desugar_inspect_calls_reporting_change(stmts), "true")
+}
+
+test "#2287 review: a plain inspect re-export still suppresses inspect lowering" {
+  let stmts = parse("export ./dep.vibe { inspect }; let main = () -> { inspect(1, \"1\") }")
+  inspect(desugar_inspect_calls_reporting_change(stmts), "false")
+}
+
 test "trait generic injection reports its exact write and then idempotence" {
   let source = "trait Show { show(Self) -> String }\ntrait Logger { write_object: [X: Show](Self, X) -> String }\nstruct Box { value: Int }\nimpl Logger for Box { write_object(self, x) -> String { X::show(x) } }"
   let stmts = parse(source)

--- a/lib/@vibe/compiler/tests/normalize_transform_change_status_test.vibe
+++ b/lib/@vibe/compiler/tests/normalize_transform_change_status_test.vibe
@@ -221,9 +221,9 @@ test "bound inspect remains inert and reports unchanged" {
   inspect(desugar_inspect_calls_reporting_change(stmts), "false")
 }
 
-test "#2287 review: a surface-only re-export alias does not suppress inspect lowering" {
+test "#2287 review: a surface-only re-export alias preserves the local inspect blocker" {
   let stmts = parse("export ./dep.vibe { f as inspect }; let main = () -> { inspect(1, \"1\") }")
-  inspect(desugar_inspect_calls_reporting_change(stmts), "true")
+  inspect(desugar_inspect_calls_reporting_change(stmts), "false")
 }
 
 test "#2287 review: a plain inspect re-export still suppresses inspect lowering" {

--- a/lib/@vibe/compiler/tests/type_db_cross_module_test.vibe
+++ b/lib/@vibe/compiler/tests/type_db_cross_module_test.vibe
@@ -946,7 +946,7 @@ test "db_typecheck_fs: extensionless directory re-export imports enum constructo
   assert(has_ctor)
 }
 
-test "projected checker root preserves direct alias re-export and companion origins" {
+test "projected checker keeps alias re-exports surface-only" {
   let dep_path = "workspace/dep.vibe"
   let dep_env = checked_test_env("export let direct = 1\nexport let renamed = \"ok\"\nexport enum Choice { Pick(Int) }")
   let source = "import ./dep.vibe { direct, renamed as alias, Choice, Pick as ExplicitPick }\nexport ./dep.vibe { direct, renamed as forwarded }\nlet use_alias: String = alias\nlet use_direct: Int = direct"
@@ -955,7 +955,7 @@ test "projected checker root preserves direct alias re-export and companion orig
   ])
   assert_module_origin(checked, "direct", dep_path, "direct")
   assert_module_origin(checked, "alias", dep_path, "renamed")
-  assert_module_origin(checked, "forwarded", dep_path, "renamed")
+  inspect(env_lookup(checked, "forwarded") == None, "true")
   assert_module_origin(checked, "Choice", dep_path, "Choice")
   assert_module_origin(checked, "ExplicitPick", dep_path, "Pick")
   // Importing the enum attaches its automatic companion using the
@@ -965,6 +965,30 @@ test "projected checker root preserves direct alias re-export and companion orig
     (Some(CtString), Some(CtInt)) => (),
     _ => assert(false)
   }
+}
+
+test "projected checker keeps an aliased re-export out of local scope" {
+  let dep_path = "workspace/dep.vibe"
+  let dep_env = checked_test_env("export let renamed = \"ok\"")
+  let message = handle {
+    let _ = projected_checked_env("export ./dep.vibe { renamed as forwarded }\nlet local_use = forwarded", "workspace/main.vibe", [
+      dep_path
+    ], [(dep_path, dep_env)])
+    ""
+  } with { Exception::Throw(msg) => msg }
+  inspect(String::contains(message, "unknown name: forwarded"), "true")
+}
+
+test "projected checker does not let builtin assert_eq claim a re-export alias" {
+  let dep_path = "workspace/dep.vibe"
+  let dep_env = checked_test_env("export fn cmp(a: Int, b: Int) -> Int { a + b }")
+  let message = handle {
+    let _ = projected_checked_env("export ./dep.vibe { cmp as assert_eq }\nlet local_use = assert_eq(1, 2)", "workspace/main.vibe", [
+      dep_path
+    ], [(dep_path, dep_env)])
+    ""
+  } with { Exception::Throw(msg) => msg }
+  inspect(String::contains(message, "unknown name: assert_eq"), "true")
 }
 
 test "projected checker root keeps path and source-order winners with cached payloads" {
@@ -1094,7 +1118,7 @@ test "exact dep projection resolves the selected package and directory candidate
   }
 }
 
-test "exact dep projection preserves duplicate order and cache first-match semantics" {
+test "exact dep projection preserves duplicate order without binding re-export aliases locally" {
   let dep_path = "workspace/dep.vibe"
   let int_env = checked_test_env("export let value = 1")
   let string_env = checked_test_env("export let value = \"first\"")
@@ -1104,18 +1128,20 @@ test "exact dep projection preserves duplicate order and cache first-match seman
     (dep_path, int_env),
     (dep_path, string_env)
   ])
-  match (env_lookup(first_int, "imported"), env_lookup(first_int, "reexported")) {
-    (Some(CtInt), Some(CtInt)) => (),
+  match env_lookup(first_int, "imported") {
+    Some(CtInt) => (),
     _ => assert(false)
   }
+  inspect(env_lookup(first_int, "reexported") == None, "true")
   let first_string = projected_import_env_for_test(source, "workspace/main.vibe", deps, [
     (dep_path, string_env),
     (dep_path, int_env)
   ])
-  match (env_lookup(first_string, "imported"), env_lookup(first_string, "reexported")) {
-    (Some(CtString), Some(CtString)) => (),
+  match env_lookup(first_string, "imported") {
+    Some(CtString) => (),
     _ => assert(false)
   }
+  inspect(env_lookup(first_string, "reexported") == None, "true")
 }
 
 test "exact dep projection fails closed when a resolved row is missing" {
@@ -1679,6 +1705,28 @@ test "db_typecheck_fs: a re-exported name IS on the middleman's surface (#1533 c
   ]))
   let err = export_surface_error([dep_path, mid_path, main_path], main_path)
   assert(err == "")
+}
+
+test "db_typecheck_fs: an aliased re-export stays importable by a consumer (#2287)" {
+  let dir = "/tmp/vibe_compiler_export_surface_reexport_alias"
+  let dep_path = String::concat(dir, "/dep.vibe")
+  let mid_path = String::concat(dir, "/mid.vibe")
+  let main_path = String::concat(dir, "/main.vibe")
+  let dep_src = "export fn public_fn(x: Int) -> Int {\n  x + 1\n}\n"
+  let mid_src = "export ./dep.vibe { public_fn as forwarded }\n"
+  let main_src = "import ./mid.vibe { forwarded }\nexport let m = forwarded(1)\n"
+  Fs::mkdir_p(dir)
+  Fs::write_bytes(dep_path, string_to_bytes(dep_src))
+  Fs::write_bytes(mid_path, string_to_bytes(mid_src))
+  Fs::write_bytes(main_path, string_to_bytes(main_src))
+  let dep_fp = build_test_fingerprint(dep_src, array_empty())
+  let mid_fp = build_test_fingerprint(mid_src, [(dep_path, dep_fp)])
+  remove_typecheck_fs_cache(dep_path, dep_src, dep_fp)
+  remove_typecheck_fs_cache(mid_path, mid_src, mid_fp)
+  remove_typecheck_fs_cache(main_path, main_src, build_test_fingerprint(main_src, [
+    (mid_path, mid_fp)
+  ]))
+  inspect(export_surface_error([dep_path, mid_path, main_path], main_path), "")
 }
 
 test "db_typecheck_fs: private struct enum and alias declarations are not importable" {

--- a/lib/@vibe/compiler/tests/types_test.vibe
+++ b/lib/@vibe/compiler/tests/types_test.vibe
@@ -307,6 +307,40 @@ test "provenance survives repeated env_cache" {
   }
 }
 
+test "re-export surface bindings stay out of local lookup and caches" {
+  let local = env_bind(EnvEmpty, "forwarded", CtInt)
+  let surface = env_bind_with_origin(local, "forwarded", CtString, BindingOriginReExportSurface("/dep.vibe", "source_value"))
+  match env_lookup(surface, "forwarded") {
+    Some(ty) => inspect(type_to_string(ty), "Int"),
+    None => assert(false)
+  }
+  let cached = env_cache(surface)
+  match env_lookup(cached, "forwarded") {
+    Some(ty) => inspect(type_to_string(ty), "Int"),
+    None => assert(false)
+  }
+  let surface_only = env_bind_with_origin(EnvEmpty, "forwarded", CtString, BindingOriginReExportSurface("/dep.vibe", "source_value"))
+  inspect(match env_lookup(surface_only, "forwarded") {
+    None => "absent",
+    Some(_) => "visible"
+  }, "absent")
+  inspect(match env_lookup(env_cache(surface_only), "forwarded") {
+    None => "absent",
+    Some(_) => "visible"
+  }, "absent")
+  let flat_surface = EnvFlat([
+    ("forwarded", EnvValueBinding::{
+      ty: CtString,
+      origin: BindingOriginReExportSurface("/dep.vibe", "source_value")
+    }),
+    ("local", env_value_binding(CtInt))
+  ])
+  match env_cache(flat_surface) {
+    EnvCached(names, _, _) => inspect(Array::length(names), "1"),
+    _ => assert(false)
+  }
+}
+
 test "cache-only indexes remain fail-closed for mutable facts" {
   let cache_only = EnvCached(["x"], [env_value_binding(CtInt)], EnvEmpty)
   inspect(mut_escape_text(cache_only, "x"), "none")

--- a/lib/@vibe/compiler/tests/types_test.vibe
+++ b/lib/@vibe/compiler/tests/types_test.vibe
@@ -341,6 +341,23 @@ test "re-export surface bindings stay out of local lookup and caches" {
   }
 }
 
+test "FS re-export blockers hide earlier sources but allow a newer local binding" {
+  let earlier = env_bind(EnvEmpty, "forwarded", CtInt)
+  let blocked = env_bind_with_origin(earlier, "forwarded", CtUnknown, BindingOriginReExportSurface("", "forwarded"))
+  inspect(match env_lookup(blocked, "forwarded") {
+    None => "blocked",
+    Some(_) => "visible"
+  }, "blocked")
+  inspect(match env_lookup(env_cache(blocked), "forwarded") {
+    None => "blocked",
+    Some(_) => "visible"
+  }, "blocked")
+  match env_lookup(env_bind(blocked, "forwarded", CtBool), "forwarded") {
+    Some(ty) => inspect(type_to_string(ty), "Bool"),
+    None => assert(false)
+  }
+}
+
 test "cache-only indexes remain fail-closed for mutable facts" {
   let cache_only = EnvCached(["x"], [env_value_binding(CtInt)], EnvEmpty)
   inspect(mut_escape_text(cache_only, "x"), "none")

--- a/lib/@vibe/compiler/tests/types_test.vibe
+++ b/lib/@vibe/compiler/tests/types_test.vibe
@@ -307,18 +307,18 @@ test "provenance survives repeated env_cache" {
   }
 }
 
-test "re-export surface bindings stay out of local lookup and caches" {
+test "re-export surface bindings block older locals and survive caches" {
   let local = env_bind(EnvEmpty, "forwarded", CtInt)
   let surface = env_bind_with_origin(local, "forwarded", CtString, BindingOriginReExportSurface("/dep.vibe", "source_value"))
-  match env_lookup(surface, "forwarded") {
-    Some(ty) => inspect(type_to_string(ty), "Int"),
-    None => assert(false)
-  }
+  inspect(match env_lookup(surface, "forwarded") {
+    None => "blocked",
+    Some(_) => "visible"
+  }, "blocked")
   let cached = env_cache(surface)
-  match env_lookup(cached, "forwarded") {
-    Some(ty) => inspect(type_to_string(ty), "Int"),
-    None => assert(false)
-  }
+  inspect(match env_lookup(cached, "forwarded") {
+    None => "blocked",
+    Some(_) => "visible"
+  }, "blocked")
   let surface_only = env_bind_with_origin(EnvEmpty, "forwarded", CtString, BindingOriginReExportSurface("/dep.vibe", "source_value"))
   inspect(match env_lookup(surface_only, "forwarded") {
     None => "absent",
@@ -328,6 +328,11 @@ test "re-export surface bindings stay out of local lookup and caches" {
     None => "absent",
     Some(_) => "visible"
   }, "absent")
+  let newer_local = env_bind(surface_only, "forwarded", CtInt)
+  match env_lookup(env_cache(newer_local), "forwarded") {
+    Some(ty) => inspect(type_to_string(ty), "Int"),
+    None => assert(false)
+  }
   let flat_surface = EnvFlat([
     ("forwarded", EnvValueBinding::{
       ty: CtString,
@@ -336,7 +341,7 @@ test "re-export surface bindings stay out of local lookup and caches" {
     ("local", env_value_binding(CtInt))
   ])
   match env_cache(flat_surface) {
-    EnvCached(names, _, _) => inspect(Array::length(names), "1"),
+    EnvCached(names, _, _) => inspect(Array::length(names), "2"),
     _ => assert(false)
   }
 }

--- a/lib/@vibe/parser/ast_detach.vibe
+++ b/lib/@vibe/parser/ast_detach.vibe
@@ -170,6 +170,7 @@ fn detach_stmt(stmt: Stmt) -> Stmt {
     SExport(names) => SExport(detach_strings(names)),
     SReExport(path, items) => SReExport(path, detach_import_items(items)),
     SAliasDecl(_, _) => stmt,
+    SReExportAliasBlockers(items) => SReExportAliasBlockers(Array::slice(items, 0, Array::length(items))),
     SQualifiedPatternRefs(items) => SQualifiedPatternRefs(Array::slice(items, 0, Array::length(items))),
     STestEffectRows(items) => STestEffectRows(Array::slice(items, 0, Array::length(items))),
     SLetPat(pat, value) => SLetPat(detach_pat(pat), detach_expr(value)),

--- a/lib/@vibe/parser/ast_detach.vibe
+++ b/lib/@vibe/parser/ast_detach.vibe
@@ -170,7 +170,7 @@ fn detach_stmt(stmt: Stmt) -> Stmt {
     SExport(names) => SExport(detach_strings(names)),
     SReExport(path, items) => SReExport(path, detach_import_items(items)),
     SAliasDecl(_, _) => stmt,
-    SReExportAliasBlockers(items) => SReExportAliasBlockers(Array::slice(items, 0, Array::length(items))),
+    SReExportLocalBlockers(items) => SReExportLocalBlockers(Array::slice(items, 0, Array::length(items))),
     SQualifiedPatternRefs(items) => SQualifiedPatternRefs(Array::slice(items, 0, Array::length(items))),
     STestEffectRows(items) => STestEffectRows(Array::slice(items, 0, Array::length(items))),
     SLetPat(pat, value) => SLetPat(detach_pat(pat), detach_expr(value)),

--- a/lib/@vibe/parser/ast_detach.vibe
+++ b/lib/@vibe/parser/ast_detach.vibe
@@ -170,7 +170,7 @@ fn detach_stmt(stmt: Stmt) -> Stmt {
     SExport(names) => SExport(detach_strings(names)),
     SReExport(path, items) => SReExport(path, detach_import_items(items)),
     SAliasDecl(_, _) => stmt,
-    SReExportLocalBlockers(items) => SReExportLocalBlockers(Array::slice(items, 0, Array::length(items))),
+    SReExportSourceBoundary(locals, blockers) => SReExportSourceBoundary(Array::slice(locals, 0, Array::length(locals)), Array::slice(blockers, 0, Array::length(blockers))),
     SQualifiedPatternRefs(items) => SQualifiedPatternRefs(Array::slice(items, 0, Array::length(items))),
     STestEffectRows(items) => STestEffectRows(Array::slice(items, 0, Array::length(items))),
     SLetPat(pat, value) => SLetPat(detach_pat(pat), detach_expr(value)),

--- a/lib/@vibe/parser/lexer.vibe
+++ b/lib/@vibe/parser/lexer.vibe
@@ -659,6 +659,25 @@ fn skip_until_newline(s: String, len: Int, i: Int) -> Int {
   }
 }
 
+/// The FS merged-source printer needs metadata that old bootstrap lexers can
+/// ignore while the current parser can restore. This exact comment pragma is
+/// therefore promoted to the same token stream as `#reexport_source_boundary`;
+/// other `//` comment remains trivia. Requiring the whole line makes the
+/// transport spelling reserved without changing ordinary export syntax.
+#zero_alloc
+fn is_reexport_source_boundary_pragma(s: String, len: Int, pos: Int) -> Bool {
+  let marker = "//#reexport_source_boundary"
+  let marker_len = String::length(marker)
+  let marker_end = pos + marker_len
+  let mut i = 0
+  let mut matches = marker_end <= len
+  while matches && i < marker_len {
+    matches = String::char_code_at(s, pos + i) == String::char_code_at(marker, i)
+    i = i + 1
+  }
+  matches && (marker_end == len || String::char_code_at(s, marker_end) == '\n' || String::char_code_at(s, marker_end) == '\r')
+}
+
 /// Pack `(next_offset, saw_newline)` into one tagged Int. This is on every
 /// token boundary; returning a tuple allocated once per token even though the
 /// offset is bounded by wasm linear memory and has a spare low bit.
@@ -677,13 +696,17 @@ fn skip_ws_with_newline(s: String, len: Int, i: Int) -> Int {
       }
       out = out + 1
     } else if c == '/' && out + 1 < len && String::char_code_at(s, out + 1) == '/' {
-      let next = skip_until_newline(s, len, out + 2)
-      if next > out + 2 && String::char_code_at(s, next - 1) == '\n' {
-        saw_newline = true
+      if is_reexport_source_boundary_pragma(s, len, out) {
+        skipping = false
       } else {
-        ()
+        let next = skip_until_newline(s, len, out + 2)
+        if next > out + 2 && String::char_code_at(s, next - 1) == '\n' {
+          saw_newline = true
+        } else {
+          ()
+        }
+        out = next
       }
-      out = next
     } else {
       skipping = false
     }
@@ -1020,7 +1043,12 @@ fn lex_one_token(source: String, len: Int, pos: Int) -> (Token, Int) with Except
       (TStarEq, pos + 2)
     } else (TStar, pos + 1)
   } else if c == '/' {
-    if pos + 1 < len && String::char_code_at(source, pos + 1) == '=' {
+    if is_reexport_source_boundary_pragma(source, len, pos) {
+      // Skip the two comment slashes and expose the embedded `#` token. The
+      // following call begins at `reexport_source_boundary`, so directive parsing
+      // consumes the remainder of the reserved pragma.
+      (THash, pos + 3)
+    } else if pos + 1 < len && String::char_code_at(source, pos + 1) == '=' {
       (TSlashEq, pos + 2)
     } else (TSlash, pos + 1)
   } else if c == '%' {

--- a/lib/@vibe/parser/lexer.vibe
+++ b/lib/@vibe/parser/lexer.vibe
@@ -659,25 +659,6 @@ fn skip_until_newline(s: String, len: Int, i: Int) -> Int {
   }
 }
 
-/// The FS merged-source printer needs metadata that old bootstrap lexers can
-/// ignore while the current parser can restore. This exact comment pragma is
-/// therefore promoted to the same token stream as `#reexport_source_boundary`;
-/// other `//` comment remains trivia. Requiring the whole line makes the
-/// transport spelling reserved without changing ordinary export syntax.
-#zero_alloc
-fn is_reexport_source_boundary_pragma(s: String, len: Int, pos: Int) -> Bool {
-  let marker = "//#reexport_source_boundary"
-  let marker_len = String::length(marker)
-  let marker_end = pos + marker_len
-  let mut i = 0
-  let mut matches = marker_end <= len
-  while matches && i < marker_len {
-    matches = String::char_code_at(s, pos + i) == String::char_code_at(marker, i)
-    i = i + 1
-  }
-  matches && (marker_end == len || String::char_code_at(s, marker_end) == '\n' || String::char_code_at(s, marker_end) == '\r')
-}
-
 /// Pack `(next_offset, saw_newline)` into one tagged Int. This is on every
 /// token boundary; returning a tuple allocated once per token even though the
 /// offset is bounded by wasm linear memory and has a spare low bit.
@@ -696,17 +677,13 @@ fn skip_ws_with_newline(s: String, len: Int, i: Int) -> Int {
       }
       out = out + 1
     } else if c == '/' && out + 1 < len && String::char_code_at(s, out + 1) == '/' {
-      if is_reexport_source_boundary_pragma(s, len, out) {
-        skipping = false
+      let next = skip_until_newline(s, len, out + 2)
+      if next > out + 2 && String::char_code_at(s, next - 1) == '\n' {
+        saw_newline = true
       } else {
-        let next = skip_until_newline(s, len, out + 2)
-        if next > out + 2 && String::char_code_at(s, next - 1) == '\n' {
-          saw_newline = true
-        } else {
-          ()
-        }
-        out = next
+        ()
       }
+      out = next
     } else {
       skipping = false
     }
@@ -1043,12 +1020,7 @@ fn lex_one_token(source: String, len: Int, pos: Int) -> (Token, Int) with Except
       (TStarEq, pos + 2)
     } else (TStar, pos + 1)
   } else if c == '/' {
-    if is_reexport_source_boundary_pragma(source, len, pos) {
-      // Skip the two comment slashes and expose the embedded `#` token. The
-      // following call begins at `reexport_source_boundary`, so directive parsing
-      // consumes the remainder of the reserved pragma.
-      (THash, pos + 3)
-    } else if pos + 1 < len && String::char_code_at(source, pos + 1) == '=' {
+    if pos + 1 < len && String::char_code_at(source, pos + 1) == '=' {
       (TSlashEq, pos + 2)
     } else (TSlash, pos + 1)
   } else if c == '%' {

--- a/lib/@vibe/parser/parser.vibe
+++ b/lib/@vibe/parser/parser.vibe
@@ -728,9 +728,8 @@ fn parse_impl_methods(tokens: Array[Token], pos: Int, simpl: Stmt, context: Opti
 // compiler understands it (docs/selfhost-bootstrap.md bump procedure).
 
 /// Parse the directive after a THash: `cfg(name)`, `cfg_enable(name)`,
-/// `zero_alloc`, or `deprecated` (#1262 ADR-0101 migration marker; optional `("message")`
-/// argument). Returns (directive_kind, flag_name, next_pos) — for
-/// `deprecated` the middle slot carries the optional message (empty if none).
+/// `zero_alloc`, or `deprecated` (#1262 ADR-0101 migration marker; optional
+/// `("message")` argument). Returns (directive_kind, payload, next_pos).
 fn parse_cfg_directive(tokens: Array[Token], pos: Int) -> (String, String, Int) with Exception {
   match peek(tokens, pos) {
     TIdent(dname) => {
@@ -852,6 +851,22 @@ fn zero_alloc_marker_ident(mode: String) -> String {
   }
 }
 
+fn lower_reexport_boundary_markers(stmts: Array[Stmt]) -> Array[Stmt] {
+  let mut i = 0
+  while i < Array::length(stmts) {
+    match Array::get(stmts, i) {
+      SExport(names) => if Array::length(names) > 0 && Array::get(names, 0) == "__vibe_reexport_boundary__" {
+        Array::set(stmts, i, SReExportLocalBlockers(Array::slice(names, 1, Array::length(names))))
+      } else {
+        ()
+      },
+      _ => ()
+    }
+    i = i + 1
+  }
+  stmts
+}
+
 /// Program parser that KEEPS `fn` declarations as SFnDecl (see
 /// parse_stmt_preserving) — used by the printer/normalize round-trip so
 /// `vibe normalize` re-emits `fn name(..) -> T where { .. } { .. }` instead
@@ -910,7 +925,7 @@ export fn parse_program_preserving(tokens: Array[Token]) -> Array[Stmt] with Exc
       }
     }
   }
-  ArrayBuilder::freeze(b)
+  lower_reexport_boundary_markers(ArrayBuilder::freeze(b))
 }
 
 /// #1455 step 3: fold the qualified-variant-pattern log this parse produced
@@ -1110,7 +1125,7 @@ fn parse_program_located_with_context_impl(tokens: Array[Token], starts: Array[I
       }
     }
   }
-  (attach_qualified_pattern_refs(expand_top_level_pattern_lets_with_binder_context(ArrayBuilder::freeze(b), context)), pos)
+  (attach_qualified_pattern_refs(lower_reexport_boundary_markers(expand_top_level_pattern_lets_with_binder_context(ArrayBuilder::freeze(b), context))), pos)
 }
 
 /// True when `t` is a resynchronization point for `parse_program_recovering`:
@@ -1307,7 +1322,7 @@ export fn parse_program_recovering(tokens: Array[Token], starts: Array[Int], sou
       }
     }
   }
-  (attach_qualified_pattern_refs(expand_top_level_pattern_lets(ArrayBuilder::freeze(b))), ArrayBuilder::freeze(diags))
+  (attach_qualified_pattern_refs(lower_reexport_boundary_markers(expand_top_level_pattern_lets(ArrayBuilder::freeze(b)))), ArrayBuilder::freeze(diags))
 }
 
 /// Like `parse_program`, but also returns per top-level statement its source
@@ -1380,7 +1395,7 @@ export fn parse_program_spans(tokens: Array[Token], starts: Array[Int], ends: Ar
   } else {
     ()
   }
-  (ArrayBuilder::freeze(b), ArrayBuilder::freeze(span_start), ArrayBuilder::freeze(span_end))
+  (lower_reexport_boundary_markers(ArrayBuilder::freeze(b)), ArrayBuilder::freeze(span_start), ArrayBuilder::freeze(span_end))
 }
 
 //# Misc

--- a/lib/@vibe/parser/parser.vibe
+++ b/lib/@vibe/parser/parser.vibe
@@ -728,9 +728,8 @@ fn parse_impl_methods(tokens: Array[Token], pos: Int, simpl: Stmt, context: Opti
 // compiler understands it (docs/selfhost-bootstrap.md bump procedure).
 
 /// Parse the directive after a THash: `cfg(name)`, `cfg_enable(name)`,
-/// `zero_alloc`, `deprecated` (#1262 ADR-0101 migration marker; optional
-/// `("message")` argument), or the private `reexport_source_boundary`
-/// merged-source transport. Returns (directive_kind, payload, next_pos).
+/// `zero_alloc`, or `deprecated` (#1262 ADR-0101 migration marker; optional
+/// `("message")` argument). Returns (directive_kind, payload, next_pos).
 fn parse_cfg_directive(tokens: Array[Token], pos: Int) -> (String, String, Int) with Exception {
   match peek(tokens, pos) {
     TIdent(dname) => {
@@ -760,8 +759,6 @@ fn parse_cfg_directive(tokens: Array[Token], pos: Int) -> (String, String, Int) 
           },
           _ => (dname, "", pos + 1)
         }
-      } else if dname == "reexport_source_boundary" {
-        (dname, "", pos + 1)
       } else if dname == "deprecated" {
         match peek(tokens, pos + 1) {
           TLParen => match peek(tokens, pos + 2) {
@@ -854,23 +851,6 @@ fn zero_alloc_marker_ident(mode: String) -> String {
   }
 }
 
-fn is_reexport_source_boundary_directive(name: String, payload: String) -> Bool {
-  name == "reexport_source_boundary" && payload == ""
-}
-
-/// Decode the private, seed-compatible transport printed for an FS-merged
-/// source boundary. The reserved comment pragma prevents an ordinary export
-/// list from being reinterpreted as compiler metadata. An old seed ignores the
-/// pragma and safely retains the two inert export lists.
-fn parse_reexport_source_boundary(tokens: Array[Token], starts: Array[Int], pos: Int, context: Option[ParserBinderContext]) -> (Stmt, Int) with Exception {
-  let (local_stmt, after_local) = parse_stmt_preserving_with_binder_context(tokens, starts, pos, context)
-  let (surface_stmt, after_surface) = parse_stmt_preserving_with_binder_context(tokens, starts, after_local, context)
-  match (local_stmt, surface_stmt) {
-    (SExport(local_names), SExport(surface_only_names)) => (SReExportSourceBoundary(local_names, surface_only_names), after_surface),
-    _ => throw("malformed internal re-export source boundary")
-  }
-}
-
 /// Program parser that KEEPS `fn` declarations as SFnDecl (see
 /// parse_stmt_preserving) — used by the printer/normalize round-trip so
 /// `vibe normalize` re-emits `fn name(..) -> T where { .. } { .. }` instead
@@ -890,11 +870,7 @@ export fn parse_program_preserving(tokens: Array[Token]) -> Array[Stmt] with Exc
       },
       THash => {
         let (dname, flag, dnext) = parse_cfg_directive(tokens, pos + 1)
-        if is_reexport_source_boundary_directive(dname, flag) {
-          let (boundary, next) = parse_reexport_source_boundary(tokens, [], dnext, None)
-          ArrayBuilder::push(b, boundary)
-          pos = next
-        } else if dname == "zero_alloc" {
+        if dname == "zero_alloc" {
           require_zero_alloc_target(tokens, dnext)
           ArrayBuilder::push(b, SExpr(EIdent(zero_alloc_marker_ident(flag), 0)))
           pos = dnext
@@ -1078,11 +1054,7 @@ fn parse_program_located_with_context_impl(tokens: Array[Token], starts: Array[I
       },
       THash => {
         let (dname, flag, dnext) = parse_cfg_directive(tokens, pos + 1)
-        if is_reexport_source_boundary_directive(dname, flag) {
-          let (boundary, next) = parse_reexport_source_boundary(tokens, starts, dnext, context)
-          ArrayBuilder::push(b, boundary)
-          pos = next
-        } else if dname == "zero_alloc" {
+        if dname == "zero_alloc" {
           require_zero_alloc_target(tokens, dnext)
           let marker_offset = if pos < Array::length(starts) {
             Array::get(starts, pos)
@@ -1219,11 +1191,7 @@ export fn parse_program_recovering(tokens: Array[Token], starts: Array[Int], sou
         // recovery machinery below by treating it like a failed statement.
         let cfg_res = handle {
           let (dname, flag, dnext) = parse_cfg_directive(tokens, pos + 1)
-          if is_reexport_source_boundary_directive(dname, flag) {
-            let (boundary, next) = parse_reexport_source_boundary(tokens, starts, dnext, None)
-            ArrayBuilder::push(b, boundary)
-            next
-          } else if dname == "zero_alloc" {
+          if dname == "zero_alloc" {
             require_zero_alloc_target(tokens, dnext)
             let marker_offset = if pos < Array::length(starts) {
               Array::get(starts, pos)
@@ -1363,15 +1331,8 @@ export fn parse_program_spans(tokens: Array[Token], starts: Array[Int], ends: Ar
         // `#zero_alloc` is part of the following declaration's source span.
         // Module-source emission therefore preserves the directive without
         // adding a synthetic statement that would desynchronise span arrays.
-        let (dname, payload, dnext) = parse_cfg_directive(tokens, pos + 1)
-        if is_reexport_source_boundary_directive(dname, payload) {
-          let st = Array::get(starts, pos)
-          let (boundary, next) = parse_reexport_source_boundary(tokens, starts, dnext, None)
-          ArrayBuilder::push(b, boundary)
-          ArrayBuilder::push(span_start, st)
-          ArrayBuilder::push(span_end, Array::get(ends, next - 1))
-          pos = next
-        } else if dname == "zero_alloc" {
+        let (dname, _, dnext) = parse_cfg_directive(tokens, pos + 1)
+        if dname == "zero_alloc" {
           require_zero_alloc_target(tokens, dnext)
           let st = Array::get(starts, pos)
           let (stmt, next) = parse_stmt(tokens, starts, dnext)

--- a/lib/@vibe/parser/parser.vibe
+++ b/lib/@vibe/parser/parser.vibe
@@ -728,8 +728,9 @@ fn parse_impl_methods(tokens: Array[Token], pos: Int, simpl: Stmt, context: Opti
 // compiler understands it (docs/selfhost-bootstrap.md bump procedure).
 
 /// Parse the directive after a THash: `cfg(name)`, `cfg_enable(name)`,
-/// `zero_alloc`, or `deprecated` (#1262 ADR-0101 migration marker; optional
-/// `("message")` argument). Returns (directive_kind, payload, next_pos).
+/// `zero_alloc`, `deprecated` (#1262 ADR-0101 migration marker; optional
+/// `("message")` argument), or the private `reexport_source_boundary`
+/// merged-source transport. Returns (directive_kind, payload, next_pos).
 fn parse_cfg_directive(tokens: Array[Token], pos: Int) -> (String, String, Int) with Exception {
   match peek(tokens, pos) {
     TIdent(dname) => {
@@ -759,6 +760,8 @@ fn parse_cfg_directive(tokens: Array[Token], pos: Int) -> (String, String, Int) 
           },
           _ => (dname, "", pos + 1)
         }
+      } else if dname == "reexport_source_boundary" {
+        (dname, "", pos + 1)
       } else if dname == "deprecated" {
         match peek(tokens, pos + 1) {
           TLParen => match peek(tokens, pos + 2) {
@@ -851,20 +854,21 @@ fn zero_alloc_marker_ident(mode: String) -> String {
   }
 }
 
-fn lower_reexport_boundary_markers(stmts: Array[Stmt]) -> Array[Stmt] {
-  let mut i = 0
-  while i < Array::length(stmts) {
-    match Array::get(stmts, i) {
-      SExport(names) => if Array::length(names) > 0 && Array::get(names, 0) == "__vibe_reexport_boundary__" {
-        Array::set(stmts, i, SReExportLocalBlockers(Array::slice(names, 1, Array::length(names))))
-      } else {
-        ()
-      },
-      _ => ()
-    }
-    i = i + 1
+fn is_reexport_source_boundary_directive(name: String, payload: String) -> Bool {
+  name == "reexport_source_boundary" && payload == ""
+}
+
+/// Decode the private, seed-compatible transport printed for an FS-merged
+/// source boundary. The reserved comment pragma prevents an ordinary export
+/// list from being reinterpreted as compiler metadata. An old seed ignores the
+/// pragma and safely retains the two inert export lists.
+fn parse_reexport_source_boundary(tokens: Array[Token], starts: Array[Int], pos: Int, context: Option[ParserBinderContext]) -> (Stmt, Int) with Exception {
+  let (local_stmt, after_local) = parse_stmt_preserving_with_binder_context(tokens, starts, pos, context)
+  let (surface_stmt, after_surface) = parse_stmt_preserving_with_binder_context(tokens, starts, after_local, context)
+  match (local_stmt, surface_stmt) {
+    (SExport(local_names), SExport(surface_only_names)) => (SReExportSourceBoundary(local_names, surface_only_names), after_surface),
+    _ => throw("malformed internal re-export source boundary")
   }
-  stmts
 }
 
 /// Program parser that KEEPS `fn` declarations as SFnDecl (see
@@ -886,7 +890,11 @@ export fn parse_program_preserving(tokens: Array[Token]) -> Array[Stmt] with Exc
       },
       THash => {
         let (dname, flag, dnext) = parse_cfg_directive(tokens, pos + 1)
-        if dname == "zero_alloc" {
+        if is_reexport_source_boundary_directive(dname, flag) {
+          let (boundary, next) = parse_reexport_source_boundary(tokens, [], dnext, None)
+          ArrayBuilder::push(b, boundary)
+          pos = next
+        } else if dname == "zero_alloc" {
           require_zero_alloc_target(tokens, dnext)
           ArrayBuilder::push(b, SExpr(EIdent(zero_alloc_marker_ident(flag), 0)))
           pos = dnext
@@ -925,7 +933,7 @@ export fn parse_program_preserving(tokens: Array[Token]) -> Array[Stmt] with Exc
       }
     }
   }
-  lower_reexport_boundary_markers(ArrayBuilder::freeze(b))
+  ArrayBuilder::freeze(b)
 }
 
 /// #1455 step 3: fold the qualified-variant-pattern log this parse produced
@@ -1070,7 +1078,11 @@ fn parse_program_located_with_context_impl(tokens: Array[Token], starts: Array[I
       },
       THash => {
         let (dname, flag, dnext) = parse_cfg_directive(tokens, pos + 1)
-        if dname == "zero_alloc" {
+        if is_reexport_source_boundary_directive(dname, flag) {
+          let (boundary, next) = parse_reexport_source_boundary(tokens, starts, dnext, context)
+          ArrayBuilder::push(b, boundary)
+          pos = next
+        } else if dname == "zero_alloc" {
           require_zero_alloc_target(tokens, dnext)
           let marker_offset = if pos < Array::length(starts) {
             Array::get(starts, pos)
@@ -1125,7 +1137,7 @@ fn parse_program_located_with_context_impl(tokens: Array[Token], starts: Array[I
       }
     }
   }
-  (attach_qualified_pattern_refs(lower_reexport_boundary_markers(expand_top_level_pattern_lets_with_binder_context(ArrayBuilder::freeze(b), context))), pos)
+  (attach_qualified_pattern_refs(expand_top_level_pattern_lets_with_binder_context(ArrayBuilder::freeze(b), context)), pos)
 }
 
 /// True when `t` is a resynchronization point for `parse_program_recovering`:
@@ -1207,7 +1219,11 @@ export fn parse_program_recovering(tokens: Array[Token], starts: Array[Int], sou
         // recovery machinery below by treating it like a failed statement.
         let cfg_res = handle {
           let (dname, flag, dnext) = parse_cfg_directive(tokens, pos + 1)
-          if dname == "zero_alloc" {
+          if is_reexport_source_boundary_directive(dname, flag) {
+            let (boundary, next) = parse_reexport_source_boundary(tokens, starts, dnext, None)
+            ArrayBuilder::push(b, boundary)
+            next
+          } else if dname == "zero_alloc" {
             require_zero_alloc_target(tokens, dnext)
             let marker_offset = if pos < Array::length(starts) {
               Array::get(starts, pos)
@@ -1322,7 +1338,7 @@ export fn parse_program_recovering(tokens: Array[Token], starts: Array[Int], sou
       }
     }
   }
-  (attach_qualified_pattern_refs(lower_reexport_boundary_markers(expand_top_level_pattern_lets(ArrayBuilder::freeze(b)))), ArrayBuilder::freeze(diags))
+  (attach_qualified_pattern_refs(expand_top_level_pattern_lets(ArrayBuilder::freeze(b))), ArrayBuilder::freeze(diags))
 }
 
 /// Like `parse_program`, but also returns per top-level statement its source
@@ -1347,8 +1363,15 @@ export fn parse_program_spans(tokens: Array[Token], starts: Array[Int], ends: Ar
         // `#zero_alloc` is part of the following declaration's source span.
         // Module-source emission therefore preserves the directive without
         // adding a synthetic statement that would desynchronise span arrays.
-        let (dname, _, dnext) = parse_cfg_directive(tokens, pos + 1)
-        if dname == "zero_alloc" {
+        let (dname, payload, dnext) = parse_cfg_directive(tokens, pos + 1)
+        if is_reexport_source_boundary_directive(dname, payload) {
+          let st = Array::get(starts, pos)
+          let (boundary, next) = parse_reexport_source_boundary(tokens, starts, dnext, None)
+          ArrayBuilder::push(b, boundary)
+          ArrayBuilder::push(span_start, st)
+          ArrayBuilder::push(span_end, Array::get(ends, next - 1))
+          pos = next
+        } else if dname == "zero_alloc" {
           require_zero_alloc_target(tokens, dnext)
           let st = Array::get(starts, pos)
           let (stmt, next) = parse_stmt(tokens, starts, dnext)
@@ -1395,7 +1418,7 @@ export fn parse_program_spans(tokens: Array[Token], starts: Array[Int], ends: Ar
   } else {
     ()
   }
-  (lower_reexport_boundary_markers(ArrayBuilder::freeze(b)), ArrayBuilder::freeze(span_start), ArrayBuilder::freeze(span_end))
+  (ArrayBuilder::freeze(b), ArrayBuilder::freeze(span_start), ArrayBuilder::freeze(span_end))
 }
 
 //# Misc

--- a/lib/@vibe/parser/parser_smoke_test.vibe
+++ b/lib/@vibe/parser/parser_smoke_test.vibe
@@ -137,6 +137,24 @@ test "parse_program: legacy @zero_alloc remains accepted during migration" {
   assert(Array::length(stmts) == 2)
 }
 
+test "generated re-export boundaries survive print and reparse" {
+  let source = "export { __vibe_reexport_boundary__, assert_eq, inspect }"
+  let stmts = parse_program(lex(source))
+  match Array::get(stmts, 0) {
+    SReExportLocalBlockers(names) => {
+      inspect(Array::length(names), "2")
+      inspect(Array::get(names, 0), "assert_eq")
+      inspect(Array::get(names, 1), "inspect")
+    },
+    _ => assert(false)
+  }
+  inspect(print_program(stmts), source)
+  match Array::get(parse_program(lex("export { __vibe_reexport_boundary__ }")), 0) {
+    SReExportLocalBlockers(names) => inspect(Array::length(names), "0"),
+    _ => assert(false)
+  }
+}
+
 fn zero_alloc_marker_name(stmts: Array[Stmt]) -> String {
   match Array::get(stmts, 0) {
     SExpr(EIdent(name, _)) => name,

--- a/lib/@vibe/parser/parser_smoke_test.vibe
+++ b/lib/@vibe/parser/parser_smoke_test.vibe
@@ -151,29 +151,23 @@ test "an ordinary export named like the old boundary sentinel stays an export" {
   inspect(print_program(stmts), source)
 }
 
-test "generated re-export source boundaries survive print and reparse" {
+test "a boundary-looking comment remains trivia" {
   let source = "//#reexport_source_boundary\nexport { assert_eq, inspect }\nexport { inspect }"
   let stmts = parse_program(lex(source))
-  inspect(Array::length(stmts), "1")
+  inspect(Array::length(stmts), "2")
   match Array::get(stmts, 0) {
-    SReExportSourceBoundary(local_names, surface_only_names) => {
-      inspect(Array::length(local_names), "2")
-      inspect(Array::get(local_names, 0), "assert_eq")
-      inspect(Array::get(local_names, 1), "inspect")
-      inspect(Array::length(surface_only_names), "1")
-      inspect(Array::get(surface_only_names, 0), "inspect")
+    SExport(names) => {
+      inspect(Array::length(names), "2")
+      inspect(Array::get(names, 0), "assert_eq")
+      inspect(Array::get(names, 1), "inspect")
     },
     _ => assert(false)
   }
-  inspect(print_program(stmts), source)
-  let empty_source = "//#reexport_source_boundary\nexport {  }\nexport {  }"
-  match Array::get(parse_program(lex(empty_source)), 0) {
-    SReExportSourceBoundary(local_names, surface_only_names) => {
-      inspect(Array::length(local_names), "0")
-      inspect(Array::length(surface_only_names), "0")
-    },
+  match Array::get(stmts, 1) {
+    SExport(names) => inspect(Array::get(names, 0), "inspect"),
     _ => assert(false)
   }
+  inspect(print_program(stmts), "export { assert_eq, inspect }\nexport { inspect }")
 }
 
 fn zero_alloc_marker_name(stmts: Array[Stmt]) -> String {

--- a/lib/@vibe/parser/parser_smoke_test.vibe
+++ b/lib/@vibe/parser/parser_smoke_test.vibe
@@ -137,20 +137,41 @@ test "parse_program: legacy @zero_alloc remains accepted during migration" {
   assert(Array::length(stmts) == 2)
 }
 
-test "generated re-export boundaries survive print and reparse" {
-  let source = "export { __vibe_reexport_boundary__, assert_eq, inspect }"
+test "an ordinary export named like the old boundary sentinel stays an export" {
+  let source = "export { __vibe_reexport_boundary__, assert_eq }"
   let stmts = parse_program(lex(source))
   match Array::get(stmts, 0) {
-    SReExportLocalBlockers(names) => {
+    SExport(names) => {
       inspect(Array::length(names), "2")
-      inspect(Array::get(names, 0), "assert_eq")
-      inspect(Array::get(names, 1), "inspect")
+      inspect(Array::get(names, 0), "__vibe_reexport_boundary__")
+      inspect(Array::get(names, 1), "assert_eq")
     },
     _ => assert(false)
   }
   inspect(print_program(stmts), source)
-  match Array::get(parse_program(lex("export { __vibe_reexport_boundary__ }")), 0) {
-    SReExportLocalBlockers(names) => inspect(Array::length(names), "0"),
+}
+
+test "generated re-export source boundaries survive print and reparse" {
+  let source = "//#reexport_source_boundary\nexport { assert_eq, inspect }\nexport { inspect }"
+  let stmts = parse_program(lex(source))
+  inspect(Array::length(stmts), "1")
+  match Array::get(stmts, 0) {
+    SReExportSourceBoundary(local_names, surface_only_names) => {
+      inspect(Array::length(local_names), "2")
+      inspect(Array::get(local_names, 0), "assert_eq")
+      inspect(Array::get(local_names, 1), "inspect")
+      inspect(Array::length(surface_only_names), "1")
+      inspect(Array::get(surface_only_names, 0), "inspect")
+    },
+    _ => assert(false)
+  }
+  inspect(print_program(stmts), source)
+  let empty_source = "//#reexport_source_boundary\nexport {  }\nexport {  }"
+  match Array::get(parse_program(lex(empty_source)), 0) {
+    SReExportSourceBoundary(local_names, surface_only_names) => {
+      inspect(Array::length(local_names), "0")
+      inspect(Array::length(surface_only_names), "0")
+    },
     _ => assert(false)
   }
 }

--- a/lib/@vibe/parser/printer.vibe
+++ b/lib/@vibe/parser/printer.vibe
@@ -856,7 +856,20 @@ export fn print_stmt(s: Stmt) -> String {
       String::concat("export ", String::concat(path, String::concat(" { ", String::concat(join(parts, ", "), " }"))))
     },
     SAliasDecl(alias_name, source_path) => String::concat("import ", String::concat(source_path, String::concat(" @", alias_name))),
-    SReExportAliasBlockers(_) => "",
+    // FS flattening removes import syntax but must retain each source's
+    // publication-only re-export boundary across print -> reparse (#2287).
+    // This uses only the seed-era `export { ... }` grammar: the current parser
+    // recognizes the reserved first name and restores the marker, while an old
+    // bootstrap seed safely treats it as the same inert export-list statement.
+    SReExportLocalBlockers(names) => {
+      let payload = Array::slice(["__vibe_reexport_boundary__"], 0, 1)
+      let mut i = 0
+      while i < Array::length(names) {
+        Array::push(payload, Array::get(names, i))
+        i = i + 1
+      }
+      String::concat("export { ", String::concat(join(payload, ", "), " }"))
+    },
     // #1455 step 3: parser bookkeeping, not source. Printing it would put a
     // node with no surface syntax into `vibe normalize` output and break the
     // print -> reparse round trip.

--- a/lib/@vibe/parser/printer.vibe
+++ b/lib/@vibe/parser/printer.vibe
@@ -856,11 +856,8 @@ export fn print_stmt(s: Stmt) -> String {
       String::concat("export ", String::concat(path, String::concat(" { ", String::concat(join(parts, ", "), " }"))))
     },
     SAliasDecl(alias_name, source_path) => String::concat("import ", String::concat(source_path, String::concat(" @", alias_name))),
-    // The reserved comment pragma is an internal transport envelope, not an
-    // export-name sentinel. Old bootstrap seeds ignore the pragma and consume
-    // two inert export lists; the current lexer exposes a private directive and
-    // the parser restores the boundary. Thus an ordinary export cannot collide.
-    SReExportSourceBoundary(local_names, surface_only_names) => String::concat("//#reexport_source_boundary\nexport { ", String::concat(join(local_names, ", "), String::concat(" }\nexport { ", String::concat(join(surface_only_names, ", "), " }")))),
+    // Source-boundary metadata is consumed before merged-source serialization.
+    SReExportSourceBoundary(_, _) => "",
     // #1455 step 3: parser bookkeeping, not source. Printing it would put a
     // node with no surface syntax into `vibe normalize` output and break the
     // print -> reparse round trip.

--- a/lib/@vibe/parser/printer.vibe
+++ b/lib/@vibe/parser/printer.vibe
@@ -856,6 +856,7 @@ export fn print_stmt(s: Stmt) -> String {
       String::concat("export ", String::concat(path, String::concat(" { ", String::concat(join(parts, ", "), " }"))))
     },
     SAliasDecl(alias_name, source_path) => String::concat("import ", String::concat(source_path, String::concat(" @", alias_name))),
+    SReExportAliasBlockers(_) => "",
     // #1455 step 3: parser bookkeeping, not source. Printing it would put a
     // node with no surface syntax into `vibe normalize` output and break the
     // print -> reparse round trip.

--- a/lib/@vibe/parser/printer.vibe
+++ b/lib/@vibe/parser/printer.vibe
@@ -856,20 +856,11 @@ export fn print_stmt(s: Stmt) -> String {
       String::concat("export ", String::concat(path, String::concat(" { ", String::concat(join(parts, ", "), " }"))))
     },
     SAliasDecl(alias_name, source_path) => String::concat("import ", String::concat(source_path, String::concat(" @", alias_name))),
-    // FS flattening removes import syntax but must retain each source's
-    // publication-only re-export boundary across print -> reparse (#2287).
-    // This uses only the seed-era `export { ... }` grammar: the current parser
-    // recognizes the reserved first name and restores the marker, while an old
-    // bootstrap seed safely treats it as the same inert export-list statement.
-    SReExportLocalBlockers(names) => {
-      let payload = Array::slice(["__vibe_reexport_boundary__"], 0, 1)
-      let mut i = 0
-      while i < Array::length(names) {
-        Array::push(payload, Array::get(names, i))
-        i = i + 1
-      }
-      String::concat("export { ", String::concat(join(payload, ", "), " }"))
-    },
+    // The reserved comment pragma is an internal transport envelope, not an
+    // export-name sentinel. Old bootstrap seeds ignore the pragma and consume
+    // two inert export lists; the current lexer exposes a private directive and
+    // the parser restores the boundary. Thus an ordinary export cannot collide.
+    SReExportSourceBoundary(local_names, surface_only_names) => String::concat("//#reexport_source_boundary\nexport { ", String::concat(join(local_names, ", "), String::concat(" }\nexport { ", String::concat(join(surface_only_names, ", "), " }")))),
     // #1455 step 3: parser bookkeeping, not source. Printing it would put a
     // node with no surface syntax into `vibe normalize` output and break the
     // print -> reparse round trip.


### PR DESCRIPTION
## Summary

- represent aliased re-exports as publication-only bindings instead of local values
- preserve those bindings for downstream imports while excluding them from local lookup and cache indexes
- prevent builtins such as `assert_eq` from silently claiming an invalid local alias use
- preserve the existing local behavior of plain, non-aliased re-exports

## TDD

Red:
- local use of `export ./dep.vibe { cmp as compare }` reached codegen instead of reporting an unknown name
- an alias named `assert_eq` was silently claimed by builtin lowering
- flat surface-only bindings leaked into cache indexes

Green:
- invalid local uses report `unknown name: compare` and `unknown name: assert_eq`
- a consumer can import and compile the forwarded alias
- raw, flat, and cached environments keep the publication surface separate from local lookup

## Validation

- `pkf run test-affected` (full fallback: 1027/1027 files passed)
- focused checker/core/artifact tests (170 tests passed)
- fresh stage2 generation and direct checker/codegen probes
- `pkf run pre-commit`
- formatter and generated-artifact freshness checks

Closes #2287