### PR TITLE
Classify unkinded import aliases by source name

### DIFF
--- a/lib/@vibe/compiler/checker/checker_stmt.vibe
+++ b/lib/@vibe/compiler/checker/checker_stmt.vibe
@@ -776,15 +776,12 @@ fn duplicate_import_value_note(seen: Array[String], item: ImportItem, errors: Ar
     ()
   } else {
     let local = import_bound_name(item)
-    // Unaliased PascalCase is the unkinded type-head form (`import { HashMap }`).
-    // An alias is a value local even when it is PascalCase (`abs as Abs`).
-    match item.alias {
-      Some(_) => duplicate_value_decl_note(seen, local, errors),
-      None => if name_is_type_head(local) {
-        ()
-      } else {
-        duplicate_value_decl_note(seen, local, errors)
-      }
+    // The source name, not its local alias, distinguishes the unkinded
+    // type-head form (`HashMap as Shared`) from a value (`abs as Abs`).
+    if name_is_type_head(item.name) {
+      ()
+    } else {
+      duplicate_value_decl_note(seen, local, errors)
     }
   }
 }

--- a/lib/@vibe/compiler/tests/import_ref_debt_test.vibe
+++ b/lib/@vibe/compiler/tests/import_ref_debt_test.vibe
@@ -47,6 +47,11 @@ test "#2293: a PascalCase type head is not a value-import duplicate" {
   assert(!String::contains(check_source_error_message(source), "duplicate declaration: HashMap"))
 }
 
+test "#2293: an aliased PascalCase type head is not a value-import duplicate" {
+  let source = "import @vibe/core { HashMap as Shared }\nimport @vibe/core { HashMap as Shared }\nfn main { 0 }\n"
+  assert(!String::contains(check_source_error_message(source), "duplicate declaration: Shared"))
+}
+
 test "#2293: a PascalCase value alias is still a duplicate" {
   let source = "import @vibe/builtin { abs as Abs }\nimport @vibe/builtin { clamp as Abs }\nAbs(-1)\n"
   inspect(check_source_error_message(source), "duplicate declaration: Abs")


### PR DESCRIPTION
## Summary

- classify an unkinded import from its source name before applying a local alias
- keep `HashMap as Shared` out of the duplicate value-import set
- keep lower-case value imports such as `abs as Abs` in that set

## Why

#2306 correctly rejected duplicate value imports, but its alias branch treated
every aliased unkinded import as a value. That made two imports of an aliased
PascalCase type head fail with `duplicate declaration`.

## Validation

- Red: the new aliased type-head regression trapped against the #2306 stage2
- Green: focused compiler tests passed (2 files, 110 tests)
- `pkf run test-affected` promoted to the full battery and passed 1027/1027 files
- `pkf run ensure-generated`
- pre-commit structural gates

Closes #2325.
