### PR TITLE
Add kinded type-constructor parameters and applied unification

### DIFF
--- a/docs/cheatsheet.md
+++ b/docs/cheatsheet.md
@@ -870,7 +870,7 @@ fn keep[T: Measured](x: T) -> T { x }
 let ok = keep([1, 2, 3])
 ```
 
-### Higher-kinded type parameters (`F[A]`)
+### Higher-kinded type parameters (`F[A]` and `F[_]`)
 
 **A type formal may stand in constructor position — `F[A]`.** Unification
 binds `F` to a type constructor (`F := Array` yields `Array[A]`). The
@@ -880,6 +880,27 @@ instance exists; a user `fn map[F, A, B](xs: F[A], f: (A) -> B) -> F[B]`
 is what instantiates `F`. A formal used both unapplied (`x: F`) and
 applied (`y: F[A]`) is rejected as mixed-kind. Ascribing `F[A]` to a
 concrete constructor (`let ys: Array[Int] = xs`) is rejected.
+
+A constructor parameter may also declare its arity with underscore slots
+(`F[_]`, `F[_, _]`). Applied constructor variables participate in ordinary
+unification, so their element arguments remain distinct and the shared
+constructor head must match:
+
+```vibe
+fn pair[F[_], A, B](left: F[A], right: F[B]) -> (F[A], F[B]) {
+  (left, right)
+}
+
+let arrays = pair([1], ["vibe"])
+let options = pair(Some(1), Some("vibe"))
+
+type Apply[F[_], A] = F[A]
+let optional: Apply[Option, Int] = Some(42)
+```
+
+Kinded binders and applied types are preserved across package interfaces.
+Passing a complete type where a constructor is required is rejected with the
+expected and actual arities. Unkinded `F[A]` remains legal.
 
 <!-- doctest-skip: mixed-kind is deliberately rejected -->
 ```vibe skip

--- a/docs/incremental-build.md
+++ b/docs/incremental-build.md
@@ -345,20 +345,22 @@ prove artifact equivalence.
 ## Trait generic provenance (bounded Phase 3)
 
 The in-memory parser and checker retain bare trait-header parameter names and
-positional method-generic rows for provenance. The header names append a sixth
+positional method-generic rows for provenance. Type-parameter keys also retain
+constructor arity (`F[_]`, `G[_, _]`) without changing the public source name.
+The header names append a sixth
 field to transparent `STrait`; checker-retained `EnvTraitDef` appends method
 rows seventh, without shifting its prior slots. This is an explicit source
-migration for positional consumers. Persistent TypeEnv v5 transports those
-trait definitions and method-generic rows, but remains a narrow environment
-transport, not a complete clean/warm typed artifact or lossless `CheckedProgram`
-claim.
+migration for positional consumers. Persistent TypeEnv v7 transports those
+trait definitions, method-generic rows, kinded constructors, and applied-type
+nodes, but remains a narrow environment transport, not a complete clean/warm
+typed artifact or lossless `CheckedProgram` claim.
 
 ## Dependency transport-environment typing reuse
 
-TDRE5 TypeEnv reuse is enabled by default for the `vibe check` filesystem
+TDRE7 TypeEnv reuse is enabled by default for the `vibe check` filesystem
 check-only lane. Build, codegen, LSP, and direct FS typecheck consumers remain
 conservative pending a compact exact-publication design: publishing the current
-exact TDRE5A/TDRE5W texts on a fresh selfcompile exceeds the signed 2 GiB guest
+exact TDRE7A/TDRE7W texts on a fresh selfcompile exceeds the signed 2 GiB guest
 heap boundary, while the conservative compile lane remains near 1.11 GB.
 `VIBE_DISABLE_TYPING_DEPENDENCY_ENV_REUSE=1` is the strict emergency opt-out for
 check-only reuse;
@@ -369,35 +371,36 @@ invalidation trace automatically forces reuse off so the trace stays
 observation-only. For compatibility, explicitly combining legacy `1` with an
 invalidation trace remains rejected.
 
-TDRE5 aliases the exact logical
+TDRE7 aliases the exact logical
 `ModuleJob` checker input to a previously checked TypeEnv: canonical owner path,
 byte-exact owner source, the canonical effective typing-semantics seed (currently
 checked versus unchecked `Exception` rows), `resolution_env_seed()`, and every
-`(path, canonical TypeEnv-v5 transport text)` row in the exact ordered resolved
+`(path, canonical TypeEnv-v7 transport text)` row in the exact ordered resolved
 direct-dependency projection. The coordinator retains the full accumulated environment cache only
 for graph coordination and upsert; it projects each `deps` occurrence in order,
 preserves duplicate paths and first-match cache lookup, and fails closed if any
 resolved row is missing. The same projected array is passed to `check_module`
-and to TDRE5 lookup/publication, so ambient non-direct cache mutations are
-semantically irrelevant and avoid quadratic canonical serialization. TDRE5 does
+and to TDRE7 lookup/publication, so ambient non-direct cache mutations are
+semantically irrelevant and avoid quadratic canonical serialization. TDRE7 does
 not replace exact transport text with a compact fingerprint. It validates and
 republishes the decoded environment under the ordinary conservative fingerprint.
 It does not use the
-trace-only `vibe-module-interface:v2` observation as a production key, and
+trace-only `vibe-module-interface:v4` observation as a production key, and
 malformed, missing, stale, torn, or cross-spliced aliases, witnesses, and targets
 fall back to a full check. The alias remains incompatible with the incremental
 invalidation trace lane so the two identities cannot be confused.
 
-The v5 TypeEnv codec round-trips every current `TypeEnv` variant, including
+The v7 TypeEnv codec round-trips every current `TypeEnv` variant, including
 trait definitions, impls, generic impl bounds, trait-header parameters,
-positional method-generic binders/bounds, and method `TypeExpr` metadata. The
+positional method-generic binders/bounds, kinded constructors, applied types,
+and method `TypeExpr` metadata. The
 checked-row cache isolation bumps the global persistent cache namespace from
-v18 to v19 and replaces TDRE4 aliases/witnesses with disjoint TDRE5 namespaces
-and `TDRE5A` / `TDRE5W` envelopes. Old entries are never reinterpreted. A
+v20 to v21 and replaces TDRE6 aliases/witnesses with disjoint TDRE7 namespaces
+and `TDRE7A` / `TDRE7W` envelopes. Old entries are never reinterpreted. A
 sidecar is still only an alias to a conservative
 TypeEnv commit, not a `CheckedProgram` or lossless typed-IR transport.
 
-A witness is published only after that module's canonical TypeEnv-v5 target and
+A witness is published only after that module's canonical TypeEnv-v7 target and
 when every direct dependency already has a validated witness for its conservative
 fingerprint. Alias and witness both bind the logical input, target conservative
 fingerprint, and exact canonical target text. Reuse reads the raw target,
@@ -848,13 +851,13 @@ The historical private-body observation is emitted under the explicit
 classification `private_dependency_edit_externally_unchanged`. That classifier
 fails closed unless `app` has exactly `library` as its sole direct dependency in
 both snapshots, the dependency's source and provisional token-stream
-implementation identities change, its interface-v2 identity does not change,
+implementation identities change, its interface-v4 identity does not change,
 and all of the consumer's own observed identities stay unchanged. The
-persistent TypeEnv-v5 transport result for the dependency is reported as a
+persistent TypeEnv-v7 transport result for the dependency is reported as a
 separate `changed`/`unchanged` observation rather than being treated as the
-exported interface. Production TDRE5 may reuse the unaffected consumer; the
+exported interface. Production TDRE7 may reuse the unaffected consumer; the
 shadow classifier remains observation-only and does not authorize that reuse.
-It does not change trace schema 6, cache namespace v19, TypeEnv-v5/TDRE5
+It does not change trace schema 6, cache namespace v21, TypeEnv-v7/TDRE7
 transport, production artifact reuse, or default-gate wiring.
 
 For this comparison, `source_fingerprint` is ingestion telemetry only;

--- a/docs/spec/syntax.md
+++ b/docs/spec/syntax.md
@@ -204,6 +204,7 @@ Function types:
 (Int) -> Int with Exception
 [T](T) -> T
 [T: Eq + Ord](T) -> Bool
