### PR TITLE
Keep re-exported declaration aliases out of local scope

### DIFF
--- a/lib/@vibe/compiler/checker/checker.vibe
+++ b/lib/@vibe/compiler/checker/checker.vibe
@@ -9507,6 +9507,26 @@ fn check_expr_capture_impl(expr: Expr, env: TypeEnv, defs: Array[TypeDef], s: Su
       }
     },
     EFn(tparams, tbounds, params, ret_ty, effect, body) => {
+      // An aliased re-export publishes a trait spelling but does not bind it
+      // in this module (#2310). The import projection retains an origin marker
+      // so this declaration site can report the invalid bound immediately,
+      // instead of accepting the generic function until a concrete call later
+      // fails with a misleading missing-impl error.
+      let mut rti = 0
+      while rti < Array::length(tbounds) {
+        let (_, declared_bounds) = Array::get(tbounds, rti)
+        let mut rbi = 0
+        while rbi < Array::length(declared_bounds) {
+          let bound = Array::get(declared_bounds, rbi)
+          if env_has_reexport_surface_binding(env, bound) {
+            Array::push(errors, String::concat("unknown trait: ", bound))
+          } else {
+            ()
+          }
+          rbi = rbi + 1
+        }
+        rti = rti + 1
+      }
       let tplen = Array::length(tparams)
       let mut tp_env = env
       let mut s0 = s

--- a/lib/@vibe/compiler/runtime/index.vpkg
+++ b/lib/@vibe/compiler/runtime/index.vpkg
@@ -221,7 +221,9 @@ fn typing_dependency_record_decode_internal(text: String, expected_tag: String, 
 
 // --- typecheck_fs.vibe
 fn build_trait_aware_import_env(stmts: Array[Stmt], base_dir: String, cache: Array[(String, TypeEnv)]) -> TypeEnv with Exception
+fn build_trait_aware_import_envs(stmts: Array[Stmt], base_dir: String, cache: Array[(String, TypeEnv)]) -> (TypeEnv, TypeEnv) with Exception
 fn checked_module_public_env(stmts: Array[Stmt], full_checked_env: TypeEnv) -> TypeEnv
+fn checked_module_public_env_with_reexport_declarations(stmts: Array[Stmt], full_checked_env: TypeEnv, reexport_declarations: TypeEnv) -> TypeEnv
 fn locate_type_error(source: String, msg: String) -> String
 fn ensure_fingerprint_fs_impl(rdb: RippleDb, env_cache: Array[(String, TypeEnv)], dep_source_cache: Array[(String, String)], parse_count: Int, path: String) -> (String, RippleDb, Array[(String, TypeEnv)], Array[(String, String)], Int) with Exception + Fs
 // #1100: memoized located lex+parse shared by the typecheck walk and the

--- a/lib/@vibe/compiler/runtime/runtime.vibe
+++ b/lib/@vibe/compiler/runtime/runtime.vibe
@@ -41,8 +41,8 @@ import @vibe/compiler/runtime/eval_loader {
 }
 
 import ./typecheck_fs.vibe {
-  build_trait_aware_import_env,
-  checked_module_public_env,
+  build_trait_aware_import_envs,
+  checked_module_public_env_with_reexport_declarations,
   ensure_fingerprint_fs_impl,
   load_persistent_dep_list,
   load_persistent_leaf_fingerprint,
@@ -313,8 +313,8 @@ export fn db_check_env(db: TypeDb, path: String) -> Option[TypeEnv] {
 /// The in-memory TypeDb accepts caller-provided modules. Delegate its import
 /// assembly to the trait-aware FS implementation rather than silently dropping
 /// trait declarations and impls from those module environments.
-fn build_import_env(stmts: Array[Stmt], base_dir: String, cache: Array[(String, TypeEnv)]) -> TypeEnv with Exception {
-  build_trait_aware_import_env(stmts, base_dir, cache)
+fn build_import_envs(stmts: Array[Stmt], base_dir: String, cache: Array[(String, TypeEnv)]) -> (TypeEnv, TypeEnv) with Exception {
+  build_trait_aware_import_envs(stmts, base_dir, cache)
 }
 
 fn upsert_env_cache(cache: Array[(String, TypeEnv)], path: String, env: TypeEnv) -> Array[(String, TypeEnv)] {
@@ -514,9 +514,9 @@ fn ensure_fingerprint(rdb: RippleDb, env_cache: Array[(String, TypeEnv)], dep_so
           } else {
             let stmts = parse_program_with_path(path, source)
             let final_parse_count = parse_count_after_deps + 1
-            let import_env = build_import_env(stmts, dir_of_path(path), env_cache_after_deps)
+            let (import_env, reexport_declarations) = build_import_envs(stmts, dir_of_path(path), env_cache_after_deps)
             let full_checked_env = check_program_with_env(stmts, import_env)
-            let checked_env = checked_module_public_env(stmts, full_checked_env)
+            let checked_env = checked_module_public_env_with_reexport_declarations(stmts, full_checked_env, reexport_declarations)
             let next_env_cache = upsert_env_cache(env_cache_after_deps, path, checked_env)
             let next_db = ripple_record_eval(db_after_deps, path, fingerprint, deps)
             (fingerprint, next_db, next_env_cache, dep_source_cache_after_deps, final_parse_count)
@@ -524,9 +524,9 @@ fn ensure_fingerprint(rdb: RippleDb, env_cache: Array[(String, TypeEnv)], dep_so
           None => {
             let stmts = parse_program_with_path(path, source)
             let final_parse_count = parse_count_after_deps + 1
-            let import_env = build_import_env(stmts, dir_of_path(path), env_cache_after_deps)
+            let (import_env, reexport_declarations) = build_import_envs(stmts, dir_of_path(path), env_cache_after_deps)
             let full_checked_env = check_program_with_env(stmts, import_env)
-            let checked_env = checked_module_public_env(stmts, full_checked_env)
+            let checked_env = checked_module_public_env_with_reexport_declarations(stmts, full_checked_env, reexport_declarations)
             let next_env_cache = upsert_env_cache(env_cache_after_deps, path, checked_env)
             let next_db = ripple_record_eval(db_after_deps, path, fingerprint, deps)
             (fingerprint, next_db, next_env_cache, dep_source_cache_after_deps, final_parse_count)

--- a/lib/@vibe/compiler/runtime/typecheck_fs.vibe
+++ b/lib/@vibe/compiler/runtime/typecheck_fs.vibe
@@ -1106,7 +1106,7 @@ fn prepend_dependency_trait_nodes(dep_env: TypeEnv, mappings: Array[(String, Str
   out
 }
 
-fn bind_import_names_from_cache_collecting(acc: TypeEnv, resolved: String, raw_path: String, names: Array[ImportItem], cache: Array[(String, TypeEnv)], unresolved: Array[String], trait_claims: Array[(String, String, Bool, String)], reexport_surface_only: Bool) -> TypeEnv {
+fn bind_import_names_from_cache_collecting(acc: TypeEnv, resolved: String, raw_path: String, names: Array[ImportItem], declaration_names: Array[ImportItem], cache: Array[(String, TypeEnv)], unresolved: Array[String], trait_claims: Array[(String, String, Bool, String)], reexport_surface_only: Bool) -> TypeEnv {
   let cached = lookup_env_cache(cache, resolved)
   let dep_env = match cached {
     Some(e) => e,
@@ -1182,7 +1182,15 @@ fn bind_import_names_from_cache_collecting(acc: TypeEnv, resolved: String, raw_p
       }
       let with_name = match imported_ty {
         Some(_) => env_bind_with_origin(nacc, bound_name, ty, selected_module_binding_origin(resolved, name, surface_only_item)),
-        None => env_bind(nacc, bound_name, ty)
+        None => if surface_only_item && (contains_str(dep_selectable_type_defs, name) || trait_defined(dep_env, name)) {
+          // Declaration aliases travel in the separate publication projection
+          // below. Retain only an origin marker here so checker diagnostics can
+          // distinguish this claimed-but-nonlocal spelling from an unrelated
+          // unknown declaration; env_lookup deliberately hides the marker.
+          env_bind_with_origin(nacc, bound_name, ty, selected_module_binding_origin(resolved, name, true))
+        } else {
+          env_bind(nacc, bound_name, ty)
+        }
       }
       let with_companions = match ty {
         CtEnum(enum_name) => bind_enum_constructor_companions(with_name, resolved, dep_bindings, enum_name, trait_mappings, surface_only_item),
@@ -1195,7 +1203,39 @@ fn bind_import_names_from_cache_collecting(acc: TypeEnv, resolved: String, raw_p
       bind_names(j + 1, with_companions)
     }
   }
-  bind_names(0, prepend_dependency_trait_nodes(dep_env, trait_mappings, prepend_dependency_type_defs(dep_env, names, acc)))
+  let declaration_trait_mappings = dependency_trait_projection_mappings(dep_env, dep_bindings, declaration_names, array_empty())
+  bind_names(0, prepend_dependency_trait_nodes(dep_env, declaration_trait_mappings, prepend_dependency_type_defs(dep_env, declaration_names, acc)))
+}
+
+fn reexport_items_with_alias(items: Array[ImportItem], want_alias: Bool) -> Array[ImportItem] {
+  let out = array_empty()
+  let mut i = 0
+  while i < Array::length(items) {
+    let item = Array::get(items, i)
+    if (item.alias != None) == want_alias {
+      Array::push(out, item)
+    } else {
+      ()
+    }
+    i = i + 1
+  }
+  out
+}
+
+/// Declaration authority from an aliased re-export is needed by the module's
+/// published interface, but the re-export statement introduces no local type
+/// or trait binder. Keep that projection apart from the checker environment;
+/// check_module_impl joins it back only while constructing the public env.
+fn prepend_reexport_alias_declarations(acc: TypeEnv, resolved: String, names: Array[ImportItem], cache: Array[(String, TypeEnv)]) -> TypeEnv {
+  let cached = lookup_env_cache(cache, resolved)
+  let dep_env = match cached {
+    Some(env) => env,
+    None => EnvEmpty
+  }
+  let dep_bindings = env_flat_bindings(dep_env)
+  let ignored = array_empty()
+  let mappings = dependency_trait_projection_mappings(dep_env, dep_bindings, names, ignored)
+  prepend_dependency_trait_nodes(dep_env, mappings, prepend_dependency_type_defs(dep_env, names, acc))
 }
 
 /// Shared by the filesystem and in-memory TypeDb lanes. The latter accepts
@@ -1218,28 +1258,35 @@ fn build_import_env(stmts: Array[Stmt], base_dir: String, cache: Array[(String, 
 /// `build_import_env`, additionally collecting the imported names the
 /// dependency does not export (#1521 -- see
 /// `bind_import_names_from_cache_collecting`).
-fn build_import_env_collecting(stmts: Array[Stmt], base_dir: String, cache: Array[(String, TypeEnv)], unresolved: Array[String]) -> TypeEnv {
+fn build_import_envs_collecting(stmts: Array[Stmt], base_dir: String, cache: Array[(String, TypeEnv)], unresolved: Array[String]) -> (TypeEnv, TypeEnv) {
   let trait_claims = array_empty()
   let len = Array::length(stmts)
-  let rec go: (Int, TypeEnv) -> TypeEnv = (i, acc) -> {
+  let rec go: (Int, TypeEnv, TypeEnv) -> (TypeEnv, TypeEnv) = (i, local_acc, surface_acc) -> {
     if i >= len {
-      acc
+      (local_acc, surface_acc)
     } else {
-      let next = match Array::get(stmts, i) {
+      let (next_local, next_surface) = match Array::get(stmts, i) {
         SImport(raw_path, names) => {
           let resolved = resolve_cached_import_path(base_dir, raw_path, cache)
-          bind_import_names_from_cache_collecting(acc, resolved, raw_path, names, cache, unresolved, trait_claims, false)
+          (bind_import_names_from_cache_collecting(local_acc, resolved, raw_path, names, names, cache, unresolved, trait_claims, false), surface_acc)
         },
         SReExport(raw_path, names) => {
           let resolved = resolve_cached_import_path(base_dir, raw_path, cache)
-          bind_import_names_from_cache_collecting(acc, resolved, raw_path, names, cache, unresolved, trait_claims, true)
+          let local_declarations = reexport_items_with_alias(names, false)
+          let surface_declarations = reexport_items_with_alias(names, true)
+          (bind_import_names_from_cache_collecting(local_acc, resolved, raw_path, names, local_declarations, cache, unresolved, trait_claims, true), prepend_reexport_alias_declarations(surface_acc, resolved, surface_declarations, cache))
         },
-        _ => acc
+        _ => (local_acc, surface_acc)
       }
-      go(i + 1, next)
+      go(i + 1, next_local, next_surface)
     }
   }
-  go(0, EnvEmpty)
+  go(0, EnvEmpty, EnvEmpty)
+}
+
+fn build_import_env_collecting(stmts: Array[Stmt], base_dir: String, cache: Array[(String, TypeEnv)], unresolved: Array[String]) -> TypeEnv {
+  let (local_env, _) = build_import_envs_collecting(stmts, base_dir, cache, unresolved)
+  local_env
 }
 
 fn upsert_env_cache(cache: Array[(String, TypeEnv)], path: String, env: TypeEnv) -> Array[(String, TypeEnv)] {
@@ -2424,11 +2471,39 @@ fn prepend_explicit_builtin_value_markers(value_surface: Array[String], env: Typ
 /// in-memory TypeDb lanes. Only declarations named by this module's explicit
 /// export surface leave the check; imported authority stays local unless the
 /// module re-exports it.
-export fn checked_module_public_env(stmts: Array[Stmt], full_checked_env: TypeEnv) -> TypeEnv {
+fn append_env_tail(head: TypeEnv, tail: TypeEnv) -> TypeEnv {
+  match head {
+    EnvEmpty => tail,
+    EnvBind(name, binding, rest) => EnvBind(name, binding, append_env_tail(rest, tail)),
+    EnvTraitDef(name, supers, is_auto, methods, rest, params, method_gens) => EnvTraitDef(name, supers, is_auto, methods, append_env_tail(rest, tail), params, method_gens),
+    EnvTraitImpl(name, target, rest) => EnvTraitImpl(name, target, append_env_tail(rest, tail)),
+    EnvTraitImplGen(name, params, bounds, target, rest) => EnvTraitImplGen(name, params, bounds, target, append_env_tail(rest, tail)),
+    EnvTypeDefs(defs, selectable, rest) => EnvTypeDefs(defs, selectable, append_env_tail(rest, tail)),
+    EnvMutCell(name, escapes, rest) => EnvMutCell(name, escapes, append_env_tail(rest, tail)),
+    EnvFlat(bindings) => {
+      let mut out = tail
+      let mut i = Array::length(bindings) - 1
+      while i >= 0 {
+        let (name, binding) = Array::get(bindings, i)
+        out = EnvBind(name, binding, out)
+        i = i - 1
+      }
+      out
+    },
+    // Cached names are derived acceleration state. Reattaching the semantic
+    // chain and letting publication discard/rebuild caches preserves meaning.
+    EnvCached(_, _, rest) => append_env_tail(rest, tail)
+  }
+}
+
+fn checked_module_public_env_with_reexport_declarations(stmts: Array[Stmt], full_checked_env: TypeEnv, reexport_declarations: TypeEnv) -> TypeEnv {
+  // Local declarations stay ahead of the publication-only projection, which
+  // preserves lexical shadowing when both select the same public spelling.
+  let publication_env = append_env_tail(full_checked_env, reexport_declarations)
   let value_surface = interface_public_value_names(stmts)
-  let trait_surface = interface_public_trait_names(stmts, full_checked_env)
-  let type_surface = interface_public_type_names(stmts, full_checked_env)
-  let published = restrict_env_to_export_surface(value_surface, trait_surface, type_surface, full_checked_env)
+  let trait_surface = interface_public_trait_names(stmts, publication_env)
+  let type_surface = interface_public_type_names(stmts, publication_env)
+  let published = restrict_env_to_export_surface(value_surface, trait_surface, type_surface, publication_env)
   // Builtin declarations have no TypeDef node to survive the restriction.
   // Their explicit selected surface still needs a transport node, otherwise
   // the importer cannot distinguish this export from an empty dependency.
@@ -2438,6 +2513,10 @@ export fn checked_module_public_env(stmts: Array[Stmt], full_checked_env: TypeEn
     published
   }
   prepend_explicit_builtin_value_markers(value_surface, with_builtin_types)
+}
+
+export fn checked_module_public_env(stmts: Array[Stmt], full_checked_env: TypeEnv) -> TypeEnv {
+  checked_module_public_env_with_reexport_declarations(stmts, full_checked_env, EnvEmpty)
 }
 
 fn interface_decl_line(prefix: String, name: String, body: String) -> String {
@@ -3984,7 +4063,7 @@ fn check_module_impl(job: ModuleJob, observe_typing_artifact: Bool) -> ModuleOut
   // the body is checked, so the diagnostic names the import rather than
   // whatever the body happened to do with it.
   let unresolved_imports = array_empty()
-  let import_env = build_import_env_collecting(stmts, dir_of_path(job.path), job.dep_envs, unresolved_imports)
+  let (import_env, reexport_declarations) = build_import_envs_collecting(stmts, dir_of_path(job.path), job.dep_envs, unresolved_imports)
   // The CANONICAL fingerprint, computed the same way the serial walk
   // computes it (build_fingerprint, same file) from the same inputs: this
   // module's own source and each dependency's fingerprint in declaration
@@ -4013,7 +4092,7 @@ fn check_module_impl(job: ModuleJob, observe_typing_artifact: Bool) -> ModuleOut
       // consumer of `Checked`'s env (env cache, persistent store, worker
       // transport, TDRE5, trace identities) is a publication path. The full
       // environment never needs to outlive the check itself.
-      let checked_env = checked_module_public_env(stmts, full_checked_env)
+      let checked_env = checked_module_public_env_with_reexport_declarations(stmts, full_checked_env, reexport_declarations)
       let interface_identity = if incremental_interface_trace_enabled() {
         incremental_interface_identity(job.source, checked_env)
       } else {

--- a/lib/@vibe/compiler/runtime/typecheck_fs.vibe
+++ b/lib/@vibe/compiler/runtime/typecheck_fs.vibe
@@ -1289,6 +1289,19 @@ fn build_import_env_collecting(stmts: Array[Stmt], base_dir: String, cache: Arra
   local_env
 }
 
+/// Build both the lexical import environment and the declaration projection
+/// that exists only while publishing aliased re-exports. Callers that publish
+/// a checked module must retain both halves until the public env is built.
+export fn build_trait_aware_import_envs(stmts: Array[Stmt], base_dir: String, cache: Array[(String, TypeEnv)]) -> (TypeEnv, TypeEnv) with Exception {
+  let unresolved = array_empty()
+  let envs = build_import_envs_collecting(stmts, base_dir, cache, unresolved)
+  if Array::length(unresolved) == 0 {
+    envs
+  } else {
+    throw(Array::get(unresolved, 0))
+  }
+}
+
 fn upsert_env_cache(cache: Array[(String, TypeEnv)], path: String, env: TypeEnv) -> Array[(String, TypeEnv)] {
   let len = Array::length(cache)
   let mut i = 0
@@ -2496,7 +2509,7 @@ fn append_env_tail(head: TypeEnv, tail: TypeEnv) -> TypeEnv {
   }
 }
 
-fn checked_module_public_env_with_reexport_declarations(stmts: Array[Stmt], full_checked_env: TypeEnv, reexport_declarations: TypeEnv) -> TypeEnv {
+export fn checked_module_public_env_with_reexport_declarations(stmts: Array[Stmt], full_checked_env: TypeEnv, reexport_declarations: TypeEnv) -> TypeEnv {
   // Local declarations stay ahead of the publication-only projection, which
   // preserves lexical shadowing when both select the same public spelling.
   let publication_env = append_env_tail(full_checked_env, reexport_declarations)

--- a/lib/@vibe/compiler/tests/type_db_cross_module_test.vibe
+++ b/lib/@vibe/compiler/tests/type_db_cross_module_test.vibe
@@ -317,6 +317,14 @@ fn typecheck_db_pair_error(dep_src: String, main_src: String) -> String with Exc
   } with { Exception::Throw(msg) => msg }
 }
 
+fn typecheck_db_reexport_chain_error(dep_src: String, mid_src: String, main_src: String) -> String with Exception {
+  handle {
+    let db = db_set_source(db_set_source(db_set_source(db_new(), "mem/dep.vibe", dep_src), "mem/mid.vibe", mid_src), "mem/main.vibe", main_src)
+    let _ = db_typecheck(db, "mem/main.vibe")
+    ""
+  } with { Exception::Throw(msg) => msg }
+}
+
 test "forward alias bodies stay resolved across module projection" {
   let dep_source = "export type Pair = StringMap[Int, String]\ntype StringMap[A, B] = (A, B)"
   let pair_binding_is_resolved = match env_lookup(checked_test_env(dep_source), "Pair") {
@@ -1800,6 +1808,13 @@ test "#2310: aliased type and trait re-exports remain importable downstream" {
     (mid_path, mid_fp)
   ]))
   inspect(export_surface_error([dep_path, mid_path, main_path], main_path), "")
+}
+
+test "#2310: in-memory TypeDb retains aliased declaration re-exports" {
+  let dep_src = "export type Original = Int\nexport trait Marker\nimpl Marker for Int\n"
+  let mid_src = "export ./dep.vibe { type Original as PublicT, trait Marker as PublicMarker }\n"
+  let main_src = "import ./mid.vibe { type PublicT, trait PublicMarker }\nexport fn use_it[T: PublicMarker](value: T) -> PublicT { let _ = value; 1 }\n"
+  inspect(typecheck_db_reexport_chain_error(dep_src, mid_src, main_src), "")
 }
 
 test "#2310: plain type and trait re-exports retain local compatibility" {

--- a/lib/@vibe/compiler/tests/type_db_cross_module_test.vibe
+++ b/lib/@vibe/compiler/tests/type_db_cross_module_test.vibe
@@ -22,6 +22,8 @@ import @vibe/compiler/core {
   env_cache,
   env_lookup,
   env_lookup_binding,
+  env_selectable_type_defs,
+  env_type_defs,
   env_value_binding,
   trait_defined
 }
@@ -1175,6 +1177,19 @@ test "exact dep projection gives explicit trait aliases precedence over selected
   assert(imported_forall_bound_label(trait_first, "accept") == "Local")
 }
 
+test "#2310: projected re-export aliases exclude local declaration authority" {
+  let dep_path = "workspace/dep.vibe"
+  let dep_env = EnvTraitDef("Marker", [], false, [], EnvTypeDefs([
+    TDAlias("Original", [], CtInt)
+  ], ["Original"], EnvEmpty), [], [])
+  let import_env = projected_import_env_for_test("export ./dep.vibe { type Original as PublicT, trait Marker as PublicMarker }", "workspace/main.vibe", [
+    dep_path
+  ], [(dep_path, dep_env)])
+  assert(Array::length(env_type_defs(import_env)) == 0)
+  assert(Array::length(env_selectable_type_defs(import_env)) == 0)
+  assert(!trait_defined(import_env, "PublicMarker"))
+}
+
 test "db_typecheck_fs: missing imported trait impl fails cold and with a warm dependency interface" {
   let dep_path = "/tmp/vibe_compiler_trait_authority_missing_impl_dep.vibe"
   let main_path = "/tmp/vibe_compiler_trait_authority_missing_impl_main.vibe"
@@ -1727,6 +1742,81 @@ test "db_typecheck_fs: an aliased re-export stays importable by a consumer (#228
     (mid_path, mid_fp)
   ]))
   inspect(export_surface_error([dep_path, mid_path, main_path], main_path), "")
+}
+
+test "#2310: an aliased type re-export is not a local declaration" {
+  let dir = "/tmp/vibe_compiler_type_reexport_alias_local_scope"
+  let dep_path = String::concat(dir, "/dep.vibe")
+  let mid_path = String::concat(dir, "/mid.vibe")
+  let dep_src = "export type Original = Int\n"
+  let mid_src = "export ./dep.vibe { type Original as PublicT }\nexport let local: PublicT = 1\n"
+  Fs::mkdir_p(dir)
+  Fs::write_bytes(dep_path, string_to_bytes(dep_src))
+  Fs::write_bytes(mid_path, string_to_bytes(mid_src))
+  let dep_fp = build_test_fingerprint(dep_src, array_empty())
+  remove_typecheck_fs_cache(dep_path, dep_src, dep_fp)
+  remove_typecheck_fs_cache(mid_path, mid_src, build_test_fingerprint(mid_src, [
+    (dep_path, dep_fp)
+  ]))
+  let err = export_surface_error([dep_path, mid_path], mid_path)
+  assert(String::contains(err, "unknown type `PublicT`"))
+}
+
+test "#2310: an aliased trait re-export is not a local declaration" {
+  let dir = "/tmp/vibe_compiler_trait_reexport_alias_local_scope"
+  let dep_path = String::concat(dir, "/dep.vibe")
+  let mid_path = String::concat(dir, "/mid.vibe")
+  let dep_src = "export trait Marker\n"
+  let mid_src = "export ./dep.vibe { trait Marker as PublicMarker }\nexport fn local[T: PublicMarker](value: T) -> Int { let _ = value; 1 }\n"
+  Fs::mkdir_p(dir)
+  Fs::write_bytes(dep_path, string_to_bytes(dep_src))
+  Fs::write_bytes(mid_path, string_to_bytes(mid_src))
+  let dep_fp = build_test_fingerprint(dep_src, array_empty())
+  remove_typecheck_fs_cache(dep_path, dep_src, dep_fp)
+  remove_typecheck_fs_cache(mid_path, mid_src, build_test_fingerprint(mid_src, [
+    (dep_path, dep_fp)
+  ]))
+  let err = export_surface_error([dep_path, mid_path], mid_path)
+  assert(String::contains(err, "unknown trait: PublicMarker"))
+}
+
+test "#2310: aliased type and trait re-exports remain importable downstream" {
+  let dir = "/tmp/vibe_compiler_decl_reexport_alias_public_surface"
+  let dep_path = String::concat(dir, "/dep.vibe")
+  let mid_path = String::concat(dir, "/mid.vibe")
+  let main_path = String::concat(dir, "/main.vibe")
+  let dep_src = "type Hidden = Int\nexport type Original = Hidden\nexport trait Marker\nimpl Marker for Int\n"
+  let mid_src = "export ./dep.vibe { type Original as PublicT, trait Marker as PublicMarker }\n"
+  let main_src = "import ./mid.vibe { type PublicT, trait PublicMarker }\nexport fn use_it[T: PublicMarker](value: T) -> PublicT { let _ = value; 1 }\n"
+  Fs::mkdir_p(dir)
+  Fs::write_bytes(dep_path, string_to_bytes(dep_src))
+  Fs::write_bytes(mid_path, string_to_bytes(mid_src))
+  Fs::write_bytes(main_path, string_to_bytes(main_src))
+  let dep_fp = build_test_fingerprint(dep_src, array_empty())
+  let mid_fp = build_test_fingerprint(mid_src, [(dep_path, dep_fp)])
+  remove_typecheck_fs_cache(dep_path, dep_src, dep_fp)
+  remove_typecheck_fs_cache(mid_path, mid_src, mid_fp)
+  remove_typecheck_fs_cache(main_path, main_src, build_test_fingerprint(main_src, [
+    (mid_path, mid_fp)
+  ]))
+  inspect(export_surface_error([dep_path, mid_path, main_path], main_path), "")
+}
+
+test "#2310: plain type and trait re-exports retain local compatibility" {
+  let dir = "/tmp/vibe_compiler_decl_plain_reexport_local_scope"
+  let dep_path = String::concat(dir, "/dep.vibe")
+  let mid_path = String::concat(dir, "/mid.vibe")
+  let dep_src = "export type PublicT = Int\nexport trait Marker\nimpl Marker for Int\n"
+  let mid_src = "export ./dep.vibe { type PublicT, trait Marker }\nexport fn local[T: Marker](value: T) -> PublicT { let _ = value; 1 }\n"
+  Fs::mkdir_p(dir)
+  Fs::write_bytes(dep_path, string_to_bytes(dep_src))
+  Fs::write_bytes(mid_path, string_to_bytes(mid_src))
+  let dep_fp = build_test_fingerprint(dep_src, array_empty())
+  remove_typecheck_fs_cache(dep_path, dep_src, dep_fp)
+  remove_typecheck_fs_cache(mid_path, mid_src, build_test_fingerprint(mid_src, [
+    (dep_path, dep_fp)
+  ]))
+  inspect(export_surface_error([dep_path, mid_path], mid_path), "")
 }
 
 test "db_typecheck_fs: private struct enum and alias declarations are not importable" {


### PR DESCRIPTION
## Summary

- separate aliased re-export TypeDef and trait projections from the environment used to check the re-exporting module
- reattach declaration closure only while constructing the published module environment
- preserve that publication-only projection in both filesystem and in-memory TypeDb lanes
- diagnose a publication-only trait alias at its local generic-bound declaration site
- retain downstream imports, declaration closure, and plain re-export compatibility

## TDD

Red:
- `export ./dep.vibe { type Original as PublicT }` allowed `PublicT` in a local annotation
- `export ./dep.vibe { trait Marker as PublicMarker }` allowed `PublicMarker` in a local generic bound
- the in-memory TypeDb lost aliased type and trait declarations before a downstream consumer imported them

Green:
- local type use reports `unknown type PublicT`
- local trait-bound use reports `unknown trait: PublicMarker`
- downstream consumers can still import both aliases through filesystem and in-memory TypeDb lanes
- private TypeDef closure remains available to interpret the published alias
- plain type and trait re-exports retain their local compatibility behavior

## Validation

- focused `type_db_cross_module_test.vibe`: 99/99 tests passed
- `pkf run test-affected`: 173/173 affected files passed
- `pkf run pre-commit`: passed
- fresh stage0 -> stage3 generation: passed
- compiler gate: all 106 checks passed
- `pkf run full-gate` reached the final gate self-tests; macOS system Bash 3 lacks `mapfile`, so the two Bash-4 self-tests could not run under the task wrapper

Closes #2310