### PR TITLE
Name the contract, not the generated types module, in a type diagnostic (#2317)

### DIFF
--- a/lib/@vibe/compiler/contract/contract.vibe
+++ b/lib/@vibe/compiler/contract/contract.vibe
@@ -946,6 +946,19 @@ export fn contract_type_family_defs(type_defs: Array[Stmt]) -> Array[Stmt] {
 /// `contract_facade_marker` / `vpkg_shared_import_marker`).
 export let vpkg_types_module_marker: String = "// vibe: vpkg contract types module (#1840)\n"
 
+/// #2317: header prefix naming the contract a types module was generated from.
+///
+/// Carried IN-BAND, for the same reason the deferred-name sentinel is (#2125):
+/// the value has to travel with the TEXT through every lane. A materialized
+/// types module is checked in-process by the serial walk, but also by an
+/// isolated worker under `VIBE_MODULE_JOB_DIR`, which is handed `source.vibe`
+/// and its dependencies' environments and never runs the loader -- so any
+/// process-local registry is empty there, and a diagnostic would name the
+/// contract in one lane and the generated file in the other. Lanes disagreeing
+/// about the same file is the bug #2317 is about; the fix must not add a new
+/// instance of it (Codex review on #2324).
+export let vpkg_types_contract_marker: String = "// vibe: generated from "
+
 /// #2125: the type-name heads `tds` reference minus the names `tds` declare
 /// -- the names this module can neither declare nor import: a
 /// contract-`opaque` name whose definition lives in a sibling impl
@@ -1104,9 +1117,12 @@ export let vpkg_deferred_type_names_prefix: String = "__vpkg_deferred_type_names
 /// names at field/payload positions without any process-lifetime registry.
 /// `uniq` keeps the binding name collision-free when several contracts'
 /// modules meet in one merge.
-export fn contract_types_module_text(tds: Array[Stmt], uniq: String) -> String {
+export fn contract_types_module_text(tds: Array[Stmt], uniq: String, contract_path: String) -> String {
   let lines = array_empty()
   Array::push(lines, vpkg_types_module_marker)
+  // Provenance, so a process holding only this text can still name the
+  // contract. Emitted even when empty so the header shape is uniform.
+  Array::push(lines, String::concat(vpkg_types_contract_marker, contract_path))
   let (decl_names, deferred) = ctm_deferred_type_names(tds)
   if Array::length(deferred) == 0 {
     ()
@@ -1123,6 +1139,30 @@ export fn contract_types_module_text(tds: Array[Stmt], uniq: String) -> String {
     i = i + 1
   }
   String::concat(String::join(lines, "\n"), "\n")
+}
+
+/// #2317: the contract a materialized types module was generated from, read
+/// from the module's OWN text, or "" when the marker is absent.
+///
+/// Text, not a registry: this has to answer the same way in the isolated
+/// worker lane, which never runs the loader. "" when absent, so a stub
+/// generated before this marker existed keeps the caller's fallback rather
+/// than producing a guess.
+export fn vpkg_types_contract_of_source(source: String) -> String {
+  let lines = String::split(source, "\n")
+  let n = Array::length(lines)
+  let mut i = 0
+  let mut found = ""
+  while i < n && found == "" {
+    let line = Array::get(lines, i)
+    if String::starts_with(line, vpkg_types_contract_marker) {
+      found = String::trim(String::substring(line, String::length(vpkg_types_contract_marker), String::length(line)))
+    } else {
+      ()
+    }
+    i = i + 1
+  }
+  found
 }
 
 /// #1840: the `type <Name>` item list for importing / re-exporting the

--- a/lib/@vibe/compiler/contract/contract.vibe
+++ b/lib/@vibe/compiler/contract/contract.vibe
@@ -967,7 +967,13 @@ export let vpkg_types_contract_marker: String = "// vibe: generated from "
 /// declarations, and the reader would recover only the truncated prefix.
 ///
 /// Backslash is escaped first so the decode is unambiguous.
-fn vpkg_marker_encode(path: String) -> String {
+///
+/// Also the DISPLAY form for a path in a diagnostic (#2324): the CLI's contract
+/// is one record per line, and a decoded newline rendered verbatim would split
+/// one diagnostic across lines -- crafted path components could even resemble
+/// further diagnostics. Round-tripping stays exact internally; only what is
+/// printed is escaped.
+export fn vpkg_path_escape_one_line(path: String) -> String {
   let sb = StringBuilder::new()
   let n = String::length(path)
   let mut i = 0
@@ -987,7 +993,7 @@ fn vpkg_marker_encode(path: String) -> String {
   StringBuilder::freeze(sb)
 }
 
-/// Inverse of `vpkg_marker_encode`. An unrecognized escape is passed through
+/// Inverse of `vpkg_path_escape_one_line`. An unrecognized escape is passed through
 /// verbatim rather than dropped: a stub written by some other producer should
 /// degrade to a wrong-looking path, never to a silently shortened one.
 fn vpkg_marker_decode(text: String) -> String {
@@ -1182,7 +1188,7 @@ export fn contract_types_module_text(tds: Array[Stmt], uniq: String, contract_pa
   Array::push(lines, vpkg_types_module_marker)
   // Provenance, so a process holding only this text can still name the
   // contract. Emitted even when empty so the header shape is uniform.
-  Array::push(lines, String::concat(vpkg_types_contract_marker, vpkg_marker_encode(contract_path)))
+  Array::push(lines, String::concat(vpkg_types_contract_marker, vpkg_path_escape_one_line(contract_path)))
   let (decl_names, deferred) = ctm_deferred_type_names(tds)
   if Array::length(deferred) == 0 {
     ()

--- a/lib/@vibe/compiler/contract/contract.vibe
+++ b/lib/@vibe/compiler/contract/contract.vibe
@@ -1156,7 +1156,19 @@ export fn vpkg_types_contract_of_source(source: String) -> String {
   while i < n && found == "" {
     let line = Array::get(lines, i)
     if String::starts_with(line, vpkg_types_contract_marker) {
-      found = String::trim(String::substring(line, String::length(vpkg_types_contract_marker), String::length(line)))
+      let raw = String::substring(line, String::length(vpkg_types_contract_marker), String::length(line))
+      // Verbatim, except a trailing CR. The marker is written with no padding,
+      // so trimming can only corrupt: a directory name may legally begin with
+      // a space, and the diagnostic would then name a file that does not exist
+      // (Codex review on #2324). The CR is the one exception -- splitting on
+      // "\n" leaves it on a CRLF file, and a CR inside the path is just as
+      // wrong as a lost space.
+      let raw_len = String::length(raw)
+      found = if raw_len > 0 && String::char_code_at(raw, raw_len - 1) == 13 {
+        String::substring(raw, 0, raw_len - 1)
+      } else {
+        raw
+      }
     } else {
       ()
     }

--- a/lib/@vibe/compiler/contract/contract.vibe
+++ b/lib/@vibe/compiler/contract/contract.vibe
@@ -959,6 +959,66 @@ export let vpkg_types_module_marker: String = "// vibe: vpkg contract types modu
 /// instance of it (Codex review on #2324).
 export let vpkg_types_contract_marker: String = "// vibe: generated from "
 
+/// #2324: escape a contract path for the single-line `//` provenance marker.
+///
+/// A POSIX path may legally contain a newline. Concatenated raw, it would end
+/// the comment and turn the remainder of the path into generated vibe source
+/// -- the types module could then fail to parse, or take crafted path text as
+/// declarations, and the reader would recover only the truncated prefix.
+///
+/// Backslash is escaped first so the decode is unambiguous.
+fn vpkg_marker_encode(path: String) -> String {
+  let sb = StringBuilder::new()
+  let n = String::length(path)
+  let mut i = 0
+  while i < n {
+    let c = String::char_code_at(path, i)
+    if c == 92 {
+      StringBuilder::push(sb, "\\\\")
+    } else if c == 10 {
+      StringBuilder::push(sb, "\\n")
+    } else if c == 13 {
+      StringBuilder::push(sb, "\\r")
+    } else {
+      StringBuilder::push(sb, String::substring(path, i, i + 1))
+    }
+    i = i + 1
+  }
+  StringBuilder::freeze(sb)
+}
+
+/// Inverse of `vpkg_marker_encode`. An unrecognized escape is passed through
+/// verbatim rather than dropped: a stub written by some other producer should
+/// degrade to a wrong-looking path, never to a silently shortened one.
+fn vpkg_marker_decode(text: String) -> String {
+  let sb = StringBuilder::new()
+  let n = String::length(text)
+  let mut i = 0
+  while i < n {
+    let c = String::char_code_at(text, i)
+    if c == 92 && i + 1 < n {
+      let d = String::char_code_at(text, i + 1)
+      if d == 110 {
+        StringBuilder::push(sb, "\n")
+        i = i + 2
+      } else if d == 114 {
+        StringBuilder::push(sb, "\r")
+        i = i + 2
+      } else if d == 92 {
+        StringBuilder::push(sb, "\\")
+        i = i + 2
+      } else {
+        StringBuilder::push(sb, String::substring(text, i, i + 1))
+        i = i + 1
+      }
+    } else {
+      StringBuilder::push(sb, String::substring(text, i, i + 1))
+      i = i + 1
+    }
+  }
+  StringBuilder::freeze(sb)
+}
+
 /// #2125: the type-name heads `tds` reference minus the names `tds` declare
 /// -- the names this module can neither declare nor import: a
 /// contract-`opaque` name whose definition lives in a sibling impl
@@ -1122,7 +1182,7 @@ export fn contract_types_module_text(tds: Array[Stmt], uniq: String, contract_pa
   Array::push(lines, vpkg_types_module_marker)
   // Provenance, so a process holding only this text can still name the
   // contract. Emitted even when empty so the header shape is uniform.
-  Array::push(lines, String::concat(vpkg_types_contract_marker, contract_path))
+  Array::push(lines, String::concat(vpkg_types_contract_marker, vpkg_marker_encode(contract_path)))
   let (decl_names, deferred) = ctm_deferred_type_names(tds)
   if Array::length(deferred) == 0 {
     ()
@@ -1164,11 +1224,14 @@ export fn vpkg_types_contract_of_source(source: String) -> String {
       // "\n" leaves it on a CRLF file, and a CR inside the path is just as
       // wrong as a lost space.
       let raw_len = String::length(raw)
-      found = if raw_len > 0 && String::char_code_at(raw, raw_len - 1) == 13 {
+      // Strip a trailing CR before decoding: the writer ESCAPES a real CR, so
+      // a literal one here can only have come from a CRLF line ending.
+      let line_body = if raw_len > 0 && String::char_code_at(raw, raw_len - 1) == 13 {
         String::substring(raw, 0, raw_len - 1)
       } else {
         raw
       }
+      found = vpkg_marker_decode(line_body)
     } else {
       ()
     }

--- a/lib/@vibe/compiler/contract/index.vpkg
+++ b/lib/@vibe/compiler/contract/index.vpkg
@@ -60,6 +60,7 @@ fn contract_facade_source(decls: Array[(String, String)], opaque_names: Array[(S
 fn contract_type_family_defs(type_defs: Array[Stmt]) -> Array[Stmt]
 fn contract_types_module_text(tds: Array[Stmt], uniq: String, contract_path: String) -> String
 fn vpkg_types_contract_of_source(source: String) -> String
+fn vpkg_path_escape_one_line(path: String) -> String
 let vpkg_deferred_type_names_prefix: String
 fn contract_types_item_names(tds: Array[Stmt]) -> Array[String]
 fn contract_types_module_line(keyword: String, types_path: String, tds: Array[Stmt]) -> String

--- a/lib/@vibe/compiler/contract/index.vpkg
+++ b/lib/@vibe/compiler/contract/index.vpkg
@@ -37,6 +37,7 @@ generated_hash =
 let contract_facade_marker: String
 let vpkg_shared_import_marker: String
 let vpkg_types_module_marker: String
+let vpkg_types_contract_marker: String
 
 // --- contract grammar
 fn parse_contract_program(tokens: Array[Token]) -> (Array[(String, String)], Array[(String, Int)], Array[Stmt]) with Exception
@@ -57,7 +58,8 @@ fn contract_facade_source(decls: Array[(String, String)], opaque_names: Array[(S
 
 // --- materialized types module (#1840)
 fn contract_type_family_defs(type_defs: Array[Stmt]) -> Array[Stmt]
-fn contract_types_module_text(tds: Array[Stmt], uniq: String) -> String
+fn contract_types_module_text(tds: Array[Stmt], uniq: String, contract_path: String) -> String
+fn vpkg_types_contract_of_source(source: String) -> String
 let vpkg_deferred_type_names_prefix: String
 fn contract_types_item_names(tds: Array[Stmt]) -> Array[String]
 fn contract_types_module_line(keyword: String, types_path: String, tds: Array[Stmt]) -> String

--- a/lib/@vibe/compiler/loader/index.vpkg
+++ b/lib/@vibe/compiler/loader/index.vpkg
@@ -115,6 +115,7 @@ fn collect_all_sources_fs(entry_path: String) -> Array[(String, String)] with Ex
 fn collect_source_groups_fs(entry_path: String) -> Array[(String, Array[(String, String)])] with Exception + Fs
 fn collect_merged_stmts(sources: Array[(String, String)]) -> Array[Stmt] with Exception
 fn find_missing_vpkg_dirs(root: String) -> Array[String] with Exception + Fs
+fn vpkg_types_contract_for_path(types_path: String) -> String
 fn check_missing_vpkg_dirs(root: String) -> Int with Exception + Fs
 fn write_generated_hash_fs(path: String) -> String with Exception + Fs
 fn find_deps_missing(root: String) -> Array[String] with Exception + Fs

--- a/lib/@vibe/compiler/loader/index.vpkg
+++ b/lib/@vibe/compiler/loader/index.vpkg
@@ -114,6 +114,7 @@ fn publish_check_fs(prev_contract_path: String, next_contract_path: String, prev
 fn collect_all_sources_fs(entry_path: String) -> Array[(String, String)] with Exception + Fs
 fn collect_source_groups_fs(entry_path: String) -> Array[(String, Array[(String, String)])] with Exception + Fs
 fn collect_merged_stmts(sources: Array[(String, String)]) -> Array[Stmt] with Exception
+let vpkg_types_module_path_prefix: String
 fn find_missing_vpkg_dirs(root: String) -> Array[String] with Exception + Fs
 fn check_missing_vpkg_dirs(root: String) -> Int with Exception + Fs
 fn write_generated_hash_fs(path: String) -> String with Exception + Fs

--- a/lib/@vibe/compiler/loader/index.vpkg
+++ b/lib/@vibe/compiler/loader/index.vpkg
@@ -115,7 +115,6 @@ fn collect_all_sources_fs(entry_path: String) -> Array[(String, String)] with Ex
 fn collect_source_groups_fs(entry_path: String) -> Array[(String, Array[(String, String)])] with Exception + Fs
 fn collect_merged_stmts(sources: Array[(String, String)]) -> Array[Stmt] with Exception
 fn find_missing_vpkg_dirs(root: String) -> Array[String] with Exception + Fs
-fn vpkg_types_contract_for_path(types_path: String) -> String
 fn check_missing_vpkg_dirs(root: String) -> Int with Exception + Fs
 fn write_generated_hash_fs(path: String) -> String with Exception + Fs
 fn find_deps_missing(root: String) -> Array[String] with Exception + Fs

--- a/lib/@vibe/compiler/loader/loader.vibe
+++ b/lib/@vibe/compiler/loader/loader.vibe
@@ -1083,6 +1083,14 @@ let vpkg_types_registry_contracts: Array[String] = [] let vpkg_types_registry_pa
   }
 }
 
+/// #2324: the exact prefix every materialized types module is written under.
+///
+/// Shared with the predicate that decides whether to trust a module's
+/// provenance marker, so the two cannot drift: a generator that moved and a
+/// predicate that did not would silently stop attributing diagnostics, or
+/// start trusting a file it should not.
+export let vpkg_types_module_path_prefix: String = "_build/vibe_vpkg_types/types_"
+
 /// Returns "" when the contract declares no type-family definitions, or when
 /// the package lives outside the repo-relative tree (an absolute VIBE_LIB
 /// external root — the relative import spelling below cannot reach _build
@@ -1137,7 +1145,7 @@ fn ensure_vpkg_types_module_fs(vpkg_path: String, extra: Array[Stmt]) -> String 
       }
       kci = kci + 1
     }
-    let types_path = String::concat("_build/vibe_vpkg_types/types_", String::concat(StringBuilder::freeze(key_sb), ".vibe"))
+    let types_path = String::concat(vpkg_types_module_path_prefix, String::concat(StringBuilder::freeze(key_sb), ".vibe"))
     if Fs::exists(types_path) {
       ()
     } else {

--- a/lib/@vibe/compiler/loader/loader.vibe
+++ b/lib/@vibe/compiler/loader/loader.vibe
@@ -1082,33 +1082,6 @@ let vpkg_types_registry_contracts: Array[String] = [] let vpkg_types_registry_pa
   }
 }
 
-/// #2317: the contract a materialized `_build/vibe_vpkg_types/` module was
-/// generated from, or "" when this process did not materialize it.
-///
-/// The stub's own name is a fingerprint of (contract path, generated text), so
-/// it cannot be inverted -- the mapping has to come from the registry that
-/// recorded it. A diagnostic about the stub is a diagnostic about the type
-/// definitions the AUTHOR wrote in the contract, and naming the generated file
-/// tells the reader to go edit a build artifact.
-///
-/// Returns "" rather than guessing when the lookup misses (a process that
-/// checks a stub it did not itself materialize has an empty registry). The
-/// caller keeps the stub path in that case, which is the current behavior --
-/// degraded, never wrong.
-export fn vpkg_types_contract_for_path(types_path: String) -> String {
-  let mut i = 0
-  let mut found = ""
-  while i < Array::length(vpkg_types_registry_paths) && found == "" {
-    if Array::get(vpkg_types_registry_paths, i) == types_path {
-      found = Array::get(vpkg_types_registry_contracts, i)
-    } else {
-      ()
-    }
-    i = i + 1
-  }
-  found
-}
-
 /// Returns "" when the contract declares no type-family definitions, or when
 /// the package lives outside the repo-relative tree (an absolute VIBE_LIB
 /// external root — the relative import spelling below cannot reach _build
@@ -1143,7 +1116,7 @@ fn ensure_vpkg_types_module_fs(vpkg_path: String, extra: Array[Stmt]) -> String 
       }
       uci = uci + 1
     }
-    let text = contract_types_module_text(tds, StringBuilder::freeze(uniq_sb))
+    let text = contract_types_module_text(tds, StringBuilder::freeze(uniq_sb), vpkg_path)
     let raw_key = compact_string_fingerprint(String::concat(vpkg_path, String::concat("|", text)))
     // Identifier-safe basename: the import-path grammar (parser_base.vibe's
     // collect_import_path) lexes path segments as identifier/keyword tokens,

--- a/lib/@vibe/compiler/loader/loader.vibe
+++ b/lib/@vibe/compiler/loader/loader.vibe
@@ -73,7 +73,8 @@ import @vibe/compiler/contract {
   replace_generated_hash_directive,
   semver_parts,
   verify_publish_bump,
-  vpkg_shared_import_marker
+  vpkg_shared_import_marker,
+  vpkg_types_contract_of_source
 }
 
 import ./ingestion_pipeline_telemetry.vibe {
@@ -1230,14 +1231,32 @@ fn vpkg_directory_shared_import_prefix_fs(path: String) -> String with Exception
           ""
         } else {
           let cached_types_path = rest[0: nl]
-          if cached_types_path == "" || Fs::exists(cached_types_path) {
+          // #2324: a stub written before the provenance marker existed is
+          // STALE, not merely present. This branch skips regeneration on
+          // mere existence, so a workspace warmed by an older compiler
+          // would keep serving a marker-less stub and the diagnostic would
+          // go on naming the generated file after the upgrade. Reading the
+          // text once folds the missing-file case in: absent reads as "",
+          // which has no marker, so both fall through to the same
+          // idempotent regeneration below.
+          let cached_types_text = if cached_types_path != "" && Fs::exists(cached_types_path) {
+            Fs::read_file(cached_types_path)
+          } else {
+            ""
+          }
+          let cached_types_fresh = if cached_types_path == "" {
+            true
+          } else {
+            vpkg_types_contract_of_source(cached_types_text) != ""
+          }
+          if cached_types_fresh {
             // Same registry note as the facade-cache hit: a warm prefix
             // used to skip ensure_vpkg_types_module_fs, so collect_merged
             // and the typecheck source set never saw the stub (#1921).
             if cached_types_path == "" {
               ()
             } else {
-              vpkg_types_registry_note(vpkg_path, cached_types_path, Fs::read_file(cached_types_path))
+              vpkg_types_registry_note(vpkg_path, cached_types_path, cached_types_text)
             }
             rest[nl + 1: String::length(rest)]
           } else {
@@ -2062,7 +2081,18 @@ fn desugar_contract_source_fs(path: String, source: String) -> String with Excep
     let fc_nl = String::index_of(fc_rest, "\n")
     if fc_nl >= 0 {
       let fc_types_path = fc_rest[0: fc_nl]
-      if fc_types_path == "" || Fs::exists(fc_types_path) {
+      // #2324: stale-not-merely-absent, exactly as in the prefix cache above.
+      let fc_types_text = if fc_types_path != "" && Fs::exists(fc_types_path) {
+        Fs::read_file(fc_types_path)
+      } else {
+        ""
+      }
+      let fc_types_fresh = if fc_types_path == "" {
+        true
+      } else {
+        vpkg_types_contract_of_source(fc_types_text) != ""
+      }
+      if fc_types_fresh {
         // #1840: the registry note must happen on the HIT path too —
         // collect_merged_stmts' fixed-source-set re-injection reads the
         // process-local registry, and a warm facade cache would otherwise
@@ -2072,7 +2102,7 @@ fn desugar_contract_source_fs(path: String, source: String) -> String with Excep
         if fc_types_path == "" {
           ()
         } else {
-          vpkg_types_registry_note(path, fc_types_path, Fs::read_file(fc_types_path))
+          vpkg_types_registry_note(path, fc_types_path, fc_types_text)
         }
         return fc_rest[fc_nl + 1: String::length(fc_rest)]
       } else {

--- a/lib/@vibe/compiler/loader/loader.vibe
+++ b/lib/@vibe/compiler/loader/loader.vibe
@@ -1082,6 +1082,33 @@ let vpkg_types_registry_contracts: Array[String] = [] let vpkg_types_registry_pa
   }
 }
 
+/// #2317: the contract a materialized `_build/vibe_vpkg_types/` module was
+/// generated from, or "" when this process did not materialize it.
+///
+/// The stub's own name is a fingerprint of (contract path, generated text), so
+/// it cannot be inverted -- the mapping has to come from the registry that
+/// recorded it. A diagnostic about the stub is a diagnostic about the type
+/// definitions the AUTHOR wrote in the contract, and naming the generated file
+/// tells the reader to go edit a build artifact.
+///
+/// Returns "" rather than guessing when the lookup misses (a process that
+/// checks a stub it did not itself materialize has an empty registry). The
+/// caller keeps the stub path in that case, which is the current behavior --
+/// degraded, never wrong.
+export fn vpkg_types_contract_for_path(types_path: String) -> String {
+  let mut i = 0
+  let mut found = ""
+  while i < Array::length(vpkg_types_registry_paths) && found == "" {
+    if Array::get(vpkg_types_registry_paths, i) == types_path {
+      found = Array::get(vpkg_types_registry_contracts, i)
+    } else {
+      ()
+    }
+    i = i + 1
+  }
+  found
+}
+
 /// Returns "" when the contract declares no type-family definitions, or when
 /// the package lives outside the repo-relative tree (an absolute VIBE_LIB
 /// external root — the relative import spelling below cannot reach _build

--- a/lib/@vibe/compiler/runtime/typecheck_fs.vibe
+++ b/lib/@vibe/compiler/runtime/typecheck_fs.vibe
@@ -89,7 +89,7 @@ import @vibe/compiler/contract {
 }
 
 import @vibe/compiler/loader {
-  ingest_source_text_fs, ingestion_pipeline_telemetry_add, load_or_parse_module_header_fs
+  ingest_source_text_fs, ingestion_pipeline_telemetry_add, load_or_parse_module_header_fs, vpkg_types_module_path_prefix
 }
 
 import @vibe/compiler/incremental {
@@ -1395,8 +1395,24 @@ fn is_vpkg_types_stub_path(path: String) -> Bool {
 /// Falls back to the stub path when the marker is absent, which is what a stub
 /// generated before it existed will have. That is the behavior this replaces,
 /// so a miss degrades rather than misreports.
+/// #2324: the EXACT shape the loader writes, not a substring test.
+///
+/// `is_vpkg_types_stub_path` matches any path CONTAINING `vibe_vpkg_types/`.
+/// That is fine for its own callers, which only decide whether to load a file
+/// from disk, but far too loose to gate an attribution: an ordinary module
+/// under a directory of that name could carry a `// vibe: generated from ...`
+/// comment and have its diagnostics attributed to whatever path that comment
+/// names -- a file the reader never edited (Codex review on #2324).
+///
+/// The marker is only trusted for a path the loader itself generates, under
+/// the build directory the compiler owns. The prefix is shared with the
+/// generator so the two cannot drift apart.
+fn is_generated_vpkg_types_path(path: String) -> Bool {
+  String::starts_with(path, vpkg_types_module_path_prefix) && String::ends_with(path, ".vibe")
+}
+
 fn type_diagnostic_display_path(path: String, source: String, located_msg: String) -> String {
-  if is_vpkg_types_stub_path(path) && !diag_already_located(located_msg) {
+  if is_generated_vpkg_types_path(path) && !diag_already_located(located_msg) {
     let owner = vpkg_types_contract_of_source(source)
     if owner == "" {
       path

--- a/lib/@vibe/compiler/runtime/typecheck_fs.vibe
+++ b/lib/@vibe/compiler/runtime/typecheck_fs.vibe
@@ -85,6 +85,7 @@ import @vibe/compiler/contract {
   extract_require_pins,
   parse_contract_program,
   parse_contract_program_spans,
+  vpkg_path_escape_one_line,
   vpkg_types_contract_of_source
 }
 
@@ -1417,7 +1418,11 @@ fn type_diagnostic_display_path(path: String, source: String, located_msg: Strin
     if owner == "" {
       path
     } else {
-      owner
+      // Escaped for DISPLAY. The marker round-trips a path exactly, newlines
+      // included, and this string goes straight into a diagnostic -- rendered
+      // verbatim it would split one record across lines, and crafted path
+      // components could resemble further diagnostics (Codex review on #2324).
+      vpkg_path_escape_one_line(owner)
     }
   } else {
     path

--- a/lib/@vibe/compiler/runtime/typecheck_fs.vibe
+++ b/lib/@vibe/compiler/runtime/typecheck_fs.vibe
@@ -80,11 +80,16 @@ import @vibe/compiler/entry/source_compile/wasi_only {
 }
 
 import @vibe/compiler/contract {
-  classify_contract_stmts, contract_unsupported_stmt_index, extract_require_pins, parse_contract_program, parse_contract_program_spans
+  classify_contract_stmts,
+  contract_unsupported_stmt_index,
+  extract_require_pins,
+  parse_contract_program,
+  parse_contract_program_spans,
+  vpkg_types_contract_of_source
 }
 
 import @vibe/compiler/loader {
-  ingest_source_text_fs, ingestion_pipeline_telemetry_add, load_or_parse_module_header_fs, vpkg_types_contract_for_path
+  ingest_source_text_fs, ingestion_pipeline_telemetry_add, load_or_parse_module_header_fs
 }
 
 import @vibe/compiler/incremental {
@@ -1319,12 +1324,20 @@ fn is_vpkg_types_stub_path(path: String) -> Bool {
 /// offset mapping back to the contract; that needs the generator to emit one,
 /// and is tracked with the rest of #2317.
 ///
-/// Falls back to the stub path when the registry has no entry, which is what a
-/// process that checks a stub it did not itself materialize will see. That is
-/// the behavior this replaces, so a miss degrades rather than misreports.
-fn type_diagnostic_display_path(path: String, located_msg: String) -> String {
+/// The owner is read from the module's OWN text, not from a registry. A types
+/// module is also checked by an isolated worker under `VIBE_MODULE_JOB_DIR`,
+/// which is handed `source.vibe` plus its dependencies' environments and never
+/// runs the loader -- so a process-local registry is empty there, and the same
+/// contract would be named in one lane and not in the other. Lanes disagreeing
+/// about one file is the bug #2317 is about, so the fix must not add a new
+/// instance of it (Codex review on #2324).
+///
+/// Falls back to the stub path when the marker is absent, which is what a stub
+/// generated before it existed will have. That is the behavior this replaces,
+/// so a miss degrades rather than misreports.
+fn type_diagnostic_display_path(path: String, source: String, located_msg: String) -> String {
   if is_vpkg_types_stub_path(path) && !diag_already_located(located_msg) {
-    let owner = vpkg_types_contract_for_path(path)
+    let owner = vpkg_types_contract_of_source(source)
     if owner == "" {
       path
     } else {
@@ -4083,7 +4096,7 @@ fn check_module_impl(job: ModuleJob, observe_typing_artifact: Bool) -> ModuleOut
     } with { Exception::Throw(msg) => {
       let located = locate_type_error(job.source, msg)
       Diagnosed(job.path, [
-        String::concat(String::concat(type_diagnostic_display_path(job.path, located), ": "), located)
+        String::concat(String::concat(type_diagnostic_display_path(job.path, job.source, located), ": "), located)
       ])
     } }
   }

--- a/lib/@vibe/compiler/runtime/typecheck_fs.vibe
+++ b/lib/@vibe/compiler/runtime/typecheck_fs.vibe
@@ -1304,11 +1304,26 @@ fn is_vpkg_types_stub_path(path: String) -> Bool {
 /// the GENERATED text, not about anything in the contract, and naming the
 /// contract for one of those would send the reader to a file that is fine.
 ///
+/// UNLOCATED messages only, and that is the whole subtlety (Codex review on
+/// #2324). `locate_type_error` computes its line and column against the STUB's
+/// source, and the stub carries neither the contract's header nor its
+/// formatting -- so a located message renamed to the contract pairs a file the
+/// author wrote with a line number from a generated one. Measured: a contract
+/// whose `struct Box[T]` sits on line 13 reports `line 4:15-18` against the
+/// stub, and line 4 of that contract is inside its `description` block.
+///
+/// A stub path with a stub-relative line is at least self-consistent -- the
+/// reader can open that file and find the line. A contract path with a stub
+/// line is confidently wrong, which this repo ranks above unhelpful. So a
+/// located diagnostic keeps the generated path until the stub carries a real
+/// offset mapping back to the contract; that needs the generator to emit one,
+/// and is tracked with the rest of #2317.
+///
 /// Falls back to the stub path when the registry has no entry, which is what a
 /// process that checks a stub it did not itself materialize will see. That is
 /// the behavior this replaces, so a miss degrades rather than misreports.
-fn type_diagnostic_display_path(path: String) -> String {
-  if is_vpkg_types_stub_path(path) {
+fn type_diagnostic_display_path(path: String, located_msg: String) -> String {
+  if is_vpkg_types_stub_path(path) && !diag_already_located(located_msg) {
     let owner = vpkg_types_contract_for_path(path)
     if owner == "" {
       path
@@ -4065,9 +4080,12 @@ fn check_module_impl(job: ModuleJob, observe_typing_artifact: Bool) -> ModuleOut
         None
       }
       Checked(job.path, fingerprint, checked_env, interface_identity, checked_env_identity, persistent_type_env_transport_identity, module_typing_artifact)
-    } with { Exception::Throw(msg) => Diagnosed(job.path, [
-      String::concat(String::concat(type_diagnostic_display_path(job.path), ": "), locate_type_error(job.source, msg))
-    ]) }
+    } with { Exception::Throw(msg) => {
+      let located = locate_type_error(job.source, msg)
+      Diagnosed(job.path, [
+        String::concat(String::concat(type_diagnostic_display_path(job.path, located), ": "), located)
+      ])
+    } }
   }
 }
 

--- a/lib/@vibe/compiler/runtime/typecheck_fs.vibe
+++ b/lib/@vibe/compiler/runtime/typecheck_fs.vibe
@@ -84,7 +84,7 @@ import @vibe/compiler/contract {
 }
 
 import @vibe/compiler/loader {
-  ingest_source_text_fs, ingestion_pipeline_telemetry_add, load_or_parse_module_header_fs
+  ingest_source_text_fs, ingestion_pipeline_telemetry_add, load_or_parse_module_header_fs, vpkg_types_contract_for_path
 }
 
 import @vibe/compiler/incremental {
@@ -1288,6 +1288,36 @@ fn ensure_env_cache_for_paths(rdb: RippleDb, env_cache: Array[(String, TypeEnv)]
 
 fn is_vpkg_types_stub_path(path: String) -> Bool {
   String::index_of(path, "vibe_vpkg_types/") >= 0
+}
+
+/// #2317: the path a TYPE diagnostic about `path` should name.
+///
+/// A `.vpkg` whose contract declares transparent types is materialized into a
+/// generated module under `_build/vibe_vpkg_types/` (#1840), and that module
+/// is what the checker walks -- so a `derive` naming an unknown trait reported
+/// `_build/vibe_vpkg_types/types_114_….vibe: unknown trait: Foo`, pointing the
+/// reader at a build artifact to go edit. The stub's content is the contract's
+/// own type-family definitions, so the diagnostic is about text the AUTHOR
+/// wrote, and the contract is the honest place to name.
+///
+/// TYPE diagnostics only. A parse or import failure inside the stub is about
+/// the GENERATED text, not about anything in the contract, and naming the
+/// contract for one of those would send the reader to a file that is fine.
+///
+/// Falls back to the stub path when the registry has no entry, which is what a
+/// process that checks a stub it did not itself materialize will see. That is
+/// the behavior this replaces, so a miss degrades rather than misreports.
+fn type_diagnostic_display_path(path: String) -> String {
+  if is_vpkg_types_stub_path(path) {
+    let owner = vpkg_types_contract_for_path(path)
+    if owner == "" {
+      path
+    } else {
+      owner
+    }
+  } else {
+    path
+  }
 }
 
 /// A materialized #1840 types stub can appear in a module's resolved deps
@@ -4036,7 +4066,7 @@ fn check_module_impl(job: ModuleJob, observe_typing_artifact: Bool) -> ModuleOut
       }
       Checked(job.path, fingerprint, checked_env, interface_identity, checked_env_identity, persistent_type_env_transport_identity, module_typing_artifact)
     } with { Exception::Throw(msg) => Diagnosed(job.path, [
-      String::concat(String::concat(job.path, ": "), locate_type_error(job.source, msg))
+      String::concat(String::concat(type_diagnostic_display_path(job.path), ": "), locate_type_error(job.source, msg))
     ]) }
   }
 }

--- a/lib/@vibe/compiler/runtime/typecheck_fs.vibe
+++ b/lib/@vibe/compiler/runtime/typecheck_fs.vibe
@@ -1409,7 +1409,31 @@ fn is_vpkg_types_stub_path(path: String) -> Bool {
 /// the build directory the compiler owns. The prefix is shared with the
 /// generator so the two cannot drift apart.
 fn is_generated_vpkg_types_path(path: String) -> Bool {
-  String::starts_with(path, vpkg_types_module_path_prefix) && String::ends_with(path, ".vibe")
+  if !String::starts_with(path, vpkg_types_module_path_prefix) || !String::ends_with(path, ".vibe") {
+    false
+  } else {
+    // The WHOLE basename, not just the ends. Prefix plus extension alone still
+    // accepts a nested `types_fake/source.vibe`, which is an ordinary file the
+    // author wrote (Codex review on #2324). The loader can only ever produce
+    // `types_<fingerprint>.vibe` in that one directory, and it builds the
+    // fingerprint by replacing every non-identifier byte with `_`, so the
+    // basename is exactly [0-9A-Za-z_]+ -- a `/`, a `.`, or anything else in
+    // there means some other producer wrote it.
+    let plen = String::length(vpkg_types_module_path_prefix)
+    let stem_end = String::length(path) - 5
+    let mut i = plen
+    let mut ok = stem_end > plen
+    while i < stem_end && ok {
+      let c = String::char_code_at(path, i)
+      let ident = (c >= 48 && c <= 57) || (c >= 97 && c <= 122) || (c >= 65 && c <= 90) || c == 95
+      if ident {
+        i = i + 1
+      } else {
+        ok = false
+      }
+    }
+    ok
+  }
 }
 
 fn type_diagnostic_display_path(path: String, source: String, located_msg: String) -> String {

--- a/lib/@vibe/compiler/tests/contract_deferred_type_names_test.vibe
+++ b/lib/@vibe/compiler/tests/contract_deferred_type_names_test.vibe
@@ -90,8 +90,12 @@ test "2324: a contract path containing a newline cannot escape the marker commen
   let defs = [SStruct(true, "HttpRequest", [map_headers_field()], [], [], [])]
   let evil = "lib/pkg\nstruct Injected { x: Int }\n/index.vpkg"
   let text = contract_types_module_text(defs, "t", evil)
-  // The marker stays on ONE line: the injected text must not appear as source.
-  assert(!String::contains(text, "struct Injected"))
+  // The marker stays on ONE line, so the injected text never BEGINS a line --
+  // it stays inside the comment, where it is inert. Asserting it is absent
+  // entirely would be false and was: the escaped marker still contains those
+  // characters, harmlessly, and the first draft of this test failed on that.
+  assert(String::index_of(text, "\nstruct Injected") < 0)
+  assert(!String::starts_with(text, "struct Injected"))
   // ...and the path still round-trips exactly.
   assert(vpkg_types_contract_of_source(text) == evil)
 }

--- a/lib/@vibe/compiler/tests/contract_deferred_type_names_test.vibe
+++ b/lib/@vibe/compiler/tests/contract_deferred_type_names_test.vibe
@@ -69,3 +69,17 @@ test "2317: the generated types module carries its contract, readable from the t
 test "2317: a types module with no provenance marker reads as empty, not as a guess" {
   assert(vpkg_types_contract_of_source("// vibe: vpkg contract types module (#1840)\nstruct P { x: Int }\n") == "")
 }
+
+test "2324: a contract path keeping leading whitespace round-trips verbatim" {
+  // A top-level directory may legally begin with a space. The marker is
+  // written with no padding, so trimming the suffix could only corrupt the
+  // path -- the diagnostic would then name a file that does not exist.
+  let defs = [SStruct(true, "HttpRequest", [map_headers_field()], [], [], [])]
+  let text = contract_types_module_text(defs, "t", " odd dir/pkg/index.vpkg")
+  assert(vpkg_types_contract_of_source(text) == " odd dir/pkg/index.vpkg")
+}
+
+test "2324: a CRLF-split marker line does not leave a CR in the path" {
+  let crlf = "// vibe: vpkg contract types module (#1840)\r\n// vibe: generated from lib/@gate/pkg/index.vpkg\r\nstruct P { x: Int }\r\n"
+  assert(vpkg_types_contract_of_source(crlf) == "lib/@gate/pkg/index.vpkg")
+}

--- a/lib/@vibe/compiler/tests/contract_deferred_type_names_test.vibe
+++ b/lib/@vibe/compiler/tests/contract_deferred_type_names_test.vibe
@@ -83,3 +83,22 @@ test "2324: a CRLF-split marker line does not leave a CR in the path" {
   let crlf = "// vibe: vpkg contract types module (#1840)\r\n// vibe: generated from lib/@gate/pkg/index.vpkg\r\nstruct P { x: Int }\r\n"
   assert(vpkg_types_contract_of_source(crlf) == "lib/@gate/pkg/index.vpkg")
 }
+
+test "2324: a contract path containing a newline cannot escape the marker comment" {
+  // A POSIX path may legally contain a newline. Raw, it would end the `//`
+  // comment and turn the rest of the path into generated source.
+  let defs = [SStruct(true, "HttpRequest", [map_headers_field()], [], [], [])]
+  let evil = "lib/pkg\nstruct Injected { x: Int }\n/index.vpkg"
+  let text = contract_types_module_text(defs, "t", evil)
+  // The marker stays on ONE line: the injected text must not appear as source.
+  assert(!String::contains(text, "struct Injected"))
+  // ...and the path still round-trips exactly.
+  assert(vpkg_types_contract_of_source(text) == evil)
+}
+
+test "2324: a backslash in a contract path round-trips" {
+  let defs = [SStruct(true, "HttpRequest", [map_headers_field()], [], [], [])]
+  let odd = "lib/we\\ird/index.vpkg"
+  let text = contract_types_module_text(defs, "t", odd)
+  assert(vpkg_types_contract_of_source(text) == odd)
+}

--- a/lib/@vibe/compiler/tests/contract_deferred_type_names_test.vibe
+++ b/lib/@vibe/compiler/tests/contract_deferred_type_names_test.vibe
@@ -7,7 +7,7 @@
 // same predicate the checker already uses (`compiler_owned_type_arity`).
 
 import @vibe/compiler/contract {
-  contract_types_module_text, vpkg_deferred_type_names_prefix
+  contract_types_module_text, vpkg_deferred_type_names_prefix, vpkg_types_contract_of_source
 }
 
 import @vibe/compiler/core {
@@ -24,7 +24,7 @@ fn map_headers_field() -> (String, TypeExpr) {
 
 test "2164: Map in a contract type is not a deferred name" {
   let defs = [SStruct(true, "HttpRequest", [map_headers_field()], [], [], [])]
-  let text = contract_types_module_text(defs, "t")
+  let text = contract_types_module_text(defs, "t", "lib/@gate/pkg/index.vpkg")
   assert(!String::contains(text, vpkg_deferred_type_names_prefix))
 }
 
@@ -34,7 +34,7 @@ test "2164: MutMap in a contract type is not a deferred name" {
       ("inner", TyApp("MutMap", [TyName("String"), TyName("Int"), TyName("r")]))
     ], [], [], ["r"])
   ]
-  let text = contract_types_module_text(defs, "t")
+  let text = contract_types_module_text(defs, "t", "lib/@gate/pkg/index.vpkg")
   assert(!String::contains(text, vpkg_deferred_type_names_prefix))
 }
 
@@ -43,7 +43,7 @@ test "2164: a typo next to Map is deferred, Map is not" {
     SStruct(true, "HttpRequest", [map_headers_field(), ("x", TyName("Intt"))], [
     ], [], [])
   ]
-  let text = contract_types_module_text(defs, "t")
+  let text = contract_types_module_text(defs, "t", "lib/@gate/pkg/index.vpkg")
   assert(String::contains(text, vpkg_deferred_type_names_prefix))
   assert(String::contains(text, "HttpRequest : Intt"))
   assert(!String::contains(text, "HttpRequest : Map"))
@@ -51,6 +51,21 @@ test "2164: a typo next to Map is deferred, Map is not" {
 
 test "2164: a cross-package name is still deferred" {
   let defs = [SStruct(true, "ModuleJob", [("env", TyName("TypeEnv"))], [], [], [])]
-  let text = contract_types_module_text(defs, "t")
+  let text = contract_types_module_text(defs, "t", "lib/@gate/pkg/index.vpkg")
   assert(String::contains(text, "ModuleJob : TypeEnv"))
+}
+
+test "2317: the generated types module carries its contract, readable from the text alone" {
+  let defs = [SStruct(true, "HttpRequest", [map_headers_field()], [], [], [])]
+  let text = contract_types_module_text(defs, "t", "lib/@gate/pkg/index.vpkg")
+  // Read back from the TEXT, with no loader and no registry -- this is the
+  // property the isolated worker lane depends on (`VIBE_MODULE_JOB_DIR` hands
+  // a worker `source.vibe` and nothing else). A process-local registry answers
+  // "" there, which is how the same contract came to be named in one lane and
+  // not in the other (Codex review on #2324).
+  assert(vpkg_types_contract_of_source(text) == "lib/@gate/pkg/index.vpkg")
+}
+
+test "2317: a types module with no provenance marker reads as empty, not as a guess" {
+  assert(vpkg_types_contract_of_source("// vibe: vpkg contract types module (#1840)\nstruct P { x: Int }\n") == "")
 }

--- a/lib/@vibe/compiler/tests/contract_deferred_type_names_test.vibe
+++ b/lib/@vibe/compiler/tests/contract_deferred_type_names_test.vibe
@@ -7,7 +7,7 @@
 // same predicate the checker already uses (`compiler_owned_type_arity`).
 
 import @vibe/compiler/contract {
-  contract_types_module_text, vpkg_deferred_type_names_prefix, vpkg_types_contract_of_source
+  contract_types_module_text, vpkg_deferred_type_names_prefix, vpkg_path_escape_one_line, vpkg_types_contract_of_source
 }
 
 import @vibe/compiler/core {
@@ -101,4 +101,14 @@ test "2324: a backslash in a contract path round-trips" {
   let odd = "lib/we\\ird/index.vpkg"
   let text = contract_types_module_text(defs, "t", odd)
   assert(vpkg_types_contract_of_source(text) == odd)
+}
+
+test "2324: a decoded path is escaped again before it reaches a diagnostic" {
+  // The marker round-trips a newline exactly, which is right for the record
+  // and wrong for the display: a diagnostic is one record per line.
+  let evil = "lib/pkg\nline 1:1: not a real diagnostic\n/index.vpkg"
+  let shown = vpkg_path_escape_one_line(evil)
+  assert(String::index_of(shown, "\n") < 0)
+  // An ordinary path is untouched, so escaping costs nothing in the normal case.
+  assert(vpkg_path_escape_one_line("lib/@gate/pkg/index.vpkg") == "lib/@gate/pkg/index.vpkg")
 }

--- a/tests/gates/late/run.sh
+++ b/tests/gates/late/run.sh
@@ -8791,5 +8791,36 @@ if printf '%s\n' "$spoof_report" | grep -qF 'NOT_THIS_FILE'; then
   printf '%s\n' "$spoof_report" >&2
   exit 1
 fi
+# ...including one NESTED under the generated directory. Prefix plus extension
+# alone still accepts `_build/vibe_vpkg_types/types_fake/source.vibe`, which is
+# an ordinary file someone wrote; the loader only ever produces a single
+# `types_<fingerprint>.vibe` basename there (Codex review on #2324).
+mkdir -p "$dpvdir/nested/_build/vibe_vpkg_types/types_fake"
+cat > "$dpvdir/nested/_build/vibe_vpkg_types/types_fake/source.vibe" <<'DPVEOF'
+// vibe: vpkg contract types module (#1840)
+// vibe: generated from lib/@gate/NOT_THIS_FILE/index.vpkg
+struct P {
+  x: Int
+} derive(Foo)
+
+fn main() -> Int {
+  0
+}
+DPVEOF
+rm -f "$dpvdir/nested.out" "$dpvdir/nested.out.diag"
+( cd "$dpvdir/nested" && VIBE_PREOPEN_DIR="$PWD" VIBE_CHECK_ONLY=1 VIBE_IMPORT_ABI=raw \
+  bash "$ROOT_DIR/scripts/run_wasm_vibe_host_runner.sh" --invoke cli_main "$stage2_wasm" \
+  "_build/vibe_vpkg_types/types_fake/source.vibe" "$ROOT_DIR/$dpvdir/nested.out" main ) >/dev/null 2>&1 || true
+nested_report="$(cat "$dpvdir/nested.out.diag" 2>/dev/null || true)"
+if ! printf '%s\n' "$nested_report" | grep -qF 'unknown trait: Foo'; then
+  echo "[compiler-gate] FAIL: the nested spoof fixture produced no unknown-derive diagnostic -- repoint this probe (#2324)" >&2
+  printf '%s\n' "$nested_report" >&2
+  exit 1
+fi
+if printf '%s\n' "$nested_report" | grep -qF 'NOT_THIS_FILE'; then
+  echo "[compiler-gate] FAIL: a file NESTED under the generated directory had its provenance comment believed (#2324)" >&2
+  printf '%s\n' "$nested_report" >&2
+  exit 1
+fi
 rm -rf "$dpvdir"
-echo "[compiler-gate] a type diagnostic on a materialized contract names the contract when unlocated, keeps the generated path when located, ignores a hand-written provenance claim, and a known derive stays clean ok (#2317, #2324)"
+echo "[compiler-gate] a type diagnostic on a materialized contract names the contract when unlocated, keeps the generated path when located, ignores a hand-written provenance claim flat or nested, and a known derive stays clean ok (#2317, #2324)"

--- a/tests/gates/late/run.sh
+++ b/tests/gates/late/run.sh
@@ -8721,5 +8721,34 @@ if ! VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_CHECK_ONLY=1 VIBE_IMPORT_ABI=raw \
   cat "$dpvdir/clean.out.diag" 2>/dev/null >&2 || true
   exit 1
 fi
+# ...and a LOCATED diagnostic keeps the generated path (Codex review on #2324).
+#
+# `locate_type_error` computes its line against the STUB's source, and the stub
+# carries neither the contract's header nor its formatting. Renaming a located
+# message to the contract pairs a file the author wrote with a line number from
+# a generated one -- confidently wrong, which outranks unhelpful.
+#
+# Measured on this fixture: `struct Box[T]` is on line 13 of the contract, and
+# the diagnostic reads `line 4:15-18`. Line 4 of the contract is inside its
+# `description` block, so the rename would point at an unrelated line.
+mkdir -p "$dpvdir/located"
+printf '%s\nstruct T {\n  a: Int\n}\n\nstruct Box[T] {\n  b: T\n}\n\nfn a(x: Int) -> Int\n' "$dpv_header" > "$dpvdir/located/index.vpkg"
+printf '%s' "$dpv_impl" > "$dpvdir/located/impl.vibe"
+rm -f "$dpvdir/located.out" "$dpvdir/located.out.diag"
+VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_CHECK_ONLY=1 VIBE_IMPORT_ABI=raw \
+  bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
+  "$dpvdir/located/index.vpkg" "$dpvdir/located.out" main >/dev/null 2>&1 || true
+loc_report="$(cat "$dpvdir/located.out.diag" 2>/dev/null || true)"
+# It must still be the LOCATED shape, or this probe stops testing the guard.
+if ! printf '%s\n' "$loc_report" | grep -q 'line [0-9]*:'; then
+  echo "[compiler-gate] FAIL: the shadowing diagnostic is no longer located -- repoint this probe, it no longer exercises the guard (#2324)" >&2
+  printf '%s\n' "$loc_report" >&2
+  exit 1
+fi
+if printf '%s\n' "$loc_report" | grep -qF "$dpvdir/located/index.vpkg"; then
+  echo "[compiler-gate] FAIL: a LOCATED diagnostic was renamed to the contract, pairing it with a line from the generated stub (#2324)" >&2
+  printf '%s\n' "$loc_report" >&2
+  exit 1
+fi
 rm -rf "$dpvdir"
-echo "[compiler-gate] a type diagnostic on a materialized contract names the contract; a known derive stays clean ok (#2317)"
+echo "[compiler-gate] a type diagnostic on a materialized contract names the contract when unlocated, keeps the generated path when located, and a known derive stays clean ok (#2317, #2324)"

--- a/tests/gates/late/run.sh
+++ b/tests/gates/late/run.sh
@@ -8750,5 +8750,46 @@ if printf '%s\n' "$loc_report" | grep -qF "$dpvdir/located/index.vpkg"; then
   printf '%s\n' "$loc_report" >&2
   exit 1
 fi
+# ...and a HAND-WRITTEN module that merely claims generated provenance is not
+# believed (Codex review on #2324).
+#
+# The predicate used to be a substring test for `vibe_vpkg_types/`, so an
+# ordinary source under a directory of that name could carry a
+# `// vibe: generated from ...` comment and have its diagnostics attributed to
+# whatever path the comment named -- a file the reader never edited. The marker
+# is now trusted only for the exact path shape the loader itself writes.
+mkdir -p "$dpvdir/vibe_vpkg_types"
+cat > "$dpvdir/vibe_vpkg_types/spoof.vibe" <<'DPVEOF'
+// vibe: vpkg contract types module (#1840)
+// vibe: generated from lib/@gate/NOT_THIS_FILE/index.vpkg
+struct P {
+  x: Int
+} derive(Foo)
+
+fn main() -> Int {
+  0
+}
+DPVEOF
+rm -f "$dpvdir/spoof.out" "$dpvdir/spoof.out.diag"
+# VIBE_CHECK_ONLY, deliberately: a plain compile of this file reports the bare
+# `unknown trait: Foo` with NO path prefix at all, so the assertion below could
+# never fire no matter what the predicate did. Measured -- the first draft of
+# this probe used a plain compile and passed on a build that DOES believe the
+# spoof. `check_module_impl`, which attaches the path, runs on the check lane.
+VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_CHECK_ONLY=1 VIBE_IMPORT_ABI=raw \
+  bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
+  "$dpvdir/vibe_vpkg_types/spoof.vibe" "$dpvdir/spoof.out" main >/dev/null 2>&1 || true
+spoof_report="$(cat "$dpvdir/spoof.out.diag" 2>/dev/null || true)"
+# It must still be diagnosed, or this probe proves nothing about attribution.
+if ! printf '%s\n' "$spoof_report" | grep -qF 'unknown trait: Foo'; then
+  echo "[compiler-gate] FAIL: the spoof fixture produced no unknown-derive diagnostic -- repoint this probe (#2324)" >&2
+  printf '%s\n' "$spoof_report" >&2
+  exit 1
+fi
+if printf '%s\n' "$spoof_report" | grep -qF 'NOT_THIS_FILE'; then
+  echo "[compiler-gate] FAIL: a hand-written module's provenance comment was believed, attributing its diagnostic to another file (#2324)" >&2
+  printf '%s\n' "$spoof_report" >&2
+  exit 1
+fi
 rm -rf "$dpvdir"
-echo "[compiler-gate] a type diagnostic on a materialized contract names the contract when unlocated, keeps the generated path when located, and a known derive stays clean ok (#2317, #2324)"
+echo "[compiler-gate] a type diagnostic on a materialized contract names the contract when unlocated, keeps the generated path when located, ignores a hand-written provenance claim, and a known derive stays clean ok (#2317, #2324)"

--- a/tests/gates/late/run.sh
+++ b/tests/gates/late/run.sh
@@ -8650,3 +8650,76 @@ if [ -s "$clsdir/clean.buf" ]; then
 fi
 rm -rf "$clsdir"
 echo "[compiler-gate] an unsupported contract statement is refused by both lanes and anchored on itself, first or later ok (#2317)"
+
+# 121/121. A type diagnostic about a contract's transparent types names the
+# CONTRACT, not the generated module it was materialized into (#2317).
+#
+# A `.vpkg` whose contract declares transparent types is materialized into
+# `_build/vibe_vpkg_types/types_<fingerprint>.vibe` (#1840), and the checker
+# walks THAT. So `derive(Foo)` on a contract struct reported
+# `_build/vibe_vpkg_types/types_114_….vibe: unknown trait: Foo` -- the reader
+# is sent to a build artifact to go edit, and the file they wrote is not
+# named at all. Measured before this, same fixture:
+#
+#   full lane    _build/vibe_vpkg_types/types_114_…vibe: unknown trait: Foo
+#   buffer lane  line 11:10: unknown trait: Foo
+#
+# The stub's name is a fingerprint of (contract path, generated text), so it
+# cannot be inverted -- the mapping comes from the registry that recorded it.
+echo "[compiler-gate] 121/121 a type diagnostic names the contract, not the generated types module (#2317)"
+dpvdir="_build/_gate_derive_provenance"
+rm -rf "$dpvdir"; mkdir -p "$dpvdir/bad" "$dpvdir/clean"
+dpv_header='name = @gate/derprov
+version = 0.0.1
+description =
+  #|gate-only package for #2317
+deps = {}
+
+generated_hash =
+'
+dpv_impl='export fn a(x: Int) -> Int {
+  x + 1
+}
+'
+printf '%s\nstruct P {\n  x: Int\n} derive(Foo)\n\nfn a(x: Int) -> Int\n' "$dpv_header" > "$dpvdir/bad/index.vpkg"
+printf '%s' "$dpv_impl" > "$dpvdir/bad/impl.vibe"
+# A transparent struct with a derive the checker KNOWS, so the package still
+# materializes a types module -- the control has to exercise the same path,
+# or it only proves that a package with no types stays quiet.
+printf '%s\nstruct P {\n  x: Int\n} derive(Eq)\n\nfn a(x: Int) -> Int\n' "$dpv_header" > "$dpvdir/clean/index.vpkg"
+printf '%s' "$dpv_impl" > "$dpvdir/clean/impl.vibe"
+rm -f "$dpvdir/bad.out" "$dpvdir/bad.out.diag"
+VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_CHECK_ONLY=1 VIBE_IMPORT_ABI=raw \
+  bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
+  "$dpvdir/bad/index.vpkg" "$dpvdir/bad.out" main >/dev/null 2>&1 || true
+dpv_report="$(cat "$dpvdir/bad.out.diag" 2>/dev/null || true)"
+# The diagnostic must still FIRE. Asserting only "no generated path" would
+# pass on a change that stopped reporting the unknown derive altogether, which
+# is the cheap wrong answer here.
+if ! printf '%s\n' "$dpv_report" | grep -qF 'unknown trait: Foo'; then
+  echo "[compiler-gate] FAIL: the full lane no longer reports an unknown derive on a contract struct -- repoint this probe (#2317)" >&2
+  printf '%s\n' "$dpv_report" >&2
+  exit 1
+fi
+if printf '%s\n' "$dpv_report" | grep -qF 'vibe_vpkg_types/'; then
+  echo "[compiler-gate] FAIL: the diagnostic still names the generated types module instead of the contract (#2317)" >&2
+  printf '%s\n' "$dpv_report" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$dpv_report" | grep -qF "$dpvdir/bad/index.vpkg"; then
+  echo "[compiler-gate] FAIL: the diagnostic does not name the contract the author wrote (#2317)" >&2
+  printf '%s\n' "$dpv_report" >&2
+  exit 1
+fi
+# ...and a contract whose derives are all known stays clean, so a change that
+# reported every materialized package cannot pass the assertions above.
+rm -f "$dpvdir/clean.out" "$dpvdir/clean.out.diag"
+if ! VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_CHECK_ONLY=1 VIBE_IMPORT_ABI=raw \
+  bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
+  "$dpvdir/clean/index.vpkg" "$dpvdir/clean.out" main >/dev/null 2>&1; then
+  echo "[compiler-gate] FAIL: a contract with a KNOWN derive is refused -- the control for the probe above is not valid (#2317)" >&2
+  cat "$dpvdir/clean.out.diag" 2>/dev/null >&2 || true
+  exit 1
+fi
+rm -rf "$dpvdir"
+echo "[compiler-gate] a type diagnostic on a materialized contract names the contract; a known derive stays clean ok (#2317)"

--- a/tests/gates/late/run.sh
+++ b/tests/gates/late/run.sh
@@ -8795,8 +8795,15 @@ fi
 # alone still accepts `_build/vibe_vpkg_types/types_fake/source.vibe`, which is
 # an ordinary file someone wrote; the loader only ever produces a single
 # `types_<fingerprint>.vibe` basename there (Codex review on #2324).
-mkdir -p "$dpvdir/nested/_build/vibe_vpkg_types/types_fake"
-cat > "$dpvdir/nested/_build/vibe_vpkg_types/types_fake/source.vibe" <<'DPVEOF'
+# The fixture has to sit at the REAL relative path, because the predicate reads
+# the path it is given -- no `cd` (this gate's `stage2_wasm` can be relative, so
+# a subshell that changed directory would stop finding the compiler; measured in
+# tests/gates/lib.sh, which sets it to `_build/_gate_lane_gen/stage2.wasm`).
+# Only the `types_fake/` subdirectory is created and removed; the real generated
+# stubs alongside it are untouched.
+nesteddir="_build/vibe_vpkg_types/types_fake"
+rm -rf "$nesteddir"; mkdir -p "$nesteddir"
+cat > "$nesteddir/source.vibe" <<'DPVEOF'
 // vibe: vpkg contract types module (#1840)
 // vibe: generated from lib/@gate/NOT_THIS_FILE/index.vpkg
 struct P {
@@ -8808,19 +8815,21 @@ fn main() -> Int {
 }
 DPVEOF
 rm -f "$dpvdir/nested.out" "$dpvdir/nested.out.diag"
-( cd "$dpvdir/nested" && VIBE_PREOPEN_DIR="$PWD" VIBE_CHECK_ONLY=1 VIBE_IMPORT_ABI=raw \
-  bash "$ROOT_DIR/scripts/run_wasm_vibe_host_runner.sh" --invoke cli_main "$stage2_wasm" \
-  "_build/vibe_vpkg_types/types_fake/source.vibe" "$ROOT_DIR/$dpvdir/nested.out" main ) >/dev/null 2>&1 || true
+VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_CHECK_ONLY=1 VIBE_IMPORT_ABI=raw \
+  bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
+  "$nesteddir/source.vibe" "$dpvdir/nested.out" main >/dev/null 2>&1 || true
 nested_report="$(cat "$dpvdir/nested.out.diag" 2>/dev/null || true)"
 if ! printf '%s\n' "$nested_report" | grep -qF 'unknown trait: Foo'; then
   echo "[compiler-gate] FAIL: the nested spoof fixture produced no unknown-derive diagnostic -- repoint this probe (#2324)" >&2
   printf '%s\n' "$nested_report" >&2
+  rm -rf "$nesteddir"
   exit 1
 fi
 if printf '%s\n' "$nested_report" | grep -qF 'NOT_THIS_FILE'; then
   echo "[compiler-gate] FAIL: a file NESTED under the generated directory had its provenance comment believed (#2324)" >&2
   printf '%s\n' "$nested_report" >&2
+  rm -rf "$nesteddir"
   exit 1
 fi
-rm -rf "$dpvdir"
+rm -rf "$dpvdir" "$nesteddir"
 echo "[compiler-gate] a type diagnostic on a materialized contract names the contract when unlocated, keeps the generated path when located, ignores a hand-written provenance claim flat or nested, and a known derive stays clean ok (#2317, #2324)"

--- a/tests/gates/registry.tsv
+++ b/tests/gates/registry.tsv
@@ -238,3 +238,4 @@ x-adr-0090-1937-exception-unwind-region-restore	late	ADR-0090 #1937 exception-un
 118/118	late	118/118 a call is checked the same above its callee's definition as below (#2318)
 119/119	late	119/119 the buffer lane reports an unknown derive, and agrees with the build (#2317)
 120/120	late	120/120 an unsupported contract statement is anchored on that statement (#2317)
+121/121	late	121/121 a type diagnostic names the contract, not the generated types module (#2317)


### PR DESCRIPTION
The last concrete row of #2317: a type diagnostic about a contract's transparent types named the **generated** module instead of the contract.

A `.vpkg` whose contract declares transparent types is materialized into `_build/vibe_vpkg_types/types_<fingerprint>.vibe` (#1840), and the checker walks that module rather than the contract. So `derive(Foo)` on a contract struct sent the reader to a build artifact to go edit, and never named the file they wrote.

Measured, same fixture:

| lane | answer |
|---|---|
| full (`vibe check`) | `_build/vibe_vpkg_types/types_114_….vibe: unknown trait: Foo` |
| buffer (`vibe diagnostics`) | `line 11:10: unknown trait: Foo` |

## Provenance is carried in-band

The generated module's header names the contract it came from, and `vpkg_types_contract_of_source` reads it back out of the text.

Not a registry — that was the first design, and it was wrong. A types module is also checked by an isolated worker under `VIBE_MODULE_JOB_DIR`, handed `source.vibe` plus its dependencies' environments, which never runs the loader; a process-local registry is empty there, so the same contract would be named in one lane and not the other. **Two lanes answering differently about one file is the bug #2317 exists to fix**, and a fix for it must not ship a new instance of the same shape.

In-band is what this generator already does for the deferred-name sentinel (#2125), whose comment gives the identical reason: the value has to travel with the text "through every lane". The result is smaller than the registry version — `vpkg_types_contract_for_path` and its loader export are gone.

### Trusted only for a path the loader can produce

`is_vpkg_types_stub_path` is a *substring* test for `vibe_vpkg_types/`. Fine for its own callers, which only decide whether to load a file; far too loose to gate an attribution. Measured — a hand-written module under a directory of that name, claiming provenance:

```
lib/@gate/NOT_THIS_FILE/index.vpkg: unknown trait: Foo
```

The marker is trusted only for the exact shape the loader writes: the `_build/vibe_vpkg_types/types_` prefix (one exported constant, shared with the generator so they cannot drift) **and** a complete basename of `[0-9A-Za-z_]+.vibe`. Prefix-plus-extension alone still accepted a nested `types_fake/source.vibe`, which is an ordinary file someone wrote.

### The path is escaped — for storage and for display

A POSIX path may legally contain a newline. Raw in a single-line `//` marker it ends the comment, so the rest becomes generated source. `vpkg_path_escape_one_line` escapes backslash, LF and CR (backslash first, so decoding is unambiguous); an unrecognized escape decodes verbatim rather than being dropped.

The same function escapes the owner **for display**. The marker round-trips a path exactly, which is right for the record and wrong for a diagnostic: a decoded newline rendered verbatim splits one record across lines, and crafted components can resemble further diagnostics. One function for both, so a second encoder cannot drift from the first.

Otherwise the suffix is read **verbatim** — no `trim`. A directory name may legally begin with a space. The one exception is a trailing CR from a CRLF line ending, unambiguous precisely because a real CR is escaped.

### Cached stubs are stale, not merely present

The `v3` prefix cache and the facade cache both accept an existing types module on mere existence and skip regeneration. Content-addressing does not save this: the stub's name *is* a fingerprint of (contract path, generated text), so the marker does change the path — but only on the branch that recomputes it, and these two never call it.

Both sites already state the rule this needs — *"a missing file falls through to full regeneration (idempotent write)"*. A marker-less stub is stale exactly as a missing one is. Migration is paid **once per contract**: the fall-through rewrites the cache row with the new `types_path`. Narrower than bumping the cache-row version, which would discard every unrelated warm entry.

## Unlocated messages only — the whole subtlety

The first version remapped the path for **every** type error, on the strength of having measured `unknown trait: Foo` and finding it carries no position. That evidence was too narrow: other type errors in the same stub *do* carry one, computed against the **stub's** source.

Reproduced on that commit's own stage2 — a contract whose `struct Box[T]` sits on line 13:

```
_build/_p2324r/pkg/index.vpkg: line 4:15-18: type parameter `T` of struct `Box` shadows the declared type `T` ...
```

Line 4 of that contract is `  #|probe`. The first version turned an unhelpful-but-honest path into a **confidently wrong location** — the class this repo ranks first.

So the remap applies only when the located message has no `line ` prefix. A stub path with a stub-relative line is at least self-consistent. Renaming it is not honest until the stub carries a real offset mapping back to the contract, which needs the generator to emit one — tracked on #2317, not guessed at here.

## Scope: type diagnostics only

Three sites put a module path into a message. The other two — a parse failure and an unresolved import — are about the **generated** text; naming the contract for one of those would send the reader to a file that is fine.

## Gate (section 121)

Every probe was verified failable, and two were caught passing vacuously before they shipped:

- the diagnostic must still **fire** before the path is asserted;
- the **located** fixture (`struct T` + `struct Box[T]`) asserts the diagnostic is still located *and* that the contract path does not appear;
- a **flat spoof** — a hand-written module claiming provenance. First draft was vacuous: a plain compile emits the bare message with no path prefix, so the assertion could never fire; it now runs with `VIBE_CHECK_ONLY=1`;
- a **nested spoof** under the generated directory. Had to be run in isolation to prove it non-vacuous — the flat assertion exits first, so it would otherwise look green by omission;
- a clean control with a derive the checker knows, which still materializes a types module.

## Verification

- section 121 **red on main's stage2**; each new assertion mutation-tested and landing on its own message
- round-trip tests: carriage from text alone (the worker-lane property), absent marker reading as `""`, leading-space path, CRLF line, newline injection, backslash path, and display escaping being the identity for an ordinary path
- `vibe fmt --check` on every changed compiler file; `ensure_generated.sh` structural probe clean; `check_gate_registry.sh`, `check_gate_portability.sh` ok
- merged `main` in (#2323 also touches `typecheck_fs.vibe`, different regions, no conflict)

**Two things fixed in my own work, not the code under change:** a CI failure traced to my newline-injection *test* asserting a falsehood (`!contains "struct Injected"` — the escaped marker legitimately contains those characters, inertly, inside a comment; a failed `assert` traps, which is why it surfaced as a trap), and a nested-spoof probe that used `( cd … )` while this gate's `stage2_wasm` can be relative.

**Not covered, stated rather than implied:** the cache-hit wiring has no gate. The freshness predicate is pinned by the round-trip tests, but constructing a valid `v3` entry pointing at a pre-marker stub is deep plumbing, and I would rather name that gap than imply coverage this does not have.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GbtLER6wNT4jsZEN1Zp6xe)_