### PR TITLE
Anchor an unsupported contract statement on that statement (#2317)

### DIFF
--- a/lib/@vibe/compiler/contract/contract.vibe
+++ b/lib/@vibe/compiler/contract/contract.vibe
@@ -119,10 +119,39 @@ fn fn_sig_text(tps: Array[String], tbs: Array[(String, Array[String])], params: 
 /// #739: opaque/bodyless type declarations carry (name, arity) so conformance
 /// can reject an impl whose type-parameter count differs and the semver
 /// surface can see `Box` -> `Box[T]` as a breaking change.
+/// #2317: record a contract statement together with the token index it
+/// started at.
+///
+/// The two arrays are read positionally by `contract_classify_diagnostic`, so
+/// a push that lands in only one of them does not fail -- it shifts every
+/// later statement's anchor onto its neighbour, which is a diagnostic pointing
+/// confidently at the wrong line. One call site each keeps them paired, and
+/// the length check at the end of the parse catches a site that bypasses this.
+fn push_contract_stmt(stmts: Array[Stmt], stmt_at: Array[Int], stmt: Stmt, at: Int) -> Unit {
+  Array::push(stmts, stmt)
+  Array::push(stmt_at, at)
+}
+
 export fn parse_contract_program(tokens: Array[Token]) -> (Array[(String, String)], Array[(String, Int)], Array[Stmt]) with Exception {
+  let (decls, opaques, stmts, _at) = parse_contract_program_spans(tokens)
+  (decls, opaques, stmts)
+}
+
+/// #2317: `parse_contract_program`, plus the TOKEN INDEX each statement
+/// started at (one entry per `Stmt`, same order).
+///
+/// `classify_contract_stmts` rejects a statement a contract may not contain,
+/// and its message carries no position -- so the buffer lane rendered it at
+/// the synthetic 0:0 and told the reader a contract is broken without saying
+/// where. The parser is the only place that knows where each statement began;
+/// it used to discard that. Recovering it by SEARCH was tried three times in
+/// the #2315 review and each attempt produced a predicate that could anchor on
+/// valid code, so the offset is carried instead.
+export fn parse_contract_program_spans(tokens: Array[Token]) -> (Array[(String, String)], Array[(String, Int)], Array[Stmt], Array[Int]) with Exception {
   let decls = array_empty()
   let opaques = array_empty()
   let stmts = array_empty()
+  let stmt_at = array_empty()
   let mut pos = 0
   let mut done = false
   while !done {
@@ -192,7 +221,7 @@ export fn parse_contract_program(tokens: Array[Token]) -> (Array[(String, String
           pos = la
         } else {
           let (stmt, next) = parse_stmt(tokens, [], pos)
-          Array::push(stmts, stmt)
+          push_contract_stmt(stmts, stmt_at, stmt, pos)
           pos = next
         }
       },
@@ -240,7 +269,7 @@ export fn parse_contract_program(tokens: Array[Token]) -> (Array[(String, String
         }
       } else {
         let (stmt, next) = parse_stmt(tokens, [], pos)
-        Array::push(stmts, stmt)
+        push_contract_stmt(stmts, stmt_at, stmt, pos)
         pos = next
       },
       // `#deprecated` is a token-level marker (`vibe check` scans the
@@ -293,12 +322,17 @@ export fn parse_contract_program(tokens: Array[Token]) -> (Array[(String, String
       },
       _ => {
         let (stmt, next) = parse_stmt(tokens, [], pos)
-        Array::push(stmts, stmt)
+        push_contract_stmt(stmts, stmt_at, stmt, pos)
         pos = next
       }
     }
   }
-  (decls, opaques, stmts)
+  if Array::length(stmts) != Array::length(stmt_at) {
+    throw("internal: contract statement offsets desynced (#2317) -- a statement was recorded without its position")
+  } else {
+    ()
+  }
+  (decls, opaques, stmts, stmt_at)
 }
 
 /// Collect (name, Some(sig) | None, exported) for every top-level let whose
@@ -841,6 +875,40 @@ export fn classify_contract_stmts(stmts: Array[Stmt]) -> (Array[String], Array[S
     i = i + 1
   }
   (raws, type_defs)
+}
+
+/// #2317: index of the first statement `classify_contract_stmts` rejects, or
+/// -1 when it accepts them all.
+///
+/// It ASKS the classifier, one statement at a time, rather than mirroring its
+/// match arms -- a second copy of the rule would drift the first time a
+/// statement kind is added, and the classifier's own loop is per-statement
+/// with no cross-statement state, so `classify_contract_stmts([s])` throws
+/// exactly when `s` is the kind it refuses. Walking in order therefore finds
+/// the same statement the full call stopped on.
+///
+/// Deliberately not a prefix search: three attempts in the #2315 review to
+/// locate a diagnostic by probing growing prefixes each produced a predicate
+/// that was not monotone, and binary search over one can anchor on valid code.
+/// This asks about each statement on its own, so there is no predicate shape
+/// to get wrong.
+export fn contract_unsupported_stmt_index(stmts: Array[Stmt]) -> Int {
+  let mut i = 0
+  let mut found = 0 - 1
+  while i < Array::length(stmts) && found < 0 {
+    let one = array_empty()
+    Array::push(one, Array::get(stmts, i))
+    let bad = handle {
+      let (_raws, _defs) = classify_contract_stmts(one)
+      false
+    } with { Exception::Throw(_) => true }
+    if bad {
+      found = i
+    } else {
+      i = i + 1
+    }
+  }
+  found
 }
 
 /// Compat shim for the strict v1 shape (implementation imports only).

--- a/lib/@vibe/compiler/contract/index.vpkg
+++ b/lib/@vibe/compiler/contract/index.vpkg
@@ -40,7 +40,9 @@ let vpkg_types_module_marker: String
 
 // --- contract grammar
 fn parse_contract_program(tokens: Array[Token]) -> (Array[(String, String)], Array[(String, Int)], Array[Stmt]) with Exception
+fn parse_contract_program_spans(tokens: Array[Token]) -> (Array[(String, String)], Array[(String, Int)], Array[Stmt], Array[Int]) with Exception
 fn classify_contract_stmts(stmts: Array[Stmt]) -> (Array[String], Array[Stmt]) with Exception
+fn contract_unsupported_stmt_index(stmts: Array[Stmt]) -> Int
 fn contract_impl_import_raw_paths(stmts: Array[Stmt]) -> Array[String] with Exception
 fn contract_directory_shared_imports(stmts: Array[Stmt]) -> Array[Stmt]
 fn contract_directory_shared_import_prefix_text(stmts: Array[Stmt]) -> String

--- a/lib/@vibe/compiler/runtime/typecheck_fs.vibe
+++ b/lib/@vibe/compiler/runtime/typecheck_fs.vibe
@@ -80,7 +80,7 @@ import @vibe/compiler/entry/source_compile/wasi_only {
 }
 
 import @vibe/compiler/contract {
-  classify_contract_stmts, extract_require_pins, parse_contract_program
+  classify_contract_stmts, contract_unsupported_stmt_index, extract_require_pins, parse_contract_program, parse_contract_program_spans
 }
 
 import @vibe/compiler/loader {
@@ -5883,6 +5883,39 @@ fn contract_parse_diagnostic(source: String, tokens: Array[Token], starts: Array
   }
 }
 
+/// #2317: anchor a `classify_contract_stmts` rejection on the statement it
+/// rejected.
+///
+/// `parse_contract_program_spans` carries the token index each statement
+/// started at, and `contract_unsupported_stmt_index` asks the classifier which
+/// statement it stops on -- so the position is READ, not searched for. The
+/// three search-based attempts in the #2315 review each produced a
+/// non-monotone predicate that binary search could resolve to valid code.
+///
+/// Falls back to unlocated rather than to a guess, the same as every other
+/// diagnostic this lane cannot place.
+fn contract_classify_diagnostic(source: String, starts: Array[Int], stmts: Array[Stmt], stmt_at: Array[Int], msg: String) -> Array[String] with Exception {
+  if diag_already_located(msg) {
+    return [msg]
+  } else {
+    ()
+  }
+  let idx = contract_unsupported_stmt_index(stmts)
+  if idx >= 0 && idx < Array::length(stmt_at) {
+    let tok = Array::get(stmt_at, idx)
+    if tok >= 0 && tok < Array::length(starts) {
+      return [
+        String::concat(offset_line_col_prefix(source, Array::get(starts, tok)), msg)
+      ]
+    } else {
+      ()
+    }
+  } else {
+    ()
+  }
+  [locate_type_error(source, msg)]
+}
+
 fn collect_all_diagnostics_on(input_path: String, source: String) -> Array[String] with Exception {
   if is_contract_ext(input_path) {
     // A contract LEXES like a program, so it gets the recovering lexer and
@@ -5912,9 +5945,22 @@ fn collect_all_diagnostics_on(input_path: String, source: String) -> Array[Strin
     // branch this replaces did catch it, through `check_program`. So run the
     // classifier the loader runs, on the statements the parse produced.
     return handle {
-      let (_cdecls, _copaques, cstmts) = parse_contract_program(ctokens)
-      let (_raws, _type_defs) = classify_contract_stmts(cstmts)
-      contract_semantic_errors(source, ctokens, cstarts, cstmts)
+      let (_cdecls, _copaques, cstmts, cstmt_at) = parse_contract_program_spans(ctokens)
+      // The classifier is caught SEPARATELY from the parse. Both throw
+      // unlocated messages, but they need different anchors: a parse error
+      // belongs at the token the parser stopped on, a rejected statement at
+      // that statement's own first token (#2317). Letting one handler take
+      // both left the classifier's message at the synthetic 0:0 -- the reader
+      // is told the contract is broken and not told where.
+      let cls_err = handle {
+        let (_raws, _type_defs) = classify_contract_stmts(cstmts)
+        ""
+      } with { Exception::Throw(m) => m }
+      if cls_err != "" {
+        contract_classify_diagnostic(source, cstarts, cstmts, cstmt_at, cls_err)
+      } else {
+        contract_semantic_errors(source, ctokens, cstarts, cstmts)
+      }
     } with { Exception::Throw(msg) => contract_parse_diagnostic(source, ctokens, cstarts, msg) }
   } else {
     ()

--- a/tests/gates/late/run.sh
+++ b/tests/gates/late/run.sh
@@ -8554,3 +8554,99 @@ if [ "$cs_noisy" -ne 0 ]; then
 fi
 rm -rf "$csdir"
 echo "[compiler-gate] an unknown derive is refused by both lanes and anchored on its own clause; no committed contract regressed ok (#2317)"
+
+# 120/120. A statement a contract may not contain is anchored on THAT
+# statement, on both lanes' shared message (#2317).
+#
+# `classify_contract_stmts` throws an unlocated message. The buffer lane caught
+# it in the same handler as a parse error, whose anchor is a token-prefix probe
+# that can only reproduce PARSER throws -- so the probe missed, and the reader
+# got the synthetic 0:0: the contract is broken, and nowhere to look. Measured
+# before this: both lanes printed the message bare.
+#
+# The offset is now READ, not searched for. `parse_contract_program_spans`
+# carries the token index each statement started at, and
+# `contract_unsupported_stmt_index` asks the classifier itself which statement
+# it stops on. Three attempts in the #2315 review to locate this by probing
+# growing prefixes each produced a non-monotone predicate that binary search
+# could resolve to VALID code, which is why searching is not used here.
+echo "[compiler-gate] 120/120 an unsupported contract statement is anchored on that statement (#2317)"
+clsdir="_build/_gate_contract_classify"
+rm -rf "$clsdir"; mkdir -p "$clsdir"
+cls_header='name = @gate/contractcls
+version = 0.0.1
+description =
+  #|gate-only package for #2317
+deps = {}
+
+generated_hash =
+'
+cls_impl='export fn a(x: Int) -> Int {
+  x + 1
+}
+
+export fn b(y: Int) -> Int {
+  y
+}
+'
+# `later`: the offending statement is the THIRD, so an anchor that always
+# points at the first statement (or at offset 0) fails. `first`: it is the
+# first, so an anchor that is off by one statement fails too. The pair pins the
+# mapping in both directions; one alone does not.
+mkdir -p "$clsdir/later" "$clsdir/first" "$clsdir/clean"
+printf '%s\nfn a(x: Int) -> Int\n\nexport let z: Int = 5\n\nfn b(y: Int) -> Int\n' "$cls_header" > "$clsdir/later/index.vpkg"
+printf '%s' "$cls_impl" > "$clsdir/later/impl.vibe"
+printf '%s\nexport let z: Int = 5\n\nfn a(x: Int) -> Int\n\nfn b(y: Int) -> Int\n' "$cls_header" > "$clsdir/first/index.vpkg"
+printf '%s' "$cls_impl" > "$clsdir/first/impl.vibe"
+printf '%s\nfn a(x: Int) -> Int\n\nfn b(y: Int) -> Int\n' "$cls_header" > "$clsdir/clean/index.vpkg"
+printf '%s' "$cls_impl" > "$clsdir/clean/impl.vibe"
+cls_msg='unsupported statement in a contract file'
+for probe in later first; do
+  if [ "$probe" = later ]; then want_line='line 11:1:'; else want_line='line 9:1:'; fi
+  rm -f "$clsdir/$probe.imp" "$clsdir/$probe.imp.diag" "$clsdir/$probe.buf"
+  # The import lane is the oracle, asserted by MESSAGE. Its exit status alone
+  # says nothing: a contract with an unimplemented declaration is refused
+  # whatever else it contains, so a status check would pass without ever
+  # reaching the classifier.
+  VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_CHECK_ONLY=1 VIBE_IMPORT_ABI=raw \
+    bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
+    "$clsdir/$probe/index.vpkg" "$clsdir/$probe.imp" main >/dev/null 2>&1 || true
+  if ! grep -qF "$cls_msg" "$clsdir/$probe.imp.diag" 2>/dev/null; then
+    echo "[compiler-gate] FAIL: the import lane no longer refuses a top-level let in a contract ($probe) -- repoint this probe (#2317)" >&2
+    cat "$clsdir/$probe.imp.diag" 2>/dev/null >&2 || true
+    exit 1
+  fi
+  VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_DIAGNOSTICS=1 VIBE_IMPORT_ABI=raw \
+    bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
+    "$clsdir/$probe/index.vpkg" "$clsdir/$probe.buf" main >/dev/null 2>&1 || true
+  if ! grep -qF "$cls_msg" "$clsdir/$probe.buf" 2>/dev/null; then
+    echo "[compiler-gate] FAIL: the buffer lane does not refuse a top-level let in a contract ($probe) (#2317)" >&2
+    cat "$clsdir/$probe.buf" 2>/dev/null >&2 || true
+    exit 1
+  fi
+  if ! grep -q "^$want_line" "$clsdir/$probe.buf" 2>/dev/null; then
+    echo "[compiler-gate] FAIL: the unsupported statement ($probe) is not anchored on itself (expected $want_line) (#2317)" >&2
+    cat "$clsdir/$probe.buf" 2>/dev/null >&2 || true
+    exit 1
+  fi
+done
+# A contract with no forbidden statement stays clean on both lanes -- without
+# this, a change that reported every contract would pass everything above.
+rm -f "$clsdir/clean.imp" "$clsdir/clean.imp.diag" "$clsdir/clean.buf"
+if ! VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_CHECK_ONLY=1 VIBE_IMPORT_ABI=raw \
+  bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
+  "$clsdir/clean/index.vpkg" "$clsdir/clean.imp" main >/dev/null 2>&1; then
+  echo "[compiler-gate] FAIL: the import lane refuses the CLEAN control contract -- the probes above are not valid (#2317)" >&2
+  cat "$clsdir/clean.imp.diag" 2>/dev/null >&2 || true
+  exit 1
+fi
+VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_DIAGNOSTICS=1 VIBE_IMPORT_ABI=raw \
+  bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
+  "$clsdir/clean/index.vpkg" "$clsdir/clean.buf" main >/dev/null 2>&1 || true
+if [ -s "$clsdir/clean.buf" ]; then
+  echo "[compiler-gate] FAIL: a contract with no forbidden statement is reported by the buffer lane (#2317)" >&2
+  cat "$clsdir/clean.buf" >&2
+  exit 1
+fi
+rm -rf "$clsdir"
+echo "[compiler-gate] an unsupported contract statement is refused by both lanes and anchored on itself, first or later ok (#2317)"

--- a/tests/gates/registry.tsv
+++ b/tests/gates/registry.tsv
@@ -237,3 +237,4 @@ x-adr-0090-1937-exception-unwind-region-restore	late	ADR-0090 #1937 exception-un
 117/117	late	117/117 a .vpkg buffer is read as a contract on the single-buffer lanes (#2314)
 118/118	late	118/118 a call is checked the same above its callee's definition as below (#2318)
 119/119	late	119/119 the buffer lane reports an unknown derive, and agrees with the build (#2317)
+120/120	late	120/120 an unsupported contract statement is anchored on that statement (#2317)


### PR DESCRIPTION
The remaining measured row of #2317's family: `classify_contract_stmts` refuses a statement a contract may not contain and throws an **unlocated** message. The buffer lane caught it in the same handler as a parse error, whose anchor is a token-prefix probe that can only reproduce *parser* throws — so the probe missed and the reader got the synthetic `0:0`. The contract is broken, and nowhere to look.

Measured before this, on `export let z: Int = 5` sitting on line 11 of a contract:

| lane | answer |
|---|---|
| `vibe check` | `unsupported statement in a contract file …` — bare |
| `vibe diagnostics` | same message — bare |

## The offset is read, not searched for

- **`parse_contract_program_spans`** returns the token index each statement started at, one per `Stmt`. `parse_contract_program` delegates to it and drops the extra array, so no existing caller changes.
- **`contract_unsupported_stmt_index`** asks the classifier, one statement at a time, which statement it stops on. It does **not** mirror the classifier's match arms — a second copy of the rule drifts the first time a statement kind is added. The classifier's loop is per-statement with no cross-statement state, so `classify_contract_stmts([s])` throws exactly when `s` is the kind it refuses, and walking in order finds the same statement the full call stopped on.
- the buffer lane now catches the classifier **separately** from the parse, because a parse error belongs at the token the parser stopped on and a rejected statement at that statement's own first token.

Deliberately **not** another prefix search. Three attempts in the #2315 review to locate a diagnostic that way each produced a predicate that was not monotone, and binary search over one can anchor on valid code.

## The desync that would not fail

The two arrays are read positionally, so a push landing in only one of them would not error — it would shift every later statement's anchor onto its neighbour, which is a diagnostic pointing confidently at the wrong line. All three push sites go through one `push_contract_stmt`, and the parse refuses to return arrays whose lengths disagree.

## Gate (section 120)

Both lanes over the same contracts, with the import lane as the oracle asserted **by message** — its exit status alone is not evidence, because a contract with an unimplemented declaration is refused whatever else it contains. (That exact trap was caught in #2321: a first-draft oracle passed on a fixture it had never actually inspected.)

- the offending statement is **first** in one fixture and **third** in the other, so an anchor off by a statement, or pinned to offset 0, fails;
- a contract with no forbidden statement is the clean control on both lanes, so a change that reported every contract cannot pass.

**Measured red on today's main**: the message assertions pass and the anchor assertion fails — `expected line 11:1:` — which is exactly the shape this change fixes.

## Verification

- `vibe fmt --check` on all three changed compiler files, `ensure_generated.sh` structural probe clean
- `check_gate_registry.sh`, `check_gate_portability.sh` ok
- section 120 red on `main`'s stage2
- section 120 **green in CI** — `compiler-gate (late)` runs it against CI's own bootstrap-built stage2, so the fixpoint build and the green run are the same artifact. (The local fixpoint build this body previously said was pending was lost when the container was reclaimed; CI performs the same build, and it passed.)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GbtLER6wNT4jsZEN1Zp6xe)_