### PR TITLE
Make parameterized traits semantically real

### DIFF
--- a/fixtures/parameterized_trait_distinct_witnesses_test.vibe
+++ b/fixtures/parameterized_trait_distinct_witnesses_test.vibe
@@ -1,0 +1,51 @@
+trait Value[A] {
+  value(Self) -> A;
+  choose(Self, A) -> A
+}
+
+struct Both {
+  number: Int;
+  text: String
+}
+
+impl Value[Int] for Both {
+  value(self: Both) -> Int {
+    self.number
+  }
+  choose(_self: Both, value: Int) -> Int {
+    value
+  }
+}
+
+impl Value[String] for Both {
+  value(self: Both) -> String {
+    self.text
+  }
+  choose(_self: Both, value: String) -> String {
+    value
+  }
+}
+
+fn int_value[T: Value[Int]](item: T) -> Int {
+  T::value(item)
+}
+
+fn string_value[T: Value[String]](item: T) -> String {
+  T::value(item)
+}
+
+fn int_choose[T: Value[Int]](item: T, value: Int) -> Int {
+  T::choose(item, value)
+}
+
+fn string_choose[T: Value[String]](item: T, value: String) -> String {
+  T::choose(item, value)
+}
+
+test "applied trait arguments select distinct witnesses" {
+  let both = Both::{ number: 42, text: "vibe" }
+  assert_eq(int_value(both), 42)
+  assert_eq(string_value(both), "vibe")
+  assert_eq(int_choose(both, 7), 7)
+  assert_eq(string_choose(both, "ok"), "ok")
+}

--- a/fixtures/parameterized_trait_generic_impl_test.vibe
+++ b/fixtures/parameterized_trait_generic_impl_test.vibe
@@ -1,0 +1,26 @@
+trait Value[A] {
+  value(Self) -> A
+}
+
+struct Box[T] {
+  value: T
+}
+
+impl [T] Value[T] for Box[T] {
+  value(self: Box[T]) -> T {
+    self.value
+  }
+}
+
+fn int_value[X: Value[Int]](item: X) -> Int {
+  X::value(item)
+}
+
+fn string_value[X: Value[String]](item: X) -> String {
+  X::value(item)
+}
+
+test "generic applied impls instantiate trait arguments" {
+  assert_eq(int_value(Box[Int]::{ value: 42 }), 42)
+  assert_eq(string_value(Box[String]::{ value: "vibe" }), "vibe")
+}

--- a/fixtures/parameterized_trait_import/dep.vibe
+++ b/fixtures/parameterized_trait_import/dep.vibe
@@ -1,0 +1,17 @@
+export trait Value[A] {
+  value(Self) -> A
+}
+
+export struct Box {
+  value: Int
+}
+
+impl Value[Int] for Box {
+  value(self: Box) -> Int {
+    self.value
+  }
+}
+
+export fn read_value[T: Value[Int]](item: T) -> Int {
+  T::value(item)
+}

--- a/fixtures/parameterized_trait_import/main_test.vibe
+++ b/fixtures/parameterized_trait_import/main_test.vibe
@@ -1,0 +1,15 @@
+import ./dep.vibe {
+  read_value, struct Box, trait Value as ImportedValue
+}
+
+fn read_imported_value[T: ImportedValue[Int]](item: T) -> Int {
+  T::value(item)
+}
+
+test "applied bounds survive exported interface transport" {
+  assert_eq(read_value(Box::{ value: 42 }), 42)
+}
+
+test "applied bounds survive an imported trait alias" {
+  assert_eq(read_imported_value(Box::{ value: 43 }), 43)
+}

--- a/lib/@vibe/ast/ast.vibe
+++ b/lib/@vibe/ast/ast.vibe
@@ -222,6 +222,43 @@ export fn impl_target_from_key(key: String) -> Option[TypeExpr] {
   }
 }
 
