### PR TITLE
Preserve applied trait impl targets

### DIFF
--- a/bench/perf/heap_baseline.txt
+++ b/bench/perf/heap_baseline.txt
@@ -231,4 +231,14 @@
 # number so the gate tracks the new compiler; the lowering is
 # intentional (unresolved `perform?` becomes `NotGranted` instead of
 # a codegen ICE).
-1416060200
+#
+# 2026-08-27 rebaseline (1416060200 -> 1469895104, +3.80%) on #2335:
+# retaining complete applied impl targets adds canonical TypeExpr encoding,
+# exact concrete/generic target matching, and witness specialization to the
+# compiler import graph. The PR perf comparison attributes +5.08% to this
+# change versus its current main base; the remaining gap is accumulated main
+# drift since the previous absolute baseline. This copies the deterministic CI
+# measurement. The feature is covered by distinct concrete/generic target,
+# alias/ascription/private-import, reordered-witness, and bootstrap-fixpoint
+# regressions.
+1469895104

--- a/docs/cheatsheet.md
+++ b/docs/cheatsheet.md
@@ -892,11 +892,13 @@ The same `F[A]` shape is legal in a parameterized alias body, a generic
 effect operation, and a trait method signature. Mixed-kind (`F` and `F[A]`
 together) is still rejected on every declaration surface.
 
