### PR TITLE
Rewrite re-export aliases in the merged program (#2287)

### DIFF
--- a/fixtures/reexport_alias_assert_eq_test.vibe
+++ b/fixtures/reexport_alias_assert_eq_test.vibe
@@ -1,0 +1,8 @@
+// #2287: a re-export aliased to `assert_eq` must not be claimed by the builtin.
+export ./reexport_alias_dep.vibe {
+  cmp as assert_eq
+}
+
+test "re-exported alias is not the builtin assert_eq" {
+  assert_true(assert_eq(1, 2) == 3)
+}

--- a/fixtures/reexport_alias_dep.vibe
+++ b/fixtures/reexport_alias_dep.vibe
@@ -1,0 +1,3 @@
+export fn cmp(a: Int, b: Int) -> Int {
+  a + b
+}

--- a/fixtures/reexport_alias_facade.vibe
+++ b/fixtures/reexport_alias_facade.vibe
@@ -1,0 +1,11 @@
+// Non-entry facade that both re-exports `cmp as compare` and uses `compare`
+// in its own function (#2287 Codex review). The origin is mangled because
+// this file is not the entry; rewrite must follow the rename plan, not the
+// one-hop `compare -> cmp` map.
+export ./reexport_alias_dep.vibe {
+  cmp as compare
+}
+
+export fn helper() -> Int {
+  compare(1, 2)
+}

--- a/fixtures/reexport_alias_mid.vibe
+++ b/fixtures/reexport_alias_mid.vibe
@@ -1,0 +1,4 @@
+// Mid-file of a nested re-export chain (#2287 review).
+export ./reexport_alias_dep.vibe {
+  cmp as bar
+}

--- a/fixtures/reexport_alias_sub.vibe
+++ b/fixtures/reexport_alias_sub.vibe
@@ -1,0 +1,3 @@
+export fn sub(a: Int, b: Int) -> Int {
+  a - b
+}

--- a/fixtures/reexport_alias_test.vibe
+++ b/fixtures/reexport_alias_test.vibe
@@ -1,0 +1,8 @@
+// #2287: a re-export alias must reach the merged program under the public name.
+export ./reexport_alias_dep.vibe {
+  cmp as compare
+}
+
+test "re-exported alias" {
+  assert_true(compare(1, 2) == 3)
+}

--- a/fixtures/reexport_facade_use_test.vibe
+++ b/fixtures/reexport_facade_use_test.vibe
@@ -1,0 +1,8 @@
+// #2287 Codex review: a non-entry facade that re-exports and uses the alias.
+import ./reexport_alias_facade.vibe {
+  helper
+}
+
+test "non-entry facade uses its own re-export alias" {
+  assert_true(helper() == 3)
+}

--- a/fixtures/reexport_import_collision_test.vibe
+++ b/fixtures/reexport_import_collision_test.vibe
@@ -1,0 +1,13 @@
+// #2287 review: import alias and re-export alias of the same local.
+// Checker last-binds the re-export (`env_bind` prepends); rewrite used the
+// import. Pin with a non-commutative operator so the two cannot agree by luck.
+import ./reexport_alias_sub.vibe {
+  sub as foo
+}
+export ./reexport_alias_dep.vibe {
+  cmp as foo
+}
+
+test "re-export last-binds over an import alias of the same local" {
+  assert_true(foo(1, 2) == 3)
+}

--- a/fixtures/reexport_nested_alias_test.vibe
+++ b/fixtures/reexport_nested_alias_test.vibe
@@ -1,0 +1,10 @@
+// #2287 review: a two-hop re-export alias must resolve to the origin def.
+// One-hop `export ./dep { cmp as compare }` is already green; `bar as baz`
+// still rewrote only to `bar` and ICE'd at codegen.
+export ./reexport_alias_mid.vibe {
+  bar as baz
+}
+
+test "nested re-exported alias" {
+  assert_true(baz(1, 2) == 3)
+}

--- a/fixtures/reexport_unaliased_nested_test.vibe
+++ b/fixtures/reexport_unaliased_nested_test.vibe
@@ -1,0 +1,10 @@
+// #2287 review: an unaliased re-export of a mid-file public name must still
+// resolve to the origin def. `export ./mid { bar }` then `bar(...)` ICE'd
+// because collect_item_aliases skipped items with no alias.
+export ./reexport_alias_mid.vibe {
+  bar
+}
+
+test "unaliased nested re-export" {
+  assert_true(bar(1, 2) == 3)
+}

--- a/lib/@vibe/compiler/core/import_alias_rewrite.vibe
+++ b/lib/@vibe/compiler/core/import_alias_rewrite.vibe
@@ -696,26 +696,29 @@ fn rewrite_alias_expr_ix(expr: Expr, am: AliasIdx) -> Expr {
   }
 }
 
