### PR TITLE
A local binding named `assert_eq` is the function that runs

### DIFF
--- a/lib/@vibe/compiler/codegen/common_analysis/common_analysis.vibe
+++ b/lib/@vibe/compiler/codegen/common_analysis/common_analysis.vibe
@@ -812,8 +812,19 @@ fn is_inlined_async_builtin(name: String) -> Bool {
 /// so `assert(false)` inside a lambda crashed with "null function or function
 /// signature mismatch" instead of the expected "unreachable" trap that the
 /// same code produces at top level.
+///
+/// #2285: `assert_true` and `assert_eq` join them. Their three arms in
+/// compile_call.vibe used to be UNGUARDED (`fn_idx_in_list < 0` alone), which
+/// made them immune to this bug by construction -- an unguarded branch lowers
+/// inline whether or not the name was wrongly captured, so the bad capture
+/// could never reach a `call_indirect`. That immunity was also what made a
+/// LOCAL binding of the name unhonorable: `local_idx_hint` finding the name
+/// among the closure's locals could equally mean "the reader bound it" or
+/// "the capture scan invented it", so the arms could not read it. Registering
+/// the two names here removes the second reading, which is what lets the arms
+/// switch to `!prefer_bound_call` and a local binding finally win.
 fn is_inlined_scalar_builtin(name: String) -> Bool {
-  name == "not" || name == "add" || name == "sub" || name == "mul" || name == "lt" || name == "assert" || name == "Double::from_i64_bits"
+  name == "not" || name == "add" || name == "sub" || name == "mul" || name == "lt" || name == "assert" || name == "assert_true" || name == "assert_eq" || name == "Double::from_i64_bits"
 }
 
 /// A namespaced source alias recognized by the builtin registry resolves

--- a/lib/@vibe/compiler/codegen/expr/compile_call.vibe
+++ b/lib/@vibe/compiler/codegen/expr/compile_call.vibe
@@ -3012,7 +3012,7 @@ fn compile_call_core(buf: Bytes, callee: Expr, args: Array[Expr], local_names: A
       // write into a region that no longer exists.
       throw("internal: `resume` reached codegen -- its handle was neither migrated (evidence dict) nor CPS-transformed (suspend class), and the replay engine was removed (ADR-0076 追記34 V2)")
     }
-    else if fname == "assert" && fn_idx_in_list < 0 {
+    else if !prefer_bound_call && fname == "assert" {
       // #1095: `prefer_bound_call` is the WRONG guard here (assert_true /
       // assert_eq below had none either). Inside a lambda, capture analysis
       // lists the
@@ -3024,13 +3024,22 @@ fn compile_call_core(buf: Bytes, callee: Expr, args: Array[Expr], local_names: A
       // actually asserted); with the minimized funcref table it surfaced as
       // "null function" traps.
       //
-      // #2283: the half of `prefer_bound_call` that is wrong is
-      // `local_idx_hint` -- the capture artifact. A name in the FUNCTION TABLE
-      // is a real top-level definition the reader wrote, and it must win, so
-      // these three arms test `fn_idx_in_list` alone. Without that the checker
-      // typed the call against the user's function while codegen emitted the
-      // builtin assert: `fn assert_eq(a: Int, b: Int) -> String` compiled clean
-      // and then trapped, with no diagnostic anywhere naming the conflict.
+      // #2283: a name in the FUNCTION TABLE is a real top-level definition the
+      // reader wrote, and it must win. Without that guard the checker typed the
+      // call against the user's function while codegen emitted the builtin
+      // assert: `fn assert_eq(a: Int, b: Int) -> String` compiled clean and then
+      // trapped, with no diagnostic anywhere naming the conflict.
+      //
+      // #2285: these three arms now test the WHOLE of `prefer_bound_call`, so a
+      // LOCAL binding wins too -- `let assert_eq = ...`, a parameter, a
+      // pattern. Reading `local_idx_hint` is only sound because `assert`,
+      // `assert_true` and `assert_eq` are all registered in
+      // `is_inlined_scalar_builtin` (common_analysis.vibe): a free use inside a
+      // lambda is skipped by the capture scan, so a hit among the closure's
+      // locals can no longer be the capture artifact this comment used to
+      // describe. Registration and guard are one change -- adding the guard
+      // without it reinstates #1095 exactly, which is what
+      // scripts/check_inline_builtin_capture.sh exists to catch.
       let nl = ce(buf, Array::get(args, 0), local_names, next_local, ctx, ld)
       emit_i32_wrap_i64(buf)
       emit_if_void(buf)
@@ -3040,7 +3049,7 @@ fn compile_call_core(buf: Bytes, callee: Expr, args: Array[Expr], local_names: A
       emit_i64_const(buf, 0)
       nl
     }
-    else if fname == "assert_true" && fn_idx_in_list < 0 {
+    else if !prefer_bound_call && fname == "assert_true" {
       let nl = ce(buf, Array::get(args, 0), local_names, next_local, ctx, ld)
       emit_i32_wrap_i64(buf)
       emit_if_void(buf)
@@ -3050,7 +3059,7 @@ fn compile_call_core(buf: Bytes, callee: Expr, args: Array[Expr], local_names: A
       emit_i64_const(buf, 0)
       nl
     }
-    else if fname == "assert_eq" && fn_idx_in_list < 0 {
+    else if !prefer_bound_call && fname == "assert_eq" {
       // Fallback only. The shipped path rewrites `assert_eq` in
       // desugar_trait_dicts (expected/actual on stderr, then trap). This
       // arm stays for lanes that skip that pass (compile_module): still

--- a/lib/@vibe/compiler/normalize/desugar_trait_dict.vibe
+++ b/lib/@vibe/compiler/normalize/desugar_trait_dict.vibe
@@ -6370,43 +6370,90 @@ fn is_assert_eq_call(callee: Expr, args: Array[Expr]) -> Bool {
 /// cell above: whether THIS program binds `assert_eq` itself.
 ///
 /// The unit is the program this pass was handed, which in the FS lane is every
-/// module merged together -- so one module defining `assert_eq` stands the
+/// module merged together -- so one module binding `assert_eq` stands the
 /// lowering down for all of them. Coarse, and deliberately so: the merged
 /// program is what this pass sees, and a per-module answer here would be
 /// invented.
-let dtd_user_assert_eq = [0]
+///
+/// COMPUTED LAZILY (#2285). The scan now descends into every expression, and
+/// paying for a whole-program AST walk on every compile is not free -- an
+/// earlier round of this work measured a 1.1% self-compile heap regression
+/// from one extra traversal and blew the KPI ceiling. Nothing asks this
+/// question unless the program actually spells `assert_eq(a, b)`, because
+/// `is_assert_eq_call` tests the name and the arity first, so a program with
+/// no such call never runs the walk at all -- which is every file in the
+/// compiler's own closure.
+///
+/// Slot 0 is the answer: -1 not computed yet, 0 no, 1 yes.
+let dtd_user_assert_eq = [-1]
+
+/// The program to answer that question from, held until something asks. One
+/// element or none; `Array::truncate` on reset is what makes a torn run
+/// (a throw mid-rewrite) unable to leave a previous program behind.
+let dtd_user_assert_eq_program: Array[Array[Stmt]] = array_empty()
 
 fn user_assert_eq_reset(stmts: Array[Stmt]) -> Unit {
-  Array::set(dtd_user_assert_eq, 0, if stmts_define_assert_eq(stmts) {
-    1
-  } else {
-    0
-  })
+  Array::set(dtd_user_assert_eq, 0, -1)
+  Array::truncate(dtd_user_assert_eq_program, 0)
+  Array::push(dtd_user_assert_eq_program, stmts)
 }
 
 fn user_assert_eq_bound() -> Bool {
-  Array::get(dtd_user_assert_eq, 0) == 1
+  let cached = Array::get(dtd_user_assert_eq, 0)
+  if cached >= 0 {
+    cached == 1
+  } else if Array::length(dtd_user_assert_eq_program) == 0 {
+    // Nothing handed us a program. Answer "not bound", which is the shipped
+    // lowering -- the same thing a caller that never reset would have got.
+    false
+  } else {
+    let answer = stmts_define_assert_eq(Array::get(dtd_user_assert_eq_program, 0))
+    Array::set(dtd_user_assert_eq, 0, if answer {
+      1
+    } else {
+      0
+    })
+    answer
+  }
 }
 
-/// Whether this program DEFINES `assert_eq` at the top level -- a
-/// statement-level definition, or an import that lands under that name.
+/// Whether this program BINDS `assert_eq` anywhere -- a top-level definition,
+/// an import that lands under that name, or a local binder at any depth: a
+/// `let`, a `for` binder, a function or lambda parameter, a `match` or
+/// `handle` pattern.
 ///
-/// Top-level only, and that boundary is not arbitrary: it is exactly what the
-/// codegen guard can honor. `compile_call.vibe` decides by `fn_idx_in_list`
-/// (the function table) and deliberately ignores `local_idx_hint`, because a
-/// lambda's captured free name appears there with an unresolved slot -- the
-/// #1095 trap. Suppressing the lowering for a LOCAL binding only moves the
-/// failure: the pass stands down, codegen's own `assert_eq` arm still claims
-/// the call, and the program traps with no message at all. Measured on
+/// The local half is #2285, and it could not be turned on until codegen could
+/// honor a local. Standing the lowering down is only half the answer: codegen
+/// has its own `assert_eq` arm, and while that arm tested `fn_idx_in_list`
+/// alone it claimed the call regardless, so suppressing here only traded the
+/// builtin's message for a bare `unreachable`. Measured on
 /// `match make_cmp() { assert_eq => assert_eq(1, 2) }`: the builtin assertion
-/// before, a bare `unreachable` after. Worse, not better -- so the local and
-/// pattern-bound cases keep their pre-existing behaviour (#2285).
+/// before, a trap with no message after. Both halves now hold -- the three
+/// assert arms in `compile_call.vibe` test `!prefer_bound_call`, and
+/// `assert_eq`/`assert_true` are registered in `is_inlined_scalar_builtin` so
+/// a free use inside a lambda is no longer recorded as the #1095 capture
+/// artifact that made `local_idx_hint` unreadable.
+///
+/// UNSCOPED, like the top-level half: one binder anywhere stands the lowering
+/// down for the whole merged program, even for call sites the binder does not
+/// reach. A scoped answer would have to thread a binder set through
+/// `rewrite_expr`, which carries nine parameters already. The coarseness errs
+/// in the safe direction -- standing down loses the expected/actual message,
+/// it never runs the wrong function -- and it costs nothing today: no file
+/// under `lib/`, `fixtures/`, or `examples/` binds the name locally.
 fn stmts_define_assert_eq(stmts: Array[Stmt]) -> Bool {
   let mut i = 0
   let mut found = false
   while i < Array::length(stmts) && !found {
     let hit = match Array::get(stmts, i) {
-      SLet(_, _, name, _, _) => name == "assert_eq",
+      SLet(_, _, name, _, value) => name == "assert_eq" || expr_binds_assert_eq(value),
+      SLetMut(name, _, value) => name == "assert_eq" || expr_binds_assert_eq(value),
+      SLetPat(pat, value) => pat_binds_assert_eq(pat) || expr_binds_assert_eq(value),
+      SExpr(e) => expr_binds_assert_eq(e),
+      STest(_, e) => expr_binds_assert_eq(e),
+      SBench(_, e) => expr_binds_assert_eq(e),
+      SExample(_, e) => expr_binds_assert_eq(e),
+      SFnDecl(_, name, e, _, _) => name == "assert_eq" || expr_binds_assert_eq(e),
       // NO `SModule` recursion. A module member declares `M::assert_eq`, not
       // the bare prelude name, so recursing would stand the lowering down for
       // an unrelated top-level `assert_eq(a, b)` -- and the function table
@@ -6439,6 +6486,127 @@ fn import_binds_assert_eq(items: Array[ImportItem]) -> Bool {
       None => item.name
     }
     if local == "assert_eq" {
+      found = true
+    } else {
+      ()
+    }
+    i = i + 1
+  }
+  found
+}
+
+/// A pattern that binds the bare name. `PBind` is the binder; every other
+/// arm is a container to look through. A `PCtor` name is a constructor, not a
+/// binder, so only its sub-patterns are asked.
+fn pat_binds_assert_eq(p: Pat) -> Bool {
+  match p {
+    PBind(name) => name == "assert_eq",
+    PCtor(_, subs) => pats_bind_assert_eq(subs),
+    PTuple(subs) => pats_bind_assert_eq(subs),
+    POr(a, b) => pat_binds_assert_eq(a) || pat_binds_assert_eq(b),
+    PStruct(_, fields) => {
+      let mut i = 0
+      let mut found = false
+      while i < Array::length(fields) && !found {
+        let (_, sub) = Array::get(fields, i)
+        if pat_binds_assert_eq(sub) {
+          found = true
+        } else {
+          ()
+        }
+        i = i + 1
+      }
+      found
+    },
+    _ => false
+  }
+}
+
+fn pats_bind_assert_eq(ps: Array[Pat]) -> Bool {
+  let mut i = 0
+  let mut found = false
+  while i < Array::length(ps) && !found {
+    if pat_binds_assert_eq(Array::get(ps, i)) {
+      found = true
+    } else {
+      ()
+    }
+    i = i + 1
+  }
+  found
+}
+
+/// Every binding form an expression can carry, then the children.
+///
+/// The recursion goes through `expr_children` on purpose: it is the AST edge's
+/// exhaustive structural traversal, so a new `Expr` variant fails to compile
+/// there rather than silently going unvisited here. Only the arms that BIND
+/// are spelled out below; everything else falls through to the walk.
+fn expr_binds_assert_eq(e: Expr) -> Bool {
+  let here = match e {
+    ELet(name, _, _, _) => name == "assert_eq",
+    ELetRec(name, _, _) => name == "assert_eq",
+    ELetMut(name, _, _, _) => name == "assert_eq",
+    EForIn(value_name, key_name, _, _) => value_name == "assert_eq" || match key_name {
+      Some(k) => k == "assert_eq",
+      None => false
+    },
+    EFn(_, _, params, _, _, _) => {
+      let mut i = 0
+      let mut found = false
+      while i < Array::length(params) && !found {
+        let (pname, _) = Array::get(params, i)
+        if pname == "assert_eq" {
+          found = true
+        } else {
+          ()
+        }
+        i = i + 1
+      }
+      found
+    },
+    ELoop(params, _) => {
+      let mut i = 0
+      let mut found = false
+      while i < Array::length(params) && !found {
+        let (pname, _) = Array::get(params, i)
+        if pname == "assert_eq" {
+          found = true
+        } else {
+          ()
+        }
+        i = i + 1
+      }
+      found
+    },
+    EMatch(_, arms) => arms_bind_assert_eq(arms),
+    EHandle(_, arms) => arms_bind_assert_eq(arms),
+    _ => false
+  }
+  if here {
+    true
+  } else {
+    let kids = expr_children(e)
+    let mut i = 0
+    let mut found = false
+    while i < Array::length(kids) && !found {
+      if expr_binds_assert_eq(Array::get(kids, i)) {
+        found = true
+      } else {
+        ()
+      }
+      i = i + 1
+    }
+    found
+  }
+}
+
+fn arms_bind_assert_eq(arms: Array[(Pat, Expr)]) -> Bool {
+  let mut i = 0
+  let mut found = false
+  while i < Array::length(arms) && !found {
+    let (pat, _) = Array::get(arms, i)
+    if pat_binds_assert_eq(pat) {
       found = true
     } else {
       ()

--- a/scripts/check_inline_builtin_capture.sh
+++ b/scripts/check_inline_builtin_capture.sh
@@ -24,18 +24,21 @@
 # is_inlined_scalar_builtin / is_inlined_simd_builtin, or to the allowlist with
 # a measured reason.
 #
-# Why only the `!prefer_bound_call`-GUARDED dispatches (Codex review on #1369
-# asked about `assert_true` / `assert_eq`, which have no guard): an UNGUARDED
-# branch is immune to this bug by construction. `prefer_bound_call` is
+# Why only the `!prefer_bound_call`-GUARDED dispatches: an UNGUARDED branch is
+# immune to this bug by construction. `prefer_bound_call` is
 # `fn_idx_in_list >= 0 || local_idx_hint >= 0` (compile_call.vibe), so a
 # wrongly-captured name sets it -- and that is precisely what makes a GUARDED
 # branch fall through to the call_indirect. An unguarded branch lowers inline
-# either way, so the bad capture cannot reach a call_indirect. Measured: a
-# lambda calling `assert_true(true)` / `assert_eq(1, 1)` runs correctly on the
-# current compiler even though neither name is registered below. This is also
-# what #1095 actually fixed for `assert` -- it removed that branch's guard.
-# Consequence: adding a `!prefer_bound_call` guard to an existing branch makes
-# that name newly in-scope here, which is the case this scan exists to catch.
+# either way, so the bad capture cannot reach a call_indirect. Consequence:
+# adding a `!prefer_bound_call` guard to an existing branch makes that name
+# newly in-scope here, which is the case this scan exists to catch.
+#
+# That is exactly what #2285 did to `assert_true` / `assert_eq`. They were
+# unguarded, and therefore out of scope here, until a LOCAL binding of the
+# name had to be honored -- which means reading `local_idx_hint`, which means
+# the capture artifact must not exist. Both names were registered in
+# is_inlined_scalar_builtin in the same change that added their guards; had
+# only the guard landed, this scan would have failed on the next run.
 set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"

--- a/tests/gates/late/run.sh
+++ b/tests/gates/late/run.sh
@@ -6691,7 +6691,7 @@ echo "[compiler-gate] non-final closure argument fixpoint ok (#2271)"
 # `assert_eq` by name, and codegen, which had no shadowing guard at all on
 # these three spellings (#1095 removed `prefer_bound_call`, and the half of it
 # that was wrong is `local_idx_hint`, not `fn_idx_in_list`).
-echo "[compiler-gate] 110/110 a user's own assert_eq is the function that runs (#2283)"
+echo "[compiler-gate] 110/110 a user's own assert_eq is the function that runs, top-level or local (#2283, #2285)"
 asdir="_build/_gate_assert_shadow"
 rm -rf "$asdir"; mkdir -p "$asdir"
 cat > "$asdir/shadow.vibe" <<'ASEOF'
@@ -6756,5 +6756,103 @@ if ! grep -qF 'assert_eq failed' "$asdir/builtin.log"; then
   cat "$asdir/builtin.log" >&2
   exit 1
 fi
+# ...and a LOCAL binding wins too (#2285). Three binder shapes, all measured
+# broken on a stage2 from `b1d42642`: the pattern-bound one reported `assert_eq
+# failed / expected: 2 / actual: 1`, and the `let` and parameter shapes did not
+# even compile ("expected Int, got ()") because the lowering had already
+# rewritten the call before the checker could read the binding.
+#
+# Two layers again, and they only work together: the desugar scan stands down
+# for a local binder, and codegen's three assert arms read the whole of
+# `prefer_bound_call`. Standing down ALONE is measurably worse -- it trades the
+# builtin's message for a bare `unreachable` -- which is why the local case
+# stayed broken until both landed.
+cat > "$asdir/local.vibe" <<'ASEOF'
+fn make_cmp() -> (Int, Int) -> Int {
+  (a, b) -> { a + b }
+}
+
+fn use_param(assert_eq: (Int, Int) -> Int) -> Int {
+  assert_eq(1, 2)
+}
+
+fn main() -> Unit with Stdout {
+  match make_cmp() {
+    assert_eq => println(Int::to_string(assert_eq(1, 2)))
+  }
+  let assert_eq = (a: Int, b: Int) -> Int { a + b }
+  println(Int::to_string(assert_eq(1, 2)))
+  println(Int::to_string(use_param(make_cmp())))
+  let assert_true = (a: Int) -> Int { a + 41 }
+  println(Int::to_string(assert_true(1)))
+}
+ASEOF
+rm -f "$asdir/local.wasm" "$asdir/local.wasm.diag"
+VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_IMPORT_ABI=raw \
+  bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
+  "$asdir/local.vibe" "$asdir/local.wasm" main >/dev/null 2>&1 || true
+if [ ! -s "$asdir/local.wasm" ]; then
+  echo "[compiler-gate] FAIL: a program binding assert_eq locally did not compile (#2285)" >&2
+  cat "$asdir/local.wasm.diag" 2>/dev/null >&2 || true
+  exit 1
+fi
+local_out="$(VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh --invoke _start "$asdir/local.wasm" 2>&1 || true)"
+if [ "$(printf '%s\n' "$local_out" | grep -c '^3$')" != "3" ] || \
+   ! printf '%s\n' "$local_out" | grep -qx '42'; then
+  echo "[compiler-gate] FAIL: a local binding of assert_eq/assert_true was claimed by the builtin (#2285)" >&2
+  echo "  want three lines of '3' (pattern, let, parameter) and one '42' (assert_true), got:" >&2
+  printf '%s\n' "$local_out" >&2
+  exit 1
+fi
+# The same shape through the FS/test lane, which is where #2285 was reported.
+cat > "$asdir/local_test.vibe" <<'ASEOF'
+fn make_cmp() -> (Int, Int) -> Int {
+  (a, b) -> { a + b }
+}
+
+test "pattern-bound assert_eq" {
+  match make_cmp() {
+    assert_eq => assert_true(assert_eq(1, 2) == 3)
+  }
+}
+ASEOF
+VIBE_TEST_CLI_WASM="$stage2_wasm" VIBE_TEST_QUIET_COMPILER_NOTE=1 \
+  bash scripts/vibe_test.sh "$asdir/local_test.vibe" >"$asdir/local.log" 2>&1 || true
+if ! grep -qF '1 passed, 0 failed' "$asdir/local.log"; then
+  echo "[compiler-gate] FAIL: a pattern-bound assert_eq did not run in the FS lane (#2285)" >&2
+  cat "$asdir/local.log" >&2
+  exit 1
+fi
+# Reading `local_idx_hint` is only sound while the capture scan skips these
+# names. Drop them from is_inlined_scalar_builtin and a lambda calling a bare
+# assert captures a slot holding nothing, so the call lowers to a
+# `call_indirect` of a nonexistent closure -- #1095, exactly. That regression is
+# silent in every other case, so it gets its own probe.
+cat > "$asdir/lambda.vibe" <<'ASEOF'
+fn main() -> Unit with Stdout {
+  let f = () -> Unit { assert_eq(1, 1) }
+  f()
+  let g = () -> Unit { assert_true(1 == 1) }
+  g()
+  let h = () -> Unit { assert(true) }
+  h()
+  println("ok")
+}
+ASEOF
+rm -f "$asdir/lambda.wasm" "$asdir/lambda.wasm.diag"
+VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_IMPORT_ABI=raw \
+  bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
+  "$asdir/lambda.vibe" "$asdir/lambda.wasm" main >/dev/null 2>&1 || true
+if [ ! -s "$asdir/lambda.wasm" ]; then
+  echo "[compiler-gate] FAIL: a lambda calling a bare assert did not compile (#1095 guard, #2285)" >&2
+  cat "$asdir/lambda.wasm.diag" 2>/dev/null >&2 || true
+  exit 1
+fi
+lambda_out="$(VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh --invoke _start "$asdir/lambda.wasm" 2>&1 || true)"
+if ! printf '%s\n' "$lambda_out" | grep -qx 'ok'; then
+  echo "[compiler-gate] FAIL: a bare assert inside a lambda no longer runs -- #1095 is back (#2285)" >&2
+  printf '%s\n' "$lambda_out" >&2
+  exit 1
+fi
 rm -rf "$asdir"
-echo "[compiler-gate] user-defined assert_eq wins; builtin still fires ok (#2283)"
+echo "[compiler-gate] user-defined assert_eq wins (top-level and local); builtin still fires; no #1095 capture regression ok (#2283, #2285)"

--- a/tests/gates/registry.tsv
+++ b/tests/gates/registry.tsv
@@ -227,4 +227,4 @@ x-adr-0090-1937-exception-unwind-region-restore	late	ADR-0090 #1937 exception-un
 107/107	late	107/107 the host runner's crash dump is opt-in (#2199)
 108/108	late	108/108 the ADR-0068 concurrency surface is opt-in, in check AND build (#2248)
 109/109	late	109/109 a multiline closure in a non-final argument slot formats to a fixpoint (#2271)
-110/110	late	110/110 a user's own assert_eq is the function that runs (#2283)
+110/110	late	110/110 a user's own assert_eq is the function that runs, top-level or local (#2283, #2285)


### PR DESCRIPTION
Closes #2285.

#2283 fixed the **top-level** case. A **local** binding was still claimed by the builtin, and measured on a stage2 from `b1d42642` it broke three ways — two of which the issue did not record:

| shape | before |
|---|---|
| `match make_cmp() { assert_eq => .. }` | `assert_eq failed / expected: 2 / actual: 1` |
| `let assert_eq = ...` used as a value | **does not compile**: `expected Int, got ()` |
| `fn f(assert_eq: ..) -> Int { assert_eq(1, 2) }` | does not compile, same |
| `let assert_true = (a) -> a + 41; assert_true(1)` | prints **`0`** |

The two compile failures are the lowering having already rewritten the call before the checker could read the binding, so the checker saw the builtin's `Unit`. The last row is silently wrong.

## Why one layer was never enough

Standing the lowering down for a local binder was tried before and measured **worse**: the pass stood down, codegen's own `assert_eq` arm claimed the call anyway, and the program traded the builtin's message for a bare `unreachable`.

Codegen could not honor a local because it could not tell one from an artifact. `local_idx_hint` finding the name among a closure's locals meant either "the reader bound it" or "the capture scan invented it" — the #1095 shape, where a free `assert` inside a lambda is recorded as a capture whose slot holds nothing and the call becomes a `call_indirect` of a null closure. So the three arms tested `fn_idx_in_list` alone.

## Three changes, which only work together

- **`is_inlined_scalar_builtin`** registers `assert_true` and `assert_eq` alongside `assert`, so a free use inside a lambda is skipped by the capture scan. That removes the second reading of `local_idx_hint`.
- **the three assert arms** in `compile_call.vibe` therefore test the whole of `prefer_bound_call`, and a local binding wins.
- **the desugar suppression scan** descends into expressions: `let`, `let mut`, `let rec`, a `for` binder, a function or lambda parameter, a `loop` parameter, a `match` or `handle` pattern.

Registering the two names is what brings them into `scripts/check_inline_builtin_capture.sh`'s scope — that detector exists to catch a guard added without the registration, which is #1095 exactly. Its stale note explaining why these two were out of scope is rewritten.

## The scan is lazy

It now walks every expression in the merged program, and an earlier round of adjacent work measured a **1.1% self-compile heap regression** from one extra traversal. `is_assert_eq_call` tests the name and the arity before asking, so a program that never spells `assert_eq(a, b)` never runs the walk — which is every file in the compiler's own closure.

Unscoped, like the top-level half it extends: one binder anywhere stands the lowering down for the whole merged program. A scoped answer would have to thread a binder set through `rewrite_expr`, which carries nine parameters already, and the coarseness errs safe — standing down loses the expected/actual message, it never runs the wrong function. It costs nothing today: no file under `lib/`, `fixtures/`, or `examples/` binds the name locally.

## Measured after, same stage2

| case | after |
|---|---|
| pattern, `let`, and parameter binders | `3`, `3`, `3` |
| `assert_true` local shadow | `42` |
| lambda calling bare `assert` / `assert_true` / `assert_eq` | runs (no #1095) |
| builtin where nothing shadows it | still reports expected/actual |
| top-level `fn assert_eq` (#2283) | still wins |

Gate section 110 pins all of them, **red-tested**: the local probe does not compile at all on a stage2 from `b1d42642`.

## Found while measuring, not fixed here

`let eq = (a: Int, b: Int) -> Int { a + b }; eq(1, 2)` prints `0`. The `eq` arm has a `cc_arg_is_scalarish` disjunct that lets the builtin beat a binding — the deliberate #710/#711 workaround for an over-broad `prefer_bound_call`. Filed as #2309 (P0) rather than folded in, since tightening it needs measurement against `leb128_test.vibe`.

## Verification

`ensure_generated` → `generations.sh build --stage3` → `cmp stage2 stage3` → **`FIXPOINT_OK`**; `compiler_gate.sh` green end to end, with section 110 running the new cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GbtLER6wNT4jsZEN1Zp6xe

---
_Generated by [Claude Code](https://claude.ai/code/session_01GbtLER6wNT4jsZEN1Zp6xe)_