### PR TITLE
Pin the `#` directive contract diagnostic, and correct what closed it (#2316)

### DIFF
--- a/lib/@vibe/compiler/runtime/typecheck_fs.vibe
+++ b/lib/@vibe/compiler/runtime/typecheck_fs.vibe
@@ -5493,14 +5493,21 @@ export fn collect_all_diagnostics_for_path(input_path: String, source: String) -
 /// The first version tested for `" eof"`, which is too loose (Codex review on
 /// #2315): `parse_contract_program` also throws `unsupported # directive in a
 /// contract file: eof (only #deprecated is allowed)`, and that contains
-/// `" eof"` too. MEASURED, that particular message cannot reach here -- this
-/// lane pin-blanks the header first, which erases a `#` directive line before
-/// the parser sees it, so the buffer answers clean where the import lane
-/// reports the directive (a real gap, but a pre-existing one in the blanking,
-/// not in this predicate; filed separately). The marker is still narrowed,
-/// because a predicate that is right only until the blanking changes is not
-/// worth keeping. Neither marker below can come out of a directive name: a
-/// name is a single token and cannot contain a space.
+/// `" eof"` too -- so `#eof` would have been anchored as a truncation, at the
+/// last real token instead of at its own `#`.
+///
+/// That message DOES reach here. This comment used to claim the opposite, on
+/// the grounds that the lane pin-blanks the header first and the blanking
+/// erases a `#` directive line before the parser sees it. Measured (#2316):
+/// `extract_require_pins` does not erase it. `scan_package_header` blanks only
+/// the directives it recognizes; a `#` line matches none of them, so it takes
+/// the scanner's final branch, which ends the header scan and copies the line
+/// through VERBATIM. Both lanes report the directive, and the buffer lane
+/// anchors it -- `line 9:2` for a `#eof` on line 9, where the import lane has
+/// no position at all.
+///
+/// Neither marker below can come out of a directive name: a name is a single
+/// token and cannot contain a space.
 fn contract_msg_mentions_eof(msg: String) -> Bool {
   String::index_of(msg, "but got eof") >= 0 || String::index_of(msg, "unexpected eof") >= 0
 }

--- a/tests/gates/late/run.sh
+++ b/tests/gates/late/run.sh
@@ -8216,8 +8216,101 @@ if grep -q '"diagnostics":\[\]' "$vpbufdir/prog.out" 2>/dev/null; then
   echo "[compiler-gate] FAIL: an ordinary .vibe buffer with a type error published as CLEAN -- the contract branch is catching everything (#2314)" >&2
   exit 1
 fi
+# ...and an unsupported `#` directive is reported, at its own `#` (#2316).
+#
+# That check lives in `parse_contract_program`, i.e. only on the contract
+# branch this section added -- before it the buffer lane read the file as
+# statements and answered CLEAN for a contract `vibe check` refuses. Measured
+# on a stage2 built before that branch: buffer lane empty, import lane
+# `unsupported # directive in a contract file: eof`. So this probe fails on the
+# pre-fix compiler rather than merely passing on the fixed one.
+#
+# #2316 blamed the pin-blanking for erasing the directive line. It does not:
+# `scan_package_header` blanks only the directives it recognizes, and a `#`
+# line takes its final branch, which copies the line through verbatim. Both
+# positions are covered below because the two reach the scanner differently --
+# a `#` AFTER the header ends the scan there, one BEFORE it ends the scan
+# immediately, so the header directives are copied through unblanked too.
+#
+# Each fixture is a real package DIRECTORY with a sibling implementation. A
+# bare `.vpkg` is refused by the import lane whatever it contains ("contract
+# declaration 'a' has no implementation"), which would make the oracle below
+# pass without ever seeing the directive -- measured, a `#deprecated` fixture
+# with no sibling was still "refused". The oracle asserts the MESSAGE, not the
+# exit status, for the same reason.
+for dirpos in after before; do
+  rm -rf "$vpbufdir/$dirpos"; mkdir -p "$vpbufdir/$dirpos"
+  rm -f "$vpbufdir/$dirpos.imp" "$vpbufdir/$dirpos.imp.diag" "$vpbufdir/$dirpos.buf"
+  hdr='name = @gate/vpkgdir
+version = 0.0.1
+description =
+  #|gate-only package for #2316
+deps = {}
+
+generated_hash =
+
+'
+  printf 'export fn a(x: Int) -> Int {\n  x + 1\n}\n' > "$vpbufdir/$dirpos/impl.vibe"
+  if [ "$dirpos" = after ]; then
+    printf '%s#eof\nfn a(x: Int) -> Int\n' "$hdr" > "$vpbufdir/$dirpos/index.vpkg"
+    want_line='line 9:2:'
+  else
+    printf '#eof\n%sfn a(x: Int) -> Int\n' "$hdr" > "$vpbufdir/$dirpos/index.vpkg"
+    want_line='line 1:2:'
+  fi
+  # The import lane is the oracle. Assert it reports THIS diagnostic before
+  # asserting the buffer lane agrees -- a directive the loader started
+  # accepting would otherwise leave this probe demanding an answer that is no
+  # longer correct.
+  VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_CHECK_ONLY=1 VIBE_IMPORT_ABI=raw \
+    bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
+    "$vpbufdir/$dirpos/index.vpkg" "$vpbufdir/$dirpos.imp" main >/dev/null 2>&1 || true
+  if ! grep -qF 'unsupported # directive in a contract file: eof' "$vpbufdir/$dirpos.imp.diag" 2>/dev/null; then
+    echo "[compiler-gate] FAIL: the import lane no longer reports a '#eof' directive ($dirpos the header) -- repoint this probe (#2316)" >&2
+    cat "$vpbufdir/$dirpos.imp.diag" 2>/dev/null >&2 || true
+    exit 1
+  fi
+  VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_DIAGNOSTICS=1 VIBE_IMPORT_ABI=raw \
+    bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
+    "$vpbufdir/$dirpos/index.vpkg" "$vpbufdir/$dirpos.buf" main >/dev/null 2>&1 || true
+  if ! grep -qF 'unsupported # directive in a contract file: eof' "$vpbufdir/$dirpos.buf" 2>/dev/null; then
+    echo "[compiler-gate] FAIL: the buffer lane does not report a '#eof' directive ($dirpos the header) that the import lane refuses (#2316)" >&2
+    cat "$vpbufdir/$dirpos.buf" 2>/dev/null >&2 || true
+    exit 1
+  fi
+  # Anchored on the directive's own '#', not left at 0:0 and not pushed to the
+  # last real token by `contract_msg_mentions_eof` matching the word `eof` in
+  # the MESSAGE -- which is the trap that predicate was narrowed to avoid.
+  if ! grep -q "^$want_line" "$vpbufdir/$dirpos.buf" 2>/dev/null; then
+    echo "[compiler-gate] FAIL: the '#eof' directive ($dirpos the header) is not anchored on its own '#' (expected $want_line) (#2316)" >&2
+    cat "$vpbufdir/$dirpos.buf" 2>/dev/null >&2 || true
+    exit 1
+  fi
+done
+# `#deprecated` is the one directive a contract may carry, so it must stay
+# clean on BOTH lanes -- otherwise the assertions above would pass on a fix
+# that rejects every `#` line.
+rm -rf "$vpbufdir/dep"; mkdir -p "$vpbufdir/dep"
+rm -f "$vpbufdir/dep.imp" "$vpbufdir/dep.imp.diag" "$vpbufdir/dep.buf"
+printf 'export fn a(x: Int) -> Int {\n  x + 1\n}\n' > "$vpbufdir/dep/impl.vibe"
+printf 'name = @gate/vpkgdir\nversion = 0.0.1\ndescription =\n  #|gate-only package for #2316\ndeps = {}\n\ngenerated_hash =\n\n#deprecated\nfn a(x: Int) -> Int\n' > "$vpbufdir/dep/index.vpkg"
+if ! VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_CHECK_ONLY=1 VIBE_IMPORT_ABI=raw \
+  bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
+  "$vpbufdir/dep/index.vpkg" "$vpbufdir/dep.imp" main >/dev/null 2>&1; then
+  echo "[compiler-gate] FAIL: the import lane refuses a '#deprecated' contract -- the control for the probes above is not valid (#2316)" >&2
+  cat "$vpbufdir/dep.imp.diag" 2>/dev/null >&2 || true
+  exit 1
+fi
+VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_DIAGNOSTICS=1 VIBE_IMPORT_ABI=raw \
+  bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
+  "$vpbufdir/dep/index.vpkg" "$vpbufdir/dep.buf" main >/dev/null 2>&1 || true
+if [ -s "$vpbufdir/dep.buf" ]; then
+  echo "[compiler-gate] FAIL: '#deprecated' -- the one directive a contract may carry -- is reported as an error (#2316)" >&2
+  cat "$vpbufdir/dep.buf" >&2
+  exit 1
+fi
 rm -rf "$vpbufdir"
-echo "[compiler-gate] a .vpkg buffer reads as a contract, still rejects a malformed declaration, and .vibe buffers still type-check ok (#2314)"
+echo "[compiler-gate] a .vpkg buffer reads as a contract, still rejects a malformed declaration, reports an unsupported # directive at its own '#', and .vibe buffers still type-check ok (#2314, #2316)"
 
 # 118/118. A call is checked the same above its callee's definition as below
 # it (#2318).


### PR DESCRIPTION
Closes #2316.

#2316 says the buffer lane reports a `.vpkg` as clean when it carries an unsupported `#` directive that `vibe check` refuses. **Measured on today's compiler, it does not** — both lanes report it, and the buffer lane anchors it where the import lane has no position at all.

| fixture | import lane | buffer lane |
|---|---|---|
| `#eof` after the header | `unsupported # directive in a contract file: eof (only #deprecated is allowed)` | `line 9:2: ` + same message |
| `#eof` before the header | same message | `line 1:2: ` + same message |
| `#cfg(x)` | same shape | `line 9:2: ` + same shape |
| `#deprecated` | clean | clean |

The LSP publishes it too: `severity 1` at 0-based `line 8, character 1`.

It was real when filed — on a stage2 built before #2314 the buffer lane answers **empty** for the first fixture — and #2314's own contract-grammar branch closed it, because the directive check lives in `parse_contract_program` and that branch is what routes a `.vpkg` buffer there.

## The stated cause was wrong, and it is written into the tree

`contract_msg_mentions_eof`'s doc comment claims the pin-blanking "erases a `#` directive line before the parser sees it". It does not. `scan_package_header` blanks only the directives it recognizes; a `#` line matches none of them, so it takes the scanner's final branch — end the header scan, copy the line through **verbatim**. Measured directly against `extract_require_pins`.

The comment is rewritten to say what is true. The narrowing of the predicate it documents still stands on its own: `#eof` would otherwise be anchored as a truncation, at the last real token instead of at its own `#`.

## Gate

Section 117 gains the `#eof` probe that was withdrawn from #2315 on the strength of that wrong explanation. Both positions are covered — a `#` **after** the header ends the scan there, one **before** it ends the scan immediately, so the header directives reach the parser unblanked too.

Verified failable, not just passing:

- the whole probe **FAILS** on a pre-#2314 stage2 (buffer lane empty);
- each new assertion was mutation-tested and lands on its own message — wrong anchor line for each position, an accepted directive in the fixture (hits the import-lane oracle), and `#deprecated` → `#deprecatedx` (hits the clean control).

The first draft of the oracle asserted only that the import lane exits nonzero, from a bare `.vpkg` with no sibling implementation — which it does for *any* content (`contract declaration 'a' has no implementation`), so it would have passed without ever seeing the directive. Measured: a `#deprecated` fixture was still "refused". Each fixture is now a real package directory with a sibling implementation, and the oracle asserts the **message**.

## Verification

- `_build/i2317/gen` fixpoint build (`stage2 == stage3`), sections 114–119 all green against it
- section 117 red on a pre-#2314 stage2; the new probe red in isolation on the same
- `vibe fmt --check` on the changed compiler file, `check_gate_registry.sh`, `check_gate_portability.sh`, `ensure_generated.sh --check` — all ok

---
_Generated by [Claude Code](https://claude.ai/code/session_01GbtLER6wNT4jsZEN1Zp6xe)_