+fn collect_item_aliases(items: Array[ImportItem], aliases: Array[(String, String)]) -> Unit {
+  let mut j = 0
+  while j < Array::length(items) {
+    let item = Array::get(items, j)
+    let original = item.name
+    let alias_opt = item.alias
+    match alias_opt {
+      Some(alias) => if alias != original {
+        Array::push(aliases, (alias, original))
+      },
+      None => ()
+    }
+    j = j + 1
+  }
+}
+
 export fn collect_import_aliases(stmts: Array[Stmt]) -> Array[(String, String)] {
   let aliases = empty_aliases()
   let mut i = 0
   while i < Array::length(stmts) {
     match Array::get(stmts, i) {
-      SImport(_, items) => {
-        let mut j = 0
-        while j < Array::length(items) {
-          let item = Array::get(items, j)
-          let original = item.name
-          let alias_opt = item.alias
-          match alias_opt {
-            Some(alias) => if alias != original {
-              Array::push(aliases, (alias, original))
-            },
-            None => ()
-          }
-          j = j + 1
-        }
-      },
+      SImport(_, items) => collect_item_aliases(items, aliases),
+      SReExport(_, items) => collect_item_aliases(items, aliases),
       _ => ()
     }
     i = i + 1
@@ -847,6 +850,7 @@ export fn stmts_have_import_deep(stmts: Array[Stmt]) -> Bool {
   let rec stmt_has_import_deep: (Stmt) -> Bool = (stmt) -> {
     match stmt {
       SImport(_, _) => true,
+      SReExport(_, _) => true,
       SModule(_, _, inner_stmts) => stmts_have_import_deep(inner_stmts),
       _ => false
     }

--- a/lib/@vibe/compiler/core/import_alias_rewrite.vibe
+++ b/lib/@vibe/compiler/core/import_alias_rewrite.vibe
@@ -175,6 +175,25 @@ fn alias_map_without_names(aliases: Array[(String, String)], names: Array[String
   }
 }
 
+fn alias_map_put_last(aliases: Array[(String, String)], local: String, target: String) -> Unit {
+  let mut i = 0
+  let mut found = false
+  while i < Array::length(aliases) && !found {
+    let (alias, _) = Array::get(aliases, i)
+    if alias == local {
+      Array::set(aliases, i, (local, target))
+      found = true
+    } else {
+      i = i + 1
+    }
+  }
+  if !found {
+    Array::push(aliases, (local, target))
+  } else {
+    ()
+  }
+}
+
 fn pat_binds_name(pat: Pat, name: String) -> Bool {
   match pat {
     PBind(bound) => bound == name,
@@ -2030,6 +2049,22 @@ export fn build_export_rename_plan(paths: Array[String], stmts_list: Array[Array
     }
     ri = ri + 1
   }
+  // Entry re-export origins stay unmangled, so they were missing from
+  // rename_idx and a nested public name could not close to the origin def.
+  // Identity mappings let the facade-closure walk (and a same-file re-export
+  // lookup) return the bare origin name.
+  let mut oi = 0
+  while oi < Array::length(excluded_paths) {
+    let origin_path = Array::get(excluded_paths, oi)
+    let origin_name = Array::get(excluded_names, oi)
+    let origin_key = plan_rename_key(origin_path, origin_name)
+    if !MutMap::has(rename_idx, origin_key) {
+      MutMap::set(rename_idx, origin_key, origin_name)
+    } else {
+      ()
+    }
+    oi = oi + 1
+  }
   // Close the rename table over re-export facades so an import THROUGH a
   // facade (`import ./index.vibe { eq }` where index re-exports float's `eq`)
   // resolves to the renamed origin in one lookup.
@@ -2114,52 +2149,45 @@ export fn export_plan_fingerprint_text(plan: ExportRenamePlan) -> String {
   StringBuilder::freeze(buf)
 }
 
-/// (local -> mangled) reference renames for one importing file, derived from
-/// its `import` statements against the plan.
+fn collect_plan_item_renames(plan: ExportRenamePlan, base_dir: String, self_path: String, raw_path: String, items: Array[ImportItem], out: Array[(String, String)]) -> Unit {
+  let target = resolve_known_import_path(plan.plan_paths, base_dir, raw_path, self_path)
+  let mut j = 0
+  while j < Array::length(items) {
+    let item = Array::get(items, j)
+    let original = item.name
+    let alias_opt = item.alias
+    let local = match alias_opt {
+      Some(alias) => alias,
+      None => original
+    }
+    if String::index_of(original, "::") < 0 {
+      match MutMap::get(plan.rename_idx, plan_rename_key(target, original)) {
+        Some(mangled) => alias_map_put_last(out, local, mangled),
+        None => ()
+      }
+    } else {
+      ()
+    }
+    j = j + 1
+  }
+}
+
+/// (local -> mangled-or-origin) reference renames for one file, derived from
+/// its `import` and re-export statements against the plan. Last bind wins,
+/// matching `env_bind` prepend / `env_lookup` first-match in the checker.
 export fn collect_import_value_renames(plan: ExportRenamePlan, path: String, stmts: Array[Stmt]) -> Array[(String, String)] {
   let out = empty_aliases()
-  let locals_seen = empty_strings()
-  let rename_paths = plan.rename_paths
-  let rename_names = plan.rename_names
-  let rename_mangled = plan.rename_mangled
-  if Array::length(rename_paths) == 0 {
-    out
-  } else {
-    let base_dir = dir_of_path(path)
-    let mut i = 0
-    while i < Array::length(stmts) {
-      match Array::get(stmts, i) {
-        SImport(raw_path, items) => {
-          let target = resolve_known_import_path(plan.plan_paths, base_dir, raw_path, path)
-          let mut j = 0
-          while j < Array::length(items) {
-            let item = Array::get(items, j)
-            let original = item.name
-            let alias_opt = item.alias
-            let local = match alias_opt {
-              Some(alias) => alias,
-              None => original
-            }
-            if String::index_of(original, "::") < 0 && !string_array_contains(locals_seen, local) {
-              match MutMap::get(plan.rename_idx, plan_rename_key(target, original)) {
-                Some(mangled) => {
-                  Array::push(out, (local, mangled))
-                  Array::push(locals_seen, local)
-                },
-                None => ()
-              }
-            } else {
-              ()
-            }
-            j = j + 1
-          }
-        },
-        _ => ()
-      }
-      i = i + 1
+  let base_dir = dir_of_path(path)
+  let mut i = 0
+  while i < Array::length(stmts) {
+    match Array::get(stmts, i) {
+      SImport(raw_path, items) => collect_plan_item_renames(plan, base_dir, path, raw_path, items, out),
+      SReExport(raw_path, items) => collect_plan_item_renames(plan, base_dir, path, raw_path, items, out),
+      _ => ()
     }
-    out
+    i = i + 1
   }
+  out
 }
 
 export fn import_value_rename_locals(renames: Array[(String, String)]) -> Array[String] {


### PR DESCRIPTION
## Summary

- `collect_import_aliases` now includes `SReExport` items, so `compare` is rewritten to `cmp` like an import alias.
- `stmts_have_import_deep` treats `SReExport` as an import. A file that only re-exports otherwise skipped the rewrite path entirely.

Fixes #2287.

## Reproduction

```vibe
export ./dep.vibe { cmp as compare }
test { assert_true(compare(1, 2) == 3) }
```

Before: internal compiler error, `compare` unresolved at codegen.
After: the test passes. A re-export aliased to `assert_eq` runs the exported function, not the builtin.

## Tests

Red then green through this checkout's stage2:

```
VIBE_TEST_CLI_WASM=_build/selfhost/generations/2293b/stage2.wasm \
  bash scripts/vibe_test.sh fixtures/reexport_alias_test.vibe
# ICE: compare unresolved

VIBE_TEST_CLI_WASM=_build/selfhost/generations/2287b/stage2.wasm \
  bash scripts/vibe_test.sh fixtures/reexport_alias_test.vibe
  bash scripts/vibe_test.sh fixtures/reexport_alias_assert_eq_test.vibe
# ok
```