-> A concrete generic impl target such as `impl M for Array[Int]` is rejected
-> (#2262). The impl AST cannot retain the `[Int]` argument; accepting it would
-> silently widen the impl to `Array[String]` and every other instantiation.
-> Write the honest generic form, `impl [T] M for Array[T]`. Impl specialization
-> for one generic instantiation is not supported yet.
+Concrete applied impl targets are preserved and matched exactly (#2335):
+`impl M for Array[Int]` does not satisfy `M` for `Array[String]`. Distinct
+concrete targets may coexist and dispatch to their own method bodies. Generic
+targets retain their complete argument pattern as well, so a declaration such
+as `impl [A, B] M for Pair[B, A]` maps each bound to the corresponding target
+slot. Duplicate or overlapping targets are rejected and the diagnostic names
+both targets.
 
 ## Collections
 

--- a/docs/spec/syntax.md
+++ b/docs/spec/syntax.md
@@ -309,10 +309,13 @@ measured (2026-08-24), it never answers by identity — a comparison it cannot
 resolve structurally traps at run time, and a length/element difference
 answers `false`. Give the trait a method and use a generic impl
 (`impl [T] M for Array[T]`) so it resolves through the witness dictionary.
-A concrete generic target such as `impl M for Array[Int]` is rejected because
-the impl AST cannot retain its type arguments; accepting it would silently
-widen the impl to every `Array[T]` (#2262). Specialization for one generic
-instantiation is not supported. See #1503.
+Concrete applied targets are retained and matched exactly (#2335), so
+`impl M for Array[Int]` does not widen to `Array[String]`. Multiple distinct
+concrete targets may coexist and dispatch to different method bodies. Generic
+targets retain the full pattern as well; reordered parameters in
+`impl [A, B] M for Pair[B, A]` keep their declared association. Duplicate or
+overlapping impl targets are rejected with both targets in the diagnostic.
+See #1503 for the separate marker-trait container restriction.
 
 ### Effects
 

--- a/fixtures/trait_alias_applied_impl_specialization_test.vibe
+++ b/fixtures/trait_alias_applied_impl_specialization_test.vibe
@@ -1,0 +1,19 @@
+trait Measured {
+  measure(Self) -> Int
+}
+
+type Vec[T] = Array[T]
+
+impl Measured for Vec[Int] {
+  measure(_self: Vec[Int]) -> Int {
+    23
+  }
+}
+
+fn measure[T: Measured](value: T) -> Int {
+  T::measure(value)
+}
+
+test "transparent aliases share specialized impl owners" {
+  assert_eq(measure([1]), 23)
+}

--- a/fixtures/trait_ascribed_applied_impl_specialization_test.vibe
+++ b/fixtures/trait_ascribed_applied_impl_specialization_test.vibe
@@ -1,0 +1,18 @@
+trait Measured {
+  measure(Self) -> Int
+}
+
+impl Measured for Array[Int] {
+  measure(_self: Array[Int]) -> Int {
+    17
+  }
+}
+
+fn measure[T: Measured](value: T) -> Int {
+  T::measure(value)
+}
+
+test "ascribed applied values retain specialization keys" {
+  let values: Array[Int] = []
+  assert_eq(measure(values), 17)
+}

--- a/fixtures/trait_concrete_impl_import_alias/main_test.vibe
+++ b/fixtures/trait_concrete_impl_import_alias/main_test.vibe
@@ -1,0 +1,21 @@
+import ./provider.vibe {
+  make_int_box, struct Box as B
+}
+
+trait Measured {
+  measure(Self) -> Int
+}
+
+impl Measured for B[Int] {
+  measure(_self: B[Int]) -> Int {
+    33
+  }
+}
+
+fn measure[T: Measured](value: T) -> Int {
+  T::measure(value)
+}
+
+test "import aliases preserve concrete impl specialization" {
+  assert_eq(measure(make_int_box()), 33)
+}

--- a/fixtures/trait_concrete_impl_import_alias/provider.vibe
+++ b/fixtures/trait_concrete_impl_import_alias/provider.vibe
@@ -1,0 +1,7 @@
+export struct Box[T] {
+  value: T
+}
+
+export fn make_int_box() -> Box[Int] {
+  Box[Int]::{ value: 1 }
+}

--- a/fixtures/trait_concrete_impl_specialization_test.vibe
+++ b/fixtures/trait_concrete_impl_specialization_test.vibe
@@ -1,0 +1,48 @@
+trait Measured {
+  measure(Self) -> Int
+}
+
+impl Measured for Array[Int] {
+  measure(_self: Array[Int]) -> Int {
+    11
+  }
+}
+
+impl Measured for Array[String] {
+  measure(_self: Array[String]) -> Int {
+    22
+  }
+}
+
+fn measure[T: Measured](value: T) -> Int {
+  T::measure(value)
+}
+
+fn int_values() -> Array[Int] {
+  [1]
+}
+
+fn string_values() -> Array[String] {
+  ["x"]
+}
+
+fn measure_int_values(values: Array[Int]) -> Int {
+  measure(values)
+}
+
+fn measure_string_values(values: Array[String]) -> Int {
+  measure(values)
+}
+
+test "concrete impl specializations dispatch their own bodies" {
+  assert_eq(measure([1]), 11)
+  assert_eq(measure(["x"]), 22)
+  let ints = [1]
+  let strings = ["x"]
+  assert_eq(measure(ints), 11)
+  assert_eq(measure(strings), 22)
+  assert_eq(measure(int_values()), 11)
+  assert_eq(measure(string_values()), 22)
+  assert_eq(measure_int_values([1]), 11)
+  assert_eq(measure_string_values(["x"]), 22)
+}

--- a/fixtures/trait_disjoint_generic_impl_specialization_test.vibe
+++ b/fixtures/trait_disjoint_generic_impl_specialization_test.vibe
@@ -1,0 +1,31 @@
+trait Measured {
+  measure(Self) -> Int
+}
+
+struct Pair[A, B] {
+  first: A;
+  second: B
+}
+
+impl [T] Measured for Pair[Int, T] {
+  measure(_self: Pair[Int, T]) -> Int {
+    31
+  }
+}
+
+impl [T] Measured for Pair[String, T] {
+  measure(_self: Pair[String, T]) -> Int {
+    47
+  }
+}
+
+fn measure[T: Measured](value: T) -> Int {
+  T::measure(value)
+}
+
+test "disjoint generic impl targets dispatch their own bodies" {
+  let int_pair = Pair[Int, Bool]::{ first: 1, second: true }
+  let string_pair = Pair[String, Bool]::{ first: "x", second: true }
+  assert_eq(measure(int_pair), 31)
+  assert_eq(measure(string_pair), 47)
+}

--- a/fixtures/trait_inline_applied_impl_specialization_test.vibe
+++ b/fixtures/trait_inline_applied_impl_specialization_test.vibe
@@ -1,0 +1,28 @@
+trait Measured {
+  measure(Self) -> Int
+}
+
+struct Box[T] {
+  value: T
+}
+
+impl Measured for Box[Int] {
+  measure(_self: Box[Int]) -> Int {
+    13
+  }
+}
+
+impl Measured for Option[Int] {
+  measure(_self: Option[Int]) -> Int {
+    29
+  }
+}
+
+fn measure[T: Measured](value: T) -> Int {
+  T::measure(value)
+}
+
+test "inline applied values retain specialization keys" {
+  assert_eq(measure(Box[Int]::{ value: 1 }), 13)
+  assert_eq(measure(Some(1)), 29)
+}

--- a/fixtures/trait_private_applied_impl_import/dep.vibe
+++ b/fixtures/trait_private_applied_impl_import/dep.vibe
@@ -1,0 +1,21 @@
+export trait Measured {
+  measure(Self) -> Int
+}
+
+struct Hidden[T] {
+  value: T
+}
+
+impl Measured for Hidden[Int] {
+  measure(_self: Hidden[Int]) -> Int {
+    31
+  }
+}
+
+fn measure[T: Measured](value: T) -> Int {
+  T::measure(value)
+}
+
+export fn hidden_measure() -> Int {
+  measure(Hidden[Int]::{ value: 1 })
+}

--- a/fixtures/trait_private_applied_impl_import/main_test.vibe
+++ b/fixtures/trait_private_applied_impl_import/main_test.vibe
@@ -1,0 +1,7 @@
+import ./dep.vibe {
+  hidden_measure
+}
+
+test "private applied impl owners follow imported type renames" {
+  assert_eq(hidden_measure(), 31)
+}

--- a/fixtures/trait_reordered_generic_impl_witness_test.vibe
+++ b/fixtures/trait_reordered_generic_impl_witness_test.vibe
@@ -1,0 +1,42 @@
+trait Keyed {
+  key(Self) -> Int
+}
+
+trait Valued {
+  value(Self) -> Int
+}
+
+trait Combined {
+  combine(Self) -> Int
+}
+
+impl Keyed for Int {
+  key(value: Int) -> Int {
+    value
+  }
+}
+
+impl Valued for String {
+  value(value: String) -> Int {
+    String::length(value)
+  }
+}
+
+struct Pair[A, B] {
+  first: A;
+  second: B
+}
+
+impl [K: Keyed, V: Valued] Combined for Pair[V, K] {
+  combine(self: Pair[V, K]) -> Int {
+    V::value(self.first) + K::key(self.second)
+  }
+}
+
+fn combine[T: Combined](value: T) -> Int {
+  T::combine(value)
+}
+
+test "reordered generic target builds witnesses from matching slots" {
+  assert_eq(combine(Pair[String, Int]::{ first: "abc", second: 7 }), 10)
+}

--- a/fixtures/typecheck/expected.tsv
+++ b/fixtures/typecheck/expected.tsv
@@ -184,8 +184,11 @@ effect_row_local_alias	reject	effect row mismatch for 'caller': missing { Log::E
 effect_row_local_alias_declared	ok	
 effect_row_local_alias_pure	ok	
 trait_marker_impl_container	reject	IS declared, but `Eq` is a marker trait
-trait_concrete_impl_param_type	reject	generic impl target
-trait_generic_impl_concrete_target	reject	generic impl target
+trait_concrete_impl_param_type	ok
+trait_concrete_impl_does_not_widen	reject	no impl `Measured` for `Array[String]`
+trait_generic_impl_concrete_target	reject	impl type parameter `U` is not used in its target
+trait_generic_impl_reordered_target	ok
+trait_generic_impl_reordered_target_reject	reject	no impl `Measured` for `Pair[String, Array[Int]]`
 trait_generic_impl_target_arity	reject	type argument(s), got
 trait_generic_impl_arraybuilder_arity	reject	type argument(s), got
 trait_generic_impl_local_shadow_arity	reject	type argument(s), got
@@ -378,8 +381,8 @@ err_type_enum_wrong_variant_pattern	debt-accepts
 err_type_record_missing_field	debt-accepts	
 err_type_reserved_wasm_type_name	debt-accepts	
 err_type_trait_duplicate_def	debt-accepts	
-err_type_trait_impl_duplicate_target_rejected	debt-accepts	
-err_type_trait_impl_overlap_rejected_when_both_apply	debt-accepts	
+err_type_trait_impl_duplicate_target_rejected	reject	overlapping impls for `LocalEq`: existing target `Int` overlaps new target `Int`
+err_type_trait_impl_overlap_rejected_when_both_apply	reject	overlapping impls for `LocalEq`: existing target `Int` overlaps new target `T`
 err_type_trait_impl_unknown_bound	debt-accepts	
 err_type_trait_supertrait_self_cycle	debt-accepts	
 err_type_trait_supertrait_unknown	debt-accepts	
@@ -472,4 +475,4 @@ err_import_missing_symbol_ref	reject	not a valid import spec
 err_import_missing_version_ref	reject	not a valid import spec
 err_import_duplicate_value_binding	reject	duplicate declaration: abs
 err_type_recursive_without_return_type	reject	lambda parameter `n` needs a type
-err_type_trait_impl_func_label_mismatch	reject	expected type name after 'for'
+err_type_trait_impl_func_label_mismatch	reject	an impl target must be a named type

--- a/fixtures/typecheck/trait_concrete_impl_does_not_widen.vibe
+++ b/fixtures/typecheck/trait_concrete_impl_does_not_widen.vibe
@@ -1,0 +1,19 @@
+// #2335: a concrete impl is exact. The Array[Int] method body must never be
+// selected for Array[String], which was the silent-wrong #2262 behavior.
+trait Measured {
+  measure(Self) -> Int
+}
+
+impl Measured for Array[Int] {
+  measure(self) -> Int {
+    Array::length(self)
+  }
+}
+
+fn measure[T: Measured](x: T) -> Int {
+  T::measure(x)
+}
+
+fn main() -> Int {
+  measure(["not", "ints"])
+}

--- a/fixtures/typecheck/trait_concrete_impl_param_type.vibe
+++ b/fixtures/typecheck/trait_concrete_impl_param_type.vibe
@@ -1,6 +1,5 @@
-// #2262: a concrete impl on one generic instantiation must fail closed. The
-// impl AST cannot retain `[Int]`; accepting this declaration would therefore
-// widen it to every `Array[T]` and run an Int-checked body on other payloads.
+// #2335: the complete target survives parsing and checking, so this impl is
+// available to Array[Int] without widening to another Array instantiation.
 trait Measured {
   measure(Self) -> Int
 }

--- a/fixtures/typecheck/trait_generic_impl_reordered_target.vibe
+++ b/fixtures/typecheck/trait_generic_impl_reordered_target.vibe
@@ -1,0 +1,44 @@
+// #2335: bounds follow binder occurrences in the retained target, not the
+// declaration order. Pair[V, K] maps String to V and Int to K here.
+trait Key {
+  key(Self) -> Int
+}
+
+trait Value {
+  value(Self) -> Int
+}
+
+trait Measured {
+  measure(Self) -> Int
+}
+
+impl Key for Int {
+  key(self) -> Int {
+    self
+  }
+}
+
+impl Value for String {
+  value(self) -> Int {
+    String::length(self)
+  }
+}
+
+struct Pair[A, B] {
+  first: A;
+  second: B
+}
+
+impl [K: Key, V: Value] Measured for Pair[V, K] {
+  measure(self) -> Int {
+    0
+  }
+}
+
+fn keep[T: Measured](x: T) -> T {
+  x
+}
+
+export fn accepted(x: Pair[String, Int]) -> Pair[String, Int] {
+  keep(x)
+}

--- a/fixtures/typecheck/trait_generic_impl_reordered_target_reject.vibe
+++ b/fixtures/typecheck/trait_generic_impl_reordered_target_reject.vibe
@@ -1,0 +1,44 @@
+// #2335: the same reordered target must not apply declaration-order bounds.
+// Array[Int] occupies K here and has no Key implementation.
+trait Key {
+  key(Self) -> Int
+}
+
+trait Value {
+  value(Self) -> Int
+}
+
+trait Measured {
+  measure(Self) -> Int
+}
+
+impl Key for Int {
+  key(self) -> Int {
+    self
+  }
+}
+
+impl Value for String {
+  value(self) -> Int {
+    String::length(self)
+  }
+}
+
+struct Pair[A, B] {
+  first: A;
+  second: B
+}
+
+impl [K: Key, V: Value] Measured for Pair[V, K] {
+  measure(self) -> Int {
+    0
+  }
+}
+
+fn keep[T: Measured](x: T) -> T {
+  x
+}
+
+export fn rejected(x: Pair[String, Array[Int]]) -> Pair[String, Array[Int]] {
+  keep(x)
+}

--- a/lib/@vibe/ast/ast.vibe
+++ b/lib/@vibe/ast/ast.vibe
@@ -4,3 +4,98 @@
 // suppresses sibling auto-discovery (test files beside the contract must
 // not join the facade).
 
+export fn impl_target_head(target: TypeExpr) -> String {
+  match target {
+    TyName(name) => name,
+    TyApp(name, _) => name,
+    _ => ""
+  }
+}
+
+fn impl_encode_name(name: String) -> String {
+  let mut out = ""
+  let mut i = 0
+  while i < String::length(name) {
+    out = String::concat(out, String::concat(Int::to_string(String::char_code_at(name, i)), "_"))
+    i = i + 1
+  }
+  out
+}
+
+export fn impl_target_key(target: TypeExpr) -> String {
+  match target {
+    TyName(name) => String::concat("N", String::concat(impl_encode_name(name), "Z")),
+    TyApp(name, args) => {
+      let keys = []
+      let mut i = 0
+      while i < Array::length(args) {
+        Array::push(keys, impl_target_key(Array::get(args, i)))
+        i = i + 1
+      }
+      impl_applied_target_key(name, keys)
+    },
+    TyFn(params, ret, effect) => {
+      let mut out = "F"
+      let mut i = 0
+      while i < Array::length(params) {
+        out = String::concat(out, impl_target_key(Array::get(params, i)))
+        i = i + 1
+      }
+      let effect_key = match effect {
+        None => "E0",
+        Some(name) => String::concat("E1", String::concat(impl_encode_name(name), "Z"))
+      }
+      String::concat(out, String::concat("T", String::concat(impl_target_key(ret), String::concat(effect_key, "R"))))
+    },
+    TyTuple(items) => {
+      let mut out = "P"
+      let mut i = 0
+      while i < Array::length(items) {
+        out = String::concat(out, impl_target_key(Array::get(items, i)))
+        i = i + 1
+      }
+      String::concat(out, "R")
+    },
+    TyUnit => "U"
+  }
+}
+
+export fn impl_applied_target_key(head: String, arg_keys: Array[String]) -> String {
+  let mut out = String::concat("A", String::concat(impl_encode_name(head), "L"))
+  let mut i = 0
+  while i < Array::length(arg_keys) {
+    out = String::concat(out, Array::get(arg_keys, i))
+    i = i + 1
+  }
+  String::concat(out, "R")
+}
+
+export fn impl_specialized_method_binding_name(head: String, trait_name: String, target_key: String, method: String) -> String {
+  let owner = String::concat(head, String::concat("$impl$", String::concat(impl_encode_name(trait_name), String::concat("$", target_key))))
+  String::concat(owner, String::concat("::", method))
+}
+
+export fn impl_method_owner(tparams: Array[String], trait_name: String, target: TypeExpr) -> String {
+  let head = impl_target_head(target)
+  if Array::length(tparams) == 0 {
+    match target {
+      TyApp(_, _) => String::concat(head, String::concat("$impl$", String::concat(impl_encode_name(trait_name), String::concat("$", impl_target_key(target))))),
+      _ => head
+    }
+  } else {
+    head
+  }
+}
+
+export fn impl_method_binding_name(tparams: Array[String], trait_name: String, target: TypeExpr, method: String) -> String {
+  String::concat(impl_method_owner(tparams, trait_name, target), String::concat("::", method))
+}
+
+export fn impl_method_owner_head(owner: String) -> String {
+  let sep = String::index_of(owner, "$impl$")
+  if sep < 0 {
+    owner
+  } else {
+    String::substring(owner, 0, sep)
+  }
+}

--- a/lib/@vibe/ast/ast.vibe
+++ b/lib/@vibe/ast/ast.vibe
@@ -60,6 +60,168 @@ export fn impl_target_key(target: TypeExpr) -> String {
   }
 }
 
+fn impl_decode_name(key: String, pos: Int, terminator: Int) -> Option[(String, Int)] {
+  let mut out = ""
+  let mut p = pos
+  let mut valid = true
+  while p < String::length(key) && String::char_code_at(key, p) != terminator && valid {
+    let mut code = 0
+    let mut digits = 0
+    while p < String::length(key) && String::char_code_at(key, p) >= '0' && String::char_code_at(key, p) <= '9' {
+      code = code * 10 + String::char_code_at(key, p) - '0'
+      digits = digits + 1
+      p = p + 1
+    }
+    if digits == 0 || p >= String::length(key) || String::char_code_at(key, p) != '_' {
+      valid = false
+    } else {
+      out = String::concat(out, String::from_char_code(code))
+      p = p + 1
+    }
+  }
+  if valid && p < String::length(key) && String::char_code_at(key, p) == terminator {
+    Some((out, p + 1))
+  } else {
+    None
+  }
+}
+
+fn impl_target_from_key_at(key: String, pos: Int) -> Option[(TypeExpr, Int)] {
+  if pos >= String::length(key) {
+    None
+  } else {
+    match String::char_code_at(key, pos) {
+      'N' => match impl_decode_name(key, pos + 1, 'Z') {
+        Some(decoded) => {
+          let (name, next) = decoded
+          Some((TyName(name), next))
+        },
+        None => None
+      },
+      'A' => match impl_decode_name(key, pos + 1, 'L') {
+        Some(decoded) => {
+          let (name, after_name) = decoded
+          let args = []
+          let mut p = after_name
+          let mut valid = true
+          while p < String::length(key) && String::char_code_at(key, p) != 'R' && valid {
+            match impl_target_from_key_at(key, p) {
+              Some(parsed) => {
+                let (arg, next) = parsed
+                Array::push(args, arg)
+                p = next
+              },
+              None => {
+                valid = false
+              }
+            }
+          }
+          if valid && p < String::length(key) && String::char_code_at(key, p) == 'R' {
+            Some((TyApp(name, args), p + 1))
+          } else {
+            None
+          }
+        },
+        None => None
+      },
+      'F' => {
+        let params = []
+        let mut p = pos + 1
+        let mut valid = true
+        while p < String::length(key) && String::char_code_at(key, p) != 'T' && valid {
+          match impl_target_from_key_at(key, p) {
+            Some(parsed) => {
+              let (param, next) = parsed
+              Array::push(params, param)
+              p = next
+            },
+            None => {
+              valid = false
+            }
+          }
+        }
+        if !valid || p >= String::length(key) || String::char_code_at(key, p) != 'T' {
+          None
+        } else {
+          match impl_target_from_key_at(key, p + 1) {
+            Some(parsed_ret) => {
+              let (ret, after_ret) = parsed_ret
+              if after_ret + 1 >= String::length(key) || String::char_code_at(key, after_ret) != 'E' {
+                None
+              } else {
+                let effect_tag = String::char_code_at(key, after_ret + 1)
+                let effect_and_pos = if effect_tag == '0' {
+                  Some((None, after_ret + 2))
+                } else if effect_tag == '1' {
+                  match impl_decode_name(key, after_ret + 2, 'Z') {
+                    Some(decoded_effect) => {
+                      let (effect_name, after_effect) = decoded_effect
+                      Some((Some(effect_name), after_effect))
+                    },
+                    None => None
+                  }
+                } else {
+                  None
+                }
+                match effect_and_pos {
+                  Some(ep) => {
+                    let (effect, after_effect) = ep
+                    if after_effect < String::length(key) && String::char_code_at(key, after_effect) == 'R' {
+                      Some((TyFn(params, ret, effect), after_effect + 1))
+                    } else {
+                      None
+                    }
+                  },
+                  None => None
+                }
+              }
+            },
+            None => None
+          }
+        }
+      },
+      'P' => {
+        let items = []
+        let mut p = pos + 1
+        let mut valid = true
+        while p < String::length(key) && String::char_code_at(key, p) != 'R' && valid {
+          match impl_target_from_key_at(key, p) {
+            Some(parsed) => {
+              let (item, next) = parsed
+              Array::push(items, item)
+              p = next
+            },
+            None => {
+              valid = false
+            }
+          }
+        }
+        if valid && p < String::length(key) && String::char_code_at(key, p) == 'R' {
+          Some((TyTuple(items), p + 1))
+        } else {
+          None
+        }
+      },
+      'U' => Some((TyUnit, pos + 1)),
+      _ => None
+    }
+  }
+}
+
+export fn impl_target_from_key(key: String) -> Option[TypeExpr] {
+  match impl_target_from_key_at(key, 0) {
+    Some(parsed) => {
+      let (target, next) = parsed
+      if next == String::length(key) {
+        Some(target)
+      } else {
+        None
+      }
+    },
+    None => None
+  }
+}
+
 export fn impl_applied_target_key(head: String, arg_keys: Array[String]) -> String {
   let mut out = String::concat("A", String::concat(impl_encode_name(head), "L"))
   let mut i = 0
@@ -77,13 +239,9 @@ export fn impl_specialized_method_binding_name(head: String, trait_name: String,
 
 export fn impl_method_owner(tparams: Array[String], trait_name: String, target: TypeExpr) -> String {
   let head = impl_target_head(target)
-  if Array::length(tparams) == 0 {
-    match target {
-      TyApp(_, _) => String::concat(head, String::concat("$impl$", String::concat(impl_encode_name(trait_name), String::concat("$", impl_target_key(target))))),
-      _ => head
-    }
-  } else {
-    head
+  match target {
+    TyApp(_, _) => String::concat(head, String::concat("$impl$", String::concat(impl_encode_name(trait_name), String::concat("$", impl_target_key(target))))),
+    _ => head
   }
 }
 

--- a/lib/@vibe/ast/ast_eq_test.vibe
+++ b/lib/@vibe/ast/ast_eq_test.vibe
@@ -23,7 +23,7 @@
 //# Imports
 
 import .{
-  Expr, ImportItem, Pat, Stmt, TypeExpr
+  Expr, ImportItem, Pat, Stmt, TypeExpr, impl_target_key
 }
 
 //# Helpers
@@ -87,6 +87,16 @@ fn every_typeexpr_alt() -> Array[TypeExpr] {
     TyTuple([TyName("z")]),
     TyUnit
   ]
+}
+
+test "impl target keys distinguish function effect rows" {
+  let pure = impl_target_key(TyApp("Box", [
+    TyFn([TyName("Int")], TyName("Int"), None)
+  ]))
+  let effectful = impl_target_key(TyApp("Box", [
+    TyFn([TyName("Int")], TyName("Int"), Some("Fs"))
+  ]))
+  assert(pure != effectful)
 }
 
 /// Exhaustive over the DECLARATION: one arm per declared variant, no `_`.
@@ -395,7 +405,7 @@ fn every_stmt() -> Array[Stmt] {
     STrait(true, "s", ["p"], [("m", [TyUnit], TyUnit)], [
       ("m", ["T"], [("T", ["C"])])
     ], ["p"]),
-    SImpl(["p"], [("t", ["C"])], "s", "s"),
+    SImpl(["p"], [("t", ["C"])], "s", TyName("s")),
     SExternLet("s", TyUnit),
     SImport("s", [
       ImportItem::{ kind: Some(ImportStruct), name: "n", alias: Some("a") }
@@ -439,7 +449,7 @@ fn every_stmt_same() -> Array[Stmt] {
     STrait(true, "s", ["p"], [("m", [TyUnit], TyUnit)], [
       ("m", ["T"], [("T", ["C"])])
     ], ["p"]),
-    SImpl(["p"], [("t", ["C"])], "s", "s"),
+    SImpl(["p"], [("t", ["C"])], "s", TyName("s")),
     SExternLet("s", TyUnit),
     SImport("s", [
       ImportItem::{ kind: Some(ImportStruct), name: "n", alias: Some("a") }
@@ -480,7 +490,7 @@ fn every_stmt_alt() -> Array[Stmt] {
     STrait(false, "t", ["q"], [("n", [TyName("z")], TyName("z"))], [
       ("n", ["U"], [("U", ["D"])])
     ], ["q"]),
-    SImpl(["q"], [("u", ["D"])], "t", "t"),
+    SImpl(["q"], [("u", ["D"])], "t", TyName("t")),
     SExternLet("t", TyName("z")),
     SImport("t", [
       ImportItem::{ kind: Some(ImportEnum), name: "o", alias: Some("b") }

--- a/lib/@vibe/ast/ast_eq_test.vibe
+++ b/lib/@vibe/ast/ast_eq_test.vibe
@@ -23,7 +23,7 @@
 //# Imports
 
 import .{
-  Expr, ImportItem, Pat, Stmt, TypeExpr, impl_target_key
+  Expr, ImportItem, Pat, Stmt, TypeExpr, impl_method_owner, impl_target_from_key, impl_target_key
 }
 
 //# Helpers
@@ -97,6 +97,29 @@ test "impl target keys distinguish function effect rows" {
     TyFn([TyName("Int")], TyName("Int"), Some("Fs"))
   ]))
   assert(pure != effectful)
+}
+
+test "disjoint generic impl targets have distinct method owners" {
+  let int_owner = impl_method_owner(["T"], "Measured", TyApp("Pair", [
+    TyName("Int"),
+    TyName("T")
+  ]))
+  let string_owner = impl_method_owner(["T"], "Measured", TyApp("Pair", [
+    TyName("String"),
+    TyName("T")
+  ]))
+  assert(int_owner != string_owner)
+}
+
+test "impl target keys roundtrip every TypeExpr shape" {
+  for target in every_typeexpr() {
+    let key = impl_target_key(target)
+    match impl_target_from_key(key) {
+      Some(decoded) => assert(impl_target_key(decoded) == key),
+      None => assert(false)
+    }
+  }
+  assert(impl_target_from_key("not-a-key") == None)
 }
 
 /// Exhaustive over the DECLARATION: one arm per declared variant, no `_`.

--- a/lib/@vibe/ast/index.vpkg
+++ b/lib/@vibe/ast/index.vpkg
@@ -42,6 +42,7 @@ export enum TypeExpr {
 
 fn impl_target_head(target: TypeExpr) -> String
 fn impl_target_key(target: TypeExpr) -> String
+fn impl_target_from_key(key: String) -> Option[TypeExpr]
 fn impl_applied_target_key(head: String, arg_keys: Array[String]) -> String
 fn impl_specialized_method_binding_name(head: String, trait_name: String, target_key: String, method: String) -> String
 fn impl_method_owner(tparams: Array[String], trait_name: String, target: TypeExpr) -> String

--- a/lib/@vibe/ast/index.vpkg
+++ b/lib/@vibe/ast/index.vpkg
@@ -40,6 +40,14 @@ export enum TypeExpr {
   TyUnit
 }
 
+fn impl_target_head(target: TypeExpr) -> String
+fn impl_target_key(target: TypeExpr) -> String
+fn impl_applied_target_key(head: String, arg_keys: Array[String]) -> String
+fn impl_specialized_method_binding_name(head: String, trait_name: String, target_key: String, method: String) -> String
+fn impl_method_owner(tparams: Array[String], trait_name: String, target: TypeExpr) -> String
+fn impl_method_binding_name(tparams: Array[String], trait_name: String, target: TypeExpr, method: String) -> String
+fn impl_method_owner_head(owner: String) -> String
+
 /// The declaration kind requested by a kind-qualified import item.
 export enum ImportKind {
   ImportType;
@@ -111,7 +119,10 @@ export enum Stmt {
   // (exported, name, supers, methods, method generic metadata, header params).
   // Header params are appended so the older five slots keep their meanings.
   STrait(Bool, String, Array[String], Array[(String, Array[TypeExpr], TypeExpr)], Array[(String, Array[String], Array[(String, Array[String])])], Array[String]);
-  SImpl(Array[String], Array[(String, Array[String])], String, String);
+  /// (type params, bounds, trait name, complete target type).
+  /// The target keeps its arguments so instance matching cannot silently
+  /// widen `Array[Int]` to every `Array[T]` (#2335).
+  SImpl(Array[String], Array[(String, Array[String])], String, TypeExpr);
   SExternLet(String, TypeExpr);
   SImport(String, Array[ImportItem]);
   STest(String, Expr);

--- a/lib/@vibe/builtin/builtin_traits.vibe
+++ b/lib/@vibe/builtin/builtin_traits.vibe
@@ -28,8 +28,6 @@ export trait Show
 
 impl Show for Int
 
-impl Show for Float
-
 impl Show for Double
 
 impl Show for Bool
@@ -39,8 +37,6 @@ impl Show for Char
 impl Show for String
 
 impl Eq for Int
-
-impl Eq for Float
 
 impl Eq for Double
 
@@ -52,15 +48,11 @@ impl Eq for String
 
 impl Ord for Int
 
-impl Ord for Float
-
 impl Ord for Double
 
 impl Ord for String
 
 impl Add for Int
-
-impl Add for Float
 
 impl Add for Double
 
@@ -68,31 +60,21 @@ impl Add for String
 
 impl Sub for Int
 
-impl Sub for Float
-
 impl Sub for Double
 
 impl Mul for Int
-
-impl Mul for Float
 
 impl Mul for Double
 
 impl Div for Int
 
-impl Div for Float
-
 impl Div for Double
 
 impl Signed for Int
 
-impl Signed for Float
-
 impl Signed for Double
 
 impl Default for Int
-
-impl Default for Float
 
 impl Default for Double
 

--- a/lib/@vibe/builtin/option.vibe
+++ b/lib/@vibe/builtin/option.vibe
@@ -10,8 +10,6 @@ export trait Eq
 
 impl Eq for Int
 
-impl Eq for Float
-
 impl Eq for Double
 
 impl Eq for Bool

--- a/lib/@vibe/compiler/checker/canonical_checked_type_state.vibe
+++ b/lib/@vibe/compiler/checker/canonical_checked_type_state.vibe
@@ -628,10 +628,11 @@ fn canonical_trait_impl_entry(trait_name: String, target: Type, s: Subst, free_i
 
 fn canonical_trait_impl_gen_entry(trait_name: String, params: Array[String], bounds: Array[(String, Array[String])], target: Type, s: Subst, free_ids: Array[Int], free_names: Array[String]) -> String {
   let encoded_bounds = canonical_trait_impl_bounds(params, bounds)
-  // The checker retains a generic impl target as its erased nominal
-  // constructor. Even when that constructor has the same spelling as a
-  // declared impl parameter, it is not a reference to that parameter.
-  let encoded_target = canonical_type(target, s, array_empty(), array_empty(), free_ids, free_names, array_empty())
+  // Generic targets retain their complete applied type. Treat the impl's
+  // rigid parameter names as bound names so alpha-renaming a declaration does
+  // not change the snapshot while argument order and concrete slots remain
+  // observable.
+  let encoded_target = canonical_type(target, s, array_empty(), params, free_ids, free_names, array_empty())
   canonical_node("G", [
     trait_name,
     __to_string(Array::length(params)),
@@ -644,12 +645,12 @@ fn canonical_trait_impl_gen_entry(trait_name: String, params: Array[String], bou
 /// preserves final-environment traversal order and includes only EnvTraitImpl
 /// and EnvTraitImplGen entries. Generic parameter names are alpha-normalized
 /// by declaration position; bounds retain association as semantic sets.
-/// The generic target is intentionally the checker's retained erased target
-/// (normally its constructor with erased type arguments), not reconstructed
-/// source syntax. EnvFlat and EnvEmpty terminate traversal; trait definitions,
-/// values, cache payloads, and all other CheckedProgram state are excluded.
+/// The complete retained target is encoded after the same alpha-normalization,
+/// so concrete slots and reordered generic arguments remain observable.
+/// EnvFlat and EnvEmpty terminate traversal; trait definitions, values, cache
+/// payloads, and all other CheckedProgram state are excluded.
 export fn canonical_retained_trait_impl_entries_snapshot(env: TypeEnv, s: Subst) -> String {
-  let fields = ["v1"]
+  let fields = ["v2"]
   let free_ids = array_empty()
   let free_names = array_empty()
   let mut cur = env

--- a/lib/@vibe/compiler/checker/checker.vibe
+++ b/lib/@vibe/compiler/checker/checker.vibe
@@ -47,6 +47,10 @@ import @vibe/compiler/core {
   unify
 }
 
+import @vibe/ast {
+  impl_method_owner_head
+}
+
 import ./builtins.vibe {
   lookup_builtin
 }
@@ -270,7 +274,7 @@ export fn trait_erased_type_param_env(env: TypeEnv, binding_name: String) -> Typ
   if sep < 0 {
     env
   } else {
-    let type_name = String::substring(binding_name, 0, sep)
+    let type_name = impl_method_owner_head(String::substring(binding_name, 0, sep))
     let method_name = String::substring(binding_name, sep + 2, String::length(binding_name))
     let names = array_empty()
     collect_impl_erased_type_params(env, env, type_name, method_name, names)

--- a/lib/@vibe/compiler/checker/checker_stmt.vibe
+++ b/lib/@vibe/compiler/checker/checker_stmt.vibe
@@ -2846,10 +2846,17 @@ fn check_stmts_with_binders(raw_stmts: Array[Stmt], i: Int, env: TypeEnv, defs: 
         } else {
           ()
         }
+        let implicit_target_params = match target_expr {
+          TyName(name) => match impl_target_declared_arity(defs, name) {
+            Some(arity) => arity > 0 && arity == Array::length(tparams),
+            None => false
+          },
+          _ => false
+        }
         let mut tpi = 0
         while tpi < Array::length(tparams) {
           let tparam = Array::get(tparams, tpi)
-          if !impl_target_mentions(target_expr, tparam) {
+          if !implicit_target_params && !impl_target_mentions(target_expr, tparam) {
             Array::push(errors, String::concat("impl type parameter `", String::concat(tparam, "` is not used in its target; remove it, or use it in the target type")))
           } else {
             ()

--- a/lib/@vibe/compiler/checker/checker_stmt.vibe
+++ b/lib/@vibe/compiler/checker/checker_stmt.vibe
@@ -47,6 +47,7 @@ import @vibe/compiler/core {
   find_typedef,
   generalize,
   is_singleton_resource_kind,
+  overlapping_impl_target_for,
   predeclared_resources,
   resolve_builtin,
   rewrite_import_alias_stmt,
@@ -117,10 +118,8 @@ import @vibe/parser {
   located_program_binder_authority_program
 }
 
-/// Declared arity of a type constructor used by an erased generic impl target.
-/// The parser can prove that target arguments mirror the impl formals, but the
-/// SImpl AST cannot carry the target TypeExpr far enough to check its arity.
-/// Keep builtin container authority here; user declarations come from defs.
+/// Declared arity of a type constructor used by an impl target. Keep builtin
+/// container authority here; user declarations come from defs.
 fn impl_target_declared_arity(defs: Array[TypeDef], name: String) -> Option[Int] {
   match find_typedef(defs, name) {
     Some(td) => match td {
@@ -137,6 +136,42 @@ fn impl_target_declared_arity(defs: Array[TypeDef], name: String) -> Option[Int]
         None => None
       }
     }
+  }
+}
+
+fn impl_target_mentions(target: TypeExpr, wanted: String) -> Bool {
+  match target {
+    TyName(name) => name == wanted,
+    TyApp(name, args) => if name == wanted {
+      true
+    } else {
+      let mut i = 0
+      let mut found = false
+      while i < Array::length(args) && !found {
+        found = impl_target_mentions(Array::get(args, i), wanted)
+        i = i + 1
+      }
+      found
+    },
+    TyFn(params, ret, _) => {
+      let mut i = 0
+      let mut found = impl_target_mentions(ret, wanted)
+      while i < Array::length(params) && !found {
+        found = impl_target_mentions(Array::get(params, i), wanted)
+        i = i + 1
+      }
+      found
+    },
+    TyTuple(items) => {
+      let mut i = 0
+      let mut found = false
+      while i < Array::length(items) && !found {
+        found = impl_target_mentions(Array::get(items, i), wanted)
+        i = i + 1
+      }
+      found
+    },
+    TyUnit => false
   }
 }
 
@@ -2798,7 +2833,12 @@ fn check_stmts_with_binders(raw_stmts: Array[Stmt], i: Int, env: TypeEnv, defs: 
         let is_open = false
         (EnvTraitDef(name, supers, is_open, methods, env, tparams, method_gens), s, c)
       },
-      SImpl(tparams, tbounds, trait_name, type_name) => {
+      SImpl(tparams, tbounds, trait_name, target_expr) => {
+        let type_name = match target_expr {
+          TyName(name) => name,
+          TyApp(name, _) => name,
+          _ => ""
+        }
         // ADR-0068: `Send` is compiler-judged (structural); user impls
         // would let a non-sendable type cross task/channel boundaries.
         if trait_name == "Send" {
@@ -2806,10 +2846,24 @@ fn check_stmts_with_binders(raw_stmts: Array[Stmt], i: Int, env: TypeEnv, defs: 
         } else {
           ()
         }
-        if Array::length(tparams) > 0 {
+        let mut tpi = 0
+        while tpi < Array::length(tparams) {
+          let tparam = Array::get(tparams, tpi)
+          if !impl_target_mentions(target_expr, tparam) {
+            Array::push(errors, String::concat("impl type parameter `", String::concat(tparam, "` is not used in its target; remove it, or use it in the target type")))
+          } else {
+            ()
+          }
+          tpi = tpi + 1
+        }
+        let target_arity = match target_expr {
+          TyApp(_, args) => Array::length(args),
+          _ => Array::length(tparams)
+        }
+        if target_arity > 0 {
           match impl_target_declared_arity(defs, type_name) {
-            Some(want) => if want != Array::length(tparams) {
-              Array::push(errors, String::concat("type `", String::concat(type_name, String::concat("` expects ", String::concat(__to_string(want), String::concat(" type argument(s), got ", String::concat(__to_string(Array::length(tparams)), " in impl target")))))))
+            Some(want) => if want != target_arity {
+              Array::push(errors, String::concat("type `", String::concat(type_name, String::concat("` expects ", String::concat(__to_string(want), String::concat(" type argument(s), got ", String::concat(__to_string(target_arity), " in impl target")))))))
             } else {
               ()
             },
@@ -2818,15 +2872,16 @@ fn check_stmts_with_binders(raw_stmts: Array[Stmt], i: Int, env: TypeEnv, defs: 
         } else {
           ()
         }
-        let target = match resolve_builtin(type_name) {
-          Some(t) => t,
-          None => CtNamed(type_name, array_empty())
+        let target = resolve_type_expr_shadowed(target_expr, defs, tparams)
+        match overlapping_impl_target_for(env, trait_name, tparams, target) {
+          Some(existing_target) => Array::push(errors, String::concat("overlapping impls for `", String::concat(trait_name, String::concat("`: existing target `", String::concat(type_to_string(existing_target), String::concat("` overlaps new target `", String::concat(type_to_string(target), "`"))))))),
+          None => ()
         }
-        // A generic impl `impl [T] Trait for C` (type parameters present) is
+        // A generic impl `impl [T] Trait for C[T]` (type parameters present) is
         // registered as `EnvTraitImplGen` so trait resolution can match the
-        // family `C[..]` against a concrete `C[K]` by constructor (the target's
-        // type args are erased). A plain `impl Trait for C` stays a nominal
-        // `EnvTraitImpl`. (#5 generic impls, Increment A.)
+        // family `C[..]` against a concrete `C[K]`. A plain impl stays a
+        // nominal `EnvTraitImpl`. The complete target is retained so concrete
+        // specializations and reordered generic parameters cannot widen.
         let new_env = if Array::length(tparams) > 0 {
           EnvTraitImplGen(trait_name, tparams, tbounds, target, env)
         } else {

--- a/lib/@vibe/compiler/checker/index.vpkg
+++ b/lib/@vibe/compiler/checker/index.vpkg
@@ -3,6 +3,7 @@ version = 0.0.1
 description =
   #|@vibe/compiler/checker — ADR-0070 / #897 compiler-internal contract.
 deps = {
+  @vibe/ast : 0.2.0
   @vibe/compiler/core : 0.0.1
   @vibe/compiler/normalize : 0.0.1
   @vibe/core : 0.2.0

--- a/lib/@vibe/compiler/core/import_alias_rewrite.vibe
+++ b/lib/@vibe/compiler/core/import_alias_rewrite.vibe
@@ -8,6 +8,10 @@ import @vibe/core {
   array_empty, struct MutMap, struct MutSet
 }
 
+import @vibe/ast {
+  impl_method_owner
+}
+
 import ./module_graph_path.vibe {
   dir_of_path, resolve_import_path_candidates
 }
@@ -781,6 +785,77 @@ export fn rewrite_import_alias_stmt(stmt: Stmt, aliases: Array[(String, String)]
   rewrite_alias_stmt_ix(stmt, aliasidx_build(aliases))
 }
 
+/// Parser-generated impl methods carry the impl target in their internal
+/// owner. Rewriting an imported type alias in `SImpl` therefore also has to
+/// rename the following method declarations; otherwise trait resolution asks
+/// for the canonical owner while codegen only has the source-spelled owner.
+fn collect_impl_method_owner_aliases(stmts: Array[Stmt], aliases: Array[(String, String)]) -> Array[(String, String)] {
+  let out = empty_aliases()
+  let am = aliasidx_build(aliases)
+  let mut i = 0
+  while i < Array::length(stmts) {
+    match Array::get(stmts, i) {
+      SImpl(tparams, _, trait_name, target) => {
+        let rewritten_target = rewrite_alias_type_expr(target, aliasidx_without_names(am, tparams))
+        let source_owner = impl_method_owner(tparams, trait_name, target)
+        let rewritten_owner = impl_method_owner(tparams, trait_name, rewritten_target)
+        if source_owner != rewritten_owner {
+          Array::push(out, (source_owner, rewritten_owner))
+        } else {
+          ()
+        }
+      },
+      _ => ()
+    }
+    i = i + 1
+  }
+  out
+}
+
+fn rewrite_impl_method_binding_name(name: String, owner_aliases: Array[(String, String)]) -> String {
+  let mut out = name
+  let mut i = 0
+  let mut found = false
+  while i < Array::length(owner_aliases) && !found {
+    let (source_owner, rewritten_owner) = Array::get(owner_aliases, i)
+    let prefix = String::concat(source_owner, "::")
+    if String::starts_with(name, prefix) {
+      out = String::concat(rewritten_owner, String::substring(name, String::length(source_owner), String::length(name)))
+      found = true
+    } else {
+      i = i + 1
+    }
+  }
+  out
+}
+
+fn rewrite_impl_method_binding(stmt: Stmt, owner_aliases: Array[(String, String)]) -> Stmt {
+  match stmt {
+    SLet(exported, is_rec, name, ty, body) => SLet(exported, is_rec, rewrite_impl_method_binding_name(name, owner_aliases), ty, body),
+    SFnDecl(exported, name, body, requires, ensures) => SFnDecl(exported, rewrite_impl_method_binding_name(name, owner_aliases), body, requires, ensures),
+    _ => stmt
+  }
+}
+
+export fn rewrite_import_alias_stmts(stmts: Array[Stmt], aliases: Array[(String, String)]) -> Array[Stmt] {
+  let owner_aliases = collect_impl_method_owner_aliases(stmts, aliases)
+  let combined = empty_aliases()
+  let mut ai = 0
+  while ai < Array::length(aliases) {
+    Array::push(combined, Array::get(aliases, ai))
+    ai = ai + 1
+  }
+  let mut oi = 0
+  while oi < Array::length(owner_aliases) {
+    Array::push(combined, Array::get(owner_aliases, oi))
+    oi = oi + 1
+  }
+  let am = aliasidx_build(combined)
+  for stmt in stmts {
+    rewrite_alias_stmt_ix(rewrite_impl_method_binding(stmt, owner_aliases), am)
+  }
+}
+
 fn rewrite_alias_stmt_ix(stmt: Stmt, am: AliasIdx) -> Stmt {
   match stmt {
     SLet(exported, is_rec, name, ty, body) => SLet(exported, is_rec, name, rewrite_alias_type_opt(ty, am), rewrite_alias_expr_ix(body, aliasidx_without_name(am, name))),
@@ -790,10 +865,7 @@ fn rewrite_alias_stmt_ix(stmt: Stmt, am: AliasIdx) -> Stmt {
     SExpr(body) => SExpr(rewrite_alias_expr_ix(body, am)),
     SLetPat(pat, body) => SLetPat(pat, rewrite_alias_expr_ix(body, am)),
     SModule(exported, name, stmts) => {
-      let module_am = aliasidx_build(collect_import_aliases(stmts))
-      SModule(exported, name, for inner_stmt in stmts {
-        rewrite_alias_stmt_ix(inner_stmt, module_am)
-      })
+      SModule(exported, name, rewrite_import_alias_stmts(stmts, collect_import_aliases(stmts)))
     },
     // #1502: an import alias used as a type-alias TARGET (`import { Attempt as
     // Att }` then `type Att2[T] = Att[T]`). The expression arm above already
@@ -812,6 +884,7 @@ fn rewrite_alias_stmt_ix(stmt: Stmt, am: AliasIdx) -> Stmt {
     // rewrite at all) and is tracked separately -- what this guard buys is that
     // the rewrite is not a SECOND, independent source of the same bug.
     STypeAlias(exported, name, params, target) => STypeAlias(exported, name, params, rewrite_alias_type_expr(target, aliasidx_without_names(am, params))),
+    SImpl(tparams, bounds, trait_name, target) => SImpl(tparams, bounds, trait_name, rewrite_alias_type_expr(target, aliasidx_without_names(am, tparams))),
     _ => stmt
   }
 }
@@ -907,8 +980,7 @@ export fn append_non_import_stmts_without_alias_rewrite(merged: Array[Stmt], stm
 
 export fn append_import_alias_rewritten_non_import_stmts_skipping(merged: Array[Stmt], stmts: Array[Stmt], skipped_locals: Array[String]) -> Unit {
   let aliases = alias_map_without_names(collect_import_aliases(stmts), skipped_locals)
-  let should_rewrite = Array::length(aliases) > 0
-  let am = aliasidx_build(aliases)
+  let rewritten = rewrite_import_alias_stmts(stmts, aliases)
   let mut i = 0
   while i < Array::length(stmts) {
     let stmt = Array::get(stmts, i)
@@ -916,12 +988,7 @@ export fn append_import_alias_rewritten_non_import_stmts_skipping(merged: Array[
       SImport(_, items) => append_stdin_provider_import_alias_markers(merged, items),
       SReExport(_, _) => (),
       SAliasDecl(_, _) => (),
-      SModule(_, _, _) => Array::push(merged, rewrite_alias_stmt_ix(stmt, am)),
-      _ => if should_rewrite {
-        Array::push(merged, rewrite_alias_stmt_ix(stmt, am))
-      } else {
-        Array::push(merged, stmt)
-      }
+      _ => Array::push(merged, Array::get(rewritten, i))
     }
     i = i + 1
   }
@@ -1479,13 +1546,7 @@ export fn namespace_private_value_stmts(path: String, stmts: Array[Stmt]) -> Arr
         }
         STypeAlias(exported, next_name, params, rewrite_private_type_expr(target, type_renames))
       },
-      SImpl(tparams, bounds, trait_name, target_name) => {
-        let next_target = match lookup_alias(type_renames, target_name) {
-          Some(renamed) => renamed,
-          None => target_name
-        }
-        SImpl(tparams, bounds, trait_name, next_target)
-      },
+      SImpl(tparams, bounds, trait_name, target) => SImpl(tparams, bounds, trait_name, rewrite_private_type_expr(target, alias_map_without_names(type_renames, tparams))),
       SExternLet(name, ty) => SExternLet(name, rewrite_private_type_expr(ty, type_renames)),
       STest(name, body) => STest(name, rewrite_private_type_ctor_expr(body, type_renames, ctor_renames)),
       SBench(name, body) => SBench(name, rewrite_private_type_ctor_expr(body, type_renames, ctor_renames)),
@@ -1627,13 +1688,7 @@ fn namespace_private_type_ctor_stmt(stmt: Stmt, type_renames: Array[(String, Str
       }
       STypeAlias(exported, next_name, params, rewrite_private_type_expr(target, type_renames))
     },
-    SImpl(tparams, bounds, trait_name, target_name) => {
-      let next_target = match lookup_alias(type_renames, target_name) {
-        Some(renamed) => renamed,
-        None => target_name
-      }
-      SImpl(tparams, bounds, trait_name, next_target)
-    },
+    SImpl(tparams, bounds, trait_name, target) => SImpl(tparams, bounds, trait_name, rewrite_private_type_expr(target, alias_map_without_names(type_renames, tparams))),
     SExternLet(name, ty) => SExternLet(name, rewrite_private_type_expr(ty, type_renames)),
     STest(name, body) => STest(name, rewrite_private_type_ctor_expr(body, type_renames, ctor_renames)),
     SBench(name, body) => SBench(name, rewrite_private_type_ctor_expr(body, type_renames, ctor_renames)),
@@ -2336,8 +2391,7 @@ export fn append_import_alias_rewritten_non_import_stmts_with_renames(merged: Ar
     Array::push(combined, Array::get(extra_renames, xi))
     xi = xi + 1
   }
-  let should_rewrite = Array::length(combined) > 0
-  let am = aliasidx_build(combined)
+  let rewritten = rewrite_import_alias_stmts(stmts, combined)
   let mut i = 0
   while i < Array::length(stmts) {
     let stmt = Array::get(stmts, i)
@@ -2345,12 +2399,7 @@ export fn append_import_alias_rewritten_non_import_stmts_with_renames(merged: Ar
       SImport(_, items) => append_stdin_provider_import_alias_markers(merged, items),
       SReExport(_, _) => (),
       SAliasDecl(_, _) => (),
-      SModule(_, _, _) => Array::push(merged, rewrite_alias_stmt_ix(stmt, am)),
-      _ => if should_rewrite {
-        Array::push(merged, rewrite_alias_stmt_ix(stmt, am))
-      } else {
-        Array::push(merged, stmt)
-      }
+      _ => Array::push(merged, Array::get(rewritten, i))
     }
     i = i + 1
   }

--- a/lib/@vibe/compiler/core/import_alias_rewrite.vibe
+++ b/lib/@vibe/compiler/core/import_alias_rewrite.vibe
@@ -837,6 +837,138 @@ fn rewrite_impl_method_binding(stmt: Stmt, owner_aliases: Array[(String, String)
   }
 }
 
+fn collect_local_type_aliases(stmts: Array[Stmt]) -> Array[(String, Array[String], TypeExpr)] {
+  let out = []
+  let mut i = 0
+  while i < Array::length(stmts) {
+    match Array::get(stmts, i) {
+      STypeAlias(_, name, params, target) => Array::push(out, (name, params, target)),
+      _ => ()
+    }
+    i = i + 1
+  }
+  out
+}
+
+fn lookup_local_type_alias(aliases: Array[(String, Array[String], TypeExpr)], name: String) -> Option[(Array[String], TypeExpr)] {
+  let mut i = 0
+  let mut found = None
+  while i < Array::length(aliases) {
+    let (alias_name, params, target) = Array::get(aliases, i)
+    if alias_name == name {
+      found = Some((params, target))
+      i = Array::length(aliases)
+    } else {
+      i = i + 1
+    }
+  }
+  found
+}
+
+fn local_alias_arg(params: Array[String], args: Array[TypeExpr], name: String) -> Option[TypeExpr] {
+  let mut i = 0
+  let mut found = None
+  while i < Array::length(params) {
+    if Array::get(params, i) == name && i < Array::length(args) {
+      found = Some(Array::get(args, i))
+      i = Array::length(params)
+    } else {
+      i = i + 1
+    }
+  }
+  found
+}
+
+fn substitute_local_alias_target(target: TypeExpr, params: Array[String], args: Array[TypeExpr]) -> TypeExpr {
+  match target {
+    TyName(name) => match local_alias_arg(params, args, name) {
+      Some(arg) => arg,
+      None => target
+    },
+    TyApp(name, items) => TyApp(name, for item in items {
+      substitute_local_alias_target(item, params, args)
+    }),
+    TyFn(fn_params, ret, effect) => TyFn(for param in fn_params {
+      substitute_local_alias_target(param, params, args)
+    }, substitute_local_alias_target(ret, params, args), effect),
+    TyTuple(items) => TyTuple(for item in items {
+      substitute_local_alias_target(item, params, args)
+    }),
+    TyUnit => target
+  }
+}
+
+fn normalize_local_alias_target_with_fuel(target: TypeExpr, aliases: Array[(String, Array[String], TypeExpr)], fuel: Int) -> TypeExpr {
+  if fuel <= 0 {
+    target
+  } else match target {
+    TyName(name) => match lookup_local_type_alias(aliases, name) {
+      Some(alias) => {
+        let (params, alias_target) = alias
+        if Array::length(params) == 0 {
+          normalize_local_alias_target_with_fuel(alias_target, aliases, fuel - 1)
+        } else {
+          target
+        }
+      },
+      None => target
+    },
+    TyApp(name, args) => match lookup_local_type_alias(aliases, name) {
+      Some(alias) => {
+        let (params, alias_target) = alias
+        if Array::length(params) == Array::length(args) {
+          normalize_local_alias_target_with_fuel(substitute_local_alias_target(alias_target, params, args), aliases, fuel - 1)
+        } else {
+          target
+        }
+      },
+      None => TyApp(name, for arg in args {
+        normalize_local_alias_target_with_fuel(arg, aliases, fuel - 1)
+      })
+    },
+    TyFn(params, ret, effect) => TyFn(for param in params {
+      normalize_local_alias_target_with_fuel(param, aliases, fuel - 1)
+    }, normalize_local_alias_target_with_fuel(ret, aliases, fuel - 1), effect),
+    TyTuple(items) => TyTuple(for item in items {
+      normalize_local_alias_target_with_fuel(item, aliases, fuel - 1)
+    }),
+    TyUnit => target
+  }
+}
+
+fn normalize_local_alias_target(target: TypeExpr, aliases: Array[(String, Array[String], TypeExpr)]) -> TypeExpr {
+  normalize_local_alias_target_with_fuel(target, aliases, Array::length(aliases) + 1)
+}
+
+fn collect_local_impl_method_owner_aliases(stmts: Array[Stmt], aliases: Array[(String, Array[String], TypeExpr)]) -> Array[(String, String)] {
+  let out = empty_aliases()
+  let mut i = 0
+  while i < Array::length(stmts) {
+    match Array::get(stmts, i) {
+      SImpl(tparams, _, trait_name, target) => {
+        let normalized_target = normalize_local_alias_target(target, aliases)
+        let source_owner = impl_method_owner(tparams, trait_name, target)
+        let normalized_owner = impl_method_owner(tparams, trait_name, normalized_target)
+        if source_owner != normalized_owner {
+          Array::push(out, (source_owner, normalized_owner))
+        } else {
+          ()
+        }
+      },
+      _ => ()
+    }
+    i = i + 1
+  }
+  out
+}
+
+fn rewrite_local_alias_impl_stmt(stmt: Stmt, aliases: Array[(String, Array[String], TypeExpr)], owner_aliases: Array[(String, String)]) -> Stmt {
+  match rewrite_impl_method_binding(stmt, owner_aliases) {
+    SImpl(tparams, bounds, trait_name, target) => SImpl(tparams, bounds, trait_name, normalize_local_alias_target(target, aliases)),
+    rewritten => rewritten
+  }
+}
+
 export fn rewrite_import_alias_stmts(stmts: Array[Stmt], aliases: Array[(String, String)]) -> Array[Stmt] {
   let owner_aliases = collect_impl_method_owner_aliases(stmts, aliases)
   let combined = empty_aliases()
@@ -851,8 +983,13 @@ export fn rewrite_import_alias_stmts(stmts: Array[Stmt], aliases: Array[(String,
     oi = oi + 1
   }
   let am = aliasidx_build(combined)
-  for stmt in stmts {
+  let imported = for stmt in stmts {
     rewrite_alias_stmt_ix(rewrite_impl_method_binding(stmt, owner_aliases), am)
+  }
+  let local_aliases = collect_local_type_aliases(imported)
+  let local_owner_aliases = collect_local_impl_method_owner_aliases(imported, local_aliases)
+  for stmt in imported {
+    rewrite_local_alias_impl_stmt(stmt, local_aliases, local_owner_aliases)
   }
 }
 
@@ -965,6 +1102,10 @@ fn append_stdin_provider_import_alias_markers(merged: Array[Stmt], items: Array[
 }
 
 export fn append_non_import_stmts_without_alias_rewrite(merged: Array[Stmt], stmts: Array[Stmt]) -> Unit {
+  // Even an import-free file needs impl owners normalized through its local
+  // transparent aliases. The empty import map keeps every ordinary name
+  // untouched while rewrite_import_alias_stmts performs that owner pass.
+  let rewritten = rewrite_import_alias_stmts(stmts, empty_aliases())
   let mut i = 0
   while i < Array::length(stmts) {
     let stmt = Array::get(stmts, i)
@@ -972,7 +1113,7 @@ export fn append_non_import_stmts_without_alias_rewrite(merged: Array[Stmt], stm
       SImport(_, items) => append_stdin_provider_import_alias_markers(merged, items),
       SReExport(_, _) => (),
       SAliasDecl(_, _) => (),
-      _ => Array::push(merged, stmt)
+      _ => Array::push(merged, Array::get(rewritten, i))
     }
     i = i + 1
   }
@@ -1605,7 +1746,11 @@ export fn namespace_private_value_stmts(path: String, stmts: Array[Stmt]) -> Arr
   if Array::length(type_renames) == 0 && Array::length(ctor_renames) == 0 {
     value_renamed
   } else {
-    for stmt in value_renamed {
+    let owner_aliases = collect_impl_method_owner_aliases(value_renamed, type_renames)
+    let owner_renamed = for stmt in value_renamed {
+      rewrite_impl_method_binding(stmt, owner_aliases)
+    }
+    for stmt in owner_renamed {
       namespace_private_type_ctor_stmt_local(stmt, type_renames, ctor_renames)
     }
   }

--- a/lib/@vibe/compiler/core/index.vpkg
+++ b/lib/@vibe/compiler/core/index.vpkg
@@ -260,6 +260,7 @@ fn types_equal(a: Type, b: Type) -> Bool
 fn unify(a: Type, b: Type, s: Subst) -> Option[Subst]
 fn types_compatible(expected: Type, actual: Type) -> Bool
 fn impls_overlap_for(env: TypeEnv, trait_name: String, new_target: Type) -> Bool
+fn overlapping_impl_target_for(env: TypeEnv, trait_name: String, new_params: Array[String], new_target: Type) -> Option[Type]
 fn collect_subst_bounds_pairs(s: Subst) -> Array[(Int, Array[String])]
 fn generalize(s: Subst, ty: Type) -> Type
 fn type_implements_trait(env: TypeEnv, s: Subst, ty: Type, trait_name: String) -> Bool
@@ -276,6 +277,7 @@ fn collect_import_aliases(stmts: Array[Stmt]) -> Array[(String, String)]
 fn collect_import_alias_collision_refs(stmts: Array[Stmt]) -> Array[(String, String, String)]
 fn collect_import_alias_collision_locals(stmts: Array[Stmt]) -> Array[String]
 fn rewrite_import_alias_stmt(stmt: Stmt, aliases: Array[(String, String)]) -> Stmt
+fn rewrite_import_alias_stmts(stmts: Array[Stmt], aliases: Array[(String, String)]) -> Array[Stmt]
 fn stmts_have_import_deep(stmts: Array[Stmt]) -> Bool
 fn append_non_import_stmts_without_alias_rewrite(merged: Array[Stmt], stmts: Array[Stmt]) -> Unit
 fn append_import_alias_rewritten_non_import_stmts_skipping(merged: Array[Stmt], stmts: Array[Stmt], skipped_locals: Array[String]) -> Unit

--- a/lib/@vibe/compiler/core/types.vibe
+++ b/lib/@vibe/compiler/core/types.vibe
@@ -1254,9 +1254,9 @@ export fn trait_method_sig(env: TypeEnv, trait_name: String, method_name: String
 }
 
 /// The declared name at the head of a (possibly generic) named type, for
-/// matching against a trait impl's target. Impl targets are stored with their
-/// type arguments erased to `CtUnknown` (see the `SImpl` handler), so element
-/// types must be matched by head name, not by `types_equal`.
+/// recognizing iterator-shaped trait impl targets. This query asks only about
+/// the constructor's protocol shape, so it deliberately ignores retained type
+/// arguments.
 fn trait_target_head_name(ty: Type) -> String {
   match ty {
     CtNamed(n, _) => n,
@@ -1335,9 +1335,9 @@ fn type_name_async_iterator_impl_scan(scan: TypeEnv, full: TypeEnv, type_name: S
     // sees the lowered `Iter::next` and injects `await` on a Future return),
     // so a generically-implemented async iterator suspended from a row-free
     // function with no diagnostic. Verified against a repro that RAN the await
-    // loop (a sync EForIn over the struct would have trapped). Impl targets
-    // store their type arguments erased, so head-name matching is exact here
-    // just as it is in the non-generic arm.
+    // loop (a sync EForIn over the struct would have trapped). This protocol
+    // query is constructor-shaped, so head-name matching mirrors the
+    // non-generic arm even though the complete impl target is retained.
     //
     // The SYNC sibling scan above deliberately keeps skipping this case: it
     // feeds element-type inference, where widening the match would change
@@ -3440,30 +3440,233 @@ export fn types_compatible(expected: Type, actual: Type) -> Bool {
   }
 }
 
-export fn impls_overlap_for(env: TypeEnv, trait_name: String, new_target: Type) -> Bool {
-  match env {
-    EnvEmpty => false,
-    EnvBind(_, _, rest) => impls_overlap_for(rest, trait_name, new_target),
-    EnvMutCell(_, _, rest) => impls_overlap_for(rest, trait_name, new_target),
-    EnvTraitDef(_, _, _, _, rest, _, _) => impls_overlap_for(rest, trait_name, new_target),
-    EnvTraitImpl(tname, target, rest) => if tname == trait_name {
-      if types_equal(target, new_target) {
-        true
+fn impl_pattern_param_index(params: Array[String], name: String) -> Int {
+  let mut result = -1
+  let mut i = 0
+  while i < Array::length(params) && result < 0 {
+    if Array::get(params, i) == name {
+      result = i
+    } else {
+      ()
+    }
+    i = i + 1
+  }
+  result
+}
+
+/// Replace each impl-target formal with a fresh checker variable. Using one
+/// stable variable per formal preserves repeated-variable constraints such as
+/// `Pair[T, T]`; using disjoint bases for the two candidates lets ordinary
+/// unification decide whether their instance sets intersect.
+fn freshen_impl_pattern(ty: Type, params: Array[String], base: Int) -> Type {
+  match ty {
+    CtNamed(name, args) => {
+      let param_index = if Array::length(args) == 0 {
+        impl_pattern_param_index(params, name)
+      } else {
+        -1
       }
-      else impls_overlap_for(rest, trait_name, new_target)
-    } else impls_overlap_for(rest, trait_name, new_target),
-    EnvTraitImplGen(_, _, _, _, rest) => impls_overlap_for(rest, trait_name, new_target),
-    EnvTypeDefs(_, _, rest) => impls_overlap_for(rest, trait_name, new_target),
-    EnvFlat(_) => false,
-    EnvCached(_, _, rest) => impls_overlap_for(rest, trait_name, new_target)
+      if param_index >= 0 {
+        CtVar(base + param_index)
+      } else {
+        CtNamed(name, for arg in args {
+          freshen_impl_pattern(arg, params, base)
+        })
+      }
+    },
+    CtArray(elem) => CtArray(freshen_impl_pattern(elem, params, base)),
+    CtOption(elem) => CtOption(freshen_impl_pattern(elem, params, base)),
+    CtTuple(items) => CtTuple(for item in items {
+      freshen_impl_pattern(item, params, base)
+    }),
+    CtFn(args, ret, effect) => CtFn(for arg in args {
+      freshen_impl_pattern(arg, params, base)
+    }, freshen_impl_pattern(ret, params, base), effect),
+    CtRecord(fields) => CtRecord(for field in fields {
+      let (name, field_ty) = field
+      (name, freshen_impl_pattern(field_ty, params, base))
+    }),
+    _ => ty
   }
 }
 
-/// #829: an `impl Trait for S` stores its target with the type arguments
-/// ERASED (the SImpl handler registers `CtNamed(S, [])` / `CtStruct(S)`), but
-/// an instantiated generic struct value is now typed `CtNamed(S, args)`.
-/// Bridge the two by head name — the unparameterized impl covers every
-/// instantiation — mirroring the CtEnum/CtNamed unify bridge.
+fn impl_pattern_effects_equal(left: Option[String], right: Option[String]) -> Bool {
+  match (left, right) {
+    (None, None) => true,
+    (Some(a), Some(b)) => a == b,
+    _ => false
+  }
+}
+
+fn is_fresh_impl_pattern_var(id: Int) -> Bool {
+  id >= 100000000 && id < 300000000
+}
+
+/// Trait-instance overlap is stricter than expression unification: assignment
+/// coercions such as Char <-> Int and the CtUnknown wildcard must not make two
+/// impl heads overlap. This unifier handles only the fresh variables introduced
+/// from impl formals and otherwise requires the same type structure.
+fn unify_impl_patterns_exact(left: Type, right: Type, subst: Subst) -> Option[Subst] {
+  let a = subst_apply(subst, left)
+  let b = subst_apply(subst, right)
+  if types_equal(a, b) {
+    Some(subst)
+  } else {
+    match a {
+      CtVar(id) => if is_fresh_impl_pattern_var(id) {
+        if occurs_in(id, b) {
+          None
+        } else {
+          Some(SubstBind(id, b, subst))
+        }
+      } else {
+        None
+      },
+      _ => match b {
+        CtVar(id) => if is_fresh_impl_pattern_var(id) {
+          if occurs_in(id, a) {
+            None
+          } else {
+            Some(SubstBind(id, a, subst))
+          }
+        } else {
+          None
+        },
+        _ => match (a, b) {
+          (CtArray(ae), CtArray(be)) => unify_impl_patterns_exact(ae, be, subst),
+          (CtOption(ae), CtOption(be)) => unify_impl_patterns_exact(ae, be, subst),
+          (CtTuple(a_items), CtTuple(b_items)) => {
+            if Array::length(a_items) != Array::length(b_items) {
+              None
+            } else {
+              let mut result = Some(subst)
+              let mut i = 0
+              while i < Array::length(a_items) {
+                result = match result {
+                  Some(current) => unify_impl_patterns_exact(Array::get(a_items, i), Array::get(b_items, i), current),
+                  None => None
+                }
+                i = i + 1
+              }
+              result
+            }
+          },
+          (CtFn(aa, ar, ae), CtFn(ba, br, be)) => {
+            if Array::length(aa) != Array::length(ba) || !impl_pattern_effects_equal(ae, be) {
+              None
+            } else {
+              let mut result = Some(subst)
+              let mut i = 0
+              while i < Array::length(aa) {
+                result = match result {
+                  Some(current) => unify_impl_patterns_exact(Array::get(aa, i), Array::get(ba, i), current),
+                  None => None
+                }
+                i = i + 1
+              }
+              match result {
+                Some(current) => unify_impl_patterns_exact(ar, br, current),
+                None => None
+              }
+            }
+          },
+          (CtNamed(an, aa), CtNamed(bn, ba)) => {
+            if an != bn || Array::length(aa) != Array::length(ba) {
+              None
+            } else {
+              let mut result = Some(subst)
+              let mut i = 0
+              while i < Array::length(aa) {
+                result = match result {
+                  Some(current) => unify_impl_patterns_exact(Array::get(aa, i), Array::get(ba, i), current),
+                  None => None
+                }
+                i = i + 1
+              }
+              result
+            }
+          },
+          (CtStruct(an), CtNamed(bn, _)) => if an == bn {
+            Some(subst)
+          } else {
+            None
+          },
+          (CtNamed(an, _), CtStruct(bn)) => if an == bn {
+            Some(subst)
+          } else {
+            None
+          },
+          (CtEnum(an), CtNamed(bn, _)) => if an == bn {
+            Some(subst)
+          } else {
+            None
+          },
+          (CtNamed(an, _), CtEnum(bn)) => if an == bn {
+            Some(subst)
+          } else {
+            None
+          },
+          _ => None
+        }
+      }
+    }
+  }
+}
+
+fn impl_target_patterns_overlap(left_params: Array[String], left_target: Type, right_params: Array[String], right_target: Type) -> Bool {
+  let left = freshen_impl_pattern(left_target, left_params, 100000000)
+  let right = freshen_impl_pattern(right_target, right_params, 200000000)
+  match unify_impl_patterns_exact(left, right, SubstEmpty) {
+    Some(_) => true,
+    None => false
+  }
+}
+
+/// Return the first existing target whose instance set intersects the new
+/// target. TypeEnv is newest-first, so this is deterministic for a fixed
+/// source order and gives the checker both candidate targets for its error.
+export fn overlapping_impl_target_for(env: TypeEnv, trait_name: String, new_params: Array[String], new_target: Type) -> Option[Type] {
+  match env {
+    EnvEmpty => None,
+    EnvBind(_, _, rest) => overlapping_impl_target_for(rest, trait_name, new_params, new_target),
+    EnvMutCell(_, _, rest) => overlapping_impl_target_for(rest, trait_name, new_params, new_target),
+    // A newer declaration of the same trait starts a new instance scope. This
+    // is how a package's method-bearing definition replaces an imported
+    // bodyless marker contract (for example @vibe/core Default replacing the
+    // @vibe/builtin bound-only declaration) without treating their mirrored
+    // primitive impl declarations as source duplicates. Impl nodes belonging
+    // to the current declaration are always above this boundary.
+    EnvTraitDef(name, _, _, _, rest, _, _) => if name == trait_name {
+      None
+    } else {
+      overlapping_impl_target_for(rest, trait_name, new_params, new_target)
+    },
+    EnvTraitImpl(tname, target, rest) => if tname == trait_name && impl_target_patterns_overlap(array_empty(), target, new_params, new_target) {
+      Some(target)
+    } else {
+      overlapping_impl_target_for(rest, trait_name, new_params, new_target)
+    },
+    EnvTraitImplGen(tname, params, _, target, rest) => if tname == trait_name && impl_target_patterns_overlap(params, target, new_params, new_target) {
+      Some(target)
+    } else {
+      overlapping_impl_target_for(rest, trait_name, new_params, new_target)
+    },
+    EnvTypeDefs(_, _, rest) => overlapping_impl_target_for(rest, trait_name, new_params, new_target),
+    EnvFlat(_) => None,
+    EnvCached(_, _, rest) => overlapping_impl_target_for(rest, trait_name, new_params, new_target)
+  }
+}
+
+export fn impls_overlap_for(env: TypeEnv, trait_name: String, new_target: Type) -> Bool {
+  match overlapping_impl_target_for(env, trait_name, array_empty(), new_target) {
+    Some(_) => true,
+    None => false
+  }
+}
+
+/// #829: a deliberately bare `impl Trait for S` has no target arguments, but
+/// an instantiated generic struct value is typed `CtNamed(S, args)`. Bridge
+/// the two by head name: the bare impl covers the constructor family.
 fn struct_impl_target_matches(target: Type, resolved: Type) -> Bool {
   match resolved {
     CtNamed(rname, rargs) => if Array::length(rargs) > 0 {
@@ -3481,9 +3684,9 @@ fn struct_impl_target_matches(target: Type, resolved: Type) -> Bool {
 
 /// #1503: a bare constructor impl (`impl Show for Array`) records
 /// `CtNamed("Array", [])`, which `types_equal` cannot match against a concrete
-/// `CtArray(CtInt)` use site. Match those intentionally erased targets by
-/// constructor. A concrete generic target (`impl Show for Array[Int]`) is
-/// rejected by the parser (#2262), so it can never be widened through here.
+/// `CtArray(CtInt)` use site. Match only that intentionally unspecialized bare
+/// spelling by constructor. Applied targets retain their arguments and must
+/// match exactly instead of passing through this fallback.
 fn erased_impl_ctor_matches(target: Type, resolved: Type) -> Bool {
   let head = type_constructor_name(resolved)
   match target {
@@ -3633,11 +3836,18 @@ fn type_implements_check_super(e2: TypeEnv, full_env: TypeEnv, s: Subst, trait_n
       }
       else type_implements_check_super(rest, full_env, s, trait_name, resolved)
     } else type_implements_check_super(rest, full_env, s, trait_name, resolved),
-    EnvTraitImplGen(itrait, _, bounds, target, rest) => {
+    EnvTraitImplGen(itrait, tparams, bounds, target, rest) => {
       let head = type_constructor_name(resolved)
       let shape_ok = head != "" && type_constructor_name(target) == head && trait_is_method_bearing(full_env, trait_name) && trait_is_subtrait(full_env, itrait, trait_name) && itrait != trait_name
-      if shape_ok && generic_bounds_hold(full_env, s, bounds, type_args_of(resolved)) {
-        true
+      if shape_ok {
+        match generic_target_args(tparams, target, resolved) {
+          Some(args) => if generic_bounds_hold(full_env, s, tparams, bounds, args) {
+            true
+          } else {
+            type_implements_check_super(rest, full_env, s, trait_name, resolved)
+          },
+          None => type_implements_check_super(rest, full_env, s, trait_name, resolved)
+        }
       } else {
         type_implements_check_super(rest, full_env, s, trait_name, resolved)
       }
@@ -3648,10 +3858,8 @@ fn type_implements_check_super(e2: TypeEnv, full_env: TypeEnv, s: Subst, trait_n
   }
 }
 
-/// Constructor/head name of a type, for matching a generic impl's erased target
-/// against a concrete type (`Array[Int]` and the impl target `Array` both have
-/// head "Array"). Returns "" for types with no nominal constructor (tuples,
-/// primitives, vars) so they never match a generic impl.
+/// Constructor/head name of a type. Returns "" for types with no nominal
+/// constructor (tuples, primitives, vars) so they never match a generic impl.
 export fn type_constructor_name(ty: Type) -> String {
   match ty {
     CtArray(_) => "Array",
@@ -3722,13 +3930,141 @@ fn type_args_of(ty: Type) -> Array[Type] {
   }
 }
 
-/// Does an in-env method-bearing generic impl `impl [T(: Bound)?] Trait for C`
-/// cover the concrete `resolved` type? Matched by constructor name (the impl
-/// target's args are erased); for a bounded impl, EVERY type argument of
-/// `resolved` must satisfy EVERY bound (recursively via `type_implements_trait`),
-/// which is the dictionary-of-dictionaries condition. The dict-passing desugar
-/// synthesizes a `{ method: C::method }` witness (unbounded) or a nested closure
-/// witness supplying the element dict (bounded). (#5 generic impls.)
+fn generic_param_index(tparams: Array[String], name: String) -> Int {
+  let mut i = 0
+  let mut found = 0 - 1
+  while i < Array::length(tparams) && found < 0 {
+    if Array::get(tparams, i) == name {
+      found = i
+    } else {
+      i = i + 1
+    }
+  }
+  found
+}
+
+fn generic_target_match(template: Type, actual: Type, tparams: Array[String], args: Array[Type]) -> Bool {
+  match template {
+    CtNamed(name, targs) => {
+      let pi = if Array::length(targs) == 0 {
+        generic_param_index(tparams, name)
+      } else {
+        0 - 1
+      }
+      if pi >= 0 {
+        match Array::get(args, pi) {
+          CtUnknown => {
+            Array::set(args, pi, actual)
+            true
+          },
+          bound => types_equal(bound, actual)
+        }
+      } else {
+        match actual {
+          CtNamed(aname, aargs) => if name == aname && Array::length(targs) == Array::length(aargs) {
+            let mut i = 0
+            let mut ok = true
+            while i < Array::length(targs) && ok {
+              ok = generic_target_match(Array::get(targs, i), Array::get(aargs, i), tparams, args)
+              i = i + 1
+            }
+            ok
+          } else {
+            false
+          },
+          _ => false
+        }
+      }
+    },
+    CtArray(inner) => match actual {
+      CtArray(actual_inner) => generic_target_match(inner, actual_inner, tparams, args),
+      _ => false
+    },
+    CtOption(inner) => match actual {
+      CtOption(actual_inner) => generic_target_match(inner, actual_inner, tparams, args),
+      _ => false
+    },
+    CtTuple(items) => match actual {
+      CtTuple(actual_items) => if Array::length(items) == Array::length(actual_items) {
+        let mut i = 0
+        let mut ok = true
+        while i < Array::length(items) && ok {
+          ok = generic_target_match(Array::get(items, i), Array::get(actual_items, i), tparams, args)
+          i = i + 1
+        }
+        ok
+      } else {
+        false
+      },
+      _ => false
+    },
+    CtFn(params, ret, effect) => match actual {
+      CtFn(actual_params, actual_ret, actual_effect) => if Array::length(params) == Array::length(actual_params) && impl_pattern_effects_equal(effect, actual_effect) {
+        let mut i = 0
+        let mut ok = true
+        while i < Array::length(params) && ok {
+          ok = generic_target_match(Array::get(params, i), Array::get(actual_params, i), tparams, args)
+          i = i + 1
+        }
+        ok && generic_target_match(ret, actual_ret, tparams, args)
+      } else {
+        false
+      },
+      _ => false
+    },
+    _ => types_equal(template, actual)
+  }
+}
+
+/// Match the retained impl target against one concrete use and return its type
+/// arguments in impl-binder order. Reordered targets such as `Pair[V, K]`
+/// therefore bind V to the first concrete slot and K to the second instead of
+/// silently applying bounds by declaration order.
+fn generic_target_args(tparams: Array[String], target: Type, resolved: Type) -> Option[Array[Type]] {
+  let target_args = type_args_of(target)
+  if Array::length(target_args) == 0 {
+    let legacy = type_args_of(resolved)
+    if type_constructor_name(target) == type_constructor_name(resolved) && Array::length(legacy) == Array::length(tparams) {
+      Some(legacy)
+    } else {
+      None
+    }
+  } else {
+    let args = array_empty()
+    let mut i = 0
+    while i < Array::length(tparams) {
+      Array::push(args, CtUnknown)
+      i = i + 1
+    }
+    if generic_target_match(target, resolved, tparams, args) {
+      let mut ai = 0
+      let mut complete = true
+      while ai < Array::length(args) {
+        match Array::get(args, ai) {
+          CtUnknown => {
+            complete = false
+          },
+          _ => ()
+        }
+        ai = ai + 1
+      }
+      if complete {
+        Some(args)
+      } else {
+        None
+      }
+    } else {
+      None
+    }
+  }
+}
+
+/// Does an in-env method-bearing generic impl cover the concrete `resolved`
+/// type? The retained target is matched structurally and each bound is checked
+/// against the concrete argument bound to its own impl parameter. The
+/// dict-passing desugar synthesizes a `{ method: C::method }` witness
+/// (unbounded) or a nested closure witness supplying the element dict
+/// (bounded). (#5 generic impls.)
 fn generic_impl_satisfies(scan: TypeEnv, full: TypeEnv, s: Subst, trait_name: String, resolved: Type) -> Bool {
   match scan {
     EnvEmpty => false,
@@ -3736,11 +4072,18 @@ fn generic_impl_satisfies(scan: TypeEnv, full: TypeEnv, s: Subst, trait_name: St
     EnvTraitDef(_, _, _, _, rest, _, _) => generic_impl_satisfies(rest, full, s, trait_name, resolved),
     EnvTraitImpl(_, _, rest) => generic_impl_satisfies(rest, full, s, trait_name, resolved),
     EnvMutCell(_, _, rest) => generic_impl_satisfies(rest, full, s, trait_name, resolved),
-    EnvTraitImplGen(itrait, _tparams, bounds, target, rest) => {
+    EnvTraitImplGen(itrait, tparams, bounds, target, rest) => {
       let head = type_constructor_name(resolved)
       let shape_ok = itrait == trait_name && head != "" && type_constructor_name(target) == head && trait_is_method_bearing(full, trait_name)
-      if shape_ok && generic_bounds_hold(full, s, bounds, type_args_of(resolved)) {
-        true
+      if shape_ok {
+        match generic_target_args(tparams, target, resolved) {
+          Some(args) => if generic_bounds_hold(full, s, tparams, bounds, args) {
+            true
+          } else {
+            generic_impl_satisfies(rest, full, s, trait_name, resolved)
+          },
+          None => generic_impl_satisfies(rest, full, s, trait_name, resolved)
+        }
       } else generic_impl_satisfies(rest, full, s, trait_name, resolved)
     },
     EnvTypeDefs(_, _, rest) => generic_impl_satisfies(rest, full, s, trait_name, resolved),
@@ -3751,32 +4094,29 @@ fn generic_impl_satisfies(scan: TypeEnv, full: TypeEnv, s: Subst, trait_name: St
 
 /// Every non-empty per-parameter bound is satisfied by every concrete type
 /// argument. Empty bound lists (Increment A) hold trivially.
-fn generic_bounds_hold(full: TypeEnv, s: Subst, bounds: Array[(String, Array[String])], args: Array[Type]) -> Bool {
+fn generic_bounds_hold(full: TypeEnv, s: Subst, tparams: Array[String], bounds: Array[(String, Array[String])], args: Array[Type]) -> Bool {
   let mut bi = 0
   let mut ok = true
   while bi < Array::length(bounds) {
-    let (_, btraits) = Array::get(bounds, bi)
+    let (param, btraits) = Array::get(bounds, bi)
+    let ai = generic_param_index(tparams, param)
     let mut ti = 0
     while ti < Array::length(btraits) {
       let bt = Array::get(btraits, ti)
-      if bt != "" {
-        let mut ai = 0
-        while ai < Array::length(args) {
-          // A still-unknown element type (e.g. a struct literal, which the
-          // checker types as `CtUnknown`) defers its bound to the dict-passing
-          // desugar — which infers the element type syntactically and either
-          // threads the nested witness or fails loudly. This mirrors how a
-          // `CtUnknown` receiver skips the top-level bound check, so accepting
-          // it here is no less sound.
-          match subst_apply(s, Array::get(args, ai)) {
-            CtUnknown => (),
-            _ => if not(type_implements_trait(full, s, Array::get(args, ai), bt)) {
-              ok = false
-            } else {
-              ()
-            }
+      if bt != "" && ai >= 0 && ai < Array::length(args) {
+        // A still-unknown element type (e.g. a struct literal, which the
+        // checker types as `CtUnknown`) defers its bound to the dict-passing
+        // desugar — which infers the element type syntactically and either
+        // threads the nested witness or fails loudly. This mirrors how a
+        // `CtUnknown` receiver skips the top-level bound check, so accepting
+        // it here is no less sound.
+        match subst_apply(s, Array::get(args, ai)) {
+          CtUnknown => (),
+          _ => if not(type_implements_trait(full, s, Array::get(args, ai), bt)) {
+            ok = false
+          } else {
+            ()
           }
-          ai = ai + 1
         }
       } else {
         ()

--- a/lib/@vibe/compiler/lower.vibe
+++ b/lib/@vibe/compiler/lower.vibe
@@ -775,7 +775,7 @@ export fn lower_stmt(node: CstChild) -> Stmt with Exception {
         let type_name = Array::get(idents, 1)
         let type_params = array_empty()
         let bounds = array_empty()
-        SImpl(type_params, bounds, trait_name, type_name)
+        SImpl(type_params, bounds, trait_name, TyName(type_name))
       } else {
         throw("NImplStmt: need trait+type names")
       }

--- a/lib/@vibe/compiler/normalize/desugar_trait_dict.vibe
+++ b/lib/@vibe/compiler/normalize/desugar_trait_dict.vibe
@@ -2601,68 +2601,71 @@ fn impl_target_fn_key(name: String) -> String {
 }
 
 fn infer_impl_target_expr(arg: Expr, struct_sets: Array[(String, Array[String])], var_types: Array[(String, String)], fn_returns: Array[(String, String)]) -> Option[TypeExpr] {
-  match arg {
-    EInt(_) => Some(TyName("Int")),
-    EBool(_) => Some(TyName("Bool")),
-    EString(_) => Some(TyName("String")),
-    EFloat(_) => Some(TyName("Double")),
-    EArray(items) => if Array::length(items) == 0 {
-      None
-    } else {
-      match infer_impl_target_expr(Array::get(items, 0), struct_sets, var_types, fn_returns) {
-        Some(elem_type) => {
-          let mut i = 1
-          let mut same = true
-          while i < Array::length(items) && same {
-            same = match infer_impl_target_expr(Array::get(items, i), struct_sets, var_types, fn_returns) {
-              Some(next) => impl_target_key(next) == impl_target_key(elem_type),
-              None => false
-            }
-            i = i + 1
-          }
-          if same {
-            Some(TyApp("Array", [elem_type]))
-          } else {
-            None
-          }
-        },
-        None => None
-      }
-    },
-    ERecord(name, _, type_args) => if name != "" {
-      if Array::length(type_args) > 0 {
-        Some(TyApp(name, type_args))
+  match dtd_ascribed_type(arg) {
+    Some(ascribed) => Some(ascribed),
+    None => match arg {
+      EInt(_) => Some(TyName("Int")),
+      EBool(_) => Some(TyName("Bool")),
+      EString(_) => Some(TyName("String")),
+      EFloat(_) => Some(TyName("Double")),
+      EArray(items) => if Array::length(items) == 0 {
+        None
       } else {
-        Some(TyName(name))
-      }
-    } else {
-      None
-    },
-    EIdent(name, _) => match lookup_var_type(var_types, impl_target_var_key(name)) {
-      Some(key) => impl_target_from_key(key),
-      None => match infer_arg_type_name(arg, struct_sets, var_types, fn_returns) {
+        match infer_impl_target_expr(Array::get(items, 0), struct_sets, var_types, fn_returns) {
+          Some(elem_type) => {
+            let mut i = 1
+            let mut same = true
+            while i < Array::length(items) && same {
+              same = match infer_impl_target_expr(Array::get(items, i), struct_sets, var_types, fn_returns) {
+                Some(next) => impl_target_key(next) == impl_target_key(elem_type),
+                None => false
+              }
+              i = i + 1
+            }
+            if same {
+              Some(TyApp("Array", [elem_type]))
+            } else {
+              None
+            }
+          },
+          None => None
+        }
+      },
+      ERecord(name, _, type_args) => if name != "" {
+        if Array::length(type_args) > 0 {
+          Some(TyApp(name, type_args))
+        } else {
+          Some(TyName(name))
+        }
+      } else {
+        None
+      },
+      EIdent(name, _) => match lookup_var_type(var_types, impl_target_var_key(name)) {
+        Some(key) => impl_target_from_key(key),
+        None => match infer_arg_type_name(arg, struct_sets, var_types, fn_returns) {
+          Some(head) => Some(TyName(head)),
+          None => None
+        }
+      },
+      ECall(EIdent("Some", _), args, _) => if Array::length(args) == 1 {
+        match infer_impl_target_expr(Array::get(args, 0), struct_sets, var_types, fn_returns) {
+          Some(payload) => Some(TyApp("Option", [payload])),
+          None => None
+        }
+      } else {
+        None
+      },
+      ECall(EIdent(name, _), _, _) => match fn_return_type(fn_returns, impl_target_fn_key(name)) {
+        Some(key) => impl_target_from_key(key),
+        None => match infer_arg_type_name(arg, struct_sets, var_types, fn_returns) {
+          Some(head) => Some(TyName(head)),
+          None => None
+        }
+      },
+      _ => match infer_arg_type_name(arg, struct_sets, var_types, fn_returns) {
         Some(head) => Some(TyName(head)),
         None => None
       }
-    },
-    ECall(EIdent("Some", _), args, _) => if Array::length(args) == 1 {
-      match infer_impl_target_expr(Array::get(args, 0), struct_sets, var_types, fn_returns) {
-        Some(payload) => Some(TyApp("Option", [payload])),
-        None => None
-      }
-    } else {
-      None
-    },
-    ECall(EIdent(name, _), _, _) => match fn_return_type(fn_returns, impl_target_fn_key(name)) {
-      Some(key) => impl_target_from_key(key),
-      None => match infer_arg_type_name(arg, struct_sets, var_types, fn_returns) {
-        Some(head) => Some(TyName(head)),
-        None => None
-      }
-    },
-    _ => match infer_arg_type_name(arg, struct_sets, var_types, fn_returns) {
-      Some(head) => Some(TyName(head)),
-      None => None
     }
   }
 }

--- a/lib/@vibe/compiler/normalize/desugar_trait_dict.vibe
+++ b/lib/@vibe/compiler/normalize/desugar_trait_dict.vibe
@@ -18,6 +18,10 @@ import @vibe/compiler/core {
   trait_method_sig_binders_deep
 }
 
+import @vibe/ast {
+  impl_applied_target_key, impl_method_owner, impl_specialized_method_binding_name, impl_target_head, impl_target_key
+}
+
 import @vibe/core {
   array_empty
 }
@@ -528,15 +532,15 @@ fn lookup_method_gen(table: Array[(String, Array[(String, Array[String], Array[(
   result
 }
 
-/// Map each impl's target type to the trait it implements
-/// (`impl Tr for C` -> (C, Tr)). A type may implement several traits; the first
-/// matching trait that declares the method is used at lookup time.
+/// Map each impl method owner to the trait it implements. Concrete applied
+/// targets have a specialization-specific internal owner; generic and bare
+/// targets keep their constructor owner.
 fn collect_impl_trait_map(stmts: Array[Stmt]) -> Array[(String, String)] {
   let out = array_empty()
   let mut i = 0
   while i < Array::length(stmts) {
     match Array::get(stmts, i) {
-      SImpl(_, _, trait_name, type_name) => Array::push(out, (type_name, trait_name)),
+      SImpl(tparams, _, trait_name, target) => Array::push(out, (impl_method_owner(tparams, trait_name, target), trait_name)),
       _ => ()
     }
     i = i + 1
@@ -2035,7 +2039,7 @@ fn collect_generic_impl_types(stmts: Array[Stmt]) -> Array[String] {
   let mut i = 0
   while i < Array::length(stmts) {
     match Array::get(stmts, i) {
-      SImpl(tparams, tbounds, _, type_name) => if Array::length(tparams) > 0 {
+      SImpl(tparams, tbounds, _, target) => if Array::length(tparams) > 0 {
         let mut has_bound = false
         let mut bi = 0
         while bi < Array::length(tbounds) {
@@ -2052,7 +2056,7 @@ fn collect_generic_impl_types(stmts: Array[Stmt]) -> Array[String] {
           bi = bi + 1
         }
         if has_bound {
-          Array::push(out, type_name)
+          Array::push(out, impl_target_head(target))
         } else {
           ()
         }
@@ -2327,6 +2331,80 @@ fn first_array_elem(e: Expr) -> Option[Expr] {
   }
 }
 
+fn impl_target_var_key(name: String) -> String {
+  String::concat("$impl_target$", name)
+}
+
+fn impl_target_fn_key(name: String) -> String {
+  String::concat("$impl_return$", name)
+}
+
+fn infer_impl_target_key(arg: Expr, struct_sets: Array[(String, Array[String])], var_types: Array[(String, String)], fn_returns: Array[(String, String)]) -> Option[String] {
+  match arg {
+    EInt(_) => Some(impl_target_key(TyName("Int"))),
+    EBool(_) => Some(impl_target_key(TyName("Bool"))),
+    EString(_) => Some(impl_target_key(TyName("String"))),
+    EFloat(_) => Some(impl_target_key(TyName("Double"))),
+    EArray(items) => if Array::length(items) == 0 {
+      None
+    } else {
+      match infer_impl_target_key(Array::get(items, 0), struct_sets, var_types, fn_returns) {
+        Some(elem_key) => {
+          let mut i = 1
+          let mut same = true
+          while i < Array::length(items) && same {
+            same = match infer_impl_target_key(Array::get(items, i), struct_sets, var_types, fn_returns) {
+              Some(next) => next == elem_key,
+              None => false
+            }
+            i = i + 1
+          }
+          if same {
+            Some(impl_applied_target_key("Array", [elem_key]))
+          } else {
+            None
+          }
+        },
+        None => None
+      }
+    },
+    EIdent(name, _) => match lookup_var_type(var_types, impl_target_var_key(name)) {
+      Some(key) => Some(key),
+      None => match infer_arg_type_name(arg, struct_sets, var_types, fn_returns) {
+        Some(head) => Some(impl_target_key(TyName(head))),
+        None => None
+      }
+    },
+    ECall(EIdent(name, _), _, _) => match fn_return_type(fn_returns, impl_target_fn_key(name)) {
+      Some(key) => Some(key),
+      None => match infer_arg_type_name(arg, struct_sets, var_types, fn_returns) {
+        Some(head) => Some(impl_target_key(TyName(head))),
+        None => None
+      }
+    },
+    _ => match infer_arg_type_name(arg, struct_sets, var_types, fn_returns) {
+      Some(head) => Some(impl_target_key(TyName(head))),
+      None => None
+    }
+  }
+}
+
+fn bind_impl_target_key(var_types: Array[(String, String)], name: String, value: Expr, struct_sets: Array[(String, Array[String])], fn_returns: Array[(String, String)]) -> Array[(String, String)] {
+  match infer_impl_target_key(value, struct_sets, var_types, fn_returns) {
+    Some(key) => {
+      let out = array_empty()
+      let mut i = 0
+      while i < Array::length(var_types) {
+        Array::push(out, Array::get(var_types, i))
+        i = i + 1
+      }
+      Array::push(out, (impl_target_var_key(name), key))
+      out
+    },
+    None => var_types
+  }
+}
+
 /// Build the witness `ERecord` for a concrete type `cname` implementing
 /// `trait_name`. Codegen resolves it to the dict struct structurally by field
 /// names.
@@ -2350,7 +2428,16 @@ fn build_concrete_dict(cname: String, trait_name: String, traits: Array[(String,
       let mut failed = false
       while mi < Array::length(mnames) {
         let m = Array::get(mnames, mi)
-        let qm = String::concat(cname, String::concat("::", m))
+        let plain_qm = String::concat(cname, String::concat("::", m))
+        let specialized_qm = match infer_impl_target_key(arg_expr, struct_sets, var_types, fn_returns) {
+          Some(target_key) => impl_specialized_method_binding_name(cname, trait_name, target_key, m),
+          None => ""
+        }
+        let qm = if specialized_qm != "" && fn_exists(fn_returns, specialized_qm) {
+          specialized_qm
+        } else {
+          plain_qm
+        }
         if not(fn_exists(fn_returns, qm)) {
           // #1445: the SYNTHETIC `Show` witness is total. A type with no
           // `C::to_string` renders through the ADR-0058 heuristic -- exactly
@@ -3919,7 +4006,8 @@ fn self_describing_fallback(v: Expr, struct_sets: Array[(String, Array[String])]
 /// The same binding-site records `rewrite_expr` makes at an `ELet`/`ELetMut`,
 /// so the walk above reads names the way the comparison site will.
 fn bound_var_types(var_types: Array[(String, String)], n: String, val: Expr, struct_sets: Array[(String, Array[String])], fn_returns: Array[(String, String)]) -> Array[(String, String)] {
-  let base = extend_var_types(var_types, n, anon_or_infer(val, struct_sets, var_types, fn_returns))
+  let inferred = extend_var_types(var_types, n, anon_or_infer(val, struct_sets, var_types, fn_returns))
+  let base = bind_impl_target_key(inferred, n, val, struct_sets, fn_returns)
   eq_shape_bind(bind_shapes(base, n, val, struct_sets, fn_returns), n, val, struct_sets, fn_returns)
 }
 
@@ -4327,10 +4415,9 @@ fn seed_ctor_payload(out: Array[(String, String)], pname: String, ctor: String, 
 /// Seed a var-type environment from a function's parameters whose annotation is
 /// a bare type name `T` — concrete (`Point`) for call-site dict synthesis, or a
 /// type parameter (`T`) for generic->generic dict forwarding. The distinction is
-/// made at use time against the in-scope dict bindings. `tparams` is retained for
-/// signature compatibility but no longer filters (both kinds are tracked).
+/// made at use time against the in-scope dict bindings. Both kinds are tracked;
+/// `tparams` prevents a same-spelled formal from expanding through a global alias.
 fn seed_var_types(params: Array[(String, Option[TypeExpr])], tparams: Array[String], base: Array[(String, String)]) -> Array[(String, String)] {
-  let _ = tparams
   let out = array_empty()
   let mut b = 0
   while b < Array::length(base) {
@@ -4372,6 +4459,11 @@ fn seed_var_types(params: Array[(String, Option[TypeExpr])], tparams: Array[Stri
       // infer_arg_type_name.
       Some(TyApp(tn, targs)) => {
         Array::push(out, (pname, tn))
+        if !ty_mentions_name_in(TyApp(tn, targs), tparams) {
+          Array::push(out, (impl_target_var_key(pname), impl_target_key(TyApp(tn, targs))))
+        } else {
+          ()
+        }
         // Equality needs the complete annotation, not only its head. Keep the
         // recursive shape for every monomorphic aggregate parameter so nested
         // Array/Option/Result paths do not fall back to word identity.
@@ -4597,6 +4689,17 @@ fn collect_fn_eq_return_shape(out: Array[(String, String)], fname: String, tpara
   }
 }
 
+fn collect_fn_impl_return_key(out: Array[(String, String)], fname: String, tparams: Array[String], ret: Option[TypeExpr]) -> Unit {
+  match ret {
+    Some(te) => if !ty_mentions_name_in(te, tparams) {
+      Array::push(out, (impl_target_fn_key(fname), impl_target_key(te)))
+    } else {
+      ()
+    },
+    None => ()
+  }
+}
+
 fn collect_fn_returns(stmts: Array[Stmt]) -> Array[(String, String)] {
   let out = array_empty()
   let mut i = 0
@@ -4615,6 +4718,7 @@ fn collect_fn_returns(stmts: Array[Stmt]) -> Array[(String, String)] {
             head
           }
           Array::push(out, (fname, head2))
+          collect_fn_impl_return_key(out, fname, tparams, ret)
           collect_fn_eq_return_shape(out, fname, tparams, ret, fbody)
         },
         _ => ()
@@ -4634,6 +4738,7 @@ fn collect_fn_returns(stmts: Array[Stmt]) -> Array[(String, String)] {
             head
           }
           Array::push(out, (fname, head2))
+          collect_fn_impl_return_key(out, fname, tparams, ret)
           collect_fn_eq_return_shape(out, fname, tparams, ret, fbody)
         },
         _ => ()
@@ -7243,7 +7348,8 @@ fn rewrite_expr(expr: Expr, gens: Array[(String, Array[(String, String, Int)])],
     EIf(c, t, e) => EIf(rewrite_expr(c, gens, traits, struct_sets, dict_binds, var_types, fn_returns), rewrite_expr(t, gens, traits, struct_sets, dict_binds, var_types, fn_returns), rewrite_expr(e, gens, traits, struct_sets, dict_binds, var_types, fn_returns)),
     ELet(name, val, body, soff) => {
       let new_val = rewrite_expr(val, gens, traits, struct_sets, dict_binds, var_types, fn_returns)
-      let body_vars0 = extend_var_types(var_types, name, anon_or_infer(val, struct_sets, var_types, fn_returns))
+      let inferred_vars = extend_var_types(var_types, name, anon_or_infer(val, struct_sets, var_types, fn_returns))
+      let body_vars0 = bind_impl_target_key(inferred_vars, name, val, struct_sets, fn_returns)
       let body_vars1 = bind_shapes(body_vars0, name, val, struct_sets, fn_returns)
       let body_vars2 = eq_shape_bind(body_vars1, name, val, struct_sets, fn_returns)
       // #2157: an unannotated `let xs = []` reads its element type off the
@@ -7254,7 +7360,8 @@ fn rewrite_expr(expr: Expr, gens: Array[(String, Array[(String, String, Int)])],
     ELetRec(name, val, body) => ELetRec(name, rewrite_expr(val, gens, traits, struct_sets, dict_binds, var_types, fn_returns), rewrite_expr(body, gens, traits, struct_sets, dict_binds, var_types, fn_returns)),
     ELetMut(name, val, body, soff) => {
       let new_val = rewrite_expr(val, gens, traits, struct_sets, dict_binds, var_types, fn_returns)
-      let body_vars0 = extend_var_types(var_types, name, anon_or_infer(val, struct_sets, var_types, fn_returns))
+      let inferred_vars = extend_var_types(var_types, name, anon_or_infer(val, struct_sets, var_types, fn_returns))
+      let body_vars0 = bind_impl_target_key(inferred_vars, name, val, struct_sets, fn_returns)
       let body_vars1 = bind_shapes(body_vars0, name, val, struct_sets, fn_returns)
       let body_vars2 = eq_shape_bind(body_vars1, name, val, struct_sets, fn_returns)
       let body_vars = empty_array_shape_from_body(body_vars2, name, body, struct_sets, fn_returns)

--- a/lib/@vibe/compiler/normalize/desugar_trait_dict.vibe
+++ b/lib/@vibe/compiler/normalize/desugar_trait_dict.vibe
@@ -19,7 +19,7 @@ import @vibe/compiler/core {
 }
 
 import @vibe/ast {
-  impl_applied_target_key, impl_method_owner, impl_specialized_method_binding_name, impl_target_head, impl_target_key
+  impl_applied_target_key, impl_method_owner, impl_specialized_method_binding_name, impl_target_from_key, impl_target_head, impl_target_key
 }
 
 import @vibe/core {
@@ -63,6 +63,21 @@ enum StoredLabeledArgBinderAuthorityNormalization {
 
 export struct LabeledArgBinderAuthorityNormalization {
   stored: StoredLabeledArgBinderAuthorityNormalization
+}
+
+struct GenericImplInfo {
+  owner: String;
+  trait_name: String;
+  type_params: Array[String];
+  target: TypeExpr
+}
+
+struct DictGen {
+  name: String;
+  threaded: Array[(String, String, Int)];
+  impl_trait: String;
+  impl_params: Array[String];
+  impl_target: Option[TypeExpr]
 }
 
 fn paired_poison(poisoned: Array[Bool]) -> Unit {
@@ -2030,16 +2045,16 @@ fn qualified_head(name: String) -> String {
   }
 }
 
-/// Type names of bounded generic impls (`impl [T: Bound] Trait for C`). Their
-/// methods (`C::m`) carry the bound `T` even though it appears nested in the
+/// Method owners of bounded generic impls (`impl [T: Bound] Trait for C[T]`).
+/// Their methods carry the bound `T` even though it appears nested in the
 /// receiver (`self: C[T]`), so they must be threaded a witness dict (the normal
 /// "type param is a direct parameter" rule misses them).
-fn collect_generic_impl_types(stmts: Array[Stmt]) -> Array[String] {
+fn collect_generic_impl_owners(stmts: Array[Stmt]) -> Array[String] {
   let out = empty_str_array()
   let mut i = 0
   while i < Array::length(stmts) {
     match Array::get(stmts, i) {
-      SImpl(tparams, tbounds, _, target) => if Array::length(tparams) > 0 {
+      SImpl(tparams, tbounds, trait_name, target) => if Array::length(tparams) > 0 {
         let mut has_bound = false
         let mut bi = 0
         while bi < Array::length(tbounds) {
@@ -2056,7 +2071,7 @@ fn collect_generic_impl_types(stmts: Array[Stmt]) -> Array[String] {
           bi = bi + 1
         }
         if has_bound {
-          Array::push(out, impl_target_head(target))
+          Array::push(out, impl_method_owner(tparams, trait_name, target))
         } else {
           ()
         }
@@ -2068,7 +2083,50 @@ fn collect_generic_impl_types(stmts: Array[Stmt]) -> Array[String] {
   out
 }
 
-fn build_gens(stmts: Array[Stmt], traits: Array[(String, Array[(String, Array[TypeExpr], TypeExpr)])], gimpl_types: Array[String]) -> Array[(String, Array[(String, String, Int)])] {
+fn collect_generic_impl_infos(stmts: Array[Stmt]) -> Array[GenericImplInfo] {
+  let out = []
+  let mut i = 0
+  while i < Array::length(stmts) {
+    match Array::get(stmts, i) {
+      SImpl(tparams, _, trait_name, target) => if Array::length(tparams) > 0 {
+        let dispatch_target = match target {
+          TyName(name) => TyApp(name, for tparam in tparams {
+            TyName(tparam)
+          }),
+          _ => target
+        }
+        Array::push(out, GenericImplInfo::{
+          owner: impl_method_owner(tparams, trait_name, target),
+          trait_name,
+          type_params: tparams,
+          target: dispatch_target
+        })
+      } else {
+        ()
+      },
+      _ => ()
+    }
+    i = i + 1
+  }
+  out
+}
+
+fn generic_impl_info_for_owner(infos: Array[GenericImplInfo], owner: String) -> Option[GenericImplInfo] {
+  let mut i = 0
+  let mut result = None
+  while i < Array::length(infos) {
+    let info = Array::get(infos, i)
+    if info.owner == owner {
+      result = Some(info)
+      i = Array::length(infos)
+    } else {
+      i = i + 1
+    }
+  }
+  result
+}
+
+fn build_gens(stmts: Array[Stmt], traits: Array[(String, Array[(String, Array[TypeExpr], TypeExpr)])], gimpl_infos: Array[GenericImplInfo]) -> Array[DictGen] {
   let out = array_empty()
   let mut i = 0
   while i < Array::length(stmts) {
@@ -2077,6 +2135,11 @@ fn build_gens(stmts: Array[Stmt], traits: Array[(String, Array[(String, Array[Ty
         EFn(_, bounds, params, _, _, _) => if already_threaded(bounds, params) {
           ()
         } else {
+          let impl_info = generic_impl_info_for_owner(gimpl_infos, qualified_head(fname))
+          let is_impl_method = match impl_info {
+            Some(_) => true,
+            None => false
+          }
           let threaded = empty_threaded()
           let mut bi = 0
           while bi < Array::length(bounds) {
@@ -2089,7 +2152,7 @@ fn build_gens(stmts: Array[Stmt], traits: Array[(String, Array[(String, Array[Ty
                   let ridx = find_recv_index(params, tp)
                   if ridx >= 0 {
                     Array::push(threaded, (tp, tr, ridx))
-                  } else if str_array_contains(gimpl_types, qualified_head(fname)) {
+                  } else if is_impl_method {
                     // bounded generic-impl method: T is nested in `self: C[T]`,
                     // so there is no inferable receiver argument — the witness
                     // dict is supplied when C's witness is built. Thread with -1.
@@ -2120,8 +2183,23 @@ fn build_gens(stmts: Array[Stmt], traits: Array[(String, Array[(String, Array[Ty
             }
             bi = bi + 1
           }
-          if Array::length(threaded) > 0 {
-            Array::push(out, (fname, threaded))
+          if Array::length(threaded) > 0 || is_impl_method {
+            match impl_info {
+              Some(info) => Array::push(out, DictGen::{
+                name: fname,
+                threaded,
+                impl_trait: info.trait_name,
+                impl_params: info.type_params,
+                impl_target: Some(info.target)
+              }),
+              None => Array::push(out, DictGen::{
+                name: fname,
+                threaded,
+                impl_trait: "",
+                impl_params: [],
+                impl_target: None
+              })
+            }
           } else {
             ()
           }
@@ -2146,7 +2224,7 @@ fn build_gens(stmts: Array[Stmt], traits: Array[(String, Array[(String, Array[Ty
 /// that ability purely from the signature: a parameter of type `T`
 /// (find_recv_index), a parameter of type `Array[T]`
 /// (find_array_elem_recv_index, #1199), or the function being a bounded
-/// generic-impl method (collect_generic_impl_types — its dict arrives with the
+/// generic-impl method (collect_generic_impl_owners — its dict arrives with the
 /// impl witness instead). A bounded generic with NONE of those is never
 /// registered in `gens`, its body is never rewritten, and `T::m` reaches
 /// codegen unresolved. This function is the checker-facing mirror of exactly
@@ -2162,7 +2240,7 @@ fn build_gens(stmts: Array[Stmt], traits: Array[(String, Array[(String, Array[Ty
 /// bound.
 export fn collect_undispatchable_trait_method_errors(stmts: Array[Stmt], env: TypeEnv) -> Array[String] {
   let out = empty_str_array()
-  let gimpl_types = collect_generic_impl_types(stmts)
+  let gimpl_owners = collect_generic_impl_owners(stmts)
   let mut i = 0
   while i < Array::length(stmts) {
     match Array::get(stmts, i) {
@@ -2197,7 +2275,7 @@ export fn collect_undispatchable_trait_method_errors(stmts: Array[Stmt], env: Ty
           let mut bi = 0
           while bi < Array::length(bounds) {
             let (tp, trait_list) = Array::get(bounds, bi)
-            let has_carrier = find_recv_index(params, tp) >= 0 || find_array_elem_recv_index(params, tp) >= 0 || str_array_contains(gimpl_types, qualified_head(fname))
+            let has_carrier = find_recv_index(params, tp) >= 0 || find_array_elem_recv_index(params, tp) >= 0 || str_array_contains(gimpl_owners, qualified_head(fname))
             if has_carrier {
               ()
             } else {
@@ -2261,19 +2339,202 @@ fn push_undispatchable_refs(e: Expr, fname: String, tp: String, trait_list: Arra
   }
 }
 
-fn lookup_gen(gens: Array[(String, Array[(String, String, Int)])], name: String) -> Option[Array[(String, String, Int)]] {
+fn lookup_gen_entry(gens: Array[DictGen], name: String) -> Option[DictGen] {
   let mut i = 0
   let mut result = None
   while i < Array::length(gens) {
-    let (gname, threaded) = Array::get(gens, i)
-    if gname == name {
-      result = Some(threaded)
+    let gen = Array::get(gens, i)
+    if gen.name == name {
+      result = Some(gen)
       i = Array::length(gens)
     } else {
       i = i + 1
     }
   }
   result
+}
+
+fn lookup_gen(gens: Array[DictGen], name: String) -> Option[Array[(String, String, Int)]] {
+  match lookup_gen_entry(gens, name) {
+    Some(gen) => Some(gen.threaded),
+    None => None
+  }
+}
+
+fn impl_pattern_binding(bindings: Array[(String, TypeExpr)], name: String) -> Option[TypeExpr] {
+  let mut i = 0
+  let mut result = None
+  while i < Array::length(bindings) {
+    let (bound_name, bound_type) = Array::get(bindings, i)
+    if bound_name == name {
+      result = Some(bound_type)
+      i = Array::length(bindings)
+    } else {
+      i = i + 1
+    }
+  }
+  result
+}
+
+fn impl_pattern_param(params: Array[String], name: String) -> Bool {
+  str_array_contains(params, name)
+}
+
+fn impl_target_pattern_matches(pattern: TypeExpr, actual: TypeExpr, params: Array[String], bindings: Array[(String, TypeExpr)]) -> Bool {
+  match pattern {
+    TyName(name) => if impl_pattern_param(params, name) {
+      match impl_pattern_binding(bindings, name) {
+        Some(bound) => impl_target_key(bound) == impl_target_key(actual),
+        None => {
+          Array::push(bindings, (name, actual))
+          true
+        }
+      }
+    } else {
+      match actual {
+        TyName(actual_name) => name == actual_name,
+        _ => false
+      }
+    },
+    TyApp(name, args) => match actual {
+      TyApp(actual_name, actual_args) => if name == actual_name && Array::length(args) == Array::length(actual_args) {
+        let mut i = 0
+        let mut ok = true
+        while i < Array::length(args) && ok {
+          ok = impl_target_pattern_matches(Array::get(args, i), Array::get(actual_args, i), params, bindings)
+          i = i + 1
+        }
+        ok
+      } else {
+        false
+      },
+      _ => false
+    },
+    TyFn(fn_params, ret, effect) => match actual {
+      TyFn(actual_params, actual_ret, actual_effect) => if effect == actual_effect && Array::length(fn_params) == Array::length(actual_params) {
+        let mut i = 0
+        let mut ok = true
+        while i < Array::length(fn_params) && ok {
+          ok = impl_target_pattern_matches(Array::get(fn_params, i), Array::get(actual_params, i), params, bindings)
+          i = i + 1
+        }
+        ok && impl_target_pattern_matches(ret, actual_ret, params, bindings)
+      } else {
+        false
+      },
+      _ => false
+    },
+    TyTuple(items) => match actual {
+      TyTuple(actual_items) => if Array::length(items) == Array::length(actual_items) {
+        let mut i = 0
+        let mut ok = true
+        while i < Array::length(items) && ok {
+          ok = impl_target_pattern_matches(Array::get(items, i), Array::get(actual_items, i), params, bindings)
+          i = i + 1
+        }
+        ok
+      } else {
+        false
+      },
+      _ => false
+    },
+    TyUnit => match actual {
+      TyUnit => true,
+      _ => false
+    }
+  }
+}
+
+/// Whether erasing this target's arguments leaves a sound match for every
+/// application of its constructor head. This is limited to a permutation of
+/// the impl formals: constrained or repeated patterns must retain their full
+/// applied target before they can dispatch.
+fn generic_impl_target_is_total(target: TypeExpr, params: Array[String]) -> Bool {
+  match target {
+    TyApp(_, args) => if Array::length(args) != Array::length(params) {
+      false
+    } else {
+      let seen = empty_str_array()
+      let mut i = 0
+      let mut total = true
+      while i < Array::length(args) && total {
+        match Array::get(args, i) {
+          TyName(name) => if impl_pattern_param(params, name) && !str_array_contains(seen, name) {
+            Array::push(seen, name)
+          } else {
+            total = false
+          },
+          _ => {
+            total = false
+          }
+        }
+        i = i + 1
+      }
+      total && Array::length(seen) == Array::length(params)
+    },
+    _ => false
+  }
+}
+
+fn matching_generic_impl_method(gens: Array[DictGen], cname: String, trait_name: String, method: String, actual: TypeExpr) -> Option[String] {
+  let mut i = 0
+  let mut result = None
+  let mut erased_result = None
+  let mut erased_count = 0
+  while i < Array::length(gens) {
+    let gen = Array::get(gens, i)
+    let bindings = []
+    if gen.impl_trait == trait_name && impl_target_head(match gen.impl_target {
+      Some(target) => target,
+      None => TyName("")
+    }) == cname && String::ends_with(gen.name, String::concat("::", method)) {
+      match gen.impl_target {
+        Some(target) => if impl_target_pattern_matches(target, actual, gen.impl_params, bindings) {
+          result = Some(gen.name)
+          i = Array::length(gens)
+        } else {
+          match actual {
+            TyName(actual_head) => if actual_head == cname && generic_impl_target_is_total(target, gen.impl_params) {
+              erased_result = Some(gen.name)
+              erased_count = erased_count + 1
+            } else (),
+            _ => ()
+          }
+          i = i + 1
+        },
+        None => {
+          i = i + 1
+        }
+      }
+    } else {
+      i = i + 1
+    }
+  }
+  match result {
+    Some(_) => result,
+    None => if erased_count == 1 {
+      erased_result
+    } else {
+      None
+    }
+  }
+}
+
+fn generic_impl_bound_target(gens: Array[DictGen], method_name: String, type_param: String, actual: TypeExpr) -> Option[TypeExpr] {
+  match lookup_gen_entry(gens, method_name) {
+    Some(gen) => match gen.impl_target {
+      Some(target) => {
+        let bindings = []
+        if impl_target_pattern_matches(target, actual, gen.impl_params, bindings) {
+          impl_pattern_binding(bindings, type_param)
+        } else {
+          None
+        }
+      },
+      None => None
+    },
+    None => None
+  }
 }
 
 /// Find the dict parameter to dispatch a `head::member` call against, given the
@@ -2339,28 +2600,28 @@ fn impl_target_fn_key(name: String) -> String {
   String::concat("$impl_return$", name)
 }
 
-fn infer_impl_target_key(arg: Expr, struct_sets: Array[(String, Array[String])], var_types: Array[(String, String)], fn_returns: Array[(String, String)]) -> Option[String] {
+fn infer_impl_target_expr(arg: Expr, struct_sets: Array[(String, Array[String])], var_types: Array[(String, String)], fn_returns: Array[(String, String)]) -> Option[TypeExpr] {
   match arg {
-    EInt(_) => Some(impl_target_key(TyName("Int"))),
-    EBool(_) => Some(impl_target_key(TyName("Bool"))),
-    EString(_) => Some(impl_target_key(TyName("String"))),
-    EFloat(_) => Some(impl_target_key(TyName("Double"))),
+    EInt(_) => Some(TyName("Int")),
+    EBool(_) => Some(TyName("Bool")),
+    EString(_) => Some(TyName("String")),
+    EFloat(_) => Some(TyName("Double")),
     EArray(items) => if Array::length(items) == 0 {
       None
     } else {
-      match infer_impl_target_key(Array::get(items, 0), struct_sets, var_types, fn_returns) {
-        Some(elem_key) => {
+      match infer_impl_target_expr(Array::get(items, 0), struct_sets, var_types, fn_returns) {
+        Some(elem_type) => {
           let mut i = 1
           let mut same = true
           while i < Array::length(items) && same {
-            same = match infer_impl_target_key(Array::get(items, i), struct_sets, var_types, fn_returns) {
-              Some(next) => next == elem_key,
+            same = match infer_impl_target_expr(Array::get(items, i), struct_sets, var_types, fn_returns) {
+              Some(next) => impl_target_key(next) == impl_target_key(elem_type),
               None => false
             }
             i = i + 1
           }
           if same {
-            Some(impl_applied_target_key("Array", [elem_key]))
+            Some(TyApp("Array", [elem_type]))
           } else {
             None
           }
@@ -2368,24 +2629,48 @@ fn infer_impl_target_key(arg: Expr, struct_sets: Array[(String, Array[String])],
         None => None
       }
     },
+    ERecord(name, _, type_args) => if name != "" {
+      if Array::length(type_args) > 0 {
+        Some(TyApp(name, type_args))
+      } else {
+        Some(TyName(name))
+      }
+    } else {
+      None
+    },
     EIdent(name, _) => match lookup_var_type(var_types, impl_target_var_key(name)) {
-      Some(key) => Some(key),
+      Some(key) => impl_target_from_key(key),
       None => match infer_arg_type_name(arg, struct_sets, var_types, fn_returns) {
-        Some(head) => Some(impl_target_key(TyName(head))),
+        Some(head) => Some(TyName(head)),
         None => None
       }
     },
+    ECall(EIdent("Some", _), args, _) => if Array::length(args) == 1 {
+      match infer_impl_target_expr(Array::get(args, 0), struct_sets, var_types, fn_returns) {
+        Some(payload) => Some(TyApp("Option", [payload])),
+        None => None
+      }
+    } else {
+      None
+    },
     ECall(EIdent(name, _), _, _) => match fn_return_type(fn_returns, impl_target_fn_key(name)) {
-      Some(key) => Some(key),
+      Some(key) => impl_target_from_key(key),
       None => match infer_arg_type_name(arg, struct_sets, var_types, fn_returns) {
-        Some(head) => Some(impl_target_key(TyName(head))),
+        Some(head) => Some(TyName(head)),
         None => None
       }
     },
     _ => match infer_arg_type_name(arg, struct_sets, var_types, fn_returns) {
-      Some(head) => Some(impl_target_key(TyName(head))),
+      Some(head) => Some(TyName(head)),
       None => None
     }
+  }
+}
+
+fn infer_impl_target_key(arg: Expr, struct_sets: Array[(String, Array[String])], var_types: Array[(String, String)], fn_returns: Array[(String, String)]) -> Option[String] {
+  match infer_impl_target_expr(arg, struct_sets, var_types, fn_returns) {
+    Some(target) => Some(impl_target_key(target)),
+    None => None
   }
 }
 
@@ -2419,7 +2704,8 @@ fn bind_impl_target_key(var_types: Array[(String, String)], name: String, value:
 /// type / dict cannot be determined the whole witness fails to build (returns
 /// None), so the call is left unrewritten (a loud arity error, never a silent
 /// miscompile).
-fn build_concrete_dict(cname: String, trait_name: String, traits: Array[(String, Array[(String, Array[TypeExpr], TypeExpr)])], gens: Array[(String, Array[(String, String, Int)])], struct_sets: Array[(String, Array[String])], var_types: Array[(String, String)], fn_returns: Array[(String, String)], arg_expr: Expr) -> Option[Expr] {
+fn build_concrete_dict_for_target(actual_target: TypeExpr, trait_name: String, traits: Array[(String, Array[(String, Array[TypeExpr], TypeExpr)])], gens: Array[DictGen], struct_sets: Array[(String, Array[String])], var_types: Array[(String, String)], fn_returns: Array[(String, String)], arg_expr: Option[Expr]) -> Option[Expr] {
+  let cname = impl_target_head(actual_target)
   match lookup_trait_sigs(traits, trait_name) {
     Some(sigs) => {
       let mnames = method_names_of_sigs(sigs)
@@ -2429,14 +2715,12 @@ fn build_concrete_dict(cname: String, trait_name: String, traits: Array[(String,
       while mi < Array::length(mnames) {
         let m = Array::get(mnames, mi)
         let plain_qm = String::concat(cname, String::concat("::", m))
-        let specialized_qm = match infer_impl_target_key(arg_expr, struct_sets, var_types, fn_returns) {
-          Some(target_key) => impl_specialized_method_binding_name(cname, trait_name, target_key, m),
-          None => ""
-        }
+        let specialized_qm = impl_specialized_method_binding_name(cname, trait_name, impl_target_key(actual_target), m)
         let qm = if specialized_qm != "" && fn_exists(fn_returns, specialized_qm) {
           specialized_qm
-        } else {
-          plain_qm
+        } else match matching_generic_impl_method(gens, cname, trait_name, m, actual_target) {
+          Some(generic_qm) => generic_qm,
+          None => plain_qm
         }
         if not(fn_exists(fn_returns, qm)) {
           // #1445: the SYNTHETIC `Show` witness is total. A type with no
@@ -2456,41 +2740,45 @@ fn build_concrete_dict(cname: String, trait_name: String, traits: Array[(String,
           }
         } else {
           match lookup_gen(gens, qm) {
-            Some(threaded) => {
-              // `qm` is a bounded generic-impl method: supply its element dict(s).
-              match first_array_elem(arg_expr) {
-                Some(elem) => match infer_arg_type_name(elem, struct_sets, var_types, fn_returns) {
-                  Some(en) => {
-                    let callargs = empty_expr_array()
-                    let mut bi = 0
-                    let mut subok = true
-                    while bi < Array::length(threaded) {
-                      let (_, btrait, _) = Array::get(threaded, bi)
-                      match build_concrete_dict(en, btrait, traits, gens, struct_sets, var_types, fn_returns, elem) {
-                        Some(sd) => Array::push(callargs, sd),
-                        None => {
-                          subok = false
-                        }
-                      }
-                      bi = bi + 1
-                    }
-                    if subok {
-                      Array::push(callargs, EIdent("__w", -1))
-                      let closure = EFn(empty_str_array(), array_empty(), Array::slice([
-                        ("__w", None)
-                      ], 0, 1), None, None, ECall(EIdent(qm, -1), callargs, -1))
-                      Array::push(recfields, (m, closure))
-                    } else {
-                      failed = true
+            Some(threaded) => if Array::length(threaded) == 0 {
+              Array::push(recfields, (m, EIdent(qm, -1)))
+            } else {
+              let callargs = empty_expr_array()
+              let mut bi = 0
+              let mut subok = true
+              while bi < Array::length(threaded) {
+                let (type_param, btrait, _) = Array::get(threaded, bi)
+                let nested_target = match generic_impl_bound_target(gens, qm, type_param, actual_target) {
+                  Some(target) => Some(target),
+                  None => match arg_expr {
+                    Some(value) => match first_array_elem(value) {
+                      Some(elem) => infer_impl_target_expr(elem, struct_sets, var_types, fn_returns),
+                      None => None
+                    },
+                    None => None
+                  }
+                }
+                match nested_target {
+                  Some(target) => match build_concrete_dict_for_target(target, btrait, traits, gens, struct_sets, var_types, fn_returns, None) {
+                    Some(sd) => Array::push(callargs, sd),
+                    None => {
+                      subok = false
                     }
                   },
                   None => {
-                    failed = true
+                    subok = false
                   }
-                },
-                None => {
-                  failed = true
                 }
+                bi = bi + 1
+              }
+              if subok {
+                Array::push(callargs, EIdent("__w", -1))
+                let closure = EFn(empty_str_array(), array_empty(), Array::slice([
+                  ("__w", None)
+                ], 0, 1), None, None, ECall(EIdent(qm, -1), callargs, -1))
+                Array::push(recfields, (m, closure))
+              } else {
+                failed = true
               }
             },
             None => Array::push(recfields, (m, EIdent(qm, -1)))
@@ -2506,6 +2794,14 @@ fn build_concrete_dict(cname: String, trait_name: String, traits: Array[(String,
     },
     None => None
   }
+}
+
+fn build_concrete_dict(cname: String, trait_name: String, traits: Array[(String, Array[(String, Array[TypeExpr], TypeExpr)])], gens: Array[DictGen], struct_sets: Array[(String, Array[String])], var_types: Array[(String, String)], fn_returns: Array[(String, String)], arg_expr: Expr) -> Option[Expr] {
+  let target = match infer_impl_target_expr(arg_expr, struct_sets, var_types, fn_returns) {
+    Some(inferred) => inferred,
+    None => TyName(cname)
+  }
+  build_concrete_dict_for_target(target, trait_name, traits, gens, struct_sets, var_types, fn_returns, Some(arg_expr))
 }
 
 /// Synthesize the witness dictionaries for a call to a transformed generic, or
@@ -2535,7 +2831,7 @@ fn infer_arg_elem_type_name(arg: Expr, struct_sets: Array[(String, Array[String]
 /// receiver type is syntactically known) or by forwarding the caller's own dict
 /// parameter (the receiver is a type parameter bound by the same trait in the
 /// enclosing generic — the generic->generic case).
-fn synth_dicts(threaded: Array[(String, String, Int)], orig_args: Array[Expr], traits: Array[(String, Array[(String, Array[TypeExpr], TypeExpr)])], struct_sets: Array[(String, Array[String])], var_types: Array[(String, String)], dict_binds: Array[(String, String, String, Array[String])], fn_returns: Array[(String, String)], gens: Array[(String, Array[(String, String, Int)])]) -> Option[Array[Expr]] {
+fn synth_dicts(threaded: Array[(String, String, Int)], orig_args: Array[Expr], traits: Array[(String, Array[(String, Array[TypeExpr], TypeExpr)])], struct_sets: Array[(String, Array[String])], var_types: Array[(String, String)], dict_binds: Array[(String, String, String, Array[String])], fn_returns: Array[(String, String)], gens: Array[DictGen]) -> Option[Array[Expr]] {
   let dicts = empty_expr_array()
   let mut ok = true
   let mut bi = 0
@@ -2561,10 +2857,20 @@ fn synth_dicts(threaded: Array[(String, String, Int)], orig_args: Array[Expr], t
       match inferred {
         Some(nm) => match find_dict_for_trait(dict_binds, nm, trait_name) {
           Some(dict_pname) => Array::push(dicts, EIdent(dict_pname, -1)),
-          None => match build_concrete_dict(nm, trait_name, traits, gens, struct_sets, var_types, fn_returns, recv_arg) {
-            Some(dict) => Array::push(dicts, dict),
-            None => {
-              ok = false
+          None => {
+            let target = if is_elem_recv {
+              // The receiver carries `Array[T]`, but this witness is for T.
+              // Do not let the richer whole-receiver target override `nm`.
+              TyName(nm)
+            } else match infer_impl_target_expr(recv_arg, struct_sets, var_types, fn_returns) {
+              Some(inferred) => inferred,
+              None => TyName(nm)
+            }
+            match build_concrete_dict_for_target(target, trait_name, traits, gens, struct_sets, var_types, fn_returns, Some(recv_arg)) {
+              Some(dict) => Array::push(dicts, dict),
+              None => {
+                ok = false
+              }
             }
           }
         },
@@ -6218,13 +6524,13 @@ fn show_tmp_name() -> String {
 /// Render one sub-expression by re-entering the interpolation rewrite on a
 /// synthetic `__to_string(sub)`, so a nested wrapper or a derive(Show) value
 /// inside one is rendered too.
-fn interp_render_sub(sub: Expr, derived_only: Bool, gens: Array[(String, Array[(String, String, Int)])], traits: Array[(String, Array[(String, Array[TypeExpr], TypeExpr)])], struct_sets: Array[(String, Array[String])], dict_binds: Array[(String, String, String, Array[String])], var_types: Array[(String, String)], fn_returns: Array[(String, String)]) -> Expr with Exception {
+fn interp_render_sub(sub: Expr, derived_only: Bool, gens: Array[DictGen], traits: Array[(String, Array[(String, Array[TypeExpr], TypeExpr)])], struct_sets: Array[(String, Array[String])], dict_binds: Array[(String, String, String, Array[String])], var_types: Array[(String, String)], fn_returns: Array[(String, String)]) -> Expr with Exception {
   rewrite_expr(ECall(EIdent("__to_string", -1), Array::slice([sub], 0, 1), -1), gens, traits, struct_sets, dict_binds, var_types, fn_returns)
 }
 
 /// `open_s ++ e0 ++ sep ++ e1 ++ .. ++ close_s`, each element rendered.
 /// (`open` is a reserved word in vibe, hence the suffixed names.)
-fn interp_join(items: Array[Expr], open_s: String, sep: String, close_s: String, derived_only: Bool, gens: Array[(String, Array[(String, String, Int)])], traits: Array[(String, Array[(String, Array[TypeExpr], TypeExpr)])], struct_sets: Array[(String, Array[String])], dict_binds: Array[(String, String, String, Array[String])], var_types: Array[(String, String)], fn_returns: Array[(String, String)]) -> Expr with Exception {
+fn interp_join(items: Array[Expr], open_s: String, sep: String, close_s: String, derived_only: Bool, gens: Array[DictGen], traits: Array[(String, Array[(String, Array[TypeExpr], TypeExpr)])], struct_sets: Array[(String, Array[String])], dict_binds: Array[(String, String, String, Array[String])], var_types: Array[(String, String)], fn_returns: Array[(String, String)]) -> Expr with Exception {
   let mut acc = EString(open_s)
   let mut i = 0
   while i < Array::length(items) {
@@ -6252,7 +6558,7 @@ fn interp_join(items: Array[Expr], open_s: String, sep: String, close_s: String,
 /// falling to the pointer heuristic. An element whose type was not inferable
 /// at the binding site carries an empty entry and simply renders through the
 /// ordinary `__to_string`, exactly as it does today.
-fn interp_expand_var_tuple(name: String, elem_types: Array[String], derived_only: Bool, gens: Array[(String, Array[(String, String, Int)])], traits: Array[(String, Array[(String, Array[TypeExpr], TypeExpr)])], struct_sets: Array[(String, Array[String])], dict_binds: Array[(String, String, String, Array[String])], var_types: Array[(String, String)], fn_returns: Array[(String, String)]) -> Expr with Exception {
+fn interp_expand_var_tuple(name: String, elem_types: Array[String], derived_only: Bool, gens: Array[DictGen], traits: Array[(String, Array[(String, Array[TypeExpr], TypeExpr)])], struct_sets: Array[(String, Array[String])], dict_binds: Array[(String, String, String, Array[String])], var_types: Array[(String, String)], fn_returns: Array[(String, String)]) -> Expr with Exception {
   let n = Array::length(elem_types)
   let pats = array_empty()
   let binders = empty_str_array()
@@ -6301,7 +6607,7 @@ fn interp_expand_var_tuple(name: String, elem_types: Array[String], derived_only
 /// -- `infer_arg_type_name` already resolves that shape through
 /// `array_elem_type_of`, so a `derive(Show)` element renders structurally
 /// without any extra plumbing here.
-fn interp_expand_var_array(name: String, derived_only: Bool, gens: Array[(String, Array[(String, String, Int)])], traits: Array[(String, Array[(String, Array[TypeExpr], TypeExpr)])], struct_sets: Array[(String, Array[String])], dict_binds: Array[(String, String, String, Array[String])], var_types: Array[(String, String)], fn_returns: Array[(String, String)]) -> Expr with Exception {
+fn interp_expand_var_array(name: String, derived_only: Bool, gens: Array[DictGen], traits: Array[(String, Array[(String, Array[TypeExpr], TypeExpr)])], struct_sets: Array[(String, Array[String])], dict_binds: Array[(String, String, String, Array[String])], var_types: Array[(String, String)], fn_returns: Array[(String, String)]) -> Expr with Exception {
   let iv = String::concat(show_tmp_name(), "_i")
   let av = String::concat(show_tmp_name(), "_acc")
   let elem_piece = interp_render_sub(ECall(EIdent("Array::get", -1), Array::slice([
@@ -6324,7 +6630,7 @@ fn interp_expand_var_array(name: String, derived_only: Bool, gens: Array[(String
 /// re-evaluated; the array case binds each element to a name inside the loop,
 /// which is what lets a NESTED composite element recurse (an element reached
 /// as `Array::get(a, i)` has no name for `var_types` to key on).
-fn interp_render_shaped(sub: Expr, sh: String, derived_only: Bool, gens: Array[(String, Array[(String, String, Int)])], traits: Array[(String, Array[(String, Array[TypeExpr], TypeExpr)])], struct_sets: Array[(String, Array[String])], dict_binds: Array[(String, String, String, Array[String])], var_types: Array[(String, String)], fn_returns: Array[(String, String)]) -> Expr with Exception {
+fn interp_render_shaped(sub: Expr, sh: String, derived_only: Bool, gens: Array[DictGen], traits: Array[(String, Array[(String, Array[TypeExpr], TypeExpr)])], struct_sets: Array[(String, Array[String])], dict_binds: Array[(String, String, String, Array[String])], var_types: Array[(String, String)], fn_returns: Array[(String, String)]) -> Expr with Exception {
   if shape_is_composite(sh) {
     interp_expand_shape(sub, sh, derived_only, gens, traits, struct_sets, dict_binds, var_types, fn_returns)
   } else if String::length(sh) == 0 {
@@ -6340,7 +6646,7 @@ fn interp_render_shaped(sub: Expr, sh: String, derived_only: Bool, gens: Array[(
 /// #1445 (#139): the tuple / array expansion for a composite shape. Supersedes
 /// interp_expand_var_tuple / interp_expand_var_array for anything that nests;
 /// those two stay for the shapes recorded by the older sentinels alone.
-fn interp_expand_shape(subject: Expr, sh: String, derived_only: Bool, gens: Array[(String, Array[(String, String, Int)])], traits: Array[(String, Array[(String, Array[TypeExpr], TypeExpr)])], struct_sets: Array[(String, Array[String])], dict_binds: Array[(String, String, String, Array[String])], var_types: Array[(String, String)], fn_returns: Array[(String, String)]) -> Expr with Exception {
+fn interp_expand_shape(subject: Expr, sh: String, derived_only: Bool, gens: Array[DictGen], traits: Array[(String, Array[(String, Array[TypeExpr], TypeExpr)])], struct_sets: Array[(String, Array[String])], dict_binds: Array[(String, String, String, Array[String])], var_types: Array[(String, String)], fn_returns: Array[(String, String)]) -> Expr with Exception {
   if String::starts_with(sh, "(") {
     let parts = shape_split(shape_inner(sh))
     let n = Array::length(parts)
@@ -6396,7 +6702,7 @@ fn interp_expand_shape(subject: Expr, sh: String, derived_only: Bool, gens: Arra
 }
 
 /// `ctor_name(<rendered payload>)`.
-fn interp_wrap1(ctor: String, payload: Expr, derived_only: Bool, gens: Array[(String, Array[(String, String, Int)])], traits: Array[(String, Array[(String, Array[TypeExpr], TypeExpr)])], struct_sets: Array[(String, Array[String])], dict_binds: Array[(String, String, String, Array[String])], var_types: Array[(String, String)], fn_returns: Array[(String, String)]) -> Expr with Exception {
+fn interp_wrap1(ctor: String, payload: Expr, derived_only: Bool, gens: Array[DictGen], traits: Array[(String, Array[(String, Array[TypeExpr], TypeExpr)])], struct_sets: Array[(String, Array[String])], dict_binds: Array[(String, String, String, Array[String])], var_types: Array[(String, String)], fn_returns: Array[(String, String)]) -> Expr with Exception {
   concat2(EString(String::concat(ctor, "(")), concat2(interp_render_sub(payload, derived_only, gens, traits, struct_sets, dict_binds, var_types, fn_returns), EString(")")))
 }
 
@@ -6422,7 +6728,7 @@ fn interp_ctor_arm_var_types(arg: Expr, ctor: String, binder: String, var_types:
   arm_binder_var_types(arg, PCtor(ctor, Array::slice([PBind(binder)], 0, 1)), var_types)
 }
 
-fn interp_expand_by_head(arg: Expr, head: String, derived_only: Bool, gens: Array[(String, Array[(String, String, Int)])], traits: Array[(String, Array[(String, Array[TypeExpr], TypeExpr)])], struct_sets: Array[(String, Array[String])], dict_binds: Array[(String, String, String, Array[String])], var_types: Array[(String, String)], fn_returns: Array[(String, String)]) -> Option[Expr] with Exception {
+fn interp_expand_by_head(arg: Expr, head: String, derived_only: Bool, gens: Array[DictGen], traits: Array[(String, Array[(String, Array[TypeExpr], TypeExpr)])], struct_sets: Array[(String, Array[String])], dict_binds: Array[(String, String, String, Array[String])], var_types: Array[(String, String)], fn_returns: Array[(String, String)]) -> Option[Expr] with Exception {
   if head == "Option" {
     let v = show_tmp_name()
     let vt_some = interp_ctor_arm_var_types(arg, "Some", v, var_types)
@@ -6462,7 +6768,7 @@ fn interp_arg_is_bool(arg: Expr, struct_sets: Array[(String, Array[String])], va
 
 /// The structural rendering for an interpolated wrapper value, or None when
 /// this pass has no shape to work from and the `__to_string` call must stand.
-fn interp_expand(arg: Expr, derived_only: Bool, gens: Array[(String, Array[(String, String, Int)])], traits: Array[(String, Array[(String, Array[TypeExpr], TypeExpr)])], struct_sets: Array[(String, Array[String])], dict_binds: Array[(String, String, String, Array[String])], var_types: Array[(String, String)], fn_returns: Array[(String, String)]) -> Option[Expr] with Exception {
+fn interp_expand(arg: Expr, derived_only: Bool, gens: Array[DictGen], traits: Array[(String, Array[(String, Array[TypeExpr], TypeExpr)])], struct_sets: Array[(String, Array[String])], dict_binds: Array[(String, String, String, Array[String])], var_types: Array[(String, String)], fn_returns: Array[(String, String)]) -> Option[Expr] with Exception {
   let head = match infer_arg_type_name(arg, struct_sets, var_types, fn_returns) {
     Some(h) => h,
     None => ""
@@ -6480,7 +6786,7 @@ fn interp_expand(arg: Expr, derived_only: Bool, gens: Array[(String, Array[(Stri
   }
 }
 
-fn interp_expand_local(arg: Expr, head: String, derived_only: Bool, gens: Array[(String, Array[(String, String, Int)])], traits: Array[(String, Array[(String, Array[TypeExpr], TypeExpr)])], struct_sets: Array[(String, Array[String])], dict_binds: Array[(String, String, String, Array[String])], var_types: Array[(String, String)], fn_returns: Array[(String, String)]) -> Option[Expr] with Exception {
+fn interp_expand_local(arg: Expr, head: String, derived_only: Bool, gens: Array[DictGen], traits: Array[(String, Array[(String, Array[TypeExpr], TypeExpr)])], struct_sets: Array[(String, Array[String])], dict_binds: Array[(String, String, String, Array[String])], var_types: Array[(String, String)], fn_returns: Array[(String, String)]) -> Option[Expr] with Exception {
   match arg {
     ETuple(items) => Some(interp_join(items, "(", ", ", ")", derived_only, gens, traits, struct_sets, dict_binds, var_types, fn_returns)),
     EArray(items) => Some(interp_join(items, "[", ", ", "]", derived_only, gens, traits, struct_sets, dict_binds, var_types, fn_returns)),
@@ -6875,7 +7181,7 @@ fn assert_eq_concat(a: Expr, b: Expr) -> Expr {
 /// Render one `assert_eq` operand. Reuses the throw-site renderer
 /// (`derived_only`) so a missing Show becomes `<unprintable>` instead of a
 /// pointer decimal or a compile error.
-fn assert_eq_render(arg: Expr, gens: Array[(String, Array[(String, String, Int)])], traits: Array[(String, Array[(String, Array[TypeExpr], TypeExpr)])], struct_sets: Array[(String, Array[String])], dict_binds: Array[(String, String, String, Array[String])], var_types: Array[(String, String)], fn_returns: Array[(String, String)]) -> Expr with Exception {
+fn assert_eq_render(arg: Expr, gens: Array[DictGen], traits: Array[(String, Array[(String, Array[TypeExpr], TypeExpr)])], struct_sets: Array[(String, Array[String])], dict_binds: Array[(String, String, String, Array[String])], var_types: Array[(String, String)], fn_returns: Array[(String, String)]) -> Expr with Exception {
   let target = interp_show_target(arg, true, struct_sets, var_types, fn_returns)
   if target != "" {
     ECall(EIdent(target, -1), Array::slice([arg], 0, 1), -1)
@@ -6909,7 +7215,7 @@ fn assert_eq_render(arg: Expr, gens: Array[(String, Array[(String, String, Int)]
   }
 }
 
-fn lower_assert_eq(args: Array[Expr], call_off: Int, gens: Array[(String, Array[(String, String, Int)])], traits: Array[(String, Array[(String, Array[TypeExpr], TypeExpr)])], struct_sets: Array[(String, Array[String])], dict_binds: Array[(String, String, String, Array[String])], var_types: Array[(String, String)], fn_returns: Array[(String, String)]) -> Expr with Exception {
+fn lower_assert_eq(args: Array[Expr], call_off: Int, gens: Array[DictGen], traits: Array[(String, Array[(String, Array[TypeExpr], TypeExpr)])], struct_sets: Array[(String, Array[String])], dict_binds: Array[(String, String, String, Array[String])], var_types: Array[(String, String)], fn_returns: Array[(String, String)]) -> Expr with Exception {
   let a2 = rewrite_expr(Array::get(args, 0), gens, traits, struct_sets, dict_binds, var_types, fn_returns)
   let b2 = rewrite_expr(Array::get(args, 1), gens, traits, struct_sets, dict_binds, var_types, fn_returns)
   let an = dinsp_fresh_name("__assert_eq_actual", a2, b2)
@@ -6966,7 +7272,7 @@ fn lower_assert_eq(args: Array[Expr], call_off: Int, gens: Array[(String, Array[
 /// threading applies everywhere a transformed generic is called. `var_types`
 /// tracks locals/params whose concrete type is known, for call-site dict
 /// synthesis when the receiver is a variable.
-fn rewrite_expr(expr: Expr, gens: Array[(String, Array[(String, String, Int)])], traits: Array[(String, Array[(String, Array[TypeExpr], TypeExpr)])], struct_sets: Array[(String, Array[String])], dict_binds: Array[(String, String, String, Array[String])], var_types: Array[(String, String)], fn_returns: Array[(String, String)]) -> Expr with Exception {
+fn rewrite_expr(expr: Expr, gens: Array[DictGen], traits: Array[(String, Array[(String, Array[TypeExpr], TypeExpr)])], struct_sets: Array[(String, Array[String])], dict_binds: Array[(String, String, String, Array[String])], var_types: Array[(String, String)], fn_returns: Array[(String, String)]) -> Expr with Exception {
   match expr {
     EIdent(name, off) => match split_qualified(name) {
       Some(parts) => {
@@ -7772,7 +8078,7 @@ fn thread_dict_params(threaded: Array[(String, String, Int)], params: Array[(Str
 /// lowers `record{}.field` dot access — without this it inherited the exact
 /// same "only resolves within a single top-level statement's own expression
 /// tree" gap.
-fn rewrite_stmt(stmt: Stmt, gens: Array[(String, Array[(String, String, Int)])], traits: Array[(String, Array[(String, Array[TypeExpr], TypeExpr)])], struct_sets: Array[(String, Array[String])], fn_returns: Array[(String, String)], toplevel_vars: Array[(String, String)]) -> Stmt with Exception {
+fn rewrite_stmt(stmt: Stmt, gens: Array[DictGen], traits: Array[(String, Array[(String, Array[TypeExpr], TypeExpr)])], struct_sets: Array[(String, Array[String])], fn_returns: Array[(String, String)], toplevel_vars: Array[(String, String)]) -> Stmt with Exception {
   let no_binds = empty_dict_binds()
   // #1392: which top-level binding's body is about to be walked, so the
   // interpolation rewrite can decline to make `T::to_string` call itself.
@@ -15793,8 +16099,8 @@ export fn desugar_trait_dicts(stmts: Array[Stmt]) -> Unit with Exception {
   inject_trait_method_generics_with(stmts, traits)
   let struct_sets = collect_struct_field_sets(stmts)
   let fn_returns = collect_fn_returns(stmts)
-  let gimpl_types = collect_generic_impl_types(stmts)
-  let gens = build_gens(stmts, traits, gimpl_types)
+  let gimpl_infos = collect_generic_impl_infos(stmts)
+  let gens = build_gens(stmts, traits, gimpl_infos)
   // #839: see `collect_toplevel_anon_records` / the `rewrite_stmt` doc comment.
   let toplevel_vars = collect_toplevel_anon_records(stmts, struct_sets)
   // #1374: reset the exception-kind pass state. An already-declared cell means

--- a/lib/@vibe/compiler/normalize/index.vpkg
+++ b/lib/@vibe/compiler/normalize/index.vpkg
@@ -3,6 +3,7 @@ version = 0.0.1
 description =
   #|@vibe/compiler/normalize — the `vibe normalize` canonicalizing source
 deps = {
+  @vibe/ast : 0.2.0
   @vibe/compiler/contract : 0.0.1
   @vibe/compiler/core : 0.0.1
   @vibe/compiler/syntax : 0.0.1

--- a/lib/@vibe/compiler/normalize/normalize.vibe
+++ b/lib/@vibe/compiler/normalize/normalize.vibe
@@ -312,10 +312,7 @@ fn collect_stmt_type_refs_into(stmt: Stmt, out: Array[String]) -> Int {
       }
       0
     },
-    SImpl(_, _, _, type_name) => {
-      Array::push(out, type_name)
-      0
-    },
+    SImpl(_, _, _, target) => collect_type_names_into(target, out),
     _ => 0
   }
 }

--- a/lib/@vibe/compiler/runtime/symbol_spans.vibe
+++ b/lib/@vibe/compiler/runtime/symbol_spans.vibe
@@ -143,7 +143,14 @@ fn sym_walk_stmt(out: Array[(String, Int, Int, Int)], source: String, stmt: Stmt
     SStruct(_, name, _, _, _, _) => sym_emit(out, source, name, 23, floor, hi),
     STypeAlias(_, name, _, _) => sym_emit(out, source, name, 26, floor, hi),
     STrait(_, name, _, _, _, _) => sym_emit(out, source, name, 11, floor, hi),
-    SImpl(_, _, _, type_name) => sym_emit(out, source, type_name, 6, floor, hi),
+    SImpl(_, _, _, target) => {
+      let type_name = match target {
+        TyName(name) => name,
+        TyApp(name, _) => name,
+        _ => ""
+      }
+      sym_emit(out, source, type_name, 6, floor, hi)
+    },
     SEffectDef(_, name, _, _) => sym_emit(out, source, name, 24, floor, hi),
     STest(name, _) => sym_emit(out, source, sym_block_name(name, "test"), 12, floor, hi),
     SBench(name, _) => sym_emit(out, source, sym_block_name(name, "bench"), 12, floor, hi),

--- a/lib/@vibe/compiler/runtime/typecheck_fs.vibe
+++ b/lib/@vibe/compiler/runtime/typecheck_fs.vibe
@@ -1056,8 +1056,8 @@ fn prepend_dependency_type_defs(dep_env: TypeEnv, names: Array[ImportItem], tail
 
 fn prepend_dependency_trait_nodes(dep_env: TypeEnv, mappings: Array[(String, String)], tail: TypeEnv) -> TypeEnv {
   // Preserve every generic implementation in source order. Its parameters and
-  // bounds are semantic payload, so deduplicating by erased target spelling
-  // could silently change obligation satisfaction.
+  // bounds are semantic payload, so deduplicating by target alone could
+  // silently change obligation satisfaction.
   let retained = array_empty()
   let seen_defs = array_empty()
   let mut cur = dep_env

--- a/lib/@vibe/compiler/tests/canonical_checked_type_state_test.vibe
+++ b/lib/@vibe/compiler/tests/canonical_checked_type_state_test.vibe
@@ -266,31 +266,42 @@ test "canonical trait impl snapshot alpha-normalizes generic bounds by declared 
   let left = EnvTraitImplGen("Map", ["T", "U"], [
     ("U", ["Ord", "Eq"]),
     ("T", ["Show"])
-  ], CtNamed("Box", array_empty()), EnvEmpty)
+  ], CtNamed("Pair", [CtNamed("U", array_empty()), CtNamed("T", array_empty())]), EnvEmpty)
   let alpha = EnvTraitImplGen("Map", ["X", "Y"], [
     ("Y", ["Ord", "Eq"]),
     ("X", ["Show"])
-  ], CtNamed("Box", array_empty()), EnvEmpty)
+  ], CtNamed("Pair", [CtNamed("Y", array_empty()), CtNamed("X", array_empty())]), EnvEmpty)
   let moved_association = EnvTraitImplGen("Map", ["X", "Y"], [
     ("X", ["Ord", "Eq"]),
     ("Y", ["Show"])
-  ], CtNamed("Box", array_empty()), EnvEmpty)
+  ], CtNamed("Pair", [CtNamed("Y", array_empty()), CtNamed("X", array_empty())]), EnvEmpty)
   let reordered_rows_and_labels = EnvTraitImplGen("Map", ["X", "Y"], [
     ("X", ["Show"]),
     ("Y", ["Eq"]),
     ("Y", ["Ord", "Eq"])
-  ], CtNamed("Box", array_empty()), EnvEmpty)
+  ], CtNamed("Pair", [CtNamed("Y", array_empty()), CtNamed("X", array_empty())]), EnvEmpty)
+  let reordered_target = EnvTraitImplGen("Map", ["X", "Y"], [
+    ("X", ["Show"]),
+    ("Y", ["Ord", "Eq"])
+  ], CtNamed("Pair", [CtNamed("X", array_empty()), CtNamed("Y", array_empty())]), EnvEmpty)
   assert(trait_impl_snapshot(left, SubstEmpty) == trait_impl_snapshot(alpha, SubstEmpty))
   assert(trait_impl_snapshot(left, SubstEmpty) == trait_impl_snapshot(reordered_rows_and_labels, SubstEmpty))
   assert(trait_impl_snapshot(left, SubstEmpty) != trait_impl_snapshot(moved_association, SubstEmpty))
+  assert(trait_impl_snapshot(left, SubstEmpty) != trait_impl_snapshot(reordered_target, SubstEmpty))
 }
 
-test "canonical trait impl snapshot keeps erased generic targets nominal" {
-  let colliding_name = EnvTraitImplGen("Tr", ["Box"], array_empty(), CtNamed("Box", array_empty()), EnvEmpty)
-  let alpha_renamed = EnvTraitImplGen("Tr", ["T"], array_empty(), CtNamed("Box", array_empty()), EnvEmpty)
-  let other_constructor = EnvTraitImplGen("Tr", ["Other"], array_empty(), CtNamed("Other", array_empty()), EnvEmpty)
-  assert(trait_impl_snapshot(colliding_name, SubstEmpty) == trait_impl_snapshot(alpha_renamed, SubstEmpty))
-  assert(trait_impl_snapshot(colliding_name, SubstEmpty) != trait_impl_snapshot(other_constructor, SubstEmpty))
+test "canonical trait impl snapshot retains and alpha-normalizes generic targets" {
+  let target = EnvTraitImplGen("Tr", ["T"], array_empty(), CtNamed("Box", [
+    CtNamed("T", array_empty())
+  ]), EnvEmpty)
+  let alpha_renamed = EnvTraitImplGen("Tr", ["X"], array_empty(), CtNamed("Box", [
+    CtNamed("X", array_empty())
+  ]), EnvEmpty)
+  let concrete = EnvTraitImplGen("Tr", ["X"], array_empty(), CtNamed("Box", [
+    CtString
+  ]), EnvEmpty)
+  assert(trait_impl_snapshot(target, SubstEmpty) == trait_impl_snapshot(alpha_renamed, SubstEmpty))
+  assert(trait_impl_snapshot(target, SubstEmpty) != trait_impl_snapshot(concrete, SubstEmpty))
 }
 
 test "canonical trait impl snapshot applies final substitution and fails closed for malformed bounds" {
@@ -312,8 +323,8 @@ test "canonical trait impl snapshot applies final substitution and fails closed 
 test "canonical trait impl snapshot observes real checker registrations" {
   let checked = check_program_result([
     STrait(false, "Observed", array_empty(), array_empty(), array_empty(), array_empty()),
-    SImpl(["T"], [("T", ["Eq", "Show"])], "Observed", "Box"),
-    SImpl(array_empty(), array_empty(), "Observed", "Int")
+    SImpl(["T"], [("T", ["Eq", "Show"])], "Observed", TyApp("Box", [TyName("T")])),
+    SImpl(array_empty(), array_empty(), "Observed", TyName("Int"))
   ])
   let snapshot = canonical_retained_trait_impl_entries_snapshot(checked.final_env, checked.final_subst)
   assert(String::contains(snapshot, "Observed"))

--- a/lib/@vibe/compiler/tests/checker_infer_test.vibe
+++ b/lib/@vibe/compiler/tests/checker_infer_test.vibe
@@ -132,7 +132,7 @@ test "trait bound basic" {
   let f_fn = EFn(["A"], [("A", ["T"])], [("x", Some(TyName("A")))], None, None, EIdent("x", -1))
   let stmts = [
     STrait(false, "T", _no_tp, _no_methods, _no_method_gens, _no_tp),
-    SImpl(_no_tp, _no_tb, "T", "Int"),
+    SImpl(_no_tp, _no_tb, "T", TyName("Int")),
     SLet(false, false, "f", None, f_fn),
     SLet(false, false, "result", None, ECall(EIdent("f", -1), [EInt(42)], -1))
   ]
@@ -147,7 +147,7 @@ test "trait registered in env" {
   // trait Show; impl Show for Int
   let stmts = [
     STrait(false, "Show", _no_tp, _no_methods, _no_method_gens, _no_tp),
-    SImpl(_no_tp, _no_tb, "Show", "Int")
+    SImpl(_no_tp, _no_tb, "Show", TyName("Int"))
   ]
   let env = check_program(stmts)
   // The env should contain trait definitions — check it's not just EnvEmpty
@@ -162,7 +162,7 @@ test "supertrait registered" {
   let stmts = [
     STrait(false, "A", _no_tp, _no_methods, _no_method_gens, _no_tp),
     STrait(false, "B", ["A"], _no_methods, _no_method_gens, _no_tp),
-    SImpl(_no_tp, _no_tb, "B", "Int")
+    SImpl(_no_tp, _no_tb, "B", TyName("Int"))
   ]
   let env = check_program(stmts)
   match env {
@@ -173,15 +173,13 @@ test "supertrait registered" {
 
 test "overlap impl detected" {
   // Two impls of the same trait for the same type
-  // trait T; impl T for Int; impl T for Int (should still compile, overlap just recorded)
   let stmts = [
     STrait(false, "T", _no_tp, _no_methods, _no_method_gens, _no_tp),
-    SImpl(_no_tp, _no_tb, "T", "Int"),
-    SImpl(_no_tp, _no_tb, "T", "Int")
+    SImpl(_no_tp, _no_tb, "T", TyName("Int")),
+    SImpl(_no_tp, _no_tb, "T", TyName("Int"))
   ]
-  let env = check_program(stmts)
-  match env {
-    EnvEmpty => assert(false),
-    _ => assert(true)
-  }
+  let errors = array_empty()
+  let _ = check_stmts(stmts, 0, EnvEmpty, array_empty(), SubstEmpty, 0, errors, array_empty())
+  assert(Array::length(errors) == 1)
+  assert(String::contains(Array::get(errors, 0), "existing target `Int` overlaps new target `Int`"))
 }

--- a/lib/@vibe/compiler/tests/checker_trait_test.vibe
+++ b/lib/@vibe/compiler/tests/checker_trait_test.vibe
@@ -4,18 +4,28 @@ import @vibe/compiler/checker {
   check_bounds_satisfied, register_builtin_traits, satisfies_bound, validate_impl_no_overlap, validate_supers_defined
 }
 
+import @vibe/ast {
+  TypeExpr
+}
+
 import @vibe/core {
   array_empty
 }
 
 import @vibe/compiler/core {
-  Subst, Type, TypeEnv, trait_defined, trait_supers, type_implements_trait
+  Subst, Type, TypeEnv, overlapping_impl_target_for, trait_defined, trait_supers, type_implements_trait
 }
 
 //# Functions
 
 fn no_type_args() -> Array[Type] {
   array_empty()
+}
+
+fn measured_trait_env() -> TypeEnv {
+  EnvTraitDef("Measured", [], false, [
+    ("measure", [TyName("Self")], TyName("Int"))
+  ], EnvEmpty, [], [])
 }
 
 //# Misc
@@ -128,6 +138,54 @@ test "two different CtNamed types dont overlap for same trait" {
 test "String implements Eq from builtins so overlap is detected" {
   let env = register_builtin_traits(EnvEmpty)
   assert(not(validate_impl_no_overlap(env, "Eq", CtString)))
+}
+
+test "impl overlap preserves repeated generic target constraints" {
+  let t = CtNamed("T", no_type_args())
+  let pair_tt = CtNamed("Pair", [t, t])
+  let env = EnvTraitImplGen("Measured", ["T"], array_empty(), pair_tt, EnvEmpty)
+  let pair_int_int = CtNamed("Pair", [CtInt, CtInt])
+  let pair_int_string = CtNamed("Pair", [CtInt, CtString])
+  match overlapping_impl_target_for(env, "Measured", array_empty(), pair_int_int) {
+    Some(_) => (),
+    None => assert(false)
+  }
+  match overlapping_impl_target_for(env, "Measured", array_empty(), pair_int_string) {
+    None => (),
+    Some(_) => assert(false)
+  }
+}
+
+test "impl overlap does not use expression coercions" {
+  let t = CtNamed("T", no_type_args())
+  let u = CtNamed("U", no_type_args())
+  let existing = CtNamed("Pair", [t, CtChar])
+  let candidate = CtNamed("Pair", [u, CtInt])
+  let env = EnvTraitImplGen("Measured", ["T"], array_empty(), existing, EnvEmpty)
+  match overlapping_impl_target_for(env, "Measured", ["U"], candidate) {
+    None => (),
+    Some(_) => assert(false)
+  }
+}
+
+test "generic impl targets bind formals nested in tuples" {
+  let env = measured_trait_env()
+  let t = CtNamed("T", no_type_args())
+  let target = CtNamed("Box", [CtTuple([t, CtInt])])
+  let env2 = EnvTraitImplGen("Measured", ["T"], array_empty(), target, env)
+  let resolved = CtNamed("Box", [CtTuple([CtString, CtInt])])
+  assert(type_implements_trait(env2, SubstEmpty, resolved, "Measured"))
+}
+
+test "generic impl targets bind formals nested in function types" {
+  let env = measured_trait_env()
+  let t = CtNamed("T", no_type_args())
+  let target = CtNamed("Box", [CtFn([t], CtInt, Some("Fs"))])
+  let env2 = EnvTraitImplGen("Measured", ["T"], array_empty(), target, env)
+  let matching = CtNamed("Box", [CtFn([CtString], CtInt, Some("Fs"))])
+  let different_effect = CtNamed("Box", [CtFn([CtString], CtInt, Some("Env"))])
+  assert(type_implements_trait(env2, SubstEmpty, matching, "Measured"))
+  assert(not(type_implements_trait(env2, SubstEmpty, different_effect, "Measured")))
 }
 
 test "i64 implements Add after registration" {

--- a/lib/@vibe/compiler/tests/codegen_parser_test.vibe
+++ b/lib/@vibe/compiler/tests/codegen_parser_test.vibe
@@ -28,6 +28,10 @@ test "wasi: parser.vibe import - compile and run" {
   let token_source = Fs::read_file("lib/@vibe/parser/token.vibe")
   let ast_path = "lib/@vibe/ast/index.vpkg"
   let syntax_paths = [
+    // #2335: parser-generated impl method names are derived by the shared AST
+    // helpers, so this manual parser self-compile must carry their bodies as
+    // well as the transparent AST declarations from the contract.
+    "lib/@vibe/ast/ast.vibe",
     // #956: the lexer's float-literal construction moved to
     // float_format.vibe (parse_decimal_float), which in turn uses the
     // parser-private __to_string polyfill — include both.

--- a/lib/@vibe/compiler/tests/import_alias_rewrite_test.vibe
+++ b/lib/@vibe/compiler/tests/import_alias_rewrite_test.vibe
@@ -4,6 +4,10 @@ import @vibe/compiler/core {
   append_import_alias_rewritten_non_import_stmts, build_export_rename_plan, collect_import_value_renames, namespace_exported_name
 }
 
+import @vibe/ast {
+  TypeExpr, impl_method_binding_name
+}
+
 import @vibe/compiler/syntax {
   lex, parse_program, print_program
 }
@@ -27,6 +31,21 @@ test "imported type aliases rewrite fn annotations but not type formals" {
   assert(String::contains(printed, "StdinStream"))
   assert(!String::contains(printed, "(stream: S)"))
   assert(String::contains(printed, "(value: S)"))
+}
+
+test "import aliases rewrite concrete impl method owners with their targets" {
+  let stmts = parse_program(lex("import ./dep.vibe { Box as B }\ntrait Measured { measure(Self) -> Int }\nimpl Measured for B[Int] { measure(self) -> Int { 1 } }"))
+  let out = Array::slice(stmts, 0, 0)
+  append_import_alias_rewritten_non_import_stmts(out, stmts)
+  let printed = print_program(out)
+  let old_name = impl_method_binding_name([], "Measured", TyApp("B", [
+    TyName("Int")
+  ]), "measure")
+  let expected_name = impl_method_binding_name([], "Measured", TyApp("Box", [
+    TyName("Int")
+  ]), "measure")
+  assert(String::contains(printed, expected_name))
+  assert(!String::contains(printed, old_name))
 }
 
 test "later plain re-export wins over an earlier import reference rename" {

--- a/lib/@vibe/compiler/tests/import_alias_rewrite_test.vibe
+++ b/lib/@vibe/compiler/tests/import_alias_rewrite_test.vibe
@@ -48,6 +48,22 @@ test "import aliases rewrite concrete impl method owners with their targets" {
   assert(!String::contains(printed, old_name))
 }
 
+test "transparent aliases rewrite concrete impl method owners with their targets" {
+  let stmts = parse_program(lex("type Vec[T] = Array[T]\ntrait Measured { measure(Self) -> Int }\nimpl Measured for Vec[Int] { measure(self) -> Int { 1 } }"))
+  let out = Array::slice(stmts, 0, 0)
+  append_import_alias_rewritten_non_import_stmts(out, stmts)
+  let printed = print_program(out)
+  let old_name = impl_method_binding_name([], "Measured", TyApp("Vec", [
+    TyName("Int")
+  ]), "measure")
+  let expected_name = impl_method_binding_name([], "Measured", TyApp("Array", [
+    TyName("Int")
+  ]), "measure")
+  assert(String::contains(printed, expected_name))
+  assert(!String::contains(printed, old_name))
+  assert(String::contains(printed, "impl Measured for Array[Int]"))
+}
+
 test "later plain re-export wins over an earlier import reference rename" {
   let a_path = "/virtual/a.vibe"
   let b_path = "/virtual/b.vibe"

--- a/lib/@vibe/compiler/tests/persistent_env_codec_test.vibe
+++ b/lib/@vibe/compiler/tests/persistent_env_codec_test.vibe
@@ -123,6 +123,32 @@ fn retained_generic_impl_bounds(env: TypeEnv, name: String) -> Array[(String, Ar
   }
 }
 
+fn retained_impl_targets(env: TypeEnv, name: String) -> Array[Type] {
+  match env {
+    EnvEmpty => [],
+    EnvBind(_, _, rest) => retained_impl_targets(rest, name),
+    EnvTraitDef(_, _, _, _, rest, _, _) => retained_impl_targets(rest, name),
+    EnvTraitImpl(trait_name, target, rest) => {
+      if trait_name == name {
+        Array::concat([target], retained_impl_targets(rest, name))
+      } else {
+        retained_impl_targets(rest, name)
+      }
+    },
+    EnvMutCell(_, _, rest) => retained_impl_targets(rest, name),
+    EnvTraitImplGen(trait_name, _, _, target, rest) => {
+      if trait_name == name {
+        Array::concat([target], retained_impl_targets(rest, name))
+      } else {
+        retained_impl_targets(rest, name)
+      }
+    },
+    EnvTypeDefs(_, _, rest) => retained_impl_targets(rest, name),
+    EnvFlat(_) => [],
+    EnvCached(_, _, rest) => retained_impl_targets(rest, name)
+  }
+}
+
 fn malformed_rejected(text: String) -> Bool {
   handle {
     match parse_persistent_type_env(text) {
@@ -249,6 +275,27 @@ test "persistent module interface v5 round-trips every variant and trait payload
         },
         None => assert(false)
       }
+    },
+    None => assert(false)
+  }
+}
+
+test "persistent module interface retains complete concrete and generic impl targets" {
+  let int_box = CtNamed("Box", [CtInt])
+  let string_box = CtNamed("Box", [CtString])
+  let reordered_pair = CtNamed("Pair", [CtNamed("B", []), CtNamed("A", [])])
+  let env = EnvTraitImpl("Observed", int_box, EnvTraitImpl("Observed", string_box, EnvTraitImplGen("Observed", [
+    "A",
+    "B"
+  ], [], reordered_pair, EnvEmpty)))
+  match parse_persistent_type_env(persistent_type_env_cache_text(env)) {
+    Some(decoded) => {
+      let targets = retained_impl_targets(decoded, "Observed")
+      assert(Array::length(targets) == 3)
+      assert(types_equal(Array::get(targets, 0), int_box))
+      assert(types_equal(Array::get(targets, 1), string_box))
+      assert(types_equal(Array::get(targets, 2), reordered_pair))
+      assert(!types_equal(Array::get(targets, 0), Array::get(targets, 1)))
     },
     None => assert(false)
   }

--- a/lib/@vibe/compiler/tests/stmt_decl_type_test.vibe
+++ b/lib/@vibe/compiler/tests/stmt_decl_type_test.vibe
@@ -31,8 +31,7 @@ test "stmt_impl" {
 }
 
 test "stmt_impl_type_params_accepted" {
-  // Generic impl headers retain their parser-stored bounds. Target type
-  // arguments are still erased by the SImpl AST representation.
-  let result = pp("impl [A: Show] Show for Int")
-  assert(result == "impl [A: Show] Show for Int")
+  // Generic impl headers retain both their bounds and complete applied target.
+  let result = pp("impl [A: Show] Show for Box[A]")
+  assert(result == "impl [A: Show] Show for Box[A]")
 }

--- a/lib/@vibe/compiler/tests/stmt_type_decl_test.vibe
+++ b/lib/@vibe/compiler/tests/stmt_type_decl_test.vibe
@@ -23,8 +23,7 @@ test "stmt_impl" {
 }
 
 test "stmt_impl_type_params_accepted" {
-  // Generic impl headers retain their parser-stored bounds. Target type
-  // arguments are still erased by the SImpl AST representation.
-  let result = pp("impl [A: Show] Show for Int")
-  assert(result == "impl [A: Show] Show for Int")
+  // Generic impl headers retain both their bounds and complete applied target.
+  let result = pp("impl [A: Show] Show for Box[A]")
+  assert(result == "impl [A: Show] Show for Box[A]")
 }

--- a/lib/@vibe/compiler/tests/trait_impl_func_label_debt_test.vibe
+++ b/lib/@vibe/compiler/tests/trait_impl_func_label_debt_test.vibe
@@ -1,11 +1,11 @@
 // #1966/#1967: was fixtures/trait_impl_func_label_no_overlap.vibe +
-// __DATA__.last "0". Stale `impl Callable for (x: Int, y~: String) -> Int`
-// is a stable parse rejection.
+// __DATA__.last "0". `impl Callable for (x: Int, y~: String) -> Int` is
+// parsed as a complete type and then rejected by the named-target contract.
 
 import ./checker_parity_test_support.vibe {
   check_source_error_message
 }
 
 test "impl for labeled function type is rejected" {
-  inspect(check_source_error_message("trait Callable {\n  call_it(Self) -> Int\n}\nimpl Callable for (x: Int, y~: String) -> Int {\n  call_it = (f) -> Int { f(0, y=\"hello\") }\n}"), "expected type name after 'for'")
+  inspect(check_source_error_message("trait Callable {\n  call_it(Self) -> Int\n}\nimpl Callable for (x: Int, y~: String) -> Int {\n  call_it = (f) -> Int { f(0, y=\"hello\") }\n}"), "an impl target must be a named type, such as `Int` or `Array[T]`")
 }

--- a/lib/@vibe/core/default.vibe
+++ b/lib/@vibe/core/default.vibe
@@ -20,12 +20,6 @@ impl Default for Int {
   }
 }
 
-impl Default for Float {
-  default() -> Float {
-    0.0
-  }
-}
-
 impl Default for Double {
   default() -> Double {
     0.0

--- a/lib/@vibe/core/map.vibe
+++ b/lib/@vibe/core/map.vibe
@@ -30,12 +30,6 @@ impl Hash for Int {
   }
 }
 
-impl Hash for Float {
-  hash_key(self) -> String {
-    __to_string(self)
-  }
-}
-
 impl Hash for Double {
   hash_key(self) -> String {
     __to_string(self)

--- a/lib/@vibe/parser/ast_detach.vibe
+++ b/lib/@vibe/parser/ast_detach.vibe
@@ -160,7 +160,7 @@ fn detach_stmt(stmt: Stmt) -> Stmt {
     STrait(exported, name, supers, methods, method_generics, params) => STrait(exported, name, detach_strings(supers), detach_methods(methods), for item in method_generics {
       (item.0, detach_strings(item.1), detach_bounds(item.2))
     }, detach_strings(params)),
-    SImpl(type_params, bounds, trait_name, target_name) => SImpl(detach_strings(type_params), detach_bounds(bounds), trait_name, target_name),
+    SImpl(type_params, bounds, trait_name, target) => SImpl(detach_strings(type_params), detach_bounds(bounds), trait_name, detach_type_expr(target)),
     SExternLet(name, ty) => SExternLet(name, detach_type_expr(ty)),
     SImport(path, items) => SImport(path, detach_import_items(items)),
     STest(name, body) => STest(name, detach_expr(body)),

--- a/lib/@vibe/parser/parser.vibe
+++ b/lib/@vibe/parser/parser.vibe
@@ -1,7 +1,7 @@
 //# Imports
 
 import @vibe/ast {
-  Expr, ImportItem, Pat, Stmt, TypeExpr
+  Expr, ImportItem, Pat, Stmt, TypeExpr, impl_method_binding_name
 }
 
 import ./parser_base.vibe {
@@ -664,9 +664,13 @@ fn parse_impl_methods(tokens: Array[Token], pos: Int, simpl: Stmt, context: Opti
   ArrayBuilder::push(out, simpl)
   match peek(tokens, pos) {
     TLBrace => {
-      let type_name = match simpl {
-        SImpl(_, _, _, tn) => tn,
+      let impl_trait = match simpl {
+        SImpl(_, _, trait_name, _) => trait_name,
         _ => ""
+      }
+      let impl_target = match simpl {
+        SImpl(_, _, _, target) => target,
+        _ => TyName("")
       }
       // A generic impl `impl [T: Bound] Trait for C { method(self){..} }` binds
       // `T` (and its bound) over each method body, so inject the impl's type
@@ -699,7 +703,7 @@ fn parse_impl_methods(tokens: Array[Token], pos: Int, simpl: Stmt, context: Opti
             } else {
               efn
             }
-            let qname = String::concat(type_name, String::concat("::", mname))
+            let qname = impl_method_binding_name(impl_tparams, impl_trait, impl_target, mname)
             ArrayBuilder::push(out, SLet(false, true, qname, None, efn2))
             p = match peek(tokens, p2) {
               TSemicolon => p2 + 1,

--- a/lib/@vibe/parser/parser_base.vibe
+++ b/lib/@vibe/parser/parser_base.vibe
@@ -919,111 +919,6 @@ export fn collect_import_path(tokens: Array[Token], pos: Int, acc: String) -> (S
   }
 }
 
-fn skip_bracketed_args(tokens: Array[Token], pos: Int) -> Int {
-  match peek(tokens, pos) {
-    TLBracket => {
-      let mut bp = pos + 1
-      let mut depth = 1
-      while depth > 0 {
-        match peek(tokens, bp) {
-          TLBracket => {
-            depth = depth + 1
-            bp = bp + 1
-          },
-          TRBracket => {
-            depth = depth - 1
-            bp = bp + 1
-          },
-          TEof => {
-            depth = 0
-          },
-          _ => {
-            bp = bp + 1
-          }
-        }
-      }
-      bp
-    },
-    _ => pos
-  }
-}
-
-/// True only for the erased generic target shape that SImpl can represent
-/// soundly: `[T1, ..., Tn]` in the same order as the impl formals. Nested,
-/// concrete, reordered, repeated, missing, and extra arguments all fail
-/// closed until SImpl retains the target TypeExpr (#2262).
-fn impl_target_formal_end(tokens: Array[Token], pos: Int, formal: String) -> Int {
-  match peek(tokens, pos) {
-    TIdent(name) => if name == formal {
-      pos + 1
-    } else {
-      0 - 1
-    },
-    TLParen => {
-      let inner_end = impl_target_formal_end(tokens, pos + 1, formal)
-      if inner_end >= 0 {
-        match peek(tokens, inner_end) {
-          TRParen => inner_end + 1,
-          _ => 0 - 1
-        }
-      } else {
-        0 - 1
-      }
-    },
-    _ => 0 - 1
-  }
-}
-
-fn impl_target_args_match_formals(tokens: Array[Token], pos: Int, formals: Array[String]) -> Bool {
-  match peek(tokens, pos) {
-    TLBracket => {
-      let mut p = pos + 1
-      let mut i = 0
-      let mut valid = Array::length(formals) > 0
-      while valid && i < Array::length(formals) {
-        let arg_end = impl_target_formal_end(tokens, p, Array::get(formals, i))
-        if arg_end >= 0 {
-          p = arg_end
-        } else {
-          valid = false
-        }
-        if valid {
-          i = i + 1
-          if i < Array::length(formals) {
-            match peek(tokens, p) {
-              TComma => {
-                p = p + 1
-              },
-              _ => {
-                valid = false
-              }
-            }
-          } else {
-            ()
-          }
-        } else {
-          ()
-        }
-      }
-      if valid && i == Array::length(formals) {
-        match peek(tokens, p) {
-          TComma => {
-            p = p + 1
-          },
-          _ => ()
-        }
-      } else {
-        ()
-      }
-      valid && i == Array::length(formals) && match peek(tokens, p) {
-        TRBracket => true,
-        _ => false
-      }
-    },
-    _ => false
-  }
-}
-
 /// #829: collect the declared type-parameter NAMES of a `[T, U, ...]` header
 /// (returning ([], pos) when there is no bracket). Mirrors parse_enum_stmt's
 /// inline collector: only depth-1 identifiers in name position are kept, so a
@@ -2019,29 +1914,11 @@ fn parse_impl_stmt_with_binder_context(tokens: Array[Token], pos: Int, context: 
   match peek(tokens, after_tp) {
     TIdent(trait_name) => {
       let fp = expect_tk(tokens, after_tp + 1, "for")
-      match peek(tokens, fp) {
-        TIdent(type_name) => {
-          // #2262: SImpl records only the target constructor name. Silently
-          // dropping a concrete argument here widens `Array[Int]` to every
-          // `Array[T]`, allowing an Int-checked method body to run on values
-          // such as Array[String]. Only the exact `[T1, ..., Tn]` family shape
-          // is safe to erase until SImpl can retain target args.
-          match peek(tokens, fp + 1) {
-            TLBracket => if !impl_target_args_match_formals(tokens, fp + 1, type_params) {
-              throw(String::concat("concrete generic impl target `", String::concat(type_name, "[...]` is not supported; write a generic impl such as `impl [T] Trait for Type[T]`")))
-            } else {
-              ()
-            },
-            _ => ()
-          }
-          // Return the position at the impl body `{` (or the next token when
-          // the impl is body-less). The caller (parser.vibe) either expands the
-          // method block into `Type::method` let-bindings or skips it; this
-          // parser layer cannot reach `parse_expr` to parse method bodies.
-          let after_targs = skip_bracketed_args(tokens, fp + 1)
-          (SImpl(type_params, type_bounds, trait_name, type_name), after_targs)
-        },
-        _ => throw("expected type name after 'for'")
+      let (target, after_target) = parse_type_impl(tokens, fp, 0)
+      match target {
+        TyName(_) => (SImpl(type_params, type_bounds, trait_name, target), after_target),
+        TyApp(_, _) => (SImpl(type_params, type_bounds, trait_name, target), after_target),
+        _ => throw("an impl target must be a named type, such as `Int` or `Array[T]`")
       }
     },
     _ => throw("expected trait name after 'impl'")

--- a/lib/@vibe/parser/parser_smoke_test.vibe
+++ b/lib/@vibe/parser/parser_smoke_test.vibe
@@ -386,23 +386,18 @@ test "parse_program: `Exception` is accepted in both positions" {
   assert(Array::length(stmts) == 2)
 }
 
-test "#2262: generic impl targets must exactly mirror their formals" {
+test "#2335: impl targets preserve concrete, reordered, and generic arguments" {
   let accepted = parse_program(lex("trait M\nimpl [K, V] M for Map[K, V]"))
   assert(Array::length(accepted) == 2)
+  assert(String::contains(print_program(accepted), "impl [K, V] M for Map[K, V]"))
   let trailing = parse_program(lex("trait M\nimpl [T] M for Array[T,]"))
   assert(Array::length(trailing) == 2)
   let grouped = parse_program(lex("trait M\nimpl [T] M for Array[((T))]"))
   assert(Array::length(grouped) == 2)
-  let concrete = handle {
-    let _ = parse_program(lex("trait M\nimpl [U] M for Array[Int]"))
-    "OK"
-  } with { Exception::Throw(e) => e }
-  assert(String::contains(concrete, "concrete generic impl target `Array[...]` is not supported"))
-  let reordered = handle {
-    let _ = parse_program(lex("trait M\nimpl [K, V] M for Map[V, K]"))
-    "OK"
-  } with { Exception::Throw(e) => e }
-  assert(String::contains(reordered, "concrete generic impl target `Map[...]` is not supported"))
+  let concrete = parse_program(lex("trait M\nimpl M for Array[Int]"))
+  assert(String::contains(print_program(concrete), "impl M for Array[Int]"))
+  let reordered = parse_program(lex("trait M\nimpl [K, V] M for Map[V, K]"))
+  assert(String::contains(print_program(reordered), "impl [K, V] M for Map[V, K]"))
 }
 
 test "parse_program: an empty handler arm set is rejected (#1678)" {

--- a/lib/@vibe/parser/printer.vibe
+++ b/lib/@vibe/parser/printer.vibe
@@ -828,14 +828,14 @@ export fn print_stmt(s: Stmt) -> String {
         String::concat(head, String::concat(" {\n", String::concat(join(method_parts, ";\n"), "\n}")))
       }
     },
-    SImpl(tparams, tbounds, trait_name, type_name) => {
+    SImpl(tparams, tbounds, trait_name, target) => {
       let generic_header = print_bounded_type_params(tparams, tbounds)
       let head = if generic_header == "" {
         "impl "
       } else {
         String::concat("impl ", String::concat(generic_header, " "))
       }
-      String::concat(head, String::concat(trait_name, String::concat(" for ", type_name)))
+      String::concat(head, String::concat(trait_name, String::concat(" for ", print_type_expr(target))))
     },
     SExternLet(name, ty) => String::concat("extern let ", String::concat(name, String::concat(": ", print_type_expr(ty)))),
     SImport(path, items) => {

--- a/scripts/method_style_naming_allowlist.txt
+++ b/scripts/method_style_naming_allowlist.txt
@@ -29,6 +29,13 @@ lib/@vibe/core/index.vpkg	set_difference
 lib/@vibe/core/index.vpkg	set_intersect
 lib/@vibe/core/index.vpkg	set_union
 
+# --- @vibe/ast (TypeExpr compiler-internal canonical encoders)
+# These are representation helpers rather than user-facing UFCS operations.
+# Keeping the existing bare spelling also avoids presenting the encoding as a
+# stable TypeExpr method API.
+lib/@vibe/ast/index.vpkg	impl_target_head	compiler-internal AST representation helper
+lib/@vibe/ast/index.vpkg	impl_target_key	compiler-internal canonical encoding helper
+
 # --- @vibe/compiler/incremental (RippleDb)
 lib/@vibe/compiler/incremental/index.vpkg	ripple_eval_count
 lib/@vibe/compiler/incremental/index.vpkg	ripple_get_deps


### PR DESCRIPTION
## Summary

- retain complete impl target `TypeExpr` values through parsing, printing, contracts, imports, source merging, and persistent checked state
- match concrete and generic trait instances structurally, including reordered/repeated parameters and nested tuple/function targets
- give concrete applied impls collision-free method owners so distinct specializations dispatch their own checked bodies
- reject duplicate/overlapping targets deterministically with both targets in the diagnostic
- replace the #2262 parser stopgap and document the implemented syntax

This is stacked on #2333 while its required GitHub check remains queued without jobs. Rebase the base to `main` after #2333 merges.

## Validation

- `VIBE_STAGE2_WASM=... bash scripts/unit_test_runner.sh` — 1031/1031
- `bash scripts/check_typecheck_fixtures.sh` — 296 rows, 22 known debt
- `pkf run generation`
- `pkf run ensure-generated`
- formatter check for every changed `.vibe` / `.vpkg` file
- `git diff --check`

Closes #2335