### PR TITLE
A call is checked the same above its callee's definition as below it

### DIFF
--- a/lib/@vibe/compiler/checker/checker_stmt.vibe
+++ b/lib/@vibe/compiler/checker/checker_stmt.vibe
@@ -1795,13 +1795,80 @@ fn hoisted_binding_type(annotation: Option[TypeExpr], defs: Array[TypeDef]) -> T
   }
 }
 
+/// #2318: the signature of a top-level `fn`, for the hoist.
+///
+/// A top-level `fn f(a: Int) -> Int { .. }` is an `SLet` whose types live on
+/// the EFn's parameter list, NOT on a binding annotation -- so it hoisted as
+/// `CtUnknown`, and a call placed ABOVE it saw a non-`CtFn` callee and fell
+/// into the `_` arm of the call checker, which returns `CtUnknown` and reports
+/// nothing. Measured: argument types, ARITY, and the return type were all
+/// unchecked, and an arity-short forward call emitted a module wasm refuses to
+/// instantiate (`not enough arguments on the stack for call`) with `vibe check`
+/// silent. The same call written BELOW the definition was rejected, so the
+/// verdict depended on source order.
+///
+/// A missing parameter or return annotation does NOT disqualify the signature:
+/// that slot resolves to `CtUnknown`, which unifies with anything, so the
+/// unannotated position goes unchecked exactly as before while arity and the
+/// annotated positions are checked. `hoisted_binding_type` is what turns each
+/// `Option[TypeExpr]` into a type, so there is one implementation of that rule
+/// rather than a copy per slot.
+///
+/// Two shapes ARE excluded, because for them a synthesized signature would be
+/// WRONG rather than merely imprecise:
+///
+///   - a type parameter makes a concrete `CtFn` a lie at every call site;
+///   - an optional or labeled parameter (a trailing `~`/`?` in the raw AST
+///     name, see `labeled_param_base_name`) may be omitted by a legitimate
+///     call, so a strict arity would report a false error.
+///
+/// Both keep the `CtUnknown` the hoist gave everything before this. Ordered
+/// (backward-reference) code is unaffected either way: the binding's own
+/// statement fills in the precise type when it is reached and shadows this
+/// pre-binding.
+fn hoisted_fn_signature(value: Expr, defs: Array[TypeDef]) -> Type {
+  match value {
+    EFn(tparams, _bounds, params, ret, eff, _body) => if Array::length(tparams) > 0 {
+      CtUnknown
+    } else {
+      let ptys = array_empty()
+      let mut usable = true
+      let mut i = 0
+      while i < Array::length(params) {
+        let (pname, pann) = Array::get(params, i)
+        if labeled_param_base_name(pname) != pname {
+          usable = false
+        } else {
+          Array::push(ptys, hoisted_binding_type(pann, defs))
+        }
+        i = i + 1
+      }
+      if usable {
+        CtFn(ptys, hoisted_binding_type(ret, defs), eff)
+      } else {
+        CtUnknown
+      }
+    },
+    _ => CtUnknown
+  }
+}
+
+/// The type to pre-bind for a hoisted `SLet`: its annotation when it has one,
+/// otherwise a `fn`'s own signature (#2318), otherwise unknown.
+fn hoisted_value_type(annotation: Option[TypeExpr], value: Expr, defs: Array[TypeDef]) -> Type {
+  match annotation {
+    Some(type_expr) => resolve_type_expr(type_expr, defs),
+    None => hoisted_fn_signature(value, defs)
+  }
+}
+
 fn hoist_merged_source_values(stmts: Array[Stmt], start: Int, env: TypeEnv, defs: Array[TypeDef]) -> TypeEnv {
   let mut out = env
   let mut i = start
   while i < Array::length(stmts) && !(Array::get(stmts, i) is SReExportSourceBoundary(_, _)) {
     match Array::get(stmts, i) {
-      SLet(_, _, name, annotation, _) => {
-        let ty = hoisted_binding_type(annotation, defs)
+      SLet(_, _, name, annotation, value) => {
+        let ty = hoisted_value_type(annotation, value, defs)
         out = env_bind(out, name, ty)
       },
       _ => ()
@@ -1908,8 +1975,8 @@ fn check_stmts_with_binders(raw_stmts: Array[Stmt], i: Int, env: TypeEnv, defs: 
   let mut hoist_i = idx
   while hoist_i < Array::length(stmts) {
     match Array::get(stmts, hoist_i) {
-      SLet(_, _, hname, hann, _) => {
-        let ht = hoisted_binding_type(hann, defs)
+      SLet(_, _, hname, hann, hval) => {
+        let ht = hoisted_value_type(hann, hval, defs)
         cur_env = env_bind(cur_env, hname, ht)
       },
       _ => ()

--- a/lib/@vibe/compiler/codegen/common_base/inline_direct_perform.vibe
+++ b/lib/@vibe/compiler/codegen/common_base/inline_direct_perform.vibe
@@ -106,8 +106,15 @@ fn array_empty_ecfg() -> Array[(String, Array[String], Array[String])] {
   Array::slice([("", array_empty_str(), array_empty_str())], 0, 0)
 }
 
-fn array_empty_scope() -> Array[(String, String)] {
-  Array::slice([("", "")], 0, 0)
+/// #2318: this said `Array[(String, String)]`, but the scope it seeds is
+/// `(binding name, kind)` with an Int kind -- every consumer
+/// (`scps_scope_bind_params`, `scps_prepass_expr`, `scps_rewrite`) declares
+/// `Array[(String, Int)]`. The array is always EMPTY, so nothing ever read a
+/// String as an Int and the mistake was inert; it survived only because the
+/// call sites sit above `scps_scope_bind_params`'s definition and a forward
+/// reference skipped argument checking entirely.
+fn array_empty_scope() -> Array[(String, Int)] {
+  Array::slice([("", 0)], 0, 0)
 }
 
 fn idp_table_is_empty(table: (Array[String], Array[Array[String]], Array[Expr])) -> Bool {

--- a/lib/@vibe/compiler/codegen/common_base/inline_direct_perform.vibe
+++ b/lib/@vibe/compiler/codegen/common_base/inline_direct_perform.vibe
@@ -106,14 +106,28 @@ fn array_empty_ecfg() -> Array[(String, Array[String], Array[String])] {
   Array::slice([("", array_empty_str(), array_empty_str())], 0, 0)
 }
 
-/// #2318: this said `Array[(String, String)]`, but the scope it seeds is
-/// `(binding name, kind)` with an Int kind -- every consumer
-/// (`scps_scope_bind_params`, `scps_prepass_expr`, `scps_rewrite`) declares
-/// `Array[(String, Int)]`. The array is always EMPTY, so nothing ever read a
-/// String as an Int and the mistake was inert; it survived only because the
-/// call sites sit above `scps_scope_bind_params`'s definition and a forward
-/// reference skipped argument checking entirely.
-fn array_empty_scope() -> Array[(String, Int)] {
+/// The `scps_rewrite` / `scps_transform_handle` / `scps_scope_push_pat` scope,
+/// whose entries are `(binding name, "")`.
+fn array_empty_scope() -> Array[(String, String)] {
+  Array::slice([("", "")], 0, 0)
+}
+
+/// #2318: the OTHER scope in this file -- `(binding name, kind)` with an Int
+/// kind, as `scps_scope_bind*`, `scps_calls_ok` and `scps_prepass_expr` all
+/// declare it (22 parameters against the 3 above).
+///
+/// Both were seeded from `array_empty_scope`, so the prepass sites were
+/// passing `Array[(String, String)]` where `Array[(String, Int)]` was
+/// declared. The arrays are always EMPTY, so nothing ever read a String as an
+/// Int and the mistake was inert -- it survived because those call sites sit
+/// above `scps_scope_bind_params`'s definition, and a forward reference
+/// skipped argument checking entirely.
+///
+/// Two helpers rather than one retyped: they are two different scopes that
+/// happen to share a parameter name, and merging them is what let the mistake
+/// exist. Retyping the single helper just moves the error to the other family
+/// -- measured, that is exactly what the next build reported.
+fn array_empty_kind_scope() -> Array[(String, Int)] {
   Array::slice([("", 0)], 0, 0)
 }
 
@@ -8335,16 +8349,16 @@ export fn suspend_cps_pass(stmts: Array[Stmt]) -> Array[String] {
         // material. Splitting it here double-wrapped the clone (emit_clone
         // re-split an already-split body into Done(Y(..))).
         SLet(exported, is_rec, name, ty, expr) => Array::set(stmts, ip, SLet(exported, is_rec, name, ty, match expr {
-          EFn(tps, tbs, params, ret, eff, b) => EFn(tps, tbs, params, ret, eff, scps_prepass_expr(b, ecfgs, ctx, st, split_effs, scps_scope_bind_params(array_empty_scope(), params, "", ctx))),
-          _ => scps_prepass_expr(expr, ecfgs, ctx, st, split_effs, array_empty_scope())
+          EFn(tps, tbs, params, ret, eff, b) => EFn(tps, tbs, params, ret, eff, scps_prepass_expr(b, ecfgs, ctx, st, split_effs, scps_scope_bind_params(array_empty_kind_scope(), params, "", ctx))),
+          _ => scps_prepass_expr(expr, ecfgs, ctx, st, split_effs, array_empty_kind_scope())
         })),
         SLetMut(name, ty, expr) => Array::set(stmts, ip, SLetMut(name, ty, match expr {
-          EFn(tps, tbs, params, ret, eff, b) => EFn(tps, tbs, params, ret, eff, scps_prepass_expr(b, ecfgs, ctx, st, split_effs, scps_scope_bind_params(array_empty_scope(), params, "", ctx))),
-          _ => scps_prepass_expr(expr, ecfgs, ctx, st, split_effs, array_empty_scope())
+          EFn(tps, tbs, params, ret, eff, b) => EFn(tps, tbs, params, ret, eff, scps_prepass_expr(b, ecfgs, ctx, st, split_effs, scps_scope_bind_params(array_empty_kind_scope(), params, "", ctx))),
+          _ => scps_prepass_expr(expr, ecfgs, ctx, st, split_effs, array_empty_kind_scope())
         })),
-        SExpr(expr) => Array::set(stmts, ip, SExpr(scps_prepass_expr(expr, ecfgs, ctx, st, split_effs, array_empty_scope()))),
-        STest(tn, expr) => Array::set(stmts, ip, STest(tn, scps_prepass_expr(expr, ecfgs, ctx, st, split_effs, array_empty_scope()))),
-        SBench(bn, expr) => Array::set(stmts, ip, SBench(bn, scps_prepass_expr(expr, ecfgs, ctx, st, split_effs, array_empty_scope()))),
+        SExpr(expr) => Array::set(stmts, ip, SExpr(scps_prepass_expr(expr, ecfgs, ctx, st, split_effs, array_empty_kind_scope()))),
+        STest(tn, expr) => Array::set(stmts, ip, STest(tn, scps_prepass_expr(expr, ecfgs, ctx, st, split_effs, array_empty_kind_scope()))),
+        SBench(bn, expr) => Array::set(stmts, ip, SBench(bn, scps_prepass_expr(expr, ecfgs, ctx, st, split_effs, array_empty_kind_scope()))),
         _ => ()
       }
       ip = ip + 1

--- a/tests/gates/late/run.sh
+++ b/tests/gates/late/run.sh
@@ -8218,3 +8218,108 @@ if grep -q '"diagnostics":\[\]' "$vpbufdir/prog.out" 2>/dev/null; then
 fi
 rm -rf "$vpbufdir"
 echo "[compiler-gate] a .vpkg buffer reads as a contract, still rejects a malformed declaration, and .vibe buffers still type-check ok (#2314)"
+
+# 118/118. A call is checked the same above its callee's definition as below
+# it (#2318).
+#
+# A forward reference skipped argument checking ENTIRELY -- types, arity, and
+# the return type -- because the hoist pre-pass bound a top-level `fn`'s name
+# with its ANNOTATION's type, and a `fn` carries its types on the EFn parameter
+# list rather than on a binding annotation. It hoisted as `CtUnknown`, so the
+# call checker's `_` arm returned `CtUnknown` and reported nothing.
+#
+# The property to pin is ORDER-INDEPENDENCE, not any single case: the verdict
+# must not depend on where the definition sits. So every probe is run BOTH ways
+# and the two verdicts compared, rather than asserting one message.
+echo "[compiler-gate] 118/118 a call is checked the same above its callee's definition as below (#2318)"
+fwddir="_build/_gate_fwd_check"
+rm -rf "$fwddir"; mkdir -p "$fwddir"
+# name|bad call|definition -- each is checked with the definition first and
+# with the call first; the two must agree.
+fwd_cases='argtype|takes(1, "s")|fn takes(a: Int, b: Int) -> Int { a + b }
+arity|takes(1)|fn takes(a: Int, b: Int) -> Int { a + b }
+unknownfn|nosuchfn(1)|fn takes(a: Int, b: Int) -> Int { a + b }'
+printf '%s\n' "$fwd_cases" | while IFS='|' read -r nm call def; do
+  [ -n "$nm" ] || continue
+  printf 'fn caller() -> Int {\n  %s\n}\n\n%s\n\nfn main() -> Int {\n  caller()\n}\n' "$call" "$def" > "$fwddir/$nm.fwd.vibe"
+  printf '%s\n\nfn caller() -> Int {\n  %s\n}\n\nfn main() -> Int {\n  caller()\n}\n' "$def" "$call" > "$fwddir/$nm.back.vibe"
+  for ord in fwd back; do
+    rm -f "$fwddir/$nm.$ord.out" "$fwddir/$nm.$ord.out.diag"
+    if VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_CHECK_ONLY=1 VIBE_IMPORT_ABI=raw \
+      bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
+      "$fwddir/$nm.$ord.vibe" "$fwddir/$nm.$ord.out" main >/dev/null 2>&1; then
+      echo "accepted" > "$fwddir/$nm.$ord.verdict"
+    else
+      echo "rejected" > "$fwddir/$nm.$ord.verdict"
+    fi
+  done
+  fv="$(cat "$fwddir/$nm.fwd.verdict")"
+  bv="$(cat "$fwddir/$nm.back.verdict")"
+  if [ "$fv" != "$bv" ]; then
+    echo "[compiler-gate] FAIL: case '$nm' depends on declaration order -- call-first says $fv, definition-first says $bv (#2318)" >&2
+    cat "$fwddir/$nm.fwd.out.diag" 2>/dev/null >&2 || true
+    exit 1
+  fi
+  # ...and both must REJECT. Agreeing by accepting everything is the failure
+  # this section exists to catch, and an order comparison alone cannot see it.
+  if [ "$fv" != "rejected" ]; then
+    echo "[compiler-gate] FAIL: case '$nm' is ACCEPTED in both orders -- the ill-typed call is not being checked at all (#2318)" >&2
+    exit 1
+  fi
+done || exit 1
+# A CORRECT forward call must still compile and run, or "reject everything"
+# would pass every assertion above.
+cat > "$fwddir/ok.vibe" <<'FWDEOF'
+fn caller() -> Int {
+  takes(1, 2)
+}
+
+fn takes(a: Int, b: Int) -> Int {
+  a + b
+}
+
+fn main() -> Int {
+  caller()
+}
+FWDEOF
+rm -f "$fwddir/ok.wasm" "$fwddir/ok.wasm.diag"
+if ! VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_IMPORT_ABI=raw \
+  bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
+  "$fwddir/ok.vibe" "$fwddir/ok.wasm" main >/dev/null 2>&1; then
+  echo "[compiler-gate] FAIL: a CORRECT forward call no longer compiles (#2318)" >&2
+  cat "$fwddir/ok.wasm.diag" 2>/dev/null >&2 || true
+  exit 1
+fi
+ok_out="$(VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh --invoke _start "$fwddir/ok.wasm" 2>&1 | head -1)"
+if [ "$ok_out" != "3" ]; then
+  echo "[compiler-gate] FAIL: the correct forward call ran to '$ok_out', expected 3 (#2318)" >&2
+  exit 1
+fi
+# An optional parameter may be omitted by a legitimate call, so the hoisted
+# signature must stand down for it rather than report a false arity error.
+cat > "$fwddir/opt.vibe" <<'FWDEOF'
+fn caller() -> Int {
+  takes(1)
+}
+
+fn takes(a: Int, b?: Int) -> Int {
+  a
+}
+
+fn main() -> Int {
+  caller()
+}
+FWDEOF
+rm -f "$fwddir/opt.out" "$fwddir/opt.out.diag"
+# `vibe check` exits 0 when clean, so the assertion is on the NEGATION -- the
+# first draft had it inverted and failed on the fixed compiler, which is how
+# the inversion was caught.
+if ! VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_CHECK_ONLY=1 VIBE_IMPORT_ABI=raw \
+  bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
+  "$fwddir/opt.vibe" "$fwddir/opt.out" main >/dev/null 2>&1; then
+  echo "[compiler-gate] FAIL: omitting an OPTIONAL parameter in a forward call is reported as an error (#2318)" >&2
+  cat "$fwddir/opt.out.diag" 2>/dev/null >&2 || true
+  exit 1
+fi
+rm -rf "$fwddir"
+echo "[compiler-gate] a call is checked identically in both declaration orders; correct forward calls still run; optional params stand down ok (#2318)"

--- a/tests/gates/registry.tsv
+++ b/tests/gates/registry.tsv
@@ -235,3 +235,4 @@ x-adr-0090-1937-exception-unwind-region-restore	late	ADR-0090 #1937 exception-un
 115/115	late	115/115 vibe lsp publishDiagnostics reports the ADR-0068 opt-in (#2297)
 116/116	late	116/116 a trait-method diagnostic names the trait, not the synthesized dict struct (#2286)
 117/117	late	117/117 a .vpkg buffer is read as a contract on the single-buffer lanes (#2314)
+118/118	late	118/118 a call is checked the same above its callee's definition as below (#2318)


### PR DESCRIPTION
Closes #2318.

A call placed **above** its callee's definition in the same file was not type-checked at all. The same call below the definition was rejected, so the verdict depended on source order.

Found by running into it: a call in this compiler's own source passed a `String` to a parameter declared `Array[String]`, `vibe check` said nothing, the tree built to `FIXPOINT_OK`, and the resulting compiler trapped with `memory access out of bounds`.

## Measured, before — wider than the issue filed

| case | before |
|---|---|
| forward call, wrong argument type | **accepted** |
| forward call, wrong **arity** | **accepted**, and the module wasm refuses to instantiate: `not enough arguments on the stack for call (need 3, got 2)` |
| forward call, wrong return type | **accepted** |
| the same call **below** the definition | rejected |
| the same call **across files** (import) | rejected |

So `vibe check` was silent about a program that cannot even load.

## Cause

The hoist pre-pass binds a top-level `SLet`'s name with its **annotation's** type. A `fn f(a: Int) -> Int { .. }` carries its types on the EFn's parameter list, not on a binding annotation, so it hoisted as `CtUnknown` — and the call checker's `_` arm returns `CtUnknown` and reports nothing.

`hoisted_fn_signature` builds the `CtFn` from the annotations already there syntactically, with the declared effect row as the third field.

A missing parameter or return annotation does **not** disqualify it: that slot becomes `CtUnknown`, so the unannotated position goes unchecked exactly as before while arity and the annotated positions are checked. Every `Option[TypeExpr]` goes through the existing `hoisted_binding_type`, so there is one implementation of that rule rather than a copy per slot.

Two shapes stay `CtUnknown`, because for them a synthesized signature would be **wrong** rather than imprecise:

- a **type parameter** — a concrete `CtFn` would be a lie at every call site;
- an **optional or labeled parameter** (a trailing `~`/`?` in the raw AST name) — a legitimate call may omit it, so a strict arity would report a false error.

Ordered code is unaffected: the binding's own statement shadows the pre-binding when reached.

## It found a real bug on its first build

```
argument type mismatch for scps_scope_bind_params:
  expected Array[(String, Int)], got Array[(String, String)]
```

`inline_direct_perform.vibe` has **two** scopes sharing a parameter name — 22 parameters of `Array[(String, Int)]` (binding name + Int kind) and 3 of `Array[(String, String)]` (`scps_rewrite`, `scps_transform_handle`, `scps_scope_push_pat`, which pushes `(n, "")`). Both were seeded from one `array_empty_scope`, so one family was always being passed the other's type.

My first fix retyped that helper, and the next build reported the mirror image — I had checked two consumers and generalized from them. There are two helpers now, one per family: merging them is what allowed the mistake, so the fix is to stop merging them rather than to pick a winner. Inert at runtime either way (both arrays are always empty), and it survived only because those call sites sit above the callee's definition.

## Gate 118

The property pinned is **order-independence**, not any single message. Each probe is compiled **both ways** and the two verdicts compared:

- wrong argument type, wrong arity, unknown callee — each must give the *same* verdict in both orders **and** be rejected. The order comparison alone cannot see a compiler that accepts everything, which is the pre-fix behaviour on one side, so both halves are asserted.

Two controls, because "reject everything" would otherwise pass:

- a correct forward call still compiles and runs to `3`;
- omitting an **optional** parameter stays clean, since the hoisted signature stands down for `~`/`?`.

Red-tested against the pre-fix stage2:

```
FAIL: case 'argtype' depends on declaration order --
  call-first says accepted, definition-first says rejected
```

The optional-parameter control was first written with its condition inverted and failed on the *fixed* compiler. I measured both orders on both compilers before changing anything: all four clean, so the fix was right and the assertion was wrong. Noted at the assertion, because an inverted check that happens to pass is the kind that survives.

## Verification

- `cmp stage2 stage3` → **`FIXPOINT_OK`**
- all six previously-unchecked cases now rejected, with positions; a correct forward call compiles and runs
- section 118 green on the fix, red on the pre-fix compiler
- `check_vibe_fmt.sh`, `check_gate_registry.sh`, `check_gate_portability.sh` ok
- no new `architecture_debt` allowlist entry: the ARCH010 lint flagged a `None => CtUnknown` in the first draft, and reusing `hoisted_binding_type` answers it by construction rather than by exemption

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GbtLER6wNT4jsZEN1Zp6xe

---
_Generated by [Claude Code](https://claude.ai/code/session_01GbtLER6wNT4jsZEN1Zp6xe)_