### PR TITLE
Restrict contract deferred type names to declared provenance (#2164)

### DIFF
--- a/lib/@vibe/compiler/contract/contract.vibe
+++ b/lib/@vibe/compiler/contract/contract.vibe
@@ -1025,28 +1025,61 @@ fn vpkg_marker_decode(text: String) -> String {
   StringBuilder::freeze(sb)
 }
 
-/// #2125: the type-name heads `tds` reference minus the names `tds` declare
-/// -- the names this module can neither declare nor import: a
-/// contract-`opaque` name whose definition lives in a sibling impl
-/// (types -> impl would be an import cycle), or a name from another package.
-/// Those resolve to the intentional bare `CtNamed` contract artifact.
-///
-/// This is textual, not provenance-checked, BY NECESSITY (Codex on #2162
-/// asked for opaque/import provenance): contract conformance is textual and
-/// a cross-package name has no declaration channel in the contract at all --
-/// measured, `TypeEnv` in incremental's `ModuleJob` is spelled with no
-/// `opaque` and no import anywhere in that index.vpkg. Compiler-owned type
-/// heads (`Map`, `MutMap`, `Array`, ...) are not deferred: they go through
-/// `is_builtin_type_name` (#2164). The residual is that a typo INSIDE a
-/// contract's transparent type, or a genuine cross-package name, keeps its
-/// pre-enforcement wildcard behavior; the sentinel enumerates that residual
-/// greppably, and closing it needs a contract-level provenance declaration.
-/// Returns (declared type names, deferred names). A declaration's own
-/// generic binders shadow its references LOCALLY only (Codex round 3 on
-/// #2162: a module-wide `declared` let `struct Box[Counter]`'s binder hide
-/// `struct Holder`'s reference to the contract-`opaque` `Counter`, dropping
-/// it from the sentinel and rejecting a valid contract).
-fn ctm_deferred_type_names(tds: Array[Stmt]) -> (Array[String], Array[String]) {
+/// #2125 / #2164: heads `tds` reference minus names `tds` declare, restricted
+/// to contract-`opaque` provenance. A sibling-impl opaque (`PerceusActionKind`)
+/// or a foreign name declared `opaque type` / bodyless `type` stays a
+/// wildcard; a typo (`Intt`) is not in that set and is reported. Compiler-owned
+/// heads (`Map`, `MutMap`, ...) go through `is_builtin_type_name`. A
+/// declaration's own generic binders shadow its references locally only.
+fn ctm_name_is_type_head(n: String) -> Bool {
+  if String::length(n) == 0 {
+    false
+  } else {
+    let c = String::char_code_at(n, 0)
+    c >= 65 && c <= 90
+  }
+}
+
+export fn contract_imported_type_names(extra: Array[Stmt]) -> Array[(String, Int)] {
+  let out = array_empty()
+  let mut i = 0
+  while i < Array::length(extra) {
+    match Array::get(extra, i) {
+      SImport(_, items) => {
+        let mut j = 0
+        while j < Array::length(items) {
+          let item = Array::get(items, j)
+          let local = match item.alias {
+            Some(a) => a,
+            None => item.name
+          }
+          if ctm_name_is_type_head(local) {
+            Array::push(out, (local, 0))
+          } else {
+            ()
+          }
+          j = j + 1
+        }
+      },
+      _ => ()
+    }
+    i = i + 1
+  }
+  out
+}
+
+fn ctm_opaque_name_list(opaque_names: Array[(String, Int)]) -> Array[String] {
+  let out = array_empty()
+  let mut i = 0
+  while i < Array::length(opaque_names) {
+    let (n, _) = Array::get(opaque_names, i)
+    Array::push(out, n)
+    i = i + 1
+  }
+  out
+}
+
+fn ctm_deferred_type_names(tds: Array[Stmt], opaque_names: Array[String]) -> (Array[String], Array[String]) {
   let declared = array_empty()
   let referenced = array_empty()
   let mut i = 0
@@ -1115,8 +1148,10 @@ fn ctm_deferred_type_names(tds: Array[Stmt]) -> (Array[String], Array[String]) {
     let n = Array::get(referenced, ri)
     if is_builtin_type_name(n) || ctm_str_list_has(declared, n) || ctm_str_list_has(out, n) {
       ()
-    } else {
+    } else if ctm_str_list_has(opaque_names, n) {
       Array::push(out, n)
+    } else {
+      ()
     }
     ri = ri + 1
   }
@@ -1183,13 +1218,13 @@ export let vpkg_deferred_type_names_prefix: String = "__vpkg_deferred_type_names
 /// names at field/payload positions without any process-lifetime registry.
 /// `uniq` keeps the binding name collision-free when several contracts'
 /// modules meet in one merge.
-export fn contract_types_module_text(tds: Array[Stmt], uniq: String, contract_path: String) -> String {
+export fn contract_types_module_text(tds: Array[Stmt], uniq: String, contract_path: String, opaque_names: Array[(String, Int)]) -> String {
   let lines = array_empty()
   Array::push(lines, vpkg_types_module_marker)
   // Provenance, so a process holding only this text can still name the
   // contract. Emitted even when empty so the header shape is uniform.
   Array::push(lines, String::concat(vpkg_types_contract_marker, vpkg_path_escape_one_line(contract_path)))
-  let (decl_names, deferred) = ctm_deferred_type_names(tds)
+  let (decl_names, deferred) = ctm_deferred_type_names(tds, ctm_opaque_name_list(opaque_names))
   if Array::length(deferred) == 0 {
     ()
   } else {

--- a/lib/@vibe/compiler/contract/contract.vibe
+++ b/lib/@vibe/compiler/contract/contract.vibe
@@ -1053,7 +1053,17 @@ export fn contract_imported_type_names(extra: Array[Stmt]) -> Array[(String, Int
             Some(a) => a,
             None => item.name
           }
-          if ctm_name_is_type_head(local) {
+          let imports_type = match item.kind {
+            Some(kind) => match kind {
+              ImportType => true,
+              ImportStruct => true,
+              ImportEnum => true,
+              ImportEffect => true,
+              ImportTrait => false
+            },
+            None => ctm_name_is_type_head(local)
+          }
+          if imports_type {
             Array::push(out, (local, 0))
           } else {
             ()

--- a/lib/@vibe/compiler/contract/index.vpkg
+++ b/lib/@vibe/compiler/contract/index.vpkg
@@ -58,7 +58,8 @@ fn contract_facade_source(decls: Array[(String, String)], opaque_names: Array[(S
 
 // --- materialized types module (#1840)
 fn contract_type_family_defs(type_defs: Array[Stmt]) -> Array[Stmt]
-fn contract_types_module_text(tds: Array[Stmt], uniq: String, contract_path: String) -> String
+fn contract_types_module_text(tds: Array[Stmt], uniq: String, contract_path: String, opaque_names: Array[(String, Int)]) -> String
+fn contract_imported_type_names(extra: Array[Stmt]) -> Array[(String, Int)]
 fn vpkg_types_contract_of_source(source: String) -> String
 fn vpkg_path_escape_one_line(path: String) -> String
 let vpkg_deferred_type_names_prefix: String

--- a/lib/@vibe/compiler/loader/loader.vibe
+++ b/lib/@vibe/compiler/loader/loader.vibe
@@ -59,6 +59,7 @@ import @vibe/compiler/contract {
   contract_facade_marker,
   contract_facade_source,
   contract_hash,
+  contract_imported_type_names,
   contract_surface_lines,
   contract_type_family_defs,
   contract_types_module_line,
@@ -1095,7 +1096,7 @@ export let vpkg_types_module_path_prefix: String = "_build/vibe_vpkg_types/types
 /// the package lives outside the repo-relative tree (an absolute VIBE_LIB
 /// external root — the relative import spelling below cannot reach _build
 /// from there, so those packages keep the verbatim-facade behavior).
-fn ensure_vpkg_types_module_fs(vpkg_path: String, extra: Array[Stmt]) -> String with Exception + Fs {
+fn ensure_vpkg_types_module_fs(vpkg_path: String, extra: Array[Stmt], opaque_names: Array[(String, Int)]) -> String with Exception + Fs {
   if String::starts_with(vpkg_path, "/") {
     return ""
   } else {
@@ -1125,7 +1126,19 @@ fn ensure_vpkg_types_module_fs(vpkg_path: String, extra: Array[Stmt]) -> String 
       }
       uci = uci + 1
     }
-    let text = contract_types_module_text(tds, StringBuilder::freeze(uniq_sb), vpkg_path)
+    let provenance = array_empty()
+    let mut oi = 0
+    while oi < Array::length(opaque_names) {
+      Array::push(provenance, Array::get(opaque_names, oi))
+      oi = oi + 1
+    }
+    let imported = contract_imported_type_names(extra)
+    let mut ii = 0
+    while ii < Array::length(imported) {
+      Array::push(provenance, Array::get(imported, ii))
+      ii = ii + 1
+    }
+    let text = contract_types_module_text(tds, StringBuilder::freeze(uniq_sb), vpkg_path, provenance)
     let raw_key = compact_string_fingerprint(String::concat(vpkg_path, String::concat("|", text)))
     // Identifier-safe basename: the import-path grammar (parser_base.vibe's
     // collect_import_path) lexes path segments as identifier/keyword tokens,
@@ -1279,13 +1292,13 @@ fn vpkg_directory_shared_import_prefix_fs(path: String) -> String with Exception
       } else {
         let vpkg_raw = Fs::read_file(vpkg_path)
         let (_, vpkg_pin_blanked) = extract_require_pins(vpkg_raw)
-        let (_, _, vpkg_extra) = parse_contract_program(lex(vpkg_pin_blanked))
+        let (_, vpkg_opaques, vpkg_extra) = parse_contract_program(lex(vpkg_pin_blanked))
         let shared_text = contract_directory_shared_import_prefix_text(vpkg_extra)
         // #1840: siblings import the contract's type family from the
         // materialized types module — this is what gives enum constructors
         // real value bindings inside impl units (the facade cannot be
         // imported from a sibling: facade → impl is already an edge).
-        let types_path = ensure_vpkg_types_module_fs(vpkg_path, vpkg_extra)
+        let types_path = ensure_vpkg_types_module_fs(vpkg_path, vpkg_extra, vpkg_opaques)
         let prefix_text = if types_path == "" {
           shared_text
         } else {
@@ -2187,7 +2200,7 @@ fn desugar_contract_source_fs(path: String, source: String) -> String with Excep
   // text needs the package-dir-RELATIVE spelling (the export grammar rejects
   // a bare root-relative head token); the cache row below keeps the
   // canonical root-relative path for its existence re-check.
-  let facade_types_path = ensure_vpkg_types_module_fs(path, extra)
+  let facade_types_path = ensure_vpkg_types_module_fs(path, extra, opaque_names)
   let facade_types_rel = if facade_types_path == "" {
     ""
   } else {

--- a/lib/@vibe/compiler/runtime/index.vpkg
+++ b/lib/@vibe/compiler/runtime/index.vpkg
@@ -297,7 +297,7 @@ fn projected_import_env_for_test(source: String, path: String, deps: Array[Strin
 // #2164: TypeEnv is defined in @vibe/compiler/core. The import is the
 // contract provenance that keeps it in the deferred-names sentinel.
 import @vibe/compiler/core {
-  type TypeEnv
+  enum TypeEnv
 }
 struct ModuleJob {
   path: String;

--- a/lib/@vibe/compiler/runtime/index.vpkg
+++ b/lib/@vibe/compiler/runtime/index.vpkg
@@ -295,9 +295,11 @@ fn projected_import_env_for_test(source: String, path: String, deps: Array[Strin
 // the canonical fingerprint itself via build_fingerprint(source, dep_fps)
 // -- an OUTPUT of the job, not an input to it.
 // #2164: TypeEnv is defined in @vibe/compiler/core. The import is the
-// contract provenance that keeps it in the deferred-names sentinel.
+// contract provenance that keeps it in the deferred-names sentinel. Keep the
+// item bare: core's bodyless `type TypeEnv` hides whether its implementation
+// is an alias, struct, or enum, just like generated opaque facade carriers.
 import @vibe/compiler/core {
-  enum TypeEnv
+  TypeEnv
 }
 struct ModuleJob {
   path: String;

--- a/lib/@vibe/compiler/runtime/index.vpkg
+++ b/lib/@vibe/compiler/runtime/index.vpkg
@@ -294,6 +294,11 @@ fn projected_import_env_for_test(source: String, path: String, deps: Array[Strin
 // folds it as an ordered sequence, not a set), so check_module can compute
 // the canonical fingerprint itself via build_fingerprint(source, dep_fps)
 // -- an OUTPUT of the job, not an input to it.
+// #2164: TypeEnv is defined in @vibe/compiler/core. The import is the
+// contract provenance that keeps it in the deferred-names sentinel.
+import @vibe/compiler/core {
+  type TypeEnv
+}
 struct ModuleJob {
   path: String;
   source: String;

--- a/lib/@vibe/compiler/tests/contract_deferred_type_names_test.vibe
+++ b/lib/@vibe/compiler/tests/contract_deferred_type_names_test.vibe
@@ -14,17 +14,25 @@ import @vibe/compiler/core {
   Stmt, TypeExpr
 }
 
+import @vibe/core {
+  array_empty
+}
+
 //# Functions
 
 fn map_headers_field() -> (String, TypeExpr) {
   ("headers", TyApp("Map", [TyName("String"), TyName("String")]))
 }
 
+fn no_opaques() -> Array[(String, Int)] {
+  array_empty()
+}
+
 //# Tests
 
 test "2164: Map in a contract type is not a deferred name" {
   let defs = [SStruct(true, "HttpRequest", [map_headers_field()], [], [], [])]
-  let text = contract_types_module_text(defs, "t", "lib/@gate/pkg/index.vpkg")
+  let text = contract_types_module_text(defs, "t", "lib/@gate/pkg/index.vpkg", no_opaques())
   assert(!String::contains(text, vpkg_deferred_type_names_prefix))
 }
 
@@ -34,30 +42,32 @@ test "2164: MutMap in a contract type is not a deferred name" {
       ("inner", TyApp("MutMap", [TyName("String"), TyName("Int"), TyName("r")]))
     ], [], [], ["r"])
   ]
-  let text = contract_types_module_text(defs, "t", "lib/@gate/pkg/index.vpkg")
+  let text = contract_types_module_text(defs, "t", "lib/@gate/pkg/index.vpkg", no_opaques())
   assert(!String::contains(text, vpkg_deferred_type_names_prefix))
 }
 
-test "2164: a typo next to Map is deferred, Map is not" {
+test "2164: a typo next to Map is not deferred" {
   let defs = [
     SStruct(true, "HttpRequest", [map_headers_field(), ("x", TyName("Intt"))], [
     ], [], [])
   ]
-  let text = contract_types_module_text(defs, "t", "lib/@gate/pkg/index.vpkg")
-  assert(String::contains(text, vpkg_deferred_type_names_prefix))
-  assert(String::contains(text, "HttpRequest : Intt"))
-  assert(!String::contains(text, "HttpRequest : Map"))
+  let text = contract_types_module_text(defs, "t", "lib/@gate/pkg/index.vpkg", no_opaques())
+  assert(!String::contains(text, vpkg_deferred_type_names_prefix))
 }
 
-test "2164: a cross-package name is still deferred" {
+test "2164: a cross-package name is deferred only with opaque provenance" {
   let defs = [SStruct(true, "ModuleJob", [("env", TyName("TypeEnv"))], [], [], [])]
-  let text = contract_types_module_text(defs, "t", "lib/@gate/pkg/index.vpkg")
-  assert(String::contains(text, "ModuleJob : TypeEnv"))
+  let without = contract_types_module_text(defs, "t", "lib/@gate/pkg/index.vpkg", no_opaques())
+  assert(!String::contains(without, vpkg_deferred_type_names_prefix))
+  let opaques = no_opaques()
+  Array::push(opaques, ("TypeEnv", 0))
+  let with_opaque = contract_types_module_text(defs, "t", "lib/@gate/pkg/index.vpkg", opaques)
+  assert(String::contains(with_opaque, "ModuleJob : TypeEnv"))
 }
 
 test "2317: the generated types module carries its contract, readable from the text alone" {
   let defs = [SStruct(true, "HttpRequest", [map_headers_field()], [], [], [])]
-  let text = contract_types_module_text(defs, "t", "lib/@gate/pkg/index.vpkg")
+  let text = contract_types_module_text(defs, "t", "lib/@gate/pkg/index.vpkg", no_opaques())
   // Read back from the TEXT, with no loader and no registry -- this is the
   // property the isolated worker lane depends on (`VIBE_MODULE_JOB_DIR` hands
   // a worker `source.vibe` and nothing else). A process-local registry answers
@@ -75,7 +85,7 @@ test "2324: a contract path keeping leading whitespace round-trips verbatim" {
   // written with no padding, so trimming the suffix could only corrupt the
   // path -- the diagnostic would then name a file that does not exist.
   let defs = [SStruct(true, "HttpRequest", [map_headers_field()], [], [], [])]
-  let text = contract_types_module_text(defs, "t", " odd dir/pkg/index.vpkg")
+  let text = contract_types_module_text(defs, "t", " odd dir/pkg/index.vpkg", no_opaques())
   assert(vpkg_types_contract_of_source(text) == " odd dir/pkg/index.vpkg")
 }
 
@@ -89,7 +99,7 @@ test "2324: a contract path containing a newline cannot escape the marker commen
   // comment and turn the rest of the path into generated source.
   let defs = [SStruct(true, "HttpRequest", [map_headers_field()], [], [], [])]
   let evil = "lib/pkg\nstruct Injected { x: Int }\n/index.vpkg"
-  let text = contract_types_module_text(defs, "t", evil)
+  let text = contract_types_module_text(defs, "t", evil, no_opaques())
   // The marker stays on ONE line, so the injected text never BEGINS a line --
   // it stays inside the comment, where it is inert. Asserting it is absent
   // entirely would be false and was: the escaped marker still contains those
@@ -103,7 +113,7 @@ test "2324: a contract path containing a newline cannot escape the marker commen
 test "2324: a backslash in a contract path round-trips" {
   let defs = [SStruct(true, "HttpRequest", [map_headers_field()], [], [], [])]
   let odd = "lib/we\\ird/index.vpkg"
-  let text = contract_types_module_text(defs, "t", odd)
+  let text = contract_types_module_text(defs, "t", odd, no_opaques())
   assert(vpkg_types_contract_of_source(text) == odd)
 }
 

--- a/lib/@vibe/compiler/tests/contract_deferred_type_names_test.vibe
+++ b/lib/@vibe/compiler/tests/contract_deferred_type_names_test.vibe
@@ -7,11 +7,15 @@
 // same predicate the checker already uses (`compiler_owned_type_arity`).
 
 import @vibe/compiler/contract {
-  contract_types_module_text, vpkg_deferred_type_names_prefix, vpkg_path_escape_one_line, vpkg_types_contract_of_source
+  contract_imported_type_names,
+  contract_types_module_text,
+  vpkg_deferred_type_names_prefix,
+  vpkg_path_escape_one_line,
+  vpkg_types_contract_of_source
 }
 
 import @vibe/compiler/core {
-  Stmt, TypeExpr
+  ImportItem, ImportKind, Stmt, TypeExpr
 }
 
 import @vibe/core {
@@ -63,6 +67,23 @@ test "2164: a cross-package name is deferred only with opaque provenance" {
   Array::push(opaques, ("TypeEnv", 0))
   let with_opaque = contract_types_module_text(defs, "t", "lib/@gate/pkg/index.vpkg", opaques)
   assert(String::contains(with_opaque, "ModuleJob : TypeEnv"))
+}
+
+test "2164: an explicit type import keeps a lowercase alias as provenance" {
+  let extra = [
+    SImport("@scope/dep", [
+      ImportItem::{
+        kind: Some(ImportStruct),
+        name: "Remote",
+        alias: Some("remote")
+      }
+    ])
+  ]
+  let imported = contract_imported_type_names(extra)
+  assert(Array::length(imported) == 1)
+  let (name, arity) = Array::get(imported, 0)
+  assert(name == "remote")
+  assert(arity == 0)
 }
 
 test "2317: the generated types module carries its contract, readable from the text alone" {


### PR DESCRIPTION
## Summary

- Restrict ctm_deferred_type_names to contract provenance from opaque or bodyless declarations and imported type bindings.
- Honor explicit ImportType, ImportStruct, ImportEnum, and ImportEffect kinds before the compatibility name-case heuristic, including lowercase aliases.
- Report transparent contract type typos instead of adding them to the deferred sentinel.
- Keep ModuleJob.env provenance through a bare TypeEnv import. The core contract bodyless type intentionally hides whether the implementation is an alias, struct, or enum.

Fixes #2164.

## Test Plan

- Focused contract/runtime tests: 3 files, 25 tests
- pkf run test-affected: 193/193 files
- Fresh stage2 generation
- tests/gates/bootstrap/stage2_oracles.sh with the fresh stage2
- Formatter and generated-artifact checks