+let applied_trait_ref_prefix: String = "$trait$"
+
+/// Canonical storage for a trait reference in the legacy String-shaped AST
+/// slots. Bare names stay byte-for-byte compatible; applied references use an
+/// identifier-impossible prefix plus the reversible impl-target encoding.
+export fn trait_ref_key(reference: TypeExpr) -> String {
+  match reference {
+    TyName(name) => name,
+    TyApp(_, _) => String::concat(applied_trait_ref_prefix, impl_target_key(reference)),
+    _ => ""
+  }
+}
+
+export fn trait_ref_from_key(key: String) -> Option[TypeExpr] {
+  if String::starts_with(key, applied_trait_ref_prefix) {
+    impl_target_from_key(String::substring(key, String::length(applied_trait_ref_prefix), String::length(key)))
+  } else if key == "" {
+    None
+  } else {
+    Some(TyName(key))
+  }
+}
+
+export fn trait_ref_name(key: String) -> String {
+  match trait_ref_from_key(key) {
+    Some(reference) => impl_target_head(reference),
+    None => ""
+  }
+}
+
+export fn trait_ref_args(key: String) -> Array[TypeExpr] {
+  match trait_ref_from_key(key) {
+    Some(TyApp(_, args)) => args,
+    _ => []
+  }
+}
+
 export fn impl_applied_target_key(head: String, arg_keys: Array[String]) -> String {
   let mut out = String::concat("A", String::concat(impl_encode_name(head), "L"))
   let mut i = 0
@@ -241,7 +278,11 @@ export fn impl_method_owner(tparams: Array[String], trait_name: String, target: 
   let head = impl_target_head(target)
   match target {
     TyApp(_, _) => String::concat(head, String::concat("$impl$", String::concat(impl_encode_name(trait_name), String::concat("$", impl_target_key(target))))),
-    _ => head
+    _ => if Array::length(trait_ref_args(trait_name)) > 0 {
+      String::concat(head, String::concat("$impl$", String::concat(impl_encode_name(trait_name), String::concat("$", impl_target_key(target)))))
+    } else {
+      head
+    }
   }
 }
 

--- a/lib/@vibe/ast/index.vpkg
+++ b/lib/@vibe/ast/index.vpkg
@@ -43,6 +43,10 @@ export enum TypeExpr {
 fn impl_target_head(target: TypeExpr) -> String
 fn impl_target_key(target: TypeExpr) -> String
 fn impl_target_from_key(key: String) -> Option[TypeExpr]
+fn trait_ref_key(reference: TypeExpr) -> String
+fn trait_ref_from_key(key: String) -> Option[TypeExpr]
+fn trait_ref_name(key: String) -> String
+fn trait_ref_args(key: String) -> Array[TypeExpr]
 fn impl_applied_target_key(head: String, arg_keys: Array[String]) -> String
 fn impl_specialized_method_binding_name(head: String, trait_name: String, target_key: String, method: String) -> String
 fn impl_method_owner(tparams: Array[String], trait_name: String, target: TypeExpr) -> String

--- a/lib/@vibe/cache/cache.vibe
+++ b/lib/@vibe/cache/cache.vibe
@@ -156,7 +156,7 @@ export fn persistent_dep_list_cache_path(version_tag: String, path: String, sour
 }
 
 export fn persistent_type_env_cache_path(version_tag: String, fingerprint: String) -> String {
-  stable_cache_path(version_tag, "selfhost_type_env_v5", fingerprint, ".tsv")
+  stable_cache_path(version_tag, "selfhost_type_env_v6", fingerprint, ".tsv")
 }
 
 export fn build_source_groups_fingerprint(groups: Array[(String, Array[(String, String)])]) -> String {

--- a/lib/@vibe/compiler/cache/persistent_cache.vibe
+++ b/lib/@vibe/compiler/cache/persistent_cache.vibe
@@ -99,6 +99,8 @@ export ../../../../lib/@vibe/cache {
 ///    invalidates stale artifacts; no manual bump needed (#630). `vNN` is still a
 ///    manual knob for pure cache-FORMAT changes that don't change the source hash.
 fn persistent_cache_version_tag() -> String {
+  // v20: TypeEnv v6 admits semantic applied-trait bound keys. The namespace
+  // bump prevents pre-#2336 bare-name witness state from being reused.
   // v19: effective checked-Exception-row semantics are bound into module, leaf, and TDRE5 identities. All v18 typing entries cold-miss.
   // v18: TypeEnv v5 declaration-authority transport and TDRE4 reuse is production-default for CLI check-only. The global namespace makes every v4 and earlier declaration transport a cold miss.
   // v17: TDRE4 TypeEnv reuse is production-default for CLI check-only.
@@ -120,7 +122,7 @@ fn persistent_cache_version_tag() -> String {
   // (`.bin`, via Fs::write_bytes / Fs::read_bytes) — a cache FORMAT change, so
   // the manual `vNN` knob is bumped. Old `.hex` entries are now unreferenced
   // (different key + suffix) and reclaimable via `pkf run cache-clean` (#631).
-  String::concat("v19|cg-", codegen_fingerprint())
+  String::concat("v20|cg-", codegen_fingerprint())
 }
 
 /// Read-only trace evidence for the exact existing persistent cache identity.
@@ -153,18 +155,18 @@ export fn persistent_type_env_cache_path(fingerprint: String) -> String {
   cache_persistent_type_env_cache_path(persistent_cache_version_tag(), fingerprint)
 }
 
-/// TDRE5 typing-input aliases are deliberately separate from the TypeEnv-v5
+/// TDRE6 typing-input aliases are deliberately separate from the TypeEnv-v6
 /// artifact namespace and all earlier TDRE namespaces. The referenced TypeEnv
 /// remains in its conservative fingerprint-addressed cache entry.
 export fn persistent_typing_dependency_env_reuse_sidecar_path(typing_input_key: String) -> String {
-  cache_stable_text_cache_path(persistent_cache_version_tag(), "selfhost_typing_dependency_env_reuse_v5", typing_input_key)
+  cache_stable_text_cache_path(persistent_cache_version_tag(), "selfhost_typing_dependency_env_reuse_v6", typing_input_key)
 }
 
-/// TDRE5 eligibility witnesses are isolated from prior marker formats and keyed
+/// TDRE6 eligibility witnesses are isolated from prior marker formats and keyed
 /// by the ordinary conservative module fingerprint. Their strict envelope also
-/// binds the logical input and exact canonical target TypeEnv-v5 text.
+/// binds the logical input and exact canonical target TypeEnv-v6 text.
 export fn persistent_typing_dependency_env_reuse_eligibility_path(fingerprint: String) -> String {
-  cache_stable_text_cache_path(persistent_cache_version_tag(), "selfhost_typing_dependency_env_reuse_eligibility_v5", fingerprint)
+  cache_stable_text_cache_path(persistent_cache_version_tag(), "selfhost_typing_dependency_env_reuse_eligibility_v6", fingerprint)
 }
 
 export fn persistent_source_list_cache_path(entry_path: String) -> String {

--- a/lib/@vibe/compiler/checker/artifacts/checked_exported_interface_artifact.vibe
+++ b/lib/@vibe/compiler/checker/artifacts/checked_exported_interface_artifact.vibe
@@ -753,7 +753,7 @@ export fn canonical_checked_exported_interface_artifact_snapshot(artifact: Check
 
 /// Stable compact fingerprint of the versioned opaque payload. It is a
 /// shadow-only comparison token and is deliberately not wired into any cache,
-/// production reuse, interface-v2, TypeEnv-v5, trace, or planner path.
+/// production reuse, interface-v3, TypeEnv-v6, trace, or planner path.
 export fn checked_exported_interface_artifact_fingerprint_v1(artifact: CheckedExportedInterfaceArtifact) -> String {
   compact_string_fingerprint(encode_checked_exported_interface_artifact_v1(artifact))
 }

--- a/lib/@vibe/compiler/checker/artifacts/index.vpkg
+++ b/lib/@vibe/compiler/checker/artifacts/index.vpkg
@@ -81,7 +81,7 @@ fn checked_module_typing_artifact_fingerprint_v2(artifact: CheckedModuleTypingAr
 // --- checked_exported_interface_artifact.vibe
 // Shadow-only complete-or-none exported declaration surface from retained
 // successful CheckedProgram data. It is not a cache/reuse input, interface-v2,
-// TypeEnv-v5 transport, artifact-input trace, or planner decision. Exported
+// TypeEnv-v6 transport, artifact-input trace, or planner decision. Exported
 // nested values fail closed because CheckedProgram retains no nested TypeEnv.
 opaque type CheckedExportedInterfaceArtifact
 fn checked_exported_interface_artifact_from_checked_program(checked: CheckedProgram) -> Option[CheckedExportedInterfaceArtifact]

--- a/lib/@vibe/compiler/checker/canonical_checked_type_state.vibe
+++ b/lib/@vibe/compiler/checker/canonical_checked_type_state.vibe
@@ -487,7 +487,7 @@ export fn canonical_effective_value_env_snapshot(env: TypeEnv, s: Subst) -> Stri
   let bindings = canonical_sorted_bindings(canonical_collect_effective_bindings(env))
   let free_ids = array_empty()
   let free_names = array_empty()
-  let fields = ["v1"]
+  let fields = ["v2"]
   let mut i = 0
   while i < Array::length(bindings) {
     let (name, ty) = Array::get(bindings, i)
@@ -650,7 +650,7 @@ fn canonical_trait_impl_gen_entry(trait_name: String, params: Array[String], bou
 /// EnvFlat and EnvEmpty terminate traversal; trait definitions, values, cache
 /// payloads, and all other CheckedProgram state are excluded.
 export fn canonical_retained_trait_impl_entries_snapshot(env: TypeEnv, s: Subst) -> String {
-  let fields = ["v2"]
+  let fields = ["v3"]
   let free_ids = array_empty()
   let free_names = array_empty()
   let mut cur = env
@@ -795,7 +795,7 @@ fn canonical_retained_trait_method_gens_entry(trait_name: String, methods: Array
 /// This is not source interface identity, trace schema, cache key, or reuse
 /// decision. EnvFlat and EnvEmpty terminate traversal.
 export fn canonical_retained_trait_method_gens_snapshot(env: TypeEnv) -> String {
-  let fields = ["v1"]
+  let fields = ["v2"]
   let mut cur = env
   let mut done = false
   while !done {

--- a/lib/@vibe/compiler/checker/checker.vibe
+++ b/lib/@vibe/compiler/checker/checker.vibe
@@ -39,6 +39,7 @@ import @vibe/compiler/core {
   subst_apply_except,
   subst_bounds_for,
   subst_lookup,
+  trait_decl_params,
   trait_method_sig_binders_deep,
   type_constructor_name,
   type_implements_trait,
@@ -48,7 +49,11 @@ import @vibe/compiler/core {
 }
 
 import @vibe/ast {
-  impl_method_owner_head
+  impl_method_owner_head, trait_ref_args, trait_ref_from_key, trait_ref_name
+}
+
+import @vibe/parser {
+  print_type_expr
 }
 
 import ./builtins.vibe {
@@ -1101,6 +1106,68 @@ fn relax_unknown_named(ty: Type, defs: Array[TypeDef]) -> Type {
   }
 }
 
+fn replace_trait_bound_vars_from_env(ty: Type, env: TypeEnv) -> Type {
+  match ty {
+    CtNamed(name, args) => if Array::length(args) == 0 {
+      match env_lookup(env, name) {
+        Some(CtVar(id)) => CtVar(id),
+        _ => ty
+      }
+    } else {
+      CtNamed(name, for arg in args {
+        replace_trait_bound_vars_from_env(arg, env)
+      })
+    },
+    CtArray(elem) => CtArray(replace_trait_bound_vars_from_env(elem, env)),
+    CtOption(elem) => CtOption(replace_trait_bound_vars_from_env(elem, env)),
+    CtTuple(items) => CtTuple(for item in items {
+      replace_trait_bound_vars_from_env(item, env)
+    }),
+    CtFn(params, ret, effect) => CtFn(for param in params {
+      replace_trait_bound_vars_from_env(param, env)
+    }, replace_trait_bound_vars_from_env(ret, env), effect),
+    _ => ty
+  }
+}
+
+fn resolve_trait_bound_args(args: Array[TypeExpr], env: TypeEnv, defs: Array[TypeDef]) -> Array[Type] {
+  for arg in args {
+    replace_trait_bound_vars_from_env(resolve_type_expr(arg, defs), env)
+  }
+}
+
+fn trait_bound_param_names(binders: Array[String], count: Int) -> Array[String] {
+  let out = array_empty()
+  let mut i = 0
+  while i < count && i < Array::length(binders) {
+    Array::push(out, Array::get(binders, i))
+    i = i + 1
+  }
+  out
+}
+
+export fn trait_reference_display(key: String) -> String {
+  match trait_ref_from_key(key) {
+    Some(reference) => print_type_expr(reference),
+    None => key
+  }
+}
+
+export fn validate_trait_reference(env: TypeEnv, key: String, context: String, errors: Array[String]) -> Unit {
+  let display = trait_reference_display(key)
+  let args = trait_ref_args(key)
+  match trait_decl_params(env, key) {
+    Some(params) => if Array::length(args) > 0 && Array::length(args) != Array::length(params) {
+      let counts = String::concat(__to_string(Array::length(params)), String::concat(" type argument(s), got ", __to_string(Array::length(args))))
+      let site = String::concat(" in ", String::concat(context, String::concat(" `", String::concat(display, "`"))))
+      Array::push(errors, String::concat("trait `", String::concat(trait_ref_name(key), String::concat("` expects ", String::concat(counts, site)))))
+    } else {
+      ()
+    },
+    None => ()
+  }
+}
+
 /// Resolve a qualified identifier `T::method` where `T` is a bounded generic
 /// type parameter (`[T: Trait]`). If the head resolves to a type variable whose
 /// recorded bounds include a trait declaring `method`, return that method's
@@ -1127,7 +1194,9 @@ fn resolve_trait_method_ident(name: String, env: TypeEnv, defs: Array[TypeDef], 
               _ => false
             }
             if pending {
-              let trait_name = Array::get(bounds, bi)
+              let trait_key = Array::get(bounds, bi)
+              let trait_name = trait_ref_name(trait_key)
+              let trait_args = trait_ref_args(trait_key)
               match trait_method_sig_binders_deep(env, trait_name, method) {
                 Some(sig) => {
                   // #1512: the trait header's params and the method's own
@@ -1135,10 +1204,12 @@ fn resolve_trait_method_ident(name: String, env: TypeEnv, defs: Array[TypeDef], 
                   // otherwise `import { Hue as T }` captures the `T` of
                   // `trait Boxed[T] { unwrap(Self) -> T }`.
                   let (params_te, ret_te, binders) = sig
+                  let param_names = trait_bound_param_names(binders, Array::length(trait_args))
+                  let resolved_trait_args = resolve_trait_bound_args(trait_args, env, defs)
                   let resolved_params = for pte in params_te {
-                    relax_unknown_named(subst_self_in_type(resolve_type_expr_shadowed(pte, defs, binders), self_ty), defs)
+                    relax_unknown_named(subst_type_params(subst_self_in_type(resolve_type_expr_shadowed(pte, defs, binders), self_ty), param_names, resolved_trait_args), defs)
                   }
-                  let resolved_ret = relax_unknown_named(subst_self_in_type(resolve_type_expr_shadowed(ret_te, defs, binders), self_ty), defs)
+                  let resolved_ret = relax_unknown_named(subst_type_params(subst_self_in_type(resolve_type_expr_shadowed(ret_te, defs, binders), self_ty), param_names, resolved_trait_args), defs)
                   result = Some(CtFn(resolved_params, resolved_ret, None))
                 },
                 None => ()
@@ -9918,10 +9989,10 @@ fn check_expr_capture_impl(expr: Expr, env: TypeEnv, defs: Array[TypeDef], s: Su
         let mut rbi = 0
         while rbi < Array::length(declared_bounds) {
           let bound = Array::get(declared_bounds, rbi)
-          if env_has_reexport_surface_binding(env, bound) {
-            Array::push(errors, String::concat("unknown trait: ", bound))
+          if env_has_reexport_surface_binding(env, trait_ref_name(bound)) {
+            Array::push(errors, String::concat("unknown trait: ", trait_reference_display(bound)))
           } else {
-            ()
+            validate_trait_reference(env, bound, "bound", errors)
           }
           rbi = rbi + 1
         }

--- a/lib/@vibe/compiler/checker/checker_stmt.vibe
+++ b/lib/@vibe/compiler/checker/checker_stmt.vibe
@@ -84,8 +84,14 @@ import ./checker.vibe {
   report_unknown_type_names,
   report_unknown_type_names_deferred_validation,
   trait_erased_type_param_env,
+  trait_reference_display,
   typed_occurrence_capture_begin_statement,
-  typed_occurrence_capture_end_statement
+  typed_occurrence_capture_end_statement,
+  validate_trait_reference
+}
+
+import @vibe/ast {
+  trait_ref_name
 }
 
 import ./checked_expression_structure_core.vibe {
@@ -2834,6 +2840,7 @@ fn check_stmts_with_binders(raw_stmts: Array[Stmt], i: Int, env: TypeEnv, defs: 
         (EnvTraitDef(name, supers, is_open, methods, env, tparams, method_gens), s, c)
       },
       SImpl(tparams, tbounds, trait_name, target_expr) => {
+        validate_trait_reference(env, trait_name, "impl head", errors)
         let type_name = match target_expr {
           TyName(name) => name,
           TyApp(name, _) => name,
@@ -2841,7 +2848,7 @@ fn check_stmts_with_binders(raw_stmts: Array[Stmt], i: Int, env: TypeEnv, defs: 
         }
         // ADR-0068: `Send` is compiler-judged (structural); user impls
         // would let a non-sendable type cross task/channel boundaries.
-        if trait_name == "Send" {
+        if trait_ref_name(trait_name) == "Send" {
           Array::push(errors, "`Send` is a compiler-judged structural marker and cannot be implemented; remove `impl Send`")
         } else {
           ()
@@ -2881,7 +2888,7 @@ fn check_stmts_with_binders(raw_stmts: Array[Stmt], i: Int, env: TypeEnv, defs: 
         }
         let target = resolve_type_expr_shadowed(target_expr, defs, tparams)
         match overlapping_impl_target_for(env, trait_name, tparams, target) {
-          Some(existing_target) => Array::push(errors, String::concat("overlapping impls for `", String::concat(trait_name, String::concat("`: existing target `", String::concat(type_to_string(existing_target), String::concat("` overlaps new target `", String::concat(type_to_string(target), "`"))))))),
+          Some(existing_target) => Array::push(errors, String::concat("overlapping impls for `", String::concat(trait_reference_display(trait_name), String::concat("`: existing target `", String::concat(type_to_string(existing_target), String::concat("` overlaps new target `", String::concat(type_to_string(target), "`"))))))),
           None => ()
         }
         // A generic impl `impl [T] Trait for C[T]` (type parameters present) is
@@ -3076,7 +3083,8 @@ fn check_stmts_with_binders(raw_stmts: Array[Stmt], i: Int, env: TypeEnv, defs: 
 /// when "no impl" is the whole truth.
 fn unsatisfied_bound_hint(env: TypeEnv, trait_name: String, resolved: Type) -> String {
   if trait_impl_declared_for_ctor(env, trait_name, resolved) && trait_is_marker(env, trait_name) {
-    String::concat(": an `impl ", String::concat(trait_name, String::concat(" for ", String::concat(type_constructor_name(resolved), String::concat("` IS declared, but `", String::concat(trait_name, String::concat("` is a marker trait (declared with no methods) so it dispatches to the builtin `==` / `<`, and those are REFERENCE equality on `Array` / `Bytes` -- honouring the impl would make the comparison silently wrong. Give `", String::concat(trait_name, "` at least one method so the impl dispatches through the witness dictionary, or drop the bound"))))))))
+    let display = trait_reference_display(trait_name)
+    String::concat(": an `impl ", String::concat(display, String::concat(" for ", String::concat(type_constructor_name(resolved), String::concat("` IS declared, but `", String::concat(display, String::concat("` is a marker trait (declared with no methods) so it dispatches to the builtin `==` / `<`, and those are REFERENCE equality on `Array` / `Bytes` -- honouring the impl would make the comparison silently wrong. Give `", String::concat(display, "` at least one method so the impl dispatches through the witness dictionary, or drop the bound"))))))))
   } else {
     ""
   }
@@ -3122,7 +3130,7 @@ fn check_program_bounds(env: TypeEnv, s: Subst, defs: Array[TypeDef], errors: Ar
             type_implements_trait(env, s, resolved, b)
           }
           if b != "" && not(sat) {
-            Array::push(errors, String::concat("no impl `", String::concat(b, String::concat("` for `", String::concat(type_to_string(resolved), String::concat("`", unsatisfied_bound_hint(env, b, resolved)))))))
+            Array::push(errors, String::concat("no impl `", String::concat(trait_reference_display(b), String::concat("` for `", String::concat(type_to_string(resolved), String::concat("`", unsatisfied_bound_hint(env, b, resolved)))))))
           }
           bi = bi + 1
         }

--- a/lib/@vibe/compiler/checker/index.vpkg
+++ b/lib/@vibe/compiler/checker/index.vpkg
@@ -132,6 +132,8 @@ fn lookup_io(name: String) -> Option[Type]
 
 // --- checker.vibe
 fn attach_unlocated_decl_name_marker(errors: Array[String], from: Int, name: String) -> Unit
+fn trait_reference_display(key: String) -> String
+fn validate_trait_reference(env: TypeEnv, key: String, context: String, errors: Array[String]) -> Unit
 fn check_assignable(expected: Type, actual: Type, s: Subst, errors: Array[String], what: String, off: Int) -> Subst
 fn detect_narrowed_generic_mismatch(expected: Type, actual: Type, s: Subst, errors: Array[String], what: String, off: Int) -> Subst
 fn preserve_generic_instantiation(resolved: Type, actual: Type) -> Type

--- a/lib/@vibe/compiler/core/import_alias_rewrite.vibe
+++ b/lib/@vibe/compiler/core/import_alias_rewrite.vibe
@@ -9,7 +9,7 @@ import @vibe/core {
 }
 
 import @vibe/ast {
-  impl_method_owner
+  impl_method_owner, trait_ref_from_key, trait_ref_key
 }
 
 import ./module_graph_path.vibe {
@@ -577,6 +577,25 @@ fn rewrite_alias_type_opt(ty: Option[TypeExpr], am: AliasIdx) -> Option[TypeExpr
   }
 }
 
+fn rewrite_alias_trait_ref(trait_ref: String, am: AliasIdx) -> String {
+  match trait_ref_from_key(trait_ref) {
+    Some(applied) => trait_ref_key(rewrite_alias_type_expr(applied, am)),
+    None => match MutMap::get(am.idx, trait_ref) {
+      Some(original) => original,
+      None => trait_ref
+    }
+  }
+}
+
+fn rewrite_alias_bounds(bounds: Array[(String, Array[String])], am: AliasIdx) -> Array[(String, Array[String])] {
+  for bound in bounds {
+    let (param, traits) = bound
+    (param, for trait_ref in traits {
+      rewrite_alias_trait_ref(trait_ref, am)
+    })
+  }
+}
+
 fn rewrite_alias_param_types(params: Array[(String, Option[TypeExpr])], am: AliasIdx) -> Array[(String, Option[TypeExpr])] {
   for param in params {
     let (name, ty) = param
@@ -666,7 +685,7 @@ fn rewrite_alias_expr_ix(expr: Expr, am: AliasIdx) -> Expr {
         // namespaces while canonicalizing imported contract aliases in fn
         // parameter and return annotations (#1539 StdinStream as S).
         let type_am = aliasidx_without_names(am, type_params)
-        EFn(type_params, bounds, rewrite_alias_param_types(params, type_am), rewrite_alias_type_opt(ret_ty, type_am), effect, rewrite_alias_expr_ix(body, aliasidx_without_params(am, params)))
+        EFn(type_params, rewrite_alias_bounds(bounds, type_am), rewrite_alias_param_types(params, type_am), rewrite_alias_type_opt(ret_ty, type_am), effect, rewrite_alias_expr_ix(body, aliasidx_without_params(am, params)))
       },
       // #897: `mod.x` written against a qualified-import namespace (`import
       // ... as mod only { x }`) is encoded as the alias key "mod.x" -- see
@@ -796,9 +815,11 @@ fn collect_impl_method_owner_aliases(stmts: Array[Stmt], aliases: Array[(String,
   while i < Array::length(stmts) {
     match Array::get(stmts, i) {
       SImpl(tparams, _, trait_name, target) => {
-        let rewritten_target = rewrite_alias_type_expr(target, aliasidx_without_names(am, tparams))
+        let type_am = aliasidx_without_names(am, tparams)
+        let rewritten_trait = rewrite_alias_trait_ref(trait_name, type_am)
+        let rewritten_target = rewrite_alias_type_expr(target, type_am)
         let source_owner = impl_method_owner(tparams, trait_name, target)
-        let rewritten_owner = impl_method_owner(tparams, trait_name, rewritten_target)
+        let rewritten_owner = impl_method_owner(tparams, rewritten_trait, rewritten_target)
         if source_owner != rewritten_owner {
           Array::push(out, (source_owner, rewritten_owner))
         } else {
@@ -1021,7 +1042,10 @@ fn rewrite_alias_stmt_ix(stmt: Stmt, am: AliasIdx) -> Stmt {
     // rewrite at all) and is tracked separately -- what this guard buys is that
     // the rewrite is not a SECOND, independent source of the same bug.
     STypeAlias(exported, name, params, target) => STypeAlias(exported, name, params, rewrite_alias_type_expr(target, aliasidx_without_names(am, params))),
-    SImpl(tparams, bounds, trait_name, target) => SImpl(tparams, bounds, trait_name, rewrite_alias_type_expr(target, aliasidx_without_names(am, tparams))),
+    SImpl(tparams, bounds, trait_name, target) => {
+      let type_am = aliasidx_without_names(am, tparams)
+      SImpl(tparams, rewrite_alias_bounds(bounds, type_am), rewrite_alias_trait_ref(trait_name, type_am), rewrite_alias_type_expr(target, type_am))
+    },
     _ => stmt
   }
 }

--- a/lib/@vibe/compiler/core/index.vpkg
+++ b/lib/@vibe/compiler/core/index.vpkg
@@ -241,6 +241,7 @@ fn hkt_apply_ctor(head: Type, args: Array[Type]) -> Type
 // rebuild is pure waste and, on a merged program, quadratic.
 fn subst_resolves_to_double(s: Subst, ty: Type) -> Bool
 fn trait_defined(env: TypeEnv, name: String) -> Bool
+fn trait_decl_params(env: TypeEnv, name: String) -> Option[Array[String]]
 fn type_to_string(ty: Type) -> String
 fn env_lookup_flat(bindings: Array[(String, Type)], name: String) -> Option[Type]
 fn compiler_owned_type_arity(name: String) -> Option[Int]

--- a/lib/@vibe/compiler/core/types.vibe
+++ b/lib/@vibe/compiler/core/types.vibe
@@ -4,6 +4,10 @@ import ./ast.vibe {
   TypeExpr
 }
 
+import @vibe/ast {
+  trait_ref_from_key, trait_ref_name
+}
+
 import ./exception_effect.vibe {
   exception_label_kind, is_exception_label
 }
@@ -1156,7 +1160,7 @@ export fn trait_supers(env: TypeEnv, name: String) -> Array[String] {
   match env {
     EnvEmpty => empty,
     EnvBind(_, _, rest) => trait_supers(rest, name),
-    EnvTraitDef(tname, supers, _, _, rest, _, _) => if tname == name {
+    EnvTraitDef(tname, supers, _, _, rest, _, _) => if tname == trait_ref_name(name) {
       supers
     } else trait_supers(rest, name),
     EnvTraitImpl(_, _, rest) => trait_supers(rest, name),
@@ -1210,7 +1214,7 @@ export fn trait_method_sig_binders(env: TypeEnv, trait_name: String, method_name
   match env {
     EnvEmpty => None,
     EnvBind(_, _, rest) => trait_method_sig_binders(rest, trait_name, method_name),
-    EnvTraitDef(tname, _, _, methods, rest, tparams, method_gens) => if tname == trait_name {
+    EnvTraitDef(tname, _, _, methods, rest, tparams, method_gens) => if tname == trait_ref_name(trait_name) {
       let mlen = Array::length(methods)
       let mut i = 0
       let mut found = None
@@ -1795,7 +1799,7 @@ export fn trait_defined(env: TypeEnv, name: String) -> Bool {
   match env {
     EnvEmpty => false,
     EnvBind(_, _, rest) => trait_defined(rest, name),
-    EnvTraitDef(tname, _, _, _, rest, _, _) => if tname == name {
+    EnvTraitDef(tname, _, _, _, rest, _, _) => if tname == trait_ref_name(name) {
       true
     } else trait_defined(rest, name),
     EnvTraitImpl(_, _, rest) => trait_defined(rest, name),
@@ -1804,6 +1808,24 @@ export fn trait_defined(env: TypeEnv, name: String) -> Bool {
     EnvTypeDefs(_, _, rest) => trait_defined(rest, name),
     EnvFlat(_) => false,
     EnvCached(_, _, rest) => trait_defined(rest, name)
+  }
+}
+
+export fn trait_decl_params(env: TypeEnv, name: String) -> Option[Array[String]] {
+  match env {
+    EnvEmpty => None,
+    EnvBind(_, _, rest) => trait_decl_params(rest, name),
+    EnvTraitDef(tname, _, _, _, rest, params, _) => if tname == trait_ref_name(name) {
+      Some(params)
+    } else {
+      trait_decl_params(rest, name)
+    },
+    EnvTraitImpl(_, _, rest) => trait_decl_params(rest, name),
+    EnvMutCell(_, _, rest) => trait_decl_params(rest, name),
+    EnvTraitImplGen(_, _, _, _, rest) => trait_decl_params(rest, name),
+    EnvTypeDefs(_, _, rest) => trait_decl_params(rest, name),
+    EnvFlat(_) => None,
+    EnvCached(_, _, rest) => trait_decl_params(rest, name)
   }
 }
 
@@ -3622,6 +3644,37 @@ fn impl_target_patterns_overlap(left_params: Array[String], left_target: Type, r
   }
 }
 
+/// Decide coherence over the trait application and target as one pattern.
+/// The same impl binder can occur in both halves (`impl [T] Value[T] for
+/// Box[T]`), so freshening and unification must share one substitution rather
+/// than comparing the trait arguments and target independently.
+fn impl_trait_and_target_patterns_overlap(left_trait: String, left_params: Array[String], left_target: Type, right_trait: String, right_params: Array[String], right_target: Type) -> Bool {
+  if trait_ref_name(left_trait) != trait_ref_name(right_trait) {
+    false
+  } else match (trait_ref_from_key(left_trait), trait_ref_from_key(right_trait)) {
+    (Some(left_ref), Some(right_ref)) => {
+      let left_pattern = CtTuple([
+        trait_ref_type_expr_type(left_ref),
+        left_target
+      ])
+      let right_pattern = CtTuple([
+        trait_ref_type_expr_type(right_ref),
+        right_target
+      ])
+      let left = freshen_impl_pattern(left_pattern, left_params, 100000000)
+      let right = freshen_impl_pattern(right_pattern, right_params, 200000000)
+      match unify_impl_patterns_exact(left, right, SubstEmpty) {
+        Some(_) => true,
+        None => false
+      }
+    },
+    // A bare parameterized trait spelling is the compatibility form that
+    // denotes the whole trait family. Its target therefore remains the only
+    // coherence discriminator when paired with an applied spelling.
+    _ => impl_target_patterns_overlap(left_params, left_target, right_params, right_target)
+  }
+}
+
 /// Return the first existing target whose instance set intersects the new
 /// target. TypeEnv is newest-first, so this is deterministic for a fixed
 /// source order and gives the checker both candidate targets for its error.
@@ -3636,17 +3689,17 @@ export fn overlapping_impl_target_for(env: TypeEnv, trait_name: String, new_para
     // @vibe/builtin bound-only declaration) without treating their mirrored
     // primitive impl declarations as source duplicates. Impl nodes belonging
     // to the current declaration are always above this boundary.
-    EnvTraitDef(name, _, _, _, rest, _, _) => if name == trait_name {
+    EnvTraitDef(name, _, _, _, rest, _, _) => if name == trait_ref_name(trait_name) {
       None
     } else {
       overlapping_impl_target_for(rest, trait_name, new_params, new_target)
     },
-    EnvTraitImpl(tname, target, rest) => if tname == trait_name && impl_target_patterns_overlap(array_empty(), target, new_params, new_target) {
+    EnvTraitImpl(tname, target, rest) => if impl_trait_and_target_patterns_overlap(tname, array_empty(), target, trait_name, new_params, new_target) {
       Some(target)
     } else {
       overlapping_impl_target_for(rest, trait_name, new_params, new_target)
     },
-    EnvTraitImplGen(tname, params, _, target, rest) => if tname == trait_name && impl_target_patterns_overlap(params, target, new_params, new_target) {
+    EnvTraitImplGen(tname, params, _, target, rest) => if impl_trait_and_target_patterns_overlap(tname, params, target, trait_name, new_params, new_target) {
       Some(target)
     } else {
       overlapping_impl_target_for(rest, trait_name, new_params, new_target)
@@ -3889,7 +3942,7 @@ fn trait_is_method_bearing(env: TypeEnv, trait_name: String) -> Bool {
   match env {
     EnvEmpty => false,
     EnvBind(_, _, rest) => trait_is_method_bearing(rest, trait_name),
-    EnvTraitDef(tname, _, _, methods, rest, _, _) => if tname == trait_name {
+    EnvTraitDef(tname, _, _, methods, rest, _, _) => if tname == trait_ref_name(trait_name) {
       Array::length(methods) > 0
     } else trait_is_method_bearing(rest, trait_name),
     EnvTraitImpl(_, _, rest) => trait_is_method_bearing(rest, trait_name),
@@ -4016,6 +4069,52 @@ fn generic_target_match(template: Type, actual: Type, tparams: Array[String], ar
   }
 }
 
+fn trait_ref_type_expr_type(expr: TypeExpr) -> Type {
+  match expr {
+    TyName(name) => match resolve_builtin(name) {
+      Some(ty) => ty,
+      None => CtNamed(name, array_empty())
+    },
+    TyApp(name, args) => {
+      let resolved = for arg in args {
+        trait_ref_type_expr_type(arg)
+      }
+      if name == "Array" && Array::length(resolved) == 1 {
+        CtArray(Array::get(resolved, 0))
+      } else if name == "Option" && Array::length(resolved) == 1 {
+        CtOption(Array::get(resolved, 0))
+      } else {
+        CtNamed(name, resolved)
+      }
+    },
+    TyTuple(items) => CtTuple(for item in items {
+      trait_ref_type_expr_type(item)
+    }),
+    TyFn(params, ret, effect) => CtFn(for param in params {
+      trait_ref_type_expr_type(param)
+    }, trait_ref_type_expr_type(ret), effect),
+    TyUnit => CtUnit
+  }
+}
+
+fn generic_trait_ref_matches(template_key: String, actual_key: String, tparams: Array[String], args: Array[Type]) -> Bool {
+  if template_key == actual_key {
+    true
+  } else {
+    match trait_ref_from_key(template_key) {
+      Some(template) => match trait_ref_from_key(actual_key) {
+        Some(actual) => if trait_ref_name(template_key) == trait_ref_name(actual_key) {
+          generic_target_match(trait_ref_type_expr_type(template), trait_ref_type_expr_type(actual), tparams, args)
+        } else {
+          false
+        },
+        None => false
+      },
+      None => false
+    }
+  }
+}
+
 /// Match the retained impl target against one concrete use and return its type
 /// arguments in impl-binder order. Reordered targets such as `Pair[V, K]`
 /// therefore bind V to the first concrete slot and K to the second instead of
@@ -4074,10 +4173,10 @@ fn generic_impl_satisfies(scan: TypeEnv, full: TypeEnv, s: Subst, trait_name: St
     EnvMutCell(_, _, rest) => generic_impl_satisfies(rest, full, s, trait_name, resolved),
     EnvTraitImplGen(itrait, tparams, bounds, target, rest) => {
       let head = type_constructor_name(resolved)
-      let shape_ok = itrait == trait_name && head != "" && type_constructor_name(target) == head && trait_is_method_bearing(full, trait_name)
+      let shape_ok = head != "" && type_constructor_name(target) == head && trait_is_method_bearing(full, trait_name)
       if shape_ok {
         match generic_target_args(tparams, target, resolved) {
-          Some(args) => if generic_bounds_hold(full, s, tparams, bounds, args) {
+          Some(args) => if generic_trait_ref_matches(itrait, trait_name, tparams, args) && generic_bounds_hold(full, s, tparams, bounds, args) {
             true
           } else {
             generic_impl_satisfies(rest, full, s, trait_name, resolved)

--- a/lib/@vibe/compiler/normalize/desugar_trait_dict.vibe
+++ b/lib/@vibe/compiler/normalize/desugar_trait_dict.vibe
@@ -19,7 +19,14 @@ import @vibe/compiler/core {
 }
 
 import @vibe/ast {
-  impl_applied_target_key, impl_method_owner, impl_specialized_method_binding_name, impl_target_from_key, impl_target_head, impl_target_key
+  impl_applied_target_key,
+  impl_method_owner,
+  impl_specialized_method_binding_name,
+  impl_target_from_key,
+  impl_target_head,
+  impl_target_key,
+  trait_ref_from_key,
+  trait_ref_name
 }
 
 import @vibe/core {
@@ -302,7 +309,7 @@ fn split_qualified(name: String) -> Option[(String, String)] {
 
 /// The dict struct name for a trait, e.g. `Measurable` -> `MeasurableDict`.
 fn dict_struct_name(trait_name: String) -> String {
-  String::concat(trait_name, "Dict")
+  String::concat(trait_ref_name(trait_name), "Dict")
 }
 
 /// #2286: which dict structs THIS program's desugar actually synthesized, and
@@ -361,7 +368,14 @@ export fn synthesized_dict_field_trait(struct_name: String, field_name: String) 
 
 /// The hidden dict parameter name for `[T: Tr]`, e.g. `__dict_Measurable_T`.
 fn dict_param_name(trait_name: String, tparam: String) -> String {
-  String::concat("__dict_", String::concat(trait_name, String::concat("_", tparam)))
+  let applied = match trait_ref_from_key(trait_name) {
+    Some(reference) => match reference {
+      TyApp(_, _) => String::concat("_", impl_target_key(reference)),
+      _ => ""
+    },
+    None => ""
+  }
+  String::concat("__dict_", String::concat(trait_ref_name(trait_name), String::concat(applied, String::concat("_", tparam))))
 }
 
 /// Collect method-bearing traits (name -> signatures). Marker-only traits
@@ -528,7 +542,7 @@ fn lookup_method_gen(table: Array[(String, Array[(String, Array[String], Array[(
   let mut result = None
   while i < Array::length(table) {
     let (tn, gens) = Array::get(table, i)
-    if tn == trait_name {
+    if tn == trait_ref_name(trait_name) {
       let mut j = 0
       while j < Array::length(gens) {
         let (mname, tps, bounds) = Array::get(gens, j)
@@ -1030,7 +1044,7 @@ fn lookup_supers(supers_map: Array[(String, Array[String])], name: String) -> Ar
   let mut result = empty_str_array()
   while i < Array::length(supers_map) {
     let (tname, supers) = Array::get(supers_map, i)
-    if tname == name {
+    if tname == trait_ref_name(name) {
       result = supers
       i = Array::length(supers_map)
     } else {
@@ -1134,7 +1148,7 @@ fn lookup_trait_sigs(traits: Array[(String, Array[(String, Array[TypeExpr], Type
   let mut result = None
   while i < Array::length(traits) {
     let (tname, sigs) = Array::get(traits, i)
-    if tname == name {
+    if tname == trait_ref_name(name) {
       result = Some(sigs)
       i = Array::length(traits)
     } else {
@@ -2476,6 +2490,22 @@ fn generic_impl_target_is_total(target: TypeExpr, params: Array[String]) -> Bool
   }
 }
 
+fn impl_trait_pattern_matches(template_key: String, actual_key: String, params: Array[String], bindings: Array[(String, TypeExpr)]) -> Bool {
+  if template_key == actual_key {
+    true
+  } else if trait_ref_name(template_key) != trait_ref_name(actual_key) {
+    false
+  } else {
+    match trait_ref_from_key(template_key) {
+      Some(template) => match trait_ref_from_key(actual_key) {
+        Some(actual) => impl_target_pattern_matches(template, actual, params, bindings),
+        None => false
+      },
+      None => false
+    }
+  }
+}
+
 fn matching_generic_impl_method(gens: Array[DictGen], cname: String, trait_name: String, method: String, actual: TypeExpr) -> Option[String] {
   let mut i = 0
   let mut result = None
@@ -2484,17 +2514,17 @@ fn matching_generic_impl_method(gens: Array[DictGen], cname: String, trait_name:
   while i < Array::length(gens) {
     let gen = Array::get(gens, i)
     let bindings = []
-    if gen.impl_trait == trait_name && impl_target_head(match gen.impl_target {
+    if impl_target_head(match gen.impl_target {
       Some(target) => target,
       None => TyName("")
     }) == cname && String::ends_with(gen.name, String::concat("::", method)) {
       match gen.impl_target {
-        Some(target) => if impl_target_pattern_matches(target, actual, gen.impl_params, bindings) {
+        Some(target) => if impl_target_pattern_matches(target, actual, gen.impl_params, bindings) && impl_trait_pattern_matches(gen.impl_trait, trait_name, gen.impl_params, bindings) {
           result = Some(gen.name)
           i = Array::length(gens)
         } else {
           match actual {
-            TyName(actual_head) => if actual_head == cname && generic_impl_target_is_total(target, gen.impl_params) {
+            TyName(actual_head) => if actual_head == cname && generic_impl_target_is_total(target, gen.impl_params) && impl_trait_pattern_matches(gen.impl_trait, trait_name, gen.impl_params, bindings) {
               erased_result = Some(gen.name)
               erased_count = erased_count + 1
             } else (),
@@ -2709,7 +2739,7 @@ fn bind_impl_target_key(var_types: Array[(String, String)], name: String, value:
 /// miscompile).
 fn build_concrete_dict_for_target(actual_target: TypeExpr, trait_name: String, traits: Array[(String, Array[(String, Array[TypeExpr], TypeExpr)])], gens: Array[DictGen], struct_sets: Array[(String, Array[String])], var_types: Array[(String, String)], fn_returns: Array[(String, String)], arg_expr: Option[Expr]) -> Option[Expr] {
   let cname = impl_target_head(actual_target)
-  match lookup_trait_sigs(traits, trait_name) {
+  match lookup_trait_sigs(traits, trait_ref_name(trait_name)) {
     Some(sigs) => {
       let mnames = method_names_of_sigs(sigs)
       let recfields = array_empty()
@@ -2732,7 +2762,7 @@ fn build_concrete_dict_for_target(actual_target: TypeExpr, trait_name: String, t
           // never turns a compiling program into a failing one. This is the
           // one trait allowed a fabricated member, and only because its
           // fallback is the status quo rather than a guess at an impl.
-          if trait_name == "Show" && m == "to_string" {
+          if trait_ref_name(trait_name) == "Show" && m == "to_string" {
             Array::push(recfields, (m, show_fallback_closure()))
           } else {
             // No `cname::m` free function exists — `cname` does not actually

--- a/lib/@vibe/compiler/runtime/index.vpkg
+++ b/lib/@vibe/compiler/runtime/index.vpkg
@@ -3,6 +3,7 @@ version = 0.0.1
 description =
   #|@vibe/compiler/runtime — ADR-0070 / #897 compiler-internal contract,
 deps = {
+  @vibe/ast : 0.0.1
   @vibe/compiler/cache : 0.0.1
   @vibe/compiler/checker : 0.0.1
   @vibe/compiler/checker/artifacts : 0.0.1

--- a/lib/@vibe/compiler/runtime/persistent_env_codec.vibe
+++ b/lib/@vibe/compiler/runtime/persistent_env_codec.vibe
@@ -995,23 +995,23 @@ export fn load_persistent_dep_list(path: String, source: String) -> Option[Array
   }
 }
 
-/// Strict v5 module-interface wire format. It preserves declaration closure
+/// Strict v6 module-interface wire format. It preserves declaration closure
 /// plus the distinct selected declaration surface. Older bytes are rejected
 /// rather than being misread as authority.
 export fn parse_persistent_type_env(text: String) -> Option[TypeEnv] with Exception {
   let normalized = normalize_persistent_cache_text(text)
-  let header = "version\t5\nenv\t"
+  let header = "version\t6\nenv\t"
   let header_len = String::length(header)
   if String::length(normalized) < header_len || normalized[0: header_len] != header {
     None
   } else {
     let (payload, after_payload) = parse_segment(normalized, header_len)
     if after_payload + 1 != String::length(normalized) || String::char_code_at(normalized, after_payload) != '\n' {
-      throw("invalid persistent type env v5 envelope")
+      throw("invalid persistent type env v6 envelope")
     } else {
       let (env, end) = parse_persistent_type_env_payload(payload, 0)
       if end != String::length(payload) {
-        throw("invalid persistent type env v5 payload")
+        throw("invalid persistent type env v6 payload")
       } else {
         Some(env)
       }
@@ -1034,7 +1034,7 @@ export fn load_persistent_type_env(fingerprint: String) -> Option[TypeEnv] with 
 }
 
 export fn persistent_type_env_cache_text(env: TypeEnv) -> String {
-  String::concat("version\t5\nenv\t", String::concat(serialize_segment(serialize_type_env(env)), "\n"))
+  String::concat("version\t6\nenv\t", String::concat(serialize_segment(serialize_type_env(env)), "\n"))
 }
 
 export fn load_persistent_leaf_fingerprint(path: String, source: String, typing_semantics_seed: String) -> Option[String] with Exception + Fs {

--- a/lib/@vibe/compiler/runtime/typecheck_fs.vibe
+++ b/lib/@vibe/compiler/runtime/typecheck_fs.vibe
@@ -14,6 +14,10 @@ import @vibe/core {
   array_empty
 }
 
+import @vibe/ast {
+  TypeExpr, trait_ref_from_key, trait_ref_key, trait_ref_name
+}
+
 import @vibe/compiler/checker {
   CheckedProgram,
   check_program,
@@ -363,6 +367,23 @@ fn trait_projection_mapping(mappings: Array[(String, String)], canonical: String
   found
 }
 
+/// Project only the trait constructor spelling while preserving its applied
+/// arguments. Applied references use an AST key internally, so treating the
+/// complete key as an ordinary name loses explicit import aliases.
+fn trait_projection_map_ref(label: String, mappings: Array[(String, String)]) -> String {
+  let source_name = trait_ref_name(label)
+  match trait_projection_mapping(mappings, source_name) {
+    Some(mapped) => match trait_ref_from_key(label) {
+      Some(applied) => match applied {
+        TyApp(_, args) => trait_ref_key(TyApp(mapped, args)),
+        _ => mapped
+      },
+      None => mapped
+    },
+    None => label
+  }
+}
+
 fn trait_projection_local_owner(mappings: Array[(String, String)], local_name: String) -> Option[String] {
   let mut i = 0
   let mut found = None
@@ -587,15 +608,16 @@ fn trait_projection_collect_generic_impl_bounds(dep_env: TypeEnv, trait_name: St
     EnvTraitImpl(_, _, rest) => trait_projection_collect_generic_impl_bounds(rest, trait_name, mappings),
     EnvMutCell(_, _, rest) => trait_projection_collect_generic_impl_bounds(rest, trait_name, mappings),
     EnvTraitImplGen(candidate, _, bounds, _, rest) => {
-      if candidate == trait_name {
+      if trait_ref_name(candidate) == trait_ref_name(trait_name) {
         let mut i = 0
         while i < Array::length(bounds) {
           let (_, labels) = Array::get(bounds, i)
           let mut j = 0
           while j < Array::length(labels) {
             let label = Array::get(labels, j)
+            let base = trait_ref_name(label)
             if trait_defined(dep_env, label) {
-              trait_projection_add_mapping(mappings, label, label)
+              trait_projection_add_mapping(mappings, base, base)
             } else {
               ()
             }
@@ -623,8 +645,9 @@ fn trait_projection_collect_type_bounds(ty: Type, mappings: Array[(String, Strin
         let mut j = 0
         while j < Array::length(labels) {
           let label = Array::get(labels, j)
+          let base = trait_ref_name(label)
           if trait_defined(dep_env, label) {
-            trait_projection_add_mapping(mappings, label, label)
+            trait_projection_add_mapping(mappings, base, base)
           } else {
             ()
           }
@@ -777,7 +800,8 @@ fn dependency_trait_projection_mappings(dep_env: TypeEnv, dep_bindings: Array[(S
     while j < Array::length(supers) {
       let super_name = Array::get(supers, j)
       if trait_defined(dep_env, super_name) {
-        trait_projection_add_mapping(mappings, super_name, super_name)
+        let super_base = trait_ref_name(super_name)
+        trait_projection_add_mapping(mappings, super_base, super_base)
       } else {
         ()
       }
@@ -797,10 +821,7 @@ fn trait_projection_map_bound_rows(bounds: Array[(Int, Array[String])], mappings
     let mut j = 0
     while j < Array::length(labels) {
       let label = Array::get(labels, j)
-      Array::push(mapped_labels, match trait_projection_mapping(mappings, label) {
-        Some(mapped) => mapped,
-        None => label
-      })
+      Array::push(mapped_labels, trait_projection_map_ref(label, mappings))
       j = j + 1
     }
     Array::push(out, (param, mapped_labels))
@@ -829,10 +850,7 @@ fn trait_projection_map_method_bound_rows(bounds: Array[(String, Array[String])]
     let mut j = 0
     while j < Array::length(labels) {
       let label = Array::get(labels, j)
-      Array::push(mapped_labels, match trait_projection_mapping(mappings, label) {
-        Some(mapped) => mapped,
-        None => label
-      })
+      Array::push(mapped_labels, trait_projection_map_ref(label, mappings))
       j = j + 1
     }
     Array::push(out, (param, mapped_labels))
@@ -1080,10 +1098,7 @@ fn prepend_dependency_trait_nodes(dep_env: TypeEnv, mappings: Array[(String, Str
             let mut j = 0
             while j < Array::length(supers) {
               let super_name = Array::get(supers, j)
-              Array::push(local_supers, match trait_projection_mapping(mappings, super_name) {
-                Some(mapped) => mapped,
-                None => super_name
-              })
+              Array::push(local_supers, trait_projection_map_ref(super_name, mappings))
               j = j + 1
             }
             Array::push(retained, EnvTraitDef(local_name, local_supers, is_auto, methods, EnvEmpty, params, trait_projection_map_method_gens(method_gens, mappings)))
@@ -1096,15 +1111,15 @@ fn prepend_dependency_trait_nodes(dep_env: TypeEnv, mappings: Array[(String, Str
         cur = rest
       },
       EnvTraitImpl(name, target, rest) => {
-        match trait_projection_mapping(mappings, name) {
-          Some(local_name) => Array::push(retained, EnvTraitImpl(local_name, trait_projection_map_type_bounds(target, mappings), EnvEmpty)),
+        match trait_projection_mapping(mappings, trait_ref_name(name)) {
+          Some(_) => Array::push(retained, EnvTraitImpl(trait_projection_map_ref(name, mappings), trait_projection_map_type_bounds(target, mappings), EnvEmpty)),
           None => ()
         }
         cur = rest
       },
       EnvTraitImplGen(name, params, bounds, target, rest) => {
-        match trait_projection_mapping(mappings, name) {
-          Some(local_name) => Array::push(retained, EnvTraitImplGen(local_name, params, trait_projection_map_method_bound_rows(bounds, mappings), trait_projection_map_type_bounds(target, mappings), EnvEmpty)),
+        match trait_projection_mapping(mappings, trait_ref_name(name)) {
+          Some(_) => Array::push(retained, EnvTraitImplGen(trait_projection_map_ref(name, mappings), params, trait_projection_map_method_bound_rows(bounds, mappings), trait_projection_map_type_bounds(target, mappings), EnvEmpty)),
           None => ()
         }
         cur = rest
@@ -1800,7 +1815,7 @@ fn collect_module_diagnostics() -> Bool {
 ///   5 current-source parse executions (ModuleJob parse memo misses)
 ///   6 checker executions
 ///   7 modules reused by conservative fingerprint authority
-///   8 modules reused by validated TDRE5 dependency transport authority
+///   8 modules reused by validated TDRE6 dependency transport authority
 ///
 /// `parse_operations` is parser work, not a unique-module count: a cold
 /// module can need one header parse during planning and one full parse for its
@@ -1824,9 +1839,10 @@ let incremental_checked_env_trace_observations: Array[(String, String)] = []
 let incremental_persistent_type_env_transport_trace_observations: Array[(String, String)] = [
 ]
 
-// TDRE5 aliases only an exact v5 decoded TypeEnv when every direct dependency
+// TDRE6 aliases only an exact v6 decoded TypeEnv when every direct dependency
 // transport environment is unchanged. It is not a CheckedProgram or typed-IR
-// transport; v5 retains the TypeEnv declaration, trait, and impl chain. The empty cell is
+// transport; v6 retains applied bounds in the TypeEnv declaration, trait, and
+// impl chain. The empty cell is
 // conservative for direct FS consumers. The CLI check-only lane explicitly
 // enables production reuse after validating its per-invocation policy; build,
 // codegen, and other FS consumers remain off pending compact publication.
@@ -2577,7 +2593,7 @@ fn restrict_env_to_export_surface(value_surface: Array[String], trait_surface: A
     },
     EnvTraitImpl(name, target, rest) => {
       let restricted = restrict_env_to_export_surface(value_surface, trait_surface, type_surface, rest)
-      if bsearch_leftmost(trait_surface, name) >= 0 {
+      if bsearch_leftmost(trait_surface, trait_ref_name(name)) >= 0 {
         EnvTraitImpl(name, target, restricted)
       } else {
         restricted
@@ -2585,7 +2601,7 @@ fn restrict_env_to_export_surface(value_surface: Array[String], trait_surface: A
     },
     EnvTraitImplGen(name, params, bounds, target, rest) => {
       let restricted = restrict_env_to_export_surface(value_surface, trait_surface, type_surface, rest)
-      if bsearch_leftmost(trait_surface, name) >= 0 {
+      if bsearch_leftmost(trait_surface, trait_ref_name(name)) >= 0 {
         EnvTraitImplGen(name, params, bounds, target, restricted)
       } else {
         restricted
@@ -2950,7 +2966,7 @@ export fn incremental_trait_generic_provenance_markers_for_test(header_params: A
 fn incremental_interface_identity(source: String, env: TypeEnv) -> String with Exception {
   let stmts = parse_program_with_path("<incremental-interface-observation>", source)
   let out = StringBuilder::new()
-  StringBuilder::push(out, "vibe-module-interface:v2\n")
+  StringBuilder::push(out, "vibe-module-interface:v3\n")
   let names = interface_public_value_names(stmts)
   let mut i = 0
   while i < Array::length(names) {
@@ -2997,7 +3013,7 @@ fn incremental_checked_env_identity(env: TypeEnv) -> String with Exception {
   }
   let names = interface_sorted_unique(raw_names)
   let out = StringBuilder::new()
-  StringBuilder::push(out, "vibe-module-checked-env:v1\n")
+  StringBuilder::push(out, "vibe-module-checked-env:v2\n")
   let mut i = 0
   while i < Array::length(names) {
     let name = Array::get(names, i)
@@ -3015,7 +3031,7 @@ fn incremental_checked_env_identity(env: TypeEnv) -> String with Exception {
   compact_string_fingerprint(StringBuilder::freeze(out))
 }
 
-/// A trace-only observation of the complete persistent TypeEnv v5 transport.
+/// A trace-only observation of the complete persistent TypeEnv v6 transport.
 /// The canonical cache-text bytes are the sole input. This is not a
 /// CheckedProgram, typed IR, exported interface, cache key, or reuse decision.
 fn incremental_persistent_type_env_transport_identity(env: TypeEnv) -> String {
@@ -3069,7 +3085,7 @@ fn incremental_trace_json_string(text: String) -> String {
 /// provisional canonical token-stream identity, not normalized typed IR.
 /// `checked_env_fingerprint` is a complete value-environment observation.
 /// `persistent_type_env_transport_fingerprint` observes only the complete
-/// persistent TypeEnv v5 transport, not a CheckedProgram, typed IR, exported
+/// persistent TypeEnv v6 transport, not a CheckedProgram, typed IR, exported
 /// interface, cache key, or reuse decision. `decision` records what this current TypeDb
 /// walk did (`rechecked` or `reused`), not a formal invalidation verdict.
 /// This function is called only after a successful check; a missing per-module
@@ -3122,19 +3138,19 @@ export fn incremental_invalidation_trace_json(entry_path: String, run_nonce: Str
       None => throw(String::concat("incremental invalidation trace: missing complete interface observation for ", path))
     }
     StringBuilder::push(out, incremental_trace_json_string(interface_fingerprint))
-    StringBuilder::push(out, ",\"interface_fingerprint_kind\":\"compact_string_fingerprint(vibe-module-interface:v2 canonical exported surface including trait-header and method-generic binders)\",\"checked_env_fingerprint\":")
+    StringBuilder::push(out, ",\"interface_fingerprint_kind\":\"compact_string_fingerprint(vibe-module-interface:v3 canonical exported surface including applied trait bounds)\",\"checked_env_fingerprint\":")
     let checked_env_fingerprint = match incremental_checked_env_trace_observation_of(path) {
       Some(value) => value,
       None => throw(String::concat("incremental invalidation trace: missing complete checked environment observation for ", path))
     }
     StringBuilder::push(out, incremental_trace_json_string(checked_env_fingerprint))
-    StringBuilder::push(out, ",\"checked_env_fingerprint_kind\":\"compact_string_fingerprint(vibe-module-checked-env:v1 canonical effective TypeEnv value bindings)\",\"persistent_type_env_transport_fingerprint\":")
+    StringBuilder::push(out, ",\"checked_env_fingerprint_kind\":\"compact_string_fingerprint(vibe-module-checked-env:v2 canonical effective TypeEnv value bindings including applied trait bounds)\",\"persistent_type_env_transport_fingerprint\":")
     let persistent_type_env_transport_fingerprint = match incremental_persistent_type_env_transport_trace_observation_of(path) {
       Some(value) => value,
       None => throw(String::concat("incremental invalidation trace: missing complete persistent TypeEnv transport observation for ", path))
     }
     StringBuilder::push(out, incremental_trace_json_string(persistent_type_env_transport_fingerprint))
-    StringBuilder::push(out, ",\"persistent_type_env_transport_fingerprint_kind\":\"compact_string_fingerprint(persistent_type_env_cache_text:v5 complete TypeEnv transport only; not CheckedProgram, typed IR, exported interface, cache key, or reuse decision)\",\"decision\":")
+    StringBuilder::push(out, ",\"persistent_type_env_transport_fingerprint_kind\":\"compact_string_fingerprint(persistent_type_env_cache_text:v6 complete TypeEnv transport only; not CheckedProgram, typed IR, exported interface, cache key, or reuse decision)\",\"decision\":")
     StringBuilder::push(out, incremental_trace_json_string(decision))
     StringBuilder::push(out, "}")
     i = i + 1
@@ -3269,14 +3285,14 @@ fn store_persistent_type_env(fingerprint: String, env: TypeEnv) -> String with E
   text
 }
 
-// TDRE5 is deliberately independent from the TypeEnv v5 envelope and from
+// TDRE6 is deliberately independent from the TypeEnv v6 envelope and from
 // every production artifact/cache identity. Both v5 envelopes use strict
 // decimal length-delimited fields and bind the logical checker input, target
-// conservative fingerprint, and exact canonical TypeEnv-v5 transport text.
+// conservative fingerprint, and exact canonical TypeEnv-v6 transport text.
 // The target text is intentionally not replaced by a compact fingerprint:
 // cache corruption must not turn a fingerprint collision into checker reuse.
-let typing_dependency_env_reuse_alias_v5_tag = "TDRE5A"
-let typing_dependency_env_reuse_witness_v5_tag = "TDRE5W"
+let typing_dependency_env_reuse_alias_v6_tag = "TDRE6A"
+let typing_dependency_env_reuse_witness_v6_tag = "TDRE6W"
 
 fn typing_reuse_segment(text: String) -> String {
   String::concat(__to_string(String::length(text)), String::concat(":", text))
@@ -3347,7 +3363,7 @@ fn parse_typing_dependency_reuse_binding(text: String, tag: String) -> Option[(S
 /// cache rows are neither checker-visible nor part of this canonical text.
 fn typing_dependency_transport_input_key(path: String, source: String, semantics_seed: String, dep_envs: Array[(String, TypeEnv)]) -> String {
   let out = StringBuilder::new()
-  StringBuilder::push(out, "vibe-typing-dependency-transport-env:v5")
+  StringBuilder::push(out, "vibe-typing-dependency-transport-env:v6")
   StringBuilder::push(out, typing_reuse_segment(normalize_path(path)))
   StringBuilder::push(out, typing_reuse_segment(source))
   StringBuilder::push(out, typing_reuse_segment(semantics_seed))
@@ -3394,7 +3410,7 @@ fn typing_dependency_env_reuse_witness_binding(fingerprint: String) -> Option[(S
   if !Fs::exists(witness_path) {
     None
   } else {
-    match parse_typing_dependency_reuse_binding(Fs::read_file(witness_path), typing_dependency_env_reuse_witness_v5_tag) {
+    match parse_typing_dependency_reuse_binding(Fs::read_file(witness_path), typing_dependency_env_reuse_witness_v6_tag) {
       Some((input_key, target_fingerprint, target_text)) =>
       if target_fingerprint != fingerprint {
         None
@@ -3416,7 +3432,7 @@ fn typing_dependency_env_reuse_eligibility_is_valid(fingerprint: String) -> Bool
   }
 }
 
-/// Eligibility is transitively witnessed by successful canonical TypeEnv-v5
+/// Eligibility is transitively witnessed by successful canonical TypeEnv-v6
 /// commits. Missing, malformed, stale, torn, or cross-spliced witnesses fail
 /// closed before the alias lookup.
 fn typing_dependency_env_reuse_is_eligible(dep_fps: Array[(String, String)]) -> Bool with Fs {
@@ -3435,7 +3451,7 @@ fn typing_dependency_env_reuse_is_eligible(dep_fps: Array[(String, String)]) -> 
 }
 
 fn publish_typing_dependency_env_reuse_eligibility(input_key: String, fingerprint: String, target_text: String) -> Unit with Fs {
-  let witness_text = typing_dependency_reuse_binding_text(typing_dependency_env_reuse_witness_v5_tag, input_key, fingerprint, target_text)
+  let witness_text = typing_dependency_reuse_binding_text(typing_dependency_env_reuse_witness_v6_tag, input_key, fingerprint, target_text)
   Fs::write_file(persistent_typing_dependency_env_reuse_eligibility_path(fingerprint), witness_text)
 }
 
@@ -3444,7 +3460,7 @@ fn load_typing_dependency_env_reuse_target(input_key: String) -> Option[(String,
   if !Fs::exists(sidecar_path) {
     None
   } else {
-    match parse_typing_dependency_reuse_binding(Fs::read_file(sidecar_path), typing_dependency_env_reuse_alias_v5_tag) {
+    match parse_typing_dependency_reuse_binding(Fs::read_file(sidecar_path), typing_dependency_env_reuse_alias_v6_tag) {
       Some((alias_input_key, target_fingerprint, target_text)) =>
       if alias_input_key != input_key {
         None
@@ -3471,7 +3487,7 @@ fn load_typing_dependency_env_reuse_target(input_key: String) -> Option[(String,
 }
 
 fn write_typing_dependency_env_reuse_sidecar(input_key: String, target_fingerprint: String, target_text: String) -> Unit with Fs {
-  let alias_text = typing_dependency_reuse_binding_text(typing_dependency_env_reuse_alias_v5_tag, input_key, target_fingerprint, target_text)
+  let alias_text = typing_dependency_reuse_binding_text(typing_dependency_env_reuse_alias_v6_tag, input_key, target_fingerprint, target_text)
   Fs::write_file(persistent_typing_dependency_env_reuse_sidecar_path(input_key), alias_text)
 }
 
@@ -4131,7 +4147,7 @@ export fn locate_type_error(source: String, msg: String) -> String {
 /// resolve from impl units against the contract definition.
 export enum ModuleOutcome {
   // The final strings are trace-only interface, checked-value-env, and
-  // complete persistent TypeEnv v5 transport identities. They are computed
+  // complete persistent TypeEnv v6 transport identities. They are computed
   // from this successful check's typed environment, never used as cache
   // inputs, and are empty unless the invalidation trace is enabled. The final
   // optional string is a canonical in-memory-only #1550 module artifact

--- a/lib/@vibe/compiler/tests/parameterized_trait_diagnostics_test.vibe
+++ b/lib/@vibe/compiler/tests/parameterized_trait_diagnostics_test.vibe
@@ -1,0 +1,46 @@
+import ./checker_parity_test_support.vibe {
+  check_source_error_message
+}
+
+test "applied trait bounds report arity at the declaration" {
+  let source = "trait Value[A] { value(Self) -> A }\nfn bad[T: Value[Int, String]](item: T) -> Int { 0 }"
+  inspect(check_source_error_message(source), "trait `Value` expects 1 type argument(s), got 2 in bound `Value[Int, String]`")
+}
+
+test "applied impl heads report arity at the declaration" {
+  let source = "trait Value[A] { value(Self) -> A }\nstruct Box { value: Int }\nimpl Value[Int, String] for Box { value(self: Box) -> Int { self.value } }"
+  let message = check_source_error_message(source)
+  assert(String::contains(message, "trait `Value` expects 1 type argument(s), got 2 in impl head `Value[Int, String]`"))
+}
+
+test "missing applied instances use source trait syntax" {
+  let source = "trait Value[A] { value(Self) -> A }\nstruct Box { value: String }\nimpl Value[String] for Box { value(self: Box) -> String { self.value } }\nfn need[T: Value[Int]](item: T) -> Int { T::value(item) }\nlet answer = need(Box::{ value: \"text\" })"
+  let message = check_source_error_message(source)
+  assert(String::contains(message, "no impl `Value[Int]` for `Box`"))
+  assert(!String::contains(message, "$trait$"))
+}
+
+test "trait parameters constrain method arguments" {
+  let source = "trait Value[A] { choose(Self, A) -> A }\nfn bad[T: Value[Int]](item: T) -> Int { T::choose(item, \"wrong\") }"
+  let message = check_source_error_message(source)
+  assert(String::contains(message, "argument type mismatch"))
+  assert(String::contains(message, "expected Int, got String"))
+}
+
+test "overlap diagnostics distinguish applied trait arguments" {
+  let source = "trait Value[A] { value(Self) -> A }\nstruct Box { value: Int }\nimpl Value[Int] for Box\nimpl Value[Int] for Box"
+  let message = check_source_error_message(source)
+  assert(String::contains(message, "overlapping impls for `Value[Int]`"))
+  assert(!String::contains(message, "$trait$"))
+}
+
+test "generic and concrete applied impls overlap when their instances intersect" {
+  let source = "trait Value[A] { value(Self) -> A }\nstruct Box[T] { value: T }\nimpl [T] Value[T] for Box[T]\nimpl Value[Int] for Box[Int]"
+  let message = check_source_error_message(source)
+  assert(String::contains(message, "overlapping impls for `Value[Int]`"))
+}
+
+test "disjoint concrete applied impls do not overlap" {
+  let source = "trait Value[A] { value(Self) -> A }\nstruct Box { value: Int }\nimpl Value[Int] for Box\nimpl Value[String] for Box"
+  inspect(check_source_error_message(source), "")
+}

--- a/lib/@vibe/compiler/tests/parser_test.vibe
+++ b/lib/@vibe/compiler/tests/parser_test.vibe
@@ -102,6 +102,17 @@ test "print impl generic bounds preserves semantic differences" {
   assert(reparsed == eq)
 }
 
+test "applied trait references roundtrip in bounds and impl heads" {
+  let bound = handle {
+    print_program(parse_program(lex("fn first[T: Iter[Int]](value: T) -> Int { T::next(value) }")))
+  } with { Exception::Throw(e) => String::concat("ERROR: ", e) }
+  assert(bound == "let rec first = [T: Iter[Int]](value: T) -> Int { T::next(value) }")
+  let impl_head = handle {
+    print_program(parse_program(lex("impl Iter[Int] for Array[Int]")))
+  } with { Exception::Throw(e) => String::concat("ERROR: ", e) }
+  assert(impl_head == "impl Iter[Int] for Array[Int]")
+}
+
 test "parse value-position generic let keeps type params" {
   // Regression: `let f = [T: Ord](...)` (a value-position type-parameter
   // header, no `: Type` annotation) must put `[T: Ord]` onto the lambda's

--- a/lib/@vibe/compiler/tests/persistent_cache_test.vibe
+++ b/lib/@vibe/compiler/tests/persistent_cache_test.vibe
@@ -44,11 +44,11 @@ test "compact string fingerprint keeps its byte-level cache identity" {
   inspect(compact_string_fingerprint("東京"), content = "6:1640623600:1554629861")
 }
 
-test "TDRE5 cache paths use isolated alias and witness namespaces" {
+test "TDRE6 cache paths use isolated alias and witness namespaces" {
   let alias_path = persistent_typing_dependency_env_reuse_sidecar_path("logical-input")
   let witness_path = persistent_typing_dependency_env_reuse_eligibility_path("conservative-target")
-  assert(String::index_of(alias_path, "selfhost_typing_dependency_env_reuse_v5") >= 0)
-  assert(String::index_of(witness_path, "selfhost_typing_dependency_env_reuse_eligibility_v5") >= 0)
+  assert(String::index_of(alias_path, "selfhost_typing_dependency_env_reuse_v6") >= 0)
+  assert(String::index_of(witness_path, "selfhost_typing_dependency_env_reuse_eligibility_v6") >= 0)
   assert(alias_path != witness_path)
   assert(String::index_of(alias_path, "reuse_v4") < 0)
   assert(String::index_of(witness_path, "eligibility_v4") < 0)

--- a/lib/@vibe/compiler/tests/persistent_env_codec_test.vibe
+++ b/lib/@vibe/compiler/tests/persistent_env_codec_test.vibe
@@ -2,6 +2,7 @@
 
 import @vibe/compiler/core {
   BindingOrigin,
+  Subst,
   Type,
   TypeDef,
   TypeEnv,
@@ -17,7 +18,12 @@ import @vibe/compiler/core {
   env_value_binding,
   trait_method_sig,
   trait_supers,
+  type_implements_trait,
   types_equal
+}
+
+import @vibe/ast {
+  trait_ref_key
 }
 
 import @vibe/compiler/runtime {
@@ -160,7 +166,7 @@ fn malformed_rejected(text: String) -> Bool {
 
 //# Tests
 
-test "persistent TypeEnv v5 bytes ignore binding provenance and decode it unavailable" {
+test "persistent TypeEnv v6 bytes ignore binding provenance and decode it unavailable" {
   let plain = EnvBind("x", env_value_binding(CtInt), EnvEmpty)
   let originated = env_bind_with_origin(EnvEmpty, "x", CtInt, BindingOriginModuleExport("/dep.vibe", "source_x"))
   let plain_text = persistent_type_env_cache_text(plain)
@@ -178,7 +184,7 @@ test "persistent TypeEnv v5 bytes ignore binding provenance and decode it unavai
   }
 }
 
-test "fixpoint bytes retain cached mut TypeEnv v5" {
+test "fixpoint bytes retain cached mut TypeEnv v6" {
   let encoded = persistent_type_env_cache_text(cached_mut_codec_fixture(BindingOriginModuleExport("/dep.vibe", "source_imported")))
   match parse_persistent_type_env(encoded) {
     Some(decoded) => inspect(persistent_type_env_cache_text(decoded) == encoded, "1"),
@@ -186,7 +192,7 @@ test "fixpoint bytes retain cached mut TypeEnv v5" {
   }
 }
 
-test "truefact survives cached mut TypeEnv v5 decode" {
+test "truefact survives cached mut TypeEnv v6 decode" {
   let encoded = persistent_type_env_cache_text(cached_mut_codec_fixture(BindingOriginUnavailable))
   match parse_persistent_type_env(encoded) {
     Some(decoded) => match env_mut_escape(decoded, "true_cell") {
@@ -197,7 +203,7 @@ test "truefact survives cached mut TypeEnv v5 decode" {
   }
 }
 
-test "falsefact survives cached mut TypeEnv v5 decode" {
+test "falsefact survives cached mut TypeEnv v6 decode" {
   let encoded = persistent_type_env_cache_text(cached_mut_codec_fixture(BindingOriginUnavailable))
   match parse_persistent_type_env(encoded) {
     Some(decoded) => match env_mut_escape(decoded, "false_cell") {
@@ -208,7 +214,7 @@ test "falsefact survives cached mut TypeEnv v5 decode" {
   }
 }
 
-test "decodedorigin is unavailable after cached mut TypeEnv v5 decode" {
+test "decodedorigin is unavailable after cached mut TypeEnv v6 decode" {
   let encoded = persistent_type_env_cache_text(cached_mut_codec_fixture(BindingOriginModuleExport("/dep.vibe", "source_imported")))
   match parse_persistent_type_env(encoded) {
     Some(decoded) => match env_lookup_binding(decoded, "imported") {
@@ -222,13 +228,13 @@ test "decodedorigin is unavailable after cached mut TypeEnv v5 decode" {
   }
 }
 
-test "persistent module interface v5 round-trips every variant and trait payload" {
+test "persistent module interface v6 round-trips every variant and trait payload" {
   let env = codec_fixture()
   let encoded = persistent_type_env_cache_text(env)
-  assert(String::starts_with(encoded, "version\t5\nenv\t"))
-  // TDRE4 hardening binds this exact canonical text externally; it does not
-  // change or wrap the production TypeEnv-v4 transport envelope itself.
-  assert(String::index_of(encoded, "TDRE4") < 0)
+  assert(String::starts_with(encoded, "version\t6\nenv\t"))
+  // TDRE6 binds this canonical text externally but does not wrap the
+  // production TypeEnv-v6 transport envelope itself.
+  assert(String::index_of(encoded, "TDRE6") < 0)
   match parse_persistent_type_env(encoded) {
     Some(decoded) => {
       assert(persistent_type_env_cache_text(decoded) == encoded)
@@ -301,7 +307,29 @@ test "persistent module interface retains complete concrete and generic impl tar
   }
 }
 
-test "persistent module interface v5 round-trips enum struct and alias authority" {
+test "persistent TypeEnv v6 retains applied trait bounds and impl heads" {
+  let applied = trait_ref_key(TyApp("Value", [TyName("Int")]))
+  let env = EnvBind("read", env_value_binding(CtForAll([7], [(7, [applied])], CtFn([
+    CtVar(7)
+  ], CtInt, None))), EnvTraitDef("Value", [], false, [], EnvTraitImpl(applied, CtInt, EnvEmpty), [
+    "A"
+  ], []))
+  match parse_persistent_type_env(persistent_type_env_cache_text(env)) {
+    Some(decoded) => {
+      match env_lookup(decoded, "read") {
+        Some(CtForAll(_, bounds, _)) => {
+          let (_, labels) = Array::get(bounds, 0)
+          assert(Array::get(labels, 0) == applied)
+        },
+        _ => assert(false)
+      }
+      assert(type_implements_trait(decoded, SubstEmpty, CtInt, applied))
+    },
+    None => assert(false)
+  }
+}
+
+test "persistent module interface v6 round-trips enum struct and alias authority" {
   let defs = [
     TDEnum("Choice", ["T"], [("Pick", [CtNamed("T", [])])]),
     TDStruct("Box", [("value", CtNamed("T", []))], [], ["T"]),
@@ -332,7 +360,7 @@ test "persistent module interface v5 round-trips enum struct and alias authority
   }
 }
 
-test "persistent module interface v5 round-trips effect and effectset authority" {
+test "persistent module interface v6 round-trips effect and effectset authority" {
   let env = EnvTypeDefs([
     TDEffect("Audit", [("Emit", [CtString], CtUnit)], []),
     TDEffectSet("Audits", ["Audit"])
@@ -357,7 +385,7 @@ test "persistent module interface v5 round-trips effect and effectset authority"
   }
 }
 
-test "legacy enum carrier bytes cannot alter v5 typedef authority" {
+test "legacy enum carrier bytes cannot alter v6 typedef authority" {
   let declared = TDEnum("Choice", [], [("Pick", [CtInt])])
   // This was the retired `Choice::__variants__` value carrier. It is valid
   // TypeEnv data but EnvTypeDefs must remain the only declaration authority.
@@ -383,7 +411,7 @@ test "legacy enum carrier bytes cannot alter v5 typedef authority" {
   }
 }
 
-test "persistent module interface v5 rebuilds untrusted cached lookup indexes" {
+test "persistent module interface v6 rebuilds untrusted cached lookup indexes" {
   let corrupt = EnvCached(["shadow", "shadow", "cached"], [
     env_value_binding(CtBool),
     env_value_binding(CtString),
@@ -408,15 +436,15 @@ test "persistent module interface v5 rebuilds untrusted cached lookup indexes" {
   }
 }
 
-test "persistent module interface v5 rejects old, truncated, and malformed envelopes" {
+test "persistent module interface v6 rejects old, truncated, and malformed envelopes" {
   assert(malformed_rejected("version\t1\nbind\tvalue\tI\n"))
   assert(malformed_rejected("version\t2\nenv\t1:0\n"))
   // Bare v3 was a value/trait-only TypeEnv, never an empty declaration interface.
   assert(malformed_rejected("version\t3\nenv\t1:0\n"))
   assert(malformed_rejected("version\t4\nenv\t1:0\n"))
-  assert(malformed_rejected("version\t5\nenv\t"))
-  assert(malformed_rejected("version\t5\nenv\t1:Z\n"))
-  assert(malformed_rejected("version\t5\nenv\t2:00\n"))
-  assert(malformed_rejected("version\t5\nenv\t4:B0:0\n"))
-  assert(malformed_rejected("version\t5\nenv\t1:0\ntrailing"))
+  assert(malformed_rejected("version\t6\nenv\t"))
+  assert(malformed_rejected("version\t6\nenv\t1:Z\n"))
+  assert(malformed_rejected("version\t6\nenv\t2:00\n"))
+  assert(malformed_rejected("version\t6\nenv\t4:B0:0\n"))
+  assert(malformed_rejected("version\t6\nenv\t1:0\ntrailing"))
 }

--- a/lib/@vibe/compiler/tests/type_db_cross_module_test.vibe
+++ b/lib/@vibe/compiler/tests/type_db_cross_module_test.vibe
@@ -14,6 +14,7 @@ import @vibe/compiler/core {
   Expr,
   ImportItem,
   Stmt,
+  Subst,
   Type,
   TypeDef,
   TypeEnv,
@@ -25,7 +26,12 @@ import @vibe/compiler/core {
   env_selectable_type_defs,
   env_type_defs,
   env_value_binding,
-  trait_defined
+  trait_defined,
+  type_implements_trait
+}
+
+import @vibe/ast {
+  trait_ref_key
 }
 
 import @vibe/compiler/checker {
@@ -1200,6 +1206,28 @@ test "exact dep projection gives explicit trait aliases precedence over selected
   assert(imported_forall_bound_label(trait_first, "accept") == "Local")
 }
 
+test "applied trait impl projection preserves explicit trait aliases" {
+  let dep_path = "workspace/dep.vibe"
+  let source_ref = trait_ref_key(TyApp("Value", [TyName("Int")]))
+  let local_ref = trait_ref_key(TyApp("ImportedValue", [TyName("Int")]))
+  let dep_env = EnvTraitDef("Value", [], false, [], EnvTraitImpl(source_ref, CtInt, EnvEmpty), [
+    "A"
+  ], [])
+  let projected = projected_import_env_for_test("import ./dep.vibe { trait Value as ImportedValue }", "workspace/main.vibe", [
+    dep_path
+  ], [(dep_path, dep_env)])
+  assert(trait_defined(projected, local_ref))
+  assert(type_implements_trait(projected, SubstEmpty, CtInt, local_ref))
+}
+
+test "public trait surfaces retain applied impl instances" {
+  let source = "export trait Value[A]\nimpl Value[Int] for Int"
+  let stmts = parse_program_with_path("workspace/dep.vibe", source)
+  let published = checked_module_public_env(stmts, checked_test_env(source))
+  let applied = trait_ref_key(TyApp("Value", [TyName("Int")]))
+  assert(type_implements_trait(published, SubstEmpty, CtInt, applied))
+}
+
 test "#2310: projected re-export aliases exclude local declaration authority" {
   let dep_path = "workspace/dep.vibe"
   let dep_env = EnvTraitDef("Marker", [], false, [], EnvTypeDefs([
@@ -1924,11 +1952,11 @@ test "db_typecheck_fs: old and malformed fs cache and leaf entries cold-recheck 
   let leaf_path = persistent_leaf_fingerprint_cache_path(path, compact_string_fingerprint(source))
   Fs::write_file(env_path, "version\t3\nenv\t1:0\n")
   let _ = db_typecheck_fs(db_set_source(db_new(), path, source), path)
-  assert(String::starts_with(Fs::read_file(env_path), "version\t5\nenv\t"))
-  Fs::write_file(env_path, "version\t5\nenv\t1:Z\n")
+  assert(String::starts_with(Fs::read_file(env_path), "version\t6\nenv\t"))
+  Fs::write_file(env_path, "version\t6\nenv\t1:Z\n")
   Fs::write_file(leaf_path, "version\t1\nnot-a-fingerprint\n")
   let _ = db_typecheck_fs(db_set_source(db_new(), path, source), path)
-  assert(String::starts_with(Fs::read_file(env_path), "version\t5\nenv\t"))
+  assert(String::starts_with(Fs::read_file(env_path), "version\t6\nenv\t"))
 }
 
 test "db_typecheck: an imported effect does not leak through a non-re-exporting module (#1549)" {

--- a/lib/@vibe/parser/parser_base.vibe
+++ b/lib/@vibe/parser/parser_base.vibe
@@ -1,7 +1,7 @@
 //# Imports
 
 import @vibe/ast {
-  Expr, ImportItem, ImportKind, Pat, Stmt, TypeExpr
+  Expr, ImportItem, ImportKind, Pat, Stmt, TypeExpr, trait_ref_key
 }
 
 import ./parser_binder_context.vibe {
@@ -560,9 +560,15 @@ fn parse_trait_bound_names(tokens: Array[Token], pos: Int) -> (Array[String], In
   let mut done = false
   while !done {
     match peek(tokens, p) {
-      TIdent(name) => {
-        ArrayBuilder::push(b, name)
-        p = p + 1
+      TIdent(_) => {
+        let (reference, next) = parse_type_impl(tokens, p, 0)
+        let key = match reference {
+          TyName(_) => trait_ref_key(reference),
+          TyApp(_, _) => trait_ref_key(reference),
+          _ => throw("a trait bound must be a named trait, such as `Eq` or `Iter[Int]`")
+        }
+        ArrayBuilder::push(b, key)
+        p = next
         match peek(tokens, p) {
           TPlus => {
             p = p + 1
@@ -1912,8 +1918,14 @@ fn parse_impl_stmt_with_binder_context(tokens: Array[Token], pos: Int, context: 
     _ => (_no_tp(), _no_tb(), pos)
   }
   match peek(tokens, after_tp) {
-    TIdent(trait_name) => {
-      let fp = expect_tk(tokens, after_tp + 1, "for")
+    TIdent(_) => {
+      let (trait_reference, after_trait) = parse_type_impl(tokens, after_tp, 0)
+      let trait_name = match trait_reference {
+        TyName(_) => trait_ref_key(trait_reference),
+        TyApp(_, _) => trait_ref_key(trait_reference),
+        _ => throw("an impl trait must be a named trait, such as `Eq` or `Iter[Int]`")
+      }
+      let fp = expect_tk(tokens, after_trait, "for")
       let (target, after_target) = parse_type_impl(tokens, fp, 0)
       match target {
         TyName(_) => (SImpl(type_params, type_bounds, trait_name, target), after_target),

--- a/lib/@vibe/parser/parser_expr.vibe
+++ b/lib/@vibe/parser/parser_expr.vibe
@@ -1,7 +1,7 @@
 //# Imports
 
 import @vibe/ast {
-  Expr, Pat, Stmt, TypeExpr
+  Expr, Pat, Stmt, TypeExpr, trait_ref_key
 }
 
 import ./parser_base.vibe {
@@ -111,9 +111,15 @@ fn parse_type_param_bound_names(tokens: Array[Token], pos: Int) -> (Array[String
   let mut done = false
   while !done {
     match peek(tokens, p) {
-      TIdent(name) => {
-        ArrayBuilder::push(b, name)
-        p = p + 1
+      TIdent(_) => {
+        let (reference, next) = parse_type_impl(tokens, p, 0)
+        let key = match reference {
+          TyName(_) => trait_ref_key(reference),
+          TyApp(_, _) => trait_ref_key(reference),
+          _ => throw("a trait bound must be a named trait, such as `Eq` or `Iter[Int]`")
+        }
+        ArrayBuilder::push(b, key)
+        p = next
         match peek(tokens, p) {
           TPlus => {
             p = p + 1

--- a/lib/@vibe/parser/parser_expr_dispatch.vibe
+++ b/lib/@vibe/parser/parser_expr_dispatch.vibe
@@ -1,7 +1,7 @@
 //# Imports
 
 import @vibe/ast {
-  Expr, Pat, TypeExpr
+  Expr, Pat, TypeExpr, trait_ref_key
 }
 
 import ./parser_base.vibe {
@@ -123,9 +123,15 @@ fn dispatch_tp_bound_names(tokens: Array[Token], pos: Int) -> (Array[String], In
   let mut done = false
   while !done {
     match peek(tokens, p) {
-      TIdent(bname) => {
-        ArrayBuilder::push(b, bname)
-        p = p + 1
+      TIdent(_) => {
+        let (reference, next) = parse_type_impl(tokens, p, 0)
+        let key = match reference {
+          TyName(_) => trait_ref_key(reference),
+          TyApp(_, _) => trait_ref_key(reference),
+          _ => throw("a trait bound must be a named trait, such as `Eq` or `Iter[Int]`")
+        }
+        ArrayBuilder::push(b, key)
+        p = next
         match peek(tokens, p) {
           TPlus => {
             p = p + 1

--- a/lib/@vibe/parser/parser_expr_primary.vibe
+++ b/lib/@vibe/parser/parser_expr_primary.vibe
@@ -1,7 +1,7 @@
 //# Imports
 
 import @vibe/ast {
-  Expr, Pat, TypeExpr
+  Expr, Pat, TypeExpr, trait_ref_key
 }
 
 import ./parser_base.vibe {
@@ -664,9 +664,15 @@ fn parse_generic_type_param_bound_names(tokens: Array[Token], pos: Int) -> (Arra
   let mut done = false
   while !done {
     match peek(tokens, p) {
-      TIdent(name) => {
-        ArrayBuilder::push(bounds, name)
-        p = p + 1
+      TIdent(_) => {
+        let (reference, next) = parse_type_impl(tokens, p, 0)
+        let key = match reference {
+          TyName(_) => trait_ref_key(reference),
+          TyApp(_, _) => trait_ref_key(reference),
+          _ => throw("a trait bound must be a named trait, such as `Eq` or `Iter[Int]`")
+        }
+        ArrayBuilder::push(bounds, key)
+        p = next
         match peek(tokens, p) {
           TPlus => {
             p = p + 1

--- a/lib/@vibe/parser/printer.vibe
+++ b/lib/@vibe/parser/printer.vibe
@@ -1,7 +1,7 @@
 //# Imports
 
 import @vibe/ast {
-  Expr, ImportItem, ImportKind, Pat, Stmt, TypeExpr
+  Expr, ImportItem, ImportKind, Pat, Stmt, TypeExpr, trait_ref_from_key
 }
 
 import ./polyfill.vibe {
@@ -102,7 +102,12 @@ fn print_bounded_type_params(params: Array[String], bounds: Array[(String, Array
         if bound_param == param {
           let mut j = 0
           while j < Array::length(bound_labels) {
-            ArrayBuilder::push(labels, Array::get(bound_labels, j))
+            let key = Array::get(bound_labels, j)
+            let label = match trait_ref_from_key(key) {
+              Some(reference) => print_type_expr(reference),
+              None => key
+            }
+            ArrayBuilder::push(labels, label)
             j = j + 1
           }
         } else {
@@ -368,27 +373,7 @@ fn print_ctor(name: String, args: Array[TypeExpr]) -> String {
 /// type-parameter scope and `T` resolves to a concrete `CtNamed("T", [])`
 /// instead of a bound type variable.
 fn print_fn_type_params(type_params: Array[String], bounds: Array[(String, Array[String])]) -> String {
-  if Array::length(type_params) == 0 {
-    ""
-  } else {
-    let parts = for tp in type_params {
-      let mut found = Array::slice([""], 0, 0)
-      let mut bi = 0
-      while bi < Array::length(bounds) {
-        let (bname, blist) = Array::get(bounds, bi)
-        if bname == tp {
-          found = blist
-        }
-        bi = bi + 1
-      }
-      if Array::length(found) == 0 {
-        tp
-      } else {
-        String::concat(tp, String::concat(": ", join(found, " + ")))
-      }
-    }
-    String::concat("[", String::concat(join(parts, ", "), "]"))
-  }
+  print_bounded_type_params(type_params, bounds)
 }
 
 fn peel_empty_handles(expr: Expr) -> Expr {
@@ -835,7 +820,11 @@ export fn print_stmt(s: Stmt) -> String {
       } else {
         String::concat("impl ", String::concat(generic_header, " "))
       }
-      String::concat(head, String::concat(trait_name, String::concat(" for ", print_type_expr(target))))
+      let printed_trait = match trait_ref_from_key(trait_name) {
+        Some(reference) => print_type_expr(reference),
+        None => trait_name
+      }
+      String::concat(head, String::concat(printed_trait, String::concat(" for ", print_type_expr(target))))
     },
     SExternLet(name, ty) => String::concat("extern let ", String::concat(name, String::concat(": ", print_type_expr(ty)))),
     SImport(path, items) => {

--- a/scripts/experimental_typing_env_reuse_oracle.mjs
+++ b/scripts/experimental_typing_env_reuse_oracle.mjs
@@ -222,40 +222,40 @@ function bindingFiles(cache, namespace) {
 }
 
 function appSidecar(cache, appSource) {
-  const candidates = bindingFiles(cache, "selfhost_typing_dependency_env_reuse_v5");
+  const candidates = bindingFiles(cache, "selfhost_typing_dependency_env_reuse_v6");
   const path = candidates.find((candidate) => {
     const text = readFileSync(candidate, "utf8");
-    return text.startsWith("TDRE5A") && text.includes(appSource);
+    return text.startsWith("TDRE6A") && text.includes(appSource);
   });
   if (!path) fail(`non-vacuous TDRE5 app sidecar missing in ${basename(cache)}`);
-  return { path, ...parseBinding(readFileSync(path, "utf8"), "TDRE5A") };
+  return { path, ...parseBinding(readFileSync(path, "utf8"), "TDRE6A") };
 }
 
 function otherSidecar(cache, target) {
-  for (const path of bindingFiles(cache, "selfhost_typing_dependency_env_reuse_v5")) {
-    const binding = parseBinding(readFileSync(path, "utf8"), "TDRE5A");
+  for (const path of bindingFiles(cache, "selfhost_typing_dependency_env_reuse_v6")) {
+    const binding = parseBinding(readFileSync(path, "utf8"), "TDRE6A");
     if (binding.target !== target) return { path, ...binding };
   }
   fail("second valid TDRE5 target missing");
 }
 
 function targetWitness(cache, target) {
-  for (const path of bindingFiles(cache, "selfhost_typing_dependency_env_reuse_eligibility_v5")) {
-    const binding = parseBinding(readFileSync(path, "utf8"), "TDRE5W");
+  for (const path of bindingFiles(cache, "selfhost_typing_dependency_env_reuse_eligibility_v6")) {
+    const binding = parseBinding(readFileSync(path, "utf8"), "TDRE6W");
     if (binding.target === target) return { path, ...binding };
   }
   fail(`bound TDRE5 witness missing for ${target}`);
 }
 
 function aliasText(input, target, targetText) {
-  return `TDRE5A${segment(input)}${segment(target)}${segment(targetText)}`;
+  return `TDRE6A${segment(input)}${segment(target)}${segment(targetText)}`;
 }
 
 function witnessText(input, target, targetText) {
-  return `TDRE5W${segment(input)}${segment(target)}${segment(targetText)}`;
+  return `TDRE6W${segment(input)}${segment(target)}${segment(targetText)}`;
 }
 
-const logicalInputTag = "vibe-typing-dependency-transport-env:v5";
+const logicalInputTag = "vibe-typing-dependency-transport-env:v6";
 function parseLogicalInput(input) {
   if (!input.startsWith(logicalInputTag)) fail("TDRE5 logical input tag changed");
   let cursor = logicalInputTag.length;
@@ -311,8 +311,8 @@ function stableCachePath(cache, version, prefix, seed, suffix) {
   return join(cache, `vibe_${prefix}_${token}${suffix}`);
 }
 
-function typeEnvPath(stage2, cache, target, major = "v19") {
-  return stableCachePath(cache, `${major}|cg-${stageCodegenFingerprint(stage2)}`, "selfhost_type_env_v5", target, ".tsv");
+function typeEnvPath(stage2, cache, target, major = "v20") {
+  return stableCachePath(cache, `${major}|cg-${stageCodegenFingerprint(stage2)}`, "selfhost_type_env_v6", target, ".tsv");
 }
 
 // Derive the exact referenced TypeEnv filename from the target conservative
@@ -351,16 +351,16 @@ function expectTraceLaneRejected(stage2, project, cache) {
 }
 
 function traceForcedOff(stage2, project, cache) {
-  const beforeAliases = bindingFiles(cache, "selfhost_typing_dependency_env_reuse_v5").length;
-  const beforeWitnesses = bindingFiles(cache, "selfhost_typing_dependency_env_reuse_eligibility_v5").length;
+  const beforeAliases = bindingFiles(cache, "selfhost_typing_dependency_env_reuse_v6").length;
+  const beforeWitnesses = bindingFiles(cache, "selfhost_typing_dependency_env_reuse_eligibility_v6").length;
   const result = check(stage2, project, cache, true, "trace-forced-off", false, {
     VIBE_INCREMENTAL_INVALIDATION_TRACE_OUT: "trace-forced-off.json",
     VIBE_INCREMENTAL_INVALIDATION_TRACE_NONCE: "trace-forced-off",
   });
   expectCounts("ordinary trace forced off", result.telemetry, 2, 0);
   if (!existsSync(join(project, "trace-forced-off.json"))) fail("ordinary trace omitted observation sidecar");
-  if (bindingFiles(cache, "selfhost_typing_dependency_env_reuse_v5").length !== beforeAliases ||
-      bindingFiles(cache, "selfhost_typing_dependency_env_reuse_eligibility_v5").length !== beforeWitnesses) {
+  if (bindingFiles(cache, "selfhost_typing_dependency_env_reuse_v6").length !== beforeAliases ||
+      bindingFiles(cache, "selfhost_typing_dependency_env_reuse_eligibility_v6").length !== beforeWitnesses) {
     fail("observation-only trace published TDRE5 state");
   }
   return result.telemetry;
@@ -389,29 +389,29 @@ function expectInvalidEnvRejected(stage2, project, cache, variable, value) {
   if (!diagnostic.includes(variable)) fail(`${variable} rejection omitted strict diagnostic`);
 }
 
-function expectV18Isolation(stage2, work) {
-  const project = join(work, "v18-isolation-project");
-  const currentCache = join(work, "v18-isolation-current-cache");
-  const oldCache = join(work, "v18-isolation-old-cache");
+function expectV19Isolation(stage2, work) {
+  const project = join(work, "v19-isolation-project");
+  const currentCache = join(work, "v19-isolation-current-cache");
+  const oldCache = join(work, "v19-isolation-old-cache");
   makeProject(project);
-  check(stage2, project, currentCache, true, "v18-source-cold");
+  check(stage2, project, currentCache, true, "v19-source-cold");
   mkdirSync(oldCache, { recursive: true });
-  const oldVersion = `v18|cg-${stageCodegenFingerprint(stage2)}`;
-  for (const path of bindingFiles(currentCache, "selfhost_typing_dependency_env_reuse_v5")) {
+  const oldVersion = `v19|cg-${stageCodegenFingerprint(stage2)}`;
+  for (const path of bindingFiles(currentCache, "selfhost_typing_dependency_env_reuse_v6")) {
     const text = readFileSync(path, "utf8");
-    const binding = parseBinding(text, "TDRE5A");
-    writeFileSync(stableCachePath(oldCache, oldVersion, "selfhost_typing_dependency_env_reuse_v5", binding.input, ".txt"), text);
-    writeFileSync(typeEnvPath(stage2, oldCache, binding.target, "v18"), readFileSync(typeEnvPath(stage2, currentCache, binding.target), "utf8"));
+    const binding = parseBinding(text, "TDRE6A");
+    writeFileSync(stableCachePath(oldCache, oldVersion, "selfhost_typing_dependency_env_reuse_v6", binding.input, ".txt"), text);
+    writeFileSync(typeEnvPath(stage2, oldCache, binding.target, "v19"), readFileSync(typeEnvPath(stage2, currentCache, binding.target), "utf8"));
   }
-  for (const path of bindingFiles(currentCache, "selfhost_typing_dependency_env_reuse_eligibility_v5")) {
+  for (const path of bindingFiles(currentCache, "selfhost_typing_dependency_env_reuse_eligibility_v6")) {
     const text = readFileSync(path, "utf8");
-    const binding = parseBinding(text, "TDRE5W");
-    writeFileSync(stableCachePath(oldCache, oldVersion, "selfhost_typing_dependency_env_reuse_eligibility_v5", binding.target, ".txt"), text);
-    writeFileSync(typeEnvPath(stage2, oldCache, binding.target, "v18"), readFileSync(typeEnvPath(stage2, currentCache, binding.target), "utf8"));
+    const binding = parseBinding(text, "TDRE6W");
+    writeFileSync(stableCachePath(oldCache, oldVersion, "selfhost_typing_dependency_env_reuse_eligibility_v6", binding.target, ".txt"), text);
+    writeFileSync(typeEnvPath(stage2, oldCache, binding.target, "v19"), readFileSync(typeEnvPath(stage2, currentCache, binding.target), "utf8"));
   }
-  if (bindingFiles(oldCache, "selfhost_typing_dependency_env_reuse_v5").length === 0) fail("v18 isolation fixture omitted valid old aliases");
-  const isolated = check(stage2, project, oldCache, true, "v18-isolated-default");
-  expectCounts("v18 namespace isolation", isolated.telemetry, 2, 0);
+  if (bindingFiles(oldCache, "selfhost_typing_dependency_env_reuse_v6").length === 0) fail("v19 isolation fixture omitted valid old aliases");
+  const isolated = check(stage2, project, oldCache, true, "v19-isolated-default");
+  expectCounts("v19 namespace isolation", isolated.telemetry, 2, 0);
   return isolated.telemetry;
 }
 
@@ -454,7 +454,7 @@ function run(stage2) {
     if (checkedCold.status === 0 || !checkedCold.output.includes("missing { Exception }")) fail("cold checked mode did not reject row-less caller");
     const uncheckedAfterChecked = check(stage2, checkedFirstProject, checkedFirstCache, true, "row-unchecked-after-checked", false, { VIBE_CHECK_ERROR_ROW: "0" });
     expectCounts("unchecked after checked mode isolation", uncheckedAfterChecked.telemetry, 2, 0);
-    const modeSeeds = bindingFiles(uncheckedFirstCache, "selfhost_typing_dependency_env_reuse_v5").map((path) => parseLogicalInput(parseBinding(readFileSync(path, "utf8"), "TDRE5A").input).typingSemantics);
+    const modeSeeds = bindingFiles(uncheckedFirstCache, "selfhost_typing_dependency_env_reuse_v6").map((path) => parseLogicalInput(parseBinding(readFileSync(path, "utf8"), "TDRE6A").input).typingSemantics);
     if (!modeSeeds.includes("checked") || !modeSeeds.includes("unchecked")) fail("TDRE5 aliases did not retain disjoint typing semantics seeds");
     const legacyCompat = check(stage2, onProject, onCache, true, "legacy-compat", false, {
       VIBE_EXPERIMENTAL_TYPING_DEPENDENCY_ENV_REUSE: "1",
@@ -511,7 +511,7 @@ function run(stage2) {
     expectTraceLaneRejected(stage2, onProject, onCache);
     expectInvalidEnvRejected(stage2, onProject, onCache, "VIBE_DISABLE_TYPING_DEPENDENCY_ENV_REUSE", "true");
     expectInvalidEnvRejected(stage2, onProject, onCache, "VIBE_EXPERIMENTAL_TYPING_DEPENDENCY_ENV_REUSE", "0");
-    const v18Isolation = expectV18Isolation(stage2, work);
+    const v19Isolation = expectV19Isolation(stage2, work);
 
     const malformedProject = join(work, "malformed-target-project");
     const malformedCache = join(work, "malformed-target-cache");
@@ -616,7 +616,7 @@ function run(stage2) {
     makeProject(malformedWitnessProject);
     check(stage2, malformedWitnessProject, malformedWitnessCache, true, "malformed-witness-cold");
     const malformedWitnessApp = appSidecar(malformedWitnessCache, readFileSync(join(malformedWitnessProject, "app.vibe"), "utf8"));
-    writeFileSync(targetWitness(malformedWitnessCache, malformedWitnessApp.target).path, "TDRE5W1:x");
+    writeFileSync(targetWitness(malformedWitnessCache, malformedWitnessApp.target).path, "TDRE6W1:x");
     privateEdit(malformedWitnessProject);
     const malformedWitnessFallback = check(stage2, malformedWitnessProject, malformedWitnessCache, true, "malformed-witness-fallback");
     expectCounts("malformed witness fallback", malformedWitnessFallback.telemetry, 2, 0);
@@ -737,8 +737,8 @@ function run(stage2) {
     writeFileSync(join(noPublishProject, "app.vibe"), failingSource);
     const noPublish = check(stage2, noPublishProject, noPublishCache, true, "diagnostic-no-publish", true);
     if (noPublish.status === 0) fail("diagnostic no-publish scenario unexpectedly succeeded");
-    const noPublishAliases = bindingFiles(noPublishCache, "selfhost_typing_dependency_env_reuse_v5");
-    const noPublishWitnesses = bindingFiles(noPublishCache, "selfhost_typing_dependency_env_reuse_eligibility_v5");
+    const noPublishAliases = bindingFiles(noPublishCache, "selfhost_typing_dependency_env_reuse_v6");
+    const noPublishWitnesses = bindingFiles(noPublishCache, "selfhost_typing_dependency_env_reuse_eligibility_v6");
     if (noPublishAliases.length !== 1 || noPublishWitnesses.length !== 1) fail("diagnosed module published TDRE5 alias or witness");
     if (noPublishAliases.some((path) => readFileSync(path, "utf8").includes(failingSource))) fail("diagnosed owner source appeared in TDRE5 alias");
 
@@ -752,7 +752,7 @@ function run(stage2) {
         explicit_disable_control: coldOff.telemetry,
         trace_forced_off: traceForcedOffTelemetry,
         post_trace_default: postTraceDefault.telemetry,
-        v18_namespace_isolation: v18Isolation,
+        v19_namespace_isolation: v19Isolation,
         conservative_compile_output_parity: true,
         invalid_env_diagnostics: true,
         checked_error_row_mode_isolation: {

--- a/scripts/incremental_invalidation_oracle.mjs
+++ b/scripts/incremental_invalidation_oracle.mjs
@@ -36,9 +36,9 @@ const telemetryKeys = [
 const fingerprintNote = "source_fingerprint is ingestion telemetry; implementation_fingerprint remains the provisional canonical token-stream identity; interface_fingerprint, checked_env_fingerprint, and persistent_type_env_transport_fingerprint are observation only; persistent_type_env_transport_fingerprint is TypeEnv transport only, not CheckedProgram, typed IR, exported interface, cache key, or reuse decision; none is a production cache key";
 const sourceFingerprintKind = "compact_string_fingerprint(ingested_source)";
 const implementationFingerprintKind = "compact_string_fingerprint(vibe-module-token-stream:v1 length_delimited(token_kind,source_lexeme))";
-const interfaceFingerprintKind = "compact_string_fingerprint(vibe-module-interface:v2 canonical exported surface including trait-header and method-generic binders)";
-const checkedEnvFingerprintKind = "compact_string_fingerprint(vibe-module-checked-env:v1 canonical effective TypeEnv value bindings)";
-const persistentTypeEnvTransportFingerprintKind = "compact_string_fingerprint(persistent_type_env_cache_text:v5 complete TypeEnv transport only; not CheckedProgram, typed IR, exported interface, cache key, or reuse decision)";
+const interfaceFingerprintKind = "compact_string_fingerprint(vibe-module-interface:v3 canonical exported surface including applied trait bounds)";
+const checkedEnvFingerprintKind = "compact_string_fingerprint(vibe-module-checked-env:v2 canonical effective TypeEnv value bindings including applied trait bounds)";
+const persistentTypeEnvTransportFingerprintKind = "compact_string_fingerprint(persistent_type_env_cache_text:v6 complete TypeEnv transport only; not CheckedProgram, typed IR, exported interface, cache key, or reuse decision)";
 
 const expectedCorpus = new Map([
   ["no_op", { sourceChanged: [], implementationChanged: [], invalidated: [] }],
@@ -395,7 +395,7 @@ function ownerNames(paths) {
 /// Classify the bounded library-body edit without promoting any observation to
 /// production policy. The consumer must name exactly the edited dependency in
 /// both snapshots: extra, missing, reordered, or changed edges fail closed.
-/// TypeEnv-v5 transport state is reported independently from interface-v2.
+/// TypeEnv-v6 transport state is reported independently from interface-v3.
 export function classifyPrivateDependencyEditExternallyUnchanged(before, after, dependencyName, consumerName) {
   const beforeDependency = moduleByName(before, dependencyName);
   const afterDependency = moduleByName(after, dependencyName);
@@ -427,7 +427,7 @@ export function classifyPrivateDependencyEditExternallyUnchanged(before, after, 
     fail("private dependency edit did not change dependency implementation identity");
   }
   if (beforeDependency.interface_fingerprint !== afterDependency.interface_fingerprint) {
-    fail("private dependency edit changed dependency interface-v2 identity");
+    fail("private dependency edit changed dependency interface-v3 identity");
   }
 
   const consumerIdentityFields = [
@@ -457,7 +457,7 @@ export function classifyPrivateDependencyEditExternallyUnchanged(before, after, 
     dependency_identity: {
       source: "changed",
       implementation_token_stream_v1: "changed",
-      interface_v2: "unchanged",
+      interface_v3: "unchanged",
     },
     dependency_type_env_transport_v5: beforeDependency.persistent_type_env_transport_fingerprint === afterDependency.persistent_type_env_transport_fingerprint
       ? "unchanged"

--- a/scripts/incremental_invalidation_oracle.test.mjs
+++ b/scripts/incremental_invalidation_oracle.test.mjs
@@ -25,11 +25,11 @@ const validTrace = {
       implementation_fingerprint: "30:1:2",
       implementation_fingerprint_kind: "compact_string_fingerprint(vibe-module-token-stream:v1 length_delimited(token_kind,source_lexeme))",
       interface_fingerprint: "31:1:2",
-      interface_fingerprint_kind: "compact_string_fingerprint(vibe-module-interface:v2 canonical exported surface including trait-header and method-generic binders)",
+      interface_fingerprint_kind: "compact_string_fingerprint(vibe-module-interface:v3 canonical exported surface including applied trait bounds)",
       checked_env_fingerprint: "32:1:2",
-      checked_env_fingerprint_kind: "compact_string_fingerprint(vibe-module-checked-env:v1 canonical effective TypeEnv value bindings)",
+      checked_env_fingerprint_kind: "compact_string_fingerprint(vibe-module-checked-env:v2 canonical effective TypeEnv value bindings including applied trait bounds)",
       persistent_type_env_transport_fingerprint: "33:1:2",
-      persistent_type_env_transport_fingerprint_kind: "compact_string_fingerprint(persistent_type_env_cache_text:v5 complete TypeEnv transport only; not CheckedProgram, typed IR, exported interface, cache key, or reuse decision)",
+      persistent_type_env_transport_fingerprint_kind: "compact_string_fingerprint(persistent_type_env_cache_text:v6 complete TypeEnv transport only; not CheckedProgram, typed IR, exported interface, cache key, or reuse decision)",
       decision: "reused",
     },
   ],
@@ -243,7 +243,7 @@ test("shadow planner keeps implementation edits local and propagates interface e
   assert.deepEqual(planObservedTypingInvalidation(before, removedEdgeAfter), ["/p/base.vibe", "/p/library.vibe", "/p/app.vibe"]);
 });
 
-test("private dependency classifier is explicit, fail-closed, and reports TypeEnv-v5 separately", () => {
+test("private dependency classifier is explicit, fail-closed, and reports TypeEnv-v6 separately", () => {
   const before = plannerTrace();
   const after = plannerTrace({
     source: { "/p/library.vibe": "source:library:private-edit" },
@@ -261,7 +261,7 @@ test("private dependency classifier is explicit, fail-closed, and reports TypeEn
     dependency_identity: {
       source: "changed",
       implementation_token_stream_v1: "changed",
-      interface_v2: "unchanged",
+      interface_v3: "unchanged",
     },
     dependency_type_env_transport_v5: "unchanged",
     consumer_own_identities: {
@@ -286,7 +286,7 @@ test("private dependency classifier is explicit, fail-closed, and reports TypeEn
     ["after relation", (_, right) => { right.modules[2].direct_dependencies = []; }, /after direct relation/],
     ["source", (_, right) => { right.modules[1].source_fingerprint = before.modules[1].source_fingerprint; }, /did not change dependency source/],
     ["implementation", (_, right) => { right.modules[1].implementation_fingerprint = before.modules[1].implementation_fingerprint; }, /did not change dependency implementation/],
-    ["interface", (_, right) => { right.modules[1].interface_fingerprint = "interface:library:changed"; }, /changed dependency interface-v2/],
+    ["interface", (_, right) => { right.modules[1].interface_fingerprint = "interface:library:changed"; }, /changed dependency interface-v3/],
     ["consumer identity", (_, right) => { right.modules[2].source_fingerprint = "source:app:changed"; }, /changed consumer own source_fingerprint/],
     ["missing transport", (_, right) => { delete right.modules[1].persistent_type_env_transport_fingerprint; }, /missing after dependency persistent_type_env_transport_fingerprint/],
     ["consumer decision", (_, right) => { right.modules[2].decision = "reused"; }, /no longer conservatively rechecked/],

--- a/scripts/method_style_naming_allowlist.txt
+++ b/scripts/method_style_naming_allowlist.txt
@@ -35,6 +35,7 @@ lib/@vibe/core/index.vpkg	set_union
 # stable TypeExpr method API.
 lib/@vibe/ast/index.vpkg	impl_target_head	compiler-internal AST representation helper
 lib/@vibe/ast/index.vpkg	impl_target_key	compiler-internal canonical encoding helper
+lib/@vibe/ast/index.vpkg	trait_ref_key	compiler-internal canonical encoding helper
 
 # --- @vibe/compiler/incremental (RippleDb)
 lib/@vibe/compiler/incremental/index.vpkg	ripple_eval_count


### PR DESCRIPTION
Closes #2336

## Summary
- preserve applied trait arguments in bounds and impl heads across parsing, checking, imports, and cached checked state
- instantiate trait methods and witness selection from applied arguments, including generic impl matching and overlap checks
- version affected persistent TypeEnv, TDRE, module interface, and checked-state encodings
- add local and cross-module positive, missing, arity, argument-mismatch, and ambiguity coverage

## Validation
- 1,041/1,041 compiler unit tests
- 481 fixture files and 219 runtime expectations
- seed to stage3 bootstrap fixpoint
- generation and incremental trace checks
- production TDRE oracle
- late compiler gate 106/106 after fixing the detected runtime package dependency declaration
- pre-commit lint gates

The aggregate local gate reaches the known macOS Bash 3 mapfile portability failure tracked by #2349; all preceding compiler gates pass.