### PR TITLE
Align contract buffer type diagnostics (#2317)

### DIFF
--- a/lib/@vibe/compiler/contract/contract.vibe
+++ b/lib/@vibe/compiler/contract/contract.vibe
@@ -1256,6 +1256,29 @@ export fn contract_imported_type_names(extra: Array[Stmt]) -> Array[(String, Int
   out
 }
 
+/// Type names whose existence a contract declares without defining them in
+/// its transparent type-family statements.
+///
+/// This is the one provenance merge used by both the materialized types-module
+/// lane and the single-buffer diagnostic lane (#2317). Keeping the merge here
+/// prevents an imported kind or alias from becoming a wildcard in one lane and
+/// an unknown name in the other.
+export fn contract_type_provenance(extra: Array[Stmt], opaque_names: Array[(String, Int)]) -> Array[(String, Int)] {
+  let out = array_empty()
+  let mut oi = 0
+  while oi < Array::length(opaque_names) {
+    Array::push(out, Array::get(opaque_names, oi))
+    oi = oi + 1
+  }
+  let imported = contract_imported_type_names(extra)
+  let mut ii = 0
+  while ii < Array::length(imported) {
+    Array::push(out, Array::get(imported, ii))
+    ii = ii + 1
+  }
+  out
+}
+
 fn ctm_opaque_name_list(opaque_names: Array[(String, Int)]) -> Array[String] {
   let out = array_empty()
   let mut i = 0

--- a/lib/@vibe/compiler/contract/index.vpkg
+++ b/lib/@vibe/compiler/contract/index.vpkg
@@ -66,6 +66,7 @@ fn contract_facade_source(decls: Array[(String, String)], opaque_names: Array[(S
 fn contract_type_family_defs(type_defs: Array[Stmt]) -> Array[Stmt]
 fn contract_types_module_text(tds: Array[Stmt], uniq: String, contract_path: String, opaque_names: Array[(String, Int)], decl_pos: Array[String]) -> String
 fn contract_imported_type_names(extra: Array[Stmt]) -> Array[(String, Int)]
+fn contract_type_provenance(extra: Array[Stmt], opaque_names: Array[(String, Int)]) -> Array[(String, Int)]
 fn vpkg_types_contract_of_source(source: String) -> String
 fn vpkg_types_decl_pos_for_line(source: String, stub_line: Int) -> String
 fn vpkg_path_escape_one_line(path: String) -> String

--- a/lib/@vibe/compiler/loader/loader.vibe
+++ b/lib/@vibe/compiler/loader/loader.vibe
@@ -61,10 +61,10 @@ import @vibe/compiler/contract {
   contract_facade_marker,
   contract_facade_source,
   contract_hash,
-  contract_imported_type_names,
   contract_surface_lines,
   contract_type_family_decl_positions,
   contract_type_family_defs,
+  contract_type_provenance,
   contract_types_module_line,
   contract_types_module_text,
   deps_missing_for_imports,
@@ -1131,18 +1131,7 @@ fn ensure_vpkg_types_module_fs(vpkg_path: String, extra: Array[Stmt], opaque_nam
       }
       uci = uci + 1
     }
-    let provenance = array_empty()
-    let mut oi = 0
-    while oi < Array::length(opaque_names) {
-      Array::push(provenance, Array::get(opaque_names, oi))
-      oi = oi + 1
-    }
-    let imported = contract_imported_type_names(extra)
-    let mut ii = 0
-    while ii < Array::length(imported) {
-      Array::push(provenance, Array::get(imported, ii))
-      ii = ii + 1
-    }
+    let provenance = contract_type_provenance(extra, opaque_names)
     let text = contract_types_module_text(tds, StringBuilder::freeze(uniq_sb), vpkg_path, provenance, decl_pos)
     let raw_key = compact_string_fingerprint(String::concat(vpkg_path, String::concat("|", text)))
     // Identifier-safe basename: the import-path grammar (parser_base.vibe's

--- a/lib/@vibe/compiler/runtime/contract_unknown_type_buffer_test.vibe
+++ b/lib/@vibe/compiler/runtime/contract_unknown_type_buffer_test.vibe
@@ -1,0 +1,45 @@
+//# Imports
+
+import ./typecheck_fs.vibe {
+  collect_all_diagnostics_for_path
+}
+
+//# Functions
+
+fn contract_source(body: String) -> String {
+  "name = @gate/contract_buffer\nversion = 0.0.1\ndescription =\n  #|single-buffer contract type provenance\ndeps = {}\n\ngenerated_hash =\n\n\{body}"
+}
+
+fn contract_diagnostics(body: String) -> Array[String] with Exception {
+  collect_all_diagnostics_for_path("lib/@gate/contract_buffer/index.vpkg", contract_source(body))
+}
+
+//# Tests
+
+test "2317: the buffer lane rejects an unknown struct field type" {
+  inspect(contract_diagnostics("struct Bad {\n  x: Intt\n}\n"), content = "[line 9:1: unknown type `Intt` in field `x` of struct `Bad`]")
+}
+
+test "2317: the buffer lane rejects an unknown enum payload type" {
+  inspect(contract_diagnostics("enum Bad {\n  V(Intt)\n}\n"), content = "[line 9:1: unknown type `Intt` in the payload of `Bad::V`]")
+}
+
+test "2317: compiler-owned and local contract types stay clean" {
+  inspect(contract_diagnostics("type Remote\n\nstruct Good[T] {\n  builtin: Array[Int];\n  local: Remote;\n  param: T\n}\n"), content = "[]")
+}
+
+test "2317: an explicitly kinded lowercase type import is provenance" {
+  inspect(contract_diagnostics("import @scope/dep { struct Remote as remote }\n\nstruct Good {\n  value: remote\n}\n"), content = "[]")
+}
+
+test "2317: a bare uppercase type import is provenance" {
+  inspect(contract_diagnostics("import @scope/dep { TypeEnv }\n\nstruct Good {\n  value: TypeEnv\n}\n"), content = "[]")
+}
+
+test "2317: a transparent contract type is provenance before its use" {
+  inspect(contract_diagnostics("struct Good {\n  value: Remote\n}\n\nstruct Remote {\n  value: Int\n}\n"), content = "[]")
+}
+
+test "2317: an imported trait alias is not type provenance" {
+  inspect(contract_diagnostics("import @scope/dep { trait Marker as Remote }\n\nstruct Bad {\n  value: Remote\n}\n"), content = "[line 11:1: unknown type `Remote` in field `value` of struct `Bad`]")
+}

--- a/lib/@vibe/compiler/runtime/typecheck_fs.vibe
+++ b/lib/@vibe/compiler/runtime/typecheck_fs.vibe
@@ -25,6 +25,7 @@ import @vibe/compiler/checker {
   detect_unbound_nonunit_returns,
   detect_unused_imports,
   import_item_kind_errors,
+  report_unknown_type_names_deferred_validation,
   typing_semantics_seed,
   validate_derives
 }
@@ -84,6 +85,8 @@ import @vibe/compiler/contract {
   contract_duplicate_decl_index,
   contract_effective_decl_indices,
   contract_effective_decls,
+  contract_type_provenance,
+  contract_types_item_names,
   contract_unsupported_stmt_index,
   extract_package_version,
   extract_require_pins,
@@ -5972,37 +5975,106 @@ fn located_lex_errors(source: String, lex_err_offsets: Array[Int], lex_err_msgs:
 /// #2317: the contract checks a single buffer CAN decide, beyond the grammar.
 ///
 /// `parse_contract_program` plus `classify_contract_stmts` answer "is this
-/// shaped like a contract". They do not answer everything the loader does, and
-/// three of those answers need nothing but the parsed statements -- so the
-/// buffer lane reported clean for contracts the build refuses. Measured, all
-/// on complete packages through `vibe check`:
+/// shaped like a contract". They do not answer everything the loader does, but
+/// derive names and type-head provenance need only the parsed contract. Before
+/// these checks the buffer lane reported clean for contracts the build refused:
 ///
 ///   struct P { x: Int } derive(Foo)  -> unknown trait: Foo
-///   fn f(..) declared twice          -> contract facade: some declarations
-///                                       have no implementation file
+///   struct P { x: Intt }              -> unknown type Intt in field x
 ///
-/// The duplicate message is the loader's, and it names the wrong cause: `f` IS
-/// implemented, and the duplicate is what breaks the facade. This lane says
-/// what is actually wrong instead, which is the point of reporting it here at
-/// all.
+/// Both rules call checker/contract-owned functions: `validate_derives`, the
+/// checker's unknown-type walker, and `contract_type_provenance`. There is no
+/// second builtin-name or import-kind table here for the lanes to disagree on.
 ///
-/// `validate_derives` is the CHECKER's own function, exported for this, so the
-/// derive message is identical to the build's rather than a second
-/// implementation that could drift.
-///
-/// Positions come from searching the buffer for the offending name, the way
-/// `locate_by_marker` already places `unknown name:` and friends. Statements
-/// carry no offsets (`SLet(Bool, Bool, String, Option[TypeExpr], Expr)` has no
-/// span), and adding them is a change at every construction site.
-fn contract_semantic_errors(source: String, tokens: Array[Token], starts: Array[Int], stmts: Array[Stmt]) -> Array[String] with Exception {
+/// Unknown type messages are declaration-granular, matching the materialized
+/// types module's source mapping: `stmt_at` carries the parser's token index and
+/// `starts` converts it to the contract's byte offset. The message itself names
+/// the field or payload, so the reported edit remains actionable.
+fn contract_type_shadow(stmts: Array[Stmt], type_defs: Array[Stmt], opaque_names: Array[(String, Int)]) -> Array[String] {
+  let out = contract_types_item_names(type_defs)
+  let provenance = contract_type_provenance(stmts, opaque_names)
+  let mut i = 0
+  while i < Array::length(provenance) {
+    let (name, _) = Array::get(provenance, i)
+    Array::push(out, name)
+    i = i + 1
+  }
+  out
+}
+
+fn contract_decl_shadow(base: Array[String], params: Array[String]) -> Array[String] {
+  let out = array_empty()
+  let mut i = 0
+  while i < Array::length(base) {
+    Array::push(out, Array::get(base, i))
+    i = i + 1
+  }
+  let mut pi = 0
+  while pi < Array::length(params) {
+    Array::push(out, Array::get(params, pi))
+    pi = pi + 1
+  }
+  out
+}
+
+fn contract_append_decl_errors(source: String, starts: Array[Int], stmt_at: Array[Int], stmt_index: Int, raw: Array[String], out: Array[String]) -> Unit {
+  let mut off = 0 - 1
+  if stmt_index >= 0 && stmt_index < Array::length(stmt_at) {
+    let tok = Array::get(stmt_at, stmt_index)
+    if tok >= 0 && tok < Array::length(starts) {
+      off = Array::get(starts, tok)
+    } else {
+      ()
+    }
+  } else {
+    ()
+  }
+  let mut i = 0
+  while i < Array::length(raw) {
+    Array::push(out, located_at_offset(source, off, Array::get(raw, i)))
+    i = i + 1
+  }
+}
+
+fn contract_semantic_errors(source: String, tokens: Array[Token], starts: Array[Int], stmts: Array[Stmt], stmt_at: Array[Int], opaque_names: Array[(String, Int)], type_defs: Array[Stmt]) -> Array[String] with Exception {
   let out = array_empty()
   let derive_names = contract_derive_name_table(tokens, starts)
   let derive_taken = contract_taken_flags(derive_names)
+  let base_shadow = contract_type_shadow(stmts, type_defs, opaque_names)
+  let no_defs: Array[TypeDef] = []
   let mut i = 0
   while i < Array::length(stmts) {
     match Array::get(stmts, i) {
-      SStruct(_, _, _, derives, _, _) => contract_derive_errors(source, derive_names, derive_taken, derives, out),
-      SEnum(_, _, _, _, derives) => contract_derive_errors(source, derive_names, derive_taken, derives, out),
+      SStruct(_, name, fields, derives, _, params) => {
+        contract_derive_errors(source, derive_names, derive_taken, derives, out)
+        let raw = array_empty()
+        let shadow = contract_decl_shadow(base_shadow, params)
+        let mut fi = 0
+        while fi < Array::length(fields) {
+          let (fname, fte) = Array::get(fields, fi)
+          let where_label = String::concat(String::concat(String::concat("field `", fname), String::concat("` of struct `", name)), "`")
+          report_unknown_type_names_deferred_validation(fte, no_defs, shadow, EnvEmpty, array_empty(), where_label, raw)
+          fi = fi + 1
+        }
+        contract_append_decl_errors(source, starts, stmt_at, i, raw, out)
+      },
+      SEnum(_, name, params, variants, derives) => {
+        contract_derive_errors(source, derive_names, derive_taken, derives, out)
+        let raw = array_empty()
+        let shadow = contract_decl_shadow(base_shadow, params)
+        let mut vi = 0
+        while vi < Array::length(variants) {
+          let (vname, vtypes) = Array::get(variants, vi)
+          let mut ti = 0
+          while ti < Array::length(vtypes) {
+            let where_label = String::concat(String::concat(String::concat("the payload of `", name), String::concat("::", vname)), "`")
+            report_unknown_type_names_deferred_validation(Array::get(vtypes, ti), no_defs, shadow, EnvEmpty, array_empty(), where_label, raw)
+            ti = ti + 1
+          }
+          vi = vi + 1
+        }
+        contract_append_decl_errors(source, starts, stmt_at, i, raw, out)
+      },
       _ => ()
     }
     i = i + 1
@@ -6255,17 +6327,17 @@ fn collect_all_diagnostics_on(input_path: String, source: String, pkg_version: S
     // branch this replaces did catch it, through `check_program`. So run the
     // classifier the loader runs, on the statements the parse produced.
     return handle {
-      let (cdecls_raw, _copaques, cstmts, cstmt_at, cdecl_at) = parse_contract_program_spans(ctokens)
+      let (cdecls_raw, copaques, cstmts, cstmt_at, cdecl_at) = parse_contract_program_spans(ctokens)
       // The classifier is caught SEPARATELY from the parse. Both throw
       // unlocated messages, but they need different anchors: a parse error
       // belongs at the token the parser stopped on, a rejected statement at
       // that statement's own first token (#2317). Letting one handler take
       // both left the classifier's message at the synthetic 0:0 -- the reader
       // is told the contract is broken and not told where.
-      let cls_err = handle {
-        let (_raws, _type_defs) = classify_contract_stmts(cstmts)
-        ""
-      } with { Exception::Throw(m) => m }
+      let (cls_err, ctype_defs) = handle {
+        let (_raws, type_defs) = classify_contract_stmts(cstmts)
+        ("", type_defs)
+      } with { Exception::Throw(m) => (m, array_empty()) }
       if cls_err != "" {
         contract_classify_diagnostic(source, cstarts, cstmts, cstmt_at, cls_err)
       } else {
@@ -6280,7 +6352,7 @@ fn collect_all_diagnostics_on(input_path: String, source: String, pkg_version: S
         if dup_at >= 0 {
           contract_duplicate_diagnostic(source, cstarts, cdecls, ceff_idx, cdecl_at, dup_at)
         } else {
-          contract_semantic_errors(source, ctokens, cstarts, cstmts)
+          contract_semantic_errors(source, ctokens, cstarts, cstmts, cstmt_at, copaques, ctype_defs)
         }
       }
     } with { Exception::Throw(msg) => contract_parse_diagnostic(source, ctokens, cstarts, msg) }

--- a/tests/gates/late/run.sh
+++ b/tests/gates/late/run.sh
@@ -9083,3 +9083,71 @@ if ! VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_CHECK_ONLY=1 VIBE_IMPORT_ABI=raw \
 fi
 rm -rf "$mapdir"
 echo "[compiler-gate] a located contract diagnostic names the contract at its own declaration; a clean contract stays clean ok (#2317)"
+
+# 124/124. An undeclared type head in a transparent contract type is refused
+# by BOTH the import lane and the single-buffer/LSP lane (#2317).
+#
+# #2327 removed the generated types module's wildcard for a typo, so the full
+# lane began refusing `Intt`. The buffer lane still ran only derive validation
+# after parsing the same contract and reported it clean. This gate asserts the
+# two answers by message, not merely status: a contract can fail later for an
+# unrelated conformance reason, which would make a status-only probe vacuous.
+echo "[compiler-gate] 124/124 contract unknown type heads are refused by the full and buffer lanes (#2317)"
+utdir="_build/_gate_contract_unknown_type"
+rm -rf "$utdir"; mkdir -p "$utdir/field" "$utdir/payload" "$utdir/clean" "$utdir/local"
+ut_header='name = @gate/contractunknown
+version = 0.0.1
+description =
+  #|gate-only package for #2317
+deps = {}
+
+generated_hash =
+'
+ut_impl='export fn plain(x: Int) -> Int {
+  x + 1
+}
+'
+printf '%s\nstruct Bad {\n  x: Intt\n}\n\nfn plain(x: Int) -> Int\n' "$ut_header" > "$utdir/field/index.vpkg"
+printf '%s\nenum Bad {\n  V(Intt)\n}\n\nfn plain(x: Int) -> Int\n' "$ut_header" > "$utdir/payload/index.vpkg"
+printf '%s\nstruct Good {\n  x: Array[Int]\n}\n\nfn plain(x: Int) -> Int\n' "$ut_header" > "$utdir/clean/index.vpkg"
+printf '%s\ntype Remote\n\nstruct Good {\n  x: Remote\n}\n\nfn plain(x: Int) -> Int\n' "$ut_header" > "$utdir/local/index.vpkg"
+for probe in field payload clean local; do
+  if [ "$probe" = local ]; then
+    printf 'export struct Remote {\n  value: Int\n}\n\n%s' "$ut_impl" > "$utdir/$probe/impl.vibe"
+  else
+    printf '%s' "$ut_impl" > "$utdir/$probe/impl.vibe"
+  fi
+  rm -f "$utdir/$probe.imp" "$utdir/$probe.imp.diag" "$utdir/$probe.buf"
+  VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_CHECK_ONLY=1 VIBE_IMPORT_ABI=raw \
+    bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
+    "$utdir/$probe/index.vpkg" "$utdir/$probe.imp" main >/dev/null 2>&1 || true
+  VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_DIAGNOSTICS=1 VIBE_IMPORT_ABI=raw \
+    bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
+    "$utdir/$probe/index.vpkg" "$utdir/$probe.buf" main >/dev/null 2>&1 || true
+done
+for lane in imp.diag buf; do
+  if ! grep -qF "unknown type \`Intt\` in field \`x\` of struct \`Bad\`" "$utdir/field.$lane" 2>/dev/null; then
+    echo "[compiler-gate] FAIL: the $lane lane does not reject an unknown contract field type (#2317)" >&2
+    cat "$utdir/field.$lane" 2>/dev/null >&2 || true
+    exit 1
+  fi
+  if ! grep -qF "unknown type \`Intt\` in the payload of \`Bad::V\`" "$utdir/payload.$lane" 2>/dev/null; then
+    echo "[compiler-gate] FAIL: the $lane lane does not reject an unknown contract payload type (#2317)" >&2
+    cat "$utdir/payload.$lane" 2>/dev/null >&2 || true
+    exit 1
+  fi
+done
+if ! grep -q '^line 9:1:' "$utdir/field.buf" 2>/dev/null || ! grep -q '^line 9:1:' "$utdir/payload.buf" 2>/dev/null; then
+  echo "[compiler-gate] FAIL: a buffer-lane unknown type is not anchored on its declaration (#2317)" >&2
+  cat "$utdir/field.buf" "$utdir/payload.buf" 2>/dev/null >&2 || true
+  exit 1
+fi
+for probe in clean local; do
+  if [ -s "$utdir/$probe.imp.diag" ] || [ -s "$utdir/$probe.buf" ]; then
+    echo "[compiler-gate] FAIL: valid contract '$probe' gained a diagnostic (#2317)" >&2
+    cat "$utdir/$probe.imp.diag" "$utdir/$probe.buf" 2>/dev/null >&2 || true
+    exit 1
+  fi
+done
+rm -rf "$utdir"
+echo "[compiler-gate] unknown contract field/payload types are refused by both lanes at the declaration; builtin and local provenance stay clean ok (#2317)"

--- a/tests/gates/registry.tsv
+++ b/tests/gates/registry.tsv
@@ -241,3 +241,4 @@ x-adr-0090-1937-exception-unwind-region-restore	late	ADR-0090 #1937 exception-un
 121/121	late	121/121 a type diagnostic names the contract, not the generated types module (#2317)
 122/122	late	122/122 a duplicated contract declaration is refused by both lanes, and named (#2317)
 123/123	late	123/123 a located contract diagnostic names the contract at its declaration (#2317)
+124/124	late	124/124 contract unknown type heads are refused by the full and buffer lanes (#2317)


### PR DESCRIPTION
## Summary

- Run the checker's unknown-type walker for transparent contract structs and enums in the single-buffer/LSP lane.
- Share the contract-layer merge of bodyless/opaque and imported type provenance with the loader, including explicit lowercase aliases.
- Anchor buffer diagnostics on the source declaration and keep builtin, local, bodyless, and imported type heads clean.
- Add a two-lane gate that asserts the full and buffer lanes reject the same field/payload typos by message.

Fixes #2317.

## Test plan

- TDD Red: the buffer API returned `[]` for `struct Bad { x: Intt }`.
- Focused contract provenance and buffer diagnostic unit files: pass.
- Fresh seed -> stage1 -> stage2 generation: pass.
- Full active unit-test battery after generated-artifact preparation: 1028/1028 files pass.
- Late gate section 124: full/buffer field and payload negatives plus builtin/bodyless controls pass.
- Gate portability self-test and pre-commit review/architecture/lock/profile/doc lints: pass.

## Local environment note

The complete late lane reached section 106, then its existing self-test invoked `mapfile`, which macOS Bash 3 does not provide. The changed section 124 was then run directly with the fresh stage2 and passed. `test-check-gate-portability` also passed.
