### PR TITLE
Stamp the freeing seq on shadow RC UAF traps (#1987)

### DIFF
--- a/lib/@vibe/compiler/codegen/builtin_bodies/bodies_core_a1a2.vibe
+++ b/lib/@vibe/compiler/codegen/builtin_bodies/bodies_core_a1a2.vibe
@@ -36,6 +36,9 @@ import @vibe/compiler/codegen/common_base {
   emit_i64_load,
   emit_i64_store,
   emit_rc_dup_inline,
+  emit_shadow_bump_seq,
+  emit_shadow_mark_freed,
+  emit_shadow_uaf_trap,
   emit_str_ref,
   expr_tag,
   get_arm_body,
@@ -672,13 +675,13 @@ fn emit_rc_free_push(b: Bytes, ptr_local: Int, bins_base: Int) -> Unit {
 /// disagree about what a dup does, including the VIBE_RC=shadow
 /// freed-block trap, which is baked in here per module instead of at every
 /// site.
-export fn gen_rc_dup_body(rc_shadow: Bool) -> Bytes {
+export fn gen_rc_dup_body(rc_shadow: Bool, uaf_abort_idx: Int, prefix_fat: Int) -> Bytes {
   let b = bytebuf_new()
-  emit_rc_dup_inline(b, 0, rc_shadow)
+  emit_rc_dup_inline(b, 0, rc_shadow, uaf_abort_idx, prefix_fat)
   b
 }
 
-export fn gen_rc_drop_body(self_idx: Int, rc_shadow: Bool, bins_base: Int) -> Bytes {
+export fn gen_rc_drop_body(self_idx: Int, rc_shadow: Bool, bins_base: Int, uaf_abort_idx: Int, prefix_fat: Int) -> Bytes {
   let b = bytebuf_new()
   // not a heap pointer (even) → nothing to do
   emit_local_get(b, 0)
@@ -710,14 +713,18 @@ export fn gen_rc_drop_body(self_idx: Int, rc_shadow: Bool, bins_base: Int) -> By
   // shadow byte says this block is already freed. For a freed block, vptr-4
   // is the free-list NEXT link, so a drop-of-freed would silently corrupt the
   // list (decrement the link) and usually return without reaching zero --
-  // the entry check is the only reliable place to catch it.
+  // the entry check is the only reliable place to catch it. #1987: name the
+  // current seq and the freeing seq instead of a bare unreachable.
   if rc_shadow {
+    emit_shadow_bump_seq(b)
     emit_local_get(b, 1)
     emit_i32_const(b, rc_shadow_base())
     emit_i32_add(b)
     emit_i32_load8_u(b, 0, 0)
     emit_if_void(b)
-    bytebuf_push(b, 0)
+    emit_shadow_uaf_trap(b, () -> {
+      emit_local_get(b, 1)
+    }, uaf_abort_idx, prefix_fat)
     emit_end(b)
   } else {
     ()
@@ -857,18 +864,18 @@ export fn gen_rc_drop_body(self_idx: Int, rc_shadow: Bool, bins_base: Int) -> By
     emit_i32_add(b)
     emit_i32_load8_u(b, 0, 0)
     emit_if_void(b)
-    bytebuf_push(b, 0)
+    emit_shadow_uaf_trap(b, () -> {
+      emit_local_get(b, 5)
+    }, uaf_abort_idx, prefix_fat)
     emit_end(b)
   } else {
     ()
   }
-  // #715 recurrence guard (VIBE_RC=shadow): mark the grown buffer freed.
+  // #715 / #1987: mark the grown buffer freed and stamp the freeing seq.
   if rc_shadow {
-    emit_local_get(b, 5)
-    emit_i32_const(b, rc_shadow_base())
-    emit_i32_add(b)
-    emit_i32_const(b, 1)
-    emit_i32_store8(b, 0, 0)
+    emit_shadow_mark_freed(b, () -> {
+      emit_local_get(b, 5)
+    })
   } else {
     ()
   }
@@ -984,15 +991,12 @@ export fn gen_rc_drop_body(self_idx: Int, rc_shadow: Bool, bins_base: Int) -> By
   emit_end(b)
   emit_end(b)
   emit_end(b)
-  // #715 recurrence guard (VIBE_RC=shadow): mark this block freed so a later
-  // dup-of-freed (emit_rc_dup_guarded) or drop-of-freed (entry check above)
-  // traps deterministically at the faulting operation.
+  // #715 / #1987: mark this block freed and stamp the freeing seq so a later
+  // dup-of-freed or drop-of-freed can name both ends.
   if rc_shadow {
-    emit_local_get(b, 1)
-    emit_i32_const(b, rc_shadow_base())
-    emit_i32_add(b)
-    emit_i32_const(b, 1)
-    emit_i32_store8(b, 0, 0)
+    emit_shadow_mark_freed(b, () -> {
+      emit_local_get(b, 1)
+    })
   } else {
     ()
   }

--- a/lib/@vibe/compiler/codegen/builtin_bodies/index.vpkg
+++ b/lib/@vibe/compiler/codegen/builtin_bodies/index.vpkg
@@ -46,8 +46,8 @@ fn gen_arr_new_body(enable_rc: Bool, rc_alloc_idx: Int) -> Bytes
 fn gen_region_arr_new_body(region_ptr_addr: Int, region_data_base: Int, region_limit: Int) -> Bytes
 fn gen_region_bytes_new_body(region_ptr_addr: Int, region_data_base: Int, region_limit: Int) -> Bytes
 fn gen_arr_set_body(enable_rc: Bool, oob_prefix_fat: Int, oob_abort_idx: Int) -> Bytes
-fn gen_rc_drop_body(self_idx: Int, rc_shadow: Bool, bins_base: Int) -> Bytes
-fn gen_rc_dup_body(rc_shadow: Bool) -> Bytes
+fn gen_rc_drop_body(self_idx: Int, rc_shadow: Bool, bins_base: Int, uaf_abort_idx: Int, prefix_fat: Int) -> Bytes
+fn gen_rc_dup_body(rc_shadow: Bool, uaf_abort_idx: Int, prefix_fat: Int) -> Bytes
 fn gen_rc_alloc_body(rc_shadow: Bool, bins_base: Int) -> Bytes
 fn gen_str_len_body(enable_rc: Bool) -> Bytes
 fn gen_arr_push_body(enable_rc: Bool, rc_alloc_idx: Int, rc_shadow: Bool, arena_ptr_addr: Int, arena_data_base: Int, arena_limit: Int) -> Bytes

--- a/lib/@vibe/compiler/codegen/common_base/common_base.vibe
+++ b/lib/@vibe/compiler/codegen/common_base/common_base.vibe
@@ -2387,6 +2387,59 @@ export fn rc_shadow_reserve() -> Int {
   536870912
 }
 
+/// Sequence counter at the start of the byte table. Heap vptrs begin at
+/// `heap_start` (>= 64 KiB), so bytes 0..3 are unused as a mark.
+export fn rc_shadow_seq_addr() -> Int {
+  rc_shadow_base()
+}
+
+export fn emit_shadow_bump_seq(buf: Bytes) -> Unit {
+  emit_i32_const(buf, rc_shadow_seq_addr())
+  emit_i32_const(buf, rc_shadow_seq_addr())
+  emit_i32_load(buf, 2, 0)
+  emit_i32_const(buf, 1)
+  emit_i32_add(buf)
+  emit_i32_store(buf, 2, 0)
+}
+
+/// Print `<prefix><current_seq>; freed at site <stored>\n` then trap.
+/// `uaf_abort_idx < 0` keeps the historical bare `unreachable`.
+export fn emit_shadow_uaf_trap(buf: Bytes, push_vptr: () -> Unit, uaf_abort_idx: Int, prefix_fat: Int) -> Unit {
+  if uaf_abort_idx < 0 {
+    bytebuf_push(buf, 0)
+  } else {
+    emit_i64_const(buf, prefix_fat)
+    emit_i32_const(buf, rc_shadow_seq_addr())
+    emit_i32_load(buf, 2, 0)
+    emit_i64_extend_i32_s(buf)
+    push_vptr()
+    emit_i32_const(buf, 4)
+    emit_i32_add(buf)
+    emit_i32_const(buf, rc_shadow_base())
+    emit_i32_add(buf)
+    emit_i32_load(buf, 2, 0)
+    emit_i64_extend_i32_s(buf)
+    emit_call(buf, uaf_abort_idx)
+  }
+}
+
+export fn emit_shadow_mark_freed(buf: Bytes, push_vptr: () -> Unit) -> Unit {
+  // vptrs are 8-aligned, so +4 sits between this mark byte and the next.
+  push_vptr()
+  emit_i32_const(buf, 4)
+  emit_i32_add(buf)
+  emit_i32_const(buf, rc_shadow_base())
+  emit_i32_add(buf)
+  emit_i32_const(buf, rc_shadow_seq_addr())
+  emit_i32_load(buf, 2, 0)
+  emit_i32_store(buf, 2, 0)
+  push_vptr()
+  emit_i32_const(buf, rc_shadow_base())
+  emit_i32_add(buf)
+  emit_i32_const(buf, 1)
+  emit_i32_store8(buf, 0, 0)
+}
+
 /// #720: the rc field is the LOW 24 BITS of the rc word (the class id lives in
 /// the high byte of the same word at vptr-1). A raw `store(load(addr)+1)` at
 /// rc == 0xFFFFFF carries into the class byte and wraps rc to 0 -- a couple of
@@ -2448,7 +2501,7 @@ export fn emit_rc_dup_guarded(buf: Bytes, local_idx: Int, rc_shadow: Bool, dup_f
   if dup_fn_idx >= 0 {
     emit_rc_dup_tagtest_call(buf, local_idx, dup_fn_idx)
   } else {
-    emit_rc_dup_inline(buf, local_idx, rc_shadow)
+    emit_rc_dup_inline(buf, local_idx, rc_shadow, 0 - 1, 0)
   }
 }
 
@@ -2496,7 +2549,7 @@ fn emit_rc_dup_tagtest_call(buf: Bytes, local_idx: Int, dup_fn_idx: Int) -> Unit
 /// The guard expanded in place. Kept as the single definition of what a dup
 /// MEANS: gen_rc_dup_body builds the out-of-line helper by calling this with
 /// local 0, so the two forms cannot drift apart.
-export fn emit_rc_dup_inline(buf: Bytes, local_idx: Int, rc_shadow: Bool) -> Unit {
+export fn emit_rc_dup_inline(buf: Bytes, local_idx: Int, rc_shadow: Bool, uaf_abort_idx: Int, prefix_fat: Int) -> Unit {
   emit_local_get(buf, local_idx)
   emit_i64_const(buf, 1)
   emit_i64_and(buf)
@@ -2507,10 +2560,12 @@ export fn emit_rc_dup_inline(buf: Bytes, local_idx: Int, rc_shadow: Bool) -> Uni
   emit_i64_shr_s(buf)
   emit_i64_eqz(buf)
   emit_if_void(buf)
-  // #715 recurrence guard (VIBE_RC=shadow): trap via `unreachable` if the
-  // shadow byte at RC_SHADOW_BASE+vptr says this block was already freed --
-  // a dup-of-freed would otherwise increment the free-list NEXT link.
+  // #715 recurrence guard (VIBE_RC=shadow): trap if the shadow byte at
+  // RC_SHADOW_BASE+vptr says this block was already freed -- a dup-of-freed
+  // would otherwise increment the free-list NEXT link. #1987: the trap names
+  // the current seq and the freeing seq, not a bare unreachable.
   if rc_shadow {
+    emit_shadow_bump_seq(buf)
     emit_local_get(buf, local_idx)
     emit_i64_const(buf, -2)
     emit_i64_and(buf)
@@ -2519,7 +2574,12 @@ export fn emit_rc_dup_inline(buf: Bytes, local_idx: Int, rc_shadow: Bool) -> Uni
     emit_i32_add(buf)
     emit_i32_load8_u(buf, 0, 0)
     emit_if_void(buf)
-    bytebuf_push(buf, 0)
+    emit_shadow_uaf_trap(buf, () -> {
+      emit_local_get(buf, local_idx)
+      emit_i64_const(buf, -2)
+      emit_i64_and(buf)
+      emit_i32_wrap_i64(buf)
+    }, uaf_abort_idx, prefix_fat)
     emit_end(buf)
   } else {
     ()

--- a/lib/@vibe/compiler/codegen/common_base/index.vpkg
+++ b/lib/@vibe/compiler/codegen/common_base/index.vpkg
@@ -203,9 +203,13 @@ fn emit_region_try_epilogue(buf: Bytes, region_ptr_addr: Int, catch_tag: Int) ->
 fn region_max_depth() -> Int
 fn rc_shadow_base() -> Int
 fn rc_shadow_reserve() -> Int
+fn rc_shadow_seq_addr() -> Int
+fn emit_shadow_bump_seq(buf: Bytes) -> Unit
+fn emit_shadow_uaf_trap(buf: Bytes, push_vptr: () -> Unit, uaf_abort_idx: Int, prefix_fat: Int) -> Unit
+fn emit_shadow_mark_freed(buf: Bytes, push_vptr: () -> Unit) -> Unit
 fn emit_rc_word_inc_saturating(buf: Bytes, push_addr: () -> Unit) -> Unit
 fn emit_rc_dup_guarded(buf: Bytes, local_idx: Int, rc_shadow: Bool, dup_fn_idx: Int) -> Unit
-fn emit_rc_dup_inline(buf: Bytes, local_idx: Int, rc_shadow: Bool) -> Unit
+fn emit_rc_dup_inline(buf: Bytes, local_idx: Int, rc_shadow: Bool, uaf_abort_idx: Int, prefix_fat: Int) -> Unit
 fn fn_type_param_types(ty: Option[TypeExpr]) -> Option[Array[TypeExpr]]
 fn is_nullary_ctor_ident(value: Expr, ct: CtorTable) -> Bool
 fn name_has_effect_prefix(full: String, eff: String) -> Bool

--- a/lib/@vibe/compiler/codegen/wasi/linked_compile.vibe
+++ b/lib/@vibe/compiler/codegen/wasi/linked_compile.vibe
@@ -4181,6 +4181,25 @@ export fn compile_wasi_module_linked_impl_with_float_offsets(stmts: Array[Stmt],
   if !array_contains_str(str_strs, "\n") {
     Array::push(str_strs, "\n")
   }
+  if rc_shadow {
+    if !array_contains_str(str_strs, "dup of freed value at site ") {
+      Array::push(str_strs, "dup of freed value at site ")
+    } else {
+      ()
+    }
+    if !array_contains_str(str_strs, "drop of freed value at site ") {
+      Array::push(str_strs, "drop of freed value at site ")
+    } else {
+      ()
+    }
+    if !array_contains_str(str_strs, "; freed at site ") {
+      Array::push(str_strs, "; freed at site ")
+    } else {
+      ()
+    }
+  } else {
+    ()
+  }
   let src_str_base = Array::length(str_strs)
   let num_src_pairs = Array::length(srcs)
   let mut __src_i = 0
@@ -5152,11 +5171,23 @@ export fn compile_wasi_module_linked_impl_with_float_offsets(stmts: Array[Stmt],
   // number, which is order-independent.
   let print_i64_raw_idx = map_probe_index_idx + 1
   let oob_abort_idx = print_i64_raw_idx + 1
+  // #1987: shadow-only UAF abort reuses gen_oob_abort_body with a different
+  // middle fragment. Off when rc_shadow is false so a normal RC build stays
+  // byte-identical (ADR-0062).
+  let shadow_uaf_abort_idx = if rc_shadow {
+    oob_abort_idx + 1
+  } else {
+    0 - 1
+  }
   // ADR-0090 (#1262) region arena bodies. Registered LAST and only when the
   // module has a region, so a module without one is byte-identical to what it
   // was before the arena existed (and max_builtin_func_idx below follows).
   let region_arr_new_idx = if need_region_arena {
-    oob_abort_idx + 1
+    (if rc_shadow {
+      shadow_uaf_abort_idx
+    } else {
+      oob_abort_idx
+    }) + 1
   } else {
     -1
   }
@@ -5503,6 +5534,8 @@ export fn compile_wasi_module_linked_impl_with_float_offsets(stmts: Array[Stmt],
   // user-function call target in the module by the number of builtins added).
   let max_builtin_func_idx = if need_region_arena {
     region_bytes_new_idx
+  } else if rc_shadow {
+    shadow_uaf_abort_idx
   } else {
     oob_abort_idx
   }
@@ -5946,10 +5979,20 @@ export fn compile_wasi_module_linked_impl_with_float_offsets(stmts: Array[Stmt],
   push_builtin(gen_bytes_slice_body(enable_rc, bytes_new_idx, bytes_get_idx, bytes_push_idx), 2, 1, 8)
   push_builtin(gen_bytes_from_array_body(enable_rc, arr_len_idx, arr_get_idx, bytes_new_idx, bytes_push_idx), 2, 1, 3)
   push_builtin(gen_bytes_to_array_body(enable_rc, arr_new_idx, arr_push_idx, bytes_len_idx, bytes_get_idx), 2, 1, 3)
+  let uaf_dup_fat = if rc_shadow {
+    oob_fat_of("dup of freed value at site ")
+  } else {
+    0
+  }
+  let uaf_drop_fat = if rc_shadow {
+    oob_fat_of("drop of freed value at site ")
+  } else {
+    0
+  }
   if enable_rc {
-    push_builtin(gen_rc_drop_body(rc_drop_idx, rc_shadow, rc_bins_base), 5, 1, 1)
+    push_builtin(gen_rc_drop_body(rc_drop_idx, rc_shadow, rc_bins_base, shadow_uaf_abort_idx, uaf_drop_fat), 5, 1, 1)
     push_builtin(gen_rc_alloc_body(rc_shadow, rc_bins_base), 5, 0, 3)
-    push_builtin(gen_rc_dup_body(rc_shadow), 0, 0, 1)
+    push_builtin(gen_rc_dup_body(rc_shadow, shadow_uaf_abort_idx, uaf_dup_fat), 0, 0, 1)
   } else {
     ()
   }
@@ -5972,6 +6015,11 @@ export fn compile_wasi_module_linked_impl_with_float_offsets(stmts: Array[Stmt],
   // oob_abort_idx slot order fixed above.
   push_builtin(gen_print_i64_raw_body(), 3, 1, 1)
   push_builtin(gen_oob_abort_body(print_str_idx, print_i64_raw_idx, oob_mid_fat, oob_nl_fat), 0, 0, 7)
+  if rc_shadow {
+    push_builtin(gen_oob_abort_body(print_str_idx, print_i64_raw_idx, oob_fat_of("; freed at site "), oob_nl_fat), 0, 0, 7)
+  } else {
+    ()
+  }
   // ADR-0090 (#1262): must stay LAST, in this order -- max_builtin_func_idx
   // above names region_bytes_new_idx (= region_arr_new_idx + 1) as the final
   // builtin, and num_generated/func_offset are derived from it.
@@ -8578,6 +8626,11 @@ export fn compile_wasi_module_linked_impl_with_float_offsets(stmts: Array[Stmt],
   Array::set(gen_sec_names, compact_fingerprint_hash_idx - num_imported_funcs, "__rt_compact_fingerprint_hash")
   Array::set(gen_sec_names, print_i64_raw_idx - num_imported_funcs, "__rt_print_i64_raw")
   Array::set(gen_sec_names, oob_abort_idx - num_imported_funcs, "__rt_oob_abort")
+  if rc_shadow {
+    Array::set(gen_sec_names, shadow_uaf_abort_idx - num_imported_funcs, "__rt_shadow_uaf_abort")
+  } else {
+    ()
+  }
   let name_sec_names = gen_sec_names
   let mut usn_i = 0
   while usn_i < num_user_funcs {

--- a/lib/@vibe/compiler/tests/builtin_bodies_test.vibe
+++ b/lib/@vibe/compiler/tests/builtin_bodies_test.vibe
@@ -9,6 +9,8 @@ import @vibe/compiler/codegen/builtin_bodies {
   gen_oob_abort_body,
   gen_print_i64_body,
   gen_print_i64_raw_body,
+  gen_rc_drop_body,
+  gen_rc_dup_body,
   gen_simd_scan_string_special_body,
   gen_str_char_code_at_body,
   gen_str_eq_body,
@@ -91,6 +93,12 @@ test "print_i64_raw drops exactly the newline emission" {
   // at scratch address 47 (three instructions); everything else is shared.
   assert(Bytes::length(gen_print_i64_raw_body()) > 0)
   assert(Bytes::length(gen_print_i64_raw_body()) < Bytes::length(gen_print_i64_body()))
+}
+
+test "shadow UAF abort form is strictly larger than a bare unreachable" {
+  // #1987: naming the freeing seq adds the abort call in place of `unreachable`.
+  assert(Bytes::length(gen_rc_dup_body(true, 7, 4242)) > Bytes::length(gen_rc_dup_body(true, 0 - 1, 0)))
+  assert(Bytes::length(gen_rc_drop_body(3, true, 0, 7, 4242)) > Bytes::length(gen_rc_drop_body(3, true, 0, 0 - 1, 0)))
 }
 
 test "oob_abort body is nonempty and grows with larger fragment constants" {


### PR DESCRIPTION
## Summary

- Shadow RC (`VIBE_RC=shadow`) records a per-op sequence at each dup/drop and stores the freeing seq beside the freed-block mark.
- A later dup/drop of that block prints `dup|drop of freed value at site N; freed at site M` before trapping, instead of a bare `unreachable`.
- Reuses `gen_oob_abort_body` with a different middle fragment (`__rt_shadow_uaf_abort`). Registered only when `rc_shadow` is on (ADR-0062: normal RC stays byte-identical).

#2199 remaining source provenance for OOB rides this print-before-trap path; the crash-debug dump is already opt-in.

## Test Plan

- [x] `builtin_bodies_test.vibe` — shadow abort form strictly larger than bare unreachable
- [x] `fixtures/rc_shadow_regression_test.vibe` compiled with this stage2 under `VIBE_RC=shadow` still prints `25297489`