### PR TITLE
A contract buffer is a contract on every lane, not just the one that resolves imports

### DIFF
--- a/lib/@vibe/compiler/cli_adapter.vibe
+++ b/lib/@vibe/compiler/cli_adapter.vibe
@@ -25,7 +25,7 @@ import @vibe/compiler/runtime {
   binding_occurrences,
   build_funcmap_from_source,
   build_module_source_from_source,
-  collect_all_diagnostics,
+  collect_all_diagnostics_for_path,
   doc_at_source,
   escape_spans,
   escape_spans_strict,
@@ -119,7 +119,7 @@ import ./cli_support.vibe {
 }
 
 import @vibe/lsp {
-  lsp_diagnostics_json_string, lsp_diagnostics_json_string_with, lsp_main
+  lsp_diagnostics_json_string, lsp_diagnostics_json_string_with_for_path, lsp_main
 }
 
 import @vibe/compiler/checker {
@@ -1853,9 +1853,9 @@ export fn cli_main() -> Int with Exception + Fs + Env + Stdin + Stdout {
       // The JSON form is what the editor consumes; dropping the opt-in
       // diagnostic here would make the LSP the one surface that still accepts
       // the unstable import (#2277 review).
-      Fs::write_bytes(output_path, adapter_string_to_bytes(lsp_diagnostics_json_string_with(src, unstable_diags)))
+      Fs::write_bytes(output_path, adapter_string_to_bytes(lsp_diagnostics_json_string_with_for_path(input_path, src, unstable_diags)))
     } else {
-      let diags = collect_all_diagnostics(src)
+      let diags = collect_all_diagnostics_for_path(input_path, src)
       let mut ui = 0
       while ui < Array::length(unstable_diags) {
         Array::push(diags, Array::get(unstable_diags, ui))

--- a/lib/@vibe/compiler/cli_adapter.vibe
+++ b/lib/@vibe/compiler/cli_adapter.vibe
@@ -25,7 +25,7 @@ import @vibe/compiler/runtime {
   binding_occurrences,
   build_funcmap_from_source,
   build_module_source_from_source,
-  collect_all_diagnostics_for_path,
+  collect_all_diagnostics_with_unstable_for_path,
   doc_at_source,
   escape_spans,
   escape_spans_strict,
@@ -119,7 +119,7 @@ import ./cli_support.vibe {
 }
 
 import @vibe/lsp {
-  lsp_diagnostics_json_string, lsp_diagnostics_json_string_with_for_path, lsp_main
+  lsp_diagnostics_json_of_messages, lsp_diagnostics_json_string, lsp_main
 }
 
 import @vibe/compiler/checker {
@@ -1842,26 +1842,26 @@ export fn cli_main() -> Int with Exception + Fs + Env + Stdin + Stdout {
     // it belongs in every lane that reads the file. Scanned on the buffer's own
     // text: this lane exists for unsaved buffers, and ingestion would answer
     // about the file on disk instead.
-    let unstable_diags = if Env::get("VIBE_UNSTABLE") == "1" {
-      adapter_no_warnings()
-    } else {
-      handle {
-        unstable_surface_diagnostics(input_path, src)
-      } with { Exception::Throw(_) => adapter_no_warnings() }
-    }
+    //
+    // ONE collector for both halves (#2314 review). This used to call
+    // `unstable_surface_diagnostics(input_path, src)` beside the base set, and
+    // that second scan read the RAW buffer -- so for a `.vpkg` whose header it
+    // could not parse, `checked_warning_stmts` returned `None` and the opt-in
+    // error was dropped. It was invisible only because the base set was
+    // answering `expected { but got eof` about the same file; removing that
+    // false error would have left the contract reporting NOTHING. Measured
+    // before this: the LSP (which already used the combined collector)
+    // reported the opt-in for such a contract and this lane did not.
+    let all_diags = handle {
+      collect_all_diagnostics_with_unstable_for_path(input_path, src, Env::get("VIBE_UNSTABLE") == "1")
+    } with { Exception::Throw(_) => adapter_no_warnings() }
     if Env::get("VIBE_DIAGNOSTICS_JSON") == "1" {
       // The JSON form is what the editor consumes; dropping the opt-in
       // diagnostic here would make the LSP the one surface that still accepts
       // the unstable import (#2277 review).
-      Fs::write_bytes(output_path, adapter_string_to_bytes(lsp_diagnostics_json_string_with_for_path(input_path, src, unstable_diags)))
+      Fs::write_bytes(output_path, adapter_string_to_bytes(lsp_diagnostics_json_of_messages(src, all_diags)))
     } else {
-      let diags = collect_all_diagnostics_for_path(input_path, src)
-      let mut ui = 0
-      while ui < Array::length(unstable_diags) {
-        Array::push(diags, Array::get(unstable_diags, ui))
-        ui = ui + 1
-      }
-      Fs::write_bytes(output_path, adapter_string_to_bytes(line_terminated(join_lines(diags))))
+      Fs::write_bytes(output_path, adapter_string_to_bytes(line_terminated(join_lines(all_diags))))
     }
     return 0
   }

--- a/lib/@vibe/compiler/runtime/index.vpkg
+++ b/lib/@vibe/compiler/runtime/index.vpkg
@@ -342,6 +342,7 @@ fn run_module_job_dir(dir: String) -> Unit with Exception + Fs
 fn run_publish_env_cache_dir(dir: String) -> Unit with Exception + Fs
 fn check_inline_wasm_fns(stmts: Array[Stmt]) -> Option[String]
 fn collect_all_diagnostics(source: String) -> Array[String] with Exception
+fn collect_all_diagnostics_for_path(input_path: String, source: String) -> Array[String] with Exception
 fn collect_all_diagnostics_with_unstable(source: String, allow_unstable: Bool) -> Array[String] with Exception
 fn collect_all_diagnostics_with_unstable_for_path(input_path: String, source: String, allow_unstable: Bool) -> Array[String] with Exception
 fn unstable_import_diagnostics(input_path: String, detected: String, located: String) -> Array[String] with Exception

--- a/lib/@vibe/compiler/runtime/typecheck_fs.vibe
+++ b/lib/@vibe/compiler/runtime/typecheck_fs.vibe
@@ -79,7 +79,7 @@ import @vibe/compiler/entry/source_compile/wasi_only {
 }
 
 import @vibe/compiler/contract {
-  extract_require_pins, parse_contract_program
+  classify_contract_stmts, extract_require_pins, parse_contract_program
 }
 
 import @vibe/compiler/loader {
@@ -5698,8 +5698,16 @@ fn collect_all_diagnostics_on(input_path: String, source: String) -> Array[Strin
     // which is the bug this section exists to remove. Multi-error recovery
     // for contract grammar is a real improvement, and it belongs in both
     // lanes at once rather than only in this one.
+    // Parsing is not the whole contract grammar: `parse_contract_program`
+    // accepts statements a contract may not CONTAIN, and the loader rejects
+    // those separately via `classify_contract_stmts` (#729). Discarding the
+    // statements reported `export let x: Int = "s"` as clean here while the
+    // build refused it (Codex review on #2315) -- and the statement-grammar
+    // branch this replaces did catch it, through `check_program`. So run the
+    // classifier the loader runs, on the statements the parse produced.
     return handle {
-      let (_, _, _stmts) = parse_contract_program(ctokens)
+      let (_, _, cstmts) = parse_contract_program(ctokens)
+      let (_raws, _type_defs) = classify_contract_stmts(cstmts)
       array_empty()
     } with { Exception::Throw(msg) => contract_parse_diagnostic(source, ctokens, cstarts, msg) }
   } else {

--- a/lib/@vibe/compiler/runtime/typecheck_fs.vibe
+++ b/lib/@vibe/compiler/runtime/typecheck_fs.vibe
@@ -5469,6 +5469,72 @@ export fn collect_all_diagnostics_for_path(input_path: String, source: String) -
 /// verb that answers the cross-file half (`contract violation: contract
 /// declaration 'x' has no implementation`, #2280) -- reporting a subset here
 /// is honest; inventing the rest from one buffer is not.
+/// Does the first `k` tokens throw exactly `msg` from the contract parser?
+///
+/// `peek` answers `TEof` past the end of the array, so a plain truncation is a
+/// well-formed token prefix -- no sentinel to append.
+fn contract_prefix_throws(tokens: Array[Token], k: Int, msg: String) -> Bool with Exception {
+  let head = array_empty()
+  let mut i = 0
+  while i < k {
+    Array::push(head, Array::get(tokens, i))
+    i = i + 1
+  }
+  handle {
+    let (_, _, _stmts) = parse_contract_program(head)
+    false
+  } with { Exception::Throw(m) => m == msg }
+}
+
+/// Byte offset of the token the contract parser stopped at, or -1.
+///
+/// `parse_contract_program` throws an UNLOCATED message, and
+/// `locate_type_error`'s heuristics key on message prefixes the contract
+/// grammar never produces ("unknown name: ", "function arity mismatch for ",
+/// ...). Without this the JSON and live-LSP forms render the synthetic 0:0
+/// range instead of pointing at the malformed declaration (#2314 review) --
+/// the reader is told a contract is broken and not told where.
+///
+/// Same shape as `header_prefix_throws` above, and for the same reason: ask
+/// the PARSER where it stopped rather than mirroring its grammar. Two earlier
+/// attempts in this file at recovering a position by reading the MESSAGE
+/// drifted from the grammar each time (#2253 rounds 3-4/6); a probe has no
+/// grammar mirror, so there is nothing to drift.
+///
+/// The predicate is monotone in k: once the prefix contains the offending
+/// token the parse stops there and every longer prefix throws the SAME
+/// message, while a shorter prefix runs out first and throws an eof-flavoured
+/// one that does not match. So binary search finds the boundary in O(log n)
+/// probes. Runs on the error path only.
+fn contract_parse_error_offset(tokens: Array[Token], starts: Array[Int], msg: String) -> Int with Exception {
+  let n = Array::length(tokens)
+  // The full-length prefix reproduces `msg` by construction; confirm it anyway
+  // so a violated assumption answers BARE rather than wrong.
+  if n <= 0 || !contract_prefix_throws(tokens, n, msg) {
+    return 0 - 1
+  } else {
+    ()
+  }
+  let mut lo = 0
+  let mut hi = n
+  while hi - lo > 1 {
+    let mid = (lo + hi) / 2
+    if contract_prefix_throws(tokens, mid, msg) {
+      hi = mid
+    } else {
+      lo = mid
+    }
+  }
+  // `hi` is the smallest throwing prefix length, so the offending token is at
+  // index hi - 1.
+  let idx = hi - 1
+  if idx >= 0 && idx < Array::length(starts) {
+    Array::get(starts, idx)
+  } else {
+    0 - 1
+  }
+}
+
 /// The recovering lexer's errors, each located and deduped.
 ///
 /// Shared by the program branch and the contract branch of
@@ -5516,12 +5582,32 @@ fn located_lex_errors(source: String, lex_err_offsets: Array[Int], lex_err_msgs:
   dedupe_diagnostics(located)
 }
 
+/// One located diagnostic for a contract parse failure.
+fn contract_parse_diagnostic(source: String, tokens: Array[Token], starts: Array[Int], msg: String) -> Array[String] with Exception {
+  if diag_already_located(msg) {
+    return [msg]
+  } else {
+    ()
+  }
+  let off = handle {
+    contract_parse_error_offset(tokens, starts, msg)
+  } with { Exception::Throw(_) => 0 - 1 }
+  if off >= 0 {
+    [String::concat(offset_line_col_prefix(source, off), msg)]
+  } else {
+    // Bare rather than wrong: `locate_type_error` will render this at the
+    // synthetic 0:0, which is what an unlocatable diagnostic already does
+    // everywhere else in this lane.
+    [locate_type_error(source, msg)]
+  }
+}
+
 fn collect_all_diagnostics_on(input_path: String, source: String) -> Array[String] with Exception {
   if is_contract_ext(input_path) {
     // A contract LEXES like a program, so it gets the recovering lexer and
     // every lex error, the same as the branch below (#2314 review). Only the
     // GRAMMAR above the tokens differs.
-    let (ctokens, _cstarts, _cends, clex_offs, clex_msgs) = lex_with_offsets_recovering(source)
+    let (ctokens, cstarts, _cends, clex_offs, clex_msgs) = lex_with_offsets_recovering(source)
     if Array::length(clex_msgs) > 0 {
       return located_lex_errors(source, clex_offs, clex_msgs)
     } else {
@@ -5540,7 +5626,7 @@ fn collect_all_diagnostics_on(input_path: String, source: String) -> Array[Strin
     return handle {
       let (_, _, _stmts) = parse_contract_program(ctokens)
       array_empty()
-    } with { Exception::Throw(msg) => [locate_type_error(source, msg)] }
+    } with { Exception::Throw(msg) => contract_parse_diagnostic(source, ctokens, cstarts, msg) }
   } else {
     ()
   }

--- a/lib/@vibe/compiler/runtime/typecheck_fs.vibe
+++ b/lib/@vibe/compiler/runtime/typecheck_fs.vibe
@@ -5477,16 +5477,16 @@ export fn collect_all_diagnostics_for_path(input_path: String, source: String) -
 ///   - `unexpected eof in block` (parser_expr_dispatch).
 ///
 /// The first version tested for `" eof"`, which is too loose (Codex review on
-/// #2315). A contract carrying an unsupported directive named `#eof` throws
-/// `unsupported # directive in a contract file: eof (only #deprecated is
-/// allowed)` -- that contains `" eof"`, so it was classified as end-of-input
-/// and anchored at the contract's LAST token, pointing at unrelated valid
-/// declarations. Neither marker below can be produced by a directive name,
-/// because a name is a single token and cannot contain a space.
-///
-/// Classifying it correctly also fixes where it lands: as a non-eof message it
-/// goes to the prefix search, which is sound for it, and anchors on the `#eof`
-/// directive itself.
+/// #2315): `parse_contract_program` also throws `unsupported # directive in a
+/// contract file: eof (only #deprecated is allowed)`, and that contains
+/// `" eof"` too. MEASURED, that particular message cannot reach here -- this
+/// lane pin-blanks the header first, which erases a `#` directive line before
+/// the parser sees it, so the buffer answers clean where the import lane
+/// reports the directive (a real gap, but a pre-existing one in the blanking,
+/// not in this predicate; filed separately). The marker is still narrowed,
+/// because a predicate that is right only until the blanking changes is not
+/// worth keeping. Neither marker below can come out of a directive name: a
+/// name is a single token and cannot contain a space.
 fn contract_msg_mentions_eof(msg: String) -> Bool {
   unstable_index_of_str(msg, "but got eof") >= 0 || unstable_index_of_str(msg, "unexpected eof") >= 0
 }

--- a/lib/@vibe/compiler/runtime/typecheck_fs.vibe
+++ b/lib/@vibe/compiler/runtime/typecheck_fs.vibe
@@ -5358,7 +5358,7 @@ export fn collect_all_diagnostics_with_unstable(source: String, allow_unstable: 
 /// `extract_require_pins` blanks to spaces and preserves byte length, so the
 /// positions this scan reports stay exact.
 export fn collect_all_diagnostics_with_unstable_for_path(input_path: String, source: String, allow_unstable: Bool) -> Array[String] with Exception {
-  let msgs = collect_all_diagnostics(source)
+  let msgs = collect_all_diagnostics_for_path(input_path, source)
   if allow_unstable {
     msgs
   } else {
@@ -5387,7 +5387,13 @@ export fn collect_all_diagnostics_with_unstable_for_path(input_path: String, sou
   }
 }
 
+/// #2314: no path, so a `.vpkg` buffer is read as statements. Callers that
+/// HAVE a path should use `collect_all_diagnostics_for_path`.
 export fn collect_all_diagnostics(source: String) -> Array[String] with Exception {
+  collect_all_diagnostics_for_path("", source)
+}
+
+export fn collect_all_diagnostics_for_path(input_path: String, source: String) -> Array[String] with Exception {
   // #2227, round 3 of the book-review eval: a leading `require @scope/name
   // x.y.z = #pkg:sha1:` head is a loader directive that every build-lane
   // ingestion blanks before parsing -- but this single-file lane parsed the
@@ -5447,10 +5453,32 @@ export fn collect_all_diagnostics(source: String) -> Array[String] with Exceptio
   } else {
     ()
   }
-  collect_all_diagnostics_on(pin_blanked)
+  collect_all_diagnostics_on(input_path, pin_blanked)
 }
 
-fn collect_all_diagnostics_on(source: String) -> Array[String] with Exception {
+/// #2314, the LSP half of #2280: a `.vpkg` is a list of BODYLESS declarations,
+/// not statement grammar. Reading it with `parse_program_recovering` answered
+/// `expected { but got eof` about `lib/@vibe/random/index.vpkg` and about every
+/// other contract the build consumes -- a diagnostic that asserts something
+/// untrue about the file, which this repo ranks above crashing.
+///
+/// A contract stops at its own grammar. It does NOT go on to `check_program` /
+/// `expand_interp_stmts` / the unused-import walk: those read a program, and a
+/// contract is a declaration surface whose implementations live in sibling
+/// files this lane cannot see. `vibe check` WITHOUT `--single-file` is the
+/// verb that answers the cross-file half (`contract violation: contract
+/// declaration 'x' has no implementation`, #2280) -- reporting a subset here
+/// is honest; inventing the rest from one buffer is not.
+fn collect_all_diagnostics_on(input_path: String, source: String) -> Array[String] with Exception {
+  if is_contract_ext(input_path) {
+    return handle {
+      let (tokens, _starts, _ends) = lex_with_offsets(source)
+      let (_, _, _stmts) = parse_contract_program(tokens)
+      array_empty()
+    } with { Exception::Throw(msg) => [locate_type_error(source, msg)] }
+  } else {
+    ()
+  }
   let (tokens, starts, _ends, lex_err_offsets, lex_err_msgs) = lex_with_offsets_recovering(source)
   if Array::length(lex_err_msgs) > 0 {
     // Report ONLY the lexer errors: the recovered token stream has holes, so

--- a/lib/@vibe/compiler/runtime/typecheck_fs.vibe
+++ b/lib/@vibe/compiler/runtime/typecheck_fs.vibe
@@ -5527,24 +5527,29 @@ fn contract_prefix_throws(tokens: Array[Token], k: Int, msg: String) -> Bool wit
     i = i + 1
   }
   handle {
-    let (_, _, hstmts) = parse_contract_program(head)
-    // Parse AND classify, because both throws reach the caller and both need
-    // anchoring (#2315 review). Probing the parser alone left a classifier
-    // rejection unlocated: the parse succeeds on every prefix, so no prefix
-    // ever matched and the anchor answered -1 -> the synthetic 0:0.
-    //
-    // Monotone for a classifier message for the same reason as a non-eof parse
-    // message: classification is a left-to-right scan with no lookahead, so
-    // the smallest prefix whose statements include the offending one throws
-    // it, and every longer prefix throws it at the same place. A shorter
-    // prefix either does not produce that statement at all (classify succeeds)
-    // or fails to parse (a different message).
-    let (_r, _t) = classify_contract_stmts(hstmts)
+    let (_, _, _hstmts) = parse_contract_program(head)
     false
   } with { Exception::Throw(m) => m == msg }
 }
 
-/// Byte offset of the token the contract parser stopped at, or -1.
+/// Byte offset of the token the contract PARSER stopped at, or -1.
+///
+/// Parser only. A round of this review extended the probe to run the
+/// classifier too, so a `classify_contract_stmts` rejection would anchor
+/// instead of rendering at 0:0 -- and that predicate is NOT monotone, which is
+/// the third time in this review I claimed monotonicity without testing the
+/// shape that breaks it. With a forbidden statement followed by a longer valid
+/// declaration it reads true (classify throws), then FALSE for prefixes ending
+/// partway through the next declaration (the parse throws first, a different
+/// message), then true again once that declaration completes. Binary search
+/// over true/false/true can discard the first match and anchor the diagnostic
+/// on later VALID code.
+///
+/// So a classifier rejection is deliberately left unlocated. That is the
+/// existing behavior for every diagnostic this lane cannot place, and it is
+/// the rule this function already states for its own failure: degraded, never
+/// wrong. Anchoring it needs the rejected statement's own offset rather than a
+/// search -- tracked with the rest of the contract-validation family in #2317.
 ///
 /// `parse_contract_program` throws an UNLOCATED message, and
 /// `locate_type_error`'s heuristics key on message prefixes the contract

--- a/lib/@vibe/compiler/runtime/typecheck_fs.vibe
+++ b/lib/@vibe/compiler/runtime/typecheck_fs.vibe
@@ -5469,12 +5469,26 @@ export fn collect_all_diagnostics_for_path(input_path: String, source: String) -
 /// verb that answers the cross-file half (`contract violation: contract
 /// declaration 'x' has no implementation`, #2280) -- reporting a subset here
 /// is honest; inventing the rest from one buffer is not.
-/// Does `msg` report hitting end of input? `tk_name(TEof)` is "eof", and every
-/// parser message that names the offending token renders it through that, so
-/// the marker is `" eof"` -- with the leading space, so a declaration named
-/// e.g. `read_eof` in some other message cannot be mistaken for one.
+/// Does `msg` report hitting end of input?
+///
+/// The two spellings the parsers actually produce, and only those:
+///
+///   - `expected <what> but got eof` (parser_base, via `tk_name(TEof)`);
+///   - `unexpected eof in block` (parser_expr_dispatch).
+///
+/// The first version tested for `" eof"`, which is too loose (Codex review on
+/// #2315). A contract carrying an unsupported directive named `#eof` throws
+/// `unsupported # directive in a contract file: eof (only #deprecated is
+/// allowed)` -- that contains `" eof"`, so it was classified as end-of-input
+/// and anchored at the contract's LAST token, pointing at unrelated valid
+/// declarations. Neither marker below can be produced by a directive name,
+/// because a name is a single token and cannot contain a space.
+///
+/// Classifying it correctly also fixes where it lands: as a non-eof message it
+/// goes to the prefix search, which is sound for it, and anchors on the `#eof`
+/// directive itself.
 fn contract_msg_mentions_eof(msg: String) -> Bool {
-  unstable_index_of_str(msg, " eof") >= 0
+  unstable_index_of_str(msg, "but got eof") >= 0 || unstable_index_of_str(msg, "unexpected eof") >= 0
 }
 
 /// Byte offset of the last token that is not `TEof`, or -1.

--- a/lib/@vibe/compiler/runtime/typecheck_fs.vibe
+++ b/lib/@vibe/compiler/runtime/typecheck_fs.vibe
@@ -5488,7 +5488,7 @@ export fn collect_all_diagnostics_for_path(input_path: String, source: String) -
 /// worth keeping. Neither marker below can come out of a directive name: a
 /// name is a single token and cannot contain a space.
 fn contract_msg_mentions_eof(msg: String) -> Bool {
-  unstable_index_of_str(msg, "but got eof") >= 0 || unstable_index_of_str(msg, "unexpected eof") >= 0
+  String::index_of(msg, "but got eof") >= 0 || String::index_of(msg, "unexpected eof") >= 0
 }
 
 /// Byte offset of the last token that is not `TEof`, or -1.
@@ -5527,7 +5527,19 @@ fn contract_prefix_throws(tokens: Array[Token], k: Int, msg: String) -> Bool wit
     i = i + 1
   }
   handle {
-    let (_, _, _stmts) = parse_contract_program(head)
+    let (_, _, hstmts) = parse_contract_program(head)
+    // Parse AND classify, because both throws reach the caller and both need
+    // anchoring (#2315 review). Probing the parser alone left a classifier
+    // rejection unlocated: the parse succeeds on every prefix, so no prefix
+    // ever matched and the anchor answered -1 -> the synthetic 0:0.
+    //
+    // Monotone for a classifier message for the same reason as a non-eof parse
+    // message: classification is a left-to-right scan with no lookahead, so
+    // the smallest prefix whose statements include the offending one throws
+    // it, and every longer prefix throws it at the same place. A shorter
+    // prefix either does not produce that statement at all (classify succeeds)
+    // or fails to parse (a different message).
+    let (_r, _t) = classify_contract_stmts(hstmts)
     false
   } with { Exception::Throw(m) => m == msg }
 }

--- a/lib/@vibe/compiler/runtime/typecheck_fs.vibe
+++ b/lib/@vibe/compiler/runtime/typecheck_fs.vibe
@@ -5469,6 +5469,38 @@ export fn collect_all_diagnostics_for_path(input_path: String, source: String) -
 /// verb that answers the cross-file half (`contract violation: contract
 /// declaration 'x' has no implementation`, #2280) -- reporting a subset here
 /// is honest; inventing the rest from one buffer is not.
+/// Does `msg` report hitting end of input? `tk_name(TEof)` is "eof", and every
+/// parser message that names the offending token renders it through that, so
+/// the marker is `" eof"` -- with the leading space, so a declaration named
+/// e.g. `read_eof` in some other message cannot be mistaken for one.
+fn contract_msg_mentions_eof(msg: String) -> Bool {
+  unstable_index_of_str(msg, " eof") >= 0
+}
+
+/// Byte offset of the last token that is not `TEof`, or -1.
+///
+/// Where an "expected ... but got eof" belongs: the parser ran out of input, so
+/// the actionable position is the end of what the author actually wrote, not
+/// the whitespace past it.
+fn last_real_token_offset(tokens: Array[Token], starts: Array[Int]) -> Int {
+  let mut i = Array::length(tokens) - 1
+  let lim = Array::length(starts)
+  let mut found = 0 - 1
+  while i >= 0 {
+    let is_eof = match Array::get(tokens, i) {
+      TEof => true,
+      _ => false
+    }
+    if is_eof || i >= lim {
+      i = i - 1
+    } else {
+      found = Array::get(starts, i)
+      i = 0 - 1
+    }
+  }
+  found
+}
+
 /// Does the first `k` tokens throw exactly `msg` from the contract parser?
 ///
 /// `peek` answers `TEof` past the end of the array, so a plain truncation is a
@@ -5501,16 +5533,45 @@ fn contract_prefix_throws(tokens: Array[Token], k: Int, msg: String) -> Bool wit
 /// drifted from the grammar each time (#2253 rounds 3-4/6); a probe has no
 /// grammar mirror, so there is nothing to drift.
 ///
-/// The predicate is monotone in k: once the prefix contains the offending
-/// token the parse stops there and every longer prefix throws the SAME
-/// message, while a shorter prefix runs out first and throws an eof-flavoured
-/// one that does not match. So binary search finds the boundary in O(log n)
-/// probes. Runs on the error path only.
+/// The search is used ONLY for a message that does not mention `eof`, because
+/// only there is the predicate monotone in k: the full parse stops at some
+/// token j with this message, every prefix longer than j stops at the same
+/// place with the same message, and every shorter prefix runs out of input
+/// first and throws an eof-flavoured message that does not match. Parsing is
+/// deterministic and left to right, so no shorter prefix can produce the same
+/// NON-eof message at an earlier position -- if it could, the full parse would
+/// have stopped there too. The smallest matching prefix is therefore exactly
+/// j + 1.
+///
+/// For an eof message that reasoning FAILS, and the first version of this
+/// claimed monotonicity without testing it (Codex review on #2315). Given
+///
+///     fn a(x: Int) -> Int
+///     fn b(x: Int) ->
+///
+/// the full stream throws `expected type but got eof` -- and so does the
+/// prefix that stops right after the FIRST `->`. A shorter prefix matches, so
+/// the search walks `hi` backwards and anchors on line 1 instead of line 2:
+/// a diagnostic pointing at correct code, which is the worst way to be wrong.
+///
+/// An eof message means the parser ran out of input, so its position is the
+/// END of the token stream by definition. Anchor it at the last real token --
+/// the declaration that ran out -- and no search is needed or sound.
 fn contract_parse_error_offset(tokens: Array[Token], starts: Array[Int], msg: String) -> Int with Exception {
   let n = Array::length(tokens)
+  if n <= 0 {
+    return 0 - 1
+  } else {
+    ()
+  }
+  if contract_msg_mentions_eof(msg) {
+    return last_real_token_offset(tokens, starts)
+  } else {
+    ()
+  }
   // The full-length prefix reproduces `msg` by construction; confirm it anyway
   // so a violated assumption answers BARE rather than wrong.
-  if n <= 0 || !contract_prefix_throws(tokens, n, msg) {
+  if !contract_prefix_throws(tokens, n, msg) {
     return 0 - 1
   } else {
     ()

--- a/lib/@vibe/compiler/runtime/typecheck_fs.vibe
+++ b/lib/@vibe/compiler/runtime/typecheck_fs.vibe
@@ -5469,11 +5469,76 @@ export fn collect_all_diagnostics_for_path(input_path: String, source: String) -
 /// verb that answers the cross-file half (`contract violation: contract
 /// declaration 'x' has no implementation`, #2280) -- reporting a subset here
 /// is honest; inventing the rest from one buffer is not.
+/// The recovering lexer's errors, each located and deduped.
+///
+/// Shared by the program branch and the contract branch of
+/// `collect_all_diagnostics_on` (#2314 review): a contract lexes with exactly
+/// the same rules as a program, so a second copy of this would be a second
+/// answer to one question.
+///
+/// #997 review (Codex): a handful of lexer throw sites (the `\(expr)`
+/// interpolation-removal message, and #997's own scientific-notation /
+/// incomplete-exponent messages) embed their OWN precise `line L:C: ` prefix
+/// directly in the message, because `lex_err_offsets` always records the START
+/// offset of the enclosing `lex_one_token` call -- wrong for a throw raised
+/// partway through a multi-char token (at the `e`/`E`, not the token's first
+/// digit). Blindly prepending the generic outer `loc` on top of an
+/// already-self-located message produced a doubled/conflicting location
+/// (`line 1:9: line 1:18: ...`, confirmed empirically via `vibe diagnostics`
+/// on `123456789e10`). Skip the outer prefix for messages that already start
+/// with "line " -- they're self-located and the outer offset would only be
+/// redundant or wrong.
+///
+/// This also collapses a separate pre-existing duplication: a
+/// non-quote-delimited lex error (anything but a broken string/char literal)
+/// resumes ONE character past the failure and retries, so a multi-digit
+/// scientific-notation literal re-throws the SAME underlying error once per
+/// remaining digit (9 identical reports for `123456789e10`) -- previously each
+/// got a DIFFERENT (wrong) outer offset, defeating the exact-string dedup
+/// below. With the outer prefix suppressed, all 9 become byte-identical and
+/// collapse to the single correctly-located report.
+fn located_lex_errors(source: String, lex_err_offsets: Array[Int], lex_err_msgs: Array[String]) -> Array[String] with Exception {
+  let located = array_empty()
+  let mut i = 0
+  while i < Array::length(lex_err_msgs) {
+    let msg = Array::get(lex_err_msgs, i)
+    let entry = if String::starts_with(msg, "line ") {
+      msg
+    } else {
+      let off = Array::get(lex_err_offsets, i)
+      let (line, col) = offset_to_line_col(source, off)
+      let loc = String::concat("line ", String::concat(__to_string(line), String::concat(":", String::concat(__to_string(col), ": "))))
+      String::concat(loc, msg)
+    }
+    Array::push(located, entry)
+    i = i + 1
+  }
+  dedupe_diagnostics(located)
+}
+
 fn collect_all_diagnostics_on(input_path: String, source: String) -> Array[String] with Exception {
   if is_contract_ext(input_path) {
+    // A contract LEXES like a program, so it gets the recovering lexer and
+    // every lex error, the same as the branch below (#2314 review). Only the
+    // GRAMMAR above the tokens differs.
+    let (ctokens, _cstarts, _cends, clex_offs, clex_msgs) = lex_with_offsets_recovering(source)
+    if Array::length(clex_msgs) > 0 {
+      return located_lex_errors(source, clex_offs, clex_msgs)
+    } else {
+      ()
+    }
+    // `parse_contract_program` throws on the first error -- there is no
+    // recovering contract parser, so a contract with two broken declarations
+    // reports one. That is NOT a loss from this change: the authoritative
+    // import lane (`vibe check`, the verb #2280 fixed) reports one too --
+    // measured, `expected type but got fn` for a contract with two of them,
+    // and unlocated at that. What the recovering STATEMENT parser used to
+    // report here was several errors that were each false about the file,
+    // which is the bug this section exists to remove. Multi-error recovery
+    // for contract grammar is a real improvement, and it belongs in both
+    // lanes at once rather than only in this one.
     return handle {
-      let (tokens, _starts, _ends) = lex_with_offsets(source)
-      let (_, _, _stmts) = parse_contract_program(tokens)
+      let (_, _, _stmts) = parse_contract_program(ctokens)
       array_empty()
     } with { Exception::Throw(msg) => [locate_type_error(source, msg)] }
   } else {
@@ -5506,22 +5571,7 @@ fn collect_all_diagnostics_on(input_path: String, source: String) -> Array[Strin
     // offset, defeating `dedupe_diagnostics`'s exact-string dedup below.
     // With the outer prefix suppressed, all 9 become byte-identical and
     // collapse to the single correctly-located report.
-    let located = array_empty()
-    let mut i = 0
-    while i < Array::length(lex_err_msgs) {
-      let msg = Array::get(lex_err_msgs, i)
-      let entry = if String::starts_with(msg, "line ") {
-        msg
-      } else {
-        let off = Array::get(lex_err_offsets, i)
-        let (line, col) = offset_to_line_col(source, off)
-        let loc = String::concat("line ", String::concat(__to_string(line), String::concat(":", String::concat(__to_string(col), ": "))))
-        String::concat(loc, msg)
-      }
-      Array::push(located, entry)
-      i = i + 1
-    }
-    dedupe_diagnostics(located)
+    located_lex_errors(source, lex_err_offsets, lex_err_msgs)
   } else {
     let (stmts, parse_diags) = parse_program_recovering(tokens, starts, source)
     if Array::length(parse_diags) > 0 {

--- a/lib/@vibe/lsp/index.vpkg
+++ b/lib/@vibe/lsp/index.vpkg
@@ -37,3 +37,4 @@ fn lsp_diagnostics_safe_with_unstable(source: String, allow_unstable: Bool) -> J
 fn lsp_diagnostics_safe_for_path(input_path: String, source: String, allow_unstable: Bool) -> Json
 fn lsp_diagnostics_json_string(source: String) -> String
 fn lsp_diagnostics_json_string_with(source: String, extra: Array[String]) -> String
+fn lsp_diagnostics_json_string_with_for_path(input_path: String, source: String, extra: Array[String]) -> String

--- a/lib/@vibe/lsp/index.vpkg
+++ b/lib/@vibe/lsp/index.vpkg
@@ -38,3 +38,4 @@ fn lsp_diagnostics_safe_for_path(input_path: String, source: String, allow_unsta
 fn lsp_diagnostics_json_string(source: String) -> String
 fn lsp_diagnostics_json_string_with(source: String, extra: Array[String]) -> String
 fn lsp_diagnostics_json_string_with_for_path(input_path: String, source: String, extra: Array[String]) -> String
+fn lsp_diagnostics_json_of_messages(source: String, msgs: Array[String]) -> String

--- a/lib/@vibe/lsp/lsp_server.vibe
+++ b/lib/@vibe/lsp/lsp_server.vibe
@@ -71,7 +71,13 @@
 //# Imports
 
 import @vibe/compiler/runtime {
-  binding_occurrences, collect_all_diagnostics, collect_all_diagnostics_with_unstable_for_path, doc_at_source, symbol_spans, type_at_source
+  binding_occurrences,
+  collect_all_diagnostics,
+  collect_all_diagnostics_for_path,
+  collect_all_diagnostics_with_unstable_for_path,
+  doc_at_source,
+  symbol_spans,
+  type_at_source
 }
 
 import @vibe/parser {
@@ -833,8 +839,14 @@ export fn lsp_diagnostics_json_string(source: String) -> String {
 /// internal failure in single-file analysis is not a reason to drop a verdict
 /// the caller already computed.
 export fn lsp_diagnostics_json_string_with(source: String, extra: Array[String]) -> String {
+  lsp_diagnostics_json_string_with_for_path("", source, extra)
+}
+
+/// #2314: with the path, a `.vpkg` buffer is read with the contract grammar
+/// instead of answering `expected { but got eof` about a valid contract.
+export fn lsp_diagnostics_json_string_with_for_path(input_path: String, source: String, extra: Array[String]) -> String {
   let msgs = handle {
-    collect_all_diagnostics(source)
+    collect_all_diagnostics_for_path(input_path, source)
   } with { Exception::Throw(_) => array_empty() }
   let mut i = 0
   while i < Array::length(extra) {

--- a/lib/@vibe/lsp/lsp_server.vibe
+++ b/lib/@vibe/lsp/lsp_server.vibe
@@ -853,6 +853,17 @@ export fn lsp_diagnostics_json_string_with_for_path(input_path: String, source: 
     Array::push(msgs, Array::get(extra, i))
     i = i + 1
   }
+  lsp_diagnostics_json_of_messages(source, msgs)
+}
+
+/// Render an ALREADY-COLLECTED message list in the LSP Diagnostic shape.
+///
+/// #2314 review: the `vibe diagnostics` adapter has to render exactly the list
+/// `collect_all_diagnostics_with_unstable_for_path` returns. Without this it
+/// had to collect the base set here and the ADR-0068 set separately, and the
+/// two drifted -- the separate scan read the RAW buffer, so a `.vpkg` header it
+/// could not parse dropped the opt-in error entirely.
+export fn lsp_diagnostics_json_of_messages(source: String, msgs: Array[String]) -> String {
   Json::stringify(handle {
     JArr(for msg in msgs {
       lsp_parse_diag_line(source, msg)

--- a/tests/gates/late/run.sh
+++ b/tests/gates/late/run.sh
@@ -7822,3 +7822,167 @@ if ! printf '%s\n' "$own_report" | grep -qF 'Child::own'; then
 fi
 rm -rf "$tdlabdir"
 echo "[compiler-gate] trait-method diagnostics name the DECLARING trait, inherited or own; a hand-written dict struct keeps its own label ok (#2286)"
+
+# 117/117. A `.vpkg` buffer is read with the contract grammar on the
+# single-buffer lanes too (#2314, the LSP half of #2280).
+#
+# #2280 taught `vibe check` (no `--single-file`) to read a contract as a
+# contract. The single-buffer lanes never got it: `collect_all_diagnostics`
+# took no path, so `vibe lsp` and the `vibe diagnostics` buffer lane answered
+# `expected { but got fn` about a valid contract -- a diagnostic that asserts
+# something untrue about a file the build consumes on every run.
+echo "[compiler-gate] 117/117 a .vpkg buffer is read as a contract on the single-buffer lanes (#2314)"
+vpbufdir="_build/_gate_vpkg_buffer"
+rm -rf "$vpbufdir"; mkdir -p "$vpbufdir"
+# A real tree contract, so a failure cannot be blamed on a synthetic fixture.
+# `lib/@vibe/random/index.vpkg` is the file #2280 named.
+real_contract="lib/@vibe/random/index.vpkg"
+if [ ! -f "$ROOT_DIR/$real_contract" ]; then
+  echo "[compiler-gate] FAIL: $real_contract is gone -- repoint this section (#2314)" >&2
+  exit 1
+fi
+# The `vibe diagnostics` buffer lane writes its report to the OUTPUT file and
+# exits 0 ("a report, not a failure"), so read that -- not just `.diag`/stdout,
+# which are empty here and would make this assertion unable to fail.
+rm -f "$vpbufdir/sf.out" "$vpbufdir/sf.out.diag"
+VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_DIAGNOSTICS=1 VIBE_IMPORT_ABI=raw \
+  bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
+  "$real_contract" "$vpbufdir/sf.out" main >"$vpbufdir/sf.stdout" 2>&1 || true
+sf_report="$(cat "$vpbufdir/sf.out" "$vpbufdir/sf.out.diag" "$vpbufdir/sf.stdout" 2>/dev/null || true)"
+if printf '%s\n' "$sf_report" | grep -qF 'expected { but got'; then
+  echo "[compiler-gate] FAIL: the vibe diagnostics buffer lane still reads $real_contract as statement grammar (#2314)" >&2
+  printf '%s\n' "$sf_report" >&2
+  exit 1
+fi
+# The live LSP is the surface the issue is filed against. Drive it over framed
+# messages, the way section 115 does.
+python3 - "$vpbufdir/lsp.bin" <<'VPBUFEOF'
+import json, sys
+
+def frame(obj):
+    b = json.dumps(obj).encode("utf-8")
+    return f"Content-Length: {len(b)}\r\n\r\n".encode("ascii") + b
+
+src = (
+    "name = @gate/vpkgbuffer\n"
+    "version = 0.0.1\n"
+    "description =\n"
+    "  #|gate-only package for #2314\n"
+    "deps = {}\n"
+    "\n"
+    "generated_hash =\n"
+    "\n"
+    "fn implemented(x: Int) -> Int\n"
+)
+msgs = [
+    frame({"jsonrpc": "2.0", "id": 1, "method": "initialize", "params": {}}),
+    frame({"jsonrpc": "2.0", "method": "initialized", "params": {}}),
+    frame({"jsonrpc": "2.0", "method": "textDocument/didOpen", "params": {
+        "textDocument": {"uri": "file:///gate/index.vpkg", "languageId": "vibe", "version": 1, "text": src}
+    }}),
+    frame({"jsonrpc": "2.0", "id": 3, "method": "shutdown"}),
+    frame({"jsonrpc": "2.0", "method": "exit"}),
+]
+with open(sys.argv[1], "wb") as f:
+    f.write(b"".join(msgs))
+VPBUFEOF
+env -u VIBE_UNSTABLE VIBE_STDIN_BYTES="$(cat "$vpbufdir/lsp.bin")" \
+  VIBE_LSP=1 VIBE_IMPORT_ABI=raw \
+  bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
+  > "$vpbufdir/lsp.out" 2>/dev/null || true
+if ! grep -q 'publishDiagnostics' "$vpbufdir/lsp.out" 2>/dev/null; then
+  echo "[compiler-gate] FAIL: vibe lsp published nothing for a .vpkg buffer (#2314)" >&2
+  exit 1
+fi
+if grep -q 'expected { but got' "$vpbufdir/lsp.out" 2>/dev/null; then
+  echo "[compiler-gate] FAIL: vibe lsp still reads a .vpkg buffer as statement grammar (#2314)" >&2
+  grep -o '"diagnostics":\[[^]]*\]' "$vpbufdir/lsp.out" >&2 || true
+  exit 1
+fi
+if ! grep -q '"diagnostics":\[\]' "$vpbufdir/lsp.out" 2>/dev/null; then
+  echo "[compiler-gate] FAIL: a well-formed .vpkg buffer is not clean on the LSP (#2314)" >&2
+  grep -o '"diagnostics":\[[^]]*\]' "$vpbufdir/lsp.out" >&2 || true
+  exit 1
+fi
+# It must still be able to REJECT. Exit-clean alone would pass on a fix that
+# simply suppressed every diagnostic for contracts -- which is the cheap wrong
+# answer here, and indistinguishable from the right one without this half.
+python3 - "$vpbufdir/bad.bin" <<'VPBUFEOF'
+import json, sys
+
+def frame(obj):
+    b = json.dumps(obj).encode("utf-8")
+    return f"Content-Length: {len(b)}\r\n\r\n".encode("ascii") + b
+
+# Broken in the DECLARATION section, not the header: a bodyless `fn` with no
+# return type. The header half is already covered by the pin-head scan.
+src = (
+    "name = @gate/vpkgbuffer\n"
+    "version = 0.0.1\n"
+    "description =\n"
+    "  #|gate-only package for #2314\n"
+    "deps = {}\n"
+    "\n"
+    "generated_hash =\n"
+    "\n"
+    "fn implemented(x: Int) ->\n"
+)
+msgs = [
+    frame({"jsonrpc": "2.0", "id": 1, "method": "initialize", "params": {}}),
+    frame({"jsonrpc": "2.0", "method": "initialized", "params": {}}),
+    frame({"jsonrpc": "2.0", "method": "textDocument/didOpen", "params": {
+        "textDocument": {"uri": "file:///gate/index.vpkg", "languageId": "vibe", "version": 1, "text": src}
+    }}),
+    frame({"jsonrpc": "2.0", "id": 3, "method": "shutdown"}),
+    frame({"jsonrpc": "2.0", "method": "exit"}),
+]
+with open(sys.argv[1], "wb") as f:
+    f.write(b"".join(msgs))
+VPBUFEOF
+env -u VIBE_UNSTABLE VIBE_STDIN_BYTES="$(cat "$vpbufdir/bad.bin")" \
+  VIBE_LSP=1 VIBE_IMPORT_ABI=raw \
+  bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
+  > "$vpbufdir/bad.out" 2>/dev/null || true
+if grep -q '"diagnostics":\[\]' "$vpbufdir/bad.out" 2>/dev/null; then
+  echo "[compiler-gate] FAIL: a malformed .vpkg declaration published as CLEAN -- the contract branch reports nothing at all (#2314)" >&2
+  grep -o '"diagnostics":\[[^]]*\]' "$vpbufdir/bad.out" >&2 || true
+  exit 1
+fi
+if ! grep -q '"severity":1' "$vpbufdir/bad.out" 2>/dev/null; then
+  echo "[compiler-gate] FAIL: the malformed .vpkg declaration is not published as an error (#2314)" >&2
+  grep -o '"diagnostics":\[[^]]*\]' "$vpbufdir/bad.out" >&2 || true
+  exit 1
+fi
+# ...and an ordinary `.vibe` buffer is untouched: it still type-checks, so a
+# real type error must survive. Routing every buffer through the contract
+# branch would pass everything above and silently stop checking programs.
+python3 - "$vpbufdir/prog.bin" <<'VPBUFEOF'
+import json, sys
+
+def frame(obj):
+    b = json.dumps(obj).encode("utf-8")
+    return f"Content-Length: {len(b)}\r\n\r\n".encode("ascii") + b
+
+src = 'fn main() -> Int {\n  let a: Int = "not an int"\n  0\n}\n'
+msgs = [
+    frame({"jsonrpc": "2.0", "id": 1, "method": "initialize", "params": {}}),
+    frame({"jsonrpc": "2.0", "method": "initialized", "params": {}}),
+    frame({"jsonrpc": "2.0", "method": "textDocument/didOpen", "params": {
+        "textDocument": {"uri": "file:///gate/prog.vibe", "languageId": "vibe", "version": 1, "text": src}
+    }}),
+    frame({"jsonrpc": "2.0", "id": 3, "method": "shutdown"}),
+    frame({"jsonrpc": "2.0", "method": "exit"}),
+]
+with open(sys.argv[1], "wb") as f:
+    f.write(b"".join(msgs))
+VPBUFEOF
+env -u VIBE_UNSTABLE VIBE_STDIN_BYTES="$(cat "$vpbufdir/prog.bin")" \
+  VIBE_LSP=1 VIBE_IMPORT_ABI=raw \
+  bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
+  > "$vpbufdir/prog.out" 2>/dev/null || true
+if grep -q '"diagnostics":\[\]' "$vpbufdir/prog.out" 2>/dev/null; then
+  echo "[compiler-gate] FAIL: an ordinary .vibe buffer with a type error published as CLEAN -- the contract branch is catching everything (#2314)" >&2
+  exit 1
+fi
+rm -rf "$vpbufdir"
+echo "[compiler-gate] a .vpkg buffer reads as a contract, still rejects a malformed declaration, and .vibe buffers still type-check ok (#2314)"

--- a/tests/gates/late/run.sh
+++ b/tests/gates/late/run.sh
@@ -8027,6 +8027,65 @@ if ! grep -q '"start":{"line":9' "$vpbufdir/eof.out" 2>/dev/null; then
   grep -o '"diagnostics":\[[^]]*\]' "$vpbufdir/eof.out" >&2 || true
   exit 1
 fi
+# ...and an error that merely CONTAINS the word eof is not an end-of-input
+# error. `#eof` is an unsupported directive, and the parser says so:
+# `unsupported # directive in a contract file: eof (only #deprecated is
+# allowed)`. A marker of `" eof"` matched that, classified it as end-of-input,
+# and anchored it at the contract's LAST token -- on the valid declaration two
+# lines below (Codex review on #2315). The declaration after it is well-formed
+# on purpose, so a mislocation has somewhere wrong to land.
+python3 - "$vpbufdir/directive.bin" <<'VPBUFEOF'
+import json, sys
+
+def frame(obj):
+    b = json.dumps(obj).encode("utf-8")
+    return f"Content-Length: {len(b)}\r\n\r\n".encode("ascii") + b
+
+src = (
+    "name = @gate/vpkgbuffer\n"
+    "version = 0.0.1\n"
+    "description =\n"
+    "  #|gate-only package for #2314\n"
+    "deps = {}\n"
+    "\n"
+    "generated_hash =\n"
+    "\n"
+    "#eof\n"
+    "fn a(x: Int) -> Int\n"
+    "fn b(y: Int) -> Int\n"
+)
+msgs = [
+    frame({"jsonrpc": "2.0", "id": 1, "method": "initialize", "params": {}}),
+    frame({"jsonrpc": "2.0", "method": "initialized", "params": {}}),
+    frame({"jsonrpc": "2.0", "method": "textDocument/didOpen", "params": {
+        "textDocument": {"uri": "file:///gate/index.vpkg", "languageId": "vibe", "version": 1, "text": src}
+    }}),
+    frame({"jsonrpc": "2.0", "id": 3, "method": "shutdown"}),
+    frame({"jsonrpc": "2.0", "method": "exit"}),
+]
+with open(sys.argv[1], "wb") as f:
+    f.write(b"".join(msgs))
+VPBUFEOF
+env -u VIBE_UNSTABLE VIBE_STDIN_BYTES="$(cat "$vpbufdir/directive.bin")" \
+  VIBE_LSP=1 VIBE_IMPORT_ABI=raw \
+  bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
+  > "$vpbufdir/directive.out" 2>/dev/null || true
+if ! grep -q '"severity":1' "$vpbufdir/directive.out" 2>/dev/null; then
+  echo "[compiler-gate] FAIL: the unsupported #eof directive published no error (#2314)" >&2
+  grep -o '"diagnostics":\[[^]]*\]' "$vpbufdir/directive.out" >&2 || true
+  exit 1
+fi
+# Line 8 (0-based) is `#eof`; lines 9 and 10 are the well-formed declarations.
+if grep -qE '"start":\{"line":(9|10)' "$vpbufdir/directive.out" 2>/dev/null; then
+  echo "[compiler-gate] FAIL: the #eof directive error is anchored on a well-formed declaration -- it was misclassified as end-of-input (#2314)" >&2
+  grep -o '"diagnostics":\[[^]]*\]' "$vpbufdir/directive.out" >&2 || true
+  exit 1
+fi
+if ! grep -q '"start":{"line":8' "$vpbufdir/directive.out" 2>/dev/null; then
+  echo "[compiler-gate] FAIL: the #eof directive error is not anchored on the directive (expected line 8, 0-based) (#2314)" >&2
+  grep -o '"diagnostics":\[[^]]*\]' "$vpbufdir/directive.out" >&2 || true
+  exit 1
+fi
 # ...and reading a contract as a contract must not COST the ADR-0068 opt-in.
 # This is the trap the rest of this section sets up: the `vibe diagnostics`
 # buffer lane used to compute the unstable set with a SECOND scan over the RAW

--- a/tests/gates/late/run.sh
+++ b/tests/gates/late/run.sh
@@ -7953,6 +7953,22 @@ if ! grep -q '"severity":1' "$vpbufdir/bad.out" 2>/dev/null; then
   grep -o '"diagnostics":\[[^]]*\]' "$vpbufdir/bad.out" >&2 || true
   exit 1
 fi
+# ...and it must POINT AT the declaration. `parse_contract_program` throws an
+# unlocated message, and `locate_type_error`'s heuristics key on message
+# prefixes the contract grammar never produces -- so without an anchor the
+# editor gets the synthetic 0:0 range and the reader is told a contract is
+# broken without being told where (#2314 review). The malformed `fn` is the
+# LAST line of the probe, so a 0:0 answer and a correct one are far apart.
+if grep -q '"start":{"line":0,"character":0}' "$vpbufdir/bad.out" 2>/dev/null; then
+  echo "[compiler-gate] FAIL: the malformed .vpkg declaration is published at the synthetic 0:0 range, not at the declaration (#2314)" >&2
+  grep -o '"diagnostics":\[[^]]*\]' "$vpbufdir/bad.out" >&2 || true
+  exit 1
+fi
+if ! grep -q '"start":{"line":8' "$vpbufdir/bad.out" 2>/dev/null; then
+  echo "[compiler-gate] FAIL: the malformed .vpkg declaration is not anchored on its own line (expected line 8, 0-based) (#2314)" >&2
+  grep -o '"diagnostics":\[[^]]*\]' "$vpbufdir/bad.out" >&2 || true
+  exit 1
+fi
 # ...and reading a contract as a contract must not COST the ADR-0068 opt-in.
 # This is the trap the rest of this section sets up: the `vibe diagnostics`
 # buffer lane used to compute the unstable set with a SECOND scan over the RAW

--- a/tests/gates/late/run.sh
+++ b/tests/gates/late/run.sh
@@ -7953,6 +7953,58 @@ if ! grep -q '"severity":1' "$vpbufdir/bad.out" 2>/dev/null; then
   grep -o '"diagnostics":\[[^]]*\]' "$vpbufdir/bad.out" >&2 || true
   exit 1
 fi
+# ...and reading a contract as a contract must not COST the ADR-0068 opt-in.
+# This is the trap the rest of this section sets up: the `vibe diagnostics`
+# buffer lane used to compute the unstable set with a SECOND scan over the RAW
+# buffer, which could not parse a `.vpkg` header and so returned nothing. That
+# was invisible while the base set was answering `expected { but got eof` about
+# the same file -- removing the false error would have left a contract that
+# imports `@vibe/concurrent` reporting NOTHING AT ALL, which is strictly worse
+# than the wrong parse error this section removes (#2314 review). Measured on
+# the pre-fix compiler: the LSP reported the opt-in for this contract and this
+# lane did not.
+cat > "$vpbufdir/unstable.vpkg" <<'VPBUFEOF'
+name = @gate/unstablecontract
+version = 0.0.1
+description =
+  #|gate-only package for #2314
+deps = {}
+
+generated_hash =
+
+import @vibe/concurrent { TaskGroup }
+
+fn implemented(x: Int) -> Int
+VPBUFEOF
+for form in text json; do
+  rm -f "$vpbufdir/u.$form.out"
+  if [ "$form" = json ]; then json_env=1; else json_env=0; fi
+  env -u VIBE_UNSTABLE VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_DIAGNOSTICS=1 \
+    VIBE_DIAGNOSTICS_JSON="$json_env" VIBE_IMPORT_ABI=raw \
+    bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
+    "$vpbufdir/unstable.vpkg" "$vpbufdir/u.$form.out" main >/dev/null 2>&1 || true
+  if ! grep -q 'VIBE_UNSTABLE=1' "$vpbufdir/u.$form.out" 2>/dev/null; then
+    echo "[compiler-gate] FAIL: the $form diagnostics form dropped the ADR-0068 opt-in for a .vpkg buffer (#2314)" >&2
+    cat "$vpbufdir/u.$form.out" >&2 || true
+    exit 1
+  fi
+  if grep -q 'expected { but got' "$vpbufdir/u.$form.out" 2>/dev/null; then
+    echo "[compiler-gate] FAIL: the $form diagnostics form still reads a .vpkg as statement grammar (#2314)" >&2
+    cat "$vpbufdir/u.$form.out" >&2 || true
+    exit 1
+  fi
+done
+# ...and the grant still suppresses it, or the assertion above would pass on a
+# lane that appends the diagnostic unconditionally.
+rm -f "$vpbufdir/u.granted.out"
+VIBE_UNSTABLE=1 VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_DIAGNOSTICS=1 VIBE_IMPORT_ABI=raw \
+  bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
+  "$vpbufdir/unstable.vpkg" "$vpbufdir/u.granted.out" main >/dev/null 2>&1 || true
+if grep -q 'VIBE_UNSTABLE=1' "$vpbufdir/u.granted.out" 2>/dev/null; then
+  echo "[compiler-gate] FAIL: VIBE_UNSTABLE=1 did not suppress the opt-in on the .vpkg buffer lane (#2314)" >&2
+  cat "$vpbufdir/u.granted.out" >&2 || true
+  exit 1
+fi
 # ...and a contract lexes like a program: EVERY lex error, not just the first.
 # The contract branch reaches for `parse_contract_program`, which throws, and
 # the first version reached for the throwing lexer to match it. But a contract

--- a/tests/gates/late/run.sh
+++ b/tests/gates/late/run.sh
@@ -7969,6 +7969,64 @@ if ! grep -q '"start":{"line":8' "$vpbufdir/bad.out" 2>/dev/null; then
   grep -o '"diagnostics":\[[^]]*\]' "$vpbufdir/bad.out" >&2 || true
   exit 1
 fi
+# ...and a contract whose EARLIER declaration is well-formed must not have the
+# error anchored on it. This is the shape that broke the first anchor (Codex
+# review on #2315): both the full token stream AND the prefix stopping right
+# after line 1's `->` throw `expected type but got eof`, so a smallest-matching-
+# prefix search walks BACKWARDS and publishes the error on line 1 -- pointing at
+# correct code, which is the worst way to be wrong. The eof case is now anchored
+# at the last real token instead of searched.
+python3 - "$vpbufdir/eof.bin" <<'VPBUFEOF'
+import json, sys
+
+def frame(obj):
+    b = json.dumps(obj).encode("utf-8")
+    return f"Content-Length: {len(b)}\r\n\r\n".encode("ascii") + b
+
+src = (
+    "name = @gate/vpkgbuffer\n"
+    "version = 0.0.1\n"
+    "description =\n"
+    "  #|gate-only package for #2314\n"
+    "deps = {}\n"
+    "\n"
+    "generated_hash =\n"
+    "\n"
+    "fn a(x: Int) -> Int\n"
+    "fn b(x: Int) ->\n"
+)
+msgs = [
+    frame({"jsonrpc": "2.0", "id": 1, "method": "initialize", "params": {}}),
+    frame({"jsonrpc": "2.0", "method": "initialized", "params": {}}),
+    frame({"jsonrpc": "2.0", "method": "textDocument/didOpen", "params": {
+        "textDocument": {"uri": "file:///gate/index.vpkg", "languageId": "vibe", "version": 1, "text": src}
+    }}),
+    frame({"jsonrpc": "2.0", "id": 3, "method": "shutdown"}),
+    frame({"jsonrpc": "2.0", "method": "exit"}),
+]
+with open(sys.argv[1], "wb") as f:
+    f.write(b"".join(msgs))
+VPBUFEOF
+env -u VIBE_UNSTABLE VIBE_STDIN_BYTES="$(cat "$vpbufdir/eof.bin")" \
+  VIBE_LSP=1 VIBE_IMPORT_ABI=raw \
+  bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
+  > "$vpbufdir/eof.out" 2>/dev/null || true
+if ! grep -q '"severity":1' "$vpbufdir/eof.out" 2>/dev/null; then
+  echo "[compiler-gate] FAIL: the two-declaration malformed .vpkg published no error (#2314)" >&2
+  grep -o '"diagnostics":\[[^]]*\]' "$vpbufdir/eof.out" >&2 || true
+  exit 1
+fi
+# Line 8 (0-based) is the WELL-FORMED `fn a`; line 9 is the malformed `fn b`.
+if grep -q '"start":{"line":8' "$vpbufdir/eof.out" 2>/dev/null; then
+  echo "[compiler-gate] FAIL: the error is anchored on the WELL-FORMED declaration -- the eof anchor searched backwards (#2314)" >&2
+  grep -o '"diagnostics":\[[^]]*\]' "$vpbufdir/eof.out" >&2 || true
+  exit 1
+fi
+if ! grep -q '"start":{"line":9' "$vpbufdir/eof.out" 2>/dev/null; then
+  echo "[compiler-gate] FAIL: the error is not anchored on the malformed declaration (expected line 9, 0-based) (#2314)" >&2
+  grep -o '"diagnostics":\[[^]]*\]' "$vpbufdir/eof.out" >&2 || true
+  exit 1
+fi
 # ...and reading a contract as a contract must not COST the ADR-0068 opt-in.
 # This is the trap the rest of this section sets up: the `vibe diagnostics`
 # buffer lane used to compute the unstable set with a SECOND scan over the RAW

--- a/tests/gates/late/run.sh
+++ b/tests/gates/late/run.sh
@@ -8077,22 +8077,15 @@ if ! grep -q 'unsupported statement in a contract file' "$vpbufdir/forbidden.out
   grep -o '"diagnostics":\[[^]]*\]' "$vpbufdir/forbidden.out" >&2 || true
   exit 1
 fi
-# ...and the CLASSIFIER's rejection is anchored too. The probe that finds the
-# position runs parse AND classify, because probing the parser alone left this
-# one unlocated: the parse succeeds on every prefix, so nothing ever matched
-# and the anchor answered -1 -> the synthetic 0:0 (Codex review on #2315).
-# Line 8 (0-based) is the forbidden statement, and it is the only declaration,
-# so 0:0 and the right answer are distinguishable.
-if grep -q '"start":{"line":0,"character":0}' "$vpbufdir/forbidden.out" 2>/dev/null; then
-  echo "[compiler-gate] FAIL: the forbidden contract statement is published at the synthetic 0:0 -- the classifier throw is not anchored (#2314)" >&2
-  grep -o '"diagnostics":\[[^]]*\]' "$vpbufdir/forbidden.out" >&2 || true
-  exit 1
-fi
-if ! grep -q '"start":{"line":8' "$vpbufdir/forbidden.out" 2>/dev/null; then
-  echo "[compiler-gate] FAIL: the forbidden contract statement is not anchored on its own line (expected line 8, 0-based) (#2314)" >&2
-  grep -o '"diagnostics":\[[^]]*\]' "$vpbufdir/forbidden.out" >&2 || true
-  exit 1
-fi
+# NOT asserted: a position for this one. A classifier rejection is deliberately
+# left unlocated -- the anchor probes the PARSER, and extending it to classify
+# gives a non-monotone predicate that can anchor on later VALID code (the
+# reasoning is in `contract_parse_error_offset`). Unlocated is what this lane
+# already does with any diagnostic it cannot place. Tracked in #2317.
+#
+# The assertions above are what keeps this case honest without a position: a
+# crash satisfies neither of them, which is how the earlier version of this
+# section passed vacuously while the compiler was trapping.
 # ...and reading a contract as a contract must not COST the ADR-0068 opt-in.
 # This is the trap the rest of this section sets up: the `vibe diagnostics`
 # buffer lane used to compute the unstable set with a SECOND scan over the RAW

--- a/tests/gates/late/run.sh
+++ b/tests/gates/late/run.sh
@@ -8077,6 +8077,22 @@ if ! grep -q 'unsupported statement in a contract file' "$vpbufdir/forbidden.out
   grep -o '"diagnostics":\[[^]]*\]' "$vpbufdir/forbidden.out" >&2 || true
   exit 1
 fi
+# ...and the CLASSIFIER's rejection is anchored too. The probe that finds the
+# position runs parse AND classify, because probing the parser alone left this
+# one unlocated: the parse succeeds on every prefix, so nothing ever matched
+# and the anchor answered -1 -> the synthetic 0:0 (Codex review on #2315).
+# Line 8 (0-based) is the forbidden statement, and it is the only declaration,
+# so 0:0 and the right answer are distinguishable.
+if grep -q '"start":{"line":0,"character":0}' "$vpbufdir/forbidden.out" 2>/dev/null; then
+  echo "[compiler-gate] FAIL: the forbidden contract statement is published at the synthetic 0:0 -- the classifier throw is not anchored (#2314)" >&2
+  grep -o '"diagnostics":\[[^]]*\]' "$vpbufdir/forbidden.out" >&2 || true
+  exit 1
+fi
+if ! grep -q '"start":{"line":8' "$vpbufdir/forbidden.out" 2>/dev/null; then
+  echo "[compiler-gate] FAIL: the forbidden contract statement is not anchored on its own line (expected line 8, 0-based) (#2314)" >&2
+  grep -o '"diagnostics":\[[^]]*\]' "$vpbufdir/forbidden.out" >&2 || true
+  exit 1
+fi
 # ...and reading a contract as a contract must not COST the ADR-0068 opt-in.
 # This is the trap the rest of this section sets up: the `vibe diagnostics`
 # buffer lane used to compute the unstable set with a SECOND scan over the RAW

--- a/tests/gates/late/run.sh
+++ b/tests/gates/late/run.sh
@@ -7953,6 +7953,53 @@ if ! grep -q '"severity":1' "$vpbufdir/bad.out" 2>/dev/null; then
   grep -o '"diagnostics":\[[^]]*\]' "$vpbufdir/bad.out" >&2 || true
   exit 1
 fi
+# ...and a contract lexes like a program: EVERY lex error, not just the first.
+# The contract branch reaches for `parse_contract_program`, which throws, and
+# the first version reached for the throwing lexer to match it. But a contract
+# lexes with exactly the same rules as a program, and the `.vibe` lane reports
+# both errors in `let p = ` + backtick twice -- so a contract reporting one was
+# a gap, not a property of contract grammar (#2314 review).
+python3 - "$vpbufdir/lex.bin" <<'VPBUFEOF'
+import json, sys
+
+def frame(obj):
+    b = json.dumps(obj).encode("utf-8")
+    return f"Content-Length: {len(b)}\r\n\r\n".encode("ascii") + b
+
+src = (
+    "name = @gate/vpkgbuffer\n"
+    "version = 0.0.1\n"
+    "description =\n"
+    "  #|gate-only package for #2314\n"
+    "deps = {}\n"
+    "\n"
+    "generated_hash =\n"
+    "\n"
+    "fn a(x: Int) -> `\n"
+    "fn b(y: Int) -> `\n"
+)
+msgs = [
+    frame({"jsonrpc": "2.0", "id": 1, "method": "initialize", "params": {}}),
+    frame({"jsonrpc": "2.0", "method": "initialized", "params": {}}),
+    frame({"jsonrpc": "2.0", "method": "textDocument/didOpen", "params": {
+        "textDocument": {"uri": "file:///gate/index.vpkg", "languageId": "vibe", "version": 1, "text": src}
+    }}),
+    frame({"jsonrpc": "2.0", "id": 3, "method": "shutdown"}),
+    frame({"jsonrpc": "2.0", "method": "exit"}),
+]
+with open(sys.argv[1], "wb") as f:
+    f.write(b"".join(msgs))
+VPBUFEOF
+env -u VIBE_UNSTABLE VIBE_STDIN_BYTES="$(cat "$vpbufdir/lex.bin")" \
+  VIBE_LSP=1 VIBE_IMPORT_ABI=raw \
+  bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
+  > "$vpbufdir/lex.out" 2>/dev/null || true
+lex_count="$(grep -o '"severity":1' "$vpbufdir/lex.out" 2>/dev/null | wc -l | tr -d ' ')"
+if [ "$lex_count" -lt 2 ]; then
+  echo "[compiler-gate] FAIL: a .vpkg buffer with two lex errors published $lex_count -- the contract branch lexes without recovery (#2314)" >&2
+  grep -o '"diagnostics":\[[^]]*\]' "$vpbufdir/lex.out" >&2 || true
+  exit 1
+fi
 # ...and an ordinary `.vibe` buffer is untouched: it still type-checks, so a
 # real type error must survive. Routing every buffer through the contract
 # branch would pass everything above and silently stop checking programs.

--- a/tests/gates/late/run.sh
+++ b/tests/gates/late/run.sh
@@ -8027,6 +8027,56 @@ if ! grep -q '"start":{"line":9' "$vpbufdir/eof.out" 2>/dev/null; then
   grep -o '"diagnostics":\[[^]]*\]' "$vpbufdir/eof.out" >&2 || true
   exit 1
 fi
+# ...and parsing is not the whole contract grammar. `parse_contract_program`
+# ACCEPTS statements a contract may not contain; the loader rejects those
+# separately with `classify_contract_stmts` (#729). Discarding the parsed
+# statements reported this buffer as clean while the build refused it -- and
+# the statement-grammar branch being replaced DID catch it, through
+# `check_program` (Codex review on #2315).
+python3 - "$vpbufdir/forbidden.bin" <<'VPBUFEOF'
+import json, sys
+
+def frame(obj):
+    b = json.dumps(obj).encode("utf-8")
+    return f"Content-Length: {len(b)}\r\n\r\n".encode("ascii") + b
+
+src = (
+    "name = @gate/vpkgbuffer\n"
+    "version = 0.0.1\n"
+    "description =\n"
+    "  #|gate-only package for #2314\n"
+    "deps = {}\n"
+    "\n"
+    "generated_hash =\n"
+    "\n"
+    "export let x: Int = \"s\"\n"
+)
+msgs = [
+    frame({"jsonrpc": "2.0", "id": 1, "method": "initialize", "params": {}}),
+    frame({"jsonrpc": "2.0", "method": "initialized", "params": {}}),
+    frame({"jsonrpc": "2.0", "method": "textDocument/didOpen", "params": {
+        "textDocument": {"uri": "file:///gate/index.vpkg", "languageId": "vibe", "version": 1, "text": src}
+    }}),
+    frame({"jsonrpc": "2.0", "id": 3, "method": "shutdown"}),
+    frame({"jsonrpc": "2.0", "method": "exit"}),
+]
+with open(sys.argv[1], "wb") as f:
+    f.write(b"".join(msgs))
+VPBUFEOF
+env -u VIBE_UNSTABLE VIBE_STDIN_BYTES="$(cat "$vpbufdir/forbidden.bin")" \
+  VIBE_LSP=1 VIBE_IMPORT_ABI=raw \
+  bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
+  > "$vpbufdir/forbidden.out" 2>/dev/null || true
+if grep -q '"diagnostics":\[\]' "$vpbufdir/forbidden.out" 2>/dev/null; then
+  echo "[compiler-gate] FAIL: a contract containing a forbidden statement published as CLEAN -- the parsed statements are not classified (#2314)" >&2
+  grep -o '"diagnostics":\[[^]]*\]' "$vpbufdir/forbidden.out" >&2 || true
+  exit 1
+fi
+if ! grep -q 'unsupported statement in a contract file' "$vpbufdir/forbidden.out" 2>/dev/null; then
+  echo "[compiler-gate] FAIL: the forbidden contract statement is not rejected for the loader's reason (#2314)" >&2
+  grep -o '"diagnostics":\[[^]]*\]' "$vpbufdir/forbidden.out" >&2 || true
+  exit 1
+fi
 # ...and an error that merely CONTAINS the word eof is not an end-of-input
 # error. `#eof` is an unsupported directive, and the parser says so:
 # `unsupported # directive in a contract file: eof (only #deprecated is

--- a/tests/gates/late/run.sh
+++ b/tests/gates/late/run.sh
@@ -8077,65 +8077,6 @@ if ! grep -q 'unsupported statement in a contract file' "$vpbufdir/forbidden.out
   grep -o '"diagnostics":\[[^]]*\]' "$vpbufdir/forbidden.out" >&2 || true
   exit 1
 fi
-# ...and an error that merely CONTAINS the word eof is not an end-of-input
-# error. `#eof` is an unsupported directive, and the parser says so:
-# `unsupported # directive in a contract file: eof (only #deprecated is
-# allowed)`. A marker of `" eof"` matched that, classified it as end-of-input,
-# and anchored it at the contract's LAST token -- on the valid declaration two
-# lines below (Codex review on #2315). The declaration after it is well-formed
-# on purpose, so a mislocation has somewhere wrong to land.
-python3 - "$vpbufdir/directive.bin" <<'VPBUFEOF'
-import json, sys
-
-def frame(obj):
-    b = json.dumps(obj).encode("utf-8")
-    return f"Content-Length: {len(b)}\r\n\r\n".encode("ascii") + b
-
-src = (
-    "name = @gate/vpkgbuffer\n"
-    "version = 0.0.1\n"
-    "description =\n"
-    "  #|gate-only package for #2314\n"
-    "deps = {}\n"
-    "\n"
-    "generated_hash =\n"
-    "\n"
-    "#eof\n"
-    "fn a(x: Int) -> Int\n"
-    "fn b(y: Int) -> Int\n"
-)
-msgs = [
-    frame({"jsonrpc": "2.0", "id": 1, "method": "initialize", "params": {}}),
-    frame({"jsonrpc": "2.0", "method": "initialized", "params": {}}),
-    frame({"jsonrpc": "2.0", "method": "textDocument/didOpen", "params": {
-        "textDocument": {"uri": "file:///gate/index.vpkg", "languageId": "vibe", "version": 1, "text": src}
-    }}),
-    frame({"jsonrpc": "2.0", "id": 3, "method": "shutdown"}),
-    frame({"jsonrpc": "2.0", "method": "exit"}),
-]
-with open(sys.argv[1], "wb") as f:
-    f.write(b"".join(msgs))
-VPBUFEOF
-env -u VIBE_UNSTABLE VIBE_STDIN_BYTES="$(cat "$vpbufdir/directive.bin")" \
-  VIBE_LSP=1 VIBE_IMPORT_ABI=raw \
-  bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
-  > "$vpbufdir/directive.out" 2>/dev/null || true
-if ! grep -q '"severity":1' "$vpbufdir/directive.out" 2>/dev/null; then
-  echo "[compiler-gate] FAIL: the unsupported #eof directive published no error (#2314)" >&2
-  grep -o '"diagnostics":\[[^]]*\]' "$vpbufdir/directive.out" >&2 || true
-  exit 1
-fi
-# Line 8 (0-based) is `#eof`; lines 9 and 10 are the well-formed declarations.
-if grep -qE '"start":\{"line":(9|10)' "$vpbufdir/directive.out" 2>/dev/null; then
-  echo "[compiler-gate] FAIL: the #eof directive error is anchored on a well-formed declaration -- it was misclassified as end-of-input (#2314)" >&2
-  grep -o '"diagnostics":\[[^]]*\]' "$vpbufdir/directive.out" >&2 || true
-  exit 1
-fi
-if ! grep -q '"start":{"line":8' "$vpbufdir/directive.out" 2>/dev/null; then
-  echo "[compiler-gate] FAIL: the #eof directive error is not anchored on the directive (expected line 8, 0-based) (#2314)" >&2
-  grep -o '"diagnostics":\[[^]]*\]' "$vpbufdir/directive.out" >&2 || true
-  exit 1
-fi
 # ...and reading a contract as a contract must not COST the ADR-0068 opt-in.
 # This is the trap the rest of this section sets up: the `vibe diagnostics`
 # buffer lane used to compute the unstable set with a SECOND scan over the RAW

--- a/tests/gates/registry.tsv
+++ b/tests/gates/registry.tsv
@@ -234,3 +234,4 @@ x-adr-0090-1937-exception-unwind-region-restore	late	ADR-0090 #1937 exception-un
 114/114	late	114/114 the ADR-0068 gate exists in the split CLI, cold and warm (#2305)
 115/115	late	115/115 vibe lsp publishDiagnostics reports the ADR-0068 opt-in (#2297)
 116/116	late	116/116 a trait-method diagnostic names the trait, not the synthesized dict struct (#2286)
+117/117	late	117/117 a .vpkg buffer is read as a contract on the single-buffer lanes (#2314)


### PR DESCRIPTION
Closes #2314.

#2280 taught `vibe check` to read a `.vpkg` as a contract instead of as statements. The single-buffer lanes never got that change; I found it while measuring #2297's follow-up, because `collect_all_diagnostics` takes no `input_path` and so always reached for `parse_program_recovering`.

## Measured, before

`lib/@vibe/random/index.vpkg` — a committed contract the build consumes on every run:

| surface | answer |
|---|---|
| `vibe diagnostics` (buffer lane) | `line 15:1: expected { but got fn` |
| `vibe lsp` `publishDiagnostics` | `"severity":1`, `expected { but got eof` |
| `vibe check` (import lane, #2280) | answers about the package |

The first two assert something untrue about the file, which this repo ranks above crashing. Not a regression from #2297 — a stage2 built from the commit before it gives the same answer.

## What landed

**Contract grammar behind the path.** `collect_all_diagnostics_for_path` picks `parse_contract_program` for a contract extension, as `checked_warning_stmts` already did for the ADR-0068 scan. The two-argument form stays for callers with no path.

**One collector for the buffer lane's two halves.** The `vibe diagnostics` adapter used to compute the ADR-0068 set with a *second* scan over the raw buffer, which cannot parse a `.vpkg` header — so `checked_warning_stmts` returned `None` and the opt-in error was dropped for every contract. That was invisible only because the false parse error was covering it; removing the parse error would have left a contract importing `@vibe/concurrent` reporting **nothing**. Both forms now render one list from `collect_all_diagnostics_with_unstable_for_path`.

**A contract lexes like a program.** Recovering lexer, so every lex error is reported rather than the first — measured against the `.vibe` lane, which reports both.

**Parse errors are anchored.** `parse_contract_program` throws unlocated and `locate_type_error`'s heuristics key on message prefixes the contract grammar never produces, so these rendered at the synthetic `0:0`. A token-prefix probe finds the failing token; an eof message is anchored at the last real token instead, because "ran out of input" is reachable from any truncation and a search there anchors on *correct* code.

**The loader's statement classifier runs.** `classify_contract_stmts` on the parsed statements, so a forbidden statement is rejected here for the same reason the build rejects it.

## What it deliberately does not do

A contract stops at the grammar plus that classifier. It does not run `check_program` / `expand_interp_stmts` / the unused-import walk: those read a *program*, and a contract's implementations live in sibling files this lane cannot see.

Review surfaced five further checks the loader runs that this lane does not — an unsupported `#` directive, `derive` naming an unknown trait, duplicate declarations, and positions for the classifier's own rejections. They are one family with one cause and one design constraint, and are consolidated in **#2317** (P0) rather than patched here; **#2316** is its first row. Each needs a *position* as well as a check, and three attempts to extend the prefix probe to a new error kind each produced a non-monotone predicate that could anchor on valid code — so they need the rejected statement's own offset, which is a different mechanism.

One finding was **declined with measurement**: restoring `check_program` for `struct Bad { x: Intt }`. The import lane *accepts* that contract (complete package, exit 0), so the two lanes now agree; restoring it would make the buffer lane the only surface reporting it — the #2280 failure mode pointed the other way.

## Two bugs found on the way

- **#2318 (P0)** — a call placed **above** its callee's definition skips argument type checking. `takes_array(s, "world")` with `s: String` against `hay: Array[String]` is rejected below the definition and accepted above it. This is not incidental: it is how a `String`-for-`Array[String]` mistake in this branch reached a `FIXPOINT_OK` build and then trapped with `memory access out of bounds` on both lanes.
- **#2317 / #2316** as above.

## Gate 117

Driving both lanes, with each assertion red-tested against a pre-fix compiler:

1. the real tree contract is no longer read as statement grammar;
2. a well-formed `.vpkg` buffer is clean on the LSP;
3. a malformed **declaration** publishes `"severity":1`, is not at `0:0`, and lands on its own line;
4. with a well-formed declaration *above* the malformed one, the error must land on the malformed line and **not** the valid one — the shape that broke the first anchor;
5. two lex errors publish two diagnostics;
6. a forbidden statement is rejected, and for the loader's own reason;
7. the text and `--json` forms each carry the ADR-0068 opt-in for a `.vpkg`, and `VIBE_UNSTABLE=1` still suppresses it;
8. an ordinary `.vibe` buffer with a type error still publishes it, so the contract branch cannot be swallowing every buffer.

Assertion 6 previously passed **vacuously**: it tested for `"diagnostics":[]`, and a process that dies emits neither a clean list nor a dirty one — which is exactly what was happening while the compiler trapped. Assertions 3–4 are what make it non-vacuous now.

Two probes were withdrawn rather than weakened: a `#eof` directive case that CI proved unreachable on this lane (the header blanking erases the line), and position assertions for the classifier rejection, which is deliberately unlocated pending #2317.

## Verification

- `cmp stage2 stage3` → **`FIXPOINT_OK`** on the final tree
- sections **114, 115, 116, 117** all green against that stage2
- the input that trapped now reports the loader's message and exits 0; `lib/@vibe/random/index.vpkg` reports clean
- `check_vibe_fmt.sh`, `check_gate_registry.sh`, `check_gate_portability.sh` ok

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GbtLER6wNT4jsZEN1Zp6xe