### PR TITLE
One effective-declaration list for both lanes, and a located diagnostic that names the contract (#2317)

### DIFF
--- a/lib/@vibe/compiler/contract/contract.vibe
+++ b/lib/@vibe/compiler/contract/contract.vibe
@@ -5,7 +5,7 @@ import @vibe/compiler/core {
 }
 
 import @vibe/compiler/syntax {
-  Token, parse_fn_signature, parse_stmt, parse_type, peek, print_stmt, print_type_expr, tk_name
+  Token, offset_to_line_col, parse_fn_signature, parse_stmt, parse_type, peek, print_stmt, print_type_expr, tk_name
 }
 
 // #741: consumed through the @vibe/core contract boundary (directory import
@@ -887,6 +887,58 @@ export fn classify_contract_stmts(stmts: Array[Stmt]) -> (Array[String], Array[S
   (raws, type_defs)
 }
 
+/// #2317: the contract offset of each type-family definition, in the order
+/// `contract_type_family_defs` yields them.
+///
+/// Derived by ASKING the two real filters one statement at a time, not by
+/// mirroring their match arms -- a second copy of those rules drifts the first
+/// time a statement kind is added. Both filters only drop entries and neither
+/// reorders, so the n-th surviving statement is the n-th materialized
+/// declaration, and its recorded offset is the one to report.
+///
+/// A statement the classifier rejects contributes nothing: by the time a types
+/// module is generated the whole list has already classified cleanly, so this
+/// only guards against being called out of order.
+export fn contract_type_family_offsets(stmts: Array[Stmt], stmt_at: Array[Int]) -> Array[Int] {
+  let out = array_empty()
+  let lim = Array::length(stmt_at)
+  let mut i = 0
+  while i < Array::length(stmts) {
+    let one = array_empty()
+    Array::push(one, Array::get(stmts, i))
+    let is_family = handle {
+      let (_raws, tds) = classify_contract_stmts(one)
+      Array::length(contract_type_family_defs(tds)) == 1
+    } with { Exception::Throw(_) => false }
+    if is_family && i < lim {
+      Array::push(out, Array::get(stmt_at, i))
+    } else {
+      ()
+    }
+    i = i + 1
+  }
+  out
+}
+
+/// #2317: the `line:col` of each type-family definition, in the order the
+/// generator emits them.
+///
+/// Rendered here, at generation time, because the diagnostic site has no `Fs`
+/// and cannot read the contract to convert an offset. `offset_to_line_col` is
+/// the same function the diagnostic renderer uses, so the two agree on what a
+/// column is (1-based bytes, ADR-0108).
+export fn contract_type_family_decl_positions(source: String, stmts: Array[Stmt], stmt_at: Array[Int]) -> Array[String] {
+  let offs = contract_type_family_offsets(stmts, stmt_at)
+  let out = array_empty()
+  let mut i = 0
+  while i < Array::length(offs) {
+    let (l, c) = offset_to_line_col(source, Array::get(offs, i))
+    Array::push(out, String::concat(__to_string(l), String::concat(":", __to_string(c))))
+    i = i + 1
+  }
+  out
+}
+
 /// #2317: the declarations a contract EFFECTIVELY has, after the one filter
 /// the loader applies before counting them.
 ///
@@ -1026,6 +1078,19 @@ export let vpkg_types_module_marker: String = "// vibe: vpkg contract types modu
 /// about the same file is the bug #2317 is about; the fix must not add a new
 /// instance of it (Codex review on #2324).
 export let vpkg_types_contract_marker: String = "// vibe: generated from "
+
+/// #2317: per-declaration position marker, emitted immediately ABOVE the
+/// declaration it describes.
+///
+/// Adjacent rather than a header table, so nothing depends on how many lines
+/// `print_stmt` renders a declaration onto -- the reader takes the nearest
+/// preceding marker, which stays correct if the printer's output grows.
+///
+/// The value is the contract's own `line:col`, precomputed here because the
+/// diagnostic site has no `Fs` and cannot read the contract to convert an
+/// offset. Declaration-granular by construction: `print_stmt` rebuilds the
+/// declaration from the AST, so positions INSIDE it are gone.
+export let vpkg_types_decl_marker: String = "// vibe: decl-at "
 
 /// #2324: escape a contract path for the single-line `//` provenance marker.
 ///
@@ -1251,7 +1316,7 @@ export let vpkg_deferred_type_names_prefix: String = "__vpkg_deferred_type_names
 /// names at field/payload positions without any process-lifetime registry.
 /// `uniq` keeps the binding name collision-free when several contracts'
 /// modules meet in one merge.
-export fn contract_types_module_text(tds: Array[Stmt], uniq: String, contract_path: String) -> String {
+export fn contract_types_module_text(tds: Array[Stmt], uniq: String, contract_path: String, decl_pos: Array[String]) -> String {
   let lines = array_empty()
   Array::push(lines, vpkg_types_module_marker)
   // Provenance, so a process holding only this text can still name the
@@ -1269,10 +1334,55 @@ export fn contract_types_module_text(tds: Array[Stmt], uniq: String, contract_pa
   }
   let mut i = 0
   while i < Array::length(tds) {
+    // Position first, then the declaration it belongs to. A missing entry is
+    // simply omitted: the reader falls back to the stub's own position, which
+    // is what every stub written before this marker existed will do.
+    if i < Array::length(decl_pos) {
+      let dp = Array::get(decl_pos, i)
+      if dp == "" {
+        ()
+      } else {
+        Array::push(lines, String::concat(vpkg_types_decl_marker, dp))
+      }
+    } else {
+      ()
+    }
     Array::push(lines, print_stmt(Array::get(tds, i)))
     i = i + 1
   }
   String::concat(String::join(lines, "\n"), "\n")
+}
+
+/// #2317: the contract `line:col` for a 1-based line of a materialized types
+/// module, or "" when the stub carries no marker for it.
+///
+/// The NEAREST PRECEDING marker wins, so this stays correct however many lines
+/// `print_stmt` renders a declaration onto. Declaration-granular by
+/// construction: the printer rebuilds the declaration from the AST, so a
+/// column inside it cannot be recovered and is not claimed to be.
+///
+/// "" for a stub written before the marker existed, so the caller keeps the
+/// stub's own position rather than inventing one.
+export fn vpkg_types_decl_pos_for_line(source: String, stub_line: Int) -> String {
+  let lines = String::split(source, "\n")
+  let n = Array::length(lines)
+  let lim = if stub_line - 1 < n {
+    stub_line - 1
+  } else {
+    n
+  }
+  let mut i = 0
+  let mut found = ""
+  while i < lim {
+    let line = Array::get(lines, i)
+    if String::starts_with(line, vpkg_types_decl_marker) {
+      found = String::trim(String::substring(line, String::length(vpkg_types_decl_marker), String::length(line)))
+    } else {
+      ()
+    }
+    i = i + 1
+  }
+  found
 }
 
 /// #2317: the contract a materialized types module was generated from, read

--- a/lib/@vibe/compiler/contract/contract.vibe
+++ b/lib/@vibe/compiler/contract/contract.vibe
@@ -132,8 +132,17 @@ fn push_contract_stmt(stmts: Array[Stmt], stmt_at: Array[Int], stmt: Stmt, at: I
   Array::push(stmt_at, at)
 }
 
+/// #2317: record a bodyless declaration together with the token index it
+/// started at, for the same reason as `push_contract_stmt` -- the two arrays
+/// are read positionally, so a push landing in only one of them would shift
+/// every later declaration's anchor onto its neighbour.
+fn push_contract_decl(decls: Array[(String, String)], decl_at: Array[Int], name: String, sig: String, at: Int) -> Unit {
+  Array::push(decls, (name, sig))
+  Array::push(decl_at, at)
+}
+
 export fn parse_contract_program(tokens: Array[Token]) -> (Array[(String, String)], Array[(String, Int)], Array[Stmt]) with Exception {
-  let (decls, opaques, stmts, _at) = parse_contract_program_spans(tokens)
+  let (decls, opaques, stmts, _at, _dat) = parse_contract_program_spans(tokens)
   (decls, opaques, stmts)
 }
 
@@ -147,8 +156,9 @@ export fn parse_contract_program(tokens: Array[Token]) -> (Array[(String, String
 /// it used to discard that. Recovering it by SEARCH was tried three times in
 /// the #2315 review and each attempt produced a predicate that could anchor on
 /// valid code, so the offset is carried instead.
-export fn parse_contract_program_spans(tokens: Array[Token]) -> (Array[(String, String)], Array[(String, Int)], Array[Stmt], Array[Int]) with Exception {
+export fn parse_contract_program_spans(tokens: Array[Token]) -> (Array[(String, String)], Array[(String, Int)], Array[Stmt], Array[Int], Array[Int]) with Exception {
   let decls = array_empty()
+  let decl_at = array_empty()
   let opaques = array_empty()
   let stmts = array_empty()
   let stmt_at = array_empty()
@@ -249,7 +259,7 @@ export fn parse_contract_program_spans(tokens: Array[Token]) -> (Array[(String, 
           TEq => throw("contract value declaration '\{vname}' must not have a definition (#752)"),
           _ => ()
         }
-        Array::push(decls, (vname, String::concat("val ", print_type_expr(vty))))
+        push_contract_decl(decls, decl_at, vname, String::concat("val ", print_type_expr(vty)), pos)
         pos = vnext
       },
       TIdent(head) => if head == "opaque" {
@@ -315,7 +325,7 @@ export fn parse_contract_program_spans(tokens: Array[Token]) -> (Array[(String, 
           _ => ()
         }
         match fn_sig_text(tps, tbs, params, ret_ty, eff_opt) {
-          Some(sig) => Array::push(decls, (name, sig)),
+          Some(sig) => push_contract_decl(decls, decl_at, name, sig, pos),
           None => throw("contract fn declaration '\{name}' requires full annotations")
         }
         pos = next
@@ -327,12 +337,12 @@ export fn parse_contract_program_spans(tokens: Array[Token]) -> (Array[(String, 
       }
     }
   }
-  if Array::length(stmts) != Array::length(stmt_at) {
-    throw("internal: contract statement offsets desynced (#2317) -- a statement was recorded without its position")
+  if Array::length(stmts) != Array::length(stmt_at) || Array::length(decls) != Array::length(decl_at) {
+    throw("internal: contract offsets desynced (#2317) -- a statement or declaration was recorded without its position")
   } else {
     ()
   }
-  (decls, opaques, stmts, stmt_at)
+  (decls, opaques, stmts, stmt_at, decl_at)
 }
 
 /// Collect (name, Some(sig) | None, exported) for every top-level let whose
@@ -875,6 +885,64 @@ export fn classify_contract_stmts(stmts: Array[Stmt]) -> (Array[String], Array[S
     i = i + 1
   }
   (raws, type_defs)
+}
+
+/// #2317: the declarations a contract EFFECTIVELY has, after the one filter
+/// the loader applies before counting them.
+///
+/// A legacy bodyless `let version: String` is dropped when the header carries
+/// a real `version` directive (#1054): the facade synthesizes that binding, so
+/// demanding an implementation for it would be wrong. Without the directive it
+/// is an ordinary declaration with a hand-written implementation and must stay.
+///
+/// This lived inline in `desugar_contract_source_fs`, which is why the buffer
+/// lane could not reproduce it: any check counting raw declarations disagrees
+/// with the build on exactly this shape. One function, both callers -- so a
+/// filter added later cannot land in only one lane (#2317's whole point).
+export fn contract_effective_decls(decls_raw: Array[(String, String)], pkg_version: String) -> Array[(String, String)] {
+  let out = array_empty()
+  let mut i = 0
+  while i < Array::length(decls_raw) {
+    let (dname, dsig) = Array::get(decls_raw, i)
+    if dname == "version" && dsig == "val String" && pkg_version != "" {
+      ()
+    } else {
+      Array::push(out, (dname, dsig))
+    }
+    i = i + 1
+  }
+  out
+}
+
+/// #2317: index of the first EFFECTIVE declaration whose name was already
+/// declared, or -1.
+///
+/// Measured: the build refuses a duplicate today, but through
+/// `contract_facade_source`, whose `allocated` list is set-like while `decls`
+/// counts multiplicity -- so the count check trips and reports "some
+/// declarations have no implementation file" about a name that is implemented.
+/// The reader is handed an edit that does nothing. Deciding it here instead
+/// lets both lanes say what is actually wrong.
+///
+/// Names only. Two declarations of one name are a duplicate whatever their
+/// signatures: the facade allocates by name, so the second can never bind.
+export fn contract_duplicate_decl_index(decls: Array[(String, String)]) -> Int {
+  let mut i = 0
+  let mut found = 0 - 1
+  while i < Array::length(decls) && found < 0 {
+    let (iname, _) = Array::get(decls, i)
+    let mut j = 0
+    while j < i && found < 0 {
+      let (jname, _) = Array::get(decls, j)
+      if jname == iname {
+        found = i
+      } else {
+        j = j + 1
+      }
+    }
+    i = i + 1
+  }
+  found
 }
 
 /// #2317: index of the first statement `classify_contract_stmts` rejects, or

--- a/lib/@vibe/compiler/contract/contract.vibe
+++ b/lib/@vibe/compiler/contract/contract.vibe
@@ -970,10 +970,41 @@ export fn contract_effective_decls(decls_raw: Array[(String, String)], pkg_versi
   let mut i = 0
   while i < Array::length(decls_raw) {
     let (dname, dsig) = Array::get(decls_raw, i)
-    if dname == "version" && dsig == "val String" && pkg_version != "" {
+    if contract_decl_is_filtered(dname, dsig, pkg_version) {
       ()
     } else {
       Array::push(out, (dname, dsig))
+    }
+    i = i + 1
+  }
+  out
+}
+
+/// The one filter rule, so `contract_effective_decls` and
+/// `contract_effective_decl_indices` cannot disagree about which entries
+/// survive.
+fn contract_decl_is_filtered(dname: String, dsig: String, pkg_version: String) -> Bool {
+  dname == "version" && dsig == "val String" && pkg_version != ""
+}
+
+/// #2317: for each EFFECTIVE declaration, its index in the raw list.
+///
+/// The offsets are recorded against the raw list, so a caller holding an
+/// effective index needs this to reach them. Counting name occurrences instead
+/// is wrong when a FILTERED entry shares the name: a dropped legacy `let
+/// version: String` beside two effective `version` declarations makes the
+/// count skip one, and the diagnostic anchors on the first declaration rather
+/// than the repeat -- telling the reader to delete the line they want to keep
+/// (Codex review on #2328).
+export fn contract_effective_decl_indices(decls_raw: Array[(String, String)], pkg_version: String) -> Array[Int] {
+  let out = array_empty()
+  let mut i = 0
+  while i < Array::length(decls_raw) {
+    let (dname, dsig) = Array::get(decls_raw, i)
+    if contract_decl_is_filtered(dname, dsig, pkg_version) {
+      ()
+    } else {
+      Array::push(out, i)
     }
     i = i + 1
   }

--- a/lib/@vibe/compiler/contract/contract.vibe
+++ b/lib/@vibe/compiler/contract/contract.vibe
@@ -927,13 +927,27 @@ export fn contract_type_family_offsets(stmts: Array[Stmt], stmt_at: Array[Int]) 
 /// and cannot read the contract to convert an offset. `offset_to_line_col` is
 /// the same function the diagnostic renderer uses, so the two agree on what a
 /// column is (1-based bytes, ADR-0108).
-export fn contract_type_family_decl_positions(source: String, stmts: Array[Stmt], stmt_at: Array[Int]) -> Array[String] {
+export fn contract_type_family_decl_positions(source: String, stmts: Array[Stmt], stmt_at: Array[Int], starts: Array[Int]) -> Array[String] {
+  // `stmt_at` holds TOKEN INDICES, not byte offsets -- `starts` is what turns
+  // one into the other. Passing the index straight to `offset_to_line_col`
+  // reads it as a byte offset and answers from the top of the file: measured,
+  // a declaration on line 13 reported `line 1:8`, which is token index 8 read
+  // as offset 8. `contract_classify_diagnostic` already does this conversion;
+  // this function was written without it.
   let offs = contract_type_family_offsets(stmts, stmt_at)
+  let lim = Array::length(starts)
   let out = array_empty()
   let mut i = 0
   while i < Array::length(offs) {
-    let (l, c) = offset_to_line_col(source, Array::get(offs, i))
-    Array::push(out, String::concat(__to_string(l), String::concat(":", __to_string(c))))
+    let tok = Array::get(offs, i)
+    if tok >= 0 && tok < lim {
+      let (l, c) = offset_to_line_col(source, Array::get(starts, tok))
+      Array::push(out, String::concat(__to_string(l), String::concat(":", __to_string(c))))
+    } else {
+      // No position rather than a wrong one; the generator omits the marker
+      // and the reader keeps the stub's own line.
+      Array::push(out, "")
+    }
     i = i + 1
   }
   out

--- a/lib/@vibe/compiler/contract/index.vpkg
+++ b/lib/@vibe/compiler/contract/index.vpkg
@@ -44,7 +44,7 @@ let vpkg_types_decl_marker: String
 fn parse_contract_program(tokens: Array[Token]) -> (Array[(String, String)], Array[(String, Int)], Array[Stmt]) with Exception
 fn parse_contract_program_spans(tokens: Array[Token]) -> (Array[(String, String)], Array[(String, Int)], Array[Stmt], Array[Int], Array[Int]) with Exception
 fn contract_type_family_offsets(stmts: Array[Stmt], stmt_at: Array[Int]) -> Array[Int]
-fn contract_type_family_decl_positions(source: String, stmts: Array[Stmt], stmt_at: Array[Int]) -> Array[String]
+fn contract_type_family_decl_positions(source: String, stmts: Array[Stmt], stmt_at: Array[Int], starts: Array[Int]) -> Array[String]
 fn contract_effective_decls(decls_raw: Array[(String, String)], pkg_version: String) -> Array[(String, String)]
 fn contract_duplicate_decl_index(decls: Array[(String, String)]) -> Int
 fn classify_contract_stmts(stmts: Array[Stmt]) -> (Array[String], Array[Stmt]) with Exception

--- a/lib/@vibe/compiler/contract/index.vpkg
+++ b/lib/@vibe/compiler/contract/index.vpkg
@@ -41,7 +41,9 @@ let vpkg_types_contract_marker: String
 
 // --- contract grammar
 fn parse_contract_program(tokens: Array[Token]) -> (Array[(String, String)], Array[(String, Int)], Array[Stmt]) with Exception
-fn parse_contract_program_spans(tokens: Array[Token]) -> (Array[(String, String)], Array[(String, Int)], Array[Stmt], Array[Int]) with Exception
+fn parse_contract_program_spans(tokens: Array[Token]) -> (Array[(String, String)], Array[(String, Int)], Array[Stmt], Array[Int], Array[Int]) with Exception
+fn contract_effective_decls(decls_raw: Array[(String, String)], pkg_version: String) -> Array[(String, String)]
+fn contract_duplicate_decl_index(decls: Array[(String, String)]) -> Int
 fn classify_contract_stmts(stmts: Array[Stmt]) -> (Array[String], Array[Stmt]) with Exception
 fn contract_unsupported_stmt_index(stmts: Array[Stmt]) -> Int
 fn contract_impl_import_raw_paths(stmts: Array[Stmt]) -> Array[String] with Exception

--- a/lib/@vibe/compiler/contract/index.vpkg
+++ b/lib/@vibe/compiler/contract/index.vpkg
@@ -38,10 +38,13 @@ let contract_facade_marker: String
 let vpkg_shared_import_marker: String
 let vpkg_types_module_marker: String
 let vpkg_types_contract_marker: String
+let vpkg_types_decl_marker: String
 
 // --- contract grammar
 fn parse_contract_program(tokens: Array[Token]) -> (Array[(String, String)], Array[(String, Int)], Array[Stmt]) with Exception
 fn parse_contract_program_spans(tokens: Array[Token]) -> (Array[(String, String)], Array[(String, Int)], Array[Stmt], Array[Int], Array[Int]) with Exception
+fn contract_type_family_offsets(stmts: Array[Stmt], stmt_at: Array[Int]) -> Array[Int]
+fn contract_type_family_decl_positions(source: String, stmts: Array[Stmt], stmt_at: Array[Int]) -> Array[String]
 fn contract_effective_decls(decls_raw: Array[(String, String)], pkg_version: String) -> Array[(String, String)]
 fn contract_duplicate_decl_index(decls: Array[(String, String)]) -> Int
 fn classify_contract_stmts(stmts: Array[Stmt]) -> (Array[String], Array[Stmt]) with Exception
@@ -60,8 +63,9 @@ fn contract_facade_source(decls: Array[(String, String)], opaque_names: Array[(S
 
 // --- materialized types module (#1840)
 fn contract_type_family_defs(type_defs: Array[Stmt]) -> Array[Stmt]
-fn contract_types_module_text(tds: Array[Stmt], uniq: String, contract_path: String) -> String
+fn contract_types_module_text(tds: Array[Stmt], uniq: String, contract_path: String, decl_pos: Array[String]) -> String
 fn vpkg_types_contract_of_source(source: String) -> String
+fn vpkg_types_decl_pos_for_line(source: String, stub_line: Int) -> String
 fn vpkg_path_escape_one_line(path: String) -> String
 let vpkg_deferred_type_names_prefix: String
 fn contract_types_item_names(tds: Array[Stmt]) -> Array[String]

--- a/lib/@vibe/compiler/contract/index.vpkg
+++ b/lib/@vibe/compiler/contract/index.vpkg
@@ -46,6 +46,7 @@ fn parse_contract_program_spans(tokens: Array[Token]) -> (Array[(String, String)
 fn contract_type_family_offsets(stmts: Array[Stmt], stmt_at: Array[Int]) -> Array[Int]
 fn contract_type_family_decl_positions(source: String, stmts: Array[Stmt], stmt_at: Array[Int], starts: Array[Int]) -> Array[String]
 fn contract_effective_decls(decls_raw: Array[(String, String)], pkg_version: String) -> Array[(String, String)]
+fn contract_effective_decl_indices(decls_raw: Array[(String, String)], pkg_version: String) -> Array[Int]
 fn contract_duplicate_decl_index(decls: Array[(String, String)]) -> Int
 fn classify_contract_stmts(stmts: Array[Stmt]) -> (Array[String], Array[Stmt]) with Exception
 fn contract_unsupported_stmt_index(stmts: Array[Stmt]) -> Int

--- a/lib/@vibe/compiler/loader/loader.vibe
+++ b/lib/@vibe/compiler/loader/loader.vibe
@@ -78,7 +78,8 @@ import @vibe/compiler/contract {
   semver_parts,
   verify_publish_bump,
   vpkg_shared_import_marker,
-  vpkg_types_contract_of_source
+  vpkg_types_contract_of_source,
+  vpkg_types_decl_marker
 }
 
 import ./ingestion_pipeline_telemetry.vibe {
@@ -1259,7 +1260,14 @@ fn vpkg_directory_shared_import_prefix_fs(path: String) -> String with Exception
           let cached_types_fresh = if cached_types_path == "" {
             true
           } else {
-            vpkg_types_contract_of_source(cached_types_text) != ""
+            // #2317: BOTH markers. A stub from the version that had only
+            // provenance passes a provenance-only check, so the cache keeps
+            // serving it and located diagnostics go on naming the artifact --
+            // the same staleness hole as #2324, one marker later. Every stub
+            // that exists has at least one declaration (none are generated for
+            // a contract with no type family), so a missing decl marker means
+            // the stub predates them.
+            vpkg_types_contract_of_source(cached_types_text) != "" && String::index_of(cached_types_text, vpkg_types_decl_marker) >= 0
           }
           if cached_types_fresh {
             // Same registry note as the facade-cache hit: a warm prefix
@@ -2120,7 +2128,8 @@ fn desugar_contract_source_fs(path: String, source: String) -> String with Excep
       let fc_types_fresh = if fc_types_path == "" {
         true
       } else {
-        vpkg_types_contract_of_source(fc_types_text) != ""
+        // #2317: both markers, exactly as in the prefix cache above.
+        vpkg_types_contract_of_source(fc_types_text) != "" && String::index_of(fc_types_text, vpkg_types_decl_marker) >= 0
       }
       if fc_types_fresh {
         // #1840: the registry note must happen on the HIT path too —

--- a/lib/@vibe/compiler/loader/loader.vibe
+++ b/lib/@vibe/compiler/loader/loader.vibe
@@ -56,6 +56,8 @@ import @vibe/compiler/contract {
   check_contract,
   classify_contract_stmts,
   contract_directory_shared_import_prefix_text,
+  contract_duplicate_decl_index,
+  contract_effective_decls,
   contract_facade_marker,
   contract_facade_source,
   contract_hash,
@@ -2012,16 +2014,24 @@ fn desugar_contract_source_fs(path: String, source: String) -> String with Excep
   // export. A contract that still spells the old bodyless `let version:
   // String` line alongside a real directive keeps parsing (this filter just
   // makes it a no-op) so existing packages migrate at their own pace.
-  let decls = array_empty()
-  let mut dvi = 0
-  while dvi < Array::length(decls_raw) {
-    let (dname, dsig) = Array::get(decls_raw, dvi)
-    if dname == "version" && dsig == "val String" && pkg_version != "" {
-      ()
-    } else {
-      Array::push(decls, (dname, dsig))
-    }
-    dvi = dvi + 1
+  let decls = contract_effective_decls(decls_raw, pkg_version)
+  // #2317: say what is actually wrong. A duplicate declaration reaches
+  // `contract_facade_source` as an extra entry that can never be allocated
+  // (its `allocated` list is set-like, `decls` counts multiplicity), so the
+  // count check there trips and reports "some declarations have no
+  // implementation file" -- about a name that IS implemented, handing the
+  // reader an edit that does nothing. Measured before this: a contract
+  // declaring `fn plain` twice with a matching impl got exactly that.
+  //
+  // Decided from the contract alone, and from the SAME effective list the
+  // buffer lane uses, so the two cannot disagree about which shapes are
+  // duplicates.
+  let dup_at = contract_duplicate_decl_index(decls)
+  if dup_at >= 0 {
+    let (dup_name, _) = Array::get(decls, dup_at)
+    throw("contract declares '\{dup_name}' more than once; remove the repeated declaration (#2317)")
+  } else {
+    ()
   }
   let (impl_raws0, type_defs) = classify_contract_stmts(extra)
   // #730: explicit `import ./impl.vibe {}` declarations win; a contract that

--- a/lib/@vibe/compiler/loader/loader.vibe
+++ b/lib/@vibe/compiler/loader/loader.vibe
@@ -2032,6 +2032,13 @@ fn desugar_contract_source_fs(path: String, source: String) -> String with Excep
   // Decided from the contract alone, and from the SAME effective list the
   // buffer lane uses, so the two cannot disagree about which shapes are
   // duplicates.
+  let (impl_raws0, type_defs) = classify_contract_stmts(extra)
+  // AFTER classification, to match the buffer lane's order. Both lanes must
+  // recommend the same first edit for the same file: a contract with a
+  // duplicate AND an unsupported statement reported the duplicate here and the
+  // unsupported statement there (Codex review on #2328), which is a fresh
+  // instance of the divergence this work exists to close. A statement the
+  // contract may not contain is the more basic error, so it leads.
   let dup_at = contract_duplicate_decl_index(decls)
   if dup_at >= 0 {
     let (dup_name, _) = Array::get(decls, dup_at)
@@ -2039,7 +2046,6 @@ fn desugar_contract_source_fs(path: String, source: String) -> String with Excep
   } else {
     ()
   }
-  let (impl_raws0, type_defs) = classify_contract_stmts(extra)
   // #730: explicit `import ./impl.vibe {}` declarations win; a contract that
   // declares none auto-discovers its sibling *.vibe files (Fs::readdir,
   // byte-sorted by the host so the facade is deterministic).

--- a/lib/@vibe/compiler/loader/loader.vibe
+++ b/lib/@vibe/compiler/loader/loader.vibe
@@ -62,6 +62,7 @@ import @vibe/compiler/contract {
   contract_facade_source,
   contract_hash,
   contract_surface_lines,
+  contract_type_family_decl_positions,
   contract_type_family_defs,
   contract_types_module_line,
   contract_types_module_text,
@@ -72,6 +73,7 @@ import @vibe/compiler/contract {
   extract_require_pins,
   package_hash_from_sources,
   parse_contract_program,
+  parse_contract_program_spans,
   replace_generated_hash_directive,
   semver_parts,
   verify_publish_bump,
@@ -1097,7 +1099,7 @@ export let vpkg_types_module_path_prefix: String = "_build/vibe_vpkg_types/types
 /// the package lives outside the repo-relative tree (an absolute VIBE_LIB
 /// external root — the relative import spelling below cannot reach _build
 /// from there, so those packages keep the verbatim-facade behavior).
-fn ensure_vpkg_types_module_fs(vpkg_path: String, extra: Array[Stmt]) -> String with Exception + Fs {
+fn ensure_vpkg_types_module_fs(vpkg_path: String, extra: Array[Stmt], decl_pos: Array[String]) -> String with Exception + Fs {
   if String::starts_with(vpkg_path, "/") {
     return ""
   } else {
@@ -1127,7 +1129,7 @@ fn ensure_vpkg_types_module_fs(vpkg_path: String, extra: Array[Stmt]) -> String 
       }
       uci = uci + 1
     }
-    let text = contract_types_module_text(tds, StringBuilder::freeze(uniq_sb), vpkg_path)
+    let text = contract_types_module_text(tds, StringBuilder::freeze(uniq_sb), vpkg_path, decl_pos)
     let raw_key = compact_string_fingerprint(String::concat(vpkg_path, String::concat("|", text)))
     // Identifier-safe basename: the import-path grammar (parser_base.vibe's
     // collect_import_path) lexes path segments as identifier/keyword tokens,
@@ -1281,13 +1283,17 @@ fn vpkg_directory_shared_import_prefix_fs(path: String) -> String with Exception
       } else {
         let vpkg_raw = Fs::read_file(vpkg_path)
         let (_, vpkg_pin_blanked) = extract_require_pins(vpkg_raw)
-        let (_, _, vpkg_extra) = parse_contract_program(lex(vpkg_pin_blanked))
+        let (_, _, vpkg_extra, vpkg_stmt_at, _vd) = parse_contract_program_spans(lex(vpkg_pin_blanked))
         let shared_text = contract_directory_shared_import_prefix_text(vpkg_extra)
         // #1840: siblings import the contract's type family from the
         // materialized types module — this is what gives enum constructors
         // real value bindings inside impl units (the facade cannot be
         // imported from a sibling: facade → impl is already an edge).
-        let types_path = ensure_vpkg_types_module_fs(vpkg_path, vpkg_extra)
+        // #2317: positions come from the SAME blanked text the parse used, so
+        // the offsets and the source agree. Blanking is offset-preserving, so
+        // a line:col computed here is the line:col in the real contract too.
+        let vpkg_decl_pos = contract_type_family_decl_positions(vpkg_pin_blanked, vpkg_extra, vpkg_stmt_at)
+        let types_path = ensure_vpkg_types_module_fs(vpkg_path, vpkg_extra, vpkg_decl_pos)
         let prefix_text = if types_path == "" {
           shared_text
         } else {
@@ -1995,7 +2001,7 @@ export fn check_module(source: String, path: String, sources: Array[(String, Str
 fn desugar_contract_source_fs(path: String, source: String) -> String with Exception + Fs {
   let dir = dir_of_path(path)
   validate_index_layout_fs(path)
-  let (decls_raw, opaque_names, extra) = parse_contract_program(lex(source))
+  let (decls_raw, opaque_names, extra, stmt_at, _decl_at) = parse_contract_program_spans(lex(source))
   // `source` here has already had its leading directive region blanked by
   // extract_require_pins (see ingest_source_text_fs), so the directive must
   // be read back from the ORIGINAL on-disk text via `path`.
@@ -2197,7 +2203,10 @@ fn desugar_contract_source_fs(path: String, source: String) -> String with Excep
   // text needs the package-dir-RELATIVE spelling (the export grammar rejects
   // a bare root-relative head token); the cache row below keeps the
   // canonical root-relative path for its existence re-check.
-  let facade_types_path = ensure_vpkg_types_module_fs(path, extra)
+  // #2317: the contract's own line:col for each materialized declaration, so a
+  // located diagnostic about the generated module can name the contract.
+  let facade_decl_pos = contract_type_family_decl_positions(source, extra, stmt_at)
+  let facade_types_path = ensure_vpkg_types_module_fs(path, extra, facade_decl_pos)
   let facade_types_rel = if facade_types_path == "" {
     ""
   } else {

--- a/lib/@vibe/compiler/loader/loader.vibe
+++ b/lib/@vibe/compiler/loader/loader.vibe
@@ -1,7 +1,7 @@
 //# Imports
 
 import @vibe/compiler/syntax {
-  lex, parse_program, parse_program_preserving
+  lex, lex_with_offsets, parse_program, parse_program_preserving
 }
 
 import @vibe/core {
@@ -1291,7 +1291,8 @@ fn vpkg_directory_shared_import_prefix_fs(path: String) -> String with Exception
       } else {
         let vpkg_raw = Fs::read_file(vpkg_path)
         let (_, vpkg_pin_blanked) = extract_require_pins(vpkg_raw)
-        let (_, _, vpkg_extra, vpkg_stmt_at, _vd) = parse_contract_program_spans(lex(vpkg_pin_blanked))
+        let (vpkg_tokens, vpkg_starts, _ve) = lex_with_offsets(vpkg_pin_blanked)
+        let (_, _, vpkg_extra, vpkg_stmt_at, _vd) = parse_contract_program_spans(vpkg_tokens)
         let shared_text = contract_directory_shared_import_prefix_text(vpkg_extra)
         // #1840: siblings import the contract's type family from the
         // materialized types module — this is what gives enum constructors
@@ -1300,7 +1301,7 @@ fn vpkg_directory_shared_import_prefix_fs(path: String) -> String with Exception
         // #2317: positions come from the SAME blanked text the parse used, so
         // the offsets and the source agree. Blanking is offset-preserving, so
         // a line:col computed here is the line:col in the real contract too.
-        let vpkg_decl_pos = contract_type_family_decl_positions(vpkg_pin_blanked, vpkg_extra, vpkg_stmt_at)
+        let vpkg_decl_pos = contract_type_family_decl_positions(vpkg_pin_blanked, vpkg_extra, vpkg_stmt_at, vpkg_starts)
         let types_path = ensure_vpkg_types_module_fs(vpkg_path, vpkg_extra, vpkg_decl_pos)
         let prefix_text = if types_path == "" {
           shared_text
@@ -2009,7 +2010,10 @@ export fn check_module(source: String, path: String, sources: Array[(String, Str
 fn desugar_contract_source_fs(path: String, source: String) -> String with Exception + Fs {
   let dir = dir_of_path(path)
   validate_index_layout_fs(path)
-  let (decls_raw, opaque_names, extra, stmt_at, _decl_at) = parse_contract_program_spans(lex(source))
+  // `lex_with_offsets`, because the declaration positions below need byte
+  // offsets and `stmt_at` records token indices.
+  let (src_tokens, src_starts, _src_ends) = lex_with_offsets(source)
+  let (decls_raw, opaque_names, extra, stmt_at, _decl_at) = parse_contract_program_spans(src_tokens)
   // `source` here has already had its leading directive region blanked by
   // extract_require_pins (see ingest_source_text_fs), so the directive must
   // be read back from the ORIGINAL on-disk text via `path`.
@@ -2220,7 +2224,7 @@ fn desugar_contract_source_fs(path: String, source: String) -> String with Excep
   // canonical root-relative path for its existence re-check.
   // #2317: the contract's own line:col for each materialized declaration, so a
   // located diagnostic about the generated module can name the contract.
-  let facade_decl_pos = contract_type_family_decl_positions(source, extra, stmt_at)
+  let facade_decl_pos = contract_type_family_decl_positions(source, extra, stmt_at, src_starts)
   let facade_types_path = ensure_vpkg_types_module_fs(path, extra, facade_decl_pos)
   let facade_types_rel = if facade_types_path == "" {
     ""

--- a/lib/@vibe/compiler/runtime/typecheck_fs.vibe
+++ b/lib/@vibe/compiler/runtime/typecheck_fs.vibe
@@ -89,7 +89,8 @@ import @vibe/compiler/contract {
   parse_contract_program,
   parse_contract_program_spans,
   vpkg_path_escape_one_line,
-  vpkg_types_contract_of_source
+  vpkg_types_contract_of_source,
+  vpkg_types_decl_pos_for_line
 }
 
 import @vibe/compiler/loader {
@@ -1439,20 +1440,82 @@ fn is_generated_vpkg_types_path(path: String) -> Bool {
   }
 }
 
-fn type_diagnostic_display_path(path: String, source: String, located_msg: String) -> String {
-  if is_generated_vpkg_types_path(path) && !diag_already_located(located_msg) {
-    let owner = vpkg_types_contract_of_source(source)
-    if owner == "" {
-      path
-    } else {
-      // Escaped for DISPLAY. The marker round-trips a path exactly, newlines
-      // included, and this string goes straight into a diagnostic -- rendered
-      // verbatim it would split one record across lines, and crafted path
-      // components could resemble further diagnostics (Codex review on #2324).
-      vpkg_path_escape_one_line(owner)
-    }
+/// #2317: split a located message into its 1-based line number and the body
+/// after the `line L:C: ` prefix. `(-1, msg)` when it carries no prefix.
+///
+/// The prefix ends at the first `": "`, which is unambiguous: the position is
+/// `L:C` or `L:C-E`, and neither contains a space.
+fn located_line_and_body(msg: String) -> (Int, String) {
+  if !String::starts_with(msg, "line ") {
+    return (0 - 1, msg)
   } else {
-    path
+    ()
+  }
+  let n = String::length(msg)
+  let mut i = 5
+  let mut num = 0
+  let mut digits = 0
+  while i < n {
+    let c = String::char_code_at(msg, i)
+    if c >= 48 && c <= 57 {
+      num = num * 10 + (c - 48)
+      digits = digits + 1
+      i = i + 1
+    } else {
+      i = n
+    }
+  }
+  if digits == 0 {
+    return (0 - 1, msg)
+  } else {
+    ()
+  }
+  let sep = String::index_of(msg, ": ")
+  if sep < 0 {
+    (0 - 1, msg)
+  } else {
+    (num, String::substring(msg, sep + 2, String::length(msg)))
+  }
+}
+
+fn type_diagnostic_display(path: String, source: String, located_msg: String) -> (String, String) with Exception {
+  if !is_generated_vpkg_types_path(path) {
+    return (path, located_msg)
+  } else {
+    ()
+  }
+  let owner_raw = vpkg_types_contract_of_source(source)
+  if owner_raw == "" {
+    return (path, located_msg)
+  } else {
+    ()
+  }
+  // Escaped for DISPLAY. The marker round-trips a path exactly, newlines
+  // included, and this string goes straight into a diagnostic -- rendered
+  // verbatim it would split one record across lines, and crafted path
+  // components could resemble further diagnostics (Codex review on #2324).
+  let owner = vpkg_path_escape_one_line(owner_raw)
+  let (lno, body) = located_line_and_body(located_msg)
+  if lno < 0 {
+    // Unlocated: nothing to remap, and nothing to get wrong.
+    return (owner, located_msg)
+  } else {
+    ()
+  }
+  // #2317: located. The stub records each declaration's contract `line:col`
+  // beside it, so the message can name the contract AND point at the
+  // declaration the author wrote. Declaration-granular: `print_stmt` rebuilds
+  // the declaration from the AST, so the column inside it is gone -- what is
+  // recovered is WHICH declaration, which is what the reader acts on.
+  //
+  // Without a marker the stub path and its own line are kept together. That
+  // pair is at least self-consistent; pairing the contract with a stub line is
+  // the confidently-wrong shape #2324 exists to avoid.
+  let pos = vpkg_types_decl_pos_for_line(source, lno)
+  if pos == "" {
+    (path, located_msg)
+  } else {
+    (owner, String::concat("line ", String::concat(pos, String::concat(": ", body))))
   }
 }
 
@@ -4235,8 +4298,9 @@ fn check_module_impl(job: ModuleJob, observe_typing_artifact: Bool) -> ModuleOut
       Checked(job.path, fingerprint, checked_env, interface_identity, checked_env_identity, persistent_type_env_transport_identity, module_typing_artifact)
     } with { Exception::Throw(msg) => {
       let located = locate_type_error(job.source, msg)
+      let (disp_path, disp_msg) = type_diagnostic_display(job.path, job.source, located)
       Diagnosed(job.path, [
-        String::concat(String::concat(type_diagnostic_display_path(job.path, job.source, located), ": "), located)
+        String::concat(String::concat(disp_path, ": "), disp_msg)
       ])
     } }
   }

--- a/lib/@vibe/compiler/runtime/typecheck_fs.vibe
+++ b/lib/@vibe/compiler/runtime/typecheck_fs.vibe
@@ -5668,7 +5668,15 @@ export fn collect_all_diagnostics_for_path(input_path: String, source: String) -
   } else {
     ()
   }
-  collect_all_diagnostics_on(input_path, pin_blanked)
+  // #2317: the version directive is BLANKED out of `pin_blanked` (measured --
+  // `scan_package_header` blanks every directive it recognizes), so the
+  // effective-declaration filter has to be told it from the RAW source. Read
+  // it here, where that source is still in hand; a header the scanner itself
+  // rejects has already returned above, so this cannot throw a second time.
+  let pkg_version = handle {
+    extract_package_version(source)
+  } with { Exception::Throw(_) => "" }
+  collect_all_diagnostics_on(input_path, pin_blanked, pkg_version)
 }
 
 /// #2314, the LSP half of #2280: a `.vpkg` is a list of BODYLESS declarations,
@@ -6173,7 +6181,7 @@ fn contract_duplicate_diagnostic(source: String, starts: Array[Int], decls: Arra
   [locate_type_error(source, msg)]
 }
 
-fn collect_all_diagnostics_on(input_path: String, source: String) -> Array[String] with Exception {
+fn collect_all_diagnostics_on(input_path: String, source: String, pkg_version: String) -> Array[String] with Exception {
   if is_contract_ext(input_path) {
     // A contract LEXES like a program, so it gets the recovering lexer and
     // every lex error, the same as the branch below (#2314 review). Only the
@@ -6221,7 +6229,7 @@ fn collect_all_diagnostics_on(input_path: String, source: String) -> Array[Strin
         // build drops (a legacy `let version: String` under a real `version`
         // directive), so the two lanes cannot disagree about which shapes
         // count. Measured: declared twice, that one IS accepted by the build.
-        let cdecls = contract_effective_decls(cdecls_raw, extract_package_version(source))
+        let cdecls = contract_effective_decls(cdecls_raw, pkg_version)
         let dup_at = contract_duplicate_decl_index(cdecls)
         if dup_at >= 0 {
           contract_duplicate_diagnostic(source, cstarts, cdecls, cdecls_raw, cdecl_at, dup_at)

--- a/lib/@vibe/compiler/runtime/typecheck_fs.vibe
+++ b/lib/@vibe/compiler/runtime/typecheck_fs.vibe
@@ -82,6 +82,7 @@ import @vibe/compiler/entry/source_compile/wasi_only {
 import @vibe/compiler/contract {
   classify_contract_stmts,
   contract_duplicate_decl_index,
+  contract_effective_decl_indices,
   contract_effective_decls,
   contract_unsupported_stmt_index,
   extract_package_version,
@@ -6191,54 +6192,34 @@ fn contract_classify_diagnostic(source: String, starts: Array[Int], stmts: Array
 
 /// #2317: anchor a duplicate declaration on the REPEAT, not on the first one.
 ///
-/// `contract_effective_decls` filters, so an index into the effective list is
-/// not an index into the raw one the offsets belong to. The name is matched
-/// back into the raw list, skipping as many earlier occurrences as the
-/// effective list already had -- the filter only ever drops entries, never
-/// reorders them, so the n-th surviving occurrence of a name is the n-th raw
-/// occurrence of it.
+/// The offsets are recorded against the RAW declaration list, so the effective
+/// index is mapped through `contract_effective_decl_indices` rather than by
+/// counting name occurrences. Counting is wrong when a FILTERED entry shares
+/// the name -- a dropped legacy `let version: String` beside two effective
+/// `version` declarations makes the count skip one, and the anchor lands on
+/// the declaration the reader wants to keep (Codex review on #2328).
+///
+/// `decl_at` holds TOKEN indices; `starts` converts one to a byte offset.
 ///
 /// Falls back to unlocated rather than to a guess, as every other diagnostic
 /// this lane cannot place does.
-fn contract_duplicate_diagnostic(source: String, starts: Array[Int], decls: Array[(String, String)], decls_raw: Array[(String, String)], decl_at: Array[Int], dup_at: Int) -> Array[String] with Exception {
+fn contract_duplicate_diagnostic(source: String, starts: Array[Int], decls: Array[(String, String)], eff_idx: Array[Int], decl_at: Array[Int], dup_at: Int) -> Array[String] with Exception {
   let (dup_name, _) = Array::get(decls, dup_at)
   let msg = String::concat(String::concat("contract declares '", dup_name), "' more than once; remove the repeated declaration (#2317)")
-  let mut seen_before = 0
-  let mut i = 0
-  while i < dup_at {
-    let (n, _) = Array::get(decls, i)
-    if n == dup_name {
-      seen_before = seen_before + 1
-    } else {
-      ()
-    }
-    i = i + 1
-  }
-  let mut want = seen_before
-  let mut r = 0
-  let mut off = 0 - 1
-  let lim = Array::length(decl_at)
-  while r < Array::length(decls_raw) && off < 0 {
-    let (rn, _) = Array::get(decls_raw, r)
-    if rn == dup_name {
-      if want == 0 {
-        if r < lim {
-          off = Array::get(decl_at, r)
-        } else {
-          ()
-        }
+  if dup_at >= 0 && dup_at < Array::length(eff_idx) {
+    let raw_i = Array::get(eff_idx, dup_at)
+    if raw_i >= 0 && raw_i < Array::length(decl_at) {
+      let tok = Array::get(decl_at, raw_i)
+      if tok >= 0 && tok < Array::length(starts) {
+        return [
+          String::concat(offset_line_col_prefix(source, Array::get(starts, tok)), msg)
+        ]
       } else {
-        want = want - 1
+        ()
       }
     } else {
       ()
     }
-    r = r + 1
-  }
-  if off >= 0 && off < Array::length(starts) {
-    return [
-      String::concat(offset_line_col_prefix(source, Array::get(starts, off)), msg)
-    ]
   } else {
     ()
   }
@@ -6294,9 +6275,10 @@ fn collect_all_diagnostics_on(input_path: String, source: String, pkg_version: S
         // directive), so the two lanes cannot disagree about which shapes
         // count. Measured: declared twice, that one IS accepted by the build.
         let cdecls = contract_effective_decls(cdecls_raw, pkg_version)
+        let ceff_idx = contract_effective_decl_indices(cdecls_raw, pkg_version)
         let dup_at = contract_duplicate_decl_index(cdecls)
         if dup_at >= 0 {
-          contract_duplicate_diagnostic(source, cstarts, cdecls, cdecls_raw, cdecl_at, dup_at)
+          contract_duplicate_diagnostic(source, cstarts, cdecls, ceff_idx, cdecl_at, dup_at)
         } else {
           contract_semantic_errors(source, ctokens, cstarts, cstmts)
         }

--- a/lib/@vibe/compiler/runtime/typecheck_fs.vibe
+++ b/lib/@vibe/compiler/runtime/typecheck_fs.vibe
@@ -81,7 +81,10 @@ import @vibe/compiler/entry/source_compile/wasi_only {
 
 import @vibe/compiler/contract {
   classify_contract_stmts,
+  contract_duplicate_decl_index,
+  contract_effective_decls,
   contract_unsupported_stmt_index,
+  extract_package_version,
   extract_require_pins,
   parse_contract_program,
   parse_contract_program_spans,
@@ -6114,6 +6117,62 @@ fn contract_classify_diagnostic(source: String, starts: Array[Int], stmts: Array
   [locate_type_error(source, msg)]
 }
 
+/// #2317: anchor a duplicate declaration on the REPEAT, not on the first one.
+///
+/// `contract_effective_decls` filters, so an index into the effective list is
+/// not an index into the raw one the offsets belong to. The name is matched
+/// back into the raw list, skipping as many earlier occurrences as the
+/// effective list already had -- the filter only ever drops entries, never
+/// reorders them, so the n-th surviving occurrence of a name is the n-th raw
+/// occurrence of it.
+///
+/// Falls back to unlocated rather than to a guess, as every other diagnostic
+/// this lane cannot place does.
+fn contract_duplicate_diagnostic(source: String, starts: Array[Int], decls: Array[(String, String)], decls_raw: Array[(String, String)], decl_at: Array[Int], dup_at: Int) -> Array[String] with Exception {
+  let (dup_name, _) = Array::get(decls, dup_at)
+  let msg = String::concat(String::concat("contract declares '", dup_name), "' more than once; remove the repeated declaration (#2317)")
+  let mut seen_before = 0
+  let mut i = 0
+  while i < dup_at {
+    let (n, _) = Array::get(decls, i)
+    if n == dup_name {
+      seen_before = seen_before + 1
+    } else {
+      ()
+    }
+    i = i + 1
+  }
+  let mut want = seen_before
+  let mut r = 0
+  let mut off = 0 - 1
+  let lim = Array::length(decl_at)
+  while r < Array::length(decls_raw) && off < 0 {
+    let (rn, _) = Array::get(decls_raw, r)
+    if rn == dup_name {
+      if want == 0 {
+        if r < lim {
+          off = Array::get(decl_at, r)
+        } else {
+          ()
+        }
+      } else {
+        want = want - 1
+      }
+    } else {
+      ()
+    }
+    r = r + 1
+  }
+  if off >= 0 && off < Array::length(starts) {
+    return [
+      String::concat(offset_line_col_prefix(source, Array::get(starts, off)), msg)
+    ]
+  } else {
+    ()
+  }
+  [locate_type_error(source, msg)]
+}
+
 fn collect_all_diagnostics_on(input_path: String, source: String) -> Array[String] with Exception {
   if is_contract_ext(input_path) {
     // A contract LEXES like a program, so it gets the recovering lexer and
@@ -6143,7 +6202,7 @@ fn collect_all_diagnostics_on(input_path: String, source: String) -> Array[Strin
     // branch this replaces did catch it, through `check_program`. So run the
     // classifier the loader runs, on the statements the parse produced.
     return handle {
-      let (_cdecls, _copaques, cstmts, cstmt_at) = parse_contract_program_spans(ctokens)
+      let (cdecls_raw, _copaques, cstmts, cstmt_at, cdecl_at) = parse_contract_program_spans(ctokens)
       // The classifier is caught SEPARATELY from the parse. Both throw
       // unlocated messages, but they need different anchors: a parse error
       // belongs at the token the parser stopped on, a rejected statement at
@@ -6157,7 +6216,18 @@ fn collect_all_diagnostics_on(input_path: String, source: String) -> Array[Strin
       if cls_err != "" {
         contract_classify_diagnostic(source, cstarts, cstmts, cstmt_at, cls_err)
       } else {
-        contract_semantic_errors(source, ctokens, cstarts, cstmts)
+        // #2317: the loader's own effective-declaration list, not a second
+        // reading of it -- `contract_effective_decls` drops exactly what the
+        // build drops (a legacy `let version: String` under a real `version`
+        // directive), so the two lanes cannot disagree about which shapes
+        // count. Measured: declared twice, that one IS accepted by the build.
+        let cdecls = contract_effective_decls(cdecls_raw, extract_package_version(source))
+        let dup_at = contract_duplicate_decl_index(cdecls)
+        if dup_at >= 0 {
+          contract_duplicate_diagnostic(source, cstarts, cdecls, cdecls_raw, cdecl_at, dup_at)
+        } else {
+          contract_semantic_errors(source, ctokens, cstarts, cstmts)
+        }
       }
     } with { Exception::Throw(msg) => contract_parse_diagnostic(source, ctokens, cstarts, msg) }
   } else {

--- a/lib/@vibe/compiler/tests/contract_deferred_type_names_test.vibe
+++ b/lib/@vibe/compiler/tests/contract_deferred_type_names_test.vibe
@@ -7,7 +7,11 @@
 // same predicate the checker already uses (`compiler_owned_type_arity`).
 
 import @vibe/compiler/contract {
-  contract_types_module_text, vpkg_deferred_type_names_prefix, vpkg_path_escape_one_line, vpkg_types_contract_of_source
+  contract_types_module_text,
+  vpkg_deferred_type_names_prefix,
+  vpkg_path_escape_one_line,
+  vpkg_types_contract_of_source,
+  vpkg_types_decl_pos_for_line
 }
 
 import @vibe/compiler/core {
@@ -24,7 +28,8 @@ fn map_headers_field() -> (String, TypeExpr) {
 
 test "2164: Map in a contract type is not a deferred name" {
   let defs = [SStruct(true, "HttpRequest", [map_headers_field()], [], [], [])]
-  let text = contract_types_module_text(defs, "t", "lib/@gate/pkg/index.vpkg")
+  let text = contract_types_module_text(defs, "t", "lib/@gate/pkg/index.vpkg", [
+  ])
   assert(!String::contains(text, vpkg_deferred_type_names_prefix))
 }
 
@@ -34,7 +39,8 @@ test "2164: MutMap in a contract type is not a deferred name" {
       ("inner", TyApp("MutMap", [TyName("String"), TyName("Int"), TyName("r")]))
     ], [], [], ["r"])
   ]
-  let text = contract_types_module_text(defs, "t", "lib/@gate/pkg/index.vpkg")
+  let text = contract_types_module_text(defs, "t", "lib/@gate/pkg/index.vpkg", [
+  ])
   assert(!String::contains(text, vpkg_deferred_type_names_prefix))
 }
 
@@ -43,7 +49,8 @@ test "2164: a typo next to Map is deferred, Map is not" {
     SStruct(true, "HttpRequest", [map_headers_field(), ("x", TyName("Intt"))], [
     ], [], [])
   ]
-  let text = contract_types_module_text(defs, "t", "lib/@gate/pkg/index.vpkg")
+  let text = contract_types_module_text(defs, "t", "lib/@gate/pkg/index.vpkg", [
+  ])
   assert(String::contains(text, vpkg_deferred_type_names_prefix))
   assert(String::contains(text, "HttpRequest : Intt"))
   assert(!String::contains(text, "HttpRequest : Map"))
@@ -51,13 +58,15 @@ test "2164: a typo next to Map is deferred, Map is not" {
 
 test "2164: a cross-package name is still deferred" {
   let defs = [SStruct(true, "ModuleJob", [("env", TyName("TypeEnv"))], [], [], [])]
-  let text = contract_types_module_text(defs, "t", "lib/@gate/pkg/index.vpkg")
+  let text = contract_types_module_text(defs, "t", "lib/@gate/pkg/index.vpkg", [
+  ])
   assert(String::contains(text, "ModuleJob : TypeEnv"))
 }
 
 test "2317: the generated types module carries its contract, readable from the text alone" {
   let defs = [SStruct(true, "HttpRequest", [map_headers_field()], [], [], [])]
-  let text = contract_types_module_text(defs, "t", "lib/@gate/pkg/index.vpkg")
+  let text = contract_types_module_text(defs, "t", "lib/@gate/pkg/index.vpkg", [
+  ])
   // Read back from the TEXT, with no loader and no registry -- this is the
   // property the isolated worker lane depends on (`VIBE_MODULE_JOB_DIR` hands
   // a worker `source.vibe` and nothing else). A process-local registry answers
@@ -75,7 +84,7 @@ test "2324: a contract path keeping leading whitespace round-trips verbatim" {
   // written with no padding, so trimming the suffix could only corrupt the
   // path -- the diagnostic would then name a file that does not exist.
   let defs = [SStruct(true, "HttpRequest", [map_headers_field()], [], [], [])]
-  let text = contract_types_module_text(defs, "t", " odd dir/pkg/index.vpkg")
+  let text = contract_types_module_text(defs, "t", " odd dir/pkg/index.vpkg", [])
   assert(vpkg_types_contract_of_source(text) == " odd dir/pkg/index.vpkg")
 }
 
@@ -89,7 +98,7 @@ test "2324: a contract path containing a newline cannot escape the marker commen
   // comment and turn the rest of the path into generated source.
   let defs = [SStruct(true, "HttpRequest", [map_headers_field()], [], [], [])]
   let evil = "lib/pkg\nstruct Injected { x: Int }\n/index.vpkg"
-  let text = contract_types_module_text(defs, "t", evil)
+  let text = contract_types_module_text(defs, "t", evil, [])
   // The marker stays on ONE line, so the injected text never BEGINS a line --
   // it stays inside the comment, where it is inert. Asserting it is absent
   // entirely would be false and was: the escaped marker still contains those
@@ -103,7 +112,7 @@ test "2324: a contract path containing a newline cannot escape the marker commen
 test "2324: a backslash in a contract path round-trips" {
   let defs = [SStruct(true, "HttpRequest", [map_headers_field()], [], [], [])]
   let odd = "lib/we\\ird/index.vpkg"
-  let text = contract_types_module_text(defs, "t", odd)
+  let text = contract_types_module_text(defs, "t", odd, [])
   assert(vpkg_types_contract_of_source(text) == odd)
 }
 
@@ -115,4 +124,45 @@ test "2324: a decoded path is escaped again before it reaches a diagnostic" {
   assert(String::index_of(shown, "\n") < 0)
   // An ordinary path is untouched, so escaping costs nothing in the normal case.
   assert(vpkg_path_escape_one_line("lib/@gate/pkg/index.vpkg") == "lib/@gate/pkg/index.vpkg")
+}
+
+test "2317: a stub records each declaration's contract position, nearest marker wins" {
+  let defs = [
+    SStruct(true, "A", [("x", TyName("Int"))], [], [], []),
+    SStruct(true, "B", [("y", TyName("Int"))], [], [], [])
+  ]
+  let text = contract_types_module_text(defs, "t", "lib/@gate/pkg/index.vpkg", [
+    "9:1",
+    "13:1"
+  ])
+  // The marker sits immediately above its declaration, so the declaration's
+  // own line resolves to it -- and so does any later line the printer might
+  // render that declaration onto.
+  let lines = String::split(text, "\n")
+  let mut a_line = 0
+  let mut b_line = 0
+  let mut i = 0
+  while i < Array::length(lines) {
+    if String::index_of(Array::get(lines, i), "struct A") >= 0 {
+      a_line = i + 1
+    } else {
+      ()
+    }
+    if String::index_of(Array::get(lines, i), "struct B") >= 0 {
+      b_line = i + 1
+    } else {
+      ()
+    }
+    i = i + 1
+  }
+  assert(a_line > 0 && b_line > a_line)
+  assert(vpkg_types_decl_pos_for_line(text, a_line) == "9:1")
+  assert(vpkg_types_decl_pos_for_line(text, b_line) == "13:1")
+}
+
+test "2317: a stub with no position markers reads as empty, not as a guess" {
+  let defs = [SStruct(true, "A", [("x", TyName("Int"))], [], [], [])]
+  let text = contract_types_module_text(defs, "t", "lib/@gate/pkg/index.vpkg", [
+  ])
+  assert(vpkg_types_decl_pos_for_line(text, 4) == "")
 }

--- a/tests/gates/late/run.sh
+++ b/tests/gates/late/run.sh
@@ -8945,6 +8945,34 @@ if ! grep -q '^line 11:1:' "$dupdir/twice.buf" 2>/dev/null; then
   cat "$dupdir/twice.buf" 2>/dev/null >&2 || true
   exit 1
 fi
+# ...and a FILTERED declaration sharing the duplicate's name does not shift the
+# anchor. A dropped legacy `let version: String` sits before two effective
+# `let version: Int` declarations; counting name occurrences in the raw list
+# would skip one and point at the first effective declaration -- the line the
+# reader wants to keep (Codex review on #2328). `version` is on lines 9, 11 and
+# 13; the repeat is 13.
+dup_mk vfiltered 'let version: String
+
+let version: Int
+
+let version: Int
+
+fn plain(x: Int) -> Int
+' "$dup_plain_impl"
+rm -f "$dupdir/vfiltered.buf"
+VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_DIAGNOSTICS=1 VIBE_IMPORT_ABI=raw \
+  bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
+  "$dupdir/vfiltered/index.vpkg" "$dupdir/vfiltered.buf" main >/dev/null 2>&1 || true
+if ! grep -qF "declares 'version' more than once" "$dupdir/vfiltered.buf" 2>/dev/null; then
+  echo "[compiler-gate] FAIL: two effective 'version' declarations beside a filtered one are not reported as a duplicate (#2328)" >&2
+  cat "$dupdir/vfiltered.buf" 2>/dev/null >&2 || true
+  exit 1
+fi
+if ! grep -q '^line 13:1:' "$dupdir/vfiltered.buf" 2>/dev/null; then
+  echo "[compiler-gate] FAIL: a filtered declaration sharing the name shifted the duplicate anchor off the repeat (expected line 13) (#2328)" >&2
+  cat "$dupdir/vfiltered.buf" 2>/dev/null >&2 || true
+  exit 1
+fi
 # ...and when a contract has BOTH faults, the two lanes recommend the SAME first
 # edit. The loader checked duplicates before classifying while the buffer lane
 # classified first, so one said "declared more than once" and the other

--- a/tests/gates/late/run.sh
+++ b/tests/gates/late/run.sh
@@ -8939,3 +8939,84 @@ if ! grep -q '^line 11:1:' "$dupdir/twice.buf" 2>/dev/null; then
 fi
 rm -rf "$dupdir"
 echo "[compiler-gate] a duplicated contract declaration is refused by both lanes and anchored on the repeat; the filtered version shape stays accepted ok (#2317)"
+
+# 123/123. A LOCATED type diagnostic about a materialized contract names the
+# contract, at the declaration the author wrote (#2317).
+#
+# #2324 remapped only UNLOCATED messages, because `locate_type_error` computes
+# its line against the STUB and pairing a contract path with a stub line is
+# confidently wrong. The stub now records each declaration's contract line:col
+# beside it, so a located message can be remapped honestly.
+#
+# Declaration-granular, and the assertions say so: `print_stmt` rebuilds a
+# declaration from the AST, so the column INSIDE it is gone. What is recovered
+# is which declaration -- which is what the reader acts on, and the message
+# already names the offending type parameter.
+echo "[compiler-gate] 123/123 a located contract diagnostic names the contract at its declaration (#2317)"
+mapdir="_build/_gate_decl_map"
+rm -rf "$mapdir"; mkdir -p "$mapdir/pkg" "$mapdir/clean"
+map_header='name = @gate/declmap
+version = 0.0.1
+description =
+  #|gate-only package for #2317
+deps = {}
+
+generated_hash =
+'
+map_impl='export fn a(x: Int) -> Int {
+  x + 1
+}
+'
+# `struct Box[T]` is on line 13 of this fixture; `struct T` on line 9. The
+# shadowing diagnostic is about Box, so line 13 is the answer and line 9 is the
+# decoy an off-by-one declaration mapping would produce.
+printf '%s\nstruct T {\n  a: Int\n}\n\nstruct Box[T] {\n  b: T\n}\n\nfn a(x: Int) -> Int\n' "$map_header" > "$mapdir/pkg/index.vpkg"
+printf '%s' "$map_impl" > "$mapdir/pkg/impl.vibe"
+printf '%s\nstruct P {\n  x: Int\n}\n\nfn a(x: Int) -> Int\n' "$map_header" > "$mapdir/clean/index.vpkg"
+printf '%s' "$map_impl" > "$mapdir/clean/impl.vibe"
+rm -f "$mapdir/pkg.out" "$mapdir/pkg.out.diag"
+VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_CHECK_ONLY=1 VIBE_IMPORT_ABI=raw \
+  bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
+  "$mapdir/pkg/index.vpkg" "$mapdir/pkg.out" main >/dev/null 2>&1 || true
+map_report="$(cat "$mapdir/pkg.out.diag" 2>/dev/null || true)"
+# Still fires, and still LOCATED -- either failing would make the rest vacuous.
+if ! printf '%s\n' "$map_report" | grep -qF 'shadows the declared type'; then
+  echo "[compiler-gate] FAIL: the shadowing diagnostic no longer fires -- repoint this probe (#2317)" >&2
+  printf '%s\n' "$map_report" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$map_report" | grep -q 'line [0-9]*:'; then
+  echo "[compiler-gate] FAIL: the shadowing diagnostic is no longer located -- this probe no longer tests the remap (#2317)" >&2
+  printf '%s\n' "$map_report" >&2
+  exit 1
+fi
+if printf '%s\n' "$map_report" | grep -qF 'vibe_vpkg_types/'; then
+  echo "[compiler-gate] FAIL: a located diagnostic still names the generated types module (#2317)" >&2
+  printf '%s\n' "$map_report" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$map_report" | grep -qF "$mapdir/pkg/index.vpkg"; then
+  echo "[compiler-gate] FAIL: a located diagnostic does not name the contract the author wrote (#2317)" >&2
+  printf '%s\n' "$map_report" >&2
+  exit 1
+fi
+# The DECLARATION, not merely some line of the contract. `struct Box[T]` is on
+# line 13; line 9 is the other declaration and is what an off-by-one mapping
+# would report.
+if ! printf '%s\n' "$map_report" | grep -qF ': line 13:'; then
+  echo "[compiler-gate] FAIL: the located diagnostic does not point at the declaration it is about (expected line 13) (#2317)" >&2
+  printf '%s\n' "$map_report" >&2
+  exit 1
+fi
+# ...and a contract with no such error stays clean, so a change that reported
+# every materialized package cannot pass the assertions above.
+rm -f "$mapdir/clean.out" "$mapdir/clean.out.diag"
+if ! VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_CHECK_ONLY=1 VIBE_IMPORT_ABI=raw \
+  bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
+  "$mapdir/clean/index.vpkg" "$mapdir/clean.out" main >/dev/null 2>&1; then
+  echo "[compiler-gate] FAIL: a contract with a plain transparent struct is refused -- the control is not valid (#2317)" >&2
+  cat "$mapdir/clean.out.diag" 2>/dev/null >&2 || true
+  exit 1
+fi
+rm -rf "$mapdir"
+echo "[compiler-gate] a located contract diagnostic names the contract at its own declaration; a clean contract stays clean ok (#2317)"

--- a/tests/gates/late/run.sh
+++ b/tests/gates/late/run.sh
@@ -8833,3 +8833,109 @@ if printf '%s\n' "$nested_report" | grep -qF 'NOT_THIS_FILE'; then
 fi
 rm -rf "$dpvdir" "$nesteddir"
 echo "[compiler-gate] a type diagnostic on a materialized contract names the contract when unlocated, keeps the generated path when located, ignores a hand-written provenance claim flat or nested, and a known derive stays clean ok (#2317, #2324)"
+
+# 122/122. A duplicated bodyless declaration is refused by both lanes, with a
+# message that names the duplication (#2317).
+#
+# The build already refused it -- through `contract_facade_source`, whose
+# `allocated` list is set-like while `decls` counts multiplicity, so the count
+# check trips and reports "some declarations have no implementation file" about
+# a name that IS implemented. Measured before this, `fn plain` declared twice
+# with a matching impl got exactly that: an edit that does nothing.
+#
+# Both lanes now decide it from `contract_effective_decls`, the SAME filter the
+# facade builder applies -- which is the whole point of the shared function.
+# The filter matters: a legacy `let version: String` under a real `version`
+# directive is dropped before counting, so declaring THAT twice is accepted by
+# the build, and a check counting raw declarations would refuse a contract the
+# build takes. Measured both ways.
+echo "[compiler-gate] 122/122 a duplicated contract declaration is refused by both lanes, and named (#2317)"
+dupdir="_build/_gate_contract_dup"
+rm -rf "$dupdir"; mkdir -p "$dupdir"
+dup_header='name = @gate/contractdup
+version = 0.0.1
+description =
+  #|gate-only package for #2317
+deps = {}
+
+generated_hash =
+'
+dup_mk() {
+  mkdir -p "$dupdir/$1"
+  printf '%s\n%s' "$dup_header" "$2" > "$dupdir/$1/index.vpkg"
+  printf '%s' "$3" > "$dupdir/$1/impl.vibe"
+}
+dup_plain_impl='export fn plain(x: Int) -> Int {
+  x + 1
+}
+'
+dup_mk once 'fn plain(x: Int) -> Int
+' "$dup_plain_impl"
+dup_mk twice 'fn plain(x: Int) -> Int
+
+fn plain(x: Int) -> Int
+' "$dup_plain_impl"
+# Qualified names go through the same facade allocation, so they duplicate the
+# same way. An earlier reading of this row claimed they were accepted; that
+# rested on a fixture whose impl did not match its contract at all.
+dup_mk qtwice 'fn Int::twice(x: Int) -> Int
+
+fn Int::twice(x: Int) -> Int
+' 'export fn Int::twice(x: Int) -> Int {
+  x + x
+}
+'
+# The filtered shape: a legacy `let version: String` beside a real `version`
+# directive is dropped before counting, so twice is FINE. This is the control
+# that a raw-declaration count would fail.
+dup_mk vtwice 'let version: String
+
+let version: String
+
+fn plain(x: Int) -> Int
+' "$dup_plain_impl"
+for probe in once twice qtwice vtwice; do
+  if [ "$probe" = twice ] || [ "$probe" = qtwice ]; then want="refused"; else want="clean"; fi
+  rm -f "$dupdir/$probe.imp" "$dupdir/$probe.imp.diag" "$dupdir/$probe.buf"
+  if VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_CHECK_ONLY=1 VIBE_IMPORT_ABI=raw \
+    bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
+    "$dupdir/$probe/index.vpkg" "$dupdir/$probe.imp" main >/dev/null 2>&1; then
+    imp="clean"
+  else
+    imp="refused"
+  fi
+  VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_DIAGNOSTICS=1 VIBE_IMPORT_ABI=raw \
+    bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
+    "$dupdir/$probe/index.vpkg" "$dupdir/$probe.buf" main >/dev/null 2>&1 || true
+  if [ -s "$dupdir/$probe.buf" ]; then buf="refused"; else buf="clean"; fi
+  if [ "$imp" != "$want" ] || [ "$buf" != "$want" ]; then
+    echo "[compiler-gate] FAIL: contract '$probe' -- import lane says $imp, buffer lane says $buf, both should say $want (#2317)" >&2
+    cat "$dupdir/$probe.imp.diag" 2>/dev/null >&2 || true
+    cat "$dupdir/$probe.buf" 2>/dev/null >&2 || true
+    exit 1
+  fi
+done
+# The message must name the DUPLICATION. "no implementation file" is the old
+# answer, and it points the reader at an edit that does nothing.
+for lane in imp.diag buf; do
+  if ! grep -qF "declares 'plain' more than once" "$dupdir/twice.$lane" 2>/dev/null; then
+    echo "[compiler-gate] FAIL: the $lane lane does not name the duplication for a repeated declaration (#2317)" >&2
+    cat "$dupdir/twice.$lane" 2>/dev/null >&2 || true
+    exit 1
+  fi
+  if grep -qF 'no implementation file' "$dupdir/twice.$lane" 2>/dev/null; then
+    echo "[compiler-gate] FAIL: the $lane lane still blames a missing implementation for a duplicate (#2317)" >&2
+    cat "$dupdir/twice.$lane" 2>/dev/null >&2 || true
+    exit 1
+  fi
+done
+# Anchored on the REPEAT, not on the first declaration. `fn plain` is on lines
+# 9 and 11 of the generated fixture; pointing at 9 would send the reader to the
+# declaration they want to keep.
+if ! grep -q '^line 11:1:' "$dupdir/twice.buf" 2>/dev/null; then
+  echo "[compiler-gate] FAIL: the duplicate is not anchored on the repeated declaration (expected line 11) (#2317)" >&2
+  cat "$dupdir/twice.buf" 2>/dev/null >&2 || true
+  exit 1
+fi
+rm -rf "$dupdir"
+echo "[compiler-gate] a duplicated contract declaration is refused by both lanes and anchored on the repeat; the filtered version shape stays accepted ok (#2317)"

--- a/tests/gates/late/run.sh
+++ b/tests/gates/late/run.sh
@@ -8721,35 +8721,43 @@ if ! VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_CHECK_ONLY=1 VIBE_IMPORT_ABI=raw \
   cat "$dpvdir/clean.out.diag" 2>/dev/null >&2 || true
   exit 1
 fi
-# ...and a LOCATED diagnostic keeps the generated path (Codex review on #2324).
+# The LOCATED case moved to section 123 (#2317). This section asserted that a
+# located diagnostic must NOT name the contract, which was right while the stub
+# recorded no declaration positions: `locate_type_error` computes its line
+# against the STUB, and pairing a contract path with a stub line is confidently
+# wrong. The stub now records each declaration's contract line:col, so the
+# remap is honest and section 123 asserts it -- including that the reported
+# line is the declaration's own.
 #
-# `locate_type_error` computes its line against the STUB's source, and the stub
-# carries neither the contract's header nor its formatting. Renaming a located
-# message to the contract pairs a file the author wrote with a line number from
-# a generated one -- confidently wrong, which outranks unhelpful.
-#
-# Measured on this fixture: `struct Box[T]` is on line 13 of the contract, and
-# the diagnostic reads `line 4:15-18`. Line 4 of the contract is inside its
-# `description` block, so the rename would point at an unrelated line.
-mkdir -p "$dpvdir/located"
-printf '%s\nstruct T {\n  a: Int\n}\n\nstruct Box[T] {\n  b: T\n}\n\nfn a(x: Int) -> Int\n' "$dpv_header" > "$dpvdir/located/index.vpkg"
-printf '%s' "$dpv_impl" > "$dpvdir/located/impl.vibe"
-rm -f "$dpvdir/located.out" "$dpvdir/located.out.diag"
+# Kept as one assertion rather than deleted outright: whatever else changes,
+# a located diagnostic must not end up pointing at a file with a line from
+# somewhere else, and the two sections must not both claim to own this. 123
+# owns the positive; this owns the fallback, where a stub carries provenance
+# but no declaration markers and therefore keeps its own path AND its own line
+# together. That is the shape every stub written before those markers has.
+locmarker="$dpvdir/nomarker"
+mkdir -p "$locmarker/_build/vibe_vpkg_types"
+locstub="_build/vibe_vpkg_types/types_nomarkerprobe.vibe"
+rm -f "$locstub"
+printf '// vibe: vpkg contract types module (#1840)\n// vibe: generated from %s/pkg/index.vpkg\nstruct T {\n  a: Int\n}\n\nstruct Box[T] {\n  b: T\n}\n\nfn main() -> Int {\n  0\n}\n' "$dpvdir" > "$locstub"
+rm -f "$dpvdir/nomarker.out" "$dpvdir/nomarker.out.diag"
 VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_CHECK_ONLY=1 VIBE_IMPORT_ABI=raw \
   bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
-  "$dpvdir/located/index.vpkg" "$dpvdir/located.out" main >/dev/null 2>&1 || true
-loc_report="$(cat "$dpvdir/located.out.diag" 2>/dev/null || true)"
-# It must still be the LOCATED shape, or this probe stops testing the guard.
-if ! printf '%s\n' "$loc_report" | grep -q 'line [0-9]*:'; then
-  echo "[compiler-gate] FAIL: the shadowing diagnostic is no longer located -- repoint this probe, it no longer exercises the guard (#2324)" >&2
-  printf '%s\n' "$loc_report" >&2
+  "$locstub" "$dpvdir/nomarker.out" main >/dev/null 2>&1 || true
+nomarker_report="$(cat "$dpvdir/nomarker.out.diag" 2>/dev/null || true)"
+if ! printf '%s\n' "$nomarker_report" | grep -q 'line [0-9]*:'; then
+  echo "[compiler-gate] FAIL: the marker-less stub produced no located diagnostic -- repoint this probe (#2317)" >&2
+  printf '%s\n' "$nomarker_report" >&2
+  rm -f "$locstub"
   exit 1
 fi
-if printf '%s\n' "$loc_report" | grep -qF "$dpvdir/located/index.vpkg"; then
-  echo "[compiler-gate] FAIL: a LOCATED diagnostic was renamed to the contract, pairing it with a line from the generated stub (#2324)" >&2
-  printf '%s\n' "$loc_report" >&2
+if printf '%s\n' "$nomarker_report" | grep -qF "$dpvdir/pkg/index.vpkg"; then
+  echo "[compiler-gate] FAIL: a stub with NO declaration markers had its located diagnostic renamed to the contract, pairing it with a stub line (#2317)" >&2
+  printf '%s\n' "$nomarker_report" >&2
+  rm -f "$locstub"
   exit 1
 fi
+rm -f "$locstub"
 # ...and a HAND-WRITTEN module that merely claims generated provenance is not
 # believed (Codex review on #2324).
 #

--- a/tests/gates/late/run.sh
+++ b/tests/gates/late/run.sh
@@ -8937,8 +8937,35 @@ if ! grep -q '^line 11:1:' "$dupdir/twice.buf" 2>/dev/null; then
   cat "$dupdir/twice.buf" 2>/dev/null >&2 || true
   exit 1
 fi
+# ...and when a contract has BOTH faults, the two lanes recommend the SAME first
+# edit. The loader checked duplicates before classifying while the buffer lane
+# classified first, so one said "declared more than once" and the other
+# "unsupported statement" about the same file (Codex review on #2328) -- a
+# fresh instance of the divergence this work exists to close.
+dup_mk both 'fn plain(x: Int) -> Int
+
+fn plain(x: Int) -> Int
+
+export let z: Int = 5
+' "$dup_plain_impl"
+rm -f "$dupdir/both.imp" "$dupdir/both.imp.diag" "$dupdir/both.buf"
+VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_CHECK_ONLY=1 VIBE_IMPORT_ABI=raw \
+  bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
+  "$dupdir/both/index.vpkg" "$dupdir/both.imp" main >/dev/null 2>&1 || true
+VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_DIAGNOSTICS=1 VIBE_IMPORT_ABI=raw \
+  bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
+  "$dupdir/both/index.vpkg" "$dupdir/both.buf" main >/dev/null 2>&1 || true
+# Both must lead with the unsupported statement: it is the more basic fault,
+# and the point is that they AGREE, not which one wins.
+for lane in imp.diag buf; do
+  if ! grep -qF 'unsupported statement in a contract file' "$dupdir/both.$lane" 2>/dev/null; then
+    echo "[compiler-gate] FAIL: with a duplicate AND an unsupported statement, the $lane lane does not lead with the unsupported statement (#2328)" >&2
+    cat "$dupdir/both.$lane" 2>/dev/null >&2 || true
+    exit 1
+  fi
+done
 rm -rf "$dupdir"
-echo "[compiler-gate] a duplicated contract declaration is refused by both lanes and anchored on the repeat; the filtered version shape stays accepted ok (#2317)"
+echo "[compiler-gate] a duplicated contract declaration is refused by both lanes and anchored on the repeat; the filtered version shape stays accepted; both lanes agree on precedence ok (#2317, #2328)"
 
 # 123/123. A LOCATED type diagnostic about a materialized contract names the
 # contract, at the declaration the author wrote (#2317).

--- a/tests/gates/registry.tsv
+++ b/tests/gates/registry.tsv
@@ -239,3 +239,4 @@ x-adr-0090-1937-exception-unwind-region-restore	late	ADR-0090 #1937 exception-un
 119/119	late	119/119 the buffer lane reports an unknown derive, and agrees with the build (#2317)
 120/120	late	120/120 an unsupported contract statement is anchored on that statement (#2317)
 121/121	late	121/121 a type diagnostic names the contract, not the generated types module (#2317)
+122/122	late	122/122 a duplicated contract declaration is refused by both lanes, and named (#2317)

--- a/tests/gates/registry.tsv
+++ b/tests/gates/registry.tsv
@@ -240,3 +240,4 @@ x-adr-0090-1937-exception-unwind-region-restore	late	ADR-0090 #1937 exception-un
 120/120	late	120/120 an unsupported contract statement is anchored on that statement (#2317)
 121/121	late	121/121 a type diagnostic names the contract, not the generated types module (#2317)
 122/122	late	122/122 a duplicated contract declaration is refused by both lanes, and named (#2317)
+123/123	late	123/123 a located contract diagnostic names the contract at its declaration (#2317)


### PR DESCRIPTION
#2317's remaining structural items: *name the buffer-decidable subset in one function both lanes call, so a check added later cannot land in only one of them*, and *map a located diagnostic on the materialized types module back to the contract*. Both are here.

## The row was withdrawn on a measurement that was wrong

#2317 recorded that a duplicated **qualified** declaration is accepted by the build while an unqualified one is refused — so a buffer-side check would reject contracts the build takes. That was my conclusion, and it was wrong: the fixture behind it had an implementation exporting a name its contract never declared, so it was refused for **conformance** and said nothing about duplication.

Re-measured, with implementations that actually match their contracts:

| contract | import lane |
|---|---|
| `fn plain` once + matching impl | clean |
| `fn plain` **twice** + same impl | refused |
| `fn Int::twice` once + matching impl | clean |
| `fn Int::twice` **twice** + same impl | refused |

Both spellings duplicate identically. The row was decidable all along.

## The exception that is real — and why it forced a shared function

A legacy `let version: String` beside a real `version` directive is dropped before the facade counts declarations (#1054), so declaring **that** twice is accepted. Measured. A check counting raw declarations would refuse a contract the build takes.

That filter lived inline in `desugar_contract_source_fs`, which is exactly why the buffer lane could not reproduce it. It is now `contract_effective_decls`, called by the loader and the buffer lane — one list, so the two cannot disagree about which shapes count.

## The message was misleading

The build refused a duplicate through `contract_facade_source`, whose `allocated` list is set-like while `decls` counts multiplicity. The count check trips and reports:

```
contract facade: some declarations have no implementation file (run check_contract first)
```

…about a name that **is** implemented. The reader is handed an edit that does nothing. Both lanes now say `contract declares 'plain' more than once`. Nothing else in the tree depended on the old wording.

The buffer lane anchors on the **repeat**, not the first declaration — pointing at the first would send the reader to the one they want to keep. Declaration offsets come out of the parser the way statement spans do, paired through one push so the arrays cannot desync, with a length check refusing to return arrays that disagree.

## A false positive my own gate caught

The `vtwice` control failed on the first build: the buffer lane refused the filtered `version` shape. Measured rather than guessed —

```
extract_package_version(raw)     == "0.0.1"
extract_package_version(blanked) == ""
```

`collect_all_diagnostics_on` receives the pin-blanked twin, and `scan_package_header` blanks every directive it recognizes. The filter saw no directive and called the repeat a duplicate. The version is now read where the raw source is still in hand.

Worth stating: this is the exact false-positive class the shared filter exists to prevent, and it landed anyway because I passed the wrong string. **A gate that only checked that bad contracts are refused would have shipped it** — it was caught solely by the control asserting a valid contract stays clean.

## Gate (section 122)

Four contracts across both lanes: `once` (clean), `twice` (refused), `qtwice` (refused), and `vtwice` — the filtered shape that must stay **accepted**. Plus the message assertions (names the duplication; no longer blames a missing implementation) and the anchor on the repeat.

**Verified red on main**: `twice` — import refused, buffer clean.

Each assertion mutation-tested and landing on its own message: wrong anchor line; the `twice` fixture reduced to one declaration; and a real duplicate added to the `vtwice` control, which then has both lanes refusing *in agreement* while the control correctly fires.

## The second half: a located diagnostic names the contract at its declaration

The body above was written when this branch held only the shared-filter work. It
now also carries #2317's other remaining item, so the "what remains" section it
ended with is out of date and is replaced by this one.

#2324 renamed **unlocated** diagnostics to the contract and deliberately stopped
there: `locate_type_error` computes its line against the *stub's* source, so
pairing the contract's path with the stub's line would be confidently wrong —
a contract whose `struct Box[T]` sits on line 13 reported `line 4:15`, and line 4
of that contract is inside its `description` block.

The generator now emits the mapping, so the located case works too. Each stub
declaration is preceded by a `// vibe: decl-at <line>:<col>` marker recording
where that declaration sits **in the contract**, rendered at generation time by
the same `offset_to_line_col` the diagnostic renderer uses — so the two agree on
what a column is (1-based bytes, ADR-0108). The reader takes the nearest
preceding marker, which makes it robust to the printer rendering a declaration
onto more lines than the contract used.

Carried **in-band**, in the generated module's own text, for the same reason
#2324's provenance marker is: a types module is also checked by an isolated
worker under `VIBE_MODULE_JOB_DIR` that never runs the loader, and a
process-local registry answers empty there. Two lanes answering differently
about one file is this issue's own bug.

### Three defects, one cause

All three came from re-deriving a correspondence instead of carrying it:

- **a token index rendered as a byte offset.** `stmt_at` holds token indices;
  `offset_to_line_col` takes bytes. A declaration on line 13 reported
  `line 1:8` — index 8 read as offset 8. Fixed by threading `starts` from
  `lex_with_offsets`, which is the conversion the rest of the file already used.
- **a cached stub judged fresh on the provenance marker alone**, so a stub
  generated before this change kept its old text and the located remap silently
  did nothing. Freshness now requires *both* markers.
- **the effective index recounted by name.** With a filtered `let version:
  String` beside two effective `version` declarations, counting occurrences in
  the raw list skips one and anchors on the first declaration — the one the
  reader wants to keep. Replaced by `contract_effective_decl_indices`, which
  maps effective index to raw index directly.

The third was caught by the `vfiltered` control, not by any assertion that a
bad contract is refused.

### Escaping, both directions

A POSIX path may contain a newline. Raw, it would end the `//` comment and turn
the rest of the path into generated source; decoded into a diagnostic, it would
split one record across lines. `vpkg_path_escape_one_line` is used for both
storage and display, and the marker is trusted only for a path the loader can
actually produce (the `_build/vibe_vpkg_types/types_` prefix plus a complete
`[0-9A-Za-z_]+.vibe` basename).

## Gate (sections 121, 123)

Section 123 asserts the located remap end to end: a contract whose declaration
is on line 13, with **line 9 as a decoy**, so an off-by-one or a nearest-wins
bug lands on a different number rather than passing. Section 121 keeps the
marker-less fallback — a stub with no marker keeps its own path and line, since
a self-consistent (generated file, generated line) pair beats a (real file,
generated line) one. The two sections contradicted each other on the first
attempt and CI caught it; 121 was repointed so each owns one half.

## Verification (whole branch)

- fixpoint build (`stage2 == stage3`), FIXPOINT_OK
- unit tests 13/13 against that fixpoint stage2
- all 28 CI checks green on this head, including `compiler-gate (late)`,
  which is the job that runs sections 117–123
- post-merge: the full late lane re-run against that fixpoint stage2 is green
  end to end (`rc=0`), sections 117–123 included

## #2317 stays open — and a correction to this PR's own earlier claim

This PR lands both items #2317 lists under *what remains*. It does not close the
issue, which still carries rows outside this scope.

An earlier revision of this body claimed that #2317's "a field type that does not
exist" row was mis-recorded — that the import lane refuses `struct Bad { x: Intt }`
while the buffer lane calls it clean. **That was wrong.** The probe contract lived
outside the repository root, where no types module is materialized at all, so
nothing defers the name and the checker's raw `unknown type` surfaces. With the
identical contract inside the tree, the types module is generated, carries
`"Bad : Intt"` in the deferred sentinel, and **both lanes are clean** — exactly
what the issue records.

The real residual (a typo inside a contract's transparent types staying a
wildcard) is #2164, with #2327 open against it. Retracted on the issue.