### PR TITLE
The buffer lane decides the contract checks it can, and agrees with the build

### DIFF
--- a/lib/@vibe/compiler/checker/checker_stmt.vibe
+++ b/lib/@vibe/compiler/checker/checker_stmt.vibe
@@ -1725,7 +1725,10 @@ fn find_other_enum_declaring_variant(defs: Array[TypeDef], local_defs_start: Int
   found
 }
 
-fn validate_derives(derives: Array[String], errors: Array[String]) -> Unit {
+/// #2317: exported so the single-buffer contract lane reports an unknown
+/// `derive` with the SAME message the build does (`unknown trait: X`), rather
+/// than a second implementation of the same rule that could drift from it.
+export fn validate_derives(derives: Array[String], errors: Array[String]) -> Unit {
   let mut i = 0
   while i < Array::length(derives) {
     let name = Array::get(derives, i)

--- a/lib/@vibe/compiler/checker/index.vpkg
+++ b/lib/@vibe/compiler/checker/index.vpkg
@@ -262,6 +262,7 @@ fn check_program_direct_expression_return_observation(stmts: Array[Stmt]) -> Opt
 fn check_program_typed_occurrence_role_lane_observation(stmts: Array[Stmt]) -> Option[CheckedTypedOccurrenceRoleLaneObservation] with Exception
 fn check_program_typed_occurrence_expression_path_observation(stmts: Array[Stmt]) -> Option[CheckedTypedOccurrenceExpressionPathObservation] with Exception
 fn check_program_binder_occurrence_observation(authority: LocatedProgramBinderAuthority) -> Option[Array[(Int, Int, Int)]] with Exception
+fn validate_derives(derives: Array[String], errors: Array[String]) -> Unit
 fn check_program(stmts: Array[Stmt]) -> TypeEnv with Exception
 fn check_program_type_table(stmts: Array[Stmt]) -> (Array[(Int, Type)], Subst) with Exception
 fn check_program_with_env_result(stmts: Array[Stmt], initial_env: TypeEnv) -> CheckedProgram with Exception

--- a/lib/@vibe/compiler/runtime/typecheck_fs.vibe
+++ b/lib/@vibe/compiler/runtime/typecheck_fs.vibe
@@ -5719,25 +5719,28 @@ fn contract_semantic_errors(source: String, tokens: Array[Token], starts: Array[
   // element, not among its statements -- a contract's `fn f(x: Int) -> Int` is
   // not an `SLet`. Opaque type declarations share the namespace, since the
   // facade allocates each name once, so both lists feed one `seen` set.
+  let heads = contract_decl_head_table(tokens, starts)
+  let head_taken = contract_taken_flags(heads)
+  let derive_names = contract_derive_name_table(tokens, starts)
+  let derive_taken = contract_taken_flags(derive_names)
   let seen: Array[String] = []
-  let derive_cursor = [0]
   let mut d = 0
   while d < Array::length(decls) {
     let (dname, _sig) = Array::get(decls, d)
-    contract_note_duplicate(source, tokens, starts, dname, seen, out)
+    contract_note_duplicate(source, heads, head_taken, dname, seen, out)
     d = d + 1
   }
   let mut o = 0
   while o < Array::length(opaques) {
     let (oname, _arity) = Array::get(opaques, o)
-    contract_note_duplicate(source, tokens, starts, oname, seen, out)
+    contract_note_duplicate(source, heads, head_taken, oname, seen, out)
     o = o + 1
   }
   let mut i = 0
   while i < Array::length(stmts) {
     match Array::get(stmts, i) {
-      SStruct(_, _, _, derives, _, _) => contract_derive_errors(source, tokens, starts, derives, derive_cursor, out),
-      SEnum(_, _, _, _, derives) => contract_derive_errors(source, tokens, starts, derives, derive_cursor, out),
+      SStruct(_, _, _, derives, _, _) => contract_derive_errors(source, derive_names, derive_taken, derives, out),
+      SEnum(_, _, _, _, derives) => contract_derive_errors(source, derive_names, derive_taken, derives, out),
       _ => ()
     }
     i = i + 1
@@ -5746,11 +5749,15 @@ fn contract_semantic_errors(source: String, tokens: Array[Token], starts: Array[
 }
 
 /// Record `name` as seen, reporting it when it was seen before.
-fn contract_note_duplicate(source: String, tokens: Array[Token], starts: Array[Int], name: String, seen: Array[String], out: Array[String]) -> Unit {
+fn contract_note_duplicate(source: String, heads: Array[(String, Int)], head_taken: Array[Bool], name: String, seen: Array[String], out: Array[String]) -> Unit {
   if str_array_contains_name(seen, name) {
     let dup_msg = String::concat(String::concat("duplicate declaration in a contract: `", name), "` is declared more than once -- a contract declares each name once, and the facade it generates can allocate the name only once")
-    Array::push(out, located_at_offset(source, contract_decl_head_offset(tokens, starts, name, 2), dup_msg))
+    Array::push(out, located_at_offset(source, contract_take_anchor(heads, head_taken, name), dup_msg))
   } else {
+    // Spend the FIRST head for this name, so the first duplicate takes the
+    // second and an Nth duplicate takes the Nth -- three declarations of one
+    // name gave three reports all pointing at the second before this.
+    let _first = contract_take_anchor(heads, head_taken, name)
     Array::push(seen, name)
   }
 }
@@ -5763,7 +5770,7 @@ fn contract_note_duplicate(source: String, tokens: Array[Token], starts: Array[I
 /// (Codex review on #2320). The trait name appears verbatim in the buffer, so
 /// the same locator the duplicate uses places it -- first occurrence, since a
 /// derive names it once.
-fn contract_derive_errors(source: String, tokens: Array[Token], starts: Array[Int], derives: Array[String], cursor: Array[Int], out: Array[String]) -> Unit {
+fn contract_derive_errors(source: String, derive_names: Array[(String, Int)], derive_taken: Array[Bool], derives: Array[String], out: Array[String]) -> Unit {
   let raw = array_empty()
   validate_derives(derives, raw)
   let mut i = 0
@@ -5780,7 +5787,7 @@ fn contract_derive_errors(source: String, tokens: Array[Token], starts: Array[In
         Array::push(out, msg)
       } else {
         let tname = String::substring(msg, sstart, send)
-        Array::push(out, located_at_offset(source, contract_derive_name_offset(tokens, starts, tname, cursor), msg))
+        Array::push(out, located_at_offset(source, contract_take_anchor(derive_names, derive_taken, tname), msg))
       }
     }
     i = i + 1
@@ -5819,18 +5826,26 @@ fn str_array_contains_name(xs: Array[String], name: String) -> Bool {
 /// A declaration head is `fn <ident>` or `type <ident>`, which is exactly what
 /// `parse_contract_program` matches to produce the lists being scanned, so this
 /// walk and that parse agree by construction.
-fn contract_decl_head_offset(tokens: Array[Token], starts: Array[Int], name: String, occurrence: Int) -> Int {
+/// Every declaration head in the buffer, in source order, as
+/// `(declared name, byte offset of the name)`.
+///
+/// Built ONCE and consumed in order, rather than searched per diagnostic. Five
+/// rounds of review found edge cases in the per-query searches -- a name that
+/// occurs earlier for another reason, a third duplicate, a multi-name derive,
+/// a qualified `fn Map::get` -- and every one of them was this code
+/// reconstructing what the parser already knew. A table consumed in order has
+/// no ordinal to get wrong: the k-th report of a name takes the k-th entry.
+///
+/// The heads are exactly the ones `parse_contract_program` accepts for a name
+/// that reaches `decls`/`opaques`: `fn`, `type`, `let`, and `opaque type`.
+/// A qualified head (`fn Map::get`) is joined the way the parser joins it, so
+/// the name here matches the name recorded there.
+fn contract_decl_head_table(tokens: Array[Token], starts: Array[Int]) -> Array[(String, Int)] {
+  let out = array_empty()
   let n = Array::length(tokens)
   let lim = Array::length(starts)
   let mut i = 0
-  let mut seen = 0
-  let mut at = 0 - 1
-  while i + 1 < n && seen < occurrence {
-    // Every head `parse_contract_program` accepts for a name that lands in the
-    // lists being scanned: `fn`, `type`, `let` (a bodyless value declaration,
-    // #752), and the `opaque` head, which is a plain identifier rather than a
-    // keyword. `let` was missing in the first token version, so a duplicated
-    // `let answer: Int` rendered at 0:0 (Codex review on #2320).
+  while i + 1 < n {
     let heads = match Array::get(tokens, i) {
       TFn => true,
       TType => true,
@@ -5849,11 +5864,9 @@ fn contract_decl_head_offset(tokens: Array[Token], starts: Array[Int], name: Str
       }
       if name_at < n && name_at < lim {
         match Array::get(tokens, name_at) {
-          TIdent(got) => if got == name {
-            seen = seen + 1
-            at = Array::get(starts, name_at)
-          } else {
-            ()
+          TIdent(head_name) => {
+            let qualified = contract_qualified_head_name(tokens, name_at, head_name)
+            Array::push(out, (qualified, Array::get(starts, name_at)))
           },
           _ => ()
         }
@@ -5865,29 +5878,35 @@ fn contract_decl_head_offset(tokens: Array[Token], starts: Array[Int], name: Str
     }
     i = i + 1
   }
-  if seen == occurrence {
-    at
+  out
+}
+
+/// `A::b` when the head is qualified, otherwise the bare name.
+fn contract_qualified_head_name(tokens: Array[Token], name_at: Int, head_name: String) -> String {
+  let n = Array::length(tokens)
+  if name_at + 2 < n {
+    let joined = match Array::get(tokens, name_at + 1) {
+      TDoubleColon => match Array::get(tokens, name_at + 2) {
+        TIdent(rest) => String::concat(head_name, String::concat("::", rest)),
+        _ => head_name
+      },
+      _ => head_name
+    }
+    joined
   } else {
-    0 - 1
+    head_name
   }
 }
 
-/// Byte offset of `name` where it appears INSIDE a `derive(..)` clause, or -1.
-///
-/// The same reasoning: the trait name can occur anywhere else in the buffer,
-/// so the anchor is the occurrence that sits between `derive (` and the
-/// matching `)`.
-fn contract_derive_name_offset(tokens: Array[Token], starts: Array[Int], name: String, cursor: Array[Int]) -> Int {
+/// Every trait name appearing inside a `derive(..)` clause, in source order.
+/// One pass, so a clause naming several traits yields several entries and a
+/// second clause continues the list -- both of which a per-query scan missed.
+fn contract_derive_name_table(tokens: Array[Token], starts: Array[Int]) -> Array[(String, Int)] {
+  let out = array_empty()
   let n = Array::length(tokens)
   let lim = Array::length(starts)
-  // Resume where the previous clause ended. Scanning from 0 each time anchored
-  // EVERY diagnostic on the first matching clause, so two structs deriving the
-  // same unknown trait both pointed at the first (Codex review on #2320).
-  // `contract_semantic_errors` walks statements in source order, so a
-  // monotonic cursor lines each error up with its own clause.
-  let mut i = Array::get(cursor, 0)
-  let mut at = 0 - 1
-  while i < n && at < 0 {
+  let mut i = 0
+  while i < n {
     let is_derive = match Array::get(tokens, i) {
       TDerive => true,
       _ => false
@@ -5905,11 +5924,12 @@ fn contract_derive_name_offset(tokens: Array[Token], starts: Array[Int], name: S
             TRParen => {
               scanning = false
             },
-            TIdent(got) => if got == name && d < lim {
-              at = Array::get(starts, d)
-              Array::set(cursor, 0, d + 1)
-              scanning = false
-            } else {
+            TIdent(tname) => {
+              if d < lim {
+                Array::push(out, (tname, Array::get(starts, d)))
+              } else {
+                ()
+              }
               d = d + 1
             },
             _ => {
@@ -5917,16 +5937,51 @@ fn contract_derive_name_offset(tokens: Array[Token], starts: Array[Int], name: S
             }
           }
         }
+        i = d
       } else {
-        ()
+        i = i + 1
       }
     } else {
-      ()
+      i = i + 1
     }
-    i = i + 1
+  }
+  out
+}
+
+/// The offset of the next unconsumed entry named `name`, or -1. `taken` marks
+/// entries already spent, so repeated reports of one name walk forward instead
+/// of all landing on the same occurrence.
+fn contract_take_anchor(table: Array[(String, Int)], taken: Array[Bool], name: String) -> Int {
+  let mut i = 0
+  let mut at = 0 - 1
+  while i < Array::length(table) && at < 0 {
+    let (entry_name, entry_off) = Array::get(table, i)
+    if entry_name == name && !Array::get(taken, i) {
+      Array::set(taken, i, true)
+      at = entry_off
+    } else {
+      i = i + 1
+    }
   }
   at
 }
+
+/// A `false` for every entry of `table`.
+fn contract_taken_flags(table: Array[(String, Int)]) -> Array[Bool] {
+  let out: Array[Bool] = []
+  let mut i = 0
+  while i < Array::length(table) {
+    Array::push(out, false)
+    i = i + 1
+  }
+  out
+}
+
+/// Byte offset of `name` where it appears INSIDE a `derive(..)` clause, or -1.
+///
+/// The same reasoning: the trait name can occur anywhere else in the buffer,
+/// so the anchor is the occurrence that sits between `derive (` and the
+/// matching `)`.
 
 /// `msg` prefixed with the position at `off`, or bare when `off` is -1 --
 /// degraded, never wrong, the same rule the parse anchor states for itself.

--- a/lib/@vibe/compiler/runtime/typecheck_fs.vibe
+++ b/lib/@vibe/compiler/runtime/typecheck_fs.vibe
@@ -5720,6 +5720,7 @@ fn contract_semantic_errors(source: String, tokens: Array[Token], starts: Array[
   // not an `SLet`. Opaque type declarations share the namespace, since the
   // facade allocates each name once, so both lists feed one `seen` set.
   let seen: Array[String] = []
+  let derive_cursor = [0]
   let mut d = 0
   while d < Array::length(decls) {
     let (dname, _sig) = Array::get(decls, d)
@@ -5735,8 +5736,8 @@ fn contract_semantic_errors(source: String, tokens: Array[Token], starts: Array[
   let mut i = 0
   while i < Array::length(stmts) {
     match Array::get(stmts, i) {
-      SStruct(_, _, _, derives, _, _) => contract_derive_errors(source, tokens, starts, derives, out),
-      SEnum(_, _, _, _, derives) => contract_derive_errors(source, tokens, starts, derives, out),
+      SStruct(_, _, _, derives, _, _) => contract_derive_errors(source, tokens, starts, derives, derive_cursor, out),
+      SEnum(_, _, _, _, derives) => contract_derive_errors(source, tokens, starts, derives, derive_cursor, out),
       _ => ()
     }
     i = i + 1
@@ -5762,7 +5763,7 @@ fn contract_note_duplicate(source: String, tokens: Array[Token], starts: Array[I
 /// (Codex review on #2320). The trait name appears verbatim in the buffer, so
 /// the same locator the duplicate uses places it -- first occurrence, since a
 /// derive names it once.
-fn contract_derive_errors(source: String, tokens: Array[Token], starts: Array[Int], derives: Array[String], out: Array[String]) -> Unit {
+fn contract_derive_errors(source: String, tokens: Array[Token], starts: Array[Int], derives: Array[String], cursor: Array[Int], out: Array[String]) -> Unit {
   let raw = array_empty()
   validate_derives(derives, raw)
   let mut i = 0
@@ -5779,7 +5780,7 @@ fn contract_derive_errors(source: String, tokens: Array[Token], starts: Array[In
         Array::push(out, msg)
       } else {
         let tname = String::substring(msg, sstart, send)
-        Array::push(out, located_at_offset(source, contract_derive_name_offset(tokens, starts, tname), msg))
+        Array::push(out, located_at_offset(source, contract_derive_name_offset(tokens, starts, tname, cursor), msg))
       }
     }
     i = i + 1
@@ -5825,20 +5826,39 @@ fn contract_decl_head_offset(tokens: Array[Token], starts: Array[Int], name: Str
   let mut seen = 0
   let mut at = 0 - 1
   while i + 1 < n && seen < occurrence {
+    // Every head `parse_contract_program` accepts for a name that lands in the
+    // lists being scanned: `fn`, `type`, `let` (a bodyless value declaration,
+    // #752), and the `opaque` head, which is a plain identifier rather than a
+    // keyword. `let` was missing in the first token version, so a duplicated
+    // `let answer: Int` rendered at 0:0 (Codex review on #2320).
     let heads = match Array::get(tokens, i) {
       TFn => true,
       TType => true,
+      TLet => true,
+      TIdent(kw) => kw == "opaque",
       _ => false
     }
     if heads {
-      match Array::get(tokens, i + 1) {
-        TIdent(got) => if got == name && i + 1 < lim {
-          seen = seen + 1
-          at = Array::get(starts, i + 1)
-        } else {
-          ()
+      // `opaque type Token` puts the name two tokens along, not one.
+      let name_at = match Array::get(tokens, i) {
+        TIdent(_) => match Array::get(tokens, i + 1) {
+          TType => i + 2,
+          _ => i + 1
         },
-        _ => ()
+        _ => i + 1
+      }
+      if name_at < n && name_at < lim {
+        match Array::get(tokens, name_at) {
+          TIdent(got) => if got == name {
+            seen = seen + 1
+            at = Array::get(starts, name_at)
+          } else {
+            ()
+          },
+          _ => ()
+        }
+      } else {
+        ()
       }
     } else {
       ()
@@ -5857,10 +5877,15 @@ fn contract_decl_head_offset(tokens: Array[Token], starts: Array[Int], name: Str
 /// The same reasoning: the trait name can occur anywhere else in the buffer,
 /// so the anchor is the occurrence that sits between `derive (` and the
 /// matching `)`.
-fn contract_derive_name_offset(tokens: Array[Token], starts: Array[Int], name: String) -> Int {
+fn contract_derive_name_offset(tokens: Array[Token], starts: Array[Int], name: String, cursor: Array[Int]) -> Int {
   let n = Array::length(tokens)
   let lim = Array::length(starts)
-  let mut i = 0
+  // Resume where the previous clause ended. Scanning from 0 each time anchored
+  // EVERY diagnostic on the first matching clause, so two structs deriving the
+  // same unknown trait both pointed at the first (Codex review on #2320).
+  // `contract_semantic_errors` walks statements in source order, so a
+  // monotonic cursor lines each error up with its own clause.
+  let mut i = Array::get(cursor, 0)
   let mut at = 0 - 1
   while i < n && at < 0 {
     let is_derive = match Array::get(tokens, i) {
@@ -5882,6 +5907,7 @@ fn contract_derive_name_offset(tokens: Array[Token], starts: Array[Int], name: S
             },
             TIdent(got) => if got == name && d < lim {
               at = Array::get(starts, d)
+              Array::set(cursor, 0, d + 1)
               scanning = false
             } else {
               d = d + 1

--- a/lib/@vibe/compiler/runtime/typecheck_fs.vibe
+++ b/lib/@vibe/compiler/runtime/typecheck_fs.vibe
@@ -25,7 +25,8 @@ import @vibe/compiler/checker {
   detect_unbound_nonunit_returns,
   detect_unused_imports,
   import_item_kind_errors,
-  typing_semantics_seed
+  typing_semantics_seed,
+  validate_derives
 }
 
 import @vibe/compiler/checker/artifacts {
@@ -5687,6 +5688,91 @@ fn located_lex_errors(source: String, lex_err_offsets: Array[Int], lex_err_msgs:
   dedupe_diagnostics(located)
 }
 
+/// #2317: the contract checks a single buffer CAN decide, beyond the grammar.
+///
+/// `parse_contract_program` plus `classify_contract_stmts` answer "is this
+/// shaped like a contract". They do not answer everything the loader does, and
+/// three of those answers need nothing but the parsed statements -- so the
+/// buffer lane reported clean for contracts the build refuses. Measured, all
+/// on complete packages through `vibe check`:
+///
+///   struct P { x: Int } derive(Foo)  -> unknown trait: Foo
+///   fn f(..) declared twice          -> contract facade: some declarations
+///                                       have no implementation file
+///
+/// The duplicate message is the loader's, and it names the wrong cause: `f` IS
+/// implemented, and the duplicate is what breaks the facade. This lane says
+/// what is actually wrong instead, which is the point of reporting it here at
+/// all.
+///
+/// `validate_derives` is the CHECKER's own function, exported for this, so the
+/// derive message is identical to the build's rather than a second
+/// implementation that could drift.
+///
+/// Positions come from searching the buffer for the offending name, the way
+/// `locate_by_marker` already places `unknown name:` and friends. Statements
+/// carry no offsets (`SLet(Bool, Bool, String, Option[TypeExpr], Expr)` has no
+/// span), and adding them is a change at every construction site.
+fn contract_semantic_errors(source: String, stmts: Array[Stmt]) -> Array[String] with Exception {
+  let out = array_empty()
+  let seen: Array[String] = []
+  let mut i = 0
+  while i < Array::length(stmts) {
+    match Array::get(stmts, i) {
+      SLet(_, _, name, _, _) => if str_array_contains_name(seen, name) {
+        Array::push(out, located_for_name(source, name, 2, String::concat(String::concat("duplicate declaration in a contract: `", name), "` is declared more than once -- a contract declares each name once, and the facade cannot allocate it twice")))
+      } else {
+        Array::push(seen, name)
+      },
+      SStruct(_, _, _, derives, _, _) => validate_derives(derives, out),
+      SEnum(_, _, _, _, derives) => validate_derives(derives, out),
+      _ => ()
+    }
+    i = i + 1
+  }
+  out
+}
+
+fn str_array_contains_name(xs: Array[String], name: String) -> Bool {
+  let mut i = 0
+  let mut found = false
+  while i < Array::length(xs) {
+    if Array::get(xs, i) == name {
+      found = true
+      i = Array::length(xs)
+    } else {
+      i = i + 1
+    }
+  }
+  found
+}
+
+/// `msg` prefixed with the position of the `occurrence`-th appearance of
+/// `name` in `source` (1-based), or bare when it cannot be found. For a
+/// duplicate that is the SECOND one: the first declaration is fine, and the
+/// second is the line to delete.
+fn located_for_name(source: String, name: String, occurrence: Int, msg: String) -> String {
+  let mut cursor = 0
+  let mut seen = 0
+  let mut at = 0 - 1
+  let total = String::length(source)
+  while seen < occurrence && cursor < total {
+    let rel = String::index_of(String::substring(source, cursor, total), name)
+    if rel < 0 {
+      cursor = total
+    } else {
+      at = cursor + rel
+      seen = seen + 1
+      cursor = at + String::length(name)
+    }
+  }
+  if seen == occurrence && at >= 0 {
+    String::concat(offset_line_col_prefix(source, at), msg)
+  } else {
+    msg
+  }
+}
+
 /// One located diagnostic for a contract parse failure.
 fn contract_parse_diagnostic(source: String, tokens: Array[Token], starts: Array[Int], msg: String) -> Array[String] with Exception {
   if diag_already_located(msg) {
@@ -5738,7 +5824,7 @@ fn collect_all_diagnostics_on(input_path: String, source: String) -> Array[Strin
     return handle {
       let (_, _, cstmts) = parse_contract_program(ctokens)
       let (_raws, _type_defs) = classify_contract_stmts(cstmts)
-      array_empty()
+      contract_semantic_errors(source, cstmts)
     } with { Exception::Throw(msg) => contract_parse_diagnostic(source, ctokens, cstarts, msg) }
   } else {
     ()

--- a/lib/@vibe/compiler/runtime/typecheck_fs.vibe
+++ b/lib/@vibe/compiler/runtime/typecheck_fs.vibe
@@ -5713,35 +5713,82 @@ fn located_lex_errors(source: String, lex_err_offsets: Array[Int], lex_err_msgs:
 /// `locate_by_marker` already places `unknown name:` and friends. Statements
 /// carry no offsets (`SLet(Bool, Bool, String, Option[TypeExpr], Expr)` has no
 /// span), and adding them is a change at every construction site.
-fn contract_semantic_errors(source: String, decls: Array[(String, String)], stmts: Array[Stmt]) -> Array[String] with Exception {
+fn contract_semantic_errors(source: String, decls: Array[(String, String)], opaques: Array[(String, Int)], stmts: Array[Stmt]) -> Array[String] with Exception {
   let out = array_empty()
   // Bodyless declarations live in `parse_contract_program`'s FIRST tuple
   // element, not among its statements -- a contract's `fn f(x: Int) -> Int` is
   // not an `SLet`. The first version scanned the statements for one and so
   // never fired; measured, the duplicate probe reported nothing until this
   // moved to `decls`.
+  //
+  // Opaque type declarations share the namespace: the facade allocates each
+  // name once, so `opaque type Token` twice is the same defect as `fn f`
+  // twice, and the second tuple element is where those live (Codex review on
+  // #2320 -- the first version discarded it).
   let seen: Array[String] = []
   let mut d = 0
   while d < Array::length(decls) {
     let (dname, _sig) = Array::get(decls, d)
-    if str_array_contains_name(seen, dname) {
-      let dup_msg = String::concat(String::concat("duplicate declaration in a contract: `", dname), "` is declared more than once -- a contract declares each name once, and the facade it generates can allocate the name only once")
-      Array::push(out, located_for_name(source, dname, 2, dup_msg))
-    } else {
-      Array::push(seen, dname)
-    }
+    contract_note_duplicate(source, dname, seen, out)
     d = d + 1
+  }
+  let mut o = 0
+  while o < Array::length(opaques) {
+    let (oname, _arity) = Array::get(opaques, o)
+    contract_note_duplicate(source, oname, seen, out)
+    o = o + 1
   }
   let mut i = 0
   while i < Array::length(stmts) {
     match Array::get(stmts, i) {
-      SStruct(_, _, _, derives, _, _) => validate_derives(derives, out),
-      SEnum(_, _, _, _, derives) => validate_derives(derives, out),
+      SStruct(_, _, _, derives, _, _) => contract_derive_errors(source, derives, out),
+      SEnum(_, _, _, _, derives) => contract_derive_errors(source, derives, out),
       _ => ()
     }
     i = i + 1
   }
   out
+}
+
+/// Record `name` as seen, reporting it when it was seen before.
+fn contract_note_duplicate(source: String, name: String, seen: Array[String], out: Array[String]) -> Unit {
+  if str_array_contains_name(seen, name) {
+    let dup_msg = String::concat(String::concat("duplicate declaration in a contract: `", name), "` is declared more than once -- a contract declares each name once, and the facade it generates can allocate the name only once")
+    Array::push(out, located_for_name(source, name, 2, dup_msg))
+  } else {
+    Array::push(seen, name)
+  }
+}
+
+/// `validate_derives`, with each message anchored on the offending trait name.
+///
+/// The checker's messages are bare (`unknown trait: Foo`), because on the
+/// import lane something downstream locates them. Returned bare from here they
+/// render at the synthetic 0:0 and an editor cannot highlight the derive clause
+/// (Codex review on #2320). The trait name appears verbatim in the buffer, so
+/// the same locator the duplicate uses places it -- first occurrence, since a
+/// derive names it once.
+fn contract_derive_errors(source: String, derives: Array[String], out: Array[String]) -> Unit {
+  let raw = array_empty()
+  validate_derives(derives, raw)
+  let mut i = 0
+  while i < Array::length(raw) {
+    let msg = Array::get(raw, i)
+    let marker = "unknown trait: "
+    let mi = String::index_of(msg, marker)
+    if mi < 0 {
+      Array::push(out, msg)
+    } else {
+      let sstart = mi + String::length(marker)
+      let send = typecheck_ident_run(msg, sstart)
+      if send <= sstart {
+        Array::push(out, msg)
+      } else {
+        Array::push(out, located_for_name(source, String::substring(msg, sstart, send), 1, msg))
+      }
+    }
+    i = i + 1
+  }
 }
 
 fn str_array_contains_name(xs: Array[String], name: String) -> Bool {
@@ -5767,14 +5814,37 @@ fn located_for_name(source: String, name: String, occurrence: Int, msg: String) 
   let mut seen = 0
   let mut at = 0 - 1
   let total = String::length(source)
+  let nlen = String::length(name)
   while seen < occurrence && cursor < total {
     let rel = String::index_of(String::substring(source, cursor, total), name)
     if rel < 0 {
       cursor = total
     } else {
-      at = cursor + rel
-      seen = seen + 1
-      cursor = at + String::length(name)
+      let hit = cursor + rel
+      // WHOLE identifier tokens only. A raw substring search counted the `f`
+      // inside the `fn` keyword as an occurrence of a declaration named `f`,
+      // so a duplicate anchored on the FIRST declaration instead of the second
+      // (Codex review on #2320). Measured: `line 9:4` for a contract whose
+      // second declaration is on line 10 -- and the gate asserted line 9, so
+      // it passed on the broken locator.
+      let before_ok = if hit == 0 {
+        true
+      } else {
+        !loc_ident_char(String::char_code_at(source, hit - 1))
+      }
+      let after = hit + nlen
+      let after_ok = if after >= total {
+        true
+      } else {
+        !loc_ident_char(String::char_code_at(source, after))
+      }
+      if before_ok && after_ok {
+        at = hit
+        seen = seen + 1
+      } else {
+        ()
+      }
+      cursor = hit + nlen
     }
   }
   if seen == occurrence && at >= 0 {
@@ -5833,9 +5903,9 @@ fn collect_all_diagnostics_on(input_path: String, source: String) -> Array[Strin
     // branch this replaces did catch it, through `check_program`. So run the
     // classifier the loader runs, on the statements the parse produced.
     return handle {
-      let (cdecls, _copaques, cstmts) = parse_contract_program(ctokens)
+      let (cdecls, copaques, cstmts) = parse_contract_program(ctokens)
       let (_raws, _type_defs) = classify_contract_stmts(cstmts)
-      contract_semantic_errors(source, cdecls, cstmts)
+      contract_semantic_errors(source, cdecls, copaques, cstmts)
     } with { Exception::Throw(msg) => contract_parse_diagnostic(source, ctokens, cstarts, msg) }
   } else {
     ()

--- a/lib/@vibe/compiler/runtime/typecheck_fs.vibe
+++ b/lib/@vibe/compiler/runtime/typecheck_fs.vibe
@@ -5713,36 +5713,30 @@ fn located_lex_errors(source: String, lex_err_offsets: Array[Int], lex_err_msgs:
 /// `locate_by_marker` already places `unknown name:` and friends. Statements
 /// carry no offsets (`SLet(Bool, Bool, String, Option[TypeExpr], Expr)` has no
 /// span), and adding them is a change at every construction site.
-fn contract_semantic_errors(source: String, decls: Array[(String, String)], opaques: Array[(String, Int)], stmts: Array[Stmt]) -> Array[String] with Exception {
+fn contract_semantic_errors(source: String, tokens: Array[Token], starts: Array[Int], decls: Array[(String, String)], opaques: Array[(String, Int)], stmts: Array[Stmt]) -> Array[String] with Exception {
   let out = array_empty()
   // Bodyless declarations live in `parse_contract_program`'s FIRST tuple
   // element, not among its statements -- a contract's `fn f(x: Int) -> Int` is
-  // not an `SLet`. The first version scanned the statements for one and so
-  // never fired; measured, the duplicate probe reported nothing until this
-  // moved to `decls`.
-  //
-  // Opaque type declarations share the namespace: the facade allocates each
-  // name once, so `opaque type Token` twice is the same defect as `fn f`
-  // twice, and the second tuple element is where those live (Codex review on
-  // #2320 -- the first version discarded it).
+  // not an `SLet`. Opaque type declarations share the namespace, since the
+  // facade allocates each name once, so both lists feed one `seen` set.
   let seen: Array[String] = []
   let mut d = 0
   while d < Array::length(decls) {
     let (dname, _sig) = Array::get(decls, d)
-    contract_note_duplicate(source, dname, seen, out)
+    contract_note_duplicate(source, tokens, starts, dname, seen, out)
     d = d + 1
   }
   let mut o = 0
   while o < Array::length(opaques) {
     let (oname, _arity) = Array::get(opaques, o)
-    contract_note_duplicate(source, oname, seen, out)
+    contract_note_duplicate(source, tokens, starts, oname, seen, out)
     o = o + 1
   }
   let mut i = 0
   while i < Array::length(stmts) {
     match Array::get(stmts, i) {
-      SStruct(_, _, _, derives, _, _) => contract_derive_errors(source, derives, out),
-      SEnum(_, _, _, _, derives) => contract_derive_errors(source, derives, out),
+      SStruct(_, _, _, derives, _, _) => contract_derive_errors(source, tokens, starts, derives, out),
+      SEnum(_, _, _, _, derives) => contract_derive_errors(source, tokens, starts, derives, out),
       _ => ()
     }
     i = i + 1
@@ -5751,10 +5745,10 @@ fn contract_semantic_errors(source: String, decls: Array[(String, String)], opaq
 }
 
 /// Record `name` as seen, reporting it when it was seen before.
-fn contract_note_duplicate(source: String, name: String, seen: Array[String], out: Array[String]) -> Unit {
+fn contract_note_duplicate(source: String, tokens: Array[Token], starts: Array[Int], name: String, seen: Array[String], out: Array[String]) -> Unit {
   if str_array_contains_name(seen, name) {
     let dup_msg = String::concat(String::concat("duplicate declaration in a contract: `", name), "` is declared more than once -- a contract declares each name once, and the facade it generates can allocate the name only once")
-    Array::push(out, located_for_name(source, name, 2, dup_msg))
+    Array::push(out, located_at_offset(source, contract_decl_head_offset(tokens, starts, name, 2), dup_msg))
   } else {
     Array::push(seen, name)
   }
@@ -5768,7 +5762,7 @@ fn contract_note_duplicate(source: String, name: String, seen: Array[String], ou
 /// (Codex review on #2320). The trait name appears verbatim in the buffer, so
 /// the same locator the duplicate uses places it -- first occurrence, since a
 /// derive names it once.
-fn contract_derive_errors(source: String, derives: Array[String], out: Array[String]) -> Unit {
+fn contract_derive_errors(source: String, tokens: Array[Token], starts: Array[Int], derives: Array[String], out: Array[String]) -> Unit {
   let raw = array_empty()
   validate_derives(derives, raw)
   let mut i = 0
@@ -5784,7 +5778,8 @@ fn contract_derive_errors(source: String, derives: Array[String], out: Array[Str
       if send <= sstart {
         Array::push(out, msg)
       } else {
-        Array::push(out, located_for_name(source, String::substring(msg, sstart, send), 1, msg))
+        let tname = String::substring(msg, sstart, send)
+        Array::push(out, located_at_offset(source, contract_derive_name_offset(tokens, starts, tname), msg))
       }
     }
     i = i + 1
@@ -5809,46 +5804,109 @@ fn str_array_contains_name(xs: Array[String], name: String) -> Bool {
 /// `name` in `source` (1-based), or bare when it cannot be found. For a
 /// duplicate that is the SECOND one: the first declaration is fine, and the
 /// second is the line to delete.
-fn located_for_name(source: String, name: String, occurrence: Int, msg: String) -> String {
-  let mut cursor = 0
+/// Byte offset of the identifier that HEADS the `occurrence`-th declaration
+/// named `name`, or -1.
+///
+/// Token-derived, not a text search. Two earlier versions searched the source
+/// for the name and both anchored on the wrong thing (Codex review on #2320):
+/// a raw substring match counted the `f` inside the first `fn` keyword, and
+/// whole-token matching still counted any other identifier with that spelling
+/// -- `struct Foo { .. }` before `derive(Foo)` anchors on the struct's name.
+/// An ordinal over the whole file cannot express "the declaration", however
+/// the matching is narrowed.
+///
+/// A declaration head is `fn <ident>` or `type <ident>`, which is exactly what
+/// `parse_contract_program` matches to produce the lists being scanned, so this
+/// walk and that parse agree by construction.
+fn contract_decl_head_offset(tokens: Array[Token], starts: Array[Int], name: String, occurrence: Int) -> Int {
+  let n = Array::length(tokens)
+  let lim = Array::length(starts)
+  let mut i = 0
   let mut seen = 0
   let mut at = 0 - 1
-  let total = String::length(source)
-  let nlen = String::length(name)
-  while seen < occurrence && cursor < total {
-    let rel = String::index_of(String::substring(source, cursor, total), name)
-    if rel < 0 {
-      cursor = total
+  while i + 1 < n && seen < occurrence {
+    let heads = match Array::get(tokens, i) {
+      TFn => true,
+      TType => true,
+      _ => false
+    }
+    if heads {
+      match Array::get(tokens, i + 1) {
+        TIdent(got) => if got == name && i + 1 < lim {
+          seen = seen + 1
+          at = Array::get(starts, i + 1)
+        } else {
+          ()
+        },
+        _ => ()
+      }
     } else {
-      let hit = cursor + rel
-      // WHOLE identifier tokens only. A raw substring search counted the `f`
-      // inside the `fn` keyword as an occurrence of a declaration named `f`,
-      // so a duplicate anchored on the FIRST declaration instead of the second
-      // (Codex review on #2320). Measured: `line 9:4` for a contract whose
-      // second declaration is on line 10 -- and the gate asserted line 9, so
-      // it passed on the broken locator.
-      let before_ok = if hit == 0 {
-        true
-      } else {
-        !loc_ident_char(String::char_code_at(source, hit - 1))
+      ()
+    }
+    i = i + 1
+  }
+  if seen == occurrence {
+    at
+  } else {
+    0 - 1
+  }
+}
+
+/// Byte offset of `name` where it appears INSIDE a `derive(..)` clause, or -1.
+///
+/// The same reasoning: the trait name can occur anywhere else in the buffer,
+/// so the anchor is the occurrence that sits between `derive (` and the
+/// matching `)`.
+fn contract_derive_name_offset(tokens: Array[Token], starts: Array[Int], name: String) -> Int {
+  let n = Array::length(tokens)
+  let lim = Array::length(starts)
+  let mut i = 0
+  let mut at = 0 - 1
+  while i < n && at < 0 {
+    let is_derive = match Array::get(tokens, i) {
+      TDerive => true,
+      _ => false
+    }
+    if is_derive {
+      let opens = match Array::get(tokens, i + 1) {
+        TLParen => true,
+        _ => false
       }
-      let after = hit + nlen
-      let after_ok = if after >= total {
-        true
-      } else {
-        !loc_ident_char(String::char_code_at(source, after))
-      }
-      if before_ok && after_ok {
-        at = hit
-        seen = seen + 1
+      if opens {
+        let mut d = i + 2
+        let mut scanning = true
+        while scanning && d < n {
+          match Array::get(tokens, d) {
+            TRParen => {
+              scanning = false
+            },
+            TIdent(got) => if got == name && d < lim {
+              at = Array::get(starts, d)
+              scanning = false
+            } else {
+              d = d + 1
+            },
+            _ => {
+              d = d + 1
+            }
+          }
+        }
       } else {
         ()
       }
-      cursor = hit + nlen
+    } else {
+      ()
     }
+    i = i + 1
   }
-  if seen == occurrence && at >= 0 {
-    String::concat(offset_line_col_prefix(source, at), msg)
+  at
+}
+
+/// `msg` prefixed with the position at `off`, or bare when `off` is -1 --
+/// degraded, never wrong, the same rule the parse anchor states for itself.
+fn located_at_offset(source: String, off: Int, msg: String) -> String {
+  if off >= 0 {
+    String::concat(offset_line_col_prefix(source, off), msg)
   } else {
     msg
   }
@@ -5905,7 +5963,7 @@ fn collect_all_diagnostics_on(input_path: String, source: String) -> Array[Strin
     return handle {
       let (cdecls, copaques, cstmts) = parse_contract_program(ctokens)
       let (_raws, _type_defs) = classify_contract_stmts(cstmts)
-      contract_semantic_errors(source, cdecls, copaques, cstmts)
+      contract_semantic_errors(source, ctokens, cstarts, cdecls, copaques, cstmts)
     } with { Exception::Throw(msg) => contract_parse_diagnostic(source, ctokens, cstarts, msg) }
   } else {
     ()

--- a/lib/@vibe/compiler/runtime/typecheck_fs.vibe
+++ b/lib/@vibe/compiler/runtime/typecheck_fs.vibe
@@ -5713,29 +5713,10 @@ fn located_lex_errors(source: String, lex_err_offsets: Array[Int], lex_err_msgs:
 /// `locate_by_marker` already places `unknown name:` and friends. Statements
 /// carry no offsets (`SLet(Bool, Bool, String, Option[TypeExpr], Expr)` has no
 /// span), and adding them is a change at every construction site.
-fn contract_semantic_errors(source: String, tokens: Array[Token], starts: Array[Int], decls: Array[(String, String)], opaques: Array[(String, Int)], stmts: Array[Stmt]) -> Array[String] with Exception {
+fn contract_semantic_errors(source: String, tokens: Array[Token], starts: Array[Int], stmts: Array[Stmt]) -> Array[String] with Exception {
   let out = array_empty()
-  // Bodyless declarations live in `parse_contract_program`'s FIRST tuple
-  // element, not among its statements -- a contract's `fn f(x: Int) -> Int` is
-  // not an `SLet`. Opaque type declarations share the namespace, since the
-  // facade allocates each name once, so both lists feed one `seen` set.
-  let heads = contract_decl_head_table(tokens, starts)
-  let head_taken = contract_taken_flags(heads)
   let derive_names = contract_derive_name_table(tokens, starts)
   let derive_taken = contract_taken_flags(derive_names)
-  let seen: Array[String] = []
-  let mut d = 0
-  while d < Array::length(decls) {
-    let (dname, _sig) = Array::get(decls, d)
-    contract_note_duplicate(source, heads, head_taken, dname, seen, out)
-    d = d + 1
-  }
-  let mut o = 0
-  while o < Array::length(opaques) {
-    let (oname, _arity) = Array::get(opaques, o)
-    contract_note_duplicate(source, heads, head_taken, oname, seen, out)
-    o = o + 1
-  }
   let mut i = 0
   while i < Array::length(stmts) {
     match Array::get(stmts, i) {
@@ -5746,20 +5727,6 @@ fn contract_semantic_errors(source: String, tokens: Array[Token], starts: Array[
     i = i + 1
   }
   out
-}
-
-/// Record `name` as seen, reporting it when it was seen before.
-fn contract_note_duplicate(source: String, heads: Array[(String, Int)], head_taken: Array[Bool], name: String, seen: Array[String], out: Array[String]) -> Unit {
-  if str_array_contains_name(seen, name) {
-    let dup_msg = String::concat(String::concat("duplicate declaration in a contract: `", name), "` is declared more than once -- a contract declares each name once, and the facade it generates can allocate the name only once")
-    Array::push(out, located_at_offset(source, contract_take_anchor(heads, head_taken, name), dup_msg))
-  } else {
-    // Spend the FIRST head for this name, so the first duplicate takes the
-    // second and an Nth duplicate takes the Nth -- three declarations of one
-    // name gave three reports all pointing at the second before this.
-    let _first = contract_take_anchor(heads, head_taken, name)
-    Array::push(seen, name)
-  }
 }
 
 /// `validate_derives`, with each message anchored on the offending trait name.
@@ -5791,110 +5758,6 @@ fn contract_derive_errors(source: String, derive_names: Array[(String, Int)], de
       }
     }
     i = i + 1
-  }
-}
-
-fn str_array_contains_name(xs: Array[String], name: String) -> Bool {
-  let mut i = 0
-  let mut found = false
-  while i < Array::length(xs) {
-    if Array::get(xs, i) == name {
-      found = true
-      i = Array::length(xs)
-    } else {
-      i = i + 1
-    }
-  }
-  found
-}
-
-/// `msg` prefixed with the position of the `occurrence`-th appearance of
-/// `name` in `source` (1-based), or bare when it cannot be found. For a
-/// duplicate that is the SECOND one: the first declaration is fine, and the
-/// second is the line to delete.
-/// Byte offset of the identifier that HEADS the `occurrence`-th declaration
-/// named `name`, or -1.
-///
-/// Token-derived, not a text search. Two earlier versions searched the source
-/// for the name and both anchored on the wrong thing (Codex review on #2320):
-/// a raw substring match counted the `f` inside the first `fn` keyword, and
-/// whole-token matching still counted any other identifier with that spelling
-/// -- `struct Foo { .. }` before `derive(Foo)` anchors on the struct's name.
-/// An ordinal over the whole file cannot express "the declaration", however
-/// the matching is narrowed.
-///
-/// A declaration head is `fn <ident>` or `type <ident>`, which is exactly what
-/// `parse_contract_program` matches to produce the lists being scanned, so this
-/// walk and that parse agree by construction.
-/// Every declaration head in the buffer, in source order, as
-/// `(declared name, byte offset of the name)`.
-///
-/// Built ONCE and consumed in order, rather than searched per diagnostic. Five
-/// rounds of review found edge cases in the per-query searches -- a name that
-/// occurs earlier for another reason, a third duplicate, a multi-name derive,
-/// a qualified `fn Map::get` -- and every one of them was this code
-/// reconstructing what the parser already knew. A table consumed in order has
-/// no ordinal to get wrong: the k-th report of a name takes the k-th entry.
-///
-/// The heads are exactly the ones `parse_contract_program` accepts for a name
-/// that reaches `decls`/`opaques`: `fn`, `type`, `let`, and `opaque type`.
-/// A qualified head (`fn Map::get`) is joined the way the parser joins it, so
-/// the name here matches the name recorded there.
-fn contract_decl_head_table(tokens: Array[Token], starts: Array[Int]) -> Array[(String, Int)] {
-  let out = array_empty()
-  let n = Array::length(tokens)
-  let lim = Array::length(starts)
-  let mut i = 0
-  while i + 1 < n {
-    let heads = match Array::get(tokens, i) {
-      TFn => true,
-      TType => true,
-      TLet => true,
-      TIdent(kw) => kw == "opaque",
-      _ => false
-    }
-    if heads {
-      // `opaque type Token` puts the name two tokens along, not one.
-      let name_at = match Array::get(tokens, i) {
-        TIdent(_) => match Array::get(tokens, i + 1) {
-          TType => i + 2,
-          _ => i + 1
-        },
-        _ => i + 1
-      }
-      if name_at < n && name_at < lim {
-        match Array::get(tokens, name_at) {
-          TIdent(head_name) => {
-            let qualified = contract_qualified_head_name(tokens, name_at, head_name)
-            Array::push(out, (qualified, Array::get(starts, name_at)))
-          },
-          _ => ()
-        }
-      } else {
-        ()
-      }
-    } else {
-      ()
-    }
-    i = i + 1
-  }
-  out
-}
-
-/// `A::b` when the head is qualified, otherwise the bare name.
-fn contract_qualified_head_name(tokens: Array[Token], name_at: Int, head_name: String) -> String {
-  let n = Array::length(tokens)
-  if name_at + 2 < n {
-    let joined = match Array::get(tokens, name_at + 1) {
-      TDoubleColon => match Array::get(tokens, name_at + 2) {
-        TIdent(rest) => String::concat(head_name, String::concat("::", rest)),
-        _ => head_name
-      },
-      _ => head_name
-    }
-    joined
-  } else {
-    head_name
   }
 }
 
@@ -6042,9 +5905,9 @@ fn collect_all_diagnostics_on(input_path: String, source: String) -> Array[Strin
     // branch this replaces did catch it, through `check_program`. So run the
     // classifier the loader runs, on the statements the parse produced.
     return handle {
-      let (cdecls, copaques, cstmts) = parse_contract_program(ctokens)
+      let (_cdecls, _copaques, cstmts) = parse_contract_program(ctokens)
       let (_raws, _type_defs) = classify_contract_stmts(cstmts)
-      contract_semantic_errors(source, ctokens, cstarts, cdecls, copaques, cstmts)
+      contract_semantic_errors(source, ctokens, cstarts, cstmts)
     } with { Exception::Throw(msg) => contract_parse_diagnostic(source, ctokens, cstarts, msg) }
   } else {
     ()

--- a/lib/@vibe/compiler/runtime/typecheck_fs.vibe
+++ b/lib/@vibe/compiler/runtime/typecheck_fs.vibe
@@ -5713,17 +5713,28 @@ fn located_lex_errors(source: String, lex_err_offsets: Array[Int], lex_err_msgs:
 /// `locate_by_marker` already places `unknown name:` and friends. Statements
 /// carry no offsets (`SLet(Bool, Bool, String, Option[TypeExpr], Expr)` has no
 /// span), and adding them is a change at every construction site.
-fn contract_semantic_errors(source: String, stmts: Array[Stmt]) -> Array[String] with Exception {
+fn contract_semantic_errors(source: String, decls: Array[(String, String)], stmts: Array[Stmt]) -> Array[String] with Exception {
   let out = array_empty()
+  // Bodyless declarations live in `parse_contract_program`'s FIRST tuple
+  // element, not among its statements -- a contract's `fn f(x: Int) -> Int` is
+  // not an `SLet`. The first version scanned the statements for one and so
+  // never fired; measured, the duplicate probe reported nothing until this
+  // moved to `decls`.
   let seen: Array[String] = []
+  let mut d = 0
+  while d < Array::length(decls) {
+    let (dname, _sig) = Array::get(decls, d)
+    if str_array_contains_name(seen, dname) {
+      let dup_msg = String::concat(String::concat("duplicate declaration in a contract: `", dname), "` is declared more than once -- a contract declares each name once, and the facade it generates can allocate the name only once")
+      Array::push(out, located_for_name(source, dname, 2, dup_msg))
+    } else {
+      Array::push(seen, dname)
+    }
+    d = d + 1
+  }
   let mut i = 0
   while i < Array::length(stmts) {
     match Array::get(stmts, i) {
-      SLet(_, _, name, _, _) => if str_array_contains_name(seen, name) {
-        Array::push(out, located_for_name(source, name, 2, String::concat(String::concat("duplicate declaration in a contract: `", name), "` is declared more than once -- a contract declares each name once, and the facade cannot allocate it twice")))
-      } else {
-        Array::push(seen, name)
-      },
       SStruct(_, _, _, derives, _, _) => validate_derives(derives, out),
       SEnum(_, _, _, _, derives) => validate_derives(derives, out),
       _ => ()
@@ -5822,9 +5833,9 @@ fn collect_all_diagnostics_on(input_path: String, source: String) -> Array[Strin
     // branch this replaces did catch it, through `check_program`. So run the
     // classifier the loader runs, on the statements the parse produced.
     return handle {
-      let (_, _, cstmts) = parse_contract_program(ctokens)
+      let (cdecls, _copaques, cstmts) = parse_contract_program(ctokens)
       let (_raws, _type_defs) = classify_contract_stmts(cstmts)
-      contract_semantic_errors(source, cstmts)
+      contract_semantic_errors(source, cdecls, cstmts)
     } with { Exception::Throw(msg) => contract_parse_diagnostic(source, ctokens, cstarts, msg) }
   } else {
     ()

--- a/tests/gates/late/run.sh
+++ b/tests/gates/late/run.sh
@@ -8356,10 +8356,21 @@ printf 'export fn a(x: Int) -> Int {\n  x + 1\n}\n' > "$csdir/clean/impl.vibe"
 mkdir -p "$csdir/dupopaque"
 printf '%s\ntype Token\ntype Token\n\nfn a(x: Int) -> Int\n' "$cs_header" > "$csdir/dupopaque/index.vpkg"
 printf 'export fn a(x: Int) -> Int {\n  x + 1\n}\n' > "$csdir/dupopaque/impl.vibe"
+# DECOYS. An anchor found by counting occurrences of the name across the whole
+# buffer picks the wrong one as soon as the name appears earlier for any other
+# reason. `struct Foo` before `derive(Foo)`, and a `Token` parameter type before
+# the two `type Token` declarations, are exactly those cases (Codex review on
+# #2320). Both must still anchor on the DECLARATION, which is why the anchors
+# are derived from `fn`/`type`/`derive` tokens rather than from ordinals.
+mkdir -p "$csdir/decoyderive" "$csdir/decoydup"
+printf '%s\nstruct Foo {\n  y: Int\n}\n\nstruct P {\n  x: Int\n} derive(Foo)\n\nfn a(x: Int) -> Int\n' "$cs_header" > "$csdir/decoyderive/index.vpkg"
+printf 'export fn a(x: Int) -> Int {\n  x + 1\n}\n' > "$csdir/decoyderive/impl.vibe"
+printf '%s\nfn uses(t: Token) -> Int\ntype Token\ntype Token\n' "$cs_header" > "$csdir/decoydup/index.vpkg"
+printf 'export fn uses(t: Token) -> Int {\n  0\n}\n' > "$csdir/decoydup/impl.vibe"
 # Each bad contract must be refused by BOTH lanes, and the clean one by
 # neither. Asserting only the buffer lane would not notice the two drifting
 # apart again, which is what #2317 is about.
-for probe in derive dup dupopaque clean; do
+for probe in derive dup dupopaque decoyderive decoydup clean; do
   rm -f "$csdir/$probe.imp" "$csdir/$probe.imp.diag" "$csdir/$probe.buf"
   if VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_CHECK_ONLY=1 VIBE_IMPORT_ABI=raw \
     bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
@@ -8408,6 +8419,26 @@ fi
 if ! grep -q '^line 11:' "$csdir/derive.buf" 2>/dev/null; then
   echo "[compiler-gate] FAIL: the unknown derive is not anchored on its derive clause (expected line 11) (#2317)" >&2
   cat "$csdir/derive.buf" >&2 || true
+  exit 1
+fi
+# The decoys: the name occurs EARLIER in the buffer for an unrelated reason, so
+# an occurrence-counting anchor lands on the decoy. `struct Foo` is on line 9
+# and the `derive(Foo)` clause on line 15; the anchor must be 15.
+if grep -q '^line 9:' "$csdir/decoyderive.buf" 2>/dev/null; then
+  echo "[compiler-gate] FAIL: the unknown derive anchored on the unrelated 'struct Foo', not on the derive clause (#2317)" >&2
+  cat "$csdir/decoyderive.buf" >&2 || true
+  exit 1
+fi
+if ! grep -q '^line 15:' "$csdir/decoyderive.buf" 2>/dev/null; then
+  echo "[compiler-gate] FAIL: the unknown derive is not anchored on its derive clause with a decoy present (expected line 15) (#2317)" >&2
+  cat "$csdir/decoyderive.buf" >&2 || true
+  exit 1
+fi
+# `Token` appears first as a PARAMETER type on line 9; the two declarations are
+# lines 10 and 11, so the duplicate must anchor on 11.
+if ! grep -q '^line 11:' "$csdir/decoydup.buf" 2>/dev/null; then
+  echo "[compiler-gate] FAIL: the duplicate type anchored somewhere other than its second declaration -- a parameter reference displaced it (expected line 11) (#2317)" >&2
+  cat "$csdir/decoydup.buf" >&2 || true
   exit 1
 fi
 # ...and NO committed contract in the tree may gain a diagnostic. A check that

--- a/tests/gates/late/run.sh
+++ b/tests/gates/late/run.sh
@@ -8367,10 +8367,20 @@ printf '%s\nstruct Foo {\n  y: Int\n}\n\nstruct P {\n  x: Int\n} derive(Foo)\n\n
 printf 'export fn a(x: Int) -> Int {\n  x + 1\n}\n' > "$csdir/decoyderive/impl.vibe"
 printf '%s\nfn uses(t: Token) -> Int\ntype Token\ntype Token\n' "$cs_header" > "$csdir/decoydup/index.vpkg"
 printf 'export fn uses(t: Token) -> Int {\n  0\n}\n' > "$csdir/decoydup/impl.vibe"
+# Two declarations deriving the SAME unknown trait: each diagnostic must point
+# at its own clause. A locator that rescans from the start anchors both on the
+# first (Codex review on #2320).
+mkdir -p "$csdir/twoderive" "$csdir/duplet"
+printf '%s\nstruct A {\n  x: Int\n} derive(Foo)\n\nstruct B {\n  y: Int\n} derive(Foo)\n\nfn a(x: Int) -> Int\n' "$cs_header" > "$csdir/twoderive/index.vpkg"
+printf 'export fn a(x: Int) -> Int {\n  x + 1\n}\n' > "$csdir/twoderive/impl.vibe"
+# A bodyless VALUE declaration (#752) duplicated: `let` is a declaration head
+# too, and the first token version recognised only `fn` and `type`.
+printf '%s\nlet answer: Int\nlet answer: Int\n' "$cs_header" > "$csdir/duplet/index.vpkg"
+printf 'export let answer: Int = 42\n' > "$csdir/duplet/impl.vibe"
 # Each bad contract must be refused by BOTH lanes, and the clean one by
 # neither. Asserting only the buffer lane would not notice the two drifting
 # apart again, which is what #2317 is about.
-for probe in derive dup dupopaque decoyderive decoydup clean; do
+for probe in derive dup dupopaque decoyderive decoydup twoderive duplet clean; do
   rm -f "$csdir/$probe.imp" "$csdir/$probe.imp.diag" "$csdir/$probe.buf"
   if VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_CHECK_ONLY=1 VIBE_IMPORT_ABI=raw \
     bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
@@ -8439,6 +8449,25 @@ fi
 if ! grep -q '^line 11:' "$csdir/decoydup.buf" 2>/dev/null; then
   echo "[compiler-gate] FAIL: the duplicate type anchored somewhere other than its second declaration -- a parameter reference displaced it (expected line 11) (#2317)" >&2
   cat "$csdir/decoydup.buf" >&2 || true
+  exit 1
+fi
+# Two clauses, two DIFFERENT anchors. `derive(Foo)` is on line 12 and line 16;
+# a locator that rescans from 0 reports line 12 twice, which is why the
+# assertion is on the second line rather than merely on the count.
+if ! grep -q '^line 12:' "$csdir/twoderive.buf" 2>/dev/null; then
+  echo "[compiler-gate] FAIL: the first of two identical unknown derives is not anchored on its own clause (expected line 12) (#2317)" >&2
+  cat "$csdir/twoderive.buf" >&2 || true
+  exit 1
+fi
+if ! grep -q '^line 16:' "$csdir/twoderive.buf" 2>/dev/null; then
+  echo "[compiler-gate] FAIL: the SECOND identical unknown derive is not anchored on its own clause (expected line 16) -- the locator rescans from the start (#2317)" >&2
+  cat "$csdir/twoderive.buf" >&2 || true
+  exit 1
+fi
+# A duplicated bodyless `let`: the second declaration is line 10.
+if ! grep -q '^line 10:' "$csdir/duplet.buf" 2>/dev/null; then
+  echo "[compiler-gate] FAIL: a duplicated bodyless let is not anchored on its second declaration (expected line 10) (#2317)" >&2
+  cat "$csdir/duplet.buf" >&2 || true
   exit 1
 fi
 # ...and NO committed contract in the tree may gain a diagnostic. A check that

--- a/tests/gates/late/run.sh
+++ b/tests/gates/late/run.sh
@@ -8350,10 +8350,16 @@ printf '%s\nfn f(x: Int) -> Int\nfn f(x: Int) -> Int\n' "$cs_header" > "$csdir/d
 printf 'export fn f(x: Int) -> Int {\n  x + 1\n}\n' > "$csdir/dup/impl.vibe"
 printf '%s\nstruct P {\n  x: Int\n} derive(Eq)\n\nfn a(x: Int) -> Int\n' "$cs_header" > "$csdir/clean/index.vpkg"
 printf 'export fn a(x: Int) -> Int {\n  x + 1\n}\n' > "$csdir/clean/impl.vibe"
+# Opaque types share the declaration namespace -- the facade allocates each name
+# once, so declaring one twice is the same defect as a duplicated `fn`. The
+# first version discarded the opaque list entirely.
+mkdir -p "$csdir/dupopaque"
+printf '%s\ntype Token\ntype Token\n\nfn a(x: Int) -> Int\n' "$cs_header" > "$csdir/dupopaque/index.vpkg"
+printf 'export fn a(x: Int) -> Int {\n  x + 1\n}\n' > "$csdir/dupopaque/impl.vibe"
 # Each bad contract must be refused by BOTH lanes, and the clean one by
 # neither. Asserting only the buffer lane would not notice the two drifting
 # apart again, which is what #2317 is about.
-for probe in derive dup clean; do
+for probe in derive dup dupopaque clean; do
   rm -f "$csdir/$probe.imp" "$csdir/$probe.imp.diag" "$csdir/$probe.buf"
   if VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_CHECK_ONLY=1 VIBE_IMPORT_ABI=raw \
     bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
@@ -8383,10 +8389,25 @@ if ! grep -qF 'unknown trait: Foo' "$csdir/derive.buf" 2>/dev/null; then
   exit 1
 fi
 # The duplicate must be anchored on the SECOND declaration -- the first is
-# fine, the second is the line to delete. Line 9 is `fn f` the second time.
-if ! grep -q '^line 9:' "$csdir/dup.buf" 2>/dev/null; then
-  echo "[compiler-gate] FAIL: the duplicate declaration is not anchored on the second declaration (expected line 9) (#2317)" >&2
+# fine, the second is the line to delete. The header is 7 lines plus a blank,
+# so the two `fn f` lines are 9 and 10: line 10 is the one to report.
+#
+# This assertion said line 9 and PASSED on a broken locator: a raw substring
+# search counted the `f` inside the first `fn` keyword, anchoring on the first
+# declaration, which happens to be line 9 (Codex review on #2320). Asserting
+# the line the fixture actually puts the second declaration on is what makes it
+# mean anything.
+if ! grep -q '^line 10:' "$csdir/dup.buf" 2>/dev/null; then
+  echo "[compiler-gate] FAIL: the duplicate declaration is not anchored on the SECOND declaration (expected line 10) (#2317)" >&2
   cat "$csdir/dup.buf" >&2 || true
+  exit 1
+fi
+# The unknown derive must be anchored too, not left at the synthetic 0:0 --
+# `validate_derives` returns a bare message and the buffer lane has to place it.
+# `derive(Foo)` is on line 11 of that fixture.
+if ! grep -q '^line 11:' "$csdir/derive.buf" 2>/dev/null; then
+  echo "[compiler-gate] FAIL: the unknown derive is not anchored on its derive clause (expected line 11) (#2317)" >&2
+  cat "$csdir/derive.buf" >&2 || true
   exit 1
 fi
 # ...and NO committed contract in the tree may gain a diagnostic. A check that

--- a/tests/gates/late/run.sh
+++ b/tests/gates/late/run.sh
@@ -8377,10 +8377,22 @@ printf 'export fn a(x: Int) -> Int {\n  x + 1\n}\n' > "$csdir/twoderive/impl.vib
 # too, and the first token version recognised only `fn` and `type`.
 printf '%s\nlet answer: Int\nlet answer: Int\n' "$cs_header" > "$csdir/duplet/index.vpkg"
 printf 'export let answer: Int = 42\n' > "$csdir/duplet/impl.vibe"
+# Three declarations of one name: the second and third reports must land on the
+# second and third declarations, not both on the second.
+mkdir -p "$csdir/triple" "$csdir/multiderive" "$csdir/qualified"
+printf '%s\nfn f(x: Int) -> Int\nfn f(x: Int) -> Int\nfn f(x: Int) -> Int\n' "$cs_header" > "$csdir/triple/index.vpkg"
+printf 'export fn f(x: Int) -> Int {\n  x + 1\n}\n' > "$csdir/triple/impl.vibe"
+# One clause naming several unknown traits: each needs its own anchor.
+printf '%s\nstruct A {\n  x: Int\n} derive(Foo, Bar)\n\nfn a(x: Int) -> Int\n' "$cs_header" > "$csdir/multiderive/index.vpkg"
+printf 'export fn a(x: Int) -> Int {\n  x + 1\n}\n' > "$csdir/multiderive/impl.vibe"
+# A qualified head: the parser records `Map::get`, so the anchor has to join
+# the same way rather than matching the first identifier alone.
+printf '%s\nfn Map::get(x: Int) -> Int\nfn Map::get(x: Int) -> Int\n' "$cs_header" > "$csdir/qualified/index.vpkg"
+printf 'export fn Map::get(x: Int) -> Int {\n  x + 1\n}\n' > "$csdir/qualified/impl.vibe"
 # Each bad contract must be refused by BOTH lanes, and the clean one by
 # neither. Asserting only the buffer lane would not notice the two drifting
 # apart again, which is what #2317 is about.
-for probe in derive dup dupopaque decoyderive decoydup twoderive duplet clean; do
+for probe in derive dup dupopaque decoyderive decoydup twoderive duplet triple multiderive qualified clean; do
   rm -f "$csdir/$probe.imp" "$csdir/$probe.imp.diag" "$csdir/$probe.buf"
   if VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_CHECK_ONLY=1 VIBE_IMPORT_ABI=raw \
     bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
@@ -8468,6 +8480,46 @@ fi
 if ! grep -q '^line 10:' "$csdir/duplet.buf" 2>/dev/null; then
   echo "[compiler-gate] FAIL: a duplicated bodyless let is not anchored on its second declaration (expected line 10) (#2317)" >&2
   cat "$csdir/duplet.buf" >&2 || true
+  exit 1
+fi
+# Three declarations on lines 9, 10, 11: the two reports must be lines 10 AND
+# 11. Anchoring both on 10 is what a fixed "occurrence 2" does, and exact-string
+# dedupe would then collapse them to one.
+if ! grep -q '^line 10:' "$csdir/triple.buf" 2>/dev/null; then
+  echo "[compiler-gate] FAIL: the second of three duplicate declarations is not anchored on line 10 (#2317)" >&2
+  cat "$csdir/triple.buf" >&2 || true
+  exit 1
+fi
+if ! grep -q '^line 11:' "$csdir/triple.buf" 2>/dev/null; then
+  echo "[compiler-gate] FAIL: the THIRD duplicate declaration is not anchored on its own line (expected 11) -- every duplicate is asking for the same occurrence (#2317)" >&2
+  cat "$csdir/triple.buf" >&2 || true
+  exit 1
+fi
+# `derive(Foo, Bar)` on line 12: two diagnostics, both anchored, neither at 0:0.
+if ! grep -qF 'unknown trait: Foo' "$csdir/multiderive.buf" 2>/dev/null; then
+  echo "[compiler-gate] FAIL: the first trait of a multi-name derive is not reported (#2317)" >&2
+  cat "$csdir/multiderive.buf" >&2 || true
+  exit 1
+fi
+if ! grep -qF 'unknown trait: Bar' "$csdir/multiderive.buf" 2>/dev/null; then
+  echo "[compiler-gate] FAIL: the SECOND trait of a multi-name derive is not reported (#2317)" >&2
+  cat "$csdir/multiderive.buf" >&2 || true
+  exit 1
+fi
+if grep -q '^unknown trait' "$csdir/multiderive.buf" 2>/dev/null; then
+  echo "[compiler-gate] FAIL: a multi-name derive left a diagnostic unanchored -- the cursor moved past its own clause (#2317)" >&2
+  cat "$csdir/multiderive.buf" >&2 || true
+  exit 1
+fi
+# A qualified head `fn Map::get` declared twice: anchored on line 10, not bare.
+if grep -q '^duplicate declaration' "$csdir/qualified.buf" 2>/dev/null; then
+  echo "[compiler-gate] FAIL: a duplicated QUALIFIED declaration is unanchored -- the head name was not joined (#2317)" >&2
+  cat "$csdir/qualified.buf" >&2 || true
+  exit 1
+fi
+if ! grep -q '^line 10:' "$csdir/qualified.buf" 2>/dev/null; then
+  echo "[compiler-gate] FAIL: a duplicated qualified declaration is not anchored on its second declaration (expected line 10) (#2317)" >&2
+  cat "$csdir/qualified.buf" >&2 || true
   exit 1
 fi
 # ...and NO committed contract in the tree may gain a diagnostic. A check that

--- a/tests/gates/late/run.sh
+++ b/tests/gates/late/run.sh
@@ -8323,3 +8323,89 @@ if ! VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_CHECK_ONLY=1 VIBE_IMPORT_ABI=raw \
 fi
 rm -rf "$fwddir"
 echo "[compiler-gate] a call is checked identically in both declaration orders; correct forward calls still run; optional params stand down ok (#2318)"
+
+# 119/119. The buffer lane reports the contract checks it CAN decide, and the
+# two lanes agree (#2317).
+#
+# `parse_contract_program` + `classify_contract_stmts` answer "is this shaped
+# like a contract". They do not answer everything the loader does, so the
+# buffer lane reported CLEAN for contracts `vibe check` refuses. Measured on
+# complete packages before this: `derive(Foo)` -> `unknown trait: Foo` on the
+# import lane and nothing on the buffer lane; a name declared twice -> the
+# facade error on the import lane and nothing on the buffer lane.
+echo "[compiler-gate] 119/119 the buffer lane decides the contract checks it can, and agrees with the build (#2317)"
+csdir="_build/_gate_contract_semantic"
+rm -rf "$csdir"; mkdir -p "$csdir/derive" "$csdir/dup" "$csdir/clean"
+cs_header='name = @gate/contractsem
+version = 0.0.1
+description =
+  #|gate-only package for #2317
+deps = {}
+
+generated_hash =
+'
+printf '%s\nstruct P {\n  x: Int\n} derive(Foo)\n\nfn a(x: Int) -> Int\n' "$cs_header" > "$csdir/derive/index.vpkg"
+printf 'export fn a(x: Int) -> Int {\n  x + 1\n}\n' > "$csdir/derive/impl.vibe"
+printf '%s\nfn f(x: Int) -> Int\nfn f(x: Int) -> Int\n' "$cs_header" > "$csdir/dup/index.vpkg"
+printf 'export fn f(x: Int) -> Int {\n  x + 1\n}\n' > "$csdir/dup/impl.vibe"
+printf '%s\nstruct P {\n  x: Int\n} derive(Eq)\n\nfn a(x: Int) -> Int\n' "$cs_header" > "$csdir/clean/index.vpkg"
+printf 'export fn a(x: Int) -> Int {\n  x + 1\n}\n' > "$csdir/clean/impl.vibe"
+# Each bad contract must be refused by BOTH lanes, and the clean one by
+# neither. Asserting only the buffer lane would not notice the two drifting
+# apart again, which is what #2317 is about.
+for probe in derive dup clean; do
+  rm -f "$csdir/$probe.imp" "$csdir/$probe.imp.diag" "$csdir/$probe.buf"
+  if VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_CHECK_ONLY=1 VIBE_IMPORT_ABI=raw \
+    bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
+    "$csdir/$probe/index.vpkg" "$csdir/$probe.imp" main >/dev/null 2>&1; then
+    imp="clean"
+  else
+    imp="refused"
+  fi
+  VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_DIAGNOSTICS=1 VIBE_IMPORT_ABI=raw \
+    bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
+    "$csdir/$probe/index.vpkg" "$csdir/$probe.buf" main >/dev/null 2>&1 || true
+  if [ -s "$csdir/$probe.buf" ]; then buf="refused"; else buf="clean"; fi
+  if [ "$probe" = clean ]; then want="clean"; else want="refused"; fi
+  if [ "$imp" != "$want" ] || [ "$buf" != "$want" ]; then
+    echo "[compiler-gate] FAIL: contract '$probe' -- import lane says $imp, buffer lane says $buf, both should say $want (#2317)" >&2
+    cat "$csdir/$probe.imp.diag" 2>/dev/null >&2 || true
+    cat "$csdir/$probe.buf" 2>/dev/null >&2 || true
+    exit 1
+  fi
+done
+# The derive message must be the CHECKER's own, not a second implementation:
+# `validate_derives` is exported for this so the two lanes cannot word it
+# differently.
+if ! grep -qF 'unknown trait: Foo' "$csdir/derive.buf" 2>/dev/null; then
+  echo "[compiler-gate] FAIL: the buffer lane does not report an unknown derive with the checker's own message (#2317)" >&2
+  cat "$csdir/derive.buf" >&2 || true
+  exit 1
+fi
+# The duplicate must be anchored on the SECOND declaration -- the first is
+# fine, the second is the line to delete. Line 9 is `fn f` the second time.
+if ! grep -q '^line 9:' "$csdir/dup.buf" 2>/dev/null; then
+  echo "[compiler-gate] FAIL: the duplicate declaration is not anchored on the second declaration (expected line 9) (#2317)" >&2
+  cat "$csdir/dup.buf" >&2 || true
+  exit 1
+fi
+# ...and NO committed contract in the tree may gain a diagnostic. A check that
+# fires on real contracts is worse than one that never fires, and the probes
+# above cannot see it.
+cs_noisy=0
+for contract in $(git ls-files 'lib/**/index.vpkg'); do
+  rm -f "$csdir/tree.out"
+  VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_DIAGNOSTICS=1 VIBE_IMPORT_ABI=raw \
+    bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
+    "$contract" "$csdir/tree.out" main >/dev/null 2>&1 || true
+  if [ -s "$csdir/tree.out" ]; then
+    echo "[compiler-gate] FAIL: committed contract $contract gained a diagnostic (#2317)" >&2
+    cat "$csdir/tree.out" >&2
+    cs_noisy=$((cs_noisy + 1))
+  fi
+done
+if [ "$cs_noisy" -ne 0 ]; then
+  exit 1
+fi
+rm -rf "$csdir"
+echo "[compiler-gate] unknown derive and duplicate declaration are refused by both lanes, anchored, and no committed contract regressed ok (#2317)"

--- a/tests/gates/late/run.sh
+++ b/tests/gates/late/run.sh
@@ -8324,18 +8324,26 @@ fi
 rm -rf "$fwddir"
 echo "[compiler-gate] a call is checked identically in both declaration orders; correct forward calls still run; optional params stand down ok (#2318)"
 
-# 119/119. The buffer lane reports the contract checks it CAN decide, and the
-# two lanes agree (#2317).
+# 119/119. The buffer lane reports an unknown `derive`, and agrees with the
+# build about it (#2317).
 #
 # `parse_contract_program` + `classify_contract_stmts` answer "is this shaped
 # like a contract". They do not answer everything the loader does, so the
-# buffer lane reported CLEAN for contracts `vibe check` refuses. Measured on
-# complete packages before this: `derive(Foo)` -> `unknown trait: Foo` on the
-# import lane and nothing on the buffer lane; a name declared twice -> the
-# facade error on the import lane and nothing on the buffer lane.
-echo "[compiler-gate] 119/119 the buffer lane decides the contract checks it can, and agrees with the build (#2317)"
+# buffer lane reported CLEAN for contracts `vibe check` refuses. Measured on a
+# complete package before this: `derive(Foo)` -> `unknown trait: Foo` on the
+# import lane and nothing on the buffer lane.
+#
+# ONLY the derive check. A duplicate-declaration check was implemented and
+# removed: the loader accepts shapes it would have rejected -- a duplicated
+# QUALIFIED declaration (`fn Map::get` twice) checks clean on the import lane
+# while an unqualified one is refused, and a repeated legacy
+# `let version: String` is filtered out entirely when the header carries a
+# `version` directive. Deciding duplicates needs the loader's own rules, which
+# is the shared-function work #2317 describes. A diagnostic on a contract the
+# build accepts is worse than the missing one it was meant to add.
+echo "[compiler-gate] 119/119 the buffer lane reports an unknown derive, and agrees with the build (#2317)"
 csdir="_build/_gate_contract_semantic"
-rm -rf "$csdir"; mkdir -p "$csdir/derive" "$csdir/dup" "$csdir/clean"
+rm -rf "$csdir"; mkdir -p "$csdir/derive" "$csdir/clean" "$csdir/decoyderive" "$csdir/twoderive" "$csdir/multiderive"
 cs_header='name = @gate/contractsem
 version = 0.0.1
 description =
@@ -8344,55 +8352,29 @@ deps = {}
 
 generated_hash =
 '
+cs_impl_a='export fn a(x: Int) -> Int {
+  x + 1
+}
+'
 printf '%s\nstruct P {\n  x: Int\n} derive(Foo)\n\nfn a(x: Int) -> Int\n' "$cs_header" > "$csdir/derive/index.vpkg"
-printf 'export fn a(x: Int) -> Int {\n  x + 1\n}\n' > "$csdir/derive/impl.vibe"
-printf '%s\nfn f(x: Int) -> Int\nfn f(x: Int) -> Int\n' "$cs_header" > "$csdir/dup/index.vpkg"
-printf 'export fn f(x: Int) -> Int {\n  x + 1\n}\n' > "$csdir/dup/impl.vibe"
+printf '%s' "$cs_impl_a" > "$csdir/derive/impl.vibe"
 printf '%s\nstruct P {\n  x: Int\n} derive(Eq)\n\nfn a(x: Int) -> Int\n' "$cs_header" > "$csdir/clean/index.vpkg"
-printf 'export fn a(x: Int) -> Int {\n  x + 1\n}\n' > "$csdir/clean/impl.vibe"
-# Opaque types share the declaration namespace -- the facade allocates each name
-# once, so declaring one twice is the same defect as a duplicated `fn`. The
-# first version discarded the opaque list entirely.
-mkdir -p "$csdir/dupopaque"
-printf '%s\ntype Token\ntype Token\n\nfn a(x: Int) -> Int\n' "$cs_header" > "$csdir/dupopaque/index.vpkg"
-printf 'export fn a(x: Int) -> Int {\n  x + 1\n}\n' > "$csdir/dupopaque/impl.vibe"
-# DECOYS. An anchor found by counting occurrences of the name across the whole
-# buffer picks the wrong one as soon as the name appears earlier for any other
-# reason. `struct Foo` before `derive(Foo)`, and a `Token` parameter type before
-# the two `type Token` declarations, are exactly those cases (Codex review on
-# #2320). Both must still anchor on the DECLARATION, which is why the anchors
-# are derived from `fn`/`type`/`derive` tokens rather than from ordinals.
-mkdir -p "$csdir/decoyderive" "$csdir/decoydup"
+printf '%s' "$cs_impl_a" > "$csdir/clean/impl.vibe"
+# The name occurs EARLIER as an unrelated struct, so an anchor found by
+# counting occurrences lands on the decoy instead of the derive clause.
 printf '%s\nstruct Foo {\n  y: Int\n}\n\nstruct P {\n  x: Int\n} derive(Foo)\n\nfn a(x: Int) -> Int\n' "$cs_header" > "$csdir/decoyderive/index.vpkg"
-printf 'export fn a(x: Int) -> Int {\n  x + 1\n}\n' > "$csdir/decoyderive/impl.vibe"
-printf '%s\nfn uses(t: Token) -> Int\ntype Token\ntype Token\n' "$cs_header" > "$csdir/decoydup/index.vpkg"
-printf 'export fn uses(t: Token) -> Int {\n  0\n}\n' > "$csdir/decoydup/impl.vibe"
-# Two declarations deriving the SAME unknown trait: each diagnostic must point
-# at its own clause. A locator that rescans from the start anchors both on the
-# first (Codex review on #2320).
-mkdir -p "$csdir/twoderive" "$csdir/duplet"
+printf '%s' "$cs_impl_a" > "$csdir/decoyderive/impl.vibe"
+# Two clauses naming the same unknown trait: each diagnostic needs its own.
 printf '%s\nstruct A {\n  x: Int\n} derive(Foo)\n\nstruct B {\n  y: Int\n} derive(Foo)\n\nfn a(x: Int) -> Int\n' "$cs_header" > "$csdir/twoderive/index.vpkg"
-printf 'export fn a(x: Int) -> Int {\n  x + 1\n}\n' > "$csdir/twoderive/impl.vibe"
-# A bodyless VALUE declaration (#752) duplicated: `let` is a declaration head
-# too, and the first token version recognised only `fn` and `type`.
-printf '%s\nlet answer: Int\nlet answer: Int\n' "$cs_header" > "$csdir/duplet/index.vpkg"
-printf 'export let answer: Int = 42\n' > "$csdir/duplet/impl.vibe"
-# Three declarations of one name: the second and third reports must land on the
-# second and third declarations, not both on the second.
-mkdir -p "$csdir/triple" "$csdir/multiderive" "$csdir/qualified"
-printf '%s\nfn f(x: Int) -> Int\nfn f(x: Int) -> Int\nfn f(x: Int) -> Int\n' "$cs_header" > "$csdir/triple/index.vpkg"
-printf 'export fn f(x: Int) -> Int {\n  x + 1\n}\n' > "$csdir/triple/impl.vibe"
-# One clause naming several unknown traits: each needs its own anchor.
+printf '%s' "$cs_impl_a" > "$csdir/twoderive/impl.vibe"
+# One clause naming several unknown traits.
 printf '%s\nstruct A {\n  x: Int\n} derive(Foo, Bar)\n\nfn a(x: Int) -> Int\n' "$cs_header" > "$csdir/multiderive/index.vpkg"
-printf 'export fn a(x: Int) -> Int {\n  x + 1\n}\n' > "$csdir/multiderive/impl.vibe"
-# A qualified head: the parser records `Map::get`, so the anchor has to join
-# the same way rather than matching the first identifier alone.
-printf '%s\nfn Map::get(x: Int) -> Int\nfn Map::get(x: Int) -> Int\n' "$cs_header" > "$csdir/qualified/index.vpkg"
-printf 'export fn Map::get(x: Int) -> Int {\n  x + 1\n}\n' > "$csdir/qualified/impl.vibe"
-# Each bad contract must be refused by BOTH lanes, and the clean one by
-# neither. Asserting only the buffer lane would not notice the two drifting
-# apart again, which is what #2317 is about.
-for probe in derive dup dupopaque decoyderive decoydup twoderive duplet triple multiderive qualified clean; do
+printf '%s' "$cs_impl_a" > "$csdir/multiderive/impl.vibe"
+# Each bad contract refused by BOTH lanes, the clean one by neither. Asserting
+# only the buffer lane would not notice the two drifting apart again, and
+# asserting only that it refuses would not notice it refusing a VALID contract
+# -- which is how the duplicate check was caught.
+for probe in derive decoyderive twoderive multiderive clean; do
   rm -f "$csdir/$probe.imp" "$csdir/$probe.imp.diag" "$csdir/$probe.buf"
   if VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_CHECK_ONLY=1 VIBE_IMPORT_ABI=raw \
     bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
@@ -8413,119 +8395,50 @@ for probe in derive dup dupopaque decoyderive decoydup twoderive duplet triple m
     exit 1
   fi
 done
-# The derive message must be the CHECKER's own, not a second implementation:
-# `validate_derives` is exported for this so the two lanes cannot word it
-# differently.
+# The message is the CHECKER's own -- `validate_derives` is exported for this,
+# so the two lanes cannot word it differently.
 if ! grep -qF 'unknown trait: Foo' "$csdir/derive.buf" 2>/dev/null; then
   echo "[compiler-gate] FAIL: the buffer lane does not report an unknown derive with the checker's own message (#2317)" >&2
   cat "$csdir/derive.buf" >&2 || true
   exit 1
 fi
-# The duplicate must be anchored on the SECOND declaration -- the first is
-# fine, the second is the line to delete. The header is 7 lines plus a blank,
-# so the two `fn f` lines are 9 and 10: line 10 is the one to report.
-#
-# This assertion said line 9 and PASSED on a broken locator: a raw substring
-# search counted the `f` inside the first `fn` keyword, anchoring on the first
-# declaration, which happens to be line 9 (Codex review on #2320). Asserting
-# the line the fixture actually puts the second declaration on is what makes it
-# mean anything.
-if ! grep -q '^line 10:' "$csdir/dup.buf" 2>/dev/null; then
-  echo "[compiler-gate] FAIL: the duplicate declaration is not anchored on the SECOND declaration (expected line 10) (#2317)" >&2
-  cat "$csdir/dup.buf" >&2 || true
-  exit 1
-fi
-# The unknown derive must be anchored too, not left at the synthetic 0:0 --
-# `validate_derives` returns a bare message and the buffer lane has to place it.
-# `derive(Foo)` is on line 11 of that fixture.
+# Anchored, not left at the synthetic 0:0. Line numbers below are read off the
+# generated fixtures, not counted by hand -- an earlier version of this section
+# asserted 12 and 16 for the twoderive clauses, which are on 11 and 15, and CI
+# caught it.
 if ! grep -q '^line 11:' "$csdir/derive.buf" 2>/dev/null; then
   echo "[compiler-gate] FAIL: the unknown derive is not anchored on its derive clause (expected line 11) (#2317)" >&2
   cat "$csdir/derive.buf" >&2 || true
   exit 1
 fi
-# The decoys: the name occurs EARLIER in the buffer for an unrelated reason, so
-# an occurrence-counting anchor lands on the decoy. `struct Foo` is on line 9
-# and the `derive(Foo)` clause on line 15; the anchor must be 15.
 if grep -q '^line 9:' "$csdir/decoyderive.buf" 2>/dev/null; then
   echo "[compiler-gate] FAIL: the unknown derive anchored on the unrelated 'struct Foo', not on the derive clause (#2317)" >&2
   cat "$csdir/decoyderive.buf" >&2 || true
   exit 1
 fi
 if ! grep -q '^line 15:' "$csdir/decoyderive.buf" 2>/dev/null; then
-  echo "[compiler-gate] FAIL: the unknown derive is not anchored on its derive clause with a decoy present (expected line 15) (#2317)" >&2
+  echo "[compiler-gate] FAIL: the unknown derive is not anchored on its clause with a decoy present (expected line 15) (#2317)" >&2
   cat "$csdir/decoyderive.buf" >&2 || true
   exit 1
 fi
-# `Token` appears first as a PARAMETER type on line 9; the two declarations are
-# lines 10 and 11, so the duplicate must anchor on 11.
-if ! grep -q '^line 11:' "$csdir/decoydup.buf" 2>/dev/null; then
-  echo "[compiler-gate] FAIL: the duplicate type anchored somewhere other than its second declaration -- a parameter reference displaced it (expected line 11) (#2317)" >&2
-  cat "$csdir/decoydup.buf" >&2 || true
-  exit 1
-fi
-# Two clauses, two DIFFERENT anchors. The `} derive(Foo)` lines are 11 and 15
-# (the header is 7 lines plus a blank, then each struct spans three). A locator
-# that rescans from 0 reports line 11 twice, which is why the assertion names
-# the second line rather than merely counting diagnostics.
-#
-# These two numbers were 12 and 16 in the first version and CI caught them: the
-# implementation was right and the expectation was wrong, because I counted the
-# fixture in my head. Every line number in this section is now read off the
-# generated file instead.
 if ! grep -q '^line 11:' "$csdir/twoderive.buf" 2>/dev/null; then
   echo "[compiler-gate] FAIL: the first of two identical unknown derives is not anchored on its own clause (expected line 11) (#2317)" >&2
   cat "$csdir/twoderive.buf" >&2 || true
   exit 1
 fi
 if ! grep -q '^line 15:' "$csdir/twoderive.buf" 2>/dev/null; then
-  echo "[compiler-gate] FAIL: the SECOND identical unknown derive is not anchored on its own clause (expected line 15) -- the locator rescans from the start (#2317)" >&2
+  echo "[compiler-gate] FAIL: the SECOND identical unknown derive is not anchored on its own clause (expected line 15) (#2317)" >&2
   cat "$csdir/twoderive.buf" >&2 || true
   exit 1
 fi
-# A duplicated bodyless `let`: the second declaration is line 10.
-if ! grep -q '^line 10:' "$csdir/duplet.buf" 2>/dev/null; then
-  echo "[compiler-gate] FAIL: a duplicated bodyless let is not anchored on its second declaration (expected line 10) (#2317)" >&2
-  cat "$csdir/duplet.buf" >&2 || true
-  exit 1
-fi
-# Three declarations on lines 9, 10, 11: the two reports must be lines 10 AND
-# 11. Anchoring both on 10 is what a fixed "occurrence 2" does, and exact-string
-# dedupe would then collapse them to one.
-if ! grep -q '^line 10:' "$csdir/triple.buf" 2>/dev/null; then
-  echo "[compiler-gate] FAIL: the second of three duplicate declarations is not anchored on line 10 (#2317)" >&2
-  cat "$csdir/triple.buf" >&2 || true
-  exit 1
-fi
-if ! grep -q '^line 11:' "$csdir/triple.buf" 2>/dev/null; then
-  echo "[compiler-gate] FAIL: the THIRD duplicate declaration is not anchored on its own line (expected 11) -- every duplicate is asking for the same occurrence (#2317)" >&2
-  cat "$csdir/triple.buf" >&2 || true
-  exit 1
-fi
-# `derive(Foo, Bar)` on line 12: two diagnostics, both anchored, neither at 0:0.
-if ! grep -qF 'unknown trait: Foo' "$csdir/multiderive.buf" 2>/dev/null; then
-  echo "[compiler-gate] FAIL: the first trait of a multi-name derive is not reported (#2317)" >&2
-  cat "$csdir/multiderive.buf" >&2 || true
-  exit 1
-fi
 if ! grep -qF 'unknown trait: Bar' "$csdir/multiderive.buf" 2>/dev/null; then
-  echo "[compiler-gate] FAIL: the SECOND trait of a multi-name derive is not reported (#2317)" >&2
+  echo "[compiler-gate] FAIL: the second trait of a multi-name derive is not reported (#2317)" >&2
   cat "$csdir/multiderive.buf" >&2 || true
   exit 1
 fi
 if grep -q '^unknown trait' "$csdir/multiderive.buf" 2>/dev/null; then
-  echo "[compiler-gate] FAIL: a multi-name derive left a diagnostic unanchored -- the cursor moved past its own clause (#2317)" >&2
+  echo "[compiler-gate] FAIL: a multi-name derive left a diagnostic unanchored (#2317)" >&2
   cat "$csdir/multiderive.buf" >&2 || true
-  exit 1
-fi
-# A qualified head `fn Map::get` declared twice: anchored on line 10, not bare.
-if grep -q '^duplicate declaration' "$csdir/qualified.buf" 2>/dev/null; then
-  echo "[compiler-gate] FAIL: a duplicated QUALIFIED declaration is unanchored -- the head name was not joined (#2317)" >&2
-  cat "$csdir/qualified.buf" >&2 || true
-  exit 1
-fi
-if ! grep -q '^line 10:' "$csdir/qualified.buf" 2>/dev/null; then
-  echo "[compiler-gate] FAIL: a duplicated qualified declaration is not anchored on its second declaration (expected line 10) (#2317)" >&2
-  cat "$csdir/qualified.buf" >&2 || true
   exit 1
 fi
 # ...and NO committed contract in the tree may gain a diagnostic. A check that
@@ -8547,4 +8460,4 @@ if [ "$cs_noisy" -ne 0 ]; then
   exit 1
 fi
 rm -rf "$csdir"
-echo "[compiler-gate] unknown derive and duplicate declaration are refused by both lanes, anchored, and no committed contract regressed ok (#2317)"
+echo "[compiler-gate] an unknown derive is refused by both lanes and anchored on its own clause; no committed contract regressed ok (#2317)"

--- a/tests/gates/late/run.sh
+++ b/tests/gates/late/run.sh
@@ -8463,16 +8463,22 @@ if ! grep -q '^line 11:' "$csdir/decoydup.buf" 2>/dev/null; then
   cat "$csdir/decoydup.buf" >&2 || true
   exit 1
 fi
-# Two clauses, two DIFFERENT anchors. `derive(Foo)` is on line 12 and line 16;
-# a locator that rescans from 0 reports line 12 twice, which is why the
-# assertion is on the second line rather than merely on the count.
-if ! grep -q '^line 12:' "$csdir/twoderive.buf" 2>/dev/null; then
-  echo "[compiler-gate] FAIL: the first of two identical unknown derives is not anchored on its own clause (expected line 12) (#2317)" >&2
+# Two clauses, two DIFFERENT anchors. The `} derive(Foo)` lines are 11 and 15
+# (the header is 7 lines plus a blank, then each struct spans three). A locator
+# that rescans from 0 reports line 11 twice, which is why the assertion names
+# the second line rather than merely counting diagnostics.
+#
+# These two numbers were 12 and 16 in the first version and CI caught them: the
+# implementation was right and the expectation was wrong, because I counted the
+# fixture in my head. Every line number in this section is now read off the
+# generated file instead.
+if ! grep -q '^line 11:' "$csdir/twoderive.buf" 2>/dev/null; then
+  echo "[compiler-gate] FAIL: the first of two identical unknown derives is not anchored on its own clause (expected line 11) (#2317)" >&2
   cat "$csdir/twoderive.buf" >&2 || true
   exit 1
 fi
-if ! grep -q '^line 16:' "$csdir/twoderive.buf" 2>/dev/null; then
-  echo "[compiler-gate] FAIL: the SECOND identical unknown derive is not anchored on its own clause (expected line 16) -- the locator rescans from the start (#2317)" >&2
+if ! grep -q '^line 15:' "$csdir/twoderive.buf" 2>/dev/null; then
+  echo "[compiler-gate] FAIL: the SECOND identical unknown derive is not anchored on its own clause (expected line 15) -- the locator rescans from the start (#2317)" >&2
   cat "$csdir/twoderive.buf" >&2 || true
   exit 1
 fi

--- a/tests/gates/registry.tsv
+++ b/tests/gates/registry.tsv
@@ -236,4 +236,4 @@ x-adr-0090-1937-exception-unwind-region-restore	late	ADR-0090 #1937 exception-un
 116/116	late	116/116 a trait-method diagnostic names the trait, not the synthesized dict struct (#2286)
 117/117	late	117/117 a .vpkg buffer is read as a contract on the single-buffer lanes (#2314)
 118/118	late	118/118 a call is checked the same above its callee's definition as below (#2318)
-119/119	late	119/119 the buffer lane decides the contract checks it can, and agrees with the build (#2317)
+119/119	late	119/119 the buffer lane reports an unknown derive, and agrees with the build (#2317)

--- a/tests/gates/registry.tsv
+++ b/tests/gates/registry.tsv
@@ -236,3 +236,4 @@ x-adr-0090-1937-exception-unwind-region-restore	late	ADR-0090 #1937 exception-un
 116/116	late	116/116 a trait-method diagnostic names the trait, not the synthesized dict struct (#2286)
 117/117	late	117/117 a .vpkg buffer is read as a contract on the single-buffer lanes (#2314)
 118/118	late	118/118 a call is checked the same above its callee's definition as below (#2318)
+119/119	late	119/119 the buffer lane decides the contract checks it can, and agrees with the build (#2317)


### PR DESCRIPTION
Addresses one row of #2317. Does **not** close it.

`parse_contract_program` plus `classify_contract_stmts` answer "is this shaped like a contract". They do not answer everything the loader does, so the single-buffer lanes report **clean** for contracts `vibe check` refuses.

## Measured, before

Complete package, through `vibe check`:

| contract | import lane | buffer lane |
|---|---|---|
| `struct P { x: Int } derive(Foo)` | `unknown trait: Foo` | clean |

## What landed

**Unknown `derive`, reported and anchored.** `validate_derives` is the **checker's own** function, exported for this, so the buffer lane's message is identical to the build's rather than a second implementation that could drift.

The anchor is derived from the **tokens**, not from a text search: every trait name inside a `derive(..)` clause is collected in one pass with its byte offset, and each diagnostic consumes the next unspent entry for its name. Five review rounds found edge cases in successive search-based versions — a name occurring earlier for an unrelated reason, a multi-name `derive(Foo, Bar)`, two clauses naming the same trait — and every one was this code re-deriving what the parser already knew. A table consumed in order has no ordinal to get wrong.

## What was implemented and then removed

A duplicate-declaration check. **It rejects contracts the build accepts**, which is the failure mode this repo ranks first — worse than the missing diagnostic it was meant to add.

My own gate caught the first shape, because section 119 asserts the two lanes *agree* rather than merely that the buffer lane reports something:

```
FAIL: contract 'qualified' -- import lane says clean, buffer lane says refused
```

Measured directly, same package shape:

| contract | import lane |
|---|---|
| `fn Map::get(x: Int) -> Int` declared twice | **clean** |
| `fn plain(x: Int) -> Int` declared twice | refused |

Review independently found a second: the loader drops a legacy `let version: String` declaration whenever the header carries a `version` directive (`loader.vibe`'s version-synthesis filter), so a contract repeating that line is accepted there too.

The build's duplicate rule is not derivable from `decls` alone — it needs the loader's own filtering, which is precisely the shared-function work #2317 describes. So the check goes back to the issue rather than shipping with known false positives, and with it go the declaration-head table, the qualified-name join and the `seen` set: that machinery existed only for duplicates, and it is what produced five rounds of locator edge cases.

## Still open

Everything else in #2317, including the `#` directive row (#2316) — erased by the header blanking before the parser sees the token, so it depends on the separate decision about what text `parse_contract_program` receives.

## Gate 119

Five probes. The two that matter most are the ones that catch me being wrong in the *other* direction:

- a **clean control** neither lane may refuse;
- **all 76 committed `index.vpkg` files** must gain no diagnostic.

The rest: the message is the checker's own; the diagnostic is anchored on its clause and not at `0:0`; a decoy `struct Foo` earlier in the buffer does not steal the anchor; two clauses naming the same trait get *different* anchors; and a multi-name `derive(Foo, Bar)` reports both, neither unanchored.

Every probe runs through **both** lanes and the verdicts are compared — that comparison is what caught the duplicate check.

Two of my own errors are recorded in the commits rather than smoothed over: an assertion that passed on a broken locator because I read its expected line off the compiler's output, and line numbers I counted by hand (12 and 16) for clauses that sit on 11 and 15, which CI caught.

## Verification

- `cmp stage2 stage3` → **`FIXPOINT_OK`**
- section 119 green on the fix, red on the pre-fix compiler
- `check_vibe_fmt.sh`, `check_gate_registry.sh`, `check_gate_portability.sh` ok

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GbtLER6wNT4jsZEN1Zp6xe