### PR TITLE
Close optional capability review gaps

### DIFF
--- a/fixtures/perform_question_granted_error_test.vibe
+++ b/fixtures/perform_question_granted_error_test.vibe
@@ -1,10 +1,35 @@
+import @vibe/core {
+  Attempt
+}
+
 fn read_missing_file() -> Attempt[String, String] with ()allows Fs::read_file? {
   perform? Fs::read_file("__vibe_missing_perform_question_fixture__")
 }
 
+fn read_missing_bytes() -> Attempt[Bytes, String] with ()allows Fs::read_bytes? {
+  perform? Fs::read_bytes("__vibe_missing_perform_question_fixture__")
+}
+
+fn read_missing_dir() -> Attempt[Array[String], String] with ()allows Fs::readdir? {
+  perform? Fs::readdir("__vibe_missing_perform_question_fixture__")
+}
+
 test "granted optional host failure becomes Errored" {
   match read_missing_file() {
-    Errored(message) => assert(String::contains(message, "fs_read_file failed")),
+    Errored(message) => {
+      assert(String::contains(message, "fs_read_file failed"))
+      assert_eq(Attempt::unwrap_or(read_missing_file(), "fallback"), "fallback")
+    },
+    NotGranted => assert(false),
+    Granted(_) => assert(false)
+  }
+  match read_missing_bytes() {
+    Errored(message) => assert(String::contains(message, "fs_read_bytes failed")),
+    NotGranted => assert(false),
+    Granted(_) => assert(false)
+  }
+  match read_missing_dir() {
+    Errored(message) => assert(String::contains(message, "fs_read_dir failed")),
     NotGranted => assert(false),
     Granted(_) => assert(false)
   }

--- a/lib/@vibe/compiler/checker/checker_effects.vibe
+++ b/lib/@vibe/compiler/checker/checker_effects.vibe
@@ -93,6 +93,7 @@ export enum EffectError {
   // diagnostic deliberately names the structural problem instead.
   EEEmptyHandle;
   EEPerformQuestionRequiresOptional(String, Int);
+  EEPerformQuestionSourceShadow(String, Int);
   EEPerformQuestionInvalidOperand(Int)
 }
 
@@ -210,6 +211,14 @@ export fn effect_error_to_string(err: EffectError) -> String {
     EEEmptyHandle => "handler must contain at least one arm; an empty handler cannot discharge an effect",
     EEPerformQuestionRequiresOptional(operation, off) => {
       let body = String::concat("`perform?` requires optional `allows ", String::concat(operation, "?`; write that grade, or use plain `perform`"))
+      if off >= 0 {
+        String::concat(body, String::concat(" [@off=", String::concat(__to_string(off), "]")))
+      } else {
+        body
+      }
+    },
+    EEPerformQuestionSourceShadow(operation, off) => {
+      let body = String::concat("`perform? ", String::concat(operation, "(..)` resolves to a source function, not a capability operation; rename the source function or call the capability under an unshadowed name"))
       if off >= 0 {
         String::concat(body, String::concat(" [@off=", String::concat(__to_string(off), "]")))
       } else {
@@ -2689,10 +2698,15 @@ fn check_perform_effects_expr_tx_in(fn_name: String, root: Expr, root_declared: 
             let lexical_callee = lookup_fn_effs(ov_names, ov_effs, name)
             if name == "perform?" && Array::length(args) == 1 {
               match perform_question_op_name(Array::get(args, 0)) {
-                Some(op_name) => if decl_authorizes_optional_op(declared, op_name) {
-                  ()
-                } else {
-                  Array::push(errors, EEPerformQuestionRequiresOptional(op_name, call_off))
+                Some(op_name) => {
+                  let lexical_operation = lookup_fn_effs(ov_names, ov_effs, op_name)
+                  if source_definition_shadows_builtin(op_name, lexical_operation, fn_names, fn_effs) {
+                    Array::push(errors, EEPerformQuestionSourceShadow(op_name, call_off))
+                  } else if decl_authorizes_optional_op(declared, op_name) {
+                    ()
+                  } else {
+                    Array::push(errors, EEPerformQuestionRequiresOptional(op_name, call_off))
+                  }
                 },
                 // The operand is not a recognizable operation call, as in
                 // `perform? 1`. Reject it here so malformed source never

--- a/lib/@vibe/compiler/codegen/common_base/common_base.vibe
+++ b/lib/@vibe/compiler/codegen/common_base/common_base.vibe
@@ -1667,6 +1667,42 @@ export fn source_declares_constructor(stmts: Array[Stmt], name: String) -> Bool 
   found
 }
 
+/// Append the compiler-private constructor spellings used by `perform?` with
+/// the exact representation of the linked `Attempt` enum. A merged @vibe/core
+/// enum receives ordinary program type tags, so fixed fallback tags are only
+/// correct when no enum declaration was linked into this compilation.
+export fn append_hidden_attempt_constructors(names: Array[String], tags: Array[Int], field_counts: Array[Int], type_names: Array[String]) -> Unit {
+  let public_names = ["NotGranted", "Errored", "Granted"]
+  let hidden_names = [
+    "$vibe_attempt_not_granted",
+    "$vibe_attempt_errored",
+    "$vibe_attempt_granted"
+  ]
+  let fallback_tags = [2, 3, 4]
+  let fallback_fields = [0, 1, 1]
+  let mut hi = 0
+  while hi < Array::length(hidden_names) {
+    let public_name = Array::get(public_names, hi)
+    let mut resolved_tag = Array::get(fallback_tags, hi)
+    let mut resolved_fields = Array::get(fallback_fields, hi)
+    let mut ci = 0
+    while ci < Array::length(names) {
+      if Array::get(names, ci) == public_name && Array::get(type_names, ci) == "Attempt" {
+        resolved_tag = Array::get(tags, ci)
+        resolved_fields = Array::get(field_counts, ci)
+        ci = Array::length(names)
+      } else {
+        ci = ci + 1
+      }
+    }
+    Array::push(names, Array::get(hidden_names, hi))
+    Array::push(tags, resolved_tag)
+    Array::push(field_counts, resolved_fields)
+    Array::push(type_names, "Attempt")
+    hi = hi + 1
+  }
+}
+
 /// O(log N) replacement for `lookup_ctor(ct.names, name, 0)` at CtorTable
 /// call sites. Falls back to the linear scan when the sorted view is absent
 /// (defensive: a table built without ctor_sorted_index stays correct).

--- a/lib/@vibe/compiler/codegen/common_base/index.vpkg
+++ b/lib/@vibe/compiler/codegen/common_base/index.vpkg
@@ -149,6 +149,7 @@ fn get_arm_pat(arm: (Pat, Expr)) -> Pat
 fn lookup_ctor(ctor_names: Array[String], name: String, i: Int) -> Int
 fn ctor_sorted_index(names: Array[String]) -> (Array[String], Array[Int])
 fn source_declares_constructor(stmts: Array[Stmt], name: String) -> Bool
+fn append_hidden_attempt_constructors(names: Array[String], tags: Array[Int], field_counts: Array[Int], type_names: Array[String]) -> Unit
 fn ctor_table_index_of(ct: CtorTable, name: String) -> Int
 fn ctor_field_is_float(ctx: CompileCtx, ctor_idx: Int, field_idx: Int) -> Bool
 fn struct_field_candidates(ct: CtorTable, field: String) -> Array[(Int, Int)]

--- a/lib/@vibe/compiler/codegen/common_base/inline_direct_perform.vibe
+++ b/lib/@vibe/compiler/codegen/common_base/inline_direct_perform.vibe
@@ -137,13 +137,24 @@ fn opq_source_value_exists(names: Array[String], name: String) -> Bool {
 /// source call, so fail here before a denied branch can erase it or a granted
 /// branch can wrap it as an optional capability result.
 fn opq_require_registry_operation(source_names: Array[String], operation: String) -> Unit with Exception {
-  match lookup_registry_builtin(operation) {
-    Some(_) => if opq_source_value_exists(source_names, operation) {
+  // `Fs::readdir` is the one checker-visible capability surface that is not a
+  // func-table registry row: compile_call lowers it to the registered
+  // `vibe_fs_read_dir_raw` import plus String::split. Keep provenance aligned
+  // with that explicit surface-to-host lowering.
+  let registered = if operation == "Fs::readdir" {
+    true
+  } else match lookup_registry_builtin(operation) {
+    Some(_) => true,
+    None => false
+  }
+  if registered {
+    if opq_source_value_exists(source_names, operation) {
       throw(String::concat("`perform? ", String::concat(operation, "(..)` resolves to a source function, not a capability operation; rename the source function or call the capability under an unshadowed name")))
     } else {
       ()
-    },
-    None => throw(String::concat("`perform? ", String::concat(operation, "(..)` is not a registered capability operation")))
+    }
+  } else {
+    throw(String::concat("`perform? ", String::concat(operation, "(..)` is not a registered capability operation")))
   }
 }
 

--- a/lib/@vibe/compiler/codegen/gc/backend_body.vibe
+++ b/lib/@vibe/compiler/codegen/gc/backend_body.vibe
@@ -42,6 +42,7 @@ import @vibe/compiler/codegen/common_base {
   LambdaTable,
   StrTable,
   agg_info_of_type_expr,
+  append_hidden_attempt_constructors,
   codegen_unresolved_name_prefix,
   compute_agg_returning,
   ctor_sorted_index,
@@ -1369,24 +1370,6 @@ fn compile_wasi_module_gc_impl(stmts: Array[Stmt], entry_name: String, generated
     }
     builtin_ctor_i = builtin_ctor_i + 1
   }
-  // Optional-perform lowering uses compiler-owned names that source cannot
-  // spell. They retain Attempt's public representation even when user code
-  // declares constructors named NotGranted, Errored, or Granted.
-  let hidden_attempt_ctor_names = [
-    "$vibe_attempt_not_granted",
-    "$vibe_attempt_errored",
-    "$vibe_attempt_granted"
-  ]
-  let hidden_attempt_ctor_tags = [2, 3, 4]
-  let hidden_attempt_ctor_fields = [0, 1, 1]
-  let mut hidden_attempt_ctor_i = 0
-  while hidden_attempt_ctor_i < Array::length(hidden_attempt_ctor_names) {
-    Array::push(ctor_names_list, Array::get(hidden_attempt_ctor_names, hidden_attempt_ctor_i))
-    Array::push(ctor_tags_list, Array::get(hidden_attempt_ctor_tags, hidden_attempt_ctor_i))
-    Array::push(ctor_field_counts_list, Array::get(hidden_attempt_ctor_fields, hidden_attempt_ctor_i))
-    Array::push(ctor_type_names_list, "Attempt")
-    hidden_attempt_ctor_i = hidden_attempt_ctor_i + 1
-  }
   let mut type_index = 1
   let mut ei2 = 0
   while ei2 < Array::length(stmts) {
@@ -1437,6 +1420,7 @@ fn compile_wasi_module_gc_impl(stmts: Array[Stmt], entry_name: String, generated
     }
     ei2 = ei2 + 1
   }
+  append_hidden_attempt_constructors(ctor_names_list, ctor_tags_list, ctor_field_counts_list, ctor_type_names_list)
   // Sorted ctor-name index (see CtorTable.names_sorted): built once here,
   // shared by every CtorTable literal below.
   let (gc_ctor_names_sorted, gc_ctor_names_sorted_pos) = ctor_sorted_index(ctor_names_list)

--- a/lib/@vibe/compiler/codegen/wasi/linked_compile.vibe
+++ b/lib/@vibe/compiler/codegen/wasi/linked_compile.vibe
@@ -149,6 +149,7 @@ import @vibe/compiler/codegen/common_base {
   LineMapState,
   StrTable,
   agg_info_of_type_expr,
+  append_hidden_attempt_constructors,
   await_poll_pass,
   codegen_body_cache_find,
   codegen_body_cache_merge,
@@ -3979,24 +3980,6 @@ export fn compile_wasi_module_linked_impl_with_float_offsets(stmts: Array[Stmt],
     }
     builtin_ctor_i = builtin_ctor_i + 1
   }
-  // Optional-perform lowering uses compiler-owned names that source cannot
-  // spell. They retain Attempt's public representation even when user code
-  // declares constructors named NotGranted, Errored, or Granted.
-  let hidden_attempt_ctor_names = [
-    "$vibe_attempt_not_granted",
-    "$vibe_attempt_errored",
-    "$vibe_attempt_granted"
-  ]
-  let hidden_attempt_ctor_tags = [2, 3, 4]
-  let hidden_attempt_ctor_fields = [0, 1, 1]
-  let mut hidden_attempt_ctor_i = 0
-  while hidden_attempt_ctor_i < Array::length(hidden_attempt_ctor_names) {
-    Array::push(ctor_names_list, Array::get(hidden_attempt_ctor_names, hidden_attempt_ctor_i))
-    Array::push(ctor_tags_list, Array::get(hidden_attempt_ctor_tags, hidden_attempt_ctor_i))
-    Array::push(ctor_field_counts_list, Array::get(hidden_attempt_ctor_fields, hidden_attempt_ctor_i))
-    Array::push(ctor_type_names_list, "Attempt")
-    hidden_attempt_ctor_i = hidden_attempt_ctor_i + 1
-  }
   // #1062: sparse `ctor_idx * 64 + field_idx` entries for Double/Float-typed
   // positional constructor fields (see CompileCtx.ctor_float_fields). Built
   // alongside ctor_names_list/ctor_field_counts_list above so ctor_idx here
@@ -4051,6 +4034,7 @@ export fn compile_wasi_module_linked_impl_with_float_offsets(stmts: Array[Stmt],
     }
     ei2 = ei2 + 1
   }
+  append_hidden_attempt_constructors(ctor_names_list, ctor_tags_list, ctor_field_counts_list, ctor_type_names_list)
   let struct_names = lc_fresh_string_array()
   let struct_field_names = lc_fresh_string_matrix()
   let mut si = 0

--- a/lib/@vibe/compiler/tests/checker_entry_effect_test.vibe
+++ b/lib/@vibe/compiler/tests/checker_entry_effect_test.vibe
@@ -259,6 +259,14 @@ test "#2236: perform? on an optional allows reaches lowering" {
   assert_eq(msg, "")
 }
 
+test "#2236 review: perform? rejects a source function shadowing a capability" {
+  let source = "fn Fs::read_file(path: String) -> String { path }\nfn main() -> Int with () allows Fs::read_file? {\n  let a = perform? Fs::read_file(\"x\")\n  0\n}\n"
+  let msg = first_located_check_error(source)
+  assert(String::contains(msg, "line 3:"))
+  assert(String::contains(msg, "resolves to a source function"))
+  assert(String::contains(msg, "not a capability operation"))
+}
+
 test "#2236: an algebraic operation is still invalid in allows" {
   // `perform?` lowering does not widen `allows`: algebraic operations remain
   // rejected by the capability-classification check.

--- a/lib/@vibe/compiler/tests/perform_question_lowering_test.vibe
+++ b/lib/@vibe/compiler/tests/perform_question_lowering_test.vibe
@@ -1,7 +1,7 @@
 //# `perform?` lowering (#2236)
 
 import @vibe/compiler/codegen/common_base {
-  lower_optional_performs, optional_perform_artifact_resolution
+  append_hidden_attempt_constructors, lower_optional_performs, optional_perform_artifact_resolution
 }
 
 import @vibe/compiler/core {
@@ -162,6 +162,29 @@ test "#2236 review: source shadow of a registry operation is not lowered" {
   } with { Exception::Throw(error) => error }
   assert(String::contains(message, "source function"))
   assert(String::contains(message, "not a capability operation"))
+}
+
+test "#2236 review: checker-only Fs::readdir is valid capability provenance" {
+  let stmts = parse_program(lex("fn main() -> Int with () allows Fs::readdir? { let _ = perform? Fs::readdir(\"x\"); 0 }\n"))
+  let message = handle {
+    lower_optional_performs(stmts, [("Fs::readdir", "Granted")])
+    ""
+  } with { Exception::Throw(error) => error }
+  assert_eq(message, "")
+}
+
+test "#2236 review: hidden constructors reuse the linked Attempt representation" {
+  let names = ["Granted", "NotGranted", "Errored", "Granted"]
+  let tags = [7, 101, 102, 103]
+  let fields = [2, 0, 1, 1]
+  let types = ["Local", "Attempt", "Attempt", "Attempt"]
+  append_hidden_attempt_constructors(names, tags, fields, types)
+  assert_eq(Array::get(names, 4), "$vibe_attempt_not_granted")
+  assert_eq(Array::get(tags, 4), 101)
+  assert_eq(Array::get(names, 5), "$vibe_attempt_errored")
+  assert_eq(Array::get(tags, 5), 102)
+  assert_eq(Array::get(names, 6), "$vibe_attempt_granted")
+  assert_eq(Array::get(tags, 6), 103)
 }
 
 test "#2236: the linear backend compiles a well-graded perform?" with Exception {

--- a/scripts/wasm_vibe_host_runner.js
+++ b/scripts/wasm_vibe_host_runner.js
@@ -2560,7 +2560,7 @@ async function main() {
           }
           return encodeHostBytes(instanceRef, buf);
         } catch (e) {
-          throw new Error(`fs_read_bytes failed for '${filePath}': ${e.message}`);
+          throwVibeHostError(`fs_read_bytes failed for '${filePath}': ${e.message}`);
         }
       },
       // #729/#730: Fs::readdir — entry NAMES, byte-sorted, "\n"-joined into
@@ -2578,7 +2578,7 @@ async function main() {
           entries.sort((a, b) => Buffer.compare(Buffer.from(a), Buffer.from(b)));
           return encodeHostString(instanceRef, entries.join("\n"));
         } catch (e) {
-          throw new Error(`fs_read_dir failed for '${dirPath}': ${e.message}`);
+          throwVibeHostError(`fs_read_dir failed for '${dirPath}': ${e.message}`);
         }
       },
       fs_exists(pathTagged) {


### PR DESCRIPTION
Follow-up to #2333 for review findings that arrived as the original PR was merging.

- reuse the linked `Attempt` enum representation for compiler-private optional-result constructors on both codegen backends
- recognize the checker-only `Fs::readdir` capability surface during optional lowering
- convert `fs_read_bytes` and `fs_read_dir` host failures through the guest exception tag
- reject source-shadowed capability operands during `vibe check`, with a located actionable diagnostic
- extend the end-to-end fixture across file, bytes, and directory failures while linking `@vibe/core`

Validation:
- fresh stage0 -> stage1 -> stage2 self-build
- `pkf run test-affected`: 1034/1034 active unit-test files passed
- linear end-to-end optional failure fixture
- wasm-gc Node-host end-to-end for all three failing FS operations
- touched-file formatter checks, `git diff --check`, and `node --check scripts/wasm_vibe_host_runner.js`