+[F[_], A](F[A]) -> F[A]
 ```
 
 Labeled arguments:
@@ -704,6 +705,9 @@ Rules:
 - `i32`, `f32`, and `f64` are aliases for `Int`, `Float`, and `Double` in type
   positions.
 - Function effects appear after return type: `-> T with Effect`.
+- A type-constructor parameter declares its arity with underscore slots:
+  `F[_]` has one input and `F[_, _]` has two. An unannotated parameter such as
+  `T` is a complete type and cannot appear as the head of `T[A]`.
 - Effect row variables such as `with e` are accepted in polymorphic
   higher-order signatures.
 - The effect row has one spelling, plus one for the empty row:

--- a/docs/spec/syntax.md
+++ b/docs/spec/syntax.md
@@ -705,9 +705,11 @@ Rules:
 - `i32`, `f32`, and `f64` are aliases for `Int`, `Float`, and `Double` in type
   positions.
 - Function effects appear after return type: `-> T with Effect`.
-- A type-constructor parameter declares its arity with underscore slots:
-  `F[_]` has one input and `F[_, _]` has two. An unannotated parameter such as
-  `T` is a complete type and cannot appear as the head of `T[A]`.
+- A type-constructor parameter may declare its arity with underscore slots:
+  `F[_]` has one input and `F[_, _]` has two, and those forms are
+  arity-enforced at each application. An unannotated parameter such as `F`
+  may still appear as the head of `F[A]` (the kernel spelling from arity-1
+  HKT); `F[_]` is the extra, arity-checked surface, not a requirement.
 - Effect row variables such as `with e` are accepted in polymorphic
   higher-order signatures.
 - The effect row has one spelling, plus one for the empty row:

--- a/fixtures/generic_derive_eq_test.vibe
+++ b/fixtures/generic_derive_eq_test.vibe
@@ -66,6 +66,10 @@ struct NestedPhantom[T] {
   value: Box[Phantom[T]]
 } derive (Eq)
 
+struct KBox[F[_], A] {
+  value: F[A]
+} derive (Eq)
+
 struct FiniteA[T] {
   value: T;
   next: Option[FiniteB[Array[Int]]]
@@ -332,4 +336,12 @@ test "explicit unit generic arguments survive equality shapes" {
   Array::push(named_left, Box[Unit]::{ value: () })
   Array::push(named_right, Box[Unit]::{ value: () })
   inspect(equality_snapshot(named_left == named_right), content = "true")
+}
+
+test "kinded constructor fields compare structurally" {
+  let a = KBox[Array, Int]::{ value: [1, 2] }
+  let b = KBox[Array, Int]::{ value: [1, 2] }
+  inspect(equality_snapshot(a == b), content = "true")
+  let c = KBox[Array, Int]::{ value: [1, 3] }
+  inspect(equality_snapshot(a == c), content = "false")
 }

--- a/fixtures/kinded_constructor_import/dep.vibe
+++ b/fixtures/kinded_constructor_import/dep.vibe
@@ -1,0 +1,5 @@
+export fn pair[F[_], A, B](left: F[A], right: F[B]) -> (F[A], F[B]) {
+  (left, right)
+}
+
+export type Apply[F[_], A] = F[A]

--- a/fixtures/kinded_constructor_import/main_test.vibe
+++ b/fixtures/kinded_constructor_import/main_test.vibe
@@ -1,0 +1,14 @@
+import ./dep.vibe {
+  Apply, pair
+}
+
+test "kinded function binders survive an import boundary" {
+  let arrays = pair([1, 2], ["vibe"])
+  assert_eq(arrays.0, [1, 2])
+  assert_eq(arrays.1, ["vibe"])
+}
+
+test "kinded alias binders survive an import boundary" {
+  let values: Apply[Option, Int] = Some(42)
+  assert_eq(values, Some(42))
+}

--- a/fixtures/kinded_constructor_unification_test.vibe
+++ b/fixtures/kinded_constructor_unification_test.vibe
@@ -1,0 +1,28 @@
+fn same_constructor_pair[F[_], A, B](left: F[A], right: F[B]) -> (F[A], F[B]) {
+  (left, right)
+}
+
+type Apply[F[_], A] = F[A]
+
+fn keep[F[_], A](value: Apply[F, A]) -> F[A] {
+  value
+}
+
+test "a unary constructor variable unifies with Array" {
+  let pair = same_constructor_pair([1, 2], ["vibe"])
+  assert_eq(pair.0, [1, 2])
+  assert_eq(pair.1, ["vibe"])
+}
+
+test "a unary constructor variable unifies with Option" {
+  let pair = same_constructor_pair(Some(42), Some("vibe"))
+  assert_eq(pair.0, Some(42))
+  assert_eq(pair.1, Some("vibe"))
+}
+
+test "a concrete constructor flows through a kinded alias" {
+  let arrays: Apply[Array, Int] = keep([1, 2])
+  let option: Apply[Option, String] = keep(Some("vibe"))
+  assert_eq(arrays, [1, 2])
+  assert_eq(option, Some("vibe"))
+}

--- a/lib/@vibe/ast/ast.vibe
+++ b/lib/@vibe/ast/ast.vibe
@@ -4,6 +4,54 @@
 // suppresses sibling auto-discovery (test files beside the contract must
 // not join the facade).
 
+let type_param_kind_prefix = "$type_param$"
+
+/// Canonical AST key for a type parameter and its constructor arity.
+/// Arity-zero parameters keep their historical spelling so old artifacts and
+/// consumers remain readable. The prefix is not a source identifier, so an
+/// encoded constructor binder cannot collide with user code.
+export fn type_param_key(name: String, arity: Int) -> String {
+  if arity <= 0 {
+    name
+  } else {
+    String::concat(type_param_kind_prefix, String::concat(Int::to_string(arity), String::concat("$", name)))
+  }
+}
+
+fn type_param_kind_split(key: String) -> Option[(String, Int)] {
+  if !String::starts_with(key, type_param_kind_prefix) {
+    None
+  } else {
+    let mut pos = String::length(type_param_kind_prefix)
+    let mut arity = 0
+    let mut digits = 0
+    while pos < String::length(key) && String::char_code_at(key, pos) >= '0' && String::char_code_at(key, pos) <= '9' {
+      arity = arity * 10 + String::char_code_at(key, pos) - '0'
+      digits = digits + 1
+      pos = pos + 1
+    }
+    if digits == 0 || arity <= 0 || pos >= String::length(key) || String::char_code_at(key, pos) != '$' {
+      None
+    } else {
+      Some((String::substring(key, pos + 1, String::length(key)), arity))
+    }
+  }
+}
+
+export fn type_param_name(key: String) -> String {
+  match type_param_kind_split(key) {
+    Some(pair) => pair.0,
+    None => key
+  }
+}
+
+export fn type_param_arity(key: String) -> Int {
+  match type_param_kind_split(key) {
+    Some(pair) => pair.1,
+    None => 0
+  }
+}
+
 export fn impl_target_head(target: TypeExpr) -> String {
   match target {
     TyName(name) => name,

--- a/lib/@vibe/ast/index.vpkg
+++ b/lib/@vibe/ast/index.vpkg
@@ -52,6 +52,9 @@ fn impl_specialized_method_binding_name(head: String, trait_name: String, target
 fn impl_method_owner(tparams: Array[String], trait_name: String, target: TypeExpr) -> String
 fn impl_method_binding_name(tparams: Array[String], trait_name: String, target: TypeExpr, method: String) -> String
 fn impl_method_owner_head(owner: String) -> String
+fn type_param_key(name: String, arity: Int) -> String
+fn type_param_name(key: String) -> String
+fn type_param_arity(key: String) -> Int
 
 /// The declaration kind requested by a kind-qualified import item.
 export enum ImportKind {

--- a/lib/@vibe/cache/cache.vibe
+++ b/lib/@vibe/cache/cache.vibe
@@ -156,7 +156,7 @@ export fn persistent_dep_list_cache_path(version_tag: String, path: String, sour
 }
 
 export fn persistent_type_env_cache_path(version_tag: String, fingerprint: String) -> String {
-  stable_cache_path(version_tag, "selfhost_type_env_v6", fingerprint, ".tsv")
+  stable_cache_path(version_tag, "selfhost_type_env_v7", fingerprint, ".tsv")
 }
 
 export fn build_source_groups_fingerprint(groups: Array[(String, Array[(String, String)])]) -> String {

--- a/lib/@vibe/compiler/cache/persistent_cache.vibe
+++ b/lib/@vibe/compiler/cache/persistent_cache.vibe
@@ -99,6 +99,8 @@ export ../../../../lib/@vibe/cache {
 ///    invalidates stale artifacts; no manual bump needed (#630). `vNN` is still a
 ///    manual knob for pure cache-FORMAT changes that don't change the source hash.
 fn persistent_cache_version_tag() -> String {
+  // v21: TypeEnv v7 and TDRE7 preserve constructor kinds and non-nominal
+  // applied type heads. Every v20 entry cold-misses rather than erasing F[_].
   // v20: TypeEnv v6 admits semantic applied-trait bound keys. The namespace
   // bump prevents pre-#2336 bare-name witness state from being reused.
   // v19: effective checked-Exception-row semantics are bound into module, leaf, and TDRE5 identities. All v18 typing entries cold-miss.
@@ -122,7 +124,7 @@ fn persistent_cache_version_tag() -> String {
   // (`.bin`, via Fs::write_bytes / Fs::read_bytes) — a cache FORMAT change, so
   // the manual `vNN` knob is bumped. Old `.hex` entries are now unreferenced
   // (different key + suffix) and reclaimable via `pkf run cache-clean` (#631).
-  String::concat("v20|cg-", codegen_fingerprint())
+  String::concat("v21|cg-", codegen_fingerprint())
 }
 
 /// Read-only trace evidence for the exact existing persistent cache identity.
@@ -155,18 +157,18 @@ export fn persistent_type_env_cache_path(fingerprint: String) -> String {
   cache_persistent_type_env_cache_path(persistent_cache_version_tag(), fingerprint)
 }
 
-/// TDRE6 typing-input aliases are deliberately separate from the TypeEnv-v6
+/// TDRE7 typing-input aliases are deliberately separate from the TypeEnv-v7
 /// artifact namespace and all earlier TDRE namespaces. The referenced TypeEnv
 /// remains in its conservative fingerprint-addressed cache entry.
 export fn persistent_typing_dependency_env_reuse_sidecar_path(typing_input_key: String) -> String {
-  cache_stable_text_cache_path(persistent_cache_version_tag(), "selfhost_typing_dependency_env_reuse_v6", typing_input_key)
+  cache_stable_text_cache_path(persistent_cache_version_tag(), "selfhost_typing_dependency_env_reuse_v7", typing_input_key)
 }
 
-/// TDRE6 eligibility witnesses are isolated from prior marker formats and keyed
+/// TDRE7 eligibility witnesses are isolated from prior marker formats and keyed
 /// by the ordinary conservative module fingerprint. Their strict envelope also
-/// binds the logical input and exact canonical target TypeEnv-v6 text.
+/// binds the logical input and exact canonical target TypeEnv-v7 text.
 export fn persistent_typing_dependency_env_reuse_eligibility_path(fingerprint: String) -> String {
-  cache_stable_text_cache_path(persistent_cache_version_tag(), "selfhost_typing_dependency_env_reuse_eligibility_v6", fingerprint)
+  cache_stable_text_cache_path(persistent_cache_version_tag(), "selfhost_typing_dependency_env_reuse_eligibility_v7", fingerprint)
 }
 
 export fn persistent_source_list_cache_path(entry_path: String) -> String {

--- a/lib/@vibe/compiler/checker/artifacts/checked_exported_interface_artifact.vibe
+++ b/lib/@vibe/compiler/checker/artifacts/checked_exported_interface_artifact.vibe
@@ -753,7 +753,7 @@ export fn canonical_checked_exported_interface_artifact_snapshot(artifact: Check
 
 /// Stable compact fingerprint of the versioned opaque payload. It is a
 /// shadow-only comparison token and is deliberately not wired into any cache,
-/// production reuse, interface-v3, TypeEnv-v6, trace, or planner path.
+/// production reuse, interface-v4, TypeEnv-v7, trace, or planner path.
 export fn checked_exported_interface_artifact_fingerprint_v1(artifact: CheckedExportedInterfaceArtifact) -> String {
   compact_string_fingerprint(encode_checked_exported_interface_artifact_v1(artifact))
 }

--- a/lib/@vibe/compiler/checker/artifacts/checked_type_defs_artifact.vibe
+++ b/lib/@vibe/compiler/checker/artifacts/checked_type_defs_artifact.vibe
@@ -1,6 +1,6 @@
 //# Checked type-definition artifact (#1379)
 //
-// This deliberately narrow, lossless-semantic v1 transport contains only
+// This deliberately narrow, lossless-semantic v2 transport contains only
 // retained TypeDefs, aligned binder provenance, and final_subst's authoritative
 // chain. It is not a
 // CheckedProgram, TypeEnv, typed IR, cache artifact, trace schema, interface,
@@ -141,6 +141,16 @@ fn artifact_type(ty: Type) -> String {
     CtBytes => "Y",
     CtUnknown => "X",
     CtVar(id) => String::concat("V", artifact_piece(__to_string(id))),
+    CtConstructor(name, arity) => String::concat("J", String::concat(artifact_piece(name), artifact_piece(__to_string(arity)))),
+    CtApplied(head, args) => {
+      let encoded = array_empty()
+      let mut i = 0
+      while i < Array::length(args) {
+        Array::push(encoded, artifact_type(Array::get(args, i)))
+        i = i + 1
+      }
+      String::concat("P", String::concat(artifact_type(head), artifact_array(encoded)))
+    },
     CtTuple(items) => {
       let encoded = array_empty()
       let mut i = 0
@@ -275,7 +285,7 @@ fn artifact_subst(s: Subst) -> String {
         StringBuilder::push(out, artifact_strings(labels))
         cur = rest
       },
-      // Callers reject SubstCached before encoding. It has no v1
+      // Callers reject SubstCached before encoding. It has no v2
       // representation: cache maps are semantically observable and must not
       // be normalized away.
       SubstCached(_, _, _) => {
@@ -293,10 +303,10 @@ fn artifact_subst(s: Subst) -> String {
   StringBuilder::freeze(out)
 }
 
-/// Strict length-delimited v1 encoder. It refuses malformed/colliding binder
-/// provenance and every SubstCached chain; v1 excludes acceleration-bearing
+/// Strict length-delimited v2 encoder. It refuses malformed/colliding binder
+/// provenance and every SubstCached chain; v2 excludes acceleration-bearing
 /// substitutions until Map[Type] codegen can preserve their semantics.
-export fn encode_checked_type_defs_artifact_v1(artifact: CheckedTypeDefsArtifact) -> Option[String] {
+export fn encode_checked_type_defs_artifact_v2(artifact: CheckedTypeDefsArtifact) -> Option[String] {
   if !artifact_valid(artifact.type_defs, artifact.type_def_binders, artifact.final_subst) {
     None
   } else {
@@ -308,7 +318,7 @@ export fn encode_checked_type_defs_artifact_v1(artifact: CheckedTypeDefsArtifact
       Array::push(binders, artifact_ints(Array::get(artifact.type_def_binders, i)))
       i = i + 1
     }
-    Some(String::concat("vibe-checked-type-defs:v1\n", String::concat(artifact_array(defs), String::concat(artifact_array(binders), artifact_subst(artifact.final_subst)))))
+    Some(String::concat("vibe-checked-type-defs:v2\n", String::concat(artifact_array(defs), String::concat(artifact_array(binders), artifact_subst(artifact.final_subst)))))
   }
 }
 
@@ -494,6 +504,52 @@ fn artifact_type_parse(text: String, pos: Int) -> Option[(Type, Int)] {
       match artifact_piece_parse(text, pos + 1) {
         Some((raw, next)) => match artifact_int(raw) {
           Some(id) => Some((CtVar(id), next)),
+          None => None
+        },
+        None => None
+      }
+    } else if tag == 74 {
+      match artifact_piece_parse(text, pos + 1) {
+        Some((name, after_name)) => match artifact_piece_parse(text, after_name) {
+          Some((raw_arity, next)) => match artifact_int(raw_arity) {
+            Some(arity) => if arity > 0 {
+              Some((CtConstructor(name, arity), next))
+            } else {
+              None
+            },
+            None => None
+          },
+          None => None
+        },
+        None => None
+      }
+    } else if tag == 80 {
+      match artifact_type_parse(text, pos + 1) {
+        Some((head, after_head)) => match artifact_array_parse(text, after_head) {
+          Some((raws, next)) => {
+            let args = array_empty()
+            let mut i = 0
+            let mut valid = true
+            while i < Array::length(raws) {
+              let raw = Array::get(raws, i)
+              match artifact_type_parse(raw, 0) {
+                Some((arg, end)) => if end == String::length(raw) {
+                  Array::push(args, arg)
+                } else {
+                  valid = false
+                },
+                None => {
+                  valid = false
+                }
+              }
+              i = i + 1
+            }
+            if valid && Array::length(args) > 0 {
+              Some((CtApplied(head, args), next))
+            } else {
+              None
+            }
+          },
           None => None
         },
         None => None
@@ -939,7 +995,7 @@ fn artifact_subst_parse(text: String, pos: Int) -> Option[(Subst, Int)] {
         None => None
       }
     }
-    // C was deliberately never assigned in v1. Reject it rather than
+    // C was deliberately never assigned in v2. Reject it rather than
     // silently interpreting a claimed raw cache payload.
     else if tag == 67 {
       None
@@ -962,11 +1018,11 @@ fn artifact_subst_parse(text: String, pos: Int) -> Option[(Subst, Int)] {
   }
 }
 
-/// Strict v1 decoder. It accepts only complete canonical encodings; unknown
+/// Strict v2 decoder. It accepts only complete canonical encodings; unknown
 /// tags, truncation, extra bytes, claimed raw SubstCached payloads, and malformed
 /// binder provenance all return None.
-export fn decode_checked_type_defs_artifact_v1(text: String) -> Option[CheckedTypeDefsArtifact] {
-  let prefix = "vibe-checked-type-defs:v1\n"
+export fn decode_checked_type_defs_artifact_v2(text: String) -> Option[CheckedTypeDefsArtifact] {
+  let prefix = "vibe-checked-type-defs:v2\n"
   if !String::starts_with(text, prefix) {
     None
   } else {
@@ -1009,7 +1065,7 @@ export fn decode_checked_type_defs_artifact_v1(text: String) -> Option[CheckedTy
             if !valid || !artifact_valid(defs, binders, subst) {
               None
             } else {
-              match encode_checked_type_defs_artifact_v1(artifact) {
+              match encode_checked_type_defs_artifact_v2(artifact) {
                 Some(canonical) => if canonical == text {
                   Some(artifact)
                 } else {

--- a/lib/@vibe/compiler/checker/artifacts/index.vpkg
+++ b/lib/@vibe/compiler/checker/artifacts/index.vpkg
@@ -81,7 +81,7 @@ fn checked_module_typing_artifact_fingerprint_v2(artifact: CheckedModuleTypingAr
 // --- checked_exported_interface_artifact.vibe
 // Shadow-only complete-or-none exported declaration surface from retained
 // successful CheckedProgram data. It is not a cache/reuse input, interface-v2,
-// TypeEnv-v6 transport, artifact-input trace, or planner decision. Exported
+// TypeEnv-v7 transport, artifact-input trace, or planner decision. Exported
 // nested values fail closed because CheckedProgram retains no nested TypeEnv.
 opaque type CheckedExportedInterfaceArtifact
 fn checked_exported_interface_artifact_from_checked_program(checked: CheckedProgram) -> Option[CheckedExportedInterfaceArtifact]
@@ -95,8 +95,8 @@ fn checked_exported_interface_artifact_fingerprint_v1(artifact: CheckedExportedI
 // TypeEnv/full CheckedProgram transport, cache/reuse, trace, and interfaces.
 opaque type CheckedTypeDefsArtifact
 fn checked_type_defs_artifact_from_observation(observation: CheckedProgramTypeDefsObservation) -> Option[CheckedTypeDefsArtifact]
-fn encode_checked_type_defs_artifact_v1(artifact: CheckedTypeDefsArtifact) -> Option[String]
-fn decode_checked_type_defs_artifact_v1(text: String) -> Option[CheckedTypeDefsArtifact]
+fn encode_checked_type_defs_artifact_v2(artifact: CheckedTypeDefsArtifact) -> Option[String]
+fn decode_checked_type_defs_artifact_v2(text: String) -> Option[CheckedTypeDefsArtifact]
 fn canonical_checked_type_defs_artifact_snapshot(artifact: CheckedTypeDefsArtifact) -> Option[String]
 
 opaque type CheckedEffectSetDeclarationsObservation

--- a/lib/@vibe/compiler/checker/canonical_checked_type_state.vibe
+++ b/lib/@vibe/compiler/checker/canonical_checked_type_state.vibe
@@ -14,6 +14,10 @@ import @vibe/core {
   array_empty
 }
 
+import @vibe/ast {
+  type_param_arity, type_param_name
+}
+
 // #2125: the two observation wrappers below annotate parameters with types
 // this package's contract declares BODYLESS (`type CheckedProgram`). A
 // bodyless declaration has no `TypeDef`, so the annotation used to resolve to
@@ -260,13 +264,23 @@ fn canonical_named_bound(names: Array[String], name: String) -> Int {
   let mut i = 0
   let mut found = -1
   while i < Array::length(names) && found < 0 {
-    if Array::get(names, i) == name {
+    if type_param_name(Array::get(names, i)) == name {
       found = i
     } else {
       i = i + 1
     }
   }
   found
+}
+
+fn canonical_param_arities(params: Array[String]) -> String {
+  let fields = array_empty()
+  let mut i = 0
+  while i < Array::length(params) {
+    Array::push(fields, __to_string(type_param_arity(Array::get(params, i))))
+    i = i + 1
+  }
+  canonical_node("K", fields)
 }
 
 fn canonical_type(ty: Type, s: Subst, bound_ids: Array[Int], bound_names: Array[String], free_ids: Array[Int], free_names: Array[String], resolving: Array[Int]) -> String {
@@ -297,6 +311,18 @@ fn canonical_type(ty: Type, s: Subst, bound_ids: Array[Int], bound_names: Array[
           ])
         }
       }
+    },
+    CtConstructor(name, arity) => canonical_node("H", [name, __to_string(arity)]),
+    CtApplied(head, args) => {
+      let fields = [
+        canonical_type(head, s, bound_ids, bound_names, free_ids, free_names, resolving)
+      ]
+      let mut i = 0
+      while i < Array::length(args) {
+        Array::push(fields, canonical_type(Array::get(args, i), s, bound_ids, bound_names, free_ids, free_names, resolving))
+        i = i + 1
+      }
+      canonical_node("P", fields)
     },
     CtTuple(items) => {
       let fields = array_empty()
@@ -487,7 +513,7 @@ export fn canonical_effective_value_env_snapshot(env: TypeEnv, s: Subst) -> Stri
   let bindings = canonical_sorted_bindings(canonical_collect_effective_bindings(env))
   let free_ids = array_empty()
   let free_names = array_empty()
-  let fields = ["v2"]
+  let fields = ["v3"]
   let mut i = 0
   while i < Array::length(bindings) {
     let (name, ty) = Array::get(bindings, i)
@@ -531,7 +557,7 @@ fn canonical_trait_impl_param_position(params: Array[String], name: String) -> I
   let mut position = -1
   let mut matches = 0
   while i < Array::length(params) {
-    if Array::get(params, i) == name {
+    if type_param_name(Array::get(params, i)) == name {
       position = i
       matches = matches + 1
     } else {
@@ -636,6 +662,7 @@ fn canonical_trait_impl_gen_entry(trait_name: String, params: Array[String], bou
   canonical_node("G", [
     trait_name,
     __to_string(Array::length(params)),
+    canonical_param_arities(params),
     encoded_bounds,
     encoded_target
   ])
@@ -650,7 +677,7 @@ fn canonical_trait_impl_gen_entry(trait_name: String, params: Array[String], bou
 /// EnvFlat and EnvEmpty terminate traversal; trait definitions, values, cache
 /// payloads, and all other CheckedProgram state are excluded.
 export fn canonical_retained_trait_impl_entries_snapshot(env: TypeEnv, s: Subst) -> String {
-  let fields = ["v3"]
+  let fields = ["v4"]
   let free_ids = array_empty()
   let free_names = array_empty()
   let mut cur = env
@@ -703,15 +730,16 @@ export fn canonical_retained_trait_impl_entries_snapshot(env: TypeEnv, s: Subst)
 fn canonical_trait_method_generic_entry(params: Array[String], bounds: Array[(String, Array[String])]) -> String {
   let fields = [
     __to_string(Array::length(params)),
+    canonical_param_arities(params),
     canonical_trait_impl_bounds(params, bounds)
   ]
   let mut position = 0
   while position < Array::length(params) {
-    let name = Array::get(params, position)
+    let name = type_param_name(Array::get(params, position))
     let mut matches = 0
     let mut i = 0
     while i < Array::length(params) {
-      if Array::get(params, i) == name {
+      if type_param_name(Array::get(params, i)) == name {
         matches = matches + 1
       } else {
         ()
@@ -795,7 +823,7 @@ fn canonical_retained_trait_method_gens_entry(trait_name: String, methods: Array
 /// This is not source interface identity, trace schema, cache key, or reuse
 /// decision. EnvFlat and EnvEmpty terminate traversal.
 export fn canonical_retained_trait_method_gens_snapshot(env: TypeEnv) -> String {
-  let fields = ["v2"]
+  let fields = ["v3"]
   let mut cur = env
   let mut done = false
   while !done {
@@ -912,7 +940,11 @@ fn canonical_typedef_type(ty: Type, s: Subst, enum_binders: Array[Int], rigid_pa
 fn canonical_typedef(def: TypeDef, binders: Array[Int], s: Subst, free_ids: Array[Int], free_names: Array[String]) -> String {
   match def {
     TDEnum(name, params, variants) => {
-      let fields = [name, __to_string(Array::length(params))]
+      let fields = [
+        name,
+        __to_string(Array::length(params)),
+        canonical_param_arities(params)
+      ]
       let mut i = 0
       while i < Array::length(variants) {
         let (variant_name, payloads) = Array::get(variants, i)
@@ -928,7 +960,11 @@ fn canonical_typedef(def: TypeDef, binders: Array[Int], s: Subst, free_ids: Arra
       canonical_node("E", fields)
     },
     TDStruct(name, fields_raw, mut_fields, params) => {
-      let fields = [name, __to_string(Array::length(params))]
+      let fields = [
+        name,
+        __to_string(Array::length(params)),
+        canonical_param_arities(params)
+      ]
       let mut i = 0
       while i < Array::length(fields_raw) {
         let (field_name, field_ty) = Array::get(fields_raw, i)
@@ -944,10 +980,15 @@ fn canonical_typedef(def: TypeDef, binders: Array[Int], s: Subst, free_ids: Arra
     TDAlias(name, params, body) => canonical_node("A", [
       name,
       __to_string(Array::length(params)),
+      canonical_param_arities(params),
       canonical_typedef_type(body, s, array_empty(), params, free_ids, free_names)
     ]),
     TDEffect(name, ops, params) => {
-      let fields = [name, __to_string(Array::length(params))]
+      let fields = [
+        name,
+        __to_string(Array::length(params)),
+        canonical_param_arities(params)
+      ]
       let mut i = 0
       while i < Array::length(ops) {
         let (op_name, args, ret) = Array::get(ops, i)
@@ -1010,7 +1051,7 @@ fn canonical_malformed_provenance(position: Int, kind: String, defs_count: Int, 
 /// Malformed provenance is represented explicitly rather than treated as an
 /// empty binder list.
 export fn canonical_checked_type_defs_snapshot(observation: CheckedProgramTypeDefsObservation) -> String {
-  let fields = ["v1"]
+  let fields = ["v2"]
   let checked = observation.checked_program
   let defs = checked.type_defs
   let binders_by_def = observation.type_def_binders

--- a/lib/@vibe/compiler/checker/checker.vibe
+++ b/lib/@vibe/compiler/checker/checker.vibe
@@ -526,8 +526,36 @@ fn report_mixed_kind_let_annotation(te: TypeExpr, env: TypeEnv, where_label: Str
   }
 }
 
+fn formals_contain_source_name(formals: Array[String], name: String) -> Bool {
+  let mut i = 0
+  let mut found = false
+  while i < Array::length(formals) && !found {
+    if type_param_name(Array::get(formals, i)) == name {
+      found = true
+    } else {
+      ()
+    }
+    i = i + 1
+  }
+  found
+}
+
+fn formals_source_arity(formals: Array[String], name: String) -> Int {
+  let mut i = 0
+  let mut arity = 0 - 1
+  while i < Array::length(formals) {
+    if type_param_name(Array::get(formals, i)) == name {
+      arity = type_param_arity(Array::get(formals, i))
+    } else {
+      ()
+    }
+    i = i + 1
+  }
+  arity
+}
+
 fn push_unique_formal(name: String, formals: Array[String], out: Array[String]) -> Unit {
-  if string_array_has(formals, name) && !string_array_has(out, name) {
+  if formals_contain_source_name(formals, name) && !string_array_has(out, name) {
     Array::push(out, name)
   } else {
     ()
@@ -573,7 +601,7 @@ fn collect_hkt_related_formals(te: TypeExpr, formals: Array[String], out: Array[
     TyName(_) => (),
     TyUnit => (),
     TyApp(head, args) => {
-      if string_array_has(formals, head) {
+      if formals_contain_source_name(formals, head) {
         push_unique_formal(head, formals, out)
         let mut i = 0
         while i < Array::length(args) {
@@ -10304,7 +10332,7 @@ fn check_expr_capture_impl(expr: Expr, env: TypeEnv, defs: Array[TypeDef], s: Su
       let sig_applied = array_empty()
       let sig_unapplied = array_empty()
       let is_sig_tp = (n) -> {
-        string_array_has(tparams, n)
+        formals_contain_source_name(tparams, n) && formals_source_arity(tparams, n) == 0
       }
       let mut spi = 0
       while spi < Array::length(params) {

--- a/lib/@vibe/compiler/checker/checker.vibe
+++ b/lib/@vibe/compiler/checker/checker.vibe
@@ -10722,19 +10722,32 @@ fn check_expr_capture_impl(expr: Expr, env: TypeEnv, defs: Array[TypeDef], s: Su
               let use_explicit = ntargs > 0 && ntargs == tplen
               let fresh_targs = array_empty()
               let mut c2 = c1
-              let mut tpi = 0
-              while tpi < tplen {
-                if use_explicit {
-                  // Resolve through the generic environment (same as param /
-                  // return annotations, ~line 3252): an explicit argument
-                  // naming an ENCLOSING fn's type parameter (`fn make[T](x:
-                  // T) -> Box[T] { Box[T]::{ v: x } }`) must become the
-                  // env-bound CtVar, not a rigid CtNamed("T") — otherwise the
-                  // construction's type loses its link to the quantified
-                  // param and `make(42).v` fails as `expected Int, got T`
-                  // (Codex review, PR #926).
-                  Array::push(fresh_targs, resolve_tparams_in(resolve_type_expr(Array::get(targs, tpi), defs), env))
-                } else {
+              if use_explicit {
+                // Resolve through the generic environment (same as param /
+                // return annotations, ~line 3252): an explicit argument
+                // naming an ENCLOSING fn's type parameter (`fn make[T](x:
+                // T) -> Box[T] { Box[T]::{ v: x } }`) must become the
+                // env-bound CtVar, not a rigid CtNamed("T") — otherwise the
+                // construction's type loses its link to the quantified
+                // param and `make(42).v` fails as `expected Int, got T`
+                // (Codex review, PR #926). Kinded parameters also reify a
+                // bare constructor argument (`Array` in `KBox[Array, Int]::{
+                // ... }`) the same way trait-bound constructor arguments do.
+                let resolved = array_empty()
+                let mut tpi = 0
+                while tpi < tplen {
+                  Array::push(resolved, resolve_tparams_in(resolve_type_expr(Array::get(targs, tpi), defs), env))
+                  tpi = tpi + 1
+                }
+                let reified = resolve_type_constructor_args(s_tparams, targs, resolved, defs, array_empty())
+                let mut ri = 0
+                while ri < Array::length(reified) {
+                  Array::push(fresh_targs, Array::get(reified, ri))
+                  ri = ri + 1
+                }
+              } else {
+                let mut tpi = 0
+                while tpi < tplen {
                   match fresh_var(c2) {
                     (tv, nc) => {
                       Array::push(fresh_targs, tv)
@@ -10742,8 +10755,8 @@ fn check_expr_capture_impl(expr: Expr, env: TypeEnv, defs: Array[TypeDef], s: Su
                     },
                     _ => ()
                   }
+                  tpi = tpi + 1
                 }
-                tpi = tpi + 1
               }
               // Missing declared fields (absent from the literal).
               let mut mi = 0

--- a/lib/@vibe/compiler/checker/checker.vibe
+++ b/lib/@vibe/compiler/checker/checker.vibe
@@ -8,9 +8,11 @@ import @vibe/compiler/core {
   TypeDef,
   TypeEnv,
   TypeExpr,
+  apply_type_constructor,
   builtin_registry,
   canonical_builtin_name,
   collect_tvars,
+  compiler_owned_type_arity,
   env_bind,
   env_bind_mut,
   env_cache_binding,
@@ -49,7 +51,7 @@ import @vibe/compiler/core {
 }
 
 import @vibe/ast {
-  impl_method_owner_head, trait_ref_args, trait_ref_from_key, trait_ref_name
+  impl_method_owner_head, trait_ref_args, trait_ref_from_key, trait_ref_name, type_param_arity, type_param_name
 }
 
 import @vibe/parser {
@@ -164,7 +166,7 @@ export fn attach_unlocated_decl_name_marker(errors: Array[String], from: Int, na
       // sites (alias bodies, effect ops, trait methods, struct fields, enum
       // payloads) stay unlocated exactly like their `unknown type` siblings
       // -- locating those is the #1567 positions program, not this marker.
-      let anchorable = String::starts_with(msg, "return type mismatch") || String::starts_with(msg, "binding type mismatch for ") || String::starts_with(msg, "unknown type `") || String::starts_with(msg, "type parameter `") || String::starts_with(msg, "if branches have incompatible types")
+      let anchorable = String::starts_with(msg, "return type mismatch") || String::starts_with(msg, "binding type mismatch for ") || String::starts_with(msg, "unknown type `") || String::starts_with(msg, "type parameter `") || String::starts_with(msg, "type constructor parameter `") || String::starts_with(msg, "if branches have incompatible types")
       if anchorable && unlocated {
         Array::set(errors, i, String::concat(msg, String::concat(" [@fn=", String::concat(name, "]"))))
       }
@@ -471,6 +473,7 @@ export fn report_formal_applications(te: TypeExpr, formals: Array[String], where
   let tes = array_empty()
   Array::push(tes, te)
   report_formal_applications_across(tes, formals, where_label, errors)
+  report_kinded_formal_applications(te, formals, where_label, errors)
 }
 
 /// Mixed-kind across a local-let annotation and the enclosing signature.
@@ -599,6 +602,64 @@ fn collect_hkt_related_formals(te: TypeExpr, formals: Array[String], out: Array[
       }
     }
   }
+}
+
+/// Kinded `F[_]` / `F[_, _]` arity. Unkinded `F[A]` stays legal (#2351).
+fn report_kinded_formal_applications(te: TypeExpr, formals: Array[String], where_label: String, errors: Array[String]) -> Unit {
+  let rec find_arity: (String, Int) -> Int = (name, i) -> {
+    if i >= Array::length(formals) {
+      0 - 1
+    } else {
+      let param = Array::get(formals, i)
+      if type_param_name(param) == name {
+        type_param_arity(param)
+      } else {
+        find_arity(name, i + 1)
+      }
+    }
+  }
+  let rec validate: (TypeExpr, Bool) -> Unit = (node, constructor_argument) -> {
+    match node {
+      TyName(name) => {
+        let arity = find_arity(name, 0)
+        if arity > 0 && !constructor_argument {
+          Array::push(errors, String::concat(String::concat(String::concat(String::concat("type constructor parameter `", name), "` must be applied to "), String::concat(__to_string(arity), " type argument(s) in ")), String::concat(where_label, "; apply it to concrete type arguments instead of returning or storing the constructor itself")))
+        } else {
+          ()
+        }
+      },
+      TyApp(head, args) => {
+        let arity = find_arity(head, 0)
+        if arity > 0 && arity != Array::length(args) {
+          Array::push(errors, String::concat(String::concat(String::concat(String::concat(String::concat(String::concat("type constructor parameter `", head), "` expects "), __to_string(arity)), " type argument(s), got "), __to_string(Array::length(args))), String::concat(" in ", where_label)))
+        } else {
+          ()
+        }
+        let mut i = 0
+        while i < Array::length(args) {
+          validate(Array::get(args, i), true)
+          i = i + 1
+        }
+      },
+      TyFn(params, ret, _) => {
+        let mut i = 0
+        while i < Array::length(params) {
+          validate(Array::get(params, i), false)
+          i = i + 1
+        }
+        validate(ret, false)
+      },
+      TyTuple(items) => {
+        let mut i = 0
+        while i < Array::length(items) {
+          validate(Array::get(items, i), false)
+          i = i + 1
+        }
+      },
+      TyUnit => ()
+    }
+  }
+  validate(te, false)
 }
 
 /// #2263: the builtin map is String-keyed -- `Map[K, V]`'s generality is not
@@ -863,6 +924,106 @@ fn structural_arity_error(name: String, given: Int, want: Int, where_label: Stri
   String::concat(String::concat(String::concat(String::concat(String::concat(String::concat(String::concat("`", name), "` takes "), Int::to_string(want)), " type argument, but "), Int::to_string(given)), " were given in "), String::concat(where_label, String::concat(String::concat(" -- write `", name), "[T]` with a single element type")))
 }
 
+fn shadow_type_constructor_arity(shadow: Array[String], name: String) -> Int {
+  let mut i = 0
+  let mut found = 0 - 1
+  while i < Array::length(shadow) {
+    let param = Array::get(shadow, i)
+    if type_param_name(param) == name {
+      found = type_param_arity(param)
+    } else {
+      ()
+    }
+    i = i + 1
+  }
+  found
+}
+
+fn declared_type_expr_kind_arity(te: TypeExpr, defs: Array[TypeDef], shadow: Array[String]) -> Option[Int] {
+  match te {
+    TyName(name) => {
+      let shadow_arity = shadow_type_constructor_arity(shadow, name)
+      if shadow_arity >= 0 {
+        Some(shadow_arity)
+      } else match find_typedef(defs, name) {
+        Some(td) => match td {
+          TDEnum(_, params, _) => Some(Array::length(params)),
+          TDStruct(_, _, _, params) => Some(Array::length(params)),
+          TDAlias(_, params, _) => Some(Array::length(params)),
+          TDEffect(_, _, params) => Some(Array::length(params)),
+          TDEffectSet(_, _) => Some(0)
+        },
+        None => match compiler_owned_type_arity(name) {
+          Some(arity) => Some(arity),
+          None => match resolve_builtin(name) {
+            Some(_) => Some(0),
+            None => None
+          }
+        }
+      }
+    },
+    _ => Some(0)
+  }
+}
+
+fn type_def_formals(td: TypeDef) -> Array[String] {
+  match td {
+    TDEnum(_, params, _) => params,
+    TDStruct(_, _, _, params) => params,
+    TDAlias(_, params, _) => params,
+    TDEffect(_, _, params) => params,
+    TDEffectSet(_, _) => array_empty()
+  }
+}
+
+fn report_one_type_argument_kind(owner: String, formal: String, expected: Int, actual_expr: TypeExpr, defs: Array[TypeDef], shadow: Array[String], where_label: String, errors: Array[String]) -> Unit {
+  match declared_type_expr_kind_arity(actual_expr, defs, shadow) {
+    Some(actual) => if actual != expected {
+      let rendered = print_type_expr(actual_expr)
+      if expected == 0 {
+        Array::push(errors, "type parameter `\{formal}` of `\{owner}` expects a complete type, but `\{rendered}` is a constructor with \{actual} argument(s) in \{where_label} -- apply the constructor to concrete type arguments")
+      } else {
+        Array::push(errors, "type parameter `\{formal}` of `\{owner}` expects a constructor with \{expected} argument(s), but `\{rendered}` has \{actual} in \{where_label} -- pass a bare constructor with the required arity")
+      }
+    } else {
+      ()
+    },
+    None => ()
+  }
+}
+
+fn report_kinded_type_arguments(name: String, args: Array[TypeExpr], defs: Array[TypeDef], shadow: Array[String], where_label: String, errors: Array[String]) -> Unit {
+  match find_typedef(defs, name) {
+    Some(td) => {
+      let formals = type_def_formals(td)
+      let mut i = 0
+      while i < Array::length(args) && i < Array::length(formals) {
+        let formal = Array::get(formals, i)
+        report_one_type_argument_kind(name, type_param_name(formal), type_param_arity(formal), Array::get(args, i), defs, shadow, where_label, errors)
+        i = i + 1
+      }
+    },
+    None => {
+      let head_arity = shadow_type_constructor_arity(shadow, name)
+      let known_arity = if head_arity > 0 {
+        head_arity
+      } else match compiler_owned_type_arity(name) {
+        Some(arity) => arity,
+        None => 0 - 1
+      }
+      if known_arity > 0 {
+        let mut i = 0
+        while i < Array::length(args) {
+          report_one_type_argument_kind(name, "element", 0, Array::get(args, i), defs, shadow, where_label, errors)
+          i = i + 1
+        }
+      } else {
+        ()
+      }
+    }
+  }
+}
+
 /// Walks the annotation WITHOUT resolving it. Resolution allocates, and this
 /// runs at every one of `report_unknown_type_names`'s ~84 sites, so the whole
 /// annotation is never re-resolved: only a `Map` head's KEY argument is
@@ -888,6 +1049,7 @@ fn report_map_key_types_walk(te: TypeExpr, defs: Array[TypeDef], shadow: Array[S
     },
     TyUnit => (),
     TyApp(name, args) => {
+      report_kinded_type_arguments(name, args, defs, shadow, where_label, errors)
       let want = structural_head_arity(name)
       if want >= 0 && Array::length(args) != want && !string_array_has(shadow, name) && find_typedef(defs, name) is None {
         Array::push(errors, structural_arity_error(name, Array::length(args), want, where_label))
@@ -1059,6 +1221,9 @@ fn subst_self_in_type(ty: Type, self_ty: Type) -> Type {
       }
       CtNamed(n, ra)
     },
+    CtApplied(head, args) => apply_type_constructor(subst_self_in_type(head, self_ty), for arg in args {
+      subst_self_in_type(arg, self_ty)
+    }),
     CtArray(e) => CtArray(subst_self_in_type(e, self_ty)),
     CtOption(e) => CtOption(subst_self_in_type(e, self_ty)),
     CtTuple(elems) => CtTuple(for e in elems {
@@ -1094,6 +1259,9 @@ fn relax_unknown_named(ty: Type, defs: Array[TypeDef]) -> Type {
         CtUnknown
       }
     },
+    CtApplied(head, args) => apply_type_constructor(relax_unknown_named(head, defs), for arg in args {
+      relax_unknown_named(arg, defs)
+    }),
     CtArray(e) => CtArray(relax_unknown_named(e, defs)),
     CtOption(e) => CtOption(relax_unknown_named(e, defs)),
     CtTuple(es) => CtTuple(for e in es {
@@ -1118,6 +1286,9 @@ fn replace_trait_bound_vars_from_env(ty: Type, env: TypeEnv) -> Type {
         replace_trait_bound_vars_from_env(arg, env)
       })
     },
+    CtApplied(head, args) => apply_type_constructor(replace_trait_bound_vars_from_env(head, env), for arg in args {
+      replace_trait_bound_vars_from_env(arg, env)
+    }),
     CtArray(elem) => CtArray(replace_trait_bound_vars_from_env(elem, env)),
     CtOption(elem) => CtOption(replace_trait_bound_vars_from_env(elem, env)),
     CtTuple(items) => CtTuple(for item in items {
@@ -4054,6 +4225,7 @@ fn type_can_carry_region(ty: Type) -> Bool {
     CtTuple(_) => true,
     CtRecord(_) => true,
     CtNamed(_, _) => true,
+    CtApplied(_, _) => true,
     CtStruct(_) => true,
     CtEnum(_) => true,
     CtVar(_) => true,
@@ -4078,6 +4250,9 @@ fn add_param_capture_dependency(ty: Type, index: Int) -> Type {
       (name, add_param_capture_dependency(field_ty, index))
     }),
     CtNamed(name, args) => CtNamed(name, for arg in args {
+      add_param_capture_dependency(arg, index)
+    }),
+    CtApplied(head, args) => apply_type_constructor(add_param_capture_dependency(head, index), for arg in args {
       add_param_capture_dependency(arg, index)
     }),
     CtForAll(vars, bounds, body) => CtForAll(vars, bounds, add_param_capture_dependency(body, index)),
@@ -4115,6 +4290,12 @@ fn collect_internal_provenance(ty: Type, out: Array[String]) -> Unit {
       if String::starts_with(name, "#region_") && !string_array_has(out, name) {
         Array::push(out, name)
       }
+      for arg in args {
+        collect_internal_provenance(arg, out)
+      }
+    },
+    CtApplied(head, args) => {
+      collect_internal_provenance(head, out)
       for arg in args {
         collect_internal_provenance(arg, out)
       }
@@ -4164,6 +4345,15 @@ fn type_has_param_marker(ty: Type, marker: Int) -> Bool {
     },
     CtNamed(_, args) => {
       let mut found = false
+      for arg in args {
+        if type_has_param_marker(arg, marker) {
+          found = true
+        }
+      }
+      found
+    },
+    CtApplied(head, args) => {
+      let mut found = type_has_param_marker(head, marker)
       for arg in args {
         if type_has_param_marker(arg, marker) {
           found = true
@@ -4227,6 +4417,9 @@ fn resolve_param_provenance(ty: Type, param_tys: Array[Type], arg_tys: Array[Typ
     CtNamed(name, args) => CtNamed(name, for arg in args {
       resolve_param_provenance(arg, param_tys, arg_tys)
     }),
+    CtApplied(head, args) => apply_type_constructor(resolve_param_provenance(head, param_tys, arg_tys), for arg in args {
+      resolve_param_provenance(arg, param_tys, arg_tys)
+    }),
     _ => ty
   }
 }
@@ -4234,7 +4427,7 @@ fn resolve_param_provenance(ty: Type, param_tys: Array[Type], arg_tys: Array[Typ
 fn call_result_with_provenance(ret: Type, param_tys: Array[Type], arg_tys: Array[Type], s: Subst) -> Type {
   let resolved_ret = subst_apply(s, ret)
   match resolved_ret {
-    CtFn(_, _, _)|CtArray(_)|CtOption(_)|CtTuple(_)|CtRecord(_)|CtNamed(_, _) => {
+    CtFn(_, _, _)|CtArray(_)|CtOption(_)|CtTuple(_)|CtRecord(_)|CtNamed(_, _)|CtApplied(_, _) => {
       let resolved_params = for param in param_tys {
         subst_apply(s, param)
       }
@@ -5319,6 +5512,10 @@ fn resolve_tparams_in(ty: Type, env: TypeEnv) -> Type {
     },
     CtArray(e) => CtArray(resolve_tparams_in(e, env)),
     CtOption(e) => CtOption(resolve_tparams_in(e, env)),
+    CtConstructor(_, _) => ty,
+    CtApplied(head, args) => apply_type_constructor(resolve_tparams_in(head, env), for arg in args {
+      resolve_tparams_in(arg, env)
+    }),
     CtTuple(es) => CtTuple(for e in es {
       resolve_tparams_in(e, env)
     }),
@@ -10019,7 +10216,8 @@ fn check_expr_capture_impl(expr: Expr, env: TypeEnv, defs: Array[TypeDef], s: Su
       }
       let mut tpi = 0
       while tpi < tplen {
-        let tpname = Array::get(tparams, tpi)
+        let tpkey = Array::get(tparams, tpi)
+        let tpname = type_param_name(tpkey)
         match fresh_var(c0) {
           (tv, nc) => {
             let vid = nc - 1
@@ -10030,7 +10228,7 @@ fn check_expr_capture_impl(expr: Expr, env: TypeEnv, defs: Array[TypeDef], s: Su
             let mut found_bounds = false
             while tbi < tblen {
               let (bname, blist) = Array::get(tbounds, tbi)
-              if !found_bounds && bname == tpname {
+              if !found_bounds && bname == tpkey {
                 bounds = blist
                 found_bounds = true
               }

--- a/lib/@vibe/compiler/checker/checker.vibe
+++ b/lib/@vibe/compiler/checker/checker.vibe
@@ -18,6 +18,7 @@ import @vibe/compiler/core {
   env_cache_binding,
   env_has_reexport_surface_binding,
   env_lookup,
+  env_type_defs,
   exception_effect_kind,
   exception_effect_labels_equal,
   expr_children,
@@ -36,6 +37,7 @@ import @vibe/compiler/core {
   registry_builtin_param_type,
   resolve_builtin,
   resolve_type_alias_params,
+  resolve_type_constructor_args,
   subst_add_bound,
   subst_apply,
   subst_apply_except,
@@ -976,19 +978,51 @@ fn type_def_formals(td: TypeDef) -> Array[String] {
   }
 }
 
-fn report_one_type_argument_kind(owner: String, formal: String, expected: Int, actual_expr: TypeExpr, defs: Array[TypeDef], shadow: Array[String], where_label: String, errors: Array[String]) -> Unit {
-  match declared_type_expr_kind_arity(actual_expr, defs, shadow) {
-    Some(actual) => if actual != expected {
-      let rendered = print_type_expr(actual_expr)
-      if expected == 0 {
-        Array::push(errors, "type parameter `\{formal}` of `\{owner}` expects a complete type, but `\{rendered}` is a constructor with \{actual} argument(s) in \{where_label} -- apply the constructor to concrete type arguments")
-      } else {
-        Array::push(errors, "type parameter `\{formal}` of `\{owner}` expects a constructor with \{expected} argument(s), but `\{rendered}` has \{actual} in \{where_label} -- pass a bare constructor with the required arity")
-      }
+fn type_params_have_nested_kind(params: Array[String]) -> Bool {
+  let mut i = 0
+  let mut found = false
+  while i < Array::length(params) && !found {
+    if type_param_arity(Array::get(params, i)) > 0 {
+      found = true
     } else {
       ()
+    }
+    i = i + 1
+  }
+  found
+}
+
+fn type_expr_has_nested_kind(te: TypeExpr, defs: Array[TypeDef]) -> Bool {
+  match te {
+    TyName(name) => {
+      match find_typedef(defs, name) {
+        Some(td) => type_params_have_nested_kind(type_def_formals(td)),
+        None => false
+      }
     },
-    None => ()
+    _ => false
+  }
+}
+
+fn report_one_type_argument_kind(owner: String, formal: String, expected: Int, actual_expr: TypeExpr, defs: Array[TypeDef], shadow: Array[String], where_label: String, errors: Array[String]) -> Unit {
+  let rendered = print_type_expr(actual_expr)
+  if expected > 0 && type_expr_has_nested_kind(actual_expr, defs) {
+    Array::push(errors, "type parameter `\{formal}` of `\{owner}` expects a constructor with \{expected} argument(s), but `\{rendered}` has nested constructor parameters and is not a flat constructor in \{where_label} -- pass a constructor whose parameters are complete types")
+  } else {
+    match declared_type_expr_kind_arity(actual_expr, defs, shadow) {
+      Some(actual) => {
+        if actual != expected {
+          if expected == 0 {
+            Array::push(errors, "type parameter `\{formal}` of `\{owner}` expects a complete type, but `\{rendered}` is a constructor with \{actual} argument(s) in \{where_label} -- apply the constructor to concrete type arguments")
+          } else {
+            Array::push(errors, "type parameter `\{formal}` of `\{owner}` expects a constructor with \{expected} argument(s), but `\{rendered}` has \{actual} in \{where_label} -- pass a bare constructor with the required arity")
+          }
+        } else {
+          ()
+        }
+      },
+      None => ()
+    }
   }
 }
 
@@ -1301,10 +1335,11 @@ fn replace_trait_bound_vars_from_env(ty: Type, env: TypeEnv) -> Type {
   }
 }
 
-fn resolve_trait_bound_args(args: Array[TypeExpr], env: TypeEnv, defs: Array[TypeDef]) -> Array[Type] {
-  for arg in args {
+fn resolve_trait_bound_args(args: Array[TypeExpr], env: TypeEnv, defs: Array[TypeDef], params: Array[String]) -> Array[Type] {
+  let resolved = for arg in args {
     replace_trait_bound_vars_from_env(resolve_type_expr(arg, defs), env)
   }
+  resolve_type_constructor_args(params, args, resolved, defs, array_empty())
 }
 
 fn trait_bound_param_names(binders: Array[String], count: Int) -> Array[String] {
@@ -1328,12 +1363,19 @@ export fn validate_trait_reference(env: TypeEnv, key: String, context: String, e
   let display = trait_reference_display(key)
   let args = trait_ref_args(key)
   match trait_decl_params(env, key) {
-    Some(params) => if Array::length(args) > 0 && Array::length(args) != Array::length(params) {
-      let counts = String::concat(__to_string(Array::length(params)), String::concat(" type argument(s), got ", __to_string(Array::length(args))))
-      let site = String::concat(" in ", String::concat(context, String::concat(" `", String::concat(display, "`"))))
-      Array::push(errors, String::concat("trait `", String::concat(trait_ref_name(key), String::concat("` expects ", String::concat(counts, site)))))
-    } else {
-      ()
+    Some(params) => {
+      if Array::length(args) > 0 && Array::length(args) != Array::length(params) {
+        let counts = String::concat(__to_string(Array::length(params)), String::concat(" type argument(s), got ", __to_string(Array::length(args))))
+        let site = String::concat(" in ", String::concat(context, String::concat(" `", String::concat(display, "`"))))
+        Array::push(errors, String::concat("trait `", String::concat(trait_ref_name(key), String::concat("` expects ", String::concat(counts, site)))))
+      } else {
+        let defs = env_type_defs(env)
+        let mut i = 0
+        while i < Array::length(args) && i < Array::length(params) {
+          report_one_type_argument_kind(trait_ref_name(key), type_param_name(Array::get(params, i)), type_param_arity(Array::get(params, i)), Array::get(args, i), defs, array_empty(), context, errors)
+          i = i + 1
+        }
+      }
     },
     None => ()
   }
@@ -1376,7 +1418,11 @@ fn resolve_trait_method_ident(name: String, env: TypeEnv, defs: Array[TypeDef], 
                   // `trait Boxed[T] { unwrap(Self) -> T }`.
                   let (params_te, ret_te, binders) = sig
                   let param_names = trait_bound_param_names(binders, Array::length(trait_args))
-                  let resolved_trait_args = resolve_trait_bound_args(trait_args, env, defs)
+                  let trait_params = match trait_decl_params(env, trait_key) {
+                    Some(ps) => ps,
+                    None => array_empty()
+                  }
+                  let resolved_trait_args = resolve_trait_bound_args(trait_args, env, defs, trait_params)
                   let resolved_params = for pte in params_te {
                     relax_unknown_named(subst_type_params(subst_self_in_type(resolve_type_expr_shadowed(pte, defs, binders), self_ty), param_names, resolved_trait_args), defs)
                   }

--- a/lib/@vibe/compiler/checker/checker_resolve.vibe
+++ b/lib/@vibe/compiler/checker/checker_resolve.vibe
@@ -15,6 +15,10 @@ import @vibe/core {
   array_empty
 }
 
+import @vibe/ast {
+  type_param_name
+}
+
 //# Functions
 
 /// Substitute a parameterized type alias's formal params with actual type args.
@@ -28,7 +32,7 @@ fn is_shadowed_tyvar(shadow: Array[String], name: String) -> Bool {
   let mut i = 0
   let mut found = false
   while i < Array::length(shadow) {
-    if Array::get(shadow, i) == name {
+    if type_param_name(Array::get(shadow, i)) == name {
       found = true
     }
     i = i + 1

--- a/lib/@vibe/compiler/checker/checker_stmt.vibe
+++ b/lib/@vibe/compiler/checker/checker_stmt.vibe
@@ -3149,14 +3149,44 @@ fn check_program_bounds(env: TypeEnv, s: Subst, defs: Array[TypeDef], errors: Ar
 /// rejected here). Unknown bases are skipped — imported effects are
 /// invisible here, the same permissive stance the containment checker
 /// takes.
-fn geff_arg_kind_arity(name: String) -> Int {
+fn geff_arg_kind_arity(name: String, ctor_names: Array[String], ctor_arities: Array[Int], formal_keys: Array[String]) -> Int {
   match compiler_owned_type_arity(name) {
     Some(arity) => arity,
-    None => 0
+    None => {
+      let mut i = 0
+      let mut found = 0 - 1
+      while i < Array::length(ctor_names) {
+        if Array::get(ctor_names, i) == name {
+          found = Array::get(ctor_arities, i)
+        } else {
+          ()
+        }
+        i = i + 1
+      }
+      if found >= 0 {
+        found
+      } else {
+        let mut j = 0
+        let mut farity = 0 - 1
+        while j < Array::length(formal_keys) {
+          if type_param_name(Array::get(formal_keys, j)) == name {
+            farity = type_param_arity(Array::get(formal_keys, j))
+          } else {
+            ()
+          }
+          j = j + 1
+        }
+        if farity >= 0 {
+          farity
+        } else {
+          0
+        }
+      }
+    }
   }
 }
 
-fn geff_row_targ_errors_into(row: Option[String], ed_names: Array[String], ed_tpcounts: Array[Int], ed_tparities: Array[Int], es_names: Array[String], errors: Array[String]) -> Unit {
+fn geff_row_targ_errors_into(row: Option[String], ed_names: Array[String], ed_tpcounts: Array[Int], ed_tparities: Array[Int], es_names: Array[String], ctor_names: Array[String], ctor_arities: Array[Int], formal_keys: Array[String], errors: Array[String]) -> Unit {
   match row {
     None => (),
     Some(r) => {
@@ -3200,7 +3230,7 @@ fn geff_row_targ_errors_into(row: Option[String], ed_names: Array[String], ed_tp
             } else if tpc > 1 {
               Array::push(errors, String::concat("effect row item `", String::concat(label, String::concat("`: effect ", String::concat(base, String::concat(" declares ", String::concat(__to_string(tpc), " type parameters; a row item supports exactly one type argument for now")))))))
             } else if expected_kind > 0 {
-              let actual_kind = geff_arg_kind_arity(inner)
+              let actual_kind = geff_arg_kind_arity(inner, ctor_names, ctor_arities, formal_keys)
               if actual_kind != expected_kind {
                 Array::push(errors, String::concat("effect row item `", String::concat(label, String::concat("`: effect ", String::concat(base, String::concat(" expects a constructor with ", String::concat(__to_string(expected_kind), String::concat(" argument(s), but `", String::concat(inner, String::concat("` has ", String::concat(__to_string(actual_kind), " -- pass a bare constructor with the required arity")))))))))))
               } else {
@@ -3224,28 +3254,28 @@ fn geff_row_targ_errors_into(row: Option[String], ed_names: Array[String], ed_tp
 /// in parameter/return position) and an EFn value's inline row + parameter
 /// annotations. Nested closure literals inside bodies are not walked (same
 /// coverage boundary as the effectset expansion pass).
-fn geff_check_texpr_rows(te: TypeExpr, ed_names: Array[String], ed_tpcounts: Array[Int], ed_tparities: Array[Int], es_names: Array[String], errors: Array[String]) -> Unit {
+fn geff_check_texpr_rows(te: TypeExpr, ed_names: Array[String], ed_tpcounts: Array[Int], ed_tparities: Array[Int], es_names: Array[String], ctor_names: Array[String], ctor_arities: Array[Int], formal_keys: Array[String], errors: Array[String]) -> Unit {
   match te {
     TyFn(params, ret, eff) => {
-      geff_row_targ_errors_into(eff, ed_names, ed_tpcounts, ed_tparities, es_names, errors)
+      geff_row_targ_errors_into(eff, ed_names, ed_tpcounts, ed_tparities, es_names, ctor_names, ctor_arities, formal_keys, errors)
       let mut i = 0
       while i < Array::length(params) {
-        geff_check_texpr_rows(Array::get(params, i), ed_names, ed_tpcounts, ed_tparities, es_names, errors)
+        geff_check_texpr_rows(Array::get(params, i), ed_names, ed_tpcounts, ed_tparities, es_names, ctor_names, ctor_arities, formal_keys, errors)
         i = i + 1
       }
-      geff_check_texpr_rows(ret, ed_names, ed_tpcounts, ed_tparities, es_names, errors)
+      geff_check_texpr_rows(ret, ed_names, ed_tpcounts, ed_tparities, es_names, ctor_names, ctor_arities, formal_keys, errors)
     },
     TyApp(_, args) => {
       let mut i = 0
       while i < Array::length(args) {
-        geff_check_texpr_rows(Array::get(args, i), ed_names, ed_tpcounts, ed_tparities, es_names, errors)
+        geff_check_texpr_rows(Array::get(args, i), ed_names, ed_tpcounts, ed_tparities, es_names, ctor_names, ctor_arities, formal_keys, errors)
         i = i + 1
       }
     },
     TyTuple(elems) => {
       let mut i = 0
       while i < Array::length(elems) {
-        geff_check_texpr_rows(Array::get(elems, i), ed_names, ed_tpcounts, ed_tparities, es_names, errors)
+        geff_check_texpr_rows(Array::get(elems, i), ed_names, ed_tpcounts, ed_tparities, es_names, ctor_names, ctor_arities, formal_keys, errors)
         i = i + 1
       }
     },
@@ -3253,24 +3283,31 @@ fn geff_check_texpr_rows(te: TypeExpr, ed_names: Array[String], ed_tpcounts: Arr
   }
 }
 
-fn geff_check_opt_texpr_rows(te: Option[TypeExpr], ed_names: Array[String], ed_tpcounts: Array[Int], ed_tparities: Array[Int], es_names: Array[String], errors: Array[String]) -> Unit {
+fn geff_check_opt_texpr_rows(te: Option[TypeExpr], ed_names: Array[String], ed_tpcounts: Array[Int], ed_tparities: Array[Int], es_names: Array[String], ctor_names: Array[String], ctor_arities: Array[Int], formal_keys: Array[String], errors: Array[String]) -> Unit {
   match te {
-    Some(t) => geff_check_texpr_rows(t, ed_names, ed_tpcounts, ed_tparities, es_names, errors),
+    Some(t) => geff_check_texpr_rows(t, ed_names, ed_tpcounts, ed_tparities, es_names, ctor_names, ctor_arities, formal_keys, errors),
     None => ()
   }
 }
 
-fn geff_check_value_rows(e: Expr, ed_names: Array[String], ed_tpcounts: Array[Int], ed_tparities: Array[Int], es_names: Array[String], errors: Array[String]) -> Unit {
+fn geff_expr_formals(e: Expr) -> Array[String] {
   match e {
-    EFn(_, _, params, ret, eff, _) => {
-      geff_row_targ_errors_into(eff, ed_names, ed_tpcounts, ed_tparities, es_names, errors)
+    EFn(tparams, _, _, _, _, _) => tparams,
+    _ => array_empty()
+  }
+}
+
+fn geff_check_value_rows(e: Expr, ed_names: Array[String], ed_tpcounts: Array[Int], ed_tparities: Array[Int], es_names: Array[String], ctor_names: Array[String], ctor_arities: Array[Int], errors: Array[String]) -> Unit {
+  match e {
+    EFn(tparams, _, params, ret, eff, _) => {
+      geff_row_targ_errors_into(eff, ed_names, ed_tpcounts, ed_tparities, es_names, ctor_names, ctor_arities, tparams, errors)
       let mut i = 0
       while i < Array::length(params) {
         let (_, pty) = Array::get(params, i)
-        geff_check_opt_texpr_rows(pty, ed_names, ed_tpcounts, ed_tparities, es_names, errors)
+        geff_check_opt_texpr_rows(pty, ed_names, ed_tpcounts, ed_tparities, es_names, ctor_names, ctor_arities, tparams, errors)
         i = i + 1
       }
-      geff_check_opt_texpr_rows(ret, ed_names, ed_tpcounts, ed_tparities, es_names, errors)
+      geff_check_opt_texpr_rows(ret, ed_names, ed_tpcounts, ed_tparities, es_names, ctor_names, ctor_arities, tparams, errors)
     },
     _ => ()
   }
@@ -3281,6 +3318,8 @@ fn geff_validate_row_targs(stmts: Array[Stmt], errors: Array[String]) -> Unit {
   let ed_tpcounts = array_empty()
   let ed_tparities = array_empty()
   let es_names = array_empty()
+  let ctor_names = array_empty()
+  let ctor_arities = array_empty()
   let mut i = 0
   while i < Array::length(stmts) {
     match Array::get(stmts, i) {
@@ -3295,6 +3334,18 @@ fn geff_validate_row_targs(stmts: Array[Stmt], errors: Array[String]) -> Unit {
         Array::push(ed_tparities, first_arity)
       },
       SEffectSet(_, esname, _) => Array::push(es_names, esname),
+      SStruct(_, sname, _, _, _, tparams) => {
+        Array::push(ctor_names, sname)
+        Array::push(ctor_arities, Array::length(tparams))
+      },
+      SEnum(_, ename, tparams, _, _) => {
+        Array::push(ctor_names, ename)
+        Array::push(ctor_arities, Array::length(tparams))
+      },
+      STypeAlias(_, aname, tparams, _) => {
+        Array::push(ctor_names, aname)
+        Array::push(ctor_arities, Array::length(tparams))
+      },
       _ => ()
     }
     i = i + 1
@@ -3303,12 +3354,14 @@ fn geff_validate_row_targs(stmts: Array[Stmt], errors: Array[String]) -> Unit {
   while j < Array::length(stmts) {
     match Array::get(stmts, j) {
       SLet(_, _, _, ty, body) => {
-        geff_check_opt_texpr_rows(ty, ed_names, ed_tpcounts, ed_tparities, es_names, errors)
-        geff_check_value_rows(body, ed_names, ed_tpcounts, ed_tparities, es_names, errors)
+        let formals = geff_expr_formals(body)
+        geff_check_opt_texpr_rows(ty, ed_names, ed_tpcounts, ed_tparities, es_names, ctor_names, ctor_arities, formals, errors)
+        geff_check_value_rows(body, ed_names, ed_tpcounts, ed_tparities, es_names, ctor_names, ctor_arities, errors)
       },
       SLetMut(_, ty, body) => {
-        geff_check_opt_texpr_rows(ty, ed_names, ed_tpcounts, ed_tparities, es_names, errors)
-        geff_check_value_rows(body, ed_names, ed_tpcounts, ed_tparities, es_names, errors)
+        let formals = geff_expr_formals(body)
+        geff_check_opt_texpr_rows(ty, ed_names, ed_tpcounts, ed_tparities, es_names, ctor_names, ctor_arities, formals, errors)
+        geff_check_value_rows(body, ed_names, ed_tpcounts, ed_tparities, es_names, ctor_names, ctor_arities, errors)
       },
       _ => ()
     }

--- a/lib/@vibe/compiler/checker/checker_stmt.vibe
+++ b/lib/@vibe/compiler/checker/checker_stmt.vibe
@@ -32,6 +32,7 @@ import @vibe/compiler/core {
   TypeEnv,
   TypeExpr,
   __to_string,
+  apply_type_constructor,
   collect_subst_bounds_pairs,
   compiler_owned_type_arity,
   env_bind,
@@ -91,7 +92,7 @@ import ./checker.vibe {
 }
 
 import @vibe/ast {
-  trait_ref_name
+  trait_ref_name, type_param_name
 }
 
 import ./checked_expression_structure_core.vibe {
@@ -4391,7 +4392,7 @@ fn type_param_index(params: Array[String], name: String) -> Int {
   let mut found = 0 - 1
   let mut i = 0
   while i < Array::length(params) && found < 0 {
-    if Array::get(params, i) == name {
+    if type_param_name(Array::get(params, i)) == name {
       found = i
     } else {
       i = i + 1
@@ -4933,6 +4934,9 @@ fn refresh_completed_type(ty: Type, defs: Array[TypeDef], shadow: Array[String],
     }),
     CtArray(item) => CtArray(refresh_completed_type(item, defs, shadow, seen)),
     CtOption(item) => CtOption(refresh_completed_type(item, defs, shadow, seen)),
+    CtApplied(head, args) => apply_type_constructor(refresh_completed_type(head, defs, shadow, seen), for arg in args {
+      refresh_completed_type(arg, defs, shadow, seen)
+    }),
     CtFn(params, ret, row) => CtFn(for param in params {
       refresh_completed_type(param, defs, shadow, seen)
     }, refresh_completed_type(ret, defs, shadow, seen), row),

--- a/lib/@vibe/compiler/checker/checker_stmt.vibe
+++ b/lib/@vibe/compiler/checker/checker_stmt.vibe
@@ -92,7 +92,7 @@ import ./checker.vibe {
 }
 
 import @vibe/ast {
-  trait_ref_name, type_param_name
+  trait_ref_name, type_param_arity, type_param_name
 }
 
 import ./checked_expression_structure_core.vibe {
@@ -3149,7 +3149,14 @@ fn check_program_bounds(env: TypeEnv, s: Subst, defs: Array[TypeDef], errors: Ar
 /// rejected here). Unknown bases are skipped — imported effects are
 /// invisible here, the same permissive stance the containment checker
 /// takes.
-fn geff_row_targ_errors_into(row: Option[String], ed_names: Array[String], ed_tpcounts: Array[Int], es_names: Array[String], errors: Array[String]) -> Unit {
+fn geff_arg_kind_arity(name: String) -> Int {
+  match compiler_owned_type_arity(name) {
+    Some(arity) => arity,
+    None => 0
+  }
+}
+
+fn geff_row_targ_errors_into(row: Option[String], ed_names: Array[String], ed_tpcounts: Array[Int], ed_tparities: Array[Int], es_names: Array[String], errors: Array[String]) -> Unit {
   match row {
     None => (),
     Some(r) => {
@@ -3178,9 +3185,11 @@ fn geff_row_targ_errors_into(row: Option[String], ed_names: Array[String], ed_tp
           } else {
             let mut edi = 0
             let mut tpc = 0 - 1
+            let mut expected_kind = 0
             while edi < Array::length(ed_names) {
               if Array::get(ed_names, edi) == base {
                 tpc = Array::get(ed_tpcounts, edi)
+                expected_kind = Array::get(ed_tparities, edi)
               } else {
                 ()
               }
@@ -3190,6 +3199,13 @@ fn geff_row_targ_errors_into(row: Option[String], ed_names: Array[String], ed_tp
               Array::push(errors, String::concat("effect row item `", String::concat(label, String::concat("`: effect ", String::concat(base, " declares no type parameters")))))
             } else if tpc > 1 {
               Array::push(errors, String::concat("effect row item `", String::concat(label, String::concat("`: effect ", String::concat(base, String::concat(" declares ", String::concat(__to_string(tpc), " type parameters; a row item supports exactly one type argument for now")))))))
+            } else if expected_kind > 0 {
+              let actual_kind = geff_arg_kind_arity(inner)
+              if actual_kind != expected_kind {
+                Array::push(errors, String::concat("effect row item `", String::concat(label, String::concat("`: effect ", String::concat(base, String::concat(" expects a constructor with ", String::concat(__to_string(expected_kind), String::concat(" argument(s), but `", String::concat(inner, String::concat("` has ", String::concat(__to_string(actual_kind), " -- pass a bare constructor with the required arity")))))))))))
+              } else {
+                ()
+              }
             } else {
               ()
             }
@@ -3208,28 +3224,28 @@ fn geff_row_targ_errors_into(row: Option[String], ed_names: Array[String], ed_tp
 /// in parameter/return position) and an EFn value's inline row + parameter
 /// annotations. Nested closure literals inside bodies are not walked (same
 /// coverage boundary as the effectset expansion pass).
-fn geff_check_texpr_rows(te: TypeExpr, ed_names: Array[String], ed_tpcounts: Array[Int], es_names: Array[String], errors: Array[String]) -> Unit {
+fn geff_check_texpr_rows(te: TypeExpr, ed_names: Array[String], ed_tpcounts: Array[Int], ed_tparities: Array[Int], es_names: Array[String], errors: Array[String]) -> Unit {
   match te {
     TyFn(params, ret, eff) => {
-      geff_row_targ_errors_into(eff, ed_names, ed_tpcounts, es_names, errors)
+      geff_row_targ_errors_into(eff, ed_names, ed_tpcounts, ed_tparities, es_names, errors)
       let mut i = 0
       while i < Array::length(params) {
-        geff_check_texpr_rows(Array::get(params, i), ed_names, ed_tpcounts, es_names, errors)
+        geff_check_texpr_rows(Array::get(params, i), ed_names, ed_tpcounts, ed_tparities, es_names, errors)
         i = i + 1
       }
-      geff_check_texpr_rows(ret, ed_names, ed_tpcounts, es_names, errors)
+      geff_check_texpr_rows(ret, ed_names, ed_tpcounts, ed_tparities, es_names, errors)
     },
     TyApp(_, args) => {
       let mut i = 0
       while i < Array::length(args) {
-        geff_check_texpr_rows(Array::get(args, i), ed_names, ed_tpcounts, es_names, errors)
+        geff_check_texpr_rows(Array::get(args, i), ed_names, ed_tpcounts, ed_tparities, es_names, errors)
         i = i + 1
       }
     },
     TyTuple(elems) => {
       let mut i = 0
       while i < Array::length(elems) {
-        geff_check_texpr_rows(Array::get(elems, i), ed_names, ed_tpcounts, es_names, errors)
+        geff_check_texpr_rows(Array::get(elems, i), ed_names, ed_tpcounts, ed_tparities, es_names, errors)
         i = i + 1
       }
     },
@@ -3237,24 +3253,24 @@ fn geff_check_texpr_rows(te: TypeExpr, ed_names: Array[String], ed_tpcounts: Arr
   }
 }
 
-fn geff_check_opt_texpr_rows(te: Option[TypeExpr], ed_names: Array[String], ed_tpcounts: Array[Int], es_names: Array[String], errors: Array[String]) -> Unit {
+fn geff_check_opt_texpr_rows(te: Option[TypeExpr], ed_names: Array[String], ed_tpcounts: Array[Int], ed_tparities: Array[Int], es_names: Array[String], errors: Array[String]) -> Unit {
   match te {
-    Some(t) => geff_check_texpr_rows(t, ed_names, ed_tpcounts, es_names, errors),
+    Some(t) => geff_check_texpr_rows(t, ed_names, ed_tpcounts, ed_tparities, es_names, errors),
     None => ()
   }
 }
 
-fn geff_check_value_rows(e: Expr, ed_names: Array[String], ed_tpcounts: Array[Int], es_names: Array[String], errors: Array[String]) -> Unit {
+fn geff_check_value_rows(e: Expr, ed_names: Array[String], ed_tpcounts: Array[Int], ed_tparities: Array[Int], es_names: Array[String], errors: Array[String]) -> Unit {
   match e {
     EFn(_, _, params, ret, eff, _) => {
-      geff_row_targ_errors_into(eff, ed_names, ed_tpcounts, es_names, errors)
+      geff_row_targ_errors_into(eff, ed_names, ed_tpcounts, ed_tparities, es_names, errors)
       let mut i = 0
       while i < Array::length(params) {
         let (_, pty) = Array::get(params, i)
-        geff_check_opt_texpr_rows(pty, ed_names, ed_tpcounts, es_names, errors)
+        geff_check_opt_texpr_rows(pty, ed_names, ed_tpcounts, ed_tparities, es_names, errors)
         i = i + 1
       }
-      geff_check_opt_texpr_rows(ret, ed_names, ed_tpcounts, es_names, errors)
+      geff_check_opt_texpr_rows(ret, ed_names, ed_tpcounts, ed_tparities, es_names, errors)
     },
     _ => ()
   }
@@ -3263,6 +3279,7 @@ fn geff_check_value_rows(e: Expr, ed_names: Array[String], ed_tpcounts: Array[In
 fn geff_validate_row_targs(stmts: Array[Stmt], errors: Array[String]) -> Unit {
   let ed_names = array_empty()
   let ed_tpcounts = array_empty()
+  let ed_tparities = array_empty()
   let es_names = array_empty()
   let mut i = 0
   while i < Array::length(stmts) {
@@ -3270,6 +3287,12 @@ fn geff_validate_row_targs(stmts: Array[Stmt], errors: Array[String]) -> Unit {
       SEffectDef(_, ename, eparams, _) => {
         Array::push(ed_names, ename)
         Array::push(ed_tpcounts, Array::length(eparams))
+        let first_arity = if Array::length(eparams) > 0 {
+          type_param_arity(Array::get(eparams, 0))
+        } else {
+          0
+        }
+        Array::push(ed_tparities, first_arity)
       },
       SEffectSet(_, esname, _) => Array::push(es_names, esname),
       _ => ()
@@ -3280,12 +3303,12 @@ fn geff_validate_row_targs(stmts: Array[Stmt], errors: Array[String]) -> Unit {
   while j < Array::length(stmts) {
     match Array::get(stmts, j) {
       SLet(_, _, _, ty, body) => {
-        geff_check_opt_texpr_rows(ty, ed_names, ed_tpcounts, es_names, errors)
-        geff_check_value_rows(body, ed_names, ed_tpcounts, es_names, errors)
+        geff_check_opt_texpr_rows(ty, ed_names, ed_tpcounts, ed_tparities, es_names, errors)
+        geff_check_value_rows(body, ed_names, ed_tpcounts, ed_tparities, es_names, errors)
       },
       SLetMut(_, ty, body) => {
-        geff_check_opt_texpr_rows(ty, ed_names, ed_tpcounts, es_names, errors)
-        geff_check_value_rows(body, ed_names, ed_tpcounts, es_names, errors)
+        geff_check_opt_texpr_rows(ty, ed_names, ed_tpcounts, ed_tparities, es_names, errors)
+        geff_check_value_rows(body, ed_names, ed_tpcounts, ed_tparities, es_names, errors)
       },
       _ => ()
     }
@@ -3973,7 +3996,7 @@ fn tps_names_contains(names: Array[String], name: String) -> Bool {
 fn tps_report(tparams: Array[String], local_types: Array[String], where_label: String, anchor: String, errors: Array[String]) -> Unit {
   let mut i = 0
   while i < Array::length(tparams) {
-    let tp = Array::get(tparams, i)
+    let tp = type_param_name(Array::get(tparams, i))
     if tps_names_contains(local_types, tp) {
       // The ` [@fn=name]` suffix is the #1941 side-channel marker: binder
       // lists carry no offset of their own, so the diagnostic anchors on the

--- a/lib/@vibe/compiler/checker/checker_trait.vibe
+++ b/lib/@vibe/compiler/checker/checker_trait.vibe
@@ -10,6 +10,7 @@ import @vibe/compiler/core {
   TypeDef,
   TypeEnv,
   TypeExpr,
+  apply_type_constructor,
   env_lookup,
   find_typedef,
   impls_overlap_for,
@@ -260,6 +261,9 @@ export fn send_subst_vars(ty: Type, vids: Array[Int], args: Array[Type]) -> Type
     CtNamed(nm, targs) => CtNamed(nm, for a in targs {
       send_subst_vars(a, vids, args)
     }),
+    CtApplied(head, targs) => apply_type_constructor(send_subst_vars(head, vids, args), for arg in targs {
+      send_subst_vars(arg, vids, args)
+    }),
     CtFn(ps, ret, eff) => {
       let rp = for p in ps {
         send_subst_vars(p, vids, args)
@@ -307,6 +311,8 @@ fn send_ok_rec(env: TypeEnv, s: Subst, defs: Array[TypeDef], ty: Type, seen: Arr
       send_ok_named(env, s, defs, name, targs, seen)
     },
     CtVar(_) => false,
+    CtConstructor(_, _) => false,
+    CtApplied(_, _) => false,
     CtForAll(_, _, _) => false,
     CtUnknown => false
   }

--- a/lib/@vibe/compiler/cli_adapter.vibe
+++ b/lib/@vibe/compiler/cli_adapter.vibe
@@ -849,7 +849,7 @@ fn configure_typing_dependency_env_reuse_policy() -> Unit with Exception + Env {
 }
 
 export fn cli_main() -> Int with Exception + Fs + Env + Stdin + Stdout {
-  // Reset the process-wide TDRE5 cell before every invocation. Only the
+  // Reset the process-wide TDRE7 cell before every invocation. Only the
   // check-only branch may enable it after strict policy validation below;
   // build/codegen lanes stay conservative, and a prior check in a long-lived
   // instance cannot leak its policy into a later invocation.
@@ -1227,11 +1227,11 @@ export fn cli_main() -> Int with Exception + Fs + Env + Stdin + Stdout {
   } else ()
   if Env::get("VIBE_CHECK_ONLY") == "1" {
     return handle {
-      // TDRE5 is production-default only for the proven check/edit-cycle lane.
+      // TDRE7 is production-default only for the proven check/edit-cycle lane.
       // This call also resets policy on every check-only invocation, including
       // strict opt-out and observation-only trace runs.
       configure_typing_dependency_env_reuse_policy()
-      // Telemetry remains opt-in even though TDRE5 reuse is now the default
+      // Telemetry remains opt-in even though TDRE7 reuse is now the default
       // for this check-only lane. The counters cover only the db_typecheck_fs walk
       // inside check_linked_file; the second linked inline-wasm validation is
       // intentionally outside this incremental-cache telemetry boundary.

--- a/lib/@vibe/compiler/codegen/common_base/common_base.vibe
+++ b/lib/@vibe/compiler/codegen/common_base/common_base.vibe
@@ -4,6 +4,10 @@ import @vibe/compiler/core {
   Expr, Pat, Stmt, TypeExpr, __to_string, apply_perm_strings, bsearch_leftmost, bytebuf_push, leb128_encode_u32, sort_perm_by_names
 }
 
+import @vibe/ast {
+  type_param_name
+}
+
 import @vibe/core {
   array_empty
 }
@@ -1335,7 +1339,7 @@ export fn ty_head_names_formal(te: TypeExpr, tparams: Array[String]) -> Bool {
     let mut i = 0
     let mut found = false
     while i < Array::length(tparams) && !found {
-      if Array::get(tparams, i) == head {
+      if type_param_name(Array::get(tparams, i)) == head {
         found = true
       } else {
         ()

--- a/lib/@vibe/compiler/codegen/common_base/index.vpkg
+++ b/lib/@vibe/compiler/codegen/common_base/index.vpkg
@@ -3,6 +3,7 @@ version = 0.0.1
 description =
   #|@vibe/compiler/codegen/common_base — the shared codegen substrate: the
 deps = {
+  @vibe/ast : 0.0.1
   @vibe/compiler/codegen/wasm_emit : 0.0.1
   @vibe/compiler/core : 0.0.1
   @vibe/compiler/normalize : 0.0.1

--- a/lib/@vibe/compiler/core/import_alias_rewrite.vibe
+++ b/lib/@vibe/compiler/core/import_alias_rewrite.vibe
@@ -9,7 +9,7 @@ import @vibe/core {
 }
 
 import @vibe/ast {
-  impl_method_owner, trait_ref_from_key, trait_ref_key
+  impl_method_owner, trait_ref_from_key, trait_ref_key, type_param_name
 }
 
 import ./module_graph_path.vibe {
@@ -143,7 +143,7 @@ fn names_shadow_alias(names: Array[String], alias: String) -> Bool {
   let mut i = 0
   let mut found = false
   while i < Array::length(names) && !found {
-    if alias_is_shadowed(alias, Array::get(names, i)) {
+    if alias_is_shadowed(alias, type_param_name(Array::get(names, i))) {
       found = true
     } else {
       i = i + 1
@@ -445,7 +445,7 @@ fn aliasidx_without_names(am: AliasIdx, names: Array[String]) -> AliasIdx {
   let mut any = false
   let mut i = 0
   while i < Array::length(names) && !any {
-    if aliasidx_shadows(am, Array::get(names, i)) {
+    if aliasidx_shadows(am, type_param_name(Array::get(names, i))) {
       any = true
     } else {
       i = i + 1

--- a/lib/@vibe/compiler/core/import_alias_rewrite.vibe
+++ b/lib/@vibe/compiler/core/import_alias_rewrite.vibe
@@ -890,7 +890,7 @@ fn local_alias_arg(params: Array[String], args: Array[TypeExpr], name: String) -
   let mut i = 0
   let mut found = None
   while i < Array::length(params) {
-    if Array::get(params, i) == name && i < Array::length(args) {
+    if type_param_name(Array::get(params, i)) == name && i < Array::length(args) {
       found = Some(Array::get(args, i))
       i = Array::length(params)
     } else {

--- a/lib/@vibe/compiler/core/index.vpkg
+++ b/lib/@vibe/compiler/core/index.vpkg
@@ -236,6 +236,7 @@ fn subst_apply_except(s: Subst, ty: Type, keep: Array[Int]) -> Type
 fn is_hkt_app(ty: Type) -> Bool
 fn hkt_apply_ctor(head: Type, args: Array[Type]) -> Type
 fn apply_type_constructor(head: Type, args: Array[Type]) -> Type
+fn resolve_type_constructor_args(params: Array[String], source_args: Array[TypeExpr], resolved_args: Array[Type], defs: Array[TypeDef], shadow: Array[String]) -> Array[Type]
 // #2158: `subst_apply(s, ty) == CtDouble` as a head query -- follows the
 // variable chain without rebuilding the substituted type. The Double
 // call-result observation runs it once per located call result, where the

--- a/lib/@vibe/compiler/core/index.vpkg
+++ b/lib/@vibe/compiler/core/index.vpkg
@@ -235,6 +235,7 @@ fn subst_apply(s: Subst, ty: Type) -> Type
 fn subst_apply_except(s: Subst, ty: Type, keep: Array[Int]) -> Type
 fn is_hkt_app(ty: Type) -> Bool
 fn hkt_apply_ctor(head: Type, args: Array[Type]) -> Type
+fn apply_type_constructor(head: Type, args: Array[Type]) -> Type
 // #2158: `subst_apply(s, ty) == CtDouble` as a head query -- follows the
 // variable chain without rebuilding the substituted type. The Double
 // call-result observation runs it once per located call result, where the

--- a/lib/@vibe/compiler/core/types.vibe
+++ b/lib/@vibe/compiler/core/types.vibe
@@ -5,7 +5,7 @@ import ./ast.vibe {
 }
 
 import @vibe/ast {
-  trait_ref_from_key, trait_ref_name
+  trait_ref_from_key, trait_ref_name, type_param_arity, type_param_name
 }
 
 import ./exception_effect.vibe {
@@ -37,6 +37,11 @@ export enum Type {
   CtStruct(String);
   CtBytes;
   CtNamed(String, Array[Type]);
+  /// A type-level constructor value. It is never a value type by itself.
+  CtConstructor(String, Int);
+  /// Application whose head may be an inference variable (`F[A]`). Concrete
+  /// heads are normalized back to CtArray/CtOption/CtNamed immediately.
+  CtApplied(Type, Array[Type]);
   CtVar(Int);
   CtForAll(Array[Int], Array[(Int, Array[String])], Type);
   CtUnknown;
@@ -753,6 +758,16 @@ export fn occurs_in(id: Int, ty: Type) -> Bool {
     },
     CtArray(elem) => occurs_in(id, elem),
     CtOption(elem) => occurs_in(id, elem),
+    CtConstructor(_, _) => false,
+    CtApplied(head, args) => {
+      let mut found = occurs_in(id, head)
+      let mut ai = 0
+      while ai < Array::length(args) && !found {
+        found = occurs_in(id, Array::get(args, ai))
+        ai = ai + 1
+      }
+      found
+    },
     CtRecord(rfields) => {
       let mut ri = 0
       let mut rfound = false
@@ -1266,6 +1281,8 @@ fn trait_target_head_name(ty: Type) -> String {
     CtNamed(n, _) => n,
     CtStruct(n) => n,
     CtEnum(n) => n,
+    CtConstructor(n, _) => n,
+    CtApplied(head, _) => type_constructor_name(head),
     _ => ""
   }
 }
@@ -1735,6 +1752,7 @@ export fn subst_apply(s: Subst, ty: Type) -> Type {
     CtChar => ty,
     CtBytes => ty,
     CtUnknown => ty,
+    CtConstructor(_, _) => ty,
     CtVar(_) => {
       let mut cur = ty
       let mut out = ty
@@ -1780,6 +1798,9 @@ export fn subst_apply(s: Subst, ty: Type) -> Type {
     },
     CtArray(elem) => CtArray(subst_apply(s, elem)),
     CtOption(elem) => CtOption(subst_apply(s, elem)),
+    CtApplied(head, args) => apply_type_constructor(subst_apply(s, head), for arg in args {
+      subst_apply(s, arg)
+    }),
     CtTuple(elems) => CtTuple(for e in elems {
       subst_apply(s, e)
     }),
@@ -1859,6 +1880,13 @@ export fn type_to_string(ty: Type) -> String {
     CtUnit => "()",
     CtBytes => "Bytes",
     CtVar(id) => "?t\{id}",
+    CtConstructor(name, arity) => String::concat(name, String::concat("/", __to_string(arity))),
+    CtApplied(head, args) => {
+      let parts = for arg in args {
+        type_to_string(arg)
+      }
+      String::concat(type_to_string(head), String::concat("[", String::concat(String::join(parts, ", "), "]")))
+    },
     CtForAll(vars, _, body) => {
       let vlen = Array::length(vars)
       let mut vi = 0
@@ -2112,6 +2140,10 @@ fn type_clone(ty: Type) -> Type {
     CtBytes => CtBytes,
     CtUnknown => CtUnknown,
     CtVar(id) => CtVar(id),
+    CtConstructor(name, arity) => CtConstructor(name, arity),
+    CtApplied(head, args) => CtApplied(type_clone(head), for arg in args {
+      type_clone(arg)
+    }),
     CtEnum(n) => CtEnum(n),
     CtStruct(n) => CtStruct(n),
     CtArray(e) => CtArray(type_clone(e)),
@@ -2156,7 +2188,7 @@ export fn resolve_type_alias_params(ty: Type, params: Array[String], args: Array
       let mut idx = 0 - 1
       let mut i = 0
       while i < Array::length(params) {
-        if Array::get(params, i) == name {
+        if type_param_name(Array::get(params, i)) == name {
           idx = i
         }
         i = i + 1
@@ -2182,6 +2214,10 @@ export fn resolve_type_alias_params(ty: Type, params: Array[String], args: Array
     },
     CtArray(e) => CtArray(resolve_type_alias_params(e, params, args)),
     CtOption(e) => CtOption(resolve_type_alias_params(e, params, args)),
+    CtConstructor(name, arity) => CtConstructor(name, arity),
+    CtApplied(head, applied_args) => apply_type_constructor(resolve_type_alias_params(head, params, args), for arg in applied_args {
+      resolve_type_alias_params(arg, params, args)
+    }),
     CtTuple(es) => CtTuple(for e in es {
       resolve_type_alias_params(e, params, args)
     }),
@@ -2196,12 +2232,102 @@ fn type_expr_name_is_shadowed(shadow: Array[String], name: String) -> Bool {
   let mut i = 0
   let mut found = false
   while i < Array::length(shadow) {
-    if Array::get(shadow, i) == name {
+    if type_param_name(Array::get(shadow, i)) == name {
       found = true
     }
     i = i + 1
   }
   found
+}
+
+fn type_expr_shadowed_arity(shadow: Array[String], name: String) -> Int {
+  let mut i = 0
+  let mut arity = 0 - 1
+  while i < Array::length(shadow) {
+    let param = Array::get(shadow, i)
+    if type_param_name(param) == name {
+      arity = type_param_arity(param)
+    }
+    i = i + 1
+  }
+  arity
+}
+
+/// Normalize a type-level constructor application. Array and Option keep
+/// their established structural nodes; nominal constructors return CtNamed.
+/// Only an unresolved variable head remains CtApplied.
+export fn apply_type_constructor(head: Type, args: Array[Type]) -> Type {
+  match head {
+    CtConstructor(name, arity) => if arity != Array::length(args) {
+      CtApplied(head, args)
+    } else if name == "Array" && arity == 1 {
+      CtArray(Array::get(args, 0))
+    } else if name == "Option" && arity == 1 {
+      CtOption(Array::get(args, 0))
+    } else {
+      CtNamed(name, args)
+    },
+    _ => CtApplied(head, args)
+  }
+}
+
+fn type_def_params(td: TypeDef) -> Array[String] {
+  match td {
+    TDEnum(_, params, _) => params,
+    TDStruct(_, _, _, params) => params,
+    TDAlias(_, params, _) => params,
+    TDEffect(_, _, params) => params,
+    TDEffectSet(_, _) => array_empty()
+  }
+}
+
+fn declared_type_constructor_arity(defs: Array[TypeDef], name: String) -> Option[Int] {
+  match find_typedef(defs, name) {
+    Some(td) => Some(Array::length(type_def_params(td))),
+    None => match compiler_owned_type_arity(name) {
+      Some(arity) => Some(arity),
+      None => match resolve_builtin(name) {
+        Some(_) => Some(0),
+        None => None
+      }
+    }
+  }
+}
+
+/// Reify bare constructor arguments according to the kind declared by the
+/// receiving type parameter. A shadowed constructor variable stays nominal so
+/// checker binding can replace its head with a CtVar; concrete constructors
+/// carry their declared arity explicitly across alias substitution and caches.
+fn resolve_type_constructor_args(params: Array[String], source_args: Array[TypeExpr], resolved_args: Array[Type], defs: Array[TypeDef], shadow: Array[String]) -> Array[Type] {
+  let out = array_empty()
+  let mut i = 0
+  while i < Array::length(resolved_args) {
+    let resolved = Array::get(resolved_args, i)
+    if i < Array::length(params) && type_param_arity(Array::get(params, i)) > 0 && i < Array::length(source_args) {
+      match Array::get(source_args, i) {
+        TyName(name) => {
+          let shadow_arity = type_expr_shadowed_arity(shadow, name)
+          if shadow_arity > 0 {
+            Array::push(out, resolved)
+          } else {
+            match declared_type_constructor_arity(defs, name) {
+              Some(arity) => if arity > 0 {
+                Array::push(out, CtConstructor(name, arity))
+              } else {
+                Array::push(out, resolved)
+              },
+              None => Array::push(out, resolved)
+            }
+          }
+        },
+        _ => Array::push(out, resolved)
+      }
+    } else {
+      Array::push(out, resolved)
+    }
+    i = i + 1
+  }
+  out
 }
 
 /// Resolve a source type expression while preserving the enclosing type
@@ -2228,14 +2354,14 @@ export fn resolve_type_expr_core_shadowed(te: TypeExpr, defs: Array[TypeDef], sh
       }
     },
     TyApp(name, args) => {
-      let ra = for a in args {
+      let raw_args = for a in args {
         resolve_type_expr_core_shadowed(a, defs, shadow)
       }
-      if name == "Array" && Array::length(ra) == 1 {
-        CtArray(Array::get(ra, 0))
-      } else if name == "Option" && Array::length(ra) == 1 {
-        CtOption(Array::get(ra, 0))
-      } else if name == "StringMap" && Array::length(ra) == 1 && !type_expr_name_is_shadowed(shadow, name) {
+      if name == "Array" && Array::length(raw_args) == 1 {
+        CtArray(Array::get(raw_args, 0))
+      } else if name == "Option" && Array::length(raw_args) == 1 {
+        CtOption(Array::get(raw_args, 0))
+      } else if name == "StringMap" && Array::length(raw_args) == 1 && !type_expr_name_is_shadowed(shadow, name) {
         // #2263: the concrete name for the builtin map, which is String-keyed
         // (`Map[K, V]`'s generality is not implemented and the name is
         // reserved for it). Resolved here rather than declared as a prelude
@@ -2247,20 +2373,25 @@ export fn resolve_type_expr_core_shadowed(te: TypeExpr, defs: Array[TypeDef], sh
         // covered by the shadow test above, and source declarations by defs.
         match find_typedef(defs, name) {
           Some(td) => match td {
-            TDAlias(_, params, body) => resolve_type_alias_params(body, params, ra),
-            _ => CtNamed(name, ra)
+            TDAlias(_, params, body) => resolve_type_alias_params(body, params, resolve_type_constructor_args(params, args, raw_args, defs, shadow)),
+            _ => CtNamed(name, raw_args)
           },
-          None => CtNamed("Map", [CtString, Array::get(ra, 0)])
+          None => CtNamed("Map", [CtString, Array::get(raw_args, 0)])
         }
       } else if type_expr_name_is_shadowed(shadow, name) {
-        CtNamed(name, ra)
+        let arity = type_expr_shadowed_arity(shadow, name)
+        if arity > 0 {
+          CtApplied(CtNamed(name, array_empty()), raw_args)
+        } else {
+          CtNamed(name, raw_args)
+        }
       } else {
         match find_typedef(defs, name) {
           Some(td) => match td {
-            TDAlias(_, params, body) => resolve_type_alias_params(body, params, ra),
-            _ => CtNamed(name, ra)
+            TDAlias(_, params, body) => resolve_type_alias_params(body, params, resolve_type_constructor_args(params, args, raw_args, defs, shadow)),
+            _ => CtNamed(name, resolve_type_constructor_args(type_def_params(td), args, raw_args, defs, shadow))
           },
-          None => CtNamed(name, ra)
+          None => CtNamed(name, raw_args)
         }
       }
     },
@@ -2589,6 +2720,14 @@ fn collect_tvars_walk(t: Type, out: Array[Int]) -> Int {
     CtNamed(_, args) => {
       for a in args {
         let _ = collect_tvars_walk(a, out)
+      }
+      0
+    },
+    CtConstructor(_, _) => 0,
+    CtApplied(head, args) => {
+      let _ = collect_tvars_walk(head, out)
+      for arg in args {
+        let _ = collect_tvars_walk(arg, out)
       }
       0
     },
@@ -2964,6 +3103,24 @@ export fn types_equal(a: Type, b: Type) -> Bool {
       CtVar(bid) => (aid == bid),
       _ => false
     },
+    CtConstructor(aname, aarity) => match b {
+      CtConstructor(bname, barity) => aname == bname && aarity == barity,
+      _ => false
+    },
+    CtApplied(ahead, aargs) => match b {
+      CtApplied(bhead, bargs) => if Array::length(aargs) != Array::length(bargs) || !types_equal(ahead, bhead) {
+        false
+      } else {
+        let mut ai = 0
+        let mut equal = true
+        while ai < Array::length(aargs) && equal {
+          equal = types_equal(Array::get(aargs, ai), Array::get(bargs, ai))
+          ai = ai + 1
+        }
+        equal
+      },
+      _ => false
+    },
     CtArray(aelem) => match b {
       CtArray(belem) => types_equal(aelem, belem),
       _ => false
@@ -3167,6 +3324,64 @@ export fn types_equal(a: Type, b: Type) -> Bool {
 /// tokens (TInt, see lexer.vibe lex_char), so a value of Char and a value of Int
 /// share one runtime representation and must unify freely — a `Char` annotation
 /// accepts an int value and vice versa (`'A' == 65`, `c + 1`, char_test).
+fn type_application_view(ty: Type) -> Option[(Type, Array[Type])] {
+  match ty {
+    CtApplied(head, args) => Some((head, args)),
+    CtArray(elem) => Some((CtConstructor("Array", 1), [elem])),
+    CtOption(elem) => Some((CtConstructor("Option", 1), [elem])),
+    CtNamed(name, args) => if Array::length(args) > 0 {
+      Some((CtConstructor(name, Array::length(args)), args))
+    } else {
+      None
+    },
+    _ => None
+  }
+}
+
+/// `Some(result)` means application decomposition handled the pair. Outer
+/// `None` means ordinary first-order unification should continue.
+fn unify_type_applications(a: Type, b: Type, s: Subst) -> Option[Option[Subst]] {
+  match type_application_view(a) {
+    Some(ap) => match type_application_view(b) {
+      Some(bp) => {
+        let (ahead, aargs) = ap
+        let (bhead, bargs) = bp
+        if Array::length(aargs) != Array::length(bargs) {
+          Some(None)
+        } else match unify(ahead, bhead, s) {
+          None => Some(None),
+          Some(head_subst) => {
+            let mut acc = head_subst
+            let mut i = 0
+            let mut ok = true
+            while i < Array::length(aargs) && ok {
+              match unify(Array::get(aargs, i), Array::get(bargs, i), acc) {
+                Some(next) => {
+                  acc = next
+                },
+                None => {
+                  ok = false
+                }
+              }
+              i = i + 1
+            }
+            if ok {
+              Some(Some(acc))
+            } else {
+              Some(None)
+            }
+          }
+        }
+      },
+      None => None
+    },
+    None => match type_application_view(b) {
+      Some(_) => None,
+      None => None
+    }
+  }
+}
+
 fn char_int_compatible(ta: Type, tb: Type) -> Bool {
   match ta {
     CtChar => match tb {
@@ -3195,247 +3410,250 @@ export fn unify(a: Type, b: Type, s: Subst) -> Option[Subst] {
       CtUnknown => Some(s),
       _ => if is_hkt_app(ta) || is_hkt_app(tb) {
         unify_hkt(ta, tb, s)
-      } else match ta {
-        CtVar(id) => if occurs_in(id, tb) {
-          None
-        } else Some(SubstBind(id, tb, s)),
-        _ => match tb {
-          CtVar(id) => if occurs_in(id, ta) {
+      } else match unify_type_applications(ta, tb, s) {
+        Some(result) => result,
+        None => match ta {
+          CtVar(id) => if occurs_in(id, tb) {
             None
-          } else Some(SubstBind(id, ta, s)),
-          _ => match ta {
-            CtForAll(_, _, body_a) => match tb {
-              CtForAll(_, _, body_b) => unify(body_a, body_b, s),
-              _ => unify(body_a, tb, s)
-            },
-            _ => match tb {
-              CtForAll(_, _, body_b) => unify(ta, body_b, s),
-              _ => match ta {
-                CtArray(ea) => match tb {
-                  CtArray(eb) => unify(ea, eb, s),
-                  _ => None
-                },
-                CtOption(ea) => match tb {
-                  CtOption(eb) => unify(ea, eb, s),
-                  _ => None
-                },
-                CtFn(pa, ra, aeffect) => match tb {
-                  CtFn(pb, rb, beffect) => if Array::length(pa) != Array::length(pb) {
-                    None
-                  }
-                  else {
-                    let ul_len = Array::length(pa)
-                    let mut ul_i = 0
-                    let mut ul_acc = s
-                    let mut ul_result = Some(s)
-                    let mut ul_done = false
-                    while !ul_done {
-                      if ul_i >= ul_len {
-                        ul_result = Some(ul_acc)
-                        ul_done = true
-                      } else {
-                        match unify(Array::get(pa, ul_i), Array::get(pb, ul_i), ul_acc) {
-                          Some(s2) => {
-                            ul_acc = s2
-                            ul_i = ul_i + 1
-                          },
-                          None => {
-                            ul_result = None
-                            ul_done = true
-                          }
-                        }
-                      }
-                    }
-                    // #626 criterion 4: unify params, then the return type, then
-                    // the EFFECT row — binding an effect variable to the other
-                    // side (or failing on a genuine effect conflict) instead of
-                    // the old unconditional-wildcard accept.
-                    match ul_result {
-                      Some(s2) => match unify(ra, rb, s2) {
-                        Some(s3) => unify_effects(aeffect, beffect, s3),
-                        None => None
-                      },
-                      None => None
-                    }
+          } else Some(SubstBind(id, tb, s)),
+          _ => match tb {
+            CtVar(id) => if occurs_in(id, ta) {
+              None
+            } else Some(SubstBind(id, ta, s)),
+            _ => match ta {
+              CtForAll(_, _, body_a) => match tb {
+                CtForAll(_, _, body_b) => unify(body_a, body_b, s),
+                _ => unify(body_a, tb, s)
+              },
+              _ => match tb {
+                CtForAll(_, _, body_b) => unify(ta, body_b, s),
+                _ => match ta {
+                  CtArray(ea) => match tb {
+                    CtArray(eb) => unify(ea, eb, s),
+                    _ => None
                   },
-                  _ => None
-                },
-                CtTuple(ea) => match tb {
-                  CtTuple(eb) => if Array::length(ea) != Array::length(eb) {
-                    None
-                  }
-                  else {
-                    let ul_len2 = Array::length(ea)
-                    let mut ul_i2 = 0
-                    let mut ul_acc2 = s
-                    let mut ul_result2 = Some(s)
-                    let mut ul_done2 = false
-                    while !ul_done2 {
-                      if ul_i2 >= ul_len2 {
-                        ul_result2 = Some(ul_acc2)
-                        ul_done2 = true
-                      } else {
-                        match unify(Array::get(ea, ul_i2), Array::get(eb, ul_i2), ul_acc2) {
-                          Some(s2) => {
-                            ul_acc2 = s2
-                            ul_i2 = ul_i2 + 1
-                          },
-                          None => {
-                            ul_result2 = None
-                            ul_done2 = true
-                          }
-                        }
-                      }
-                    }
-                    ul_result2
+                  CtOption(ea) => match tb {
+                    CtOption(eb) => unify(ea, eb, s),
+                    _ => None
                   },
-                  _ => None
-                },
-                // #1839: records unify only with records of the same shape —
-                // same field names in the same order (order IS the runtime
-                // slot layout), field types unified pairwise. Against any
-                // nominal type (CtStruct/CtNamed/...) the catch-all below
-                // rejects, which is the point: an anonymous record can never
-                // silently satisfy a struct-typed position.
-                CtRecord(raf) => match tb {
-                  CtRecord(rbf) => if Array::length(raf) != Array::length(rbf) {
-                    None
-                  }
-                  else {
-                    let ur_len = Array::length(raf)
-                    let mut ur_i = 0
-                    let mut ur_acc = s
-                    let mut ur_result = Some(s)
-                    let mut ur_done = false
-                    while !ur_done {
-                      if ur_i >= ur_len {
-                        ur_result = Some(ur_acc)
-                        ur_done = true
-                      } else {
-                        let (ur_an, ur_at) = Array::get(raf, ur_i)
-                        let (ur_bn, ur_bt) = Array::get(rbf, ur_i)
-                        if ur_an != ur_bn {
-                          ur_result = None
-                          ur_done = true
+                  CtFn(pa, ra, aeffect) => match tb {
+                    CtFn(pb, rb, beffect) => if Array::length(pa) != Array::length(pb) {
+                      None
+                    }
+                    else {
+                      let ul_len = Array::length(pa)
+                      let mut ul_i = 0
+                      let mut ul_acc = s
+                      let mut ul_result = Some(s)
+                      let mut ul_done = false
+                      while !ul_done {
+                        if ul_i >= ul_len {
+                          ul_result = Some(ul_acc)
+                          ul_done = true
                         } else {
-                          match unify(ur_at, ur_bt, ur_acc) {
+                          match unify(Array::get(pa, ul_i), Array::get(pb, ul_i), ul_acc) {
                             Some(s2) => {
-                              ur_acc = s2
-                              ur_i = ur_i + 1
+                              ul_acc = s2
+                              ul_i = ul_i + 1
                             },
                             None => {
-                              ur_result = None
-                              ur_done = true
+                              ul_result = None
+                              ul_done = true
                             }
                           }
                         }
                       }
-                    }
-                    ur_result
+                      // #626 criterion 4: unify params, then the return type, then
+                      // the EFFECT row — binding an effect variable to the other
+                      // side (or failing on a genuine effect conflict) instead of
+                      // the old unconditional-wildcard accept.
+                      match ul_result {
+                        Some(s2) => match unify(ra, rb, s2) {
+                          Some(s3) => unify_effects(aeffect, beffect, s3),
+                          None => None
+                        },
+                        None => None
+                      }
+                    },
+                    _ => None
                   },
-                  _ => None
-                },
-                CtEnum(a_name) => match tb {
-                  CtEnum(b_name) => if a_name == b_name {
-                    Some(s)
-                  } else None,
-                  // Bridge `CtEnum(X)` with `CtNamed(X, args)` of any arity: an
-                  // enum VALUE carries no type args (constructors yield a bare
-                  // CtEnum), so it must still unify by name with an applied
-                  // annotation like `Result[U, E]`.
-                  CtNamed(b_name, _) => if a_name == b_name {
-                    Some(s)
-                  } else None,
-                  _ => None
-                },
-                CtStruct(a_name) => match tb {
-                  CtStruct(b_name) => if a_name == b_name {
-                    Some(s)
-                  } else None,
-                  // #829: a bare `CtStruct(S)` (unparameterized annotation /
-                  // pre-bound structural fn signature) unifies by name with an
-                  // INSTANTIATED `CtNamed(S, args)` of any arity — the bare
-                  // form carries no argument information to conflict with,
-                  // exactly like the CtEnum/CtNamed bridge below.
-                  //
-                  // #843 review follow-up (Codex P1): this bridge (both this
-                  // arm and its mirror in the `CtNamed(a_name, _)` case below)
-                  // lets a value's real #829-instantiated args get discarded
-                  // when it flows through a bare annotation (`let x: Box =
-                  // Box::{v:1}` types `x` as bare `Box`, forgetting `[Int]`),
-                  // and a LATER, unrelated annotation can then silently
-                  // re-narrow it (`let y: Box[String] = x; y.v` reads a
-                  // stored Int as String) — this is a real, confirmed hole.
-                  // It is NOT fixed by restricting the bridge's direction:
-                  // call sites are inconsistent about which side is
-                  // "expected" (`check_assignable(expected, actual, ..)` →
-                  // `unify(expected, actual, ..)`, but the function-body
-                  // return-type check calls `unify(body_ty, declared_ret,
-                  // ..)` — actual FIRST) — a one-directional restriction here
-                  // broke the legitimate mirror case instead (a trait `impl
-                  // Trait for S { ... }` method's bare-`S`-typed return
-                  // accepting a freshly `S::{...}`-constructed `S[X]`, gate
-                  // section 18) without closing the hole (the erasure
-                  // happens earlier, in the ascription-lambda / `let`
-                  // annotation machinery that decides which of {declared,
-                  // inferred} type to keep — not in `unify` itself). Full
-                  // bridge restored pending a real fix (tracked in #844:
-                  // thread fresh type vars through bare generic-struct
-                  // annotations instead of erasing to `CtStruct`, so the
-                  // annotation's own vars — not a name-only bridge — carry
-                  // the value's real args forward).
-                  CtNamed(b_name, _) => if a_name == b_name {
-                    Some(s)
-                  } else None,
-                  _ => None
-                },
-                CtNamed(a_name, a_args) => match tb {
-                  // Symmetric to the CtEnum bridge: an applied `CtNamed(X, args)`
-                  // unifies with the bare enum value `CtEnum(X)` by name.
-                  CtEnum(b_name) => if a_name == b_name {
-                    Some(s)
-                  } else None,
-                  // #829: symmetric bridge — an applied `CtNamed(S, args)`
-                  // unifies with the bare struct `CtStruct(S)` by name. See
-                  // the long #843/#844 note on the `CtStruct(a_name)` arm
-                  // above — restored (not narrowed) for the same reason.
-                  CtStruct(b_name) => if a_name == b_name {
-                    Some(s)
-                  } else None,
-                  CtNamed(b_name, b_args) => if a_name != b_name {
-                    None
-                  }
-                  else if Array::length(a_args) != Array::length(b_args) {
-                    None
-                  }
-                  else {
-                    let ul_len3 = Array::length(a_args)
-                    let mut ul_i3 = 0
-                    let mut ul_acc3 = s
-                    let mut ul_result3 = Some(s)
-                    let mut ul_done3 = false
-                    while !ul_done3 {
-                      if ul_i3 >= ul_len3 {
-                        ul_result3 = Some(ul_acc3)
-                        ul_done3 = true
-                      } else {
-                        match unify(Array::get(a_args, ul_i3), Array::get(b_args, ul_i3), ul_acc3) {
-                          Some(s2) => {
-                            ul_acc3 = s2
-                            ul_i3 = ul_i3 + 1
-                          },
-                          None => {
-                            ul_result3 = None
-                            ul_done3 = true
+                  CtTuple(ea) => match tb {
+                    CtTuple(eb) => if Array::length(ea) != Array::length(eb) {
+                      None
+                    }
+                    else {
+                      let ul_len2 = Array::length(ea)
+                      let mut ul_i2 = 0
+                      let mut ul_acc2 = s
+                      let mut ul_result2 = Some(s)
+                      let mut ul_done2 = false
+                      while !ul_done2 {
+                        if ul_i2 >= ul_len2 {
+                          ul_result2 = Some(ul_acc2)
+                          ul_done2 = true
+                        } else {
+                          match unify(Array::get(ea, ul_i2), Array::get(eb, ul_i2), ul_acc2) {
+                            Some(s2) => {
+                              ul_acc2 = s2
+                              ul_i2 = ul_i2 + 1
+                            },
+                            None => {
+                              ul_result2 = None
+                              ul_done2 = true
+                            }
                           }
                         }
                       }
+                      ul_result2
+                    },
+                    _ => None
+                  },
+                  // #1839: records unify only with records of the same shape —
+                  // same field names in the same order (order IS the runtime
+                  // slot layout), field types unified pairwise. Against any
+                  // nominal type (CtStruct/CtNamed/...) the catch-all below
+                  // rejects, which is the point: an anonymous record can never
+                  // silently satisfy a struct-typed position.
+                  CtRecord(raf) => match tb {
+                    CtRecord(rbf) => if Array::length(raf) != Array::length(rbf) {
+                      None
                     }
-                    ul_result3
+                    else {
+                      let ur_len = Array::length(raf)
+                      let mut ur_i = 0
+                      let mut ur_acc = s
+                      let mut ur_result = Some(s)
+                      let mut ur_done = false
+                      while !ur_done {
+                        if ur_i >= ur_len {
+                          ur_result = Some(ur_acc)
+                          ur_done = true
+                        } else {
+                          let (ur_an, ur_at) = Array::get(raf, ur_i)
+                          let (ur_bn, ur_bt) = Array::get(rbf, ur_i)
+                          if ur_an != ur_bn {
+                            ur_result = None
+                            ur_done = true
+                          } else {
+                            match unify(ur_at, ur_bt, ur_acc) {
+                              Some(s2) => {
+                                ur_acc = s2
+                                ur_i = ur_i + 1
+                              },
+                              None => {
+                                ur_result = None
+                                ur_done = true
+                              }
+                            }
+                          }
+                        }
+                      }
+                      ur_result
+                    },
+                    _ => None
+                  },
+                  CtEnum(a_name) => match tb {
+                    CtEnum(b_name) => if a_name == b_name {
+                      Some(s)
+                    } else None,
+                    // Bridge `CtEnum(X)` with `CtNamed(X, args)` of any arity: an
+                    // enum VALUE carries no type args (constructors yield a bare
+                    // CtEnum), so it must still unify by name with an applied
+                    // annotation like `Result[U, E]`.
+                    CtNamed(b_name, _) => if a_name == b_name {
+                      Some(s)
+                    } else None,
+                    _ => None
+                  },
+                  CtStruct(a_name) => match tb {
+                    CtStruct(b_name) => if a_name == b_name {
+                      Some(s)
+                    } else None,
+                    // #829: a bare `CtStruct(S)` (unparameterized annotation /
+                    // pre-bound structural fn signature) unifies by name with an
+                    // INSTANTIATED `CtNamed(S, args)` of any arity — the bare
+                    // form carries no argument information to conflict with,
+                    // exactly like the CtEnum/CtNamed bridge below.
+                    //
+                    // #843 review follow-up (Codex P1): this bridge (both this
+                    // arm and its mirror in the `CtNamed(a_name, _)` case below)
+                    // lets a value's real #829-instantiated args get discarded
+                    // when it flows through a bare annotation (`let x: Box =
+                    // Box::{v:1}` types `x` as bare `Box`, forgetting `[Int]`),
+                    // and a LATER, unrelated annotation can then silently
+                    // re-narrow it (`let y: Box[String] = x; y.v` reads a
+                    // stored Int as String) — this is a real, confirmed hole.
+                    // It is NOT fixed by restricting the bridge's direction:
+                    // call sites are inconsistent about which side is
+                    // "expected" (`check_assignable(expected, actual, ..)` →
+                    // `unify(expected, actual, ..)`, but the function-body
+                    // return-type check calls `unify(body_ty, declared_ret,
+                    // ..)` — actual FIRST) — a one-directional restriction here
+                    // broke the legitimate mirror case instead (a trait `impl
+                    // Trait for S { ... }` method's bare-`S`-typed return
+                    // accepting a freshly `S::{...}`-constructed `S[X]`, gate
+                    // section 18) without closing the hole (the erasure
+                    // happens earlier, in the ascription-lambda / `let`
+                    // annotation machinery that decides which of {declared,
+                    // inferred} type to keep — not in `unify` itself). Full
+                    // bridge restored pending a real fix (tracked in #844:
+                    // thread fresh type vars through bare generic-struct
+                    // annotations instead of erasing to `CtStruct`, so the
+                    // annotation's own vars — not a name-only bridge — carry
+                    // the value's real args forward).
+                    CtNamed(b_name, _) => if a_name == b_name {
+                      Some(s)
+                    } else None,
+                    _ => None
+                  },
+                  CtNamed(a_name, a_args) => match tb {
+                    // Symmetric to the CtEnum bridge: an applied `CtNamed(X, args)`
+                    // unifies with the bare enum value `CtEnum(X)` by name.
+                    CtEnum(b_name) => if a_name == b_name {
+                      Some(s)
+                    } else None,
+                    // #829: symmetric bridge — an applied `CtNamed(S, args)`
+                    // unifies with the bare struct `CtStruct(S)` by name. See
+                    // the long #843/#844 note on the `CtStruct(a_name)` arm
+                    // above — restored (not narrowed) for the same reason.
+                    CtStruct(b_name) => if a_name == b_name {
+                      Some(s)
+                    } else None,
+                    CtNamed(b_name, b_args) => if a_name != b_name {
+                      None
+                    }
+                    else if Array::length(a_args) != Array::length(b_args) {
+                      None
+                    }
+                    else {
+                      let ul_len3 = Array::length(a_args)
+                      let mut ul_i3 = 0
+                      let mut ul_acc3 = s
+                      let mut ul_result3 = Some(s)
+                      let mut ul_done3 = false
+                      while !ul_done3 {
+                        if ul_i3 >= ul_len3 {
+                          ul_result3 = Some(ul_acc3)
+                          ul_done3 = true
+                        } else {
+                          match unify(Array::get(a_args, ul_i3), Array::get(b_args, ul_i3), ul_acc3) {
+                            Some(s2) => {
+                              ul_acc3 = s2
+                              ul_i3 = ul_i3 + 1
+                            },
+                            None => {
+                              ul_result3 = None
+                              ul_done3 = true
+                            }
+                          }
+                        }
+                      }
+                      ul_result3
+                    },
+                    _ => None
                   },
                   _ => None
-                },
-                _ => None
+                }
               }
             }
           }
@@ -3459,7 +3677,7 @@ fn impl_pattern_param_index(params: Array[String], name: String) -> Int {
   let mut result = -1
   let mut i = 0
   while i < Array::length(params) && result < 0 {
-    if Array::get(params, i) == name {
+    if type_param_name(Array::get(params, i)) == name {
       result = i
     } else {
       ()
@@ -3917,6 +4135,8 @@ export fn type_constructor_name(ty: Type) -> String {
     } else {
       n
     },
+    CtConstructor(name, _) => name,
+    CtApplied(head, _) => type_constructor_name(head),
     CtStruct(n) => n,
     CtEnum(n) => n,
     _ => ""
@@ -3980,7 +4200,7 @@ fn generic_param_index(tparams: Array[String], name: String) -> Int {
   let mut i = 0
   let mut found = 0 - 1
   while i < Array::length(tparams) && found < 0 {
-    if Array::get(tparams, i) == name {
+    if type_param_name(Array::get(tparams, i)) == name {
       found = i
     } else {
       i = i + 1

--- a/lib/@vibe/compiler/core/types.vibe
+++ b/lib/@vibe/compiler/core/types.vibe
@@ -452,33 +452,47 @@ export fn hkt_apply_ctor(head: Type, args: Array[Type]) -> Type {
   if Array::length(args) == 0 {
     head
   } else {
-    match head {
-      CtNamed(n, ha) => if n == "Array" && Array::length(ha) == 0 && Array::length(args) == 1 {
-        CtArray(Array::get(args, 0))
-      } else if n == "Option" && Array::length(ha) == 0 && Array::length(args) == 1 {
-        CtOption(Array::get(args, 0))
-      } else if n == hkt_app_name() {
-        let out = array_empty()
-        let mut i = 0
-        while i < Array::length(ha) {
-          Array::push(out, Array::get(ha, i))
-          i = i + 1
-        }
-        let mut j = 0
-        while j < Array::length(args) {
-          Array::push(out, Array::get(args, j))
-          j = j + 1
-        }
-        CtNamed(hkt_app_name(), out)
-      } else if String::starts_with(n, hkt_ctor_prefix()) && Array::length(ha) == 0 {
-        let ctor = n[String::length(hkt_ctor_prefix()): String::length(n)]
-        hkt_apply_ctor(CtNamed(ctor, array_empty()), args)
-      } else if Array::length(ha) == 0 {
-        if n == "Array" && Array::length(args) == 1 {
+    match try_apply_alias_constructor(head, args) {
+      Some(applied) => applied,
+      None => match head {
+        CtNamed(n, ha) => if n == "Array" && Array::length(ha) == 0 && Array::length(args) == 1 {
           CtArray(Array::get(args, 0))
-        } else if n == "Option" && Array::length(args) == 1 {
+        } else if n == "Option" && Array::length(ha) == 0 && Array::length(args) == 1 {
           CtOption(Array::get(args, 0))
-        } else if String::starts_with(n, "#hktformal.") {
+        } else if n == hkt_app_name() {
+          let out = array_empty()
+          let mut i = 0
+          while i < Array::length(ha) {
+            Array::push(out, Array::get(ha, i))
+            i = i + 1
+          }
+          let mut j = 0
+          while j < Array::length(args) {
+            Array::push(out, Array::get(args, j))
+            j = j + 1
+          }
+          CtNamed(hkt_app_name(), out)
+        } else if String::starts_with(n, hkt_ctor_prefix()) && Array::length(ha) == 0 {
+          let ctor = n[String::length(hkt_ctor_prefix()): String::length(n)]
+          hkt_apply_ctor(CtNamed(ctor, array_empty()), args)
+        } else if Array::length(ha) == 0 {
+          if n == "Array" && Array::length(args) == 1 {
+            CtArray(Array::get(args, 0))
+          } else if n == "Option" && Array::length(args) == 1 {
+            CtOption(Array::get(args, 0))
+          } else if String::starts_with(n, "#hktformal.") {
+            let all = array_empty()
+            Array::push(all, head)
+            let mut k = 0
+            while k < Array::length(args) {
+              Array::push(all, Array::get(args, k))
+              k = k + 1
+            }
+            CtNamed(hkt_app_name(), all)
+          } else {
+            CtNamed(n, args)
+          }
+        } else {
           let all = array_empty()
           Array::push(all, head)
           let mut k = 0
@@ -487,38 +501,27 @@ export fn hkt_apply_ctor(head: Type, args: Array[Type]) -> Type {
             k = k + 1
           }
           CtNamed(hkt_app_name(), all)
-        } else {
-          CtNamed(n, args)
+        },
+        CtVar(_) => {
+          let all = array_empty()
+          Array::push(all, head)
+          let mut k = 0
+          while k < Array::length(args) {
+            Array::push(all, Array::get(args, k))
+            k = k + 1
+          }
+          CtNamed(hkt_app_name(), all)
+        },
+        _ => {
+          let all = array_empty()
+          Array::push(all, head)
+          let mut k = 0
+          while k < Array::length(args) {
+            Array::push(all, Array::get(args, k))
+            k = k + 1
+          }
+          CtNamed(hkt_app_name(), all)
         }
-      } else {
-        let all = array_empty()
-        Array::push(all, head)
-        let mut k = 0
-        while k < Array::length(args) {
-          Array::push(all, Array::get(args, k))
-          k = k + 1
-        }
-        CtNamed(hkt_app_name(), all)
-      },
-      CtVar(_) => {
-        let all = array_empty()
-        Array::push(all, head)
-        let mut k = 0
-        while k < Array::length(args) {
-          Array::push(all, Array::get(args, k))
-          k = k + 1
-        }
-        CtNamed(hkt_app_name(), all)
-      },
-      _ => {
-        let all = array_empty()
-        Array::push(all, head)
-        let mut k = 0
-        while k < Array::length(args) {
-          Array::push(all, Array::get(args, k))
-          k = k + 1
-        }
-        CtNamed(hkt_app_name(), all)
       }
     }
   }
@@ -2257,26 +2260,71 @@ fn type_expr_shadowed_arity(shadow: Array[String], name: String) -> Int {
 /// their established structural nodes; nominal constructors return CtNamed.
 /// Only an unresolved variable head remains CtApplied.
 export fn apply_type_constructor(head: Type, args: Array[Type]) -> Type {
+  match try_apply_alias_constructor(head, args) {
+    Some(applied) => applied,
+    None => match head {
+      CtConstructor(name, arity) => if arity != Array::length(args) {
+        CtApplied(head, args)
+      } else if name == "Array" && arity == 1 {
+        CtArray(Array::get(args, 0))
+      } else if name == "Option" && arity == 1 {
+        CtOption(Array::get(args, 0))
+      } else {
+        CtNamed(name, args)
+      },
+      _ => CtApplied(head, args)
+    }
+  }
+}
+
+let alias_ctor_tag = "#alias_ctor"
+
+fn make_alias_constructor(params: Array[String], body: Type) -> Type {
+  let meta = array_empty()
+  Array::push(meta, type_clone(body))
+  let mut i = 0
+  while i < Array::length(params) {
+    Array::push(meta, CtNamed(Array::get(params, i), array_empty()))
+    i = i + 1
+  }
+  CtApplied(CtNamed(alias_ctor_tag, array_empty()), meta)
+}
+
+fn apply_alias_constructor(head: Type, args: Array[Type]) -> Type {
   match head {
-    CtConstructor(name, arity) => if arity != Array::length(args) {
+    CtApplied(_, meta) => if Array::length(meta) == 0 {
       CtApplied(head, args)
-    } else if name == "Array" && arity == 1 {
-      CtArray(Array::get(args, 0))
-    } else if name == "Option" && arity == 1 {
-      CtOption(Array::get(args, 0))
     } else {
-      CtNamed(name, args)
+      let body = Array::get(meta, 0)
+      let params = array_empty()
+      let mut i = 1
+      while i < Array::length(meta) {
+        match Array::get(meta, i) {
+          CtNamed(n, _) => Array::push(params, n),
+          _ => ()
+        }
+        i = i + 1
+      }
+      if Array::length(params) == Array::length(args) {
+        resolve_type_alias_params(body, params, args)
+      } else {
+        CtApplied(head, args)
+      }
     },
     _ => CtApplied(head, args)
   }
 }
 
-fn alias_body_constructor(body: Type) -> Option[Type] {
-  match body {
-    CtArray(_) => Some(CtConstructor("Array", 1)),
-    CtOption(_) => Some(CtConstructor("Option", 1)),
-    CtNamed(n, args) => Some(CtConstructor(n, Array::length(args))),
-    CtConstructor(n, arity) => Some(CtConstructor(n, arity)),
+fn try_apply_alias_constructor(head: Type, args: Array[Type]) -> Option[Type] {
+  match head {
+    CtApplied(inner, _) => match inner {
+      CtNamed(n, ha) => if n == alias_ctor_tag && Array::length(ha) == 0 {
+        Some(apply_alias_constructor(head, args))
+      } else {
+        None
+      },
+      _ => None
+    },
     _ => None
   }
 }
@@ -2299,9 +2347,10 @@ fn reify_named_constructor(name: String, defs: Array[TypeDef], shadow: Array[Str
   } else {
     match find_typedef(defs, name) {
       Some(td) => match td {
-        TDAlias(_, _, body) => match alias_body_constructor(body) {
-          Some(ctor) => ctor,
-          None => named_constructor_or_resolved(name, defs, resolved)
+        TDAlias(_, alias_params, body) => if Array::length(alias_params) > 0 {
+          make_alias_constructor(alias_params, body)
+        } else {
+          named_constructor_or_resolved(name, defs, resolved)
         },
         _ => named_constructor_or_resolved(name, defs, resolved)
       },

--- a/lib/@vibe/compiler/core/types.vibe
+++ b/lib/@vibe/compiler/core/types.vibe
@@ -2271,6 +2271,45 @@ export fn apply_type_constructor(head: Type, args: Array[Type]) -> Type {
   }
 }
 
+fn alias_body_constructor(body: Type) -> Option[Type] {
+  match body {
+    CtArray(_) => Some(CtConstructor("Array", 1)),
+    CtOption(_) => Some(CtConstructor("Option", 1)),
+    CtNamed(n, args) => Some(CtConstructor(n, Array::length(args))),
+    CtConstructor(n, arity) => Some(CtConstructor(n, arity)),
+    _ => None
+  }
+}
+
+fn named_constructor_or_resolved(name: String, defs: Array[TypeDef], resolved: Type) -> Type {
+  match declared_type_constructor_arity(defs, name) {
+    Some(arity) => if arity > 0 {
+      CtConstructor(name, arity)
+    } else {
+      resolved
+    },
+    None => resolved
+  }
+}
+
+fn reify_named_constructor(name: String, defs: Array[TypeDef], shadow: Array[String], resolved: Type) -> Type {
+  let shadow_arity = type_expr_shadowed_arity(shadow, name)
+  if shadow_arity > 0 {
+    resolved
+  } else {
+    match find_typedef(defs, name) {
+      Some(td) => match td {
+        TDAlias(_, _, body) => match alias_body_constructor(body) {
+          Some(ctor) => ctor,
+          None => named_constructor_or_resolved(name, defs, resolved)
+        },
+        _ => named_constructor_or_resolved(name, defs, resolved)
+      },
+      None => named_constructor_or_resolved(name, defs, resolved)
+    }
+  }
+}
+
 fn type_def_params(td: TypeDef) -> Array[String] {
   match td {
     TDEnum(_, params, _) => params,
@@ -2298,28 +2337,16 @@ fn declared_type_constructor_arity(defs: Array[TypeDef], name: String) -> Option
 /// receiving type parameter. A shadowed constructor variable stays nominal so
 /// checker binding can replace its head with a CtVar; concrete constructors
 /// carry their declared arity explicitly across alias substitution and caches.
-fn resolve_type_constructor_args(params: Array[String], source_args: Array[TypeExpr], resolved_args: Array[Type], defs: Array[TypeDef], shadow: Array[String]) -> Array[Type] {
+/// Parameterized aliases expand to the constructor of their body (`Vec` for
+/// `type Vec[T] = Array[T]` becomes Array) rather than a nominal head.
+export fn resolve_type_constructor_args(params: Array[String], source_args: Array[TypeExpr], resolved_args: Array[Type], defs: Array[TypeDef], shadow: Array[String]) -> Array[Type] {
   let out = array_empty()
   let mut i = 0
   while i < Array::length(resolved_args) {
     let resolved = Array::get(resolved_args, i)
     if i < Array::length(params) && type_param_arity(Array::get(params, i)) > 0 && i < Array::length(source_args) {
       match Array::get(source_args, i) {
-        TyName(name) => {
-          let shadow_arity = type_expr_shadowed_arity(shadow, name)
-          if shadow_arity > 0 {
-            Array::push(out, resolved)
-          } else {
-            match declared_type_constructor_arity(defs, name) {
-              Some(arity) => if arity > 0 {
-                Array::push(out, CtConstructor(name, arity))
-              } else {
-                Array::push(out, resolved)
-              },
-              None => Array::push(out, resolved)
-            }
-          }
-        },
+        TyName(name) => Array::push(out, reify_named_constructor(name, defs, shadow, resolved)),
         _ => Array::push(out, resolved)
       }
     } else {
@@ -2357,11 +2384,18 @@ export fn resolve_type_expr_core_shadowed(te: TypeExpr, defs: Array[TypeDef], sh
       let raw_args = for a in args {
         resolve_type_expr_core_shadowed(a, defs, shadow)
       }
-      if name == "Array" && Array::length(raw_args) == 1 {
+      if type_expr_name_is_shadowed(shadow, name) {
+        let arity = type_expr_shadowed_arity(shadow, name)
+        if arity > 0 {
+          CtApplied(CtNamed(name, array_empty()), raw_args)
+        } else {
+          CtNamed(name, raw_args)
+        }
+      } else if name == "Array" && Array::length(raw_args) == 1 {
         CtArray(Array::get(raw_args, 0))
       } else if name == "Option" && Array::length(raw_args) == 1 {
         CtOption(Array::get(raw_args, 0))
-      } else if name == "StringMap" && Array::length(raw_args) == 1 && !type_expr_name_is_shadowed(shadow, name) {
+      } else if name == "StringMap" && Array::length(raw_args) == 1 {
         // #2263: the concrete name for the builtin map, which is String-keyed
         // (`Map[K, V]`'s generality is not implemented and the name is
         // reserved for it). Resolved here rather than declared as a prelude
@@ -2377,13 +2411,6 @@ export fn resolve_type_expr_core_shadowed(te: TypeExpr, defs: Array[TypeDef], sh
             _ => CtNamed(name, raw_args)
           },
           None => CtNamed("Map", [CtString, Array::get(raw_args, 0)])
-        }
-      } else if type_expr_name_is_shadowed(shadow, name) {
-        let arity = type_expr_shadowed_arity(shadow, name)
-        if arity > 0 {
-          CtApplied(CtNamed(name, array_empty()), raw_args)
-        } else {
-          CtNamed(name, raw_args)
         }
       } else {
         match find_typedef(defs, name) {

--- a/lib/@vibe/compiler/core/types_eq_test.vibe
+++ b/lib/@vibe/compiler/core/types_eq_test.vibe
@@ -53,10 +53,12 @@ fn type_tag(v: Type) -> Int {
     CtStruct(_) => 11,
     CtBytes => 12,
     CtNamed(_, _) => 13,
-    CtVar(_) => 14,
-    CtForAll(_, _, _) => 15,
-    CtUnknown => 16,
-    CtRecord(_) => 17
+    CtConstructor(_, _) => 14,
+    CtApplied(_, _) => 15,
+    CtVar(_) => 16,
+    CtForAll(_, _, _) => 17,
+    CtUnknown => 18,
+    CtRecord(_) => 19
   }
 }
 
@@ -77,6 +79,8 @@ fn every_type() -> Array[Type] {
     CtStruct("s"),
     CtBytes,
     CtNamed("s", [CtUnit]),
+    CtConstructor("s", 1),
+    CtApplied(CtVar(7), [CtUnit]),
     CtVar(7),
     CtForAll([3], [(1, ["C"])], CtUnit),
     CtUnknown,
@@ -107,6 +111,8 @@ fn every_type_same() -> Array[Type] {
     CtStruct("s"),
     CtBytes,
     CtNamed("s", [CtUnit]),
+    CtConstructor("s", 1),
+    CtApplied(CtVar(7), [CtUnit]),
     CtVar(7),
     CtForAll([3], [(1, ["C"])], CtUnit),
     CtUnknown,
@@ -134,6 +140,8 @@ fn every_type_alt() -> Array[Type] {
     CtStruct("t"),
     CtBytes,
     CtNamed("t", [CtInt]),
+    CtConstructor("t", 2),
+    CtApplied(CtVar(8), [CtInt]),
     CtVar(8),
     CtForAll([4], [(2, ["D"])], CtInt),
     CtUnknown,
@@ -279,7 +287,7 @@ test "Type ==: every variant is structurally equal to itself" {
     }
     i = i + 1
   }
-  inspect(same, "18")
+  inspect(same, "20")
 }
 
 test "Type ==: distinct variants are never equal" {
@@ -302,7 +310,7 @@ test "Type ==: distinct variants are never equal" {
     }
     i = i + 1
   }
-  inspect(differ, "18")
+  inspect(differ, "20")
 }
 
 test "Type ==: structurally equal but distinct values are equal" {
@@ -323,7 +331,7 @@ test "Type ==: structurally equal but distinct values are equal" {
   }
   // Every variant, including the ones carrying arrays and nested values. A
   // regression from structural to reference comparison drops this below n.
-  inspect(equal, "18")
+  inspect(equal, "20")
 }
 
 test "Type: every represented variant is the declared one, in order" {
@@ -335,7 +343,28 @@ test "Type: every represented variant is the declared one, in order" {
   // variant this file has no sample for is omitted and leaves a gap. Writing
   // `tag(vs[i]) == i` instead was wrong for exactly that reason, and this test
   // is what caught it.
-  let want = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17]
+  let want = [
+    0,
+    1,
+    2,
+    3,
+    4,
+    5,
+    6,
+    7,
+    8,
+    9,
+    10,
+    11,
+    12,
+    13,
+    14,
+    15,
+    16,
+    17,
+    18,
+    19
+  ]
   let vs = every_type()
   let n = Array::length(vs)
   let mut in_order = 0
@@ -349,8 +378,8 @@ test "Type: every represented variant is the declared one, in order" {
     }
     i = i + 1
   }
-  inspect(Array::length(want), "18")
-  inspect(in_order, "18")
+  inspect(Array::length(want), "20")
+  inspect(in_order, "20")
 }
 
 test "Type ==: same variant with different payloads is not equal" {
@@ -372,8 +401,8 @@ test "Type ==: same variant with different payloads is not equal" {
   // Exactly the variants that CARRY a payload must differ; the nullary ones
   // rebuild identically and must still compare equal. A derive that compared
   // tags only would report 0 here.
-  inspect(Array::length(alt), "18")
-  inspect(differ, "10")
+  inspect(Array::length(alt), "20")
+  inspect(differ, "12")
 }
 
 test "TypeDef ==: every variant is structurally equal to itself" {

--- a/lib/@vibe/compiler/index.vpkg
+++ b/lib/@vibe/compiler/index.vpkg
@@ -3,6 +3,7 @@ version = 0.0.1
 description =
   #|@vibe/compiler (top level) — ADR-0070 / #897 compiler-internal contract.
 deps = {
+  @vibe/ast : 0.0.1
   @vibe/compiler/cache : 0.0.1
   @vibe/compiler/checker : 0.0.1
   @vibe/compiler/codegen : 0.0.1

--- a/lib/@vibe/compiler/normalize/desugar_trait_dict.vibe
+++ b/lib/@vibe/compiler/normalize/desugar_trait_dict.vibe
@@ -26,7 +26,8 @@ import @vibe/ast {
   impl_target_head,
   impl_target_key,
   trait_ref_from_key,
-  trait_ref_name
+  trait_ref_name,
+  type_param_name
 }
 
 import @vibe/core {
@@ -9941,24 +9942,37 @@ fn gen_eq_fn(tname: String, fields: Array[(String, TypeExpr)], known_types: Arra
   SLet(false, false, qualified_name(tname, "equals"), None, EFn(no_tp, no_tb, params, Some(TyName("Bool")), None, body))
 }
 
+fn eq_subst_lookup(params: Array[String], args: Array[TypeExpr], n: String) -> Option[TypeExpr] {
+  let mut i = 0
+  let mut found = None
+  while i < Array::length(params) && i < Array::length(args) {
+    if type_param_name(Array::get(params, i)) == type_param_name(n) {
+      found = Some(Array::get(args, i))
+    } else {
+      ()
+    }
+    i = i + 1
+  }
+  found
+}
+
 fn eq_subst_ty(ty: TypeExpr, params: Array[String], args: Array[TypeExpr]) -> TypeExpr {
   match ty {
-    TyName(n) => {
-      let mut i = 0
-      let mut out = ty
-      while i < Array::length(params) && i < Array::length(args) {
-        if Array::get(params, i) == n {
-          out = Array::get(args, i)
-        } else {
-          ()
-        }
-        i = i + 1
-      }
-      out
+    TyName(n) => match eq_subst_lookup(params, args, n) {
+      Some(arg) => arg,
+      None => ty
     },
-    TyApp(n, xs) => TyApp(n, for x in xs {
-      eq_subst_ty(x, params, args)
-    }),
+    TyApp(n, xs) => {
+      let subst_xs = for x in xs {
+        eq_subst_ty(x, params, args)
+      }
+      match eq_subst_lookup(params, args, n) {
+        Some(TyName(hn)) => TyApp(hn, subst_xs),
+        Some(TyApp(hn, _)) => TyApp(hn, subst_xs),
+        Some(_) => TyApp(n, subst_xs),
+        None => TyApp(n, subst_xs)
+      }
+    },
     TyFn(ps, result, effect) => TyFn(for p in ps {
       eq_subst_ty(p, params, args)
     }, eq_subst_ty(result, params, args), effect),

--- a/lib/@vibe/compiler/normalize/desugar_trait_dict.vibe
+++ b/lib/@vibe/compiler/normalize/desugar_trait_dict.vibe
@@ -8418,9 +8418,23 @@ fn subst_formals_ty(ty: TypeExpr, formals: Array[String]) -> TypeExpr {
   }
 }
 
+fn formals_contain_source_name(formals: Array[String], n: String) -> Bool {
+  let mut i = 0
+  let mut found = false
+  while i < Array::length(formals) {
+    if type_param_name(Array::get(formals, i)) == n {
+      found = true
+    } else {
+      ()
+    }
+    i = i + 1
+  }
+  found
+}
+
 fn subst_formals_ty_body(ty: TypeExpr, formals: Array[String]) -> TypeExpr {
   match ty {
-    TyName(n) => if str_array_contains(formals, n) {
+    TyName(n) => if formals_contain_source_name(formals, n) {
       TyName(mark_formal_name(n))
     } else {
       ty
@@ -8432,7 +8446,7 @@ fn subst_formals_ty_body(ty: TypeExpr, formals: Array[String]) -> TypeExpr {
         Array::push(out, subst_formals_ty(Array::get(args, i), formals))
         i = i + 1
       }
-      if str_array_contains(formals, n) {
+      if formals_contain_source_name(formals, n) {
         TyApp(mark_formal_name(n), out)
       } else {
         TyApp(n, out)
@@ -10714,6 +10728,18 @@ fn ty_to_eq_shape_expanded(t: TypeExpr) -> String {
   }
 }
 
+/// A constructor argument inside `{g:Head,...}`. Bare `Array`/`Map`/`Tuple`
+/// here are type constructors (`KBox[Array, Int]`), not complete values, so
+/// they must round-trip as `TyName` rather than the `__EqUnknown` marker
+/// `shape_to_eq_ty` uses for an element-free array binding.
+fn shape_to_eq_ctor_arg(sh: String) -> TypeExpr {
+  if sh == "Array" || sh == "Map" || sh == "Tuple" {
+    TyName(sh)
+  } else {
+    shape_to_eq_ty(sh)
+  }
+}
+
 /// A shape string back into the TypeExpr `eq_for_typed` dispatches on. An
 /// unknown position becomes the `__EqUnknown` marker (raw `==`, the status
 /// quo for that position). A bare "Option"/"Result" head keeps its
@@ -10766,7 +10792,7 @@ fn shape_to_eq_ty(sh: String) -> TypeExpr {
       let args = empty_type_exprs()
       let mut i = 0
       while i + 1 < Array::length(parts) {
-        Array::push(args, shape_to_eq_ty(Array::get(parts, i + 1)))
+        Array::push(args, shape_to_eq_ctor_arg(Array::get(parts, i + 1)))
         i = i + 1
       }
       TyApp(Array::get(parts, 0), args)

--- a/lib/@vibe/compiler/runtime/grep.vibe
+++ b/lib/@vibe/compiler/runtime/grep.vibe
@@ -2023,6 +2023,14 @@ fn grep_type_matches(expected: Type, actual: Type) -> Bool {
       CtNamed(aname, aargs) => name == aname && Array::length(aargs) == 0,
       _ => false
     },
+    CtConstructor(name, arity) => match actual {
+      CtConstructor(aname, aarity) => name == aname && arity == aarity,
+      _ => false
+    },
+    CtApplied(head, args) => match actual {
+      CtApplied(ahead, aargs) => grep_type_matches(head, ahead) && grep_type_list_matches(args, aargs),
+      _ => false
+    },
     CtVar(_) => false,
     CtForAll(_, _, body) => grep_type_matches(body, actual),
     CtUnknown => false

--- a/lib/@vibe/compiler/runtime/index.vpkg
+++ b/lib/@vibe/compiler/runtime/index.vpkg
@@ -215,7 +215,7 @@ fn deprecated_warning_lines_visible(entry_source: String, dep_sources: Array[Str
 fn legacy_handler_warning_lines(source: String) -> Array[String] with Exception
 
 // --- typing_dependency_record_codec.vibe
-// Compiler-internal generic framing only; TDRE5 semantic field schemas remain
+// Compiler-internal generic framing only; TDRE7 semantic field schemas remain
 // private to typecheck_fs and are not frozen in this contract.
 fn typing_dependency_record_encode_internal(tag: String, fields: Array[String]) -> String
 fn typing_dependency_record_decode_internal(text: String, expected_tag: String, expected_fields: Int) -> Option[Array[String]]
@@ -257,7 +257,7 @@ fn set_collect_module_diagnostics(on: Bool) -> Unit
 // the row format and scripts/scheduler_trace_oracle.sh for the checks.
 fn set_scheduler_trace_path(path: String) -> Unit
 // Incremental typecheck work counters and successful-check observation sidecar.
-// Telemetry/interface tracing remain default-off observations. TDRE5 TypeEnv
+// Telemetry/interface tracing remain default-off observations. TDRE7 TypeEnv
 // reuse is production-default only for CLI check-only; its setter resets
 // per-invocation policy and does not widen reuse beyond existing validation.
 fn set_incremental_typecheck_telemetry_enabled(enabled: Bool) -> Unit
@@ -269,7 +269,7 @@ fn incremental_invalidation_trace_json(entry_path: String, run_nonce: String) ->
 fn incremental_trait_generic_provenance_markers_for_test(header_params: Array[String], method_params: Array[String], generic_bounds: Array[(String, Array[String])], method_count: Int, method_gens: Array[(String, Array[String], Array[(String, Array[String])])]) -> String
 fn incremental_interface_effect_set_for_test(effect_name: Option[String], ids: Array[Int], names: Array[String]) -> String
 // Test-only semantic seam for the exact dependency projection used by
-// ModuleJob.dep_envs and TDRE5. Throws when a resolved dependency row is absent.
+// ModuleJob.dep_envs and TDRE7. Throws when a resolved dependency row is absent.
 fn projected_import_env_for_test(source: String, path: String, deps: Array[String], full_cache: Array[(String, TypeEnv)]) -> TypeEnv with Exception
 // #906 Phase 1: the module job / outcome seam. `check_module` is the unit a
 // Phase 2 worker will receive; it takes no `Fs` row because every
@@ -282,7 +282,7 @@ fn projected_import_env_for_test(source: String, path: String, deps: Array[Strin
 // PerceusAction precedent): the field layout IS the worker contract.
 // dep_envs is exactly the driver's ordered resolved direct-dependency
 // projection. The coordinator keeps its full accumulated cache separately;
-// check_module and TDRE5 consume the same projected array so ambient rows
+// check_module and TDRE7 consume the same projected array so ambient rows
 // cannot affect either import resolution or the logical reuse key.
 // `fingerprint` is deliberately NOT a field here. An earlier cut had the
 // caller supply one, which check_module simply echoed back into `Checked`

--- a/lib/@vibe/compiler/runtime/persistent_env_codec.vibe
+++ b/lib/@vibe/compiler/runtime/persistent_env_codec.vibe
@@ -233,6 +233,30 @@ fn parse_cached_type(source: String, pos: Int) -> (Type, Int) with Exception {
         let (raw, next) = parse_segment(source, pos + 1)
         (CtVar(parse_int_strict(raw)), next)
       },
+      'J' => {
+        let (name, after_name) = parse_segment(source, pos + 1)
+        let (raw_arity, next) = parse_segment(source, after_name)
+        let arity = parse_int_strict(raw_arity)
+        if arity <= 0 {
+          throw("invalid persistent type constructor arity")
+        } else {
+          (CtConstructor(name, arity), next)
+        }
+      },
+      'P' => {
+        let (head_raw, after_head) = parse_segment(source, pos + 1)
+        let (head, head_end) = parse_cached_type(head_raw, 0)
+        if head_end != String::length(head_raw) {
+          throw("invalid persistent applied type head")
+        } else {
+          let (args, next) = parse_type_array(source, after_head)
+          if Array::length(args) == 0 {
+            throw("invalid persistent applied type arguments")
+          } else {
+            (CtApplied(head, args), next)
+          }
+        }
+      },
       'E' => {
         let (name, next) = parse_segment(source, pos + 1)
         (CtEnum(name), next)
@@ -316,6 +340,8 @@ fn serialize_type(ty: Type) -> String {
     CtBytes => "Y",
     CtUnknown => "X",
     CtVar(id) => String::concat("V", serialize_segment(__to_string(id))),
+    CtConstructor(name, arity) => String::concat("J", String::concat(serialize_segment(name), serialize_segment(__to_string(arity)))),
+    CtApplied(head, args) => String::concat("P", String::concat(serialize_segment(serialize_type(head)), serialize_type_array(args))),
     CtEnum(name) => String::concat("E", serialize_segment(name)),
     CtStruct(name) => String::concat("R", serialize_segment(name)),
     CtArray(elem) => String::concat("A", serialize_type(elem)),
@@ -995,23 +1021,23 @@ export fn load_persistent_dep_list(path: String, source: String) -> Option[Array
   }
 }
 
-/// Strict v6 module-interface wire format. It preserves declaration closure
+/// Strict v7 module-interface wire format. It preserves declaration closure
 /// plus the distinct selected declaration surface. Older bytes are rejected
 /// rather than being misread as authority.
 export fn parse_persistent_type_env(text: String) -> Option[TypeEnv] with Exception {
   let normalized = normalize_persistent_cache_text(text)
-  let header = "version\t6\nenv\t"
+  let header = "version\t7\nenv\t"
   let header_len = String::length(header)
   if String::length(normalized) < header_len || normalized[0: header_len] != header {
     None
   } else {
     let (payload, after_payload) = parse_segment(normalized, header_len)
     if after_payload + 1 != String::length(normalized) || String::char_code_at(normalized, after_payload) != '\n' {
-      throw("invalid persistent type env v6 envelope")
+      throw("invalid persistent type env v7 envelope")
     } else {
       let (env, end) = parse_persistent_type_env_payload(payload, 0)
       if end != String::length(payload) {
-        throw("invalid persistent type env v6 payload")
+        throw("invalid persistent type env v7 payload")
       } else {
         Some(env)
       }
@@ -1034,7 +1060,7 @@ export fn load_persistent_type_env(fingerprint: String) -> Option[TypeEnv] with 
 }
 
 export fn persistent_type_env_cache_text(env: TypeEnv) -> String {
-  String::concat("version\t6\nenv\t", String::concat(serialize_segment(serialize_type_env(env)), "\n"))
+  String::concat("version\t7\nenv\t", String::concat(serialize_segment(serialize_type_env(env)), "\n"))
 }
 
 export fn load_persistent_leaf_fingerprint(path: String, source: String, typing_semantics_seed: String) -> Option[String] with Exception + Fs {

--- a/lib/@vibe/compiler/runtime/typecheck_fs.vibe
+++ b/lib/@vibe/compiler/runtime/typecheck_fs.vibe
@@ -15,7 +15,7 @@ import @vibe/core {
 }
 
 import @vibe/ast {
-  TypeExpr, trait_ref_from_key, trait_ref_key, trait_ref_name
+  TypeExpr, trait_ref_from_key, trait_ref_key, trait_ref_name, type_param_arity, type_param_name
 }
 
 import @vibe/compiler/checker {
@@ -1574,7 +1574,7 @@ fn load_planned_module_source(rdb: RippleDb, path: String) -> (RippleDb, Option[
 ///
 /// Order and duplicate paths are preserved verbatim. lookup_env_cache's
 /// first-match rule is intentional: it is the same rule build_import_env uses,
-/// so a duplicate cache path cannot select one interface while TDRE5 keys a
+/// so a duplicate cache path cannot select one interface while TDRE7 keys a
 /// different one. A missing row is an infrastructure error, never EnvEmpty:
 /// continuing would let an unreadable dependency silently weaken checking.
 fn project_exact_dependency_envs(deps: Array[String], full_cache: Array[(String, TypeEnv)]) -> Array[(String, TypeEnv)] with Exception {
@@ -1815,7 +1815,7 @@ fn collect_module_diagnostics() -> Bool {
 ///   5 current-source parse executions (ModuleJob parse memo misses)
 ///   6 checker executions
 ///   7 modules reused by conservative fingerprint authority
-///   8 modules reused by validated TDRE6 dependency transport authority
+///   8 modules reused by validated TDRE7 dependency transport authority
 ///
 /// `parse_operations` is parser work, not a unique-module count: a cold
 /// module can need one header parse during planning and one full parse for its
@@ -1839,9 +1839,9 @@ let incremental_checked_env_trace_observations: Array[(String, String)] = []
 let incremental_persistent_type_env_transport_trace_observations: Array[(String, String)] = [
 ]
 
-// TDRE6 aliases only an exact v6 decoded TypeEnv when every direct dependency
+// TDRE7 aliases only an exact v7 decoded TypeEnv when every direct dependency
 // transport environment is unchanged. It is not a CheckedProgram or typed-IR
-// transport; v6 retains applied bounds in the TypeEnv declaration, trait, and
+// transport; v7 retains kinded applications in the TypeEnv declaration, trait, and
 // impl chain. The empty cell is
 // conservative for direct FS consumers. The CLI check-only lane explicitly
 // enables production reuse after validating its per-invocation policy; build,
@@ -2126,6 +2126,8 @@ fn interface_canonical_type(ty: Type, ids: Array[Int], names: Array[String]) -> 
     CtBytes => "bytes",
     CtUnknown => "unknown",
     CtVar(id) => String::concat("var:", interface_lookup_var(ids, names, id)),
+    CtConstructor(name, arity) => String::concat("constructor:", String::concat(interface_segment(name), __to_string(arity))),
+    CtApplied(head, args) => String::concat("applied:", String::concat(interface_segment(interface_canonical_type(head, ids, names)), types(args, ids, names))),
     CtEnum(name) => String::concat("enum:", interface_segment(name)),
     CtStruct(name) => String::concat("struct:", interface_segment(name)),
     CtArray(elem) => String::concat("array:", interface_segment(interface_canonical_type(elem, ids, names))),
@@ -2185,8 +2187,8 @@ fn interface_lookup_type_param(params: Array[String], name: String) -> String {
   let mut result = name
   let mut found = false
   while i < Array::length(params) && !found {
-    if Array::get(params, i) == name {
-      result = String::concat("p", __to_string(i))
+    if type_param_name(Array::get(params, i)) == name {
+      result = String::concat("p", String::concat(__to_string(i), String::concat("/", __to_string(type_param_arity(Array::get(params, i))))))
       found = true
     } else {
       i = i + 1
@@ -2203,8 +2205,8 @@ fn interface_lookup_trait_type_param(header_params: Array[String], method_params
   let mut method_result = String::concat("free:", name)
   let mut found_method = false
   while i < Array::length(method_params) && !found_method {
-    if Array::get(method_params, i) == name {
-      method_result = String::concat("method:", __to_string(i))
+    if type_param_name(Array::get(method_params, i)) == name {
+      method_result = String::concat("method:", String::concat(__to_string(i), String::concat("/", __to_string(type_param_arity(Array::get(method_params, i))))))
       found_method = true
     } else {
       i = i + 1
@@ -2217,8 +2219,8 @@ fn interface_lookup_trait_type_param(header_params: Array[String], method_params
     let mut header_result = String::concat("free:", name)
     let mut found_header = false
     while j < Array::length(header_params) && !found_header {
-      if Array::get(header_params, j) == name {
-        header_result = String::concat("header:", __to_string(j))
+      if type_param_name(Array::get(header_params, j)) == name {
+        header_result = String::concat("header:", String::concat(__to_string(j), String::concat("/", __to_string(type_param_arity(Array::get(header_params, j))))))
         found_header = true
       } else {
         j = j + 1
@@ -2258,11 +2260,11 @@ fn interface_trait_header_malformed_rows(header_params: Array[String]) -> Array[
   let rows = array_empty()
   let mut p = 0
   while p < Array::length(header_params) {
-    let param_name = Array::get(header_params, p)
+    let param_name = type_param_name(Array::get(header_params, p))
     let mut matches = 0
     let mut p2 = 0
     while p2 < Array::length(header_params) {
-      if Array::get(header_params, p2) == param_name {
+      if type_param_name(Array::get(header_params, p2)) == param_name {
         matches = matches + 1
       } else {
         ()
@@ -2557,7 +2559,7 @@ fn interface_public_type_names(stmts: Array[Stmt], checked_env: TypeEnv) -> Arra
 /// name the module itself imported -- so testing an import against it let
 /// `import ./dep.vibe { private_fn }` through to die in codegen. Dropping
 /// the non-exported bindings here, at the single point every publication
-/// path flows through (persistent store, env cache, worker env.out, TDRE5),
+/// path flows through (persistent store, env cache, worker env.out, TDRE7),
 /// makes the existing membership check in
 /// bind_import_names_from_cache_collecting the export test itself.
 ///
@@ -2966,7 +2968,7 @@ export fn incremental_trait_generic_provenance_markers_for_test(header_params: A
 fn incremental_interface_identity(source: String, env: TypeEnv) -> String with Exception {
   let stmts = parse_program_with_path("<incremental-interface-observation>", source)
   let out = StringBuilder::new()
-  StringBuilder::push(out, "vibe-module-interface:v3\n")
+  StringBuilder::push(out, "vibe-module-interface:v4\n")
   let names = interface_public_value_names(stmts)
   let mut i = 0
   while i < Array::length(names) {
@@ -3013,7 +3015,7 @@ fn incremental_checked_env_identity(env: TypeEnv) -> String with Exception {
   }
   let names = interface_sorted_unique(raw_names)
   let out = StringBuilder::new()
-  StringBuilder::push(out, "vibe-module-checked-env:v2\n")
+  StringBuilder::push(out, "vibe-module-checked-env:v3\n")
   let mut i = 0
   while i < Array::length(names) {
     let name = Array::get(names, i)
@@ -3031,7 +3033,7 @@ fn incremental_checked_env_identity(env: TypeEnv) -> String with Exception {
   compact_string_fingerprint(StringBuilder::freeze(out))
 }
 
-/// A trace-only observation of the complete persistent TypeEnv v6 transport.
+/// A trace-only observation of the complete persistent TypeEnv v7 transport.
 /// The canonical cache-text bytes are the sole input. This is not a
 /// CheckedProgram, typed IR, exported interface, cache key, or reuse decision.
 fn incremental_persistent_type_env_transport_identity(env: TypeEnv) -> String {
@@ -3085,7 +3087,7 @@ fn incremental_trace_json_string(text: String) -> String {
 /// provisional canonical token-stream identity, not normalized typed IR.
 /// `checked_env_fingerprint` is a complete value-environment observation.
 /// `persistent_type_env_transport_fingerprint` observes only the complete
-/// persistent TypeEnv v6 transport, not a CheckedProgram, typed IR, exported
+/// persistent TypeEnv v7 transport, not a CheckedProgram, typed IR, exported
 /// interface, cache key, or reuse decision. `decision` records what this current TypeDb
 /// walk did (`rechecked` or `reused`), not a formal invalidation verdict.
 /// This function is called only after a successful check; a missing per-module
@@ -3138,19 +3140,19 @@ export fn incremental_invalidation_trace_json(entry_path: String, run_nonce: Str
       None => throw(String::concat("incremental invalidation trace: missing complete interface observation for ", path))
     }
     StringBuilder::push(out, incremental_trace_json_string(interface_fingerprint))
-    StringBuilder::push(out, ",\"interface_fingerprint_kind\":\"compact_string_fingerprint(vibe-module-interface:v3 canonical exported surface including applied trait bounds)\",\"checked_env_fingerprint\":")
+    StringBuilder::push(out, ",\"interface_fingerprint_kind\":\"compact_string_fingerprint(vibe-module-interface:v4 canonical exported surface including kinded applications)\",\"checked_env_fingerprint\":")
     let checked_env_fingerprint = match incremental_checked_env_trace_observation_of(path) {
       Some(value) => value,
       None => throw(String::concat("incremental invalidation trace: missing complete checked environment observation for ", path))
     }
     StringBuilder::push(out, incremental_trace_json_string(checked_env_fingerprint))
-    StringBuilder::push(out, ",\"checked_env_fingerprint_kind\":\"compact_string_fingerprint(vibe-module-checked-env:v2 canonical effective TypeEnv value bindings including applied trait bounds)\",\"persistent_type_env_transport_fingerprint\":")
+    StringBuilder::push(out, ",\"checked_env_fingerprint_kind\":\"compact_string_fingerprint(vibe-module-checked-env:v3 canonical effective TypeEnv value bindings including kinded applications)\",\"persistent_type_env_transport_fingerprint\":")
     let persistent_type_env_transport_fingerprint = match incremental_persistent_type_env_transport_trace_observation_of(path) {
       Some(value) => value,
       None => throw(String::concat("incremental invalidation trace: missing complete persistent TypeEnv transport observation for ", path))
     }
     StringBuilder::push(out, incremental_trace_json_string(persistent_type_env_transport_fingerprint))
-    StringBuilder::push(out, ",\"persistent_type_env_transport_fingerprint_kind\":\"compact_string_fingerprint(persistent_type_env_cache_text:v6 complete TypeEnv transport only; not CheckedProgram, typed IR, exported interface, cache key, or reuse decision)\",\"decision\":")
+    StringBuilder::push(out, ",\"persistent_type_env_transport_fingerprint_kind\":\"compact_string_fingerprint(persistent_type_env_cache_text:v7 complete TypeEnv transport only; not CheckedProgram, typed IR, exported interface, cache key, or reuse decision)\",\"decision\":")
     StringBuilder::push(out, incremental_trace_json_string(decision))
     StringBuilder::push(out, "}")
     i = i + 1
@@ -3285,14 +3287,14 @@ fn store_persistent_type_env(fingerprint: String, env: TypeEnv) -> String with E
   text
 }
 
-// TDRE6 is deliberately independent from the TypeEnv v6 envelope and from
-// every production artifact/cache identity. Both v5 envelopes use strict
+// TDRE7 is deliberately independent from the TypeEnv v7 envelope and from
+// every production artifact/cache identity. Both v7 envelopes use strict
 // decimal length-delimited fields and bind the logical checker input, target
-// conservative fingerprint, and exact canonical TypeEnv-v6 transport text.
+// conservative fingerprint, and exact canonical TypeEnv-v7 transport text.
 // The target text is intentionally not replaced by a compact fingerprint:
 // cache corruption must not turn a fingerprint collision into checker reuse.
-let typing_dependency_env_reuse_alias_v6_tag = "TDRE6A"
-let typing_dependency_env_reuse_witness_v6_tag = "TDRE6W"
+let typing_dependency_env_reuse_alias_v7_tag = "TDRE7A"
+let typing_dependency_env_reuse_witness_v7_tag = "TDRE7W"
 
 fn typing_reuse_segment(text: String) -> String {
   String::concat(__to_string(String::length(text)), String::concat(":", text))
@@ -3359,11 +3361,11 @@ fn parse_typing_dependency_reuse_binding(text: String, tag: String) -> Option[(S
 /// source, effective typing semantics, resolution authority, and every resolved direct dependency row of
 /// ModuleJob.dep_envs in its actual array order. finish_typecheck_fs_impl builds
 /// this table once with project_exact_dependency_envs and gives the same value
-/// to both check_module and TDRE5 lookup/publication, so ambient coordinator
+/// to both check_module and TDRE7 lookup/publication, so ambient coordinator
 /// cache rows are neither checker-visible nor part of this canonical text.
 fn typing_dependency_transport_input_key(path: String, source: String, semantics_seed: String, dep_envs: Array[(String, TypeEnv)]) -> String {
   let out = StringBuilder::new()
-  StringBuilder::push(out, "vibe-typing-dependency-transport-env:v6")
+  StringBuilder::push(out, "vibe-typing-dependency-transport-env:v7")
   StringBuilder::push(out, typing_reuse_segment(normalize_path(path)))
   StringBuilder::push(out, typing_reuse_segment(source))
   StringBuilder::push(out, typing_reuse_segment(semantics_seed))
@@ -3410,7 +3412,7 @@ fn typing_dependency_env_reuse_witness_binding(fingerprint: String) -> Option[(S
   if !Fs::exists(witness_path) {
     None
   } else {
-    match parse_typing_dependency_reuse_binding(Fs::read_file(witness_path), typing_dependency_env_reuse_witness_v6_tag) {
+    match parse_typing_dependency_reuse_binding(Fs::read_file(witness_path), typing_dependency_env_reuse_witness_v7_tag) {
       Some((input_key, target_fingerprint, target_text)) =>
       if target_fingerprint != fingerprint {
         None
@@ -3432,7 +3434,7 @@ fn typing_dependency_env_reuse_eligibility_is_valid(fingerprint: String) -> Bool
   }
 }
 
-/// Eligibility is transitively witnessed by successful canonical TypeEnv-v6
+/// Eligibility is transitively witnessed by successful canonical TypeEnv-v7
 /// commits. Missing, malformed, stale, torn, or cross-spliced witnesses fail
 /// closed before the alias lookup.
 fn typing_dependency_env_reuse_is_eligible(dep_fps: Array[(String, String)]) -> Bool with Fs {
@@ -3451,7 +3453,7 @@ fn typing_dependency_env_reuse_is_eligible(dep_fps: Array[(String, String)]) -> 
 }
 
 fn publish_typing_dependency_env_reuse_eligibility(input_key: String, fingerprint: String, target_text: String) -> Unit with Fs {
-  let witness_text = typing_dependency_reuse_binding_text(typing_dependency_env_reuse_witness_v6_tag, input_key, fingerprint, target_text)
+  let witness_text = typing_dependency_reuse_binding_text(typing_dependency_env_reuse_witness_v7_tag, input_key, fingerprint, target_text)
   Fs::write_file(persistent_typing_dependency_env_reuse_eligibility_path(fingerprint), witness_text)
 }
 
@@ -3460,7 +3462,7 @@ fn load_typing_dependency_env_reuse_target(input_key: String) -> Option[(String,
   if !Fs::exists(sidecar_path) {
     None
   } else {
-    match parse_typing_dependency_reuse_binding(Fs::read_file(sidecar_path), typing_dependency_env_reuse_alias_v6_tag) {
+    match parse_typing_dependency_reuse_binding(Fs::read_file(sidecar_path), typing_dependency_env_reuse_alias_v7_tag) {
       Some((alias_input_key, target_fingerprint, target_text)) =>
       if alias_input_key != input_key {
         None
@@ -3487,7 +3489,7 @@ fn load_typing_dependency_env_reuse_target(input_key: String) -> Option[(String,
 }
 
 fn write_typing_dependency_env_reuse_sidecar(input_key: String, target_fingerprint: String, target_text: String) -> Unit with Fs {
-  let alias_text = typing_dependency_reuse_binding_text(typing_dependency_env_reuse_alias_v6_tag, input_key, target_fingerprint, target_text)
+  let alias_text = typing_dependency_reuse_binding_text(typing_dependency_env_reuse_alias_v7_tag, input_key, target_fingerprint, target_text)
   Fs::write_file(persistent_typing_dependency_env_reuse_sidecar_path(input_key), alias_text)
 }
 
@@ -4147,7 +4149,7 @@ export fn locate_type_error(source: String, msg: String) -> String {
 /// resolve from impl units against the contract definition.
 export enum ModuleOutcome {
   // The final strings are trace-only interface, checked-value-env, and
-  // complete persistent TypeEnv v6 transport identities. They are computed
+  // complete persistent TypeEnv v7 transport identities. They are computed
   // from this successful check's typed environment, never used as cache
   // inputs, and are empty unless the invalidation trace is enabled. The final
   // optional string is a canonical in-memory-only #1550 module artifact
@@ -4306,7 +4308,7 @@ fn check_module_impl(job: ModuleJob, observe_typing_artifact: Bool) -> ModuleOut
       // #1533: what leaves this function is the module's PUBLISHED
       // environment -- restricted to its export surface -- because every
       // consumer of `Checked`'s env (env cache, persistent store, worker
-      // transport, TDRE5, trace identities) is a publication path. The full
+      // transport, TDRE7, trace identities) is a publication path. The full
       // environment never needs to outlive the check itself.
       let checked_env = checked_module_public_env_with_reexport_declarations(stmts, full_checked_env, reexport_declarations)
       let interface_identity = if incremental_interface_trace_enabled() {
@@ -4366,7 +4368,7 @@ fn commit_module_outcome(rdb: RippleDb, env_cache: Array[(String, TypeEnv)], dep
       throw(String::concat(job.path, ": type error"))
     },
     Checked(path, fingerprint, checked_env, interface_identity, checked_env_identity, persistent_type_env_transport_identity, _) => {
-      // Serialize the TypeEnv once. Production-default TDRE5 publication binds
+      // Serialize the TypeEnv once. Production-default TDRE7 publication binds
       // the exact same text as the conservative target; serializing it a second
       // time materially inflates fresh selfcompile heap without adding evidence.
       let target_text = store_persistent_type_env(fingerprint, checked_env)
@@ -4641,7 +4643,7 @@ fn finish_typecheck_fs_impl(rdb: RippleDb, env_cache: Array[(String, TypeEnv)], 
     },
     None => {
       // Keep the accumulated cache as coordinator state, but expose exactly the
-      // resolved dependency sequence to the checker and TDRE5. Construct this
+      // resolved dependency sequence to the checker and TDRE7. Construct this
       // once: lookup, check, and publication must describe the same value.
       let coordinated_env_cache = ensure_env_cache_for_paths(rdb, env_cache, deps)
       let projected_dep_envs = project_exact_dependency_envs(deps, coordinated_env_cache)

--- a/lib/@vibe/compiler/tests/checked_type_defs_artifact_test.vibe
+++ b/lib/@vibe/compiler/tests/checked_type_defs_artifact_test.vibe
@@ -1,4 +1,4 @@
-//# #1379 narrow checked TypeDef artifact v1 codec tests.
+//# #1379 narrow checked TypeDef artifact v2 codec tests.
 
 import @vibe/compiler/checker {
   CheckedProgram, CheckedProgramTypeDefsObservation, canonical_checked_type_defs_snapshot, check_program_type_defs_observation
@@ -7,8 +7,8 @@ import @vibe/compiler/checker {
 import @vibe/compiler/checker/artifacts {
   canonical_checked_type_defs_artifact_snapshot,
   checked_type_defs_artifact_from_observation,
-  decode_checked_type_defs_artifact_v1,
-  encode_checked_type_defs_artifact_v1
+  decode_checked_type_defs_artifact_v2,
+  encode_checked_type_defs_artifact_v2
 }
 
 import @vibe/compiler/core {
@@ -34,17 +34,17 @@ fn typedef_observation(defs: Array[TypeDef], binders: Array[Array[Int]], subst: 
 
 fn encode_from(defs: Array[TypeDef], binders: Array[Array[Int]], subst: Subst) -> Option[String] {
   match checked_type_defs_artifact_from_observation(typedef_observation(defs, binders, subst)) {
-    Some(artifact) => encode_checked_type_defs_artifact_v1(artifact),
+    Some(artifact) => encode_checked_type_defs_artifact_v2(artifact),
     None => None
   }
 }
 
 fn assert_round_trip(observation: CheckedProgramTypeDefsObservation) -> Unit {
   match checked_type_defs_artifact_from_observation(observation) {
-    Some(artifact) => match encode_checked_type_defs_artifact_v1(artifact) {
-      Some(text) => match decode_checked_type_defs_artifact_v1(text) {
+    Some(artifact) => match encode_checked_type_defs_artifact_v2(artifact) {
+      Some(text) => match decode_checked_type_defs_artifact_v2(text) {
         Some(decoded) => {
-          match encode_checked_type_defs_artifact_v1(decoded) {
+          match encode_checked_type_defs_artifact_v2(decoded) {
             Some(reencoded) => assert(reencoded == text),
             None => assert(false)
           }
@@ -61,7 +61,7 @@ fn assert_round_trip(observation: CheckedProgramTypeDefsObservation) -> Unit {
   }
 }
 
-test "checked typedef artifact v1 round-trips real checker retained definitions" {
+test "checked typedef artifact v2 round-trips real checker retained definitions" {
   let observation = check_program_type_defs_observation([
     SEnum(false, "Choice", ["A", "B"], [("Only", [TyName("B")])], array_empty()),
     SStruct(false, "Box", [("value", TyName("T"))], array_empty(), ["value"], [
@@ -73,7 +73,7 @@ test "checked typedef artifact v1 round-trips real checker retained definitions"
   assert_round_trip(observation)
 }
 
-test "checked typedef artifact v1 preserves every retained variant and order" {
+test "checked typedef artifact v2 preserves every retained variant and order" {
   let min_int = 0 - 2305843009213693951 - 1
   let max_int = 2305843009213693951
   let defs = [
@@ -88,6 +88,8 @@ test "checked typedef artifact v1 preserves every retained variant and order" {
         CtBytes,
         CtUnknown,
         CtVar(min_int),
+        CtConstructor("Array", 1),
+        CtApplied(CtVar(max_int), [CtString]),
         CtTuple([CtEnum("E"), CtStruct("S")]),
         CtArray(CtOption(CtNamed("Named", [CtVar(max_int)]))),
         CtFn([CtInt], CtUnit, None),
@@ -120,7 +122,7 @@ test "checked typedef artifact v1 preserves every retained variant and order" {
   assert_round_trip(typedef_observation(defs, binders, subst))
 }
 
-test "checked typedef artifact v1 distinguishes function effect None from Some empty" {
+test "checked typedef artifact v2 distinguishes function effect None from Some empty" {
   let none_defs = [
     TDAlias("Effect", array_empty(), CtFn(array_empty(), CtUnit, None))
   ]
@@ -132,8 +134,8 @@ test "checked typedef artifact v1 distinguishes function effect None from Some e
   ], SubstEmpty)) {
     (Some(none_text), Some(some_text)) => {
       assert(none_text != some_text)
-      match decode_checked_type_defs_artifact_v1(some_text) {
-        Some(decoded) => match encode_checked_type_defs_artifact_v1(decoded) {
+      match decode_checked_type_defs_artifact_v2(some_text) {
+        Some(decoded) => match encode_checked_type_defs_artifact_v2(decoded) {
           Some(reencoded) => assert(reencoded == some_text),
           None => assert(false)
         },
@@ -144,7 +146,7 @@ test "checked typedef artifact v1 distinguishes function effect None from Some e
   }
 }
 
-test "checked typedef artifact v1 preserves final-substitution-sensitive canonical parity" {
+test "checked typedef artifact v2 preserves final-substitution-sensitive canonical parity" {
   let defs = [TDAlias("Resolved", array_empty(), CtVar(9))]
   let binders = [array_empty()]
   let resolved = typedef_observation(defs, binders, SubstBind(9, CtInt, SubstEmpty))
@@ -153,7 +155,7 @@ test "checked typedef artifact v1 preserves final-substitution-sensitive canonic
   assert_round_trip(resolved)
 }
 
-test "checked typedef artifact v1 rejects binder collisions and cached substitutions" {
+test "checked typedef artifact v2 rejects binder collisions and cached substitutions" {
   let duplicate_in_row = typedef_observation([
     TDEnum("Bad", ["A", "B"], array_empty())
   ], [[7, 7]], SubstEmpty)
@@ -178,40 +180,40 @@ test "checked typedef artifact v1 rejects binder collisions and cached substitut
   }
 }
 
-test "checked typedef artifact v1 rejects strict malformed payloads" {
-  let prefix = "vibe-checked-type-defs:v1\n"
-  match decode_checked_type_defs_artifact_v1("vibe-checked-type-defs:v2\n0[]0[]0") {
+test "checked typedef artifact v2 rejects strict malformed payloads" {
+  let prefix = "vibe-checked-type-defs:v2\n"
+  match decode_checked_type_defs_artifact_v2("vibe-checked-type-defs:v1\n0[]0[]0") {
     Some(_) => assert(false),
     None => assert(true)
   }
-  // The exact delimiter prevents v10 from being accepted as v1.
-  match decode_checked_type_defs_artifact_v1("vibe-checked-type-defs:v10\n0[]0[]0") {
+  // The exact delimiter prevents v10 from being accepted as v2.
+  match decode_checked_type_defs_artifact_v2("vibe-checked-type-defs:v20\n0[]0[]0") {
     Some(_) => assert(false),
     None => assert(true)
   }
-  match decode_checked_type_defs_artifact_v1(prefix) {
+  match decode_checked_type_defs_artifact_v2(prefix) {
     Some(_) => assert(false),
     None => assert(true)
   }
-  match decode_checked_type_defs_artifact_v1(String::concat(prefix, "1[")) {
+  match decode_checked_type_defs_artifact_v2(String::concat(prefix, "1[")) {
     Some(_) => assert(false),
     None => assert(true)
   }
-  // Unknown and cache tags are not assigned wire meanings in v1.
-  match decode_checked_type_defs_artifact_v1(String::concat(prefix, "0[]0[]Z")) {
+  // Unknown and cache tags are not assigned wire meanings in v2.
+  match decode_checked_type_defs_artifact_v2(String::concat(prefix, "0[]0[]Z")) {
     Some(_) => assert(false),
     None => assert(true)
   }
-  match decode_checked_type_defs_artifact_v1(String::concat(prefix, "0[]0[]C0")) {
+  match decode_checked_type_defs_artifact_v2(String::concat(prefix, "0[]0[]C0")) {
     Some(_) => assert(false),
     None => assert(true)
   }
-  match decode_checked_type_defs_artifact_v1(String::concat(prefix, "0[]0[]0!")) {
+  match decode_checked_type_defs_artifact_v2(String::concat(prefix, "0[]0[]0!")) {
     Some(_) => assert(false),
     None => assert(true)
   }
   // A generic enum requires one globally unique retained binder per parameter.
-  match decode_checked_type_defs_artifact_v1(String::concat(prefix, "2[15:E3:Bad1[1:T]0[]15:E3:Bad1[1:T]0[]]2[6:1[1:7]6:1[1:7]]0")) {
+  match decode_checked_type_defs_artifact_v2(String::concat(prefix, "2[15:E3:Bad1[1:T]0[]15:E3:Bad1[1:T]0[]]2[6:1[1:7]6:1[1:7]]0")) {
     Some(_) => assert(false),
     None => assert(true)
   }

--- a/lib/@vibe/compiler/tests/derive_array_helper_tparams_test.vibe
+++ b/lib/@vibe/compiler/tests/derive_array_helper_tparams_test.vibe
@@ -218,3 +218,13 @@ test "2136: the desugared nested-array program still checks clean" {
 test "2136: the desugared generic-struct show program still checks clean" {
   inspect(desugared_check_message("struct Box[T] { xs: Array[T] } derive(Show)\nlet main = () -> Unit { () }"), content = "")
 }
+
+test "kinded constructor Eq specializes Array fields" {
+  let src = "struct KBox[F[_], A] { value: F[A] } derive (Eq)\nfn eq_it() -> Bool {\n  let a = KBox[Array, Int]::{ value: [1, 2] }\n  let b = KBox[Array, Int]::{ value: [1, 2] }\n  a == b\n}"
+  let equals = generated_helper_sigs(src, "KBox::equals")
+  assert(String::contains(equals, "KBox::equals"))
+  assert(!String::contains(equals, "__EqUnknown"))
+  let arrays = generated_helper_sigs(src, "__arr_equals__")
+  assert(String::contains(arrays, "__arr_equals__"))
+  inspect(desugared_check_message(src), content = "")
+}

--- a/lib/@vibe/compiler/tests/hkt_rigid_formals_test.vibe
+++ b/lib/@vibe/compiler/tests/hkt_rigid_formals_test.vibe
@@ -30,6 +30,12 @@ test "identity F[A] as F[B] is rejected" {
   assert(String::contains(msg, "return type mismatch"))
 }
 
+test "kinded identity F[A] as F[B] is rejected" {
+  let src = "fn cast[F[_], A, B](x: F[A]) -> F[B] {\n  x\n}\nfn main { () }\n"
+  let msg = first_check_error(src)
+  assert(String::contains(msg, "return type mismatch"))
+}
+
 test "F[A] to F[A] identity is accepted" {
   let src = "fn keep[F, A](xs: F[A]) -> F[A] {\n  xs\n}\nfn main { () }\n"
   let msg = first_check_error(src)

--- a/lib/@vibe/compiler/tests/import_alias_rewrite_test.vibe
+++ b/lib/@vibe/compiler/tests/import_alias_rewrite_test.vibe
@@ -33,6 +33,16 @@ test "imported type aliases rewrite fn annotations but not type formals" {
   assert(String::contains(printed, "(value: S)"))
 }
 
+test "kinded constructor formals shadow imported type aliases" {
+  let stmts = parse_program(lex("import ./dep.vibe { StdinStream as F }\nfn id[F[_], A](x: F[A]) -> F[A] { x }"))
+  let out = Array::slice(stmts, 0, 0)
+  append_import_alias_rewritten_non_import_stmts(out, stmts)
+  let printed = print_program(out)
+  assert(String::contains(printed, "(x: F[A])"))
+  assert(String::contains(printed, "-> F[A]"))
+  assert(!String::contains(printed, "StdinStream"))
+}
+
 test "import aliases rewrite concrete impl method owners with their targets" {
   let stmts = parse_program(lex("import ./dep.vibe { Box as B }\ntrait Measured { measure(Self) -> Int }\nimpl Measured for B[Int] { measure(self) -> Int { 1 } }"))
   let out = Array::slice(stmts, 0, 0)

--- a/lib/@vibe/compiler/tests/import_alias_rewrite_test.vibe
+++ b/lib/@vibe/compiler/tests/import_alias_rewrite_test.vibe
@@ -58,6 +58,15 @@ test "import aliases rewrite concrete impl method owners with their targets" {
   assert(!String::contains(printed, old_name))
 }
 
+test "kinded local alias impl targets substitute constructor arguments" {
+  let stmts = parse_program(lex("trait Trait { }\nstruct Holder[F[_], A] { value: A }\ntype Wrap[G[_], A] = Holder[G, A]\nimpl Trait for Wrap[Array, Int] { }"))
+  let out = Array::slice(stmts, 0, 0)
+  append_import_alias_rewritten_non_import_stmts(out, stmts)
+  let printed = print_program(out)
+  assert(String::contains(printed, "impl Trait for Holder[Array, Int]"))
+  assert(!String::contains(printed, "Holder[G, Int]"))
+}
+
 test "transparent aliases rewrite concrete impl method owners with their targets" {
   let stmts = parse_program(lex("type Vec[T] = Array[T]\ntrait Measured { measure(Self) -> Int }\nimpl Measured for Vec[Int] { measure(self) -> Int { 1 } }"))
   let out = Array::slice(stmts, 0, 0)

--- a/lib/@vibe/compiler/tests/kinded_constructor_unification_test.vibe
+++ b/lib/@vibe/compiler/tests/kinded_constructor_unification_test.vibe
@@ -30,10 +30,12 @@ test "constructor values cannot escape into value types" {
   assert(String::contains(message, "type constructor parameter `F` must be applied to 1 type argument(s) in the return type"))
 }
 
-test "arity-zero parameters remain fail-closed in constructor position" {
-  let source = "fn bad[F, A](value: F[A]) -> Int { 0 }"
-  let message = check_source_error_message(source)
-  assert(String::contains(message, "type parameter `F` cannot take type arguments in parameter `value`"))
+test "unkinded F[A] stays legal after arity-1 HKT" {
+  // #2351: `F[A]` without `F[_]` is the kernel spelling. Mixed-kind
+  // (`F` and `F[A]` together) is still rejected; constructor position
+  // alone is not.
+  let source = "fn keep[F, A](value: F[A]) -> F[A] { value }\nfn main { () }"
+  inspect(check_source_error_message(source), "")
 }
 
 test "one constructor variable cannot unify Array with Option" {

--- a/lib/@vibe/compiler/tests/kinded_constructor_unification_test.vibe
+++ b/lib/@vibe/compiler/tests/kinded_constructor_unification_test.vibe
@@ -97,3 +97,38 @@ test "constructor heads participate in occurs checks" {
     None => assert(false)
   }
 }
+
+test "an alias constructor expands instead of becoming nominal" {
+  let source = "type Vec[T] = Array[T]\ntype Apply[F[_], A] = F[A]\nfn keep(x: Apply[Vec, Int]) -> Vec[Int] { x }\nfn keep_array(x: Apply[Vec, Int]) -> Array[Int] { x }"
+  inspect(check_source_error_message(source), "")
+}
+
+test "a kinded Option formal shadows the builtin Option" {
+  let source = "fn id[Option[_], A](x: Option[A]) -> Option[A] { x }\nfn use_it(xs: Array[Int]) -> Array[Int] { id(xs) }"
+  inspect(check_source_error_message(source), "")
+}
+
+test "a kinded trait application rejects a complete type argument" {
+  let source = "trait Functor[F[_]] { }\nstruct X { v: Int }\nimpl Functor[Int] for X { }"
+  let message = check_source_error_message(source)
+  assert(String::contains(message, "expects a constructor with 1 argument(s), but `Int` has 0"))
+}
+
+test "a kinded effect application rejects a complete type argument" {
+  let source = "effect Read[F[_]] {\n  Get() -> F[Int]\n}\nfn f() -> Int with Read[Int] {\n  0\n}"
+  let message = check_source_error_message(source)
+  assert(String::contains(message, "expects a constructor"))
+  assert(String::contains(message, "`Int`"))
+}
+
+test "a nested-kind constructor is not a flat arity-N argument" {
+  let source = "struct Higher[F[_], A] { value: A }\ntype Apply[C[_, _], X, Y] = C[X, Y]\nfn bad(x: Apply[Higher, Int, Int]) -> Int { 0 }"
+  let message = check_source_error_message(source)
+  assert(String::contains(message, "Higher"))
+  assert(String::contains(message, "constructor"))
+}
+
+test "a kinded trait bound reifies Array as a constructor" {
+  let source = "trait Wrap[F[_]] { make(Self) -> F[Int] }\nfn wrap_it[T: Wrap[Array]](x: T) -> Array[Int] { T::make(x) }"
+  inspect(check_source_error_message(source), "")
+}

--- a/lib/@vibe/compiler/tests/kinded_constructor_unification_test.vibe
+++ b/lib/@vibe/compiler/tests/kinded_constructor_unification_test.vibe
@@ -143,3 +143,23 @@ test "a kinded trait bound reifies Array as a constructor" {
   let source = "trait Wrap[F[_]] { make(Self) -> F[Int] }\nfn wrap_it[T: Wrap[Array]](x: T) -> Array[Int] { T::make(x) }"
   inspect(check_source_error_message(source), "")
 }
+
+test "a kinded struct literal reifies Array as a constructor" {
+  let source = "struct Holder[F[_], A] { value: F[A] }\nfn make() -> Holder[Array, Int] { Holder[Array, Int]::{ value: [1, 2] } }"
+  inspect(check_source_error_message(source), "")
+}
+
+test "a kinded derived-Eq struct literal typechecks" {
+  let source = "struct KBox[F[_], A] { value: F[A] } derive (Eq)\nfn eq_it() -> Bool {\n  let a = KBox[Array, Int]::{ value: [1, 2] }\n  let b = KBox[Array, Int]::{ value: [1, 2] }\n  a == b\n}"
+  inspect(check_source_error_message(source), "")
+}
+
+test "a kinded effect application accepts a user constructor" {
+  let source = "effect Read[F[_]] {\n  Get() -> F[Int]\n}\nstruct Vec[T] { value: T }\nfn f() -> Int with Read[Vec] {\n  0\n}"
+  inspect(check_source_error_message(source), "")
+}
+
+test "a kinded effect application accepts a constructor formal" {
+  let source = "effect Read[F[_]] {\n  Get() -> F[Int]\n}\nfn f[G[_]]() -> Int with Read[G] {\n  0\n}"
+  inspect(check_source_error_message(source), "")
+}

--- a/lib/@vibe/compiler/tests/kinded_constructor_unification_test.vibe
+++ b/lib/@vibe/compiler/tests/kinded_constructor_unification_test.vibe
@@ -1,0 +1,97 @@
+import ./checker_parity_test_support.vibe {
+  check_source_error_message, check_source_located_err_contains
+}
+
+import @vibe/compiler/core {
+  CtApplied, CtArray, CtConstructor, CtForAll, CtInt, CtString, CtVar, SubstEmpty, generalize, instantiate, subst_apply, types_equal, unify
+}
+
+test "a unary constructor variable preserves distinct argument types" {
+  let source = "fn pair[F[_], A, B](left: F[A], right: F[B]) -> (F[A], F[B]) { (left, right) }\nlet arrays = pair([1], [\"vibe\"])\nlet options = pair(Some(1), Some(\"vibe\"))"
+  inspect(check_source_error_message(source), "")
+}
+
+test "a trait method can quantify over a unary constructor" {
+  let source = "trait Mappable[F[_]] { map[A, B](F[A], (A) -> B) -> F[B] }"
+  inspect(check_source_error_message(source), "")
+}
+
+test "constructor parameter arity errors name the edit site" {
+  let source = "fn bad[F[_], A](value: F[A, String]) -> Int { 0 }"
+  let message = check_source_error_message(source)
+  assert(check_source_located_err_contains(source, "line 1:"))
+  assert(String::contains(message, "type constructor parameter `F` expects 1 type argument(s), got 2 in parameter `value`"))
+}
+
+test "constructor values cannot escape into value types" {
+  let source = "fn bad[F[_]](value: Int) -> F { value }"
+  let message = check_source_error_message(source)
+  assert(check_source_located_err_contains(source, "line 1:"))
+  assert(String::contains(message, "type constructor parameter `F` must be applied to 1 type argument(s) in the return type"))
+}
+
+test "arity-zero parameters remain fail-closed in constructor position" {
+  let source = "fn bad[F, A](value: F[A]) -> Int { 0 }"
+  let message = check_source_error_message(source)
+  assert(String::contains(message, "type parameter `F` cannot take type arguments in parameter `value`"))
+}
+
+test "one constructor variable cannot unify Array with Option" {
+  let source = "fn pair[F[_], A, B](left: F[A], right: F[B]) -> Int { 0 }\nlet bad = pair([1], Some(\"vibe\"))"
+  let message = check_source_error_message(source)
+  assert(String::contains(message, "argument type mismatch"))
+}
+
+test "one applied argument variable remains shared" {
+  let source = "fn same[F[_], A](left: F[A], right: F[A]) -> Int { 0 }\nlet bad = same([1], [\"vibe\"])"
+  let message = check_source_error_message(source)
+  assert(String::contains(message, "argument type mismatch"))
+}
+
+test "a constructor parameter can flow through a type alias" {
+  let source = "type Apply[F[_], A] = F[A]\nfn keep[F[_], A](value: Apply[F, A]) -> F[A] { value }\nfn keep_array(value: Apply[Array, Int]) -> Array[Int] { value }\nfn keep_option(value: Apply[Option, String]) -> Option[String] { value }\ntest \"alias\" { let xs: Apply[Array, Int] = [1] }"
+  inspect(check_source_error_message(source), "")
+}
+
+test "constructor parameters flow through nominal type arguments" {
+  let source = "struct Holder[F[_], A] { value: F[A] }\nfn array_holder(value: Holder[Array, Int]) -> Holder[Array, Int] { value }\nfn generic_holder[F[_], A](value: Holder[F, A]) -> Holder[F, A] { value }"
+  inspect(check_source_error_message(source), "")
+}
+
+test "kinded alias arguments reject complete types" {
+  let source = "type Apply[F[_], A] = F[A]\nfn bad(value: Apply[Int, String]) -> Int { 0 }"
+  let message = check_source_error_message(source)
+  assert(check_source_located_err_contains(source, "line 2:"))
+  assert(String::contains(message, "type parameter `F` of `Apply` expects a constructor with 1 argument(s), but `Int` has 0"))
+}
+
+test "complete type arguments reject bare constructor variables" {
+  let source = "fn bad[F[_]](value: Array[F]) -> Int { 0 }"
+  let message = check_source_error_message(source)
+  assert(String::contains(message, "expects a complete type, but `F` is a constructor with 1 argument(s)"))
+}
+
+test "applied constructor variables survive generalization and instantiation" {
+  let applied = CtApplied(CtVar(4), [CtVar(5)])
+  let scheme = generalize(SubstEmpty, applied)
+  match scheme {
+    CtForAll(ids, _, _) => assert(Array::length(ids) == 2),
+    _ => assert(false)
+  }
+  let (instantiated, _, _) = instantiate(scheme, 20)
+  match unify(instantiated, CtArray(CtInt), SubstEmpty) {
+    Some(subst) => assert(types_equal(subst_apply(subst, instantiated), CtArray(CtInt))),
+    None => assert(false)
+  }
+}
+
+test "constructor heads participate in occurs checks" {
+  match unify(CtVar(7), CtApplied(CtVar(7), [CtString]), SubstEmpty) {
+    Some(_) => assert(false),
+    None => assert(true)
+  }
+  match unify(CtApplied(CtVar(8), [CtInt]), CtArray(CtInt), SubstEmpty) {
+    Some(subst) => assert(types_equal(subst_apply(subst, CtVar(8)), CtConstructor("Array", 1))),
+    None => assert(false)
+  }
+}

--- a/lib/@vibe/compiler/tests/kinded_constructor_unification_test.vibe
+++ b/lib/@vibe/compiler/tests/kinded_constructor_unification_test.vibe
@@ -103,6 +103,17 @@ test "an alias constructor expands instead of becoming nominal" {
   inspect(check_source_error_message(source), "")
 }
 
+test "a constant alias constructor keeps its fixed argument" {
+  let source = "struct Box[T] { value: T }\ntype Const[A] = Box[Int]\ntype Apply[F[_], X] = F[X]\nfn keep(x: Apply[Const, String]) -> Box[Int] { x }"
+  inspect(check_source_error_message(source), "")
+}
+
+test "a constant alias constructor does not take the applied argument" {
+  let source = "struct Box[T] { value: T }\ntype Const[A] = Box[Int]\ntype Apply[F[_], X] = F[X]\nfn bad(x: Apply[Const, String]) -> Box[String] { x }"
+  let message = check_source_error_message(source)
+  assert(String::contains(message, "mismatch"))
+}
+
 test "a kinded Option formal shadows the builtin Option" {
   let source = "fn id[Option[_], A](x: Option[A]) -> Option[A] { x }\nfn use_it(xs: Array[Int]) -> Array[Int] { id(xs) }"
   inspect(check_source_error_message(source), "")

--- a/lib/@vibe/compiler/tests/persistent_cache_test.vibe
+++ b/lib/@vibe/compiler/tests/persistent_cache_test.vibe
@@ -44,11 +44,11 @@ test "compact string fingerprint keeps its byte-level cache identity" {
   inspect(compact_string_fingerprint("東京"), content = "6:1640623600:1554629861")
 }
 
-test "TDRE6 cache paths use isolated alias and witness namespaces" {
+test "TDRE7 cache paths use isolated alias and witness namespaces" {
   let alias_path = persistent_typing_dependency_env_reuse_sidecar_path("logical-input")
   let witness_path = persistent_typing_dependency_env_reuse_eligibility_path("conservative-target")
-  assert(String::index_of(alias_path, "selfhost_typing_dependency_env_reuse_v6") >= 0)
-  assert(String::index_of(witness_path, "selfhost_typing_dependency_env_reuse_eligibility_v6") >= 0)
+  assert(String::index_of(alias_path, "selfhost_typing_dependency_env_reuse_v7") >= 0)
+  assert(String::index_of(witness_path, "selfhost_typing_dependency_env_reuse_eligibility_v7") >= 0)
   assert(alias_path != witness_path)
   assert(String::index_of(alias_path, "reuse_v4") < 0)
   assert(String::index_of(witness_path, "eligibility_v4") < 0)

--- a/lib/@vibe/compiler/tests/persistent_env_codec_test.vibe
+++ b/lib/@vibe/compiler/tests/persistent_env_codec_test.vibe
@@ -23,7 +23,7 @@ import @vibe/compiler/core {
 }
 
 import @vibe/ast {
-  trait_ref_key
+  trait_ref_key, type_param_key
 }
 
 import @vibe/compiler/runtime {
@@ -40,11 +40,18 @@ fn cached_polymorphic_type() -> Type {
   CtForAll([7], [(7, ["Eq"])], CtFn([CtVar(7)], CtNamed("Box", [CtVar(7)]), Some("Async")))
 }
 
+fn cached_kinded_type() -> Type {
+  CtForAll([8, 9], array_empty(), CtFn([CtApplied(CtVar(8), [CtVar(9)])], CtApplied(CtVar(8), [
+    CtVar(9)
+  ]), None))
+}
+
 fn cached_flat_rest() -> TypeEnv {
   EnvFlat([
     ("shadow", env_value_binding(CtInt)),
     ("flat", env_value_binding(CtTuple([CtChar, CtBytes]))),
-    ("cached", env_value_binding(cached_polymorphic_type()))
+    ("cached", env_value_binding(cached_polymorphic_type())),
+    ("kinded", env_value_binding(cached_kinded_type()))
   ])
 }
 
@@ -72,7 +79,9 @@ fn codec_fixture() -> TypeEnv {
     env_value_binding(cached_polymorphic_type()),
     env_value_binding(CtTuple([CtChar, CtBytes])),
     env_value_binding(CtInt)
-  ], cached_flat_rest()), ["T", "E"], [("map", ["A"], [("A", ["Eq", "Show"])])]))))
+  ], cached_flat_rest()), [type_param_key("F", 1), "E"], [
+    ("map", [type_param_key("G", 2)], [(type_param_key("G", 2), ["Eq", "Show"])])
+  ]))))
 }
 
 fn retained_trait_header_params(env: TypeEnv, name: String) -> Array[String] {
@@ -166,7 +175,7 @@ fn malformed_rejected(text: String) -> Bool {
 
 //# Tests
 
-test "persistent TypeEnv v6 bytes ignore binding provenance and decode it unavailable" {
+test "persistent TypeEnv v7 bytes ignore binding provenance and decode it unavailable" {
   let plain = EnvBind("x", env_value_binding(CtInt), EnvEmpty)
   let originated = env_bind_with_origin(EnvEmpty, "x", CtInt, BindingOriginModuleExport("/dep.vibe", "source_x"))
   let plain_text = persistent_type_env_cache_text(plain)
@@ -184,7 +193,7 @@ test "persistent TypeEnv v6 bytes ignore binding provenance and decode it unavai
   }
 }
 
-test "fixpoint bytes retain cached mut TypeEnv v6" {
+test "fixpoint bytes retain cached mut TypeEnv v7" {
   let encoded = persistent_type_env_cache_text(cached_mut_codec_fixture(BindingOriginModuleExport("/dep.vibe", "source_imported")))
   match parse_persistent_type_env(encoded) {
     Some(decoded) => inspect(persistent_type_env_cache_text(decoded) == encoded, "1"),
@@ -192,7 +201,7 @@ test "fixpoint bytes retain cached mut TypeEnv v6" {
   }
 }
 
-test "truefact survives cached mut TypeEnv v6 decode" {
+test "truefact survives cached mut TypeEnv v7 decode" {
   let encoded = persistent_type_env_cache_text(cached_mut_codec_fixture(BindingOriginUnavailable))
   match parse_persistent_type_env(encoded) {
     Some(decoded) => match env_mut_escape(decoded, "true_cell") {
@@ -203,7 +212,7 @@ test "truefact survives cached mut TypeEnv v6 decode" {
   }
 }
 
-test "falsefact survives cached mut TypeEnv v6 decode" {
+test "falsefact survives cached mut TypeEnv v7 decode" {
   let encoded = persistent_type_env_cache_text(cached_mut_codec_fixture(BindingOriginUnavailable))
   match parse_persistent_type_env(encoded) {
     Some(decoded) => match env_mut_escape(decoded, "false_cell") {
@@ -214,7 +223,7 @@ test "falsefact survives cached mut TypeEnv v6 decode" {
   }
 }
 
-test "decodedorigin is unavailable after cached mut TypeEnv v6 decode" {
+test "decodedorigin is unavailable after cached mut TypeEnv v7 decode" {
   let encoded = persistent_type_env_cache_text(cached_mut_codec_fixture(BindingOriginModuleExport("/dep.vibe", "source_imported")))
   match parse_persistent_type_env(encoded) {
     Some(decoded) => match env_lookup_binding(decoded, "imported") {
@@ -228,13 +237,13 @@ test "decodedorigin is unavailable after cached mut TypeEnv v6 decode" {
   }
 }
 
-test "persistent module interface v6 round-trips every variant and trait payload" {
+test "persistent module interface v7 round-trips every variant and trait payload" {
   let env = codec_fixture()
   let encoded = persistent_type_env_cache_text(env)
-  assert(String::starts_with(encoded, "version\t6\nenv\t"))
-  // TDRE6 binds this canonical text externally but does not wrap the
-  // production TypeEnv-v6 transport envelope itself.
-  assert(String::index_of(encoded, "TDRE6") < 0)
+  assert(String::starts_with(encoded, "version\t7\nenv\t"))
+  // TDRE7 binds this canonical text externally but does not wrap the
+  // production TypeEnv-v7 transport envelope itself.
+  assert(String::index_of(encoded, "TDRE7") < 0)
   match parse_persistent_type_env(encoded) {
     Some(decoded) => {
       assert(persistent_type_env_cache_text(decoded) == encoded)
@@ -246,18 +255,22 @@ test "persistent module interface v6 round-trips every variant and trait payload
         Some(ty) => assert(types_equal(ty, cached_polymorphic_type())),
         None => assert(false)
       }
+      match env_lookup(decoded, "kinded") {
+        Some(ty) => assert(types_equal(ty, cached_kinded_type())),
+        None => assert(false)
+      }
       assert(Array::get(trait_supers(decoded, "Functor"), 0) == "Show")
       let header_params = retained_trait_header_params(decoded, "Functor")
       assert(Array::length(header_params) == 2)
-      assert(Array::get(header_params, 0) == "T")
+      assert(Array::get(header_params, 0) == type_param_key("F", 1))
       assert(Array::get(header_params, 1) == "E")
       let method_gens = retained_trait_method_gens(decoded, "Functor")
       assert(Array::length(method_gens) == 1)
       let (generic_method, generic_params, generic_bounds) = Array::get(method_gens, 0)
       assert(generic_method == "map")
-      assert(Array::get(generic_params, 0) == "A")
+      assert(Array::get(generic_params, 0) == type_param_key("G", 2))
       let (generic_bound_name, generic_bound_labels) = Array::get(generic_bounds, 0)
-      assert(generic_bound_name == "A")
+      assert(generic_bound_name == type_param_key("G", 2))
       assert(Array::get(generic_bound_labels, 0) == "Eq")
       let impl_bounds = retained_generic_impl_bounds(decoded, "Functor")
       assert(Array::length(impl_bounds) == 1)
@@ -307,7 +320,7 @@ test "persistent module interface retains complete concrete and generic impl tar
   }
 }
 
-test "persistent TypeEnv v6 retains applied trait bounds and impl heads" {
+test "persistent TypeEnv v7 retains applied trait bounds and impl heads" {
   let applied = trait_ref_key(TyApp("Value", [TyName("Int")]))
   let env = EnvBind("read", env_value_binding(CtForAll([7], [(7, [applied])], CtFn([
     CtVar(7)
@@ -329,7 +342,7 @@ test "persistent TypeEnv v6 retains applied trait bounds and impl heads" {
   }
 }
 
-test "persistent module interface v6 round-trips enum struct and alias authority" {
+test "persistent module interface v7 round-trips enum struct and alias authority" {
   let defs = [
     TDEnum("Choice", ["T"], [("Pick", [CtNamed("T", [])])]),
     TDStruct("Box", [("value", CtNamed("T", []))], [], ["T"]),
@@ -360,7 +373,7 @@ test "persistent module interface v6 round-trips enum struct and alias authority
   }
 }
 
-test "persistent module interface v6 round-trips effect and effectset authority" {
+test "persistent module interface v7 round-trips effect and effectset authority" {
   let env = EnvTypeDefs([
     TDEffect("Audit", [("Emit", [CtString], CtUnit)], []),
     TDEffectSet("Audits", ["Audit"])
@@ -411,7 +424,7 @@ test "legacy enum carrier bytes cannot alter v6 typedef authority" {
   }
 }
 
-test "persistent module interface v6 rebuilds untrusted cached lookup indexes" {
+test "persistent module interface v7 rebuilds untrusted cached lookup indexes" {
   let corrupt = EnvCached(["shadow", "shadow", "cached"], [
     env_value_binding(CtBool),
     env_value_binding(CtString),
@@ -436,15 +449,15 @@ test "persistent module interface v6 rebuilds untrusted cached lookup indexes" {
   }
 }
 
-test "persistent module interface v6 rejects old, truncated, and malformed envelopes" {
+test "persistent module interface v7 rejects old, truncated, and malformed envelopes" {
   assert(malformed_rejected("version\t1\nbind\tvalue\tI\n"))
   assert(malformed_rejected("version\t2\nenv\t1:0\n"))
   // Bare v3 was a value/trait-only TypeEnv, never an empty declaration interface.
   assert(malformed_rejected("version\t3\nenv\t1:0\n"))
   assert(malformed_rejected("version\t4\nenv\t1:0\n"))
-  assert(malformed_rejected("version\t6\nenv\t"))
-  assert(malformed_rejected("version\t6\nenv\t1:Z\n"))
-  assert(malformed_rejected("version\t6\nenv\t2:00\n"))
-  assert(malformed_rejected("version\t6\nenv\t4:B0:0\n"))
-  assert(malformed_rejected("version\t6\nenv\t1:0\ntrailing"))
+  assert(malformed_rejected("version\t7\nenv\t"))
+  assert(malformed_rejected("version\t7\nenv\t1:Z\n"))
+  assert(malformed_rejected("version\t7\nenv\t2:00\n"))
+  assert(malformed_rejected("version\t7\nenv\t4:B0:0\n"))
+  assert(malformed_rejected("version\t7\nenv\t1:0\ntrailing"))
 }

--- a/lib/@vibe/compiler/tests/type_db_cross_module_test.vibe
+++ b/lib/@vibe/compiler/tests/type_db_cross_module_test.vibe
@@ -1939,7 +1939,7 @@ test "db_typecheck_fs: private unknown effects and effectsets are not selectable
   assert(String::contains(unknown, "imported name 'Missing' is not exported by"))
 }
 
-test "db_typecheck_fs: old and malformed fs cache and leaf entries cold-recheck as v5" {
+test "db_typecheck_fs: old and malformed fs cache and leaf entries cold-recheck as v7" {
   let dir = "/tmp/vibe_v4_cache_cold_recheck"
   let path = String::concat(dir, "/main.vibe")
   let source = "export let value = 1\n"
@@ -1952,11 +1952,11 @@ test "db_typecheck_fs: old and malformed fs cache and leaf entries cold-recheck 
   let leaf_path = persistent_leaf_fingerprint_cache_path(path, compact_string_fingerprint(source))
   Fs::write_file(env_path, "version\t3\nenv\t1:0\n")
   let _ = db_typecheck_fs(db_set_source(db_new(), path, source), path)
-  assert(String::starts_with(Fs::read_file(env_path), "version\t6\nenv\t"))
-  Fs::write_file(env_path, "version\t6\nenv\t1:Z\n")
+  assert(String::starts_with(Fs::read_file(env_path), "version\t7\nenv\t"))
+  Fs::write_file(env_path, "version\t7\nenv\t1:Z\n")
   Fs::write_file(leaf_path, "version\t1\nnot-a-fingerprint\n")
   let _ = db_typecheck_fs(db_set_source(db_new(), path, source), path)
-  assert(String::starts_with(Fs::read_file(env_path), "version\t6\nenv\t"))
+  assert(String::starts_with(Fs::read_file(env_path), "version\t7\nenv\t"))
 }
 
 test "db_typecheck: an imported effect does not leak through a non-re-exporting module (#1549)" {

--- a/lib/@vibe/compiler/tests/type_param_shadowing_guard_test.vibe
+++ b/lib/@vibe/compiler/tests/type_param_shadowing_guard_test.vibe
@@ -78,6 +78,11 @@ test "#2141: a type declaration cannot borrow the reserved __Vfp_ prefix" {
   inspect(first_check_error("struct __Vfp_Point {\n  x: Int\n}\n"), content = "struct `__Vfp_Point` uses the reserved `__Vfp_` prefix (compiler-generated type-variable spellings) -- rename the type (#2141)")
 }
 
+test "#2141: a kinded constructor formal still collides by source name" {
+  let src = "struct F {\n  v: Int\n}\n\nfn id[F[_], A](x: F[A]) -> F[A] {\n  x\n}\n"
+  inspect(first_check_error(src), content = "type parameter `F` of declaration `id` shadows the declared type `F`; rename the type parameter or the declared type -- generated generic helpers resolve type names by spelling, so a shadowed formal silently takes the declared type's semantics (#2141) [@fn=id]")
+}
+
 test "#2141: a user-written binder with the prefix stays legal" {
   // With declarations rejected, a binder spelled with the prefix is genuinely
   // a formal -- the marking machinery treats it as the variable it is.

--- a/lib/@vibe/compiler/tests/wit_gen_test.vibe
+++ b/lib/@vibe/compiler/tests/wit_gen_test.vibe
@@ -221,6 +221,20 @@ test "wit_from_program: a GENERIC BINDER named StringMap shadows the builtin" {
   assert(String::contains(message, "no WIT mapping"))
 }
 
+test "wit_from_program: a KINDED GENERIC BINDER named StringMap shadows the builtin" {
+  let params = array_empty()
+  Array::push(params, ("m", Some(TyApp("StringMap", [TyName("Int")]))))
+  let generic_fn = EFn(["$type_param$1$StringMap"], array_empty(), params, Some(TyName("Int")), None, EUnit)
+  let stmts = [
+    SLet(true, false, "read", Some(TyFn([TyApp("StringMap", [TyName("Int")])], TyName("Int"), None)), generic_fn)
+  ]
+  let message = handle {
+    let _ = wit_from_program(stmts, stmts, "generic")
+    ""
+  } with { Exception::Throw(m) => m }
+  assert(String::contains(message, "no WIT mapping"))
+}
+
 test "wit_from_program: an UNAPPLIED StringMap binder does not shadow the builtin" {
   // #2276 (Codex round 16): `fn id[StringMap](x: StringMap) -> StringMap` is a
   // VALID program -- #2268 rejects an APPLIED formal, not a declared one -- so

--- a/lib/@vibe/compiler/wit_gen.vibe
+++ b/lib/@vibe/compiler/wit_gen.vibe
@@ -12,6 +12,10 @@ import @vibe/compiler/core {
   is_exception_effect_name
 }
 
+import @vibe/ast {
+  type_param_name
+}
+
 import @vibe/compiler/checker {
   is_instantiate_authority
 }
@@ -809,7 +813,7 @@ fn expr_binds_applied_type_param(body: Expr, needle: String) -> Bool {
       let mut i = 0
       let mut binds = false
       while i < Array::length(tparams) {
-        if Array::get(tparams, i) == needle {
+        if type_param_name(Array::get(tparams, i)) == needle {
           binds = true
         } else {
           ()

--- a/lib/@vibe/parser/index.vpkg
+++ b/lib/@vibe/parser/index.vpkg
@@ -87,6 +87,7 @@ fn collect_doc_comments(src: String) -> Array[(Int, String)]
 
 // --- parser_base
 fn peek(tokens: Array[Token], pos: Int) -> Token
+fn parse_type_param_kind(tokens: Array[Token], pos: Int, name: String) -> (String, Int) with Exception
 fn tk_name(t: Token) -> String
 fn binder_name_error(actual: String, kind: String, pos: Int) -> String
 fn skip_semi(tokens: Array[Token], pos: Int) -> Int
@@ -116,7 +117,7 @@ fn parse_pattern_with_binder_context(tokens: Array[Token], pos: Int, context: Op
 fn parse_param_list_with_binder_context(tokens: Array[Token], pos: Int, context: Option[ParserBinderContext]) -> (Array[(String, Option[TypeExpr])], Int) with Exception
 fn parse_import_item_with_binder_context(tokens: Array[Token], pos: Int, context: Option[ParserBinderContext]) -> (ImportItem, Int) with Exception
 fn parse_binding_name_with_binder_context(tokens: Array[Token], pos: Int, context: Option[ParserBinderContext]) -> (String, Int) with Exception
-fn parse_tparam_names_with_binder_context(tokens: Array[Token], pos: Int, context: Option[ParserBinderContext]) -> (Array[String], Int)
+fn parse_tparam_names_with_binder_context(tokens: Array[Token], pos: Int, context: Option[ParserBinderContext]) -> (Array[String], Int) with Exception
 fn parse_struct_field_with_binder_context(tokens: Array[Token], pos: Int, context: Option[ParserBinderContext]) -> ((String, TypeExpr), Bool, Int) with Exception
 fn parse_trait_stmt_with_binder_context(tokens: Array[Token], pos: Int, exported: Bool, context: Option[ParserBinderContext]) -> (Stmt, Int) with Exception
 fn parse_enum_stmt_with_binder_context(tokens: Array[Token], pos: Int, exported: Bool, context: Option[ParserBinderContext]) -> (Stmt, Int) with Exception

--- a/lib/@vibe/parser/parser_base.vibe
+++ b/lib/@vibe/parser/parser_base.vibe
@@ -1,7 +1,7 @@
 //# Imports
 
 import @vibe/ast {
-  Expr, ImportItem, ImportKind, Pat, Stmt, TypeExpr, trait_ref_key
+  Expr, ImportItem, ImportKind, Pat, Stmt, TypeExpr, trait_ref_key, type_param_key
 }
 
 import ./parser_binder_context.vibe {
@@ -18,6 +18,43 @@ export fn peek(tokens: Array[Token], pos: Int) -> Token {
   if pos < Array::length(tokens) {
     Array::get(tokens, pos)
   } else TEof
+}
+
+/// Parse the optional constructor-kind suffix of a type binder. `F` has kind
+/// Type, `F[_]` has kind Type -> Type, and each additional underscore adds one
+/// input. The returned String is the AST contract key, not source spelling.
+export fn parse_type_param_kind(tokens: Array[Token], pos: Int, name: String) -> (String, Int) with Exception {
+  match peek(tokens, pos) {
+    TLBracket => {
+      let mut p = pos + 1
+      let mut arity = 0
+      let mut done = false
+      while !done {
+        match peek(tokens, p) {
+          TIdent(hole) => if hole == "_" {
+            arity = arity + 1
+            p = p + 1
+            match peek(tokens, p) {
+              TComma => {
+                p = p + 1
+              },
+              TRBracket => {
+                p = p + 1
+                done = true
+              },
+              _ => throw("expected ',' or ']' after '_' in a constructor type parameter")
+            }
+          } else {
+            throw("a constructor type parameter kind contains only '_' placeholders, such as F[_]")
+          },
+          TRBracket => throw("a constructor type parameter needs at least one '_' placeholder"),
+          _ => throw("expected '_' in a constructor type parameter, such as F[_]")
+        }
+      }
+      (type_param_key(name, arity), p)
+    },
+    _ => (type_param_key(name, 0), pos)
+  }
 }
 
 fn _no_tp() -> Array[String] {
@@ -599,12 +636,13 @@ fn parse_bounded_type_params_with_binder_context(tokens: Array[Token], pos: Int,
       },
       TIdent(name) => {
         binder_capture_source(context, name, p, p)
-        ArrayBuilder::push(names, name)
-        p = p + 1
+        let (param_key, after_kind) = parse_type_param_kind(tokens, p + 1, name)
+        ArrayBuilder::push(names, param_key)
+        p = after_kind
         match peek(tokens, p) {
           TColon => if allow_bounds {
             let (bound_names, next) = parse_trait_bound_names(tokens, p + 1)
-            ArrayBuilder::push(bounds, (name, bound_names))
+            ArrayBuilder::push(bounds, (param_key, bound_names))
             p = next
           } else {
             ()
@@ -929,7 +967,7 @@ export fn collect_import_path(tokens: Array[Token], pos: Int, acc: String) -> (S
 /// (returning ([], pos) when there is no bracket). Mirrors parse_enum_stmt's
 /// inline collector: only depth-1 identifiers in name position are kept, so a
 /// bound like `[T: Eq]` still records just `T`.
-export fn parse_tparam_names_with_binder_context(tokens: Array[Token], pos: Int, context: Option[ParserBinderContext]) -> (Array[String], Int) {
+export fn parse_tparam_names_with_binder_context(tokens: Array[Token], pos: Int, context: Option[ParserBinderContext]) -> (Array[String], Int) with Exception {
   match peek(tokens, pos) {
     TLBracket => {
       let b = ArrayBuilder::new()
@@ -953,10 +991,13 @@ export fn parse_tparam_names_with_binder_context(tokens: Array[Token], pos: Int,
           TIdent(nm) => {
             if depth == 1 && expect_name {
               binder_capture_source(context, nm, skip, skip)
-              ArrayBuilder::push(b, nm)
+              let (param_key, after_kind) = parse_type_param_kind(tokens, skip + 1, nm)
+              ArrayBuilder::push(b, param_key)
               expect_name = false
+              skip = after_kind
+            } else {
+              skip = skip + 1
             }
-            skip = skip + 1
           },
           TEof => {
             depth = 0
@@ -972,7 +1013,7 @@ export fn parse_tparam_names_with_binder_context(tokens: Array[Token], pos: Int,
   }
 }
 
-fn parse_tparam_names(tokens: Array[Token], pos: Int) -> (Array[String], Int) {
+fn parse_tparam_names(tokens: Array[Token], pos: Int) -> (Array[String], Int) with Exception {
   parse_tparam_names_with_binder_context(tokens, pos, None)
 }
 
@@ -1826,43 +1867,7 @@ export fn parse_enum_stmt_with_binder_context(tokens: Array[Token], pos: Int, ex
   match peek(tokens, pos) {
     TIdent(name) => {
       binder_capture_source(context, name, pos, pos)
-      let (params, after_name) = match peek(tokens, pos + 1) {
-        TLBracket => {
-          let b = ArrayBuilder::new()
-          let mut skip = pos + 2
-          let mut depth = 1
-          let mut expect_name = true
-          while depth > 0 {
-            match peek(tokens, skip) {
-              TLBracket => {
-                depth = depth + 1; skip = skip + 1
-              },
-              TRBracket => {
-                depth = depth - 1; skip = skip + 1
-              },
-              TComma => {
-                if depth == 1 {
-                  expect_name = true
-                }
-                skip = skip + 1
-              },
-              TIdent(nm) => {
-                if depth == 1 && expect_name {
-                  binder_capture_source(context, nm, skip, skip)
-                  ArrayBuilder::push(b, nm)
-                  expect_name = false
-                }
-                skip = skip + 1
-              },
-              _ => {
-                skip = skip + 1
-              }
-            }
-          }
-          (ArrayBuilder::freeze(b), skip)
-        },
-        _ => (ArrayBuilder::freeze(ArrayBuilder::new()), pos + 1)
-      }
+      let (params, after_name) = parse_tparam_names_with_binder_context(tokens, pos + 1, context)
       let br = expect_tk(tokens, after_name, "{")
       let (ctors, end) = parse_enum_ctors_with_binder_context(tokens, br, context);
       let (derives, final_pos) = parse_derive_names(tokens, end)

--- a/lib/@vibe/parser/parser_binder_authority.vibe
+++ b/lib/@vibe/parser/parser_binder_authority.vibe
@@ -1,7 +1,7 @@
 //# Imports
 
 import @vibe/ast {
-  Expr, Pat, Stmt
+  Expr, Pat, Stmt, type_param_name
 }
 
 import ./ast_detach.vibe {
@@ -469,7 +469,7 @@ fn validate_expr(expr: Expr, rows: Array[SourceBinder], source: String, at: Int)
       let slots = ArrayBuilder::new()
       let mut next = at
       for name in type_params {
-        match validate_slot(name, ExpressionFunctionTypeParameterBinder, rows, source, next) {
+        match validate_slot(type_param_name(name), ExpressionFunctionTypeParameterBinder, rows, source, next) {
           Some(result) => {
             ArrayBuilder::push(slots, result.0)
             next = result.1
@@ -686,7 +686,7 @@ fn validate_stmt(stmt: Stmt, rows: Array[SourceBinder], source: String, at: Int)
         ArrayBuilder::push(slots, first.0)
         let mut next = first.1
         for param in params {
-          match validate_slot(param, StatementTypeParameterBinder, rows, source, next) {
+          match validate_slot(type_param_name(param), StatementTypeParameterBinder, rows, source, next) {
             Some(slot) => {
               ArrayBuilder::push(slots, slot.0)
               next = slot.1

--- a/lib/@vibe/parser/parser_expr.vibe
+++ b/lib/@vibe/parser/parser_expr.vibe
@@ -34,6 +34,7 @@ import ./parser_base.vibe {
   parse_type,
   parse_type_alias_stmt,
   parse_type_impl,
+  parse_type_param_kind,
   peek,
   skip_braced_body,
   tk_name
@@ -147,12 +148,13 @@ fn parse_let_type_params(tokens: Array[Token], pos: Int, context: Option[ParserB
       },
       TIdent(name) => {
         binder_capture_source(context, name, p, p)
-        ArrayBuilder::push(names, name)
-        p = p + 1
+        let (param_key, after_kind) = parse_type_param_kind(tokens, p + 1, name)
+        ArrayBuilder::push(names, param_key)
+        p = after_kind
         match peek(tokens, p) {
           TColon => {
             let (bound_names, next) = parse_type_param_bound_names(tokens, p + 1)
-            ArrayBuilder::push(bounds, (name, bound_names))
+            ArrayBuilder::push(bounds, (param_key, bound_names))
             p = next
           },
           _ => ()
@@ -300,6 +302,13 @@ fn skip_generic_value_start(tokens: Array[Token], pos: Int) -> Int {
           },
           TColon => true,
           TComma => true,
+          // A constructor-kind binder starts with a nested `[_]`. Restrict
+          // this recognition to the underscore form so `[f[x], y]` remains an
+          // array literal in value position.
+          TLBracket => match peek(tokens, pos + 3) {
+            TIdent(hole) => hole == "_",
+            _ => false
+          },
           _ => false
         }
         if maybe_generic {

--- a/lib/@vibe/parser/parser_expr_dispatch.vibe
+++ b/lib/@vibe/parser/parser_expr_dispatch.vibe
@@ -16,6 +16,7 @@ import ./parser_base.vibe {
   parse_pattern_with_binder_context,
   parse_struct_stmt_with_binder_context,
   parse_type_impl,
+  parse_type_param_kind,
   peek,
   reject_retired_effect_label,
   skip_semi,
@@ -163,12 +164,13 @@ fn dispatch_type_params_with_binder_context(tokens: Array[Token], pos: Int, cont
       },
       TIdent(name) => {
         binder_capture_source(context, name, p, p)
-        ArrayBuilder::push(names, name)
-        p = p + 1
+        let (param_key, after_kind) = parse_type_param_kind(tokens, p + 1, name)
+        ArrayBuilder::push(names, param_key)
+        p = after_kind
         match peek(tokens, p) {
           TColon => {
             let (bound_names, next) = dispatch_tp_bound_names(tokens, p + 1)
-            ArrayBuilder::push(bounds, (name, bound_names))
+            ArrayBuilder::push(bounds, (param_key, bound_names))
             p = next
           },
           _ => ()

--- a/lib/@vibe/parser/parser_expr_primary.vibe
+++ b/lib/@vibe/parser/parser_expr_primary.vibe
@@ -16,6 +16,7 @@ import ./parser_base.vibe {
   parse_param_list,
   parse_param_list_with_binder_context,
   parse_type_impl,
+  parse_type_param_kind,
   peek,
   tk_name,
   untyped_brace_lambda_param
@@ -705,12 +706,13 @@ fn parse_generic_fn_type_params_with_binder_context(tokens: Array[Token], pos: I
         // Only the depth-one identifier is a binder. Capture its exact token
         // before advancing into trait-bound references, value params, or body.
         binder_capture_source(context, name, p, p)
-        ArrayBuilder::push(names, name)
-        p = p + 1
+        let (param_key, after_kind) = parse_type_param_kind(tokens, p + 1, name)
+        ArrayBuilder::push(names, param_key)
+        p = after_kind
         match peek(tokens, p) {
           TColon => {
             let (bound_names, next) = parse_generic_type_param_bound_names(tokens, p + 1)
-            ArrayBuilder::push(bounds, (name, bound_names))
+            ArrayBuilder::push(bounds, (param_key, bound_names))
             p = next
           },
           _ => ()

--- a/lib/@vibe/parser/parser_smoke_test.vibe
+++ b/lib/@vibe/parser/parser_smoke_test.vibe
@@ -400,6 +400,16 @@ test "#2335: impl targets preserve concrete, reordered, and generic arguments" {
   assert(String::contains(print_program(reordered), "impl [K, V] M for Map[V, K]"))
 }
 
+test "#2337: constructor-kind binders survive parse and print" {
+  let source = "fn pair[F[_], G[_, _], A](left: F[A], right: G[A, A]) -> F[A] { left }"
+  inspect(print_program(parse_program(lex(source))), "let rec pair = [F[_], G[_, _], A](left: F[A], right: G[A, A]) -> F[A] { left }")
+}
+
+test "#2337: declaration printers decode constructor-kind binders" {
+  let source = "enum Box[F[_], A] { Value(F[A]) }\nstruct Holder[F[_], A] { value: F[A] }\ntype Apply[F[_], A] = F[A]\ntrait Functor[F[_]]\neffect Read[F[_], A] { Get(F[A]) -> A }"
+  inspect(print_program(parse_program(lex(source))), "enum Box[F[_], A] { Value(F[A]) }\nstruct Holder[F[_], A] { value: F[A] }\ntype Apply[F[_], A] = F[A]\ntrait Functor[F[_]]\neffect Read[F[_], A] {\n  Get(F[A]) -> A\n}")
+}
+
 test "parse_program: an empty handler arm set is rejected (#1678)" {
   let result = handle {
     let _ =

--- a/lib/@vibe/parser/printer.vibe
+++ b/lib/@vibe/parser/printer.vibe
@@ -1,7 +1,7 @@
 //# Imports
 
 import @vibe/ast {
-  Expr, ImportItem, ImportKind, Pat, Stmt, TypeExpr, trait_ref_from_key
+  Expr, ImportItem, ImportKind, Pat, Stmt, TypeExpr, trait_ref_from_key, type_param_arity, type_param_name
 }
 
 import ./polyfill.vibe {
@@ -30,6 +30,10 @@ fn join(arr: Array[String], sep: String) -> String {
     }
     String::join(ArrayBuilder::freeze(b), "")
   }
+}
+
+fn empty_type_bounds() -> Array[(String, Array[String])] {
+  ArrayBuilder::freeze(ArrayBuilder::new())
 }
 
 fn print_import_item(item: ImportItem) -> String {
@@ -95,6 +99,19 @@ fn print_bounded_type_params(params: Array[String], bounds: Array[(String, Array
     ""
   } else {
     let parts = for param in params {
+      let param_name = type_param_name(param)
+      let param_arity = type_param_arity(param)
+      let rendered_param = if param_arity == 0 {
+        param_name
+      } else {
+        let holes = ArrayBuilder::new()
+        let mut hi = 0
+        while hi < param_arity {
+          ArrayBuilder::push(holes, "_")
+          hi = hi + 1
+        }
+        String::concat(param_name, String::concat("[", String::concat(join(ArrayBuilder::freeze(holes), ", "), "]")))
+      }
       let labels = ArrayBuilder::new()
       let mut i = 0
       while i < Array::length(bounds) {
@@ -117,9 +134,9 @@ fn print_bounded_type_params(params: Array[String], bounds: Array[(String, Array
       }
       let labels = ArrayBuilder::freeze(labels)
       if Array::length(labels) == 0 {
-        param
+        rendered_param
       } else {
-        String::concat(param, String::concat(": ", join(labels, " + ")))
+        String::concat(rendered_param, String::concat(": ", join(labels, " + ")))
       }
     }
     String::concat("[", String::concat(join(parts, ", "), "]"))
@@ -699,7 +716,7 @@ export fn print_stmt(s: Stmt) -> String {
       let tp = if Array::length(params) == 0 {
         ""
       } else {
-        String::concat("[", String::concat(join(params, ", "), "]"))
+        print_bounded_type_params(params, empty_type_bounds())
       }
       let base = String::concat(prefix(exported), String::concat("enum ", String::concat(name, String::concat(tp, String::concat(" { ", String::concat(print_ctor_list(ctors), " }"))))))
       if Array::length(derives) == 0 {
@@ -744,7 +761,7 @@ export fn print_stmt(s: Stmt) -> String {
       let tp = if Array::length(tparams) == 0 {
         ""
       } else {
-        String::concat("[", String::concat(join(tparams, ", "), "]"))
+        print_bounded_type_params(tparams, empty_type_bounds())
       }
       let base = String::concat(prefix(exported), String::concat("struct ", String::concat(name, String::concat(tp, String::concat(" { ", String::concat(join(parts, "; "), " }"))))))
       if Array::length(derives) == 0 {
@@ -758,7 +775,7 @@ export fn print_stmt(s: Stmt) -> String {
       let tp = if Array::length(params) == 0 {
         ""
       } else {
-        String::concat("[", String::concat(join(params, ", "), "]"))
+        print_bounded_type_params(params, empty_type_bounds())
       }
       String::concat(prefix(exported), String::concat("type ", String::concat(name, String::concat(tp, String::concat(" = ", print_type_expr(ty))))))
     },
@@ -766,7 +783,7 @@ export fn print_stmt(s: Stmt) -> String {
       let tp = if Array::length(tparams) == 0 {
         ""
       } else {
-        String::concat("[", String::concat(join(tparams, ", "), "]"))
+        print_bounded_type_params(tparams, empty_type_bounds())
       }
       let base = String::concat(prefix(exported), String::concat("trait ", String::concat(name, tp)))
       let head = if Array::length(supers) == 0 {
@@ -867,7 +884,7 @@ export fn print_stmt(s: Stmt) -> String {
         "export "
       } else ""
       let tp = if Array::length(type_params) > 0 {
-        String::concat("[", String::concat(join(type_params, ", "), "]"))
+        print_bounded_type_params(type_params, empty_type_bounds())
       } else ""
       let op_parts = for op in ops {
         let (op_name, params, ret) = op

--- a/scripts/experimental_typing_env_reuse_oracle.mjs
+++ b/scripts/experimental_typing_env_reuse_oracle.mjs
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-// Production E2E oracle for default-on check-only TDRE5 TypeEnv reuse. The
+// Production E2E oracle for default-on check-only TDRE7 TypeEnv reuse. The
 // explicit disable flag is the conservative control. Trace-only observations
 // force reuse off and are never used to establish a production reuse key.
 import { existsSync, mkdtempSync, mkdirSync, readdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
@@ -138,7 +138,7 @@ function check(stage2, project, cache, gate, name, allowFailure = false, extraEn
       VIBE_CHECK_ONLY: "1",
       VIBE_INCREMENTAL_TELEMETRY_OUT: telemetryOut,
       VIBE_IMPORT_ABI: "raw",
-      // Resolution authority is part of the TDRE5 logical input. Keep it
+      // Resolution authority is part of the TDRE7 logical input. Keep it
       // stable within each scenario; varying it per invocation would correctly
       // force a full check rather than exercise reuse.
       VIBE_HOME: join(project, ".home"),
@@ -193,7 +193,7 @@ function expectCounts(name, actual, rechecked, reused, planned = 2, dependencyTr
   if (actual.current_source_parse_executions !== rechecked || actual.checker_executions !== rechecked ||
       actual.modules_reused_conservative_fingerprint !== conservativeReuse ||
       actual.modules_reused_dependency_transport_env !== dependencyTransportReuse) {
-    fail(`${name}: expected parse/check/conservative/TDRE5 ${rechecked}/${rechecked}/${conservativeReuse}/${dependencyTransportReuse}, got ${actual.current_source_parse_executions}/${actual.checker_executions}/${actual.modules_reused_conservative_fingerprint}/${actual.modules_reused_dependency_transport_env}`);
+    fail(`${name}: expected parse/check/conservative/TDRE7 ${rechecked}/${rechecked}/${conservativeReuse}/${dependencyTransportReuse}, got ${actual.current_source_parse_executions}/${actual.checker_executions}/${actual.modules_reused_conservative_fingerprint}/${actual.modules_reused_dependency_transport_env}`);
   }
 }
 
@@ -222,42 +222,42 @@ function bindingFiles(cache, namespace) {
 }
 
 function appSidecar(cache, appSource) {
-  const candidates = bindingFiles(cache, "selfhost_typing_dependency_env_reuse_v6");
+  const candidates = bindingFiles(cache, "selfhost_typing_dependency_env_reuse_v7");
   const path = candidates.find((candidate) => {
     const text = readFileSync(candidate, "utf8");
-    return text.startsWith("TDRE6A") && text.includes(appSource);
+    return text.startsWith("TDRE7A") && text.includes(appSource);
   });
-  if (!path) fail(`non-vacuous TDRE5 app sidecar missing in ${basename(cache)}`);
-  return { path, ...parseBinding(readFileSync(path, "utf8"), "TDRE6A") };
+  if (!path) fail(`non-vacuous TDRE7 app sidecar missing in ${basename(cache)}`);
+  return { path, ...parseBinding(readFileSync(path, "utf8"), "TDRE7A") };
 }
 
 function otherSidecar(cache, target) {
-  for (const path of bindingFiles(cache, "selfhost_typing_dependency_env_reuse_v6")) {
-    const binding = parseBinding(readFileSync(path, "utf8"), "TDRE6A");
+  for (const path of bindingFiles(cache, "selfhost_typing_dependency_env_reuse_v7")) {
+    const binding = parseBinding(readFileSync(path, "utf8"), "TDRE7A");
     if (binding.target !== target) return { path, ...binding };
   }
-  fail("second valid TDRE5 target missing");
+  fail("second valid TDRE7 target missing");
 }
 
 function targetWitness(cache, target) {
-  for (const path of bindingFiles(cache, "selfhost_typing_dependency_env_reuse_eligibility_v6")) {
-    const binding = parseBinding(readFileSync(path, "utf8"), "TDRE6W");
+  for (const path of bindingFiles(cache, "selfhost_typing_dependency_env_reuse_eligibility_v7")) {
+    const binding = parseBinding(readFileSync(path, "utf8"), "TDRE7W");
     if (binding.target === target) return { path, ...binding };
   }
-  fail(`bound TDRE5 witness missing for ${target}`);
+  fail(`bound TDRE7 witness missing for ${target}`);
 }
 
 function aliasText(input, target, targetText) {
-  return `TDRE6A${segment(input)}${segment(target)}${segment(targetText)}`;
+  return `TDRE7A${segment(input)}${segment(target)}${segment(targetText)}`;
 }
 
 function witnessText(input, target, targetText) {
-  return `TDRE6W${segment(input)}${segment(target)}${segment(targetText)}`;
+  return `TDRE7W${segment(input)}${segment(target)}${segment(targetText)}`;
 }
 
-const logicalInputTag = "vibe-typing-dependency-transport-env:v6";
+const logicalInputTag = "vibe-typing-dependency-transport-env:v7";
 function parseLogicalInput(input) {
-  if (!input.startsWith(logicalInputTag)) fail("TDRE5 logical input tag changed");
+  if (!input.startsWith(logicalInputTag)) fail("TDRE7 logical input tag changed");
   let cursor = logicalInputTag.length;
   const fields = [];
   for (let i = 0; i < 5; i += 1) {
@@ -265,9 +265,9 @@ function parseLogicalInput(input) {
     fields.push(field);
     cursor = next;
   }
-  if (fields[2] !== "checked" && fields[2] !== "unchecked") fail("invalid TDRE5 typing semantics seed");
+  if (fields[2] !== "checked" && fields[2] !== "unchecked") fail("invalid TDRE7 typing semantics seed");
   const count = Number(fields[4]);
-  if (!Number.isInteger(count) || count < 0) fail("invalid TDRE5 dep_env count");
+  if (!Number.isInteger(count) || count < 0) fail("invalid TDRE7 dep_env count");
   const rows = [];
   for (let i = 0; i < count; i += 1) {
     const [path, afterPath] = parseSegment(input, cursor);
@@ -275,7 +275,7 @@ function parseLogicalInput(input) {
     rows.push([path, text]);
     cursor = afterText;
   }
-  if (cursor !== input.length) fail("TDRE5 logical input has trailing data");
+  if (cursor !== input.length) fail("TDRE7 logical input has trailing data");
   return { owner: fields[0], source: fields[1], typingSemantics: fields[2], resolutionSeed: fields[3], rows };
 }
 
@@ -311,8 +311,8 @@ function stableCachePath(cache, version, prefix, seed, suffix) {
   return join(cache, `vibe_${prefix}_${token}${suffix}`);
 }
 
-function typeEnvPath(stage2, cache, target, major = "v20") {
-  return stableCachePath(cache, `${major}|cg-${stageCodegenFingerprint(stage2)}`, "selfhost_type_env_v6", target, ".tsv");
+function typeEnvPath(stage2, cache, target, major = "v21") {
+  return stableCachePath(cache, `${major}|cg-${stageCodegenFingerprint(stage2)}`, "selfhost_type_env_v7", target, ".tsv");
 }
 
 // Derive the exact referenced TypeEnv filename from the target conservative
@@ -351,17 +351,17 @@ function expectTraceLaneRejected(stage2, project, cache) {
 }
 
 function traceForcedOff(stage2, project, cache) {
-  const beforeAliases = bindingFiles(cache, "selfhost_typing_dependency_env_reuse_v6").length;
-  const beforeWitnesses = bindingFiles(cache, "selfhost_typing_dependency_env_reuse_eligibility_v6").length;
+  const beforeAliases = bindingFiles(cache, "selfhost_typing_dependency_env_reuse_v7").length;
+  const beforeWitnesses = bindingFiles(cache, "selfhost_typing_dependency_env_reuse_eligibility_v7").length;
   const result = check(stage2, project, cache, true, "trace-forced-off", false, {
     VIBE_INCREMENTAL_INVALIDATION_TRACE_OUT: "trace-forced-off.json",
     VIBE_INCREMENTAL_INVALIDATION_TRACE_NONCE: "trace-forced-off",
   });
   expectCounts("ordinary trace forced off", result.telemetry, 2, 0);
   if (!existsSync(join(project, "trace-forced-off.json"))) fail("ordinary trace omitted observation sidecar");
-  if (bindingFiles(cache, "selfhost_typing_dependency_env_reuse_v6").length !== beforeAliases ||
-      bindingFiles(cache, "selfhost_typing_dependency_env_reuse_eligibility_v6").length !== beforeWitnesses) {
-    fail("observation-only trace published TDRE5 state");
+  if (bindingFiles(cache, "selfhost_typing_dependency_env_reuse_v7").length !== beforeAliases ||
+      bindingFiles(cache, "selfhost_typing_dependency_env_reuse_eligibility_v7").length !== beforeWitnesses) {
+    fail("observation-only trace published TDRE7 state");
   }
   return result.telemetry;
 }
@@ -389,29 +389,29 @@ function expectInvalidEnvRejected(stage2, project, cache, variable, value) {
   if (!diagnostic.includes(variable)) fail(`${variable} rejection omitted strict diagnostic`);
 }
 
-function expectV19Isolation(stage2, work) {
-  const project = join(work, "v19-isolation-project");
-  const currentCache = join(work, "v19-isolation-current-cache");
-  const oldCache = join(work, "v19-isolation-old-cache");
+function expectV20Isolation(stage2, work) {
+  const project = join(work, "v20-isolation-project");
+  const currentCache = join(work, "v20-isolation-current-cache");
+  const oldCache = join(work, "v20-isolation-old-cache");
   makeProject(project);
-  check(stage2, project, currentCache, true, "v19-source-cold");
+  check(stage2, project, currentCache, true, "v20-source-cold");
   mkdirSync(oldCache, { recursive: true });
-  const oldVersion = `v19|cg-${stageCodegenFingerprint(stage2)}`;
-  for (const path of bindingFiles(currentCache, "selfhost_typing_dependency_env_reuse_v6")) {
+  const oldVersion = `v20|cg-${stageCodegenFingerprint(stage2)}`;
+  for (const path of bindingFiles(currentCache, "selfhost_typing_dependency_env_reuse_v7")) {
     const text = readFileSync(path, "utf8");
-    const binding = parseBinding(text, "TDRE6A");
-    writeFileSync(stableCachePath(oldCache, oldVersion, "selfhost_typing_dependency_env_reuse_v6", binding.input, ".txt"), text);
-    writeFileSync(typeEnvPath(stage2, oldCache, binding.target, "v19"), readFileSync(typeEnvPath(stage2, currentCache, binding.target), "utf8"));
+    const binding = parseBinding(text, "TDRE7A");
+    writeFileSync(stableCachePath(oldCache, oldVersion, "selfhost_typing_dependency_env_reuse_v7", binding.input, ".txt"), text);
+    writeFileSync(typeEnvPath(stage2, oldCache, binding.target, "v20"), readFileSync(typeEnvPath(stage2, currentCache, binding.target), "utf8"));
   }
-  for (const path of bindingFiles(currentCache, "selfhost_typing_dependency_env_reuse_eligibility_v6")) {
+  for (const path of bindingFiles(currentCache, "selfhost_typing_dependency_env_reuse_eligibility_v7")) {
     const text = readFileSync(path, "utf8");
-    const binding = parseBinding(text, "TDRE6W");
-    writeFileSync(stableCachePath(oldCache, oldVersion, "selfhost_typing_dependency_env_reuse_eligibility_v6", binding.target, ".txt"), text);
-    writeFileSync(typeEnvPath(stage2, oldCache, binding.target, "v19"), readFileSync(typeEnvPath(stage2, currentCache, binding.target), "utf8"));
+    const binding = parseBinding(text, "TDRE7W");
+    writeFileSync(stableCachePath(oldCache, oldVersion, "selfhost_typing_dependency_env_reuse_eligibility_v7", binding.target, ".txt"), text);
+    writeFileSync(typeEnvPath(stage2, oldCache, binding.target, "v20"), readFileSync(typeEnvPath(stage2, currentCache, binding.target), "utf8"));
   }
-  if (bindingFiles(oldCache, "selfhost_typing_dependency_env_reuse_v6").length === 0) fail("v19 isolation fixture omitted valid old aliases");
-  const isolated = check(stage2, project, oldCache, true, "v19-isolated-default");
-  expectCounts("v19 namespace isolation", isolated.telemetry, 2, 0);
+  if (bindingFiles(oldCache, "selfhost_typing_dependency_env_reuse_v7").length === 0) fail("v20 isolation fixture omitted valid old aliases");
+  const isolated = check(stage2, project, oldCache, true, "v20-isolated-default");
+  expectCounts("v20 namespace isolation", isolated.telemetry, 2, 0);
   return isolated.telemetry;
 }
 
@@ -454,8 +454,8 @@ function run(stage2) {
     if (checkedCold.status === 0 || !checkedCold.output.includes("missing { Exception }")) fail("cold checked mode did not reject row-less caller");
     const uncheckedAfterChecked = check(stage2, checkedFirstProject, checkedFirstCache, true, "row-unchecked-after-checked", false, { VIBE_CHECK_ERROR_ROW: "0" });
     expectCounts("unchecked after checked mode isolation", uncheckedAfterChecked.telemetry, 2, 0);
-    const modeSeeds = bindingFiles(uncheckedFirstCache, "selfhost_typing_dependency_env_reuse_v6").map((path) => parseLogicalInput(parseBinding(readFileSync(path, "utf8"), "TDRE6A").input).typingSemantics);
-    if (!modeSeeds.includes("checked") || !modeSeeds.includes("unchecked")) fail("TDRE5 aliases did not retain disjoint typing semantics seeds");
+    const modeSeeds = bindingFiles(uncheckedFirstCache, "selfhost_typing_dependency_env_reuse_v7").map((path) => parseLogicalInput(parseBinding(readFileSync(path, "utf8"), "TDRE7A").input).typingSemantics);
+    if (!modeSeeds.includes("checked") || !modeSeeds.includes("unchecked")) fail("TDRE7 aliases did not retain disjoint typing semantics seeds");
     const legacyCompat = check(stage2, onProject, onCache, true, "legacy-compat", false, {
       VIBE_EXPERIMENTAL_TYPING_DEPENDENCY_ENV_REUSE: "1",
     });
@@ -511,7 +511,7 @@ function run(stage2) {
     expectTraceLaneRejected(stage2, onProject, onCache);
     expectInvalidEnvRejected(stage2, onProject, onCache, "VIBE_DISABLE_TYPING_DEPENDENCY_ENV_REUSE", "true");
     expectInvalidEnvRejected(stage2, onProject, onCache, "VIBE_EXPERIMENTAL_TYPING_DEPENDENCY_ENV_REUSE", "0");
-    const v19Isolation = expectV19Isolation(stage2, work);
+    const v20Isolation = expectV20Isolation(stage2, work);
 
     const malformedProject = join(work, "malformed-target-project");
     const malformedCache = join(work, "malformed-target-cache");
@@ -616,7 +616,7 @@ function run(stage2) {
     makeProject(malformedWitnessProject);
     check(stage2, malformedWitnessProject, malformedWitnessCache, true, "malformed-witness-cold");
     const malformedWitnessApp = appSidecar(malformedWitnessCache, readFileSync(join(malformedWitnessProject, "app.vibe"), "utf8"));
-    writeFileSync(targetWitness(malformedWitnessCache, malformedWitnessApp.target).path, "TDRE6W1:x");
+    writeFileSync(targetWitness(malformedWitnessCache, malformedWitnessApp.target).path, "TDRE7W1:x");
     privateEdit(malformedWitnessProject);
     const malformedWitnessFallback = check(stage2, malformedWitnessProject, malformedWitnessCache, true, "malformed-witness-fallback");
     expectCounts("malformed witness fallback", malformedWitnessFallback.telemetry, 2, 0);
@@ -629,14 +629,14 @@ function run(stage2) {
     const ambientColdApp = appSidecar(ambientCache, readFileSync(join(ambientProject, "app.vibe"), "utf8"));
     const ambientColdInput = parseLogicalInput(ambientColdApp.input);
     if (ambientColdInput.rows.length !== 1 || basename(ambientColdInput.rows[0][0]) !== "middle.vibe") {
-      fail("TDRE5 app logical input was not the exact direct-dependency projection");
+      fail("TDRE7 app logical input was not the exact direct-dependency projection");
     }
     ambientOnlyTransportEdit(ambientProject);
     const ambientReuse = check(stage2, ambientProject, ambientCache, true, "ambient-change-reuse");
     expectCounts("ambient non-direct cache change reuse", ambientReuse.telemetry, 2, 1, 3, 1);
     const ambientWarmApp = appSidecar(ambientCache, readFileSync(join(ambientProject, "app.vibe"), "utf8"));
     if (ambientWarmApp.input !== ambientColdApp.input || ambientWarmApp.path !== ambientColdApp.path) {
-      fail("ambient non-direct cache mutation changed the app TDRE5 input key");
+      fail("ambient non-direct cache mutation changed the app TDRE7 input key");
     }
 
     const resolutionProject = join(work, "resolution-seed-project");
@@ -656,7 +656,7 @@ function run(stage2) {
     const rowApp = appSidecar(rowCache, readFileSync(join(rowProject, "app.vibe"), "utf8"));
     const parsedRowInput = parseLogicalInput(rowApp.input);
     if (parsedRowInput.rows.length !== 1 || basename(parsedRowInput.rows[0][0]) !== "helper.vibe") {
-      fail("TDRE5 direct dependency row missing before row mutation");
+      fail("TDRE7 direct dependency row missing before row mutation");
     }
     const changedRowInput = logicalInputText({
       ...parsedRowInput,
@@ -676,7 +676,7 @@ function run(stage2) {
     const parsedOrderInput = parseLogicalInput(orderApp.input);
     const orderPaths = parsedOrderInput.rows.map(([path]) => basename(path)).sort();
     if (parsedOrderInput.rows.length !== 2 || orderPaths[0] !== "a.vibe" || orderPaths[1] !== "b.vibe") {
-      fail("TDRE5 app logical input omitted exact dep_env rows");
+      fail("TDRE7 app logical input omitted exact dep_env rows");
     }
     const swappedOrderInput = logicalInputText({
       ...parsedOrderInput,
@@ -737,10 +737,10 @@ function run(stage2) {
     writeFileSync(join(noPublishProject, "app.vibe"), failingSource);
     const noPublish = check(stage2, noPublishProject, noPublishCache, true, "diagnostic-no-publish", true);
     if (noPublish.status === 0) fail("diagnostic no-publish scenario unexpectedly succeeded");
-    const noPublishAliases = bindingFiles(noPublishCache, "selfhost_typing_dependency_env_reuse_v6");
-    const noPublishWitnesses = bindingFiles(noPublishCache, "selfhost_typing_dependency_env_reuse_eligibility_v6");
-    if (noPublishAliases.length !== 1 || noPublishWitnesses.length !== 1) fail("diagnosed module published TDRE5 alias or witness");
-    if (noPublishAliases.some((path) => readFileSync(path, "utf8").includes(failingSource))) fail("diagnosed owner source appeared in TDRE5 alias");
+    const noPublishAliases = bindingFiles(noPublishCache, "selfhost_typing_dependency_env_reuse_v7");
+    const noPublishWitnesses = bindingFiles(noPublishCache, "selfhost_typing_dependency_env_reuse_eligibility_v7");
+    if (noPublishAliases.length !== 1 || noPublishWitnesses.length !== 1) fail("diagnosed module published TDRE7 alias or witness");
+    if (noPublishAliases.some((path) => readFileSync(path, "utf8").includes(failingSource))) fail("diagnosed owner source appeared in TDRE7 alias");
 
     console.log(JSON.stringify({
       schema: 2,
@@ -752,7 +752,7 @@ function run(stage2) {
         explicit_disable_control: coldOff.telemetry,
         trace_forced_off: traceForcedOffTelemetry,
         post_trace_default: postTraceDefault.telemetry,
-        v19_namespace_isolation: v19Isolation,
+        v20_namespace_isolation: v20Isolation,
         conservative_compile_output_parity: true,
         invalid_env_diagnostics: true,
         checked_error_row_mode_isolation: {

--- a/scripts/incremental_invalidation_oracle.mjs
+++ b/scripts/incremental_invalidation_oracle.mjs
@@ -36,9 +36,9 @@ const telemetryKeys = [
 const fingerprintNote = "source_fingerprint is ingestion telemetry; implementation_fingerprint remains the provisional canonical token-stream identity; interface_fingerprint, checked_env_fingerprint, and persistent_type_env_transport_fingerprint are observation only; persistent_type_env_transport_fingerprint is TypeEnv transport only, not CheckedProgram, typed IR, exported interface, cache key, or reuse decision; none is a production cache key";
 const sourceFingerprintKind = "compact_string_fingerprint(ingested_source)";
 const implementationFingerprintKind = "compact_string_fingerprint(vibe-module-token-stream:v1 length_delimited(token_kind,source_lexeme))";
-const interfaceFingerprintKind = "compact_string_fingerprint(vibe-module-interface:v3 canonical exported surface including applied trait bounds)";
-const checkedEnvFingerprintKind = "compact_string_fingerprint(vibe-module-checked-env:v2 canonical effective TypeEnv value bindings including applied trait bounds)";
-const persistentTypeEnvTransportFingerprintKind = "compact_string_fingerprint(persistent_type_env_cache_text:v6 complete TypeEnv transport only; not CheckedProgram, typed IR, exported interface, cache key, or reuse decision)";
+const interfaceFingerprintKind = "compact_string_fingerprint(vibe-module-interface:v4 canonical exported surface including kinded applications)";
+const checkedEnvFingerprintKind = "compact_string_fingerprint(vibe-module-checked-env:v3 canonical effective TypeEnv value bindings including kinded applications)";
+const persistentTypeEnvTransportFingerprintKind = "compact_string_fingerprint(persistent_type_env_cache_text:v7 complete TypeEnv transport only; not CheckedProgram, typed IR, exported interface, cache key, or reuse decision)";
 
 const expectedCorpus = new Map([
   ["no_op", { sourceChanged: [], implementationChanged: [], invalidated: [] }],
@@ -395,7 +395,7 @@ function ownerNames(paths) {
 /// Classify the bounded library-body edit without promoting any observation to
 /// production policy. The consumer must name exactly the edited dependency in
 /// both snapshots: extra, missing, reordered, or changed edges fail closed.
-/// TypeEnv-v6 transport state is reported independently from interface-v3.
+/// TypeEnv-v7 transport state is reported independently from interface-v4.
 export function classifyPrivateDependencyEditExternallyUnchanged(before, after, dependencyName, consumerName) {
   const beforeDependency = moduleByName(before, dependencyName);
   const afterDependency = moduleByName(after, dependencyName);
@@ -427,7 +427,7 @@ export function classifyPrivateDependencyEditExternallyUnchanged(before, after, 
     fail("private dependency edit did not change dependency implementation identity");
   }
   if (beforeDependency.interface_fingerprint !== afterDependency.interface_fingerprint) {
-    fail("private dependency edit changed dependency interface-v3 identity");
+    fail("private dependency edit changed dependency interface-v4 identity");
   }
 
   const consumerIdentityFields = [

--- a/scripts/incremental_invalidation_oracle.test.mjs
+++ b/scripts/incremental_invalidation_oracle.test.mjs
@@ -25,11 +25,11 @@ const validTrace = {
       implementation_fingerprint: "30:1:2",
       implementation_fingerprint_kind: "compact_string_fingerprint(vibe-module-token-stream:v1 length_delimited(token_kind,source_lexeme))",
       interface_fingerprint: "31:1:2",
-      interface_fingerprint_kind: "compact_string_fingerprint(vibe-module-interface:v3 canonical exported surface including applied trait bounds)",
+      interface_fingerprint_kind: "compact_string_fingerprint(vibe-module-interface:v4 canonical exported surface including kinded applications)",
       checked_env_fingerprint: "32:1:2",
-      checked_env_fingerprint_kind: "compact_string_fingerprint(vibe-module-checked-env:v2 canonical effective TypeEnv value bindings including applied trait bounds)",
+      checked_env_fingerprint_kind: "compact_string_fingerprint(vibe-module-checked-env:v3 canonical effective TypeEnv value bindings including kinded applications)",
       persistent_type_env_transport_fingerprint: "33:1:2",
-      persistent_type_env_transport_fingerprint_kind: "compact_string_fingerprint(persistent_type_env_cache_text:v6 complete TypeEnv transport only; not CheckedProgram, typed IR, exported interface, cache key, or reuse decision)",
+      persistent_type_env_transport_fingerprint_kind: "compact_string_fingerprint(persistent_type_env_cache_text:v7 complete TypeEnv transport only; not CheckedProgram, typed IR, exported interface, cache key, or reuse decision)",
       decision: "reused",
     },
   ],
@@ -243,7 +243,7 @@ test("shadow planner keeps implementation edits local and propagates interface e
   assert.deepEqual(planObservedTypingInvalidation(before, removedEdgeAfter), ["/p/base.vibe", "/p/library.vibe", "/p/app.vibe"]);
 });
 
-test("private dependency classifier is explicit, fail-closed, and reports TypeEnv-v6 separately", () => {
+test("private dependency classifier is explicit, fail-closed, and reports TypeEnv-v7 separately", () => {
   const before = plannerTrace();
   const after = plannerTrace({
     source: { "/p/library.vibe": "source:library:private-edit" },
@@ -286,7 +286,7 @@ test("private dependency classifier is explicit, fail-closed, and reports TypeEn
     ["after relation", (_, right) => { right.modules[2].direct_dependencies = []; }, /after direct relation/],
     ["source", (_, right) => { right.modules[1].source_fingerprint = before.modules[1].source_fingerprint; }, /did not change dependency source/],
     ["implementation", (_, right) => { right.modules[1].implementation_fingerprint = before.modules[1].implementation_fingerprint; }, /did not change dependency implementation/],
-    ["interface", (_, right) => { right.modules[1].interface_fingerprint = "interface:library:changed"; }, /changed dependency interface-v3/],
+    ["interface", (_, right) => { right.modules[1].interface_fingerprint = "interface:library:changed"; }, /changed dependency interface-v4/],
     ["consumer identity", (_, right) => { right.modules[2].source_fingerprint = "source:app:changed"; }, /changed consumer own source_fingerprint/],
     ["missing transport", (_, right) => { delete right.modules[1].persistent_type_env_transport_fingerprint; }, /missing after dependency persistent_type_env_transport_fingerprint/],
     ["consumer decision", (_, right) => { right.modules[2].decision = "reused"; }, /no longer conservatively rechecked/],


### PR DESCRIPTION
## Summary

- add `F[_]` / `F[_, _]` constructor binders and preserve their arity through parser and AST contracts
- add `CtConstructor` and `CtApplied`, including structural Array/Option normalization and applied-head unification
- reject wrong kinds, wrong arities, and escaping constructor values with positioned actionable diagnostics
- version persistent TypeEnv, checked-state, module-interface, and artifact codecs for kind/application preservation
- cover direct inference, aliases, nominal types, imports, codecs, generalization, instantiation, and occurs checks

## Validation

- `bash scripts/generations.sh build --out-dir _build/hkt-final --stage3` (stage2 == stage3, SHA-256 `5e02f0eb350a8b025310f41c4df771a8e8672ce5b75e336b7dfa7adbcbe3089e`)
- `VIBE_STAGE2_WASM=_build/hkt-dev/stage2.wasm bash scripts/unit_test_runner.sh` (1,044/1,044 files)
- focused kinded-constructor suite (3/3 files)
- `node --test scripts/incremental_invalidation_oracle.test.mjs` (10/10)
- production typing dependency reuse oracle
- formatter fixpoint for every changed `.vibe` / `.vpkg`
- `pkf run full-gate`: compiler gate 106/106; final gate-self-tests stop only on the known macOS stock-Bash `mapfile` portability issue #2349

Closes #2337.

Stacked on #2352.
