### PR TITLE
SIMD-first data-structure foundation: proposal, benches, and the P0 it found (#2340, #2341)

### DIFF
--- a/bench/bench_simd_bytes_find.vibe
+++ b/bench/bench_simd_bytes_find.vibe
@@ -1,0 +1,148 @@
+// Byte search over `Bytes`, four ways (#536 follow-up; see
+// docs/simd-data-structures.md). `Bytes` has no native search builtin, so a
+// library that scans bytes must write the scalar loop below by hand.
+//
+//   find_4k_simd_inline_wasm       hand-written v128 kernel (this file)
+//   find_4k_boxed_intrinsics       the same algorithm through the v128_* intrinsics
+//   find_4k_scalar                 the loop a library has to write today
+//   find_4k_String_index_of        the native scalar builtin, for scale
+//
+// The boxed lane is the one to watch: every v128_load / v128_eq_i8x16 heap-
+// allocates a 16-byte box, so the intrinsic surface allocates ~2 boxes per
+// 16 bytes scanned.
+
+fn simd_find(hay: Bytes, needle: Int, from: Int, len: Int) -> Int = wasm
+"(local $p i32) (local $i i32) (local $e i32) (local $m i32) (local $c i32)"
+"(local $r i64)"
+"(local $nv v128)"
+"i64.const -2 local.set $r"
+"local.get $hay i32.wrap_i64 i32.load offset=8 local.set $p"
+"local.get $from i64.const 1 i64.shr_s i32.wrap_i64 local.set $i"
+"local.get $len i64.const 1 i64.shr_s i32.wrap_i64 local.set $e"
+"local.get $needle i64.const 1 i64.shr_s i32.wrap_i64 local.set $c"
+"local.get $c i8x16.splat local.set $nv"
+"(block $done"
+"  (block $tail"
+"    (loop $chunk"
+"      (br_if $tail (i32.gt_s (i32.add (local.get $i) (i32.const 16)) (local.get $e)))"
+"      (local.set $m (i8x16.bitmask (i8x16.eq (v128.load align=1 (i32.add (local.get $p) (local.get $i))) (local.get $nv))))"
+"      (if (i32.ne (local.get $m) (i32.const 0))"
+"        (then"
+"          (local.set $r (i64.shl (i64.extend_i32_s (i32.add (local.get $i) (i32.ctz (local.get $m)))) (i64.const 1)))"
+"          (br $done)"
+"        )"
+"      )"
+"      (local.set $i (i32.add (local.get $i) (i32.const 16)))"
+"      (br $chunk)"
+"    )"
+"  )"
+"  (loop $t"
+"    (if (i32.lt_s (local.get $i) (local.get $e))"
+"      (then"
+"        (if (i32.eq (i32.load8_u (i32.add (local.get $p) (local.get $i))) (local.get $c))"
+"          (then"
+"            (local.set $r (i64.shl (i64.extend_i32_s (local.get $i)) (i64.const 1)))"
+"            (br $done)"
+"          )"
+"        )"
+"        (local.set $i (i32.add (local.get $i) (i32.const 1)))"
+"        (br $t)"
+"      )"
+"    )"
+"  )"
+")"
+"local.get $r"
+
+fn ctz32(x: Int) -> Int = wasm
+"(i64.shl (i64.extend_i32_u (i32.ctz (i32.wrap_i64 (i64.shr_s (local.get $x) (i64.const 1))))) (i64.const 1))"
+
+fn scalar_find(hay: Bytes, needle: Int, from: Int, len: Int) -> Int {
+  let mut i = from
+  let mut r = -1
+  while i < len {
+    if Bytes::get(hay, i) == needle {
+      r = i
+      i = len
+    } else {
+      i = i + 1
+    }
+  }
+  r
+}
+
+fn boxed_find(hay: Bytes, needle: Int, from: Int, len: Int) -> Int {
+  let nv = v128_splat_i8x16(needle)
+  let mut i = from
+  let mut r = -1
+  while i + 16 <= len {
+    let m = v128_bitmask_i8x16(v128_eq_i8x16(v128_load(hay, i), nv))
+    if m != 0 {
+      r = i + ctz32(m)
+      i = len
+    } else {
+      i = i + 16
+    }
+  }
+  while i < len {
+    if Bytes::get(hay, i) == needle {
+      r = i
+      i = len
+    } else {
+      i = i + 1
+    }
+  }
+  r
+}
+
+fn mkb(n: Int, at: Int) -> Bytes {
+  let b = Bytes::new()
+  let mut i = 0
+  while i < n {
+    Bytes::push(b, if i == at { 88 } else { 97 })
+    i = i + 1
+  }
+  b
+}
+
+fn mks(n: Int, at: Int) -> String {
+  let sb = StringBuilder::new()
+  let mut i = 0
+  while i < n {
+    StringBuilder::push(sb, if i == at { "X" } else { "a" })
+    i = i + 1
+  }
+  StringBuilder::freeze(sb)
+}
+
+let hay = mkb(4096, 4000)
+
+let hay_s = mks(4096, 4000)
+
+let sink = [
+  0
+]
+
+test "the four lanes agree" {
+  assert_eq(simd_find(hay, 88, 0, 4096), 4000)
+  assert_eq(boxed_find(hay, 88, 0, 4096), 4000)
+  assert_eq(scalar_find(hay, 88, 0, 4096), 4000)
+  assert_eq(String::index_of(hay_s, "X"), 4000)
+  assert_eq(simd_find(hay, 66, 0, 4096), -1)
+  assert_eq(scalar_find(hay, 66, 0, 4096), -1)
+}
+
+bench "find_4k_simd_inline_wasm" {
+  Array::set(sink, 0, simd_find(hay, 88, 0, 4096))
+}
+
+bench "find_4k_boxed_intrinsics" {
+  Array::set(sink, 0, boxed_find(hay, 88, 0, 4096))
+}
+
+bench "find_4k_scalar" {
+  Array::set(sink, 0, scalar_find(hay, 88, 0, 4096))
+}
+
+bench "find_4k_String_index_of_builtin" {
+  Array::set(sink, 0, String::index_of(hay_s, "X"))
+}

--- a/bench/bench_simd_hash_probe.vibe
+++ b/bench/bench_simd_hash_probe.vibe
@@ -1,9 +1,19 @@
 // SwissTable-shaped frozen Int-key set (1-byte control array + i32 key column,
 // group-of-16 SIMD probe) vs the stdlib MutMap[Int, Int].
 //
-// NOT apples to apples: MutMap is generic over K/V with closed-over hash/eq;
-// this is a monomorphic frozen set of non-negative Ints. The point is to size
-// the headroom a frozen, byte-packed representation leaves on the table.
+// NOT apples to apples: MutMap is generic over K/V with closed-over hash/eq and
+// Option-wrapped slots; this is a monomorphic frozen SET of non-negative Ints
+// with a different hash and a group-of-16 probe. At least eight things differ at
+// once, so the MutMap-vs-frozen ratio is AGGREGATE HEADROOM and cannot be split
+// between them. The three frozen lanes are controlled against each other and are
+// where the readable numbers are:
+//
+//   lookup_4k_simd_frozen_set             loop inside the kernel
+//   ..._point_api_packed_queries          loop in vibe, SAME query storage
+//   ..._point_api                         loop in vibe, queries in Array[Int]
+//
+// first vs second isolates the call boundary; second vs third isolates the
+// query representation.
 //
 // Two inline-wasm frictions are visible in the source and are part of the
 // finding (docs/simd-data-structures.md, Layer 0): the kernel cannot call
@@ -162,6 +172,55 @@ fn simd_has(ctrl: Bytes, kcol: Bytes, k: Int) -> Int = wasm
 ")"
 "(i64.shl (i64.extend_i32_s (local.get $hit)) (i64.const 1))"
 
+/// Point API over the SAME packed query column the bulk kernel reads, so the
+/// only remaining difference is where the loop lives. `simd_has` below reads
+/// its key from an `Array[Int]` instead, which is a second variable -- Codex
+/// caught the two being compared as if it were one (PR #2339).
+fn simd_has_at(ctrl: Bytes, kcol: Bytes, qs: Bytes, i: Int) -> Int = wasm
+"(local $cp i32) (local $kp i32) (local $kk i32) (local $h i32) (local $g i32)"
+"(local $m i32) (local $me i32) (local $j i32) (local $hit i32)"
+"(local $v v128) (local $f v128)"
+"local.get $ctrl i32.wrap_i64 i32.load offset=8 local.set $cp"
+"local.get $kcol i32.wrap_i64 i32.load offset=8 local.set $kp"
+"local.get $qs i32.wrap_i64 i32.load offset=8"
+"local.get $i i64.const 1 i64.shr_s i32.wrap_i64 i32.const 2 i32.shl i32.add"
+"i32.load align=1 local.set $kk"
+"(local.set $h (i32.mul (local.get $kk) (i32.const -1640531535)))"
+"(local.set $g (i32.and (i32.and (i32.shr_u (local.get $h) (i32.const 16)) (i32.const 8191)) (i32.const 8176)))"
+"(local.set $f (i8x16.splat (i32.and (local.get $h) (i32.const 127))))"
+"(block $qdone"
+"  (loop $group"
+"    (local.set $v (v128.load align=1 (i32.add (local.get $cp) (local.get $g))))"
+"    (local.set $m (i8x16.bitmask (i8x16.eq (local.get $v) (local.get $f))))"
+"    (block $cands"
+"      (loop $cand"
+"        (br_if $cands (i32.eqz (local.get $m)))"
+"        (local.set $j (i32.ctz (local.get $m)))"
+"        (if (i32.eq (i32.load align=1 (i32.add (local.get $kp) (i32.shl (i32.add (local.get $g) (local.get $j)) (i32.const 2)))) (local.get $kk))"
+"          (then (local.set $hit (i32.const 1)) (br $qdone))"
+"        )"
+"        (local.set $m (i32.and (local.get $m) (i32.sub (local.get $m) (i32.const 1))))"
+"        (br $cand)"
+"      )"
+"    )"
+"    (local.set $me (i8x16.bitmask (i8x16.eq (local.get $v) (i8x16.splat (i32.const 128)))))"
+"    (br_if $qdone (i32.ne (local.get $me) (i32.const 0)))"
+"    (local.set $g (i32.and (i32.add (local.get $g) (i32.const 16)) (i32.const 8176)))"
+"    (br $group)"
+"  )"
+")"
+"(i64.shl (i64.extend_i32_s (local.get $hit)) (i64.const 1))"
+
+fn point_count_hits_packed(ctrl: Bytes, kcol: Bytes, qs: Bytes, nq: Int) -> Int {
+  let mut i = 0
+  let mut hits = 0
+  while i < nq {
+    hits = hits + simd_has_at(ctrl, kcol, qs, i)
+    i = i + 1
+  }
+  hits
+}
+
 fn point_count_hits(ctrl: Bytes, kcol: Bytes, qs: Array[Int]) -> Int {
   let n = Array::length(qs)
   let mut i = 0
@@ -243,8 +302,10 @@ test "both agree" {
   assert_eq(simd_count_hits(ctrl, kcol, qbytes, 4000), 2000)
   assert_eq(mutmap_count_hits(mm, queries), 2000)
   assert_eq(point_count_hits(ctrl, kcol, queries), 2000)
+  assert_eq(point_count_hits_packed(ctrl, kcol, qbytes, 4000), 2000)
 }
 
 bench "lookup_4k_simd_frozen_set" { Array::set(sink, 0, simd_count_hits(ctrl, kcol, qbytes, 4000)) }
 bench "lookup_4k_stdlib_mutmap" { Array::set(sink, 0, mutmap_count_hits(mm, queries)) }
 bench "lookup_4k_simd_point_api" { Array::set(sink, 0, point_count_hits(ctrl, kcol, queries)) }
+bench "lookup_4k_simd_point_api_packed_queries" { Array::set(sink, 0, point_count_hits_packed(ctrl, kcol, qbytes, 4000)) }

--- a/bench/bench_simd_hash_probe.vibe
+++ b/bench/bench_simd_hash_probe.vibe
@@ -15,12 +15,21 @@
 // first vs second isolates the call boundary; second vs third isolates the
 // query representation.
 //
-// Two inline-wasm frictions are visible in the source and are part of the
-// finding (docs/simd-data-structures.md, Layer 0): the kernel cannot call
-// another vibe fn, so `cap`, the group mask and the hash constant are spelled
-// twice -- once in vibe, once as literals inside the WAT; and the WAT needs the
-// SIGNED i32 spelling of 0x9E3779B1 (-1640531535), because an out-of-range
-// `i32.const` passes `vibe check` clean and only fails at module load.
+// One inline-wasm friction is visible in the source and is part of the finding
+// (docs/simd-data-structures.md, Layer 0, #2348): the kernel cannot call another
+// vibe fn, so `cap`, the group mask and the hash constant are spelled twice --
+// once in vibe, once as literals inside the WAT.
+//
+// The WAT spells the hash constant -1640531535 where vibe spells it 2654435761.
+// Same bit pattern, 0x9E3779B1. That is NOT the old #2341 workaround, which this
+// PR fixed -- both spellings of an `iN` immediate are accepted now, per the text
+// format's `iN ::= n:uN | i:sN`. It is because `vibe test` compiles with the
+// COMMITTED SEED by default (CLAUDE.md, "Which compiler answered?"), and the seed
+// predates the fix: measured, `(i32.const -1640531535)` here makes this whole file
+// FAIL under `scripts/vibe_test.sh` until the next bootstrap bump. The regression
+// for both spellings lives in lib/@vibe/compiler/tests/inline_wasm_test.vibe,
+// which tests the assembler through the checkout's own source and so answers for
+// the compiler being changed rather than for whichever one ran the file.
 
 import @vibe/core {
   MutMap, MutMap::has, MutMap::new_int, MutMap::set

--- a/bench/bench_simd_hash_probe.vibe
+++ b/bench/bench_simd_hash_probe.vibe
@@ -1,0 +1,250 @@
+// SwissTable-shaped frozen Int-key set (1-byte control array + i32 key column,
+// group-of-16 SIMD probe) vs the stdlib MutMap[Int, Int].
+//
+// NOT apples to apples: MutMap is generic over K/V with closed-over hash/eq;
+// this is a monomorphic frozen set of non-negative Ints. The point is to size
+// the headroom a frozen, byte-packed representation leaves on the table.
+//
+// Two inline-wasm frictions are visible in the source and are part of the
+// finding (docs/simd-data-structures.md, Layer 0): the kernel cannot call
+// another vibe fn, so `cap`, the group mask and the hash constant are spelled
+// twice -- once in vibe, once as literals inside the WAT; and the WAT needs the
+// SIGNED i32 spelling of 0x9E3779B1 (-1640531535), because an out-of-range
+// `i32.const` passes `vibe check` clean and only fails at module load.
+
+import @vibe/core {
+  MutMap, MutMap::has, MutMap::new_int, MutMap::set
+}
+
+let cap = 8192
+
+let empty_ctrl = 128
+
+fn mix(k: Int) -> Int {
+  (k * 2654435761) & 4294967295
+}
+
+fn h1_of(k: Int) -> Int {
+  ((mix(k) >> 16) & (cap - 1)) & (cap - 16)
+}
+
+fn h2_of(k: Int) -> Int {
+  mix(k) & 127
+}
+
+fn put_i32(b: Bytes, i: Int, v: Int) -> Unit {
+  Bytes::set(b, i * 4, v & 255)
+  Bytes::set(b, i * 4 + 1, (v >> 8) & 255)
+  Bytes::set(b, i * 4 + 2, (v >> 16) & 255)
+  Bytes::set(b, i * 4 + 3, (v >> 24) & 255)
+}
+
+fn zeros(n: Int, fill: Int) -> Bytes {
+  let b = Bytes::new()
+  let mut i = 0
+  while i < n {
+    Bytes::push(b, fill)
+    i = i + 1
+  }
+  b
+}
+
+/// Build the frozen table: ctrl[cap] bytes, keys[cap] i32.
+fn build(keys: Array[Int]) -> (Bytes, Bytes) {
+  let ctrl = zeros(cap, empty_ctrl)
+  let kcol = zeros(cap * 4, 0)
+  let n = Array::length(keys)
+  let mut i = 0
+  while i < n {
+    let k = Array::get(keys, i)
+    let mut g = h1_of(k)
+    let mut placed = false
+    while !placed {
+      let mut j = 0
+      while j < 16 && !placed {
+        if Bytes::get(ctrl, g + j) == empty_ctrl {
+          Bytes::set(ctrl, g + j, h2_of(k))
+          put_i32(kcol, g + j, k)
+          placed = true
+        } else {
+          j = j + 1
+        }
+      }
+      if !placed {
+        g = (g + 16) & (cap - 16)
+      }
+    }
+    i = i + 1
+  }
+  (ctrl, kcol)
+}
+
+/// Bulk membership: how many of the nq i32 queries are present.
+fn simd_count_hits(ctrl: Bytes, kcol: Bytes, qs: Bytes, nq: Int) -> Int = wasm
+"(local $cp i32) (local $kp i32) (local $qp i32) (local $q i32) (local $n i32)"
+"(local $k i32) (local $h i32) (local $g i32) (local $m i32) (local $me i32)"
+"(local $j i32) (local $hits i32) (local $found i32) (local $stop i32)"
+"(local $v v128) (local $f v128)"
+"local.get $ctrl i32.wrap_i64 i32.load offset=8 local.set $cp"
+"local.get $kcol i32.wrap_i64 i32.load offset=8 local.set $kp"
+"local.get $qs i32.wrap_i64 i32.load offset=8 local.set $qp"
+"local.get $nq i64.const 1 i64.shr_s i32.wrap_i64 local.set $n"
+"(block $alldone"
+"  (loop $each"
+"    (br_if $alldone (i32.ge_s (local.get $q) (local.get $n)))"
+"    (local.set $k (i32.load align=1 (i32.add (local.get $qp) (i32.shl (local.get $q) (i32.const 2)))))"
+"    (local.set $h (i32.mul (local.get $k) (i32.const -1640531535)))"
+"    (local.set $g (i32.and (i32.and (i32.shr_u (local.get $h) (i32.const 16)) (i32.const 8191)) (i32.const 8176)))"
+"    (local.set $f (i8x16.splat (i32.and (local.get $h) (i32.const 127))))"
+"    (local.set $stop (i32.const 0))"
+"    (block $qdone"
+"      (loop $group"
+"        (local.set $v (v128.load align=1 (i32.add (local.get $cp) (local.get $g))))"
+"        (local.set $m (i8x16.bitmask (i8x16.eq (local.get $v) (local.get $f))))"
+"        (block $cands"
+"          (loop $cand"
+"            (br_if $cands (i32.eqz (local.get $m)))"
+"            (local.set $j (i32.ctz (local.get $m)))"
+"            (if (i32.eq (i32.load align=1 (i32.add (local.get $kp) (i32.shl (i32.add (local.get $g) (local.get $j)) (i32.const 2)))) (local.get $k))"
+"              (then"
+"                (local.set $hits (i32.add (local.get $hits) (i32.const 1)))"
+"                (br $qdone)"
+"              )"
+"            )"
+"            (local.set $m (i32.and (local.get $m) (i32.sub (local.get $m) (i32.const 1))))"
+"            (br $cand)"
+"          )"
+"        )"
+"        (local.set $me (i8x16.bitmask (i8x16.eq (local.get $v) (i8x16.splat (i32.const 128)))))"
+"        (br_if $qdone (i32.ne (local.get $me) (i32.const 0)))"
+"        (local.set $g (i32.and (i32.add (local.get $g) (i32.const 16)) (i32.const 8176)))"
+"        (br $group)"
+"      )"
+"    )"
+"    (local.set $q (i32.add (local.get $q) (i32.const 1)))"
+"    (br $each)"
+"  )"
+")"
+"(i64.shl (i64.extend_i32_s (local.get $hits)) (i64.const 1))"
+
+
+/// Point API: one lookup per call, driven from a vibe loop.
+fn simd_has(ctrl: Bytes, kcol: Bytes, k: Int) -> Int = wasm
+"(local $cp i32) (local $kp i32) (local $kk i32) (local $h i32) (local $g i32)"
+"(local $m i32) (local $me i32) (local $j i32) (local $hit i32)"
+"(local $v v128) (local $f v128)"
+"local.get $ctrl i32.wrap_i64 i32.load offset=8 local.set $cp"
+"local.get $kcol i32.wrap_i64 i32.load offset=8 local.set $kp"
+"local.get $k i64.const 1 i64.shr_s i32.wrap_i64 local.set $kk"
+"(local.set $h (i32.mul (local.get $kk) (i32.const -1640531535)))"
+"(local.set $g (i32.and (i32.and (i32.shr_u (local.get $h) (i32.const 16)) (i32.const 8191)) (i32.const 8176)))"
+"(local.set $f (i8x16.splat (i32.and (local.get $h) (i32.const 127))))"
+"(block $qdone"
+"  (loop $group"
+"    (local.set $v (v128.load align=1 (i32.add (local.get $cp) (local.get $g))))"
+"    (local.set $m (i8x16.bitmask (i8x16.eq (local.get $v) (local.get $f))))"
+"    (block $cands"
+"      (loop $cand"
+"        (br_if $cands (i32.eqz (local.get $m)))"
+"        (local.set $j (i32.ctz (local.get $m)))"
+"        (if (i32.eq (i32.load align=1 (i32.add (local.get $kp) (i32.shl (i32.add (local.get $g) (local.get $j)) (i32.const 2)))) (local.get $kk))"
+"          (then (local.set $hit (i32.const 1)) (br $qdone))"
+"        )"
+"        (local.set $m (i32.and (local.get $m) (i32.sub (local.get $m) (i32.const 1))))"
+"        (br $cand)"
+"      )"
+"    )"
+"    (local.set $me (i8x16.bitmask (i8x16.eq (local.get $v) (i8x16.splat (i32.const 128)))))"
+"    (br_if $qdone (i32.ne (local.get $me) (i32.const 0)))"
+"    (local.set $g (i32.and (i32.add (local.get $g) (i32.const 16)) (i32.const 8176)))"
+"    (br $group)"
+"  )"
+")"
+"(i64.shl (i64.extend_i32_s (local.get $hit)) (i64.const 1))"
+
+fn point_count_hits(ctrl: Bytes, kcol: Bytes, qs: Array[Int]) -> Int {
+  let n = Array::length(qs)
+  let mut i = 0
+  let mut hits = 0
+  while i < n {
+    hits = hits + simd_has(ctrl, kcol, Array::get(qs, i))
+    i = i + 1
+  }
+  hits
+}
+
+fn mk_keys(n: Int) -> Array[Int] {
+  let xs: Array[Int] = []
+  let mut i = 0
+  while i < n {
+    Array::push(xs, i * 7 + 3)
+    i = i + 1
+  }
+  xs
+}
+
+fn mk_queries(n: Int) -> Array[Int] {
+  let xs: Array[Int] = []
+  let mut i = 0
+  while i < n {
+    Array::push(xs, if i % 2 == 0 { i * 7 + 3 } else { i * 7 + 4 })
+    i = i + 1
+  }
+  xs
+}
+
+fn qcol(xs: Array[Int]) -> Bytes {
+  let n = Array::length(xs)
+  let b = zeros(n * 4, 0)
+  let mut i = 0
+  while i < n {
+    put_i32(b, i, Array::get(xs, i))
+    i = i + 1
+  }
+  b
+}
+
+fn mutmap_of(keys: Array[Int]) -> MutMap[Int, Int] {
+  let m: MutMap[Int, Int] = MutMap::new_int()
+  let n = Array::length(keys)
+  let mut i = 0
+  while i < n {
+    MutMap::set(m, Array::get(keys, i), 1)
+    i = i + 1
+  }
+  m
+}
+
+fn mutmap_count_hits(m: MutMap[Int, Int], qs: Array[Int]) -> Int {
+  let n = Array::length(qs)
+  let mut i = 0
+  let mut hits = 0
+  while i < n {
+    if MutMap::has(m, Array::get(qs, i)) {
+      hits = hits + 1
+    }
+    i = i + 1
+  }
+  hits
+}
+
+let keys = mk_keys(4000)
+let queries = mk_queries(4000)
+let table = build(keys)
+let ctrl = table.0
+let kcol = table.1
+let qbytes = qcol(queries)
+let mm = mutmap_of(keys)
+let sink = [
+  0
+]
+
+test "both agree" {
+  assert_eq(simd_count_hits(ctrl, kcol, qbytes, 4000), 2000)
+  assert_eq(mutmap_count_hits(mm, queries), 2000)
+  assert_eq(point_count_hits(ctrl, kcol, queries), 2000)
+}
+
+bench "lookup_4k_simd_frozen_set" { Array::set(sink, 0, simd_count_hits(ctrl, kcol, qbytes, 4000)) }
+bench "lookup_4k_stdlib_mutmap" { Array::set(sink, 0, mutmap_count_hits(mm, queries)) }
+bench "lookup_4k_simd_point_api" { Array::set(sink, 0, point_count_hits(ctrl, kcol, queries)) }

--- a/bench/bench_simd_int_column.vibe
+++ b/bench/bench_simd_int_column.vibe
@@ -1,0 +1,114 @@
+// Sum 4096 Ints three ways (see docs/simd-data-structures.md):
+//
+//   sum_4k_vibe_array_loop          the loop a library writes today
+//   sum_4k_simd_over_tagged_array   SIMD over vibe's 8-byte tagged slots
+//   sum_4k_simd_over_i32_column     SIMD over a packed i32 column in `Bytes`
+//
+// The tagged lane needs no untag/retag at all: `Int` n is represented n<<1 and
+// addition is tag-transparent, so `i64x2.add` over the raw slots is already
+// correct. What it cannot do is halve the memory traffic -- that is what the
+// packed i32 column buys, and it is the case vibe has no type for.
+
+fn vibe_sum(xs: Array[Int]) -> Int {
+  let mut i = 0
+  let mut acc = 0
+  let n = Array::length(xs)
+  while i < n {
+    acc = acc + Array::get(xs, i)
+    i = i + 1
+  }
+  acc
+}
+
+// Array block layout: [capacity@0][length@4][data_ptr@8], slots are tagged i64.
+// n<<1 is tag-transparent under addition, so no untag/retag is needed at all.
+fn simd_sum_tagged(xs: Bytes, n: Int) -> Int = wasm
+"(local $p i32) (local $i i32) (local $e i32) (local $a v128)"
+"local.get $xs i32.wrap_i64 i32.load offset=8 local.set $p"
+"local.get $n i64.const 1 i64.shr_s i32.wrap_i64 local.set $e"
+"(block $done"
+"  (loop $w"
+"    (br_if $done (i32.gt_s (i32.add (local.get $i) (i32.const 2)) (local.get $e)))"
+"    (local.set $a (i64x2.add (local.get $a) (v128.load align=1 (i32.add (local.get $p) (i32.shl (local.get $i) (i32.const 3))))))"
+"    (local.set $i (i32.add (local.get $i) (i32.const 2)))"
+"    (br $w)"
+"  )"
+")"
+"(i64.add (i64x2.extract_lane 0 (local.get $a)) (i64x2.extract_lane 1 (local.get $a)))"
+
+// i32 column packed into Bytes, 4 lanes per vector.
+fn simd_sum_i32col(b: Bytes, n: Int) -> Int = wasm
+"(local $p i32) (local $i i32) (local $e i32) (local $a v128)"
+"local.get $b i32.wrap_i64 i32.load offset=8 local.set $p"
+"local.get $n i64.const 1 i64.shr_s i32.wrap_i64 local.set $e"
+"(block $done"
+"  (loop $w"
+"    (br_if $done (i32.gt_s (i32.add (local.get $i) (i32.const 4)) (local.get $e)))"
+"    (local.set $a (i32x4.add (local.get $a) (v128.load align=1 (i32.add (local.get $p) (i32.shl (local.get $i) (i32.const 2))))))"
+"    (local.set $i (i32.add (local.get $i) (i32.const 4)))"
+"    (br $w)"
+"  )"
+")"
+"(i64.shl (i64.extend_i32_s (i32.add (i32.add (i32x4.extract_lane 0 (local.get $a)) (i32x4.extract_lane 1 (local.get $a))) (i32.add (i32x4.extract_lane 2 (local.get $a)) (i32x4.extract_lane 3 (local.get $a))))) (i64.const 1))"
+
+// NOTE: `fn arr_as_bytes(xs: Array[Int]) -> Bytes = wasm "..."` is REJECTED --
+// "param must be typed Int or Bytes". A SIMD kernel cannot see an Array[T] at
+// all, so the tagged-slot lane below rebuilds the same 8-byte tagged layout in
+// a Bytes by hand to measure the representation rather than the container.
+fn mk_tagged(n: Int) -> Bytes {
+  let b = Bytes::new()
+  let mut i = 0
+  while i < n {
+    let v = (i % 100) * 2
+    Bytes::push(b, v & 255)
+    Bytes::push(b, (v >> 8) & 255)
+    let mut k = 0
+    while k < 6 {
+      Bytes::push(b, 0)
+      k = k + 1
+    }
+    i = i + 1
+  }
+  b
+}
+
+fn mk_arr(n: Int) -> Array[Int] {
+  let xs: Array[Int] = []
+  let mut i = 0
+  while i < n {
+    Array::push(xs, i % 100)
+    i = i + 1
+  }
+  xs
+}
+
+fn mk_col(n: Int) -> Bytes {
+  let b = Bytes::new()
+  let mut i = 0
+  while i < n {
+    let v = i % 100
+    Bytes::push(b, v & 255)
+    Bytes::push(b, (v >> 8) & 255)
+    Bytes::push(b, 0)
+    Bytes::push(b, 0)
+    i = i + 1
+  }
+  b
+}
+
+let xs = mk_arr(4096)
+let col = mk_col(4096)
+let tagged = mk_tagged(4096)
+let sink = [
+  0
+]
+
+test "sums agree" {
+  assert_eq(vibe_sum(xs), 202560)
+  assert_eq(simd_sum_tagged(tagged, 4096), 202560)
+  assert_eq(simd_sum_i32col(col, 4096), 202560)
+}
+
+bench "sum_4k_vibe_array_loop" { Array::set(sink, 0, vibe_sum(xs)) }
+bench "sum_4k_simd_over_tagged_array" { Array::set(sink, 0, simd_sum_tagged(tagged, 4096)) }
+bench "sum_4k_simd_over_i32_column" { Array::set(sink, 0, simd_sum_i32col(col, 4096)) }

--- a/bench/bench_simd_rank.vibe
+++ b/bench/bench_simd_rank.vibe
@@ -1,0 +1,110 @@
+// rank1 over a 32 Kibit bitmap: the core primitive of every succinct structure
+// (rank/select bit vector, wavelet matrix, FM-index). See
+// docs/simd-data-structures.md.
+//
+// The point of this file is that the win is NOT SIMD. `i64.popcnt` -- one
+// scalar instruction vibe does not expose to library code -- carries almost
+// all of it; widening the load to v128 adds ~15%, and `i8x16.popcnt` with a
+// horizontal sum adds nothing.
+
+fn scalar_rank(b: Bytes, nbits: Int) -> Int {
+  let mut i = 0
+  let mut c = 0
+  while i < nbits {
+    let byte = Bytes::get(b, i / 8)
+    if (byte >> (i % 8)) & 1 == 1 {
+      c = c + 1
+    }
+    i = i + 1
+  }
+  c
+}
+
+/// 8 bytes per iteration, one `i64.popcnt`.
+fn popcnt_rank(b: Bytes, nbits: Int) -> Int = wasm
+"(local $p i32) (local $i i32) (local $e i32) (local $c i64)"
+"local.get $b i32.wrap_i64 i32.load offset=8 local.set $p"
+"local.get $nbits i64.const 1 i64.shr_s i32.wrap_i64 i32.const 3 i32.shr_u local.set $e"
+"(block $done"
+"  (loop $w"
+"    (br_if $done (i32.gt_s (i32.add (local.get $i) (i32.const 8)) (local.get $e)))"
+"    (local.set $c (i64.add (local.get $c) (i64.popcnt (i64.load align=1 (i32.add (local.get $p) (local.get $i))))))"
+"    (local.set $i (i32.add (local.get $i) (i32.const 8)))"
+"    (br $w)"
+"  )"
+")"
+"(i64.shl (local.get $c) (i64.const 1))"
+
+/// 16 bytes per iteration: one v128 load, two scalar popcounts on the lanes.
+fn simd_rank_lanes(b: Bytes, nbits: Int) -> Int = wasm
+"(local $p i32) (local $i i32) (local $e i32) (local $c i64) (local $v v128)"
+"local.get $b i32.wrap_i64 i32.load offset=8 local.set $p"
+"local.get $nbits i64.const 1 i64.shr_s i32.wrap_i64 i32.const 3 i32.shr_u local.set $e"
+"(block $done"
+"  (loop $w"
+"    (br_if $done (i32.gt_s (i32.add (local.get $i) (i32.const 16)) (local.get $e)))"
+"    (local.set $v (v128.load align=1 (i32.add (local.get $p) (local.get $i))))"
+"    (local.set $c (i64.add (local.get $c) (i64.add (i64.popcnt (i64x2.extract_lane 0 (local.get $v))) (i64.popcnt (i64x2.extract_lane 1 (local.get $v))))))"
+"    (local.set $i (i32.add (local.get $i) (i32.const 16)))"
+"    (br $w)"
+"  )"
+")"
+"(i64.shl (local.get $c) (i64.const 1))"
+
+/// 16 bytes per iteration, `i8x16.popcnt` plus the 0x01..01 multiply trick to
+/// sum the 16 lane counts (each <= 8, so the byte sum <= 128 cannot overflow).
+fn simd_rank_popcnt16(b: Bytes, nbits: Int) -> Int = wasm
+"(local $p i32) (local $i i32) (local $e i32) (local $c i64) (local $v v128)"
+"local.get $b i32.wrap_i64 i32.load offset=8 local.set $p"
+"local.get $nbits i64.const 1 i64.shr_s i32.wrap_i64 i32.const 3 i32.shr_u local.set $e"
+"(block $done"
+"  (loop $w"
+"    (br_if $done (i32.gt_s (i32.add (local.get $i) (i32.const 16)) (local.get $e)))"
+"    (local.set $v (i8x16.popcnt (v128.load align=1 (i32.add (local.get $p) (local.get $i)))))"
+"    (local.set $c (i64.add (local.get $c) (i64.add"
+"       (i64.shr_u (i64.mul (i64x2.extract_lane 0 (local.get $v)) (i64.const 0x0101010101010101)) (i64.const 56))"
+"       (i64.shr_u (i64.mul (i64x2.extract_lane 1 (local.get $v)) (i64.const 0x0101010101010101)) (i64.const 56)))))"
+"    (local.set $i (i32.add (local.get $i) (i32.const 16)))"
+"    (br $w)"
+"  )"
+")"
+"(i64.shl (local.get $c) (i64.const 1))"
+
+fn mkbits(n: Int) -> Bytes {
+  let b = Bytes::new()
+  let mut i = 0
+  while i < n {
+    Bytes::push(b, (i * 37) % 256)
+    i = i + 1
+  }
+  b
+}
+
+let bits = mkbits(4096)
+
+let sink = [
+  0
+]
+
+test "every rank lane agrees" {
+  assert_eq(scalar_rank(bits, 32768), 16384)
+  assert_eq(popcnt_rank(bits, 32768), 16384)
+  assert_eq(simd_rank_lanes(bits, 32768), 16384)
+  assert_eq(simd_rank_popcnt16(bits, 32768), 16384)
+}
+
+bench "rank_32kbit_scalar_vibe" {
+  Array::set(sink, 0, scalar_rank(bits, 32768))
+}
+
+bench "rank_32kbit_i64_popcnt" {
+  Array::set(sink, 0, popcnt_rank(bits, 32768))
+}
+
+bench "rank_32kbit_v128load_2xpopcnt" {
+  Array::set(sink, 0, simd_rank_lanes(bits, 32768))
+}
+
+bench "rank_32kbit_i8x16popcnt_hsum" {
+  Array::set(sink, 0, simd_rank_popcnt16(bits, 32768))
+}

--- a/docs/README.md
+++ b/docs/README.md
@@ -101,6 +101,7 @@ the repo; not the user manual.
 | [region-mutable-state.md](region-mutable-state.md) | `internal/design/` | ADR-0090, proposed |
 | [registry-design.md](registry-design.md) | `internal/design/` | ADR-0065 Phase 5 |
 | [resource-kind-parameters.md](resource-kind-parameters.md) | `internal/design/` | ADR-0094, proposed |
+| [simd-data-structures.md](simd-data-structures.md) | `internal/design/` | Measured proposal: SIMD-first data-structure foundation |
 | [vibex-runtime-contract.md](vibex-runtime-contract.md) | `internal/design/` | ADR-0075, proposed |
 | [wasip3-effect-alignment.md](wasip3-effect-alignment.md) | `internal/design/` | ADR-0089, proposed |
 | [zero-alloc-check.md](zero-alloc-check.md) | `internal/design/` | ADR-0091, proposed |

--- a/docs/cheatsheet.md
+++ b/docs/cheatsheet.md
@@ -2037,7 +2037,10 @@ fn simd_add(a: Int, b: Int) -> Int = wasm
   `(i32.const -1640531535)` are the same instruction. Out of range for the
   instruction's width — or longer than a vibe `Int` — is a **located error**
   from `vibe check`, not a truncation and not a module that only fails at load
-  (#2341).
+  (#2341). NOTE until the next bootstrap bump: the committed seed predates this,
+  and `vibe test` compiles with the seed by default, so inside `lib/**` and
+  anything run through `scripts/vibe_test.sh` keep spelling an out-of-signed-range
+  i32 immediate the signed way.
 - **WAT text**: ordinary string literal(s) — the lexer has no raw/multiline
   strings; adjacent literals after `= wasm` are joined with newlines. `;;`
   line and `(; ;)` block comments work inside the text.

--- a/docs/cheatsheet.md
+++ b/docs/cheatsheet.md
@@ -2032,6 +2032,12 @@ fn simd_add(a: Int, b: Int) -> Int = wasm
   locals index past the params + closure-env slot. v128 locals are what let
   a kernel keep vector state across instructions (e.g. the BLAKE3 compress
   in `lib/@vibe/blake3/simd.vibe`).
+- **Integer immediates** accept BOTH spellings the text format defines
+  (`iN ::= n:uN | i:sN`), so `(i32.const 2654435761)` and
+  `(i32.const -1640531535)` are the same instruction. Out of range for the
+  instruction's width — or longer than a vibe `Int` — is a **located error**
+  from `vibe check`, not a truncation and not a module that only fails at load
+  (#2341).
 - **WAT text**: ordinary string literal(s) — the lexer has no raw/multiline
   strings; adjacent literals after `= wasm` are joined with newlines. `;;`
   line and `(; ;)` block comments work inside the text.

--- a/docs/simd-data-structures.md
+++ b/docs/simd-data-structures.md
@@ -280,7 +280,10 @@ in library code:
    assembles to the same bytes as `-1640531535`) and gives a located error for
    what is genuinely out of range — for `v128.const` lanes, which silently
    truncated, and for an integer literal longer than a vibe `Int`, which
-   silently wrapped, as well.
+   silently wrapped, as well. Until the next bootstrap bump the committed seed
+   predates the fix, and `vibe test` compiles with the seed by default — so the
+   benches here still spell that constant the signed way, and
+   `bench/bench_simd_hash_probe.vibe` says why at the top.
 2. **No `call`.** Kernels cannot compose, so every structure re-inlines its own
    hash, its own group probe, its own tail handling. Allowing a call to another
    inline-wasm `fn` in the same module would remove most of the duplication.

--- a/docs/simd-data-structures.md
+++ b/docs/simd-data-structures.md
@@ -253,12 +253,17 @@ first, because that is where the measurements say the value is.
 Unbox `V128` or retire it. Independently, three inline-wasm gaps block kernels
 in library code:
 
-1. **Out-of-range `i32.const` produces an invalid module with no diagnostic.**
-   Measured: `(i32.const 2654435761)` — in range for a vibe `Int`, out of range
-   for `i32` — passes `vibe check` **clean** and then fails at load with
-   `viberun: from_file: failed to compile: wasm[0]::function[70]::f` and a Rust
-   backtrace. `vibe check` answering "clean" for a program that cannot be built
-   breaks the CLI contract in `CLAUDE.md`; this deserves its own issue.
+1. ~~**Out-of-range `i32.const` produces an invalid module with no
+   diagnostic.**~~ **Fixed** (#2341). It used to be: `(i32.const 2654435761)` —
+   in range for a vibe `Int`, out of range for a *signed* `i32` — passed
+   `vibe check` **clean** and then failed at load with `viberun: from_file:
+   failed to compile: wasm[0]::function[70]::f` and a Rust backtrace, which is
+   `vibe check` lying about whether a program builds. The fix accepts both
+   spellings the text format defines (`iN ::= n:uN | i:sN`, so that literal now
+   assembles to the same bytes as `-1640531535`) and gives a located error for
+   what is genuinely out of range — for `v128.const` lanes, which silently
+   truncated, and for an integer literal longer than a vibe `Int`, which
+   silently wrapped, as well.
 2. **No `call`.** Kernels cannot compose, so every structure re-inlines its own
    hash, its own group probe, its own tail handling. Allowing a call to another
    inline-wasm `fn` in the same module would remove most of the duplication.

--- a/docs/simd-data-structures.md
+++ b/docs/simd-data-structures.md
@@ -391,19 +391,28 @@ layers above are proposed in dependency order for that reason, and Layer 3's
 `F32Column` and `U8Column` are explicitly gated behind a workload that wants
 them.
 
-## 7. Suggested issue tree
+## 7. Issue tree
 
-One parent, six children, three-axis labels per
-[docs/issue-triage.md](issue-triage.md):
+Parent [#2340](https://github.com/mizchi/vibe-lang/issues/2340), three-axis
+labels per [docs/issue-triage.md](issue-triage.md). Priority is the symptom the
+issue states and nothing else, so most of this is P2 — almost none of it is
+something that works today being broken.
 
 | # | item | kind | priority |
 | :-- | :--- | :--- | :--- |
-| parent | SIMD-first data-structure foundation | epic | — |
-| 1 | `V128` intrinsics: unbox or retire (§3.1) | bug | P1 |
-| 2 | inline wasm: out-of-range `i32.const` passes `vibe check`, fails at load (§4/Layer 0) | bug | **P0** |
-| 3 | `Int::popcount` / `ctz` / `clz` / `select1` and `~` (§3.2) | feature | P1 |
-| 4 | `Bytes` search/compare/count kernels; route `String::*` through them (§4/Layer 2) | feature | P1 |
-| 5 | `MutMap`: `Array[Int]` state -> `Bytes` control byte + fingerprint (§3.4) | perf | P1 |
-| 6 | `I32Column` builder/frozen pair (§4/Layer 3) | feature | P2 |
+| [#2340](https://github.com/mizchi/vibe-lang/issues/2340) | SIMD-first data-structure foundation (index) | `epic` | P2 |
+| [#2341](https://github.com/mizchi/vibe-lang/issues/2341) | inline wasm: out-of-range `i32.const` passes `vibe check`, fails at module load (§4/Layer 0) | `bug` | **P0** |
+| [#2342](https://github.com/mizchi/vibe-lang/issues/2342) | `V128` intrinsics heap-box every vector and never reclaim it — unbox or retire (§3.1) | `bug` `performance` | P1 |
+| [#2343](https://github.com/mizchi/vibe-lang/issues/2343) | the low-level wasm intrinsic block in `declarations.vibe` does not resolve from user code (§3.2) | `bug` | P2 |
+| [#2344](https://github.com/mizchi/vibe-lang/issues/2344) | `Int::popcount` / `ctz` / `clz` / `select1`, and `~` (§3.2) | `enhancement` `blocker` | P2 |
+| [#2345](https://github.com/mizchi/vibe-lang/issues/2345) | `Bytes` search/compare/count kernels; route `String::*` through them (§4/Layer 2) | `enhancement` | P2 |
+| [#2346](https://github.com/mizchi/vibe-lang/issues/2346) | `MutMap`: `Array[Int]` state -> `Bytes` control byte + fingerprint (§3.4) | `performance` | P2 |
+| [#2347](https://github.com/mizchi/vibe-lang/issues/2347) | `I32Column` builder/frozen pair (§4/Layer 3) | `enhancement` | P2 |
+| [#2348](https://github.com/mizchi/vibe-lang/issues/2348) | inline wasm: no `call` between kernels, no `Array[T]` param (§3.3, §4/Layer 0) | `enhancement` | P2 |
 
-Items 2, 3, 4 and 5 need no new language surface and no decision from item 1.
+Layers 4 and 5 have no issue yet, deliberately: by §5 each needs a documented
+end-to-end workload that wins against a native builtin before it is written.
+
+The order falls out of the triage rules — #2341, then #2342, then #2344 (the
+`blocker`), then the rest. #2343, #2344, #2345 and #2346 need no new language
+surface and no decision from #2342.

--- a/docs/simd-data-structures.md
+++ b/docs/simd-data-structures.md
@@ -45,12 +45,17 @@ nothing new has to be invented — the discipline just has to be applied to the
 new structures.
 
 **Transfers — design bulk operations first, point conveniences second.**
-Measured here on a 4000-key lookup (§3.4): the same frozen table costs
-5.1 ns/lookup through a point API and 2.6 ns/lookup when the loop stays inside
-the kernel. Nothing about the data changed; the difference is entirely the
-per-call boundary. jsimd states this as a contract — "individual gets were
-12.5x slower" is written into `byte-key-flat-hash`'s own row — and vibe should
-do the same rather than let a fast structure be quoted at its slowest call.
+Measured here on a 4000-key lookup (§3.4), same table, same packed query
+column, the only difference being where the loop lives: 2.7 ns/lookup with the
+loop inside the kernel, 3.6 ns/lookup with it in vibe. **1.32x** for the
+per-call boundary alone. A third lane that also moves the queries back into an
+`Array[Int]` costs 6.6 ns/lookup — so in the first draft of this document, which
+had no packed-query point lane, the boundary looked like 1.9x because it was
+carrying the query representation with it. Two variables, one number; the fix
+was another lane, not a softer sentence. jsimd states the bulk-vs-point rule as
+a contract — "individual gets were 12.5x slower" is written into
+`byte-key-flat-hash`'s own row — and vibe should do the same rather than let a
+fast structure be quoted at its slowest call.
 
 **Transfers — export algorithms, not vector values.** jsimd deliberately does
 not export `v128`: "JavaScript cannot pass `v128` across the Wasm boundary, and
@@ -224,23 +229,35 @@ keys, 500 iters:
 
 | lane | ns/op (mean) | ns/lookup | B/op |
 | :--- | ---: | ---: | ---: |
-| stdlib `MutMap[Int, Int]` (`MutMap::has` in a vibe loop) | 151134 | 37.8 | 0 |
-| frozen control-byte table, point API, vibe loop | 20158 | 5.0 | 0 |
-| frozen control-byte table, bulk kernel | **10522** | **2.6** | 0 |
+| stdlib `MutMap[Int, Int]` (`MutMap::has` in a vibe loop) | 149739 | 37.4 | 0 |
+| frozen table, point API, queries in an `Array[Int]` | 26293 | 6.6 | 0 |
+| frozen table, point API, queries in the packed column | 14284 | 3.6 | 0 |
+| frozen table, bulk kernel | **10850** | **2.7** | 0 |
 
-This is **not** apples to apples and the file says so: `MutMap` is generic over
-`K`/`V` with closed-over `hash_fn`/`eq_fn` and `Option`-wrapped slots, while the
-frozen table is a monomorphic set of non-negative `Int`s. The comparison sizes
-headroom, it does not indict the stdlib. But the decomposition is the
-interesting part: **7.5x comes from the representation, and a further 1.9x from
-keeping the loop inside the kernel.**
+**Read the 13.8x between the first and last rows as aggregate headroom and
+nothing finer.** The two ends differ in at least eight ways at once: generic
+`K`/`V` vs monomorphic `Int`; a map vs a set; `Option`-wrapped slots vs raw
+ones; closed-over `hash_fn`/`eq_fn` indirect calls vs an inlined multiply; a
+different hash; linear probing vs group-of-16; an 8-byte state slot vs a
+1-byte control byte; and tagged 8-byte keys vs a packed i32 column. **Not one of
+those is isolated by this bench**, so no single one of them can be credited with
+a share of the 13.8x. It sizes what a specialized frozen representation can
+reach; it does not indict the stdlib and it does not price any individual
+change.
 
-The representational cost is concrete. `lib/@vibe/core/hashmap.vibe` stores slot
-state as `Array[Int]` — one tagged i64, **8 bytes per slot**, for a value with
-three possible states. A SwissTable control byte is 1 byte and carries a 7-bit
-fingerprint as well, so one `v128.load` covers 16 slots where `Array[Int]`
-covers 2. Even with no SIMD at all, moving that array to a `Bytes` control array
-cuts probe-metadata traffic 8x.
+The three frozen rows *are* controlled against each other, and that is where
+the readable numbers are: same table, same probe, same hash. Loop-in-kernel vs
+loop-in-vibe is **1.32x**; moving the queries from an `Array[Int]` to the packed
+column is another **1.84x**.
+
+The case for changing `MutMap` is therefore structural, not measured here.
+`lib/@vibe/core/hashmap.vibe` stores slot state as `Array[Int]` — one tagged
+i64, **8 bytes per slot**, for a value with three possible states. A SwissTable
+control byte is 1 byte and carries a 7-bit fingerprint as well, so one
+`v128.load` covers 16 slots where `Array[Int]` covers 2, and the fingerprint
+skips most of the `eq_fn` indirect calls. Even with no SIMD, that is an 8x cut
+in probe-metadata traffic. What it is *worth* is [#2346](https://github.com/mizchi/vibe-lang/issues/2346)'s
+job to measure, with the rest of `MutMap` held fixed.
 
 ## 4. Proposal: five layers, bottom-up
 
@@ -352,8 +369,9 @@ and point access as a convenience that is explicitly *not* in the contract.
 Separately and independently of any of this: **change `MutMap`'s `state:
 Array[Int]` to a `Bytes` control array carrying a 7-bit fingerprint.** It is a
 local change to one file, it needs no new language surface, and it cuts
-probe-metadata traffic 8x with the fingerprint eliminating most key comparisons.
-That is the single highest value-per-line item in this document.
+probe-metadata traffic 8x with the fingerprint skipping most `eq_fn` calls. It
+is the cheapest change proposed here by a wide margin — but §3.4 does not price
+it, so it ships with its own before/after bench or not at all.
 
 ## 5. Admission policy
 
@@ -419,5 +437,7 @@ Layers 4 and 5 have no issue yet, deliberately: by §5 each needs a documented
 end-to-end workload that wins against a native builtin before it is written.
 
 The order falls out of the triage rules — #2341, then #2342, then #2344 (the
-`blocker`), then the rest. #2343, #2344, #2345 and #2346 need no new language
-surface and no decision from #2342.
+`blocker`), then the rest. None of #2343 / #2344 / #2345 / #2346 waits on the
+#2342 decision. Of those, #2343, #2345 and #2346 need no new language surface
+at all; #2344 does — `Int::popcount` and friends are builtin additions, and `~`
+is a new operator, so it touches the lexer, the parser and the printer as well.

--- a/docs/simd-data-structures.md
+++ b/docs/simd-data-structures.md
@@ -1,0 +1,409 @@
+# SIMD-first data structures: where vibe stands and what to build
+
+Written 2026-08-26. Every number below was measured on this checkout with
+`vibe bench`; the benches are committed next to the claims (`bench/bench_simd_*.vibe`)
+so any of them can be re-run or refuted.
+
+The starting point is [`mizchi/jsimd`](https://github.com/mizchi/jsimd), which
+asked "how much do succinct/SIMD data structures actually buy?" for JavaScript
+hot paths and answered it with ~30 measured subpaths and a written admission
+policy. This document asks the same question for vibe, keeps the parts of
+jsimd's answer that transfer, and proposes what to add or change in vibe's
+own data-structure foundation.
+
+## Re-running the evidence
+
+```bash
+vibe test  bench/bench_simd_bytes_find.vibe   # every lane agrees
+vibe bench bench/bench_simd_bytes_find.vibe --iters 500
+vibe bench bench/bench_simd_rank.vibe --iters 500
+vibe bench bench/bench_simd_int_column.vibe --iters 500
+vibe bench bench/bench_simd_hash_probe.vibe --iters 500
+```
+
+All four files are linear-backend only (they use inline wasm), which is
+`vibe bench`'s default lane.
+
+## 1. What jsimd established, and what transfers
+
+jsimd's headline results (Apple M5, Node 24 / Deno 2.6; its READMEs carry the
+setups) cluster into three groups:
+
+| group | jsimd result |
+| :--- | :--- |
+| byte-level scanning (`bytes`, `json`) | 4.9–18.1x over the JS baseline |
+| frozen, resident, bulk-queried structures (wavelet matrix, roaring, bit-sliced column, flat hash) | 2–100x+ on bulk, **slower** on point access and on construction |
+| symmetric "SIMD versions of things that already exist" (`SuccinctTrie`, `LoudsTree`, `StringInterner`, `PackedUint32Array`, `PackedDeltaArray`, `StaticMphfBytes`) | **rejected** — lost to the JS builtin |
+
+Three of its conclusions transfer to vibe unchanged, and one does not.
+
+**Transfers — separate the mutable builder from the frozen query
+representation.** Their layouts conflict; a structure that tries to be both is
+worse at both. vibe already has the vocabulary for this
+(`ArrayBuilder::freeze`, `MapBuilder::freeze`, `StringBuilder::freeze`), so
+nothing new has to be invented — the discipline just has to be applied to the
+new structures.
+
+**Transfers — design bulk operations first, point conveniences second.**
+Measured here on a 4000-key lookup (§3.4): the same frozen table costs
+5.1 ns/lookup through a point API and 2.6 ns/lookup when the loop stays inside
+the kernel. Nothing about the data changed; the difference is entirely the
+per-call boundary. jsimd states this as a contract — "individual gets were
+12.5x slower" is written into `byte-key-flat-hash`'s own row — and vibe should
+do the same rather than let a fast structure be quoted at its slowest call.
+
+**Transfers — export algorithms, not vector values.** jsimd deliberately does
+not export `v128`: "JavaScript cannot pass `v128` across the Wasm boundary, and
+copying is only worthwhile when one call performs enough work." vibe hit the
+same wall from the other side and has not yet drawn the same conclusion — see
+§3.1, where its `v128_*` intrinsics turn out to cost 22x the algorithm they
+exist to express.
+
+**Does NOT transfer — the baseline.** jsimd's rejections are measured against
+V8's `Map`, `Set`, typed arrays and `TextDecoder`: hand-tuned native code. A
+vibe library's baseline is usually a **vibe-level loop**, which is roughly two
+orders of magnitude slower (§3.1 measures 6.1 ns per byte scanned). So a
+structure jsimd rejected can still win handily in vibe — and that is a trap,
+not an opportunity: winning against a vibe loop proves nothing except that the
+loop was never the right implementation. **The honest baseline for anything
+proposed here is a native scalar builtin implemented in the compiler**, and
+against that baseline the margins collapse: `String::index_of` (native, scalar)
+runs a 4 KiB search in 352 ns where a hand-written SIMD kernel takes 248 ns —
+1.4x, not 100x.
+
+## 2. Where vibe's SIMD support actually is
+
+Two unrelated mechanisms exist today, and they are very far apart in quality.
+
+**Fused builtins written in the compiler** (`codegen/builtin_bodies/`,
+`codegen/expr/compile_call.vibe`). Five exist: `simd_skip_ws`,
+`simd_scan_alnum`, `simd_scan_alnum_str`, `simd_scan_string_special_str`,
+`simd_scan_line_end_str`. They keep the `v128` on the operand stack for the
+whole loop and are fast. Two of the five have a production caller
+(`lib/@vibe/parser/lexer.vibe:653,750`); the other three have only fixtures.
+This mechanism works, but every kernel costs a compiler change, a registry row,
+and a per-lane index arm — it does not scale to a data-structure library.
+
+**Inline wasm** (`fn f(b: Bytes, n: Int) -> Int = wasm "..."`, #805/ADR-0072).
+A ~600-line WAT assembler with the full integer/float/SIMD opcode set, `v128`
+locals, `i8x16.shuffle`, structured control flow. This is the mechanism that
+makes a SIMD data-structure library possible in *library* code —
+`lib/@vibe/blake3/simd.vibe` already proves it at scale, and every kernel in the
+benches here is written this way. It is linear-backend only (the wasm-gc backend
+rejects it).
+
+**The `V128` intrinsic surface** (`v128_load`, `v128_eq_i8x16`, … — 12 names in
+`builtins/declarations.vibe`, typed in `checker/builtins_simd.vibe`) sits between the two and belongs to neither. It is
+measured in §3.1.
+
+## 3. Measured: four gaps
+
+### 3.1 The `V128` intrinsics are the wrong shape
+
+`bench/bench_simd_bytes_find.vibe`, 4 KiB single-byte search, 500 iters:
+
+| lane | ns/op (mean) | B/op | vs. best |
+| :--- | ---: | ---: | ---: |
+| inline-wasm SIMD kernel | **248** | **0** | 1.0x |
+| native `String::index_of` (scalar builtin) | 352 | 0 | 1.4x |
+| same algorithm through `v128_*` intrinsics | 5564 | **8048** | 22x |
+| vibe-level scalar loop over `Bytes::get` | 25001 | 0 | 101x |
+
+The intrinsic lane runs the *identical algorithm* as the kernel lane and is 22x
+slower, because each `v128_load` / `v128_eq_i8x16` / `v128_and` returns a tagged
+pointer to a freshly bump-allocated 16-byte box (`codegen/expr/compile_call.vibe`,
+`perceus/perceus.vibe:922-930,1287-1294` — the boxes deliberately carry no RC
+header, so they are never reclaimed). Scanning 4096 bytes allocates 8 KiB. The compiler's
+own fused builtins avoid this by never letting the vector become a value; the
+comment in `compile_call.vibe:2065` says so outright ("NO heap boxing — the
+per-op boxed v128 intrinsics would bump-allocate 16 bytes each and leak").
+
+So the intrinsics are documented, type-checked, reachable from user code, and
+wrong to use. They never give a wrong answer, so this is not a P0 by the triage
+rules — but it is the shape the design policy cares about for a different
+reason: the surface reads as the supported way to write SIMD, and taking it
+costs 22x and 2 bytes of unreclaimable heap per byte scanned. They have no
+caller in the tree except `fixtures/v128_intrinsics_test.vibe`.
+
+**Proposal.** Pick one and write it down:
+
+- **(a) Unbox them.** Keep `V128` a first-class type but require it to stay in
+  a wasm local: reject (with a located diagnostic) any `V128` that escapes a
+  function body, and lower non-escaping ones to a `v128` local. This is the same
+  shape as ADR-0090's `let mut` escape analysis, and `vibe escapes` already
+  exists as the CLI surface for that question.
+- **(b) Retire them.** Delete the 12 names, keep the fixture as a regression
+  for the emitters, and point the cheatsheet at inline wasm. This is jsimd's
+  answer ("export algorithms rather than raw `v128` values") and is much
+  cheaper.
+
+Either is fine. Leaving them as they are is not: a surface that is 22x slower
+than the thing it wraps is a trap for exactly the LLM-driven loop this repo
+optimizes for.
+
+### 3.2 The bit primitives are missing, and they matter more than SIMD
+
+`bench/bench_simd_rank.vibe`, rank1 over 32 Kibit, 500 iters:
+
+| lane | ns/op (mean) | vs. scalar |
+| :--- | ---: | ---: |
+| vibe loop over `Bytes::get`, bit by bit | 159834 | 1x |
+| `i64.popcnt`, 8 B/iter | 465 | **344x** |
+| `v128.load` + 2x `i64.popcnt`, 16 B/iter | **365** | 438x |
+| `i8x16.popcnt` + horizontal sum, 16 B/iter | 518 | 309x |
+
+This is the most useful negative result in the set. **Essentially the whole win
+is one scalar instruction**; widening the load to `v128` adds 27%, and the
+dedicated `i8x16.popcnt` adds nothing at all. rank/select, and therefore every
+succinct structure built on it, is a *popcount* story, not a SIMD story.
+
+And vibe does not expose popcount. `declarations.vibe` has a
+`//# WASM intrinsics (low-level)` block of ~50 names (`i32_eqz`, `i32_load8_u`,
+`int_ctz`, `f32_sqrt`, …) described as the "Single Source of Truth for all
+builtin function signatures" — measured, **none of them resolve from user
+code**:
+
+```
+$ vibe check probe.vibe        # fn f(x: Int) -> Int { let _ = int_ctz; 0 }
+line 1:31-38: unknown name: int_ctz
+```
+
+(The `v128_*` block in the same file does resolve. The low-level block is
+compiler-internal, and the file's header comment does not say so.)
+
+**Proposal.** Add a small, stable, scalar bit surface on `Int`, lowered to the
+corresponding wasm opcode:
+
+```
+Int::popcount(Int) -> Int      // i64.popcnt on the untagged value
+Int::ctz(Int) -> Int           // define the zero case (wasm i64.ctz gives 64)
+Int::clz(Int) -> Int
+Int::select1(Int, Int) -> Int  // position of the k-th set bit, -1 if absent
+```
+
+`~` (bit-not) is also still missing — `CLAUDE.md` tells readers to spell it
+`x ^ mask`, and measured, `~x` is a parse error ("unexpected token: ~"); it
+belongs in the same change. These four are cheap, they are
+tag-safe (untag, operate, retag), they work on both backends, and they unblock
+every bit-level structure in §4 without any SIMD at all.
+
+### 3.3 There is no packed numeric buffer
+
+`bench/bench_simd_int_column.vibe`, sum of 4096 `Int`s, 500 iters:
+
+| lane | ns/op (mean) | vs. loop |
+| :--- | ---: | ---: |
+| vibe loop over `Array[Int]` | 9240 | 1x |
+| SIMD over vibe's 8-byte tagged slots | 1541 | 6.0x |
+| SIMD over a packed i32 column in `Bytes` | **630** | **14.7x** |
+
+Two things to read out of this.
+
+First, **vibe's tag choice is already SIMD-friendly**: `Int` n is represented
+`n<<1`, and addition is tag-transparent, so `i64x2.add` straight over an array's
+raw slots is correct with no untag/retag at all. That is a genuine asset and
+should be written down before someone "fixes" the representation.
+
+Second, the remaining 2.4x is pure memory traffic: 8 bytes per element where 4
+would do, and 2 lanes per vector where 4 would fit. vibe has exactly two array
+shapes — `Array[T]` (tagged 8-byte slots) and `Bytes` (u8) — and nothing in
+between. jsimd's entire middle layer (`i32-array`, `f32-vector`, `columnar`,
+`bit-sliced-column`, `blocked-vector-array`, `matrix2d/3d`) is built on typed
+arrays that vibe has no type for.
+
+There is a second, harder edge here: **a SIMD kernel cannot see an `Array[T]`
+at all.** Inline wasm accepts only `Int` and `Bytes` params —
+`fn f(xs: Array[Int]) -> Bytes = wasm "..."` is rejected with "param must be
+typed Int or Bytes". So the tagged lane above had to rebuild the tagged layout
+inside a `Bytes` by hand to be measurable.
+
+### 3.4 `MutMap`'s probe metadata is 8x wider than it needs to be
+
+`bench/bench_simd_hash_probe.vibe`, 4000 membership tests against 4000 `Int`
+keys, 500 iters:
+
+| lane | ns/op (mean) | ns/lookup | B/op |
+| :--- | ---: | ---: | ---: |
+| stdlib `MutMap[Int, Int]` (`MutMap::has` in a vibe loop) | 151134 | 37.8 | 0 |
+| frozen control-byte table, point API, vibe loop | 20158 | 5.0 | 0 |
+| frozen control-byte table, bulk kernel | **10522** | **2.6** | 0 |
+
+This is **not** apples to apples and the file says so: `MutMap` is generic over
+`K`/`V` with closed-over `hash_fn`/`eq_fn` and `Option`-wrapped slots, while the
+frozen table is a monomorphic set of non-negative `Int`s. The comparison sizes
+headroom, it does not indict the stdlib. But the decomposition is the
+interesting part: **7.5x comes from the representation, and a further 1.9x from
+keeping the loop inside the kernel.**
+
+The representational cost is concrete. `lib/@vibe/core/hashmap.vibe` stores slot
+state as `Array[Int]` — one tagged i64, **8 bytes per slot**, for a value with
+three possible states. A SwissTable control byte is 1 byte and carries a 7-bit
+fingerprint as well, so one `v128.load` covers 16 slots where `Array[Int]`
+covers 2. Even with no SIMD at all, moving that array to a `Bytes` control array
+cuts probe-metadata traffic 8x.
+
+## 4. Proposal: five layers, bottom-up
+
+Each layer is useful on its own and each is a precondition for the next. The
+ordering is deliberate — it puts the cheapest and least SIMD-dependent work
+first, because that is where the measurements say the value is.
+
+### Layer 0 — decide the SIMD surface (§3.1)
+
+Unbox `V128` or retire it. Independently, three inline-wasm gaps block kernels
+in library code:
+
+1. **Out-of-range `i32.const` produces an invalid module with no diagnostic.**
+   Measured: `(i32.const 2654435761)` — in range for a vibe `Int`, out of range
+   for `i32` — passes `vibe check` **clean** and then fails at load with
+   `viberun: from_file: failed to compile: wasm[0]::function[70]::f` and a Rust
+   backtrace. `vibe check` answering "clean" for a program that cannot be built
+   breaks the CLI contract in `CLAUDE.md`; this deserves its own issue.
+2. **No `call`.** Kernels cannot compose, so every structure re-inlines its own
+   hash, its own group probe, its own tail handling. Allowing a call to another
+   inline-wasm `fn` in the same module would remove most of the duplication.
+3. **`Bytes` params only.** See §3.3. At minimum, a supported way to hand a
+   kernel the payload pointer and length of an `Array[T]`.
+
+### Layer 1 — scalar bit primitives (§3.2)
+
+`Int::popcount` / `Int::ctz` / `Int::clz` / `Int::select1`, plus `~`. No SIMD,
+both backends, ~344x on rank.
+
+### Layer 2 — `Bytes` bulk kernels
+
+`Bytes` today has `get`/`set`/`push`/`slice`/`concat`/`fill`/`blit` and
+structural `==`. It has **no search, no ordering, no counting** — so any library
+that scans bytes writes the 6.1 ns/byte loop from §3.1 by hand. This is jsimd's
+best-measured group (4.9–18.1x) and the one moonbitlang/core already covers with
+the patterns jsimd inventories in its `CORE_PATTERNS.md`:
+
+```
+Bytes::index_of(Bytes, Int) -> Int              // single byte
+Bytes::index_of_bytes(Bytes, Bytes) -> Int      // first/last-byte SIMD prefilter,
+                                                // then verify the middle
+Bytes::last_index_of(Bytes, Int) -> Int
+Bytes::count(Bytes, Int) -> Int
+Bytes::compare(Bytes, Bytes) -> Int             // lexicographic, first differing lane
+```
+
+Two design notes. `String` is a byte string since ADR-0098, so
+`String::index_of` / `contains` / `split` / `starts_with` should route through
+the same kernels rather than keeping a second scalar implementation — that is
+where the 1.4x of §3.1 gets collected, across a surface that already has
+callers. And a kernel wants to over-read its tail: guaranteeing at
+least 15 bytes of readable slack past `len` would let every kernel drop its
+scalar tail loop. Today's block is `[alloc@0][len@4][data@8]` with capacity
+seeded at 64 and doubling, always a multiple of 8
+(`gen_bytes_push_body`) — so the slack is 0..7 bytes and a 16-byte tail load
+can read past the block.
+
+### Layer 3 — packed columns (§3.3)
+
+Not a new primitive type: a **frozen typed view over `Bytes`, built through a
+builder**, matching vibe's existing `Builder::freeze` idiom.
+
+```
+I32Column::builder() -> I32ColumnBuilder
+I32ColumnBuilder::push(I32ColumnBuilder, Int) -> Unit
+I32ColumnBuilder::freeze(I32ColumnBuilder) -> I32Column
+
+I32Column::length(I32Column) -> Int
+I32Column::get(I32Column, Int) -> Int          // point convenience, outside the contract
+I32Column::sum(I32Column) -> Int               // bulk: the operations that earn the type
+I32Column::min / max / count_eq / count_lt
+I32Column::mask_range(I32Column, Int, Int) -> Bitmap
+```
+
+`F32Column` and `U8Column` follow the same shape. `I32Column` first: it is the
+one the compiler itself would use (token offsets, span tables, module indices).
+
+### Layer 4 — bit-level structures
+
+```
+Bitmap                 // mutable dense bitmap: set/clear/test, bulk and/or/andnot/count
+BitVector              // frozen packed bits + rank/select index
+```
+
+Built on Layer 1, not on SIMD (§3.2). `Bitmap`'s bulk set operations
+(`and`/`or`/`andnot` over whole words) are where `v128` genuinely pays, and
+jsimd measures that group at 9.8–19.8x.
+
+Name them exactly this way and reserve them: jsimd spent a release cycle
+cleaning up `bitset` / `bit-vector` / `rank-select-bitvector` /
+`rank-select-bitmap` aliases and concluded "do not add compatibility aliases
+before a real compatibility obligation exists". vibe can start there.
+
+### Layer 5 — frozen collections (§3.4)
+
+```
+FrozenIntSet           // control byte + i32 key column, group-of-16 probe
+FrozenIntMap[V]
+```
+
+with bulk entry points (`contains_many`, `get_many`) as the documented contract
+and point access as a convenience that is explicitly *not* in the contract.
+
+Separately and independently of any of this: **change `MutMap`'s `state:
+Array[Int]` to a `Bytes` control array carrying a 7-bit fingerprint.** It is a
+local change to one file, it needs no new language surface, and it cuts
+probe-metadata traffic 8x with the fingerprint eliminating most key comparisons.
+That is the single highest value-per-line item in this document.
+
+## 5. Admission policy
+
+Adapted from jsimd's, which exists because it kept the package honest — seven
+prototypes are recorded there as *rejected*, with the numbers that rejected
+them. The adaptation is §1's transfer caveat:
+
+1. A new structure or bulk operation must beat **the best existing vibe
+   spelling** on a documented end-to-end workload. Where a native builtin
+   exists, that builtin is the baseline — **not** a vibe-level loop.
+2. Where the documented usage does not amortize them, the measurement includes
+   construction, key conversion, and materializing the result.
+3. Storage savings alone, or an isolated kernel win alone, is not sufficient.
+4. A bulk structure may keep slower point conveniences, but the documentation
+   must name them as outside the performance contract.
+5. The bench that justifies the claim is committed next to it in `bench/`, and
+   the claim cites its numbers.
+6. If nothing wins, the prototype is deleted and only the bench survives, as
+   rejection evidence.
+
+Rule 5 is the one this repository will feel most: a performance claim with no
+committed bench is folklore, and `CLAUDE.md` already treats folklore as a
+defect.
+
+## 6. What not to build
+
+jsimd rejected `SuccinctTrie`, `LoudsTree`, `StringInterner`,
+`PackedUint32Array`, `PackedDeltaArray`, `StaticMphfBytes`, and sparse-matrix
+BFS — each lost to the JavaScript builtin it was meant to replace. Per §1 those
+rejections do **not** carry over automatically, since vibe's builtins are
+weaker. But they carry over as a warning about *shape*: every one of them is a
+compressed representation whose decode cost exceeded what the compression saved.
+Any vibe proposal with that shape should be measured against a native builtin
+before it is written, not after.
+
+The same goes for symmetric naming. jsimd's queue ends with "do not add
+symmetric names such as `SimdFloat32Array`, `SimdInt32Vector`, or a standalone
+`BitVector` without a measured workload that wins after boundary costs." The
+layers above are proposed in dependency order for that reason, and Layer 3's
+`F32Column` and `U8Column` are explicitly gated behind a workload that wants
+them.
+
+## 7. Suggested issue tree
+
+One parent, six children, three-axis labels per
+[docs/issue-triage.md](issue-triage.md):
+
+| # | item | kind | priority |
+| :-- | :--- | :--- | :--- |
+| parent | SIMD-first data-structure foundation | epic | — |
+| 1 | `V128` intrinsics: unbox or retire (§3.1) | bug | P1 |
+| 2 | inline wasm: out-of-range `i32.const` passes `vibe check`, fails at load (§4/Layer 0) | bug | **P0** |
+| 3 | `Int::popcount` / `ctz` / `clz` / `select1` and `~` (§3.2) | feature | P1 |
+| 4 | `Bytes` search/compare/count kernels; route `String::*` through them (§4/Layer 2) | feature | P1 |
+| 5 | `MutMap`: `Array[Int]` state -> `Bytes` control byte + fingerprint (§3.4) | perf | P1 |
+| 6 | `I32Column` builder/frozen pair (§4/Layer 3) | feature | P2 |
+
+Items 2, 3, 4 and 5 need no new language surface and no decision from item 1.

--- a/lib/@vibe/compiler/codegen/common_base/inline_wat.vibe
+++ b/lib/@vibe/compiler/codegen/common_base/inline_wat.vibe
@@ -45,7 +45,8 @@ import @vibe/core {
 //     declarations would silently renumber; a located error enforces the
 //     grouping). Declared locals index from `extra_base` (the caller's
 //     param-slot count including the closure-env slot).
-//   - i32/i64 const (decimal / hex / `_` separators; vibe Int range only),
+//   - i32/i64 const (decimal / hex / `_` separators; BOTH the signed and the
+//     unsigned spelling of an immediate, per the spec's `iN ::= n:uN | i:sN`),
 //     full i32/i64 integer arithmetic / compare / shift / rotate /
 //     conversion set, f32/f64 arithmetic + compares (no f32/f64.const)
 //   - memory loads/stores with optional `offset=` / `align=` (align in
@@ -192,11 +193,13 @@ fn iw_parse_int(fn_name: String, s: String, off: Int) -> Int with Exception {
       } else {
         ()
       }
+      iw_check_digit_fits(fn_name, s, v, 16, d, off)
       v = v * 16 + d
       any = true
       i = i + 1
     } else {
       if c >= '0' && c <= '9' {
+        iw_check_digit_fits(fn_name, s, v, 10, c - '0', off)
         v = v * 10 + (c - '0')
         any = true
         i = i + 1
@@ -214,6 +217,48 @@ fn iw_parse_int(fn_name: String, s: String, off: Int) -> Int with Exception {
     0 - v
   } else {
     v
+  }
+}
+
+/// The largest vibe `Int`, 2^62-1. Spelled by arithmetic on purpose: until the
+/// next bootstrap bump the committed seed still enforces the pre-#1877 literal
+/// bound of 2^61-1, and seed-driven tooling (`vibe fmt`) lexes all of `lib/**`.
+fn iw_int_max() -> Int {
+  (2305843009213693951<<1)|1
+}
+
+/// Reject `v * base + d` BEFORE it wraps. #1877 made `Int` arithmetic wrap as
+/// 63-bit two's complement, so an over-long literal used to silently become a
+/// different number -- the worst way to break, and invisible in a WAT string.
+fn iw_check_digit_fits(fn_name: String, s: String, v: Int, base: Int, d: Int, off: Int) -> Unit with Exception {
+  if v > (iw_int_max() - d) / base {
+    throw(iw_err(fn_name, "integer literal '\{s}' is out of range for a vibe Int (max \{iw_int_max()})", off))
+  } else {
+    ()
+  }
+}
+
+/// Fold a WAT integer immediate into the signed range wasm actually encodes.
+///
+/// The text format accepts BOTH spellings of an `iN` immediate (spec:
+/// `iN ::= n:uN | i:sN`), so `(i32.const 2654435761)` and
+/// `(i32.const -1640531535)` are the same instruction -- 0x9E3779B1 either way.
+/// This used to encode the first one verbatim as a 5-byte s32 LEB, which no
+/// validator accepts: `vibe check` reported the file CLEAN and the module then
+/// failed at load with a wasmtime backtrace naming a function index the author
+/// never wrote (#2341).
+///
+/// `bits` is 8 / 16 / 32; 64-bit immediates need no folding because every vibe
+/// `Int` already fits in an i64.
+fn iw_fold_signed_imm(fn_name: String, what: String, v: Int, bits: Int, off: Int) -> Int with Exception {
+  let span = 1<<bits
+  let half = span / 2
+  if v >= 0 - half && v < half {
+    v
+  } else if v >= half && v < span {
+    v - span
+  } else {
+    throw(iw_err(fn_name, "\{what} \{v} is out of range for i\{bits}: write a value in \{0 - half}..\{span - 1} (either spelling of the same bit pattern is accepted), or widen the instruction", off))
   }
 }
 
@@ -758,7 +803,15 @@ fn iw_v128_const(buf: Bytes, fn_name: String, kinds: Array[Int], texts: Array[St
   let mut li = 0
   while li < lane_count {
     let t = iw_want_word(fn_name, kinds, texts, offs, p, end, "v128.const")
-    let v = iw_parse_int(fn_name, t, Array::get(offs, p))
+    let raw = iw_parse_int(fn_name, t, Array::get(offs, p))
+    // `(v >> bi*8) & 255` truncated an out-of-range lane silently, so
+    // `v128.const i8x16 300 ...` used to assemble as 44 (#2341). i64x2 needs no
+    // check: every vibe Int fits in an i64.
+    let v = if lane_bytes == 8 {
+      raw
+    } else {
+      iw_fold_signed_imm(fn_name, "v128.const \{shape} lane", raw, lane_bytes * 8, Array::get(offs, p))
+    }
     let mut bi = 0
     while bi < lane_bytes {
       bytebuf_push(buf, (v>>(bi * 8))&255)
@@ -807,7 +860,8 @@ fn iw_plain_op(buf: Bytes, fn_name: String, kinds: Array[Int], texts: Array[Stri
     pos + 2
   } else if name == "i32.const" {
     let t = iw_want_word(fn_name, kinds, texts, offs, pos + 1, end, name)
-    let v = iw_parse_int(fn_name, t, Array::get(offs, pos + 1))
+    let raw = iw_parse_int(fn_name, t, Array::get(offs, pos + 1))
+    let v = iw_fold_signed_imm(fn_name, "i32.const", raw, 32, Array::get(offs, pos + 1))
     bytebuf_push(buf, 0x41)
     leb128_encode_s32(buf, v)
     pos + 2

--- a/lib/@vibe/compiler/tests/inline_wasm_test.vibe
+++ b/lib/@vibe/compiler/tests/inline_wasm_test.vibe
@@ -139,6 +139,65 @@ test "inline wasm assembler: lane and align immediates are validated (Codex P2 o
   assert(String::contains(e5, "align=0 is invalid"))
 }
 
+test "inline wasm assembler: integer immediates accept both spellings (#2341)" {
+  // The text format defines `iN ::= n:uN | i:sN`, so 0x9E3779B1 may be written
+  // either way and both mean the same instruction. The unsigned spelling used
+  // to be LEB-encoded verbatim as an out-of-range s32: `vibe check` reported
+  // the file CLEAN and the module then failed at LOAD with a wasmtime
+  // backtrace naming a function index the author never wrote.
+  let unsigned_spelling = compile_inline_wat("probe", "(i32.const 2654435761)", [
+    "a"
+  ])
+  let signed_spelling = compile_inline_wat("probe", "(i32.const -1640531535)", [
+    "a"
+  ])
+  assert(unsigned_spelling == signed_spelling)
+  assert(Bytes::length(unsigned_spelling) == 6)
+  assert(unsigned_spelling[0] == 0x41)
+  let hex_spelling = compile_inline_wat("probe", "(i32.const 0x9E3779B1)", ["a"])
+  assert(hex_spelling == signed_spelling)
+  // ... and out of range is a LOCATED error, not a truncation and not a
+  // load-time failure.
+  let e1 = wat_err("(i32.const 5000000000)")
+  assert(String::contains(e1, "i32.const 5000000000 is out of range for i32"))
+  assert(String::contains(e1, "-2147483648..4294967295"))
+  assert(String::contains(e1, "WAT offset"))
+  let e2 = wat_err("(i32.const -2147483649)")
+  assert(String::contains(e2, "is out of range for i32"))
+}
+
+test "inline wasm assembler: v128.const lanes are range-checked (#2341)" {
+  // `(v >> bi * 8) & 255` truncated an out-of-range lane silently, so
+  // `v128.const i8x16 300 ...` assembled as 44.
+  let ok = compile_inline_wat("probe", "(v128.const i8x16 200 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0)", [
+    "a"
+  ])
+  assert(Bytes::length(ok) == 18)
+  assert(ok[0] == 0xFD)
+  assert(ok[1] == 12)
+  assert(ok[2] == 200)
+  let e1 = wat_err("(v128.const i8x16 300 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0)")
+  assert(String::contains(e1, "v128.const i8x16 lane 300 is out of range for i8"))
+  assert(String::contains(e1, "-128..255"))
+  let e2 = wat_err("(v128.const i16x8 70000 0 0 0 0 0 0 0)")
+  assert(String::contains(e2, "is out of range for i16"))
+  // i64x2 needs no check: every vibe Int already fits in an i64.
+  let wide = compile_inline_wat("probe", "(v128.const i64x2 4611686018427387903 -1)", [
+    "a"
+  ])
+  assert(Bytes::length(wide) == 18)
+}
+
+test "inline wasm assembler: an over-long integer literal is a located error (#2341)" {
+  // #1877 made Int arithmetic wrap, so the digit accumulator used to turn an
+  // over-long literal into a DIFFERENT number with no complaint.
+  let e = wat_err("(i64.const 99999999999999999999)")
+  assert(String::contains(e, "integer literal '99999999999999999999' is out of range for a vibe Int"))
+  assert(String::contains(e, "WAT offset"))
+  let e_hex = wat_err("(i64.const 0xFFFFFFFFFFFFFFFF)")
+  assert(String::contains(e_hex, "is out of range for a vibe Int"))
+}
+
 test "inline wasm assembler: (local ...) declarations resolve and count by type" {
   // one i32 + two v128 locals, params $a (idx 0) + env (idx 1) -> extra_base 2:
   // $p = 2, $u = 3, $v = 4. Body: local.get $v / local.set $p is a type error


### PR DESCRIPTION
Reads [`mizchi/jsimd`](https://github.com/mizchi/jsimd) against vibe's current data-structure foundation and proposes what to add or change. Adds `docs/simd-data-structures.md` (the proposal), four runnable benches (`bench/bench_simd_*.vibe`) as the evidence behind every number in it, and fixes the one **P0** the benches turned up.

Issue tree: **#2340** (epic) with #2341 · #2342 · #2343 · #2344 · #2345 · #2346 · #2347 · #2348.

## Behaviour change in this PR: #2341

`vibe check` reported a file **clean** and the module then failed at load:

```console
$ vibe check probe.vibe      # fn f(x: Int) -> Int = wasm "... (i32.const 2654435761) ..."
$ echo $?
0
$ vibe test probe.vibe
viberun: from_file: failed to compile: wasm[0]::function[70]::f
Stack backtrace: ...
```

No source location, and a wasm function index the author never wrote. An oracle that answers "clean" for a program that cannot be built is the one thing `vibe check` must not do.

`2654435761` is `0x9E3779B1` — an ordinary vibe `Int`, out of range for a **signed** i32. The text format accepts both spellings of an `iN` immediate (`iN ::= n:uN | i:sN`), so the fix is not only a diagnostic: fold the unsigned half into the signed range and that literal now assembles to the same bytes as `-1640531535`, which is what any other WAT assembler does. What is genuinely out of range gets a located error from `vibe check`.

Two neighbours in `inline_wat.vibe` had the same shape and are fixed with it:

- `v128.const` lane values were masked with `& 255`, so `v128.const i8x16 300 …` silently assembled as `44`.
- the digit accumulator in `iw_parse_int` wrapped (#1877 made `Int` arithmetic wrap), so an over-long literal silently became a different number.

Verified **red then green, each new test in isolation and for the right reason** — with the source change reverted, all three fail naming their own test, not an import or a neighbour. `scripts/compiler_gate.sh bootstrap` passes; `vibe fmt --check` clean.

## What was measured

`vibe bench`, 500 iters, mean ns/op:

| workload | best | vibe today | ratio |
| :--- | ---: | ---: | ---: |
| 4 KiB single-byte search | inline-wasm SIMD kernel **248 ns / 0 B** | `v128_*` intrinsics 5564 ns / **8048 B**; vibe loop 25001 ns; native `String::index_of` 352 ns | 22x / 101x / 1.4x |
| rank1 over 32 Kibit | `v128` load + 2× `i64.popcnt` **365 ns** | vibe loop 159834 ns; `i64.popcnt` alone 465 ns | 438x / 344x |
| sum of 4096 `Int`s | packed i32 column **630 ns** | `Array[Int]` loop 9240 ns; SIMD over tagged slots 1541 ns | 14.7x / 2.4x |
| 4000 membership tests | frozen control-byte table, bulk **10850 ns** | `MutMap[Int, Int]` 149739 ns | 13.8x **aggregate** |

## What the numbers say

- **The `V128` intrinsic surface is the wrong shape** (#2342). It runs the identical algorithm as a hand-written kernel and costs 22x, because every `v128_load` / `v128_eq_i8x16` heap-boxes its result into an unreclaimable 16-byte block — 4 KiB scanned allocates 8 KiB. No caller in the tree except its own fixture.
- **rank/select is a popcount story, not a SIMD story** (#2344). One scalar instruction carries 344x of the 438x; widening the load adds 27% and `i8x16.popcnt` adds nothing. vibe exposes no popcount — and measured, the whole `//# WASM intrinsics (low-level)` block in `declarations.vibe` does not resolve from user code (#2343).
- **`Int`'s `n<<1` tagging is already SIMD-friendly** — addition is tag-transparent, so `i64x2.add` over raw array slots is correct with no untag/retag. The remaining 2.4x is purely the memory traffic of an 8-byte slot, and vibe has no type between `Array[T]` and `Bytes` (#2347).
- **`MutMap` stores its slot state as `Array[Int]`** — 8 bytes per slot for a three-state value (#2346).
- **The honest baseline is a native builtin, not a vibe loop.** jsimd's rejections were measured against V8 builtins; vibe's baseline is a vibe-level loop at ~6.1 ns/byte, so almost anything "wins". Against `String::index_of` the SIMD margin is 1.4x, not 100x. The admission policy in §5 is written around that.

## Review round (Codex, all three findings accepted)

1. The 1.9x credited to "the per-call boundary" was **two variables** — the point lane read queries from an `Array[Int]` while the bulk kernel read a packed i32 column. Added `point_count_hits_packed` / `simd_has_at`, a point lane over the *same* packed column. Measured: the call boundary is **1.32x**, the query representation another **1.84x**. The fix was another lane, not a softer sentence.
2. "7.5x comes from the representation" over-attributed an aggregate. Now stated as 13.8x of aggregate headroom with the **eight** simultaneous differences listed, the controlled frozen-vs-frozen ratios called out separately, and #2346's case restated as structural — it ships with its own before/after bench or not at all.
3. #2344 *does* need a new language surface: `~` is a new operator, not just a builtin addition. Corrected.

## Verification

```bash
vibe test  bench/bench_simd_bytes_find.vibe   # and the other three: every lane agrees
vibe bench bench/bench_simd_bytes_find.vibe --iters 500
vibe test  lib/@vibe/compiler/tests/inline_wasm_test.vibe fixtures/inline_wasm_test.vibe
bash scripts/compiler_gate.sh bootstrap
```

All bench files are `vibe check`-clean; `check-doc-path-citations`, `check-doc-commands`, `vibe fmt --check` and the `pre-commit` review-lint gates pass. The benches use inline wasm and so are linear-backend only, which is `vibe bench`'s default lane.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FYMVd6D2o82suTfTwoJPMf