### PR TITLE
Share one sized-Bytes::new synthesis between the backends (#2363), and extract the substring search (#2345 step 1)

### DIFF
--- a/docs/cheatsheet.md
+++ b/docs/cheatsheet.md
@@ -1641,7 +1641,7 @@ via `memory.copy`, so `push` is amortised O(1)):
 | function | meaning | backend |
 |---|---|---|
 | `Bytes::new()` | empty buffer (initial capacity 64) | linear / gc |
-| `Bytes::new(n)` | **zero-filled** buffer of length `n`. **linear only** (see below) | linear only |
+| `Bytes::new(n)` | **zero-filled** buffer of length `n` | linear / gc |
 | `Bytes::length(b)` / `get(b, i)` / `set(b, i, v)` | length, element access | linear / gc |
 | `Bytes::push(b, v)` | append one byte (amortised O(1)) | linear / gc |
 | `Bytes::append(dst, src)` | **bulk concatenation. One `memory.copy`** | linear / gc |
@@ -1664,19 +1664,19 @@ via `memory.copy`, so `push` is amortised O(1)):
 > (`codegen/builtin_bodies/bodies_core_a2.vibe`) — a single body shared by the
 > linear and gc backends.
 >
-> **The one-argument `Bytes::new(n)` only works on the linear backend** (measured
-> 2026-08-27, [#2363](https://github.com/mizchi/vibe-lang/issues/2363)).
-> `compile_call.vibe` special-cases a one-argument `Bytes::new` and synthesises the
-> fill loop; `codegen/gc/backend_call.vibe` has no counterpart, and the registry
-> declares `Bytes::new` with `reg_p0()`, so on wasm-gc the argument is pushed and
-> then the zero-parameter runtime body is called. Measured on one self-contained
-> file, linear passes and gc **fails** — and it fails at run time, not at
-> validation, so the module is accepted by `wasmtime compile` first.
+> **The one-argument `Bytes::new(n)` used to be linear-only** and is not any
+> more (#2363, fixed 2026-08-27). `compile_call.vibe` special-cases a
+> one-argument `Bytes::new` and synthesises `new()` plus a zero-push loop;
+> `codegen/gc/backend_call.vibe` had no counterpart, and the registry declares
+> `Bytes::new` with `reg_p0()`, so on wasm-gc the argument was pushed and the
+> zero-parameter runtime body called anyway. It type-checked on both lanes,
+> passed `wasmtime compile`, and failed at run time on one of them. The gc call
+> path now carries the same synthesis, and
+> `fixtures/bytes_alloc_backend_parity_test.vibe` pins both spellings on both
+> lanes.
 >
-> The spelling that works on both backends is `Bytes::new()` +
-> `Bytes::fill(b, 0, n)`. Use it wherever portability matters; `MutMap`'s control
-> array uses it for exactly this reason (`lib/@vibe/core/hashmap.vibe`), and
-> `fixtures/bytes_alloc_backend_parity_test.vibe` pins it on both lanes.
+> `Bytes::new()` + `Bytes::fill(b, 0, n)` remains equivalent and is what
+> `MutMap`'s control array uses (`lib/@vibe/core/hashmap.vibe`).
 
 **SIMD scans** (scan `Bytes` / `String` in 16-byte chunks; available on both
 the linear and GC backends):

--- a/fixtures/bytes_alloc_backend_parity_test.vibe
+++ b/fixtures/bytes_alloc_backend_parity_test.vibe
@@ -1,27 +1,33 @@
-// `Bytes::new() + Bytes::fill` is the zero-filled-buffer spelling that works on
-// BOTH backends. Deliberately free of imports and prelude dependencies so the
-// wasm-gc lane -- which compiles one file as self-contained -- can run it:
+// Zero-filled `Bytes` allocation must mean the same thing on both backends.
+// Deliberately free of imports and prelude dependencies so the wasm-gc lane --
+// which compiles one file as self-contained -- can run it:
 //
 //   vibe test fixtures/bytes_alloc_backend_parity_test.vibe
 //   VIBE_TEST_BACKEND=gc vibe test fixtures/bytes_alloc_backend_parity_test.vibe
 //
-// WHY THIS EXISTS. `MutMap`'s control array (#2346) needs a zero-filled buffer
-// of a runtime length. The obvious spelling is the one-argument `Bytes::new(cap)`
-// overload, and it is a trap: `compile_call.vibe` synthesises a fill loop for it,
-// `codegen/gc/backend_call.vibe` has no counterpart, so on wasm-gc the argument is
-// emitted and then the ZERO-parameter runtime body is called. Measured on a
-// single self-contained file, `Bytes::new(8)` passes on linear and FAILS on gc,
-// while the spelling below passes on both -- so the failure is specific to the
-// overload, not to sized buffers.
+// Registered in the enforced gc lists (tests/gates/mid/run.sh step 40h8,
+// .github/workflows/ci.yml, scripts/test_gc_selfbuild.sh) -- without that it
+// would run on linear only and assert backend parity while never testing it.
 //
-// This fixture pins the spelling that works. It cannot pin the one that does
-// not, because a test that must fail on one backend is not expressible here;
-// that gap is tracked as its own compiler issue.
+// WHY THIS EXISTS. `MutMap`'s control array (#2346) needs a zero-filled buffer
+// of a runtime length. Both spellings below produce one, and until #2363 they
+// did NOT agree across backends: the one-argument `Bytes::new(n)` overload was
+// synthesised into `new()` + a zero-push loop by the linear lane only, so on
+// wasm-gc the argument was pushed and the ZERO-parameter runtime body called
+// anyway. It type-checked on both lanes and failed on one, past validation, at
+// run time. #2363 gave the gc call path the same synthesis; this fixture pins
+// BOTH spellings on BOTH lanes so they cannot diverge again.
 
+/// The portable spelling: worked on both lanes even before #2363.
 fn alloc_zeroed(n: Int) -> Bytes {
   let b = Bytes::new()
   Bytes::fill(b, 0, n)
   b
+}
+
+/// The one-argument overload: linear-only until #2363, both lanes after it.
+fn alloc_sized(n: Int) -> Bytes {
+  Bytes::new(n)
 }
 
 test "zero-filled Bytes of a runtime length, on either backend" {
@@ -52,4 +58,29 @@ test "a control-byte encoding survives the round trip" {
   assert_eq(Bytes::get(b, 1), 1)
   assert_eq(Bytes::get(b, 2), 128)
   assert_eq(Bytes::get(b, 3), 255)
+}
+
+test "the sized overload allocates the same buffer (#2363)" {
+  let b = alloc_sized(8)
+  assert_eq(Bytes::length(b), 8)
+  assert_eq(Bytes::get(b, 0), 0)
+  assert_eq(Bytes::get(b, 7), 0)
+  Bytes::set(b, 3, 200)
+  assert_eq(Bytes::get(b, 3), 200)
+  assert_eq(Bytes::get(b, 4), 0)
+}
+
+test "both spellings agree, element for element" {
+  let a = alloc_zeroed(16)
+  let b = alloc_sized(16)
+  assert_eq(Bytes::length(a), Bytes::length(b))
+  let mut i = 0
+  let mut same = true
+  while i < 16 {
+    if Bytes::get(a, i) != Bytes::get(b, i) {
+      same = false
+    }
+    i = i + 1
+  }
+  assert_eq(same, true)
 }

--- a/lib/@vibe/compiler/codegen/builtin_bodies/bodies_core_b.vibe
+++ b/lib/@vibe/compiler/codegen/builtin_bodies/bodies_core_b.vibe
@@ -1301,51 +1301,31 @@ export fn gen_string_contains_body(enable_rc: Bool, string_index_of_idx: Int) ->
 /// packed). Locals (all i32, meta 8/0): 2=hay_len 3=ndl_len 4=i 5=hay_ptr
 /// 6=ndl_ptr 7=first_byte 8=limit (= hay_len - ndl_len, last valid start)
 /// 9=chunk_limit (window phase bound; 0 when the range is under 16 starts).
-export fn gen_string_index_of_body(enable_rc: Bool, str_len_idx: Int, str_substring_idx: Int, str_eq_idx: Int) -> Bytes {
-  let _ = str_substring_idx
-  let b = bytebuf_new()
-  emit_local_get(b, 0)
-  emit_call(b, str_len_idx)
-  // ADR-0055: String::length is value-world (tagged) under RC; untag both
-  // lengths for raw arithmetic, tag the returned index back at the exits.
-  if enable_rc {
-    emit_i64_const(b, 1)
-    emit_i64_shr_s(b)
-  }
-  emit_i32_wrap_i64(b)
-  emit_local_set(b, 2)
-  emit_local_get(b, 1)
-  emit_call(b, str_len_idx)
-  if enable_rc {
-    emit_i64_const(b, 1)
-    emit_i64_shr_s(b)
-  }
-  emit_i32_wrap_i64(b)
-  emit_local_set(b, 3)
-  emit_local_get(b, 3)
-  emit_local_get(b, 2)
-  emit_i32_gt_u(b)
-  emit_if_i64(b)
-  emit_i64_const(b, -1)
-  if enable_rc {
-    emit_i64_const(b, 1)
-    emit_i64_shl(b)
-  }
-  emit_else(b)
-  emit_local_get(b, 0)
-  emit_i64_const(b, 32)
-  emit_i64_shr_s(b)
-  emit_i32_wrap_i64(b)
-  emit_local_set(b, 5)
-  emit_local_get(b, 1)
-  emit_i64_const(b, 32)
-  emit_i64_shr_s(b)
-  emit_i32_wrap_i64(b)
-  emit_local_set(b, 6)
-  emit_local_get(b, 2)
-  emit_local_get(b, 3)
-  emit_i32_sub(b)
-  emit_local_set(b, 8)
+/// #2345: the windowed substring search, emitted over four i32 locals that the
+/// CALLER has already populated:
+///
+///   local 2  haystack length      local 5  haystack data pointer
+///   local 3  needle length        local 6  needle data pointer
+///   local 8  last valid start (hay_len - ndl_len)
+///
+/// and locals 4 / 7 / 9 as scratch. That is the whole interface: everything
+/// above this point is unpacking a handle, and every byte below it is
+/// representation-independent. `String` reaches those locals from a packed
+/// `(ptr << 32) | len` fat value; `Bytes` reaches the same locals from a heap
+/// handle (`i32.load offset=8` for the data, `offset=4` for the length), which
+/// is why the search itself can be shared even though the two types have
+/// nothing else in common.
+///
+/// Extracted as PURE CODE MOTION -- byte-for-byte the emitter calls that were
+/// inline in gen_string_index_of_body -- so `String::index_of`'s emitted bytes
+/// are unchanged, which is the property that makes the extraction safe to
+/// believe. The SIMD window (splat the needle's first byte, scan 16 bytes with
+/// i8x16.eq + v128.any_true, skip the whole window when no candidate byte is
+/// present, scalar full-match only on candidate windows) lives here now, so a
+/// second caller gets it rather than reimplementing it. ADR-0054 measured that
+/// window at ~5.1x over the scalar baseline; a Bytes search written without it
+/// would be the slow one.
+fn emit_windowed_substring_search(b: Bytes, enable_rc: Bool, str_eq_idx: Int) -> Unit {
   emit_block_i64(b)
   emit_local_get(b, 3)
   emit_i32_eqz(b)
@@ -1441,6 +1421,54 @@ export fn gen_string_index_of_body(enable_rc: Bool, str_len_idx: Int, str_substr
   }
   emit_end(b)
   emit_end(b)
+}
+
+export fn gen_string_index_of_body(enable_rc: Bool, str_len_idx: Int, str_substring_idx: Int, str_eq_idx: Int) -> Bytes {
+  let _ = str_substring_idx
+  let b = bytebuf_new()
+  emit_local_get(b, 0)
+  emit_call(b, str_len_idx)
+  // ADR-0055: String::length is value-world (tagged) under RC; untag both
+  // lengths for raw arithmetic, tag the returned index back at the exits.
+  if enable_rc {
+    emit_i64_const(b, 1)
+    emit_i64_shr_s(b)
+  }
+  emit_i32_wrap_i64(b)
+  emit_local_set(b, 2)
+  emit_local_get(b, 1)
+  emit_call(b, str_len_idx)
+  if enable_rc {
+    emit_i64_const(b, 1)
+    emit_i64_shr_s(b)
+  }
+  emit_i32_wrap_i64(b)
+  emit_local_set(b, 3)
+  emit_local_get(b, 3)
+  emit_local_get(b, 2)
+  emit_i32_gt_u(b)
+  emit_if_i64(b)
+  emit_i64_const(b, -1)
+  if enable_rc {
+    emit_i64_const(b, 1)
+    emit_i64_shl(b)
+  }
+  emit_else(b)
+  emit_local_get(b, 0)
+  emit_i64_const(b, 32)
+  emit_i64_shr_s(b)
+  emit_i32_wrap_i64(b)
+  emit_local_set(b, 5)
+  emit_local_get(b, 1)
+  emit_i64_const(b, 32)
+  emit_i64_shr_s(b)
+  emit_i32_wrap_i64(b)
+  emit_local_set(b, 6)
+  emit_local_get(b, 2)
+  emit_local_get(b, 3)
+  emit_i32_sub(b)
+  emit_local_set(b, 8)
+  emit_windowed_substring_search(b, enable_rc, str_eq_idx)
   b
 }
 

--- a/lib/@vibe/compiler/codegen/common_base/index.vpkg
+++ b/lib/@vibe/compiler/codegen/common_base/index.vpkg
@@ -228,6 +228,10 @@ fn int_parse_expr(arg: Expr) -> Expr
 // --- double_parse_expr.vibe (#841 item E1)
 fn double_parse_expr(arg: Expr) -> Expr
 
+// --- sized_bytes_new_expr.vibe (#2363): ONE synthesis for `Bytes::new(n)`,
+// called by both backends so the lanes cannot drift apart again.
+fn sized_bytes_new_expr(n_expr: Expr) -> Expr
+
 // --- inline_wat.vibe (relocated here, see #897 header note above)
 fn compile_inline_wat(fn_name: String, wat: String, param_names: Array[String]) -> Bytes with Exception
 fn compile_inline_wat_full(fn_name: String, wat: String, param_names: Array[String], extra_base: Int) -> (Bytes, Int, Int, Int) with Exception

--- a/lib/@vibe/compiler/codegen/common_base/sized_bytes_new_expr.vibe
+++ b/lib/@vibe/compiler/codegen/common_base/sized_bytes_new_expr.vibe
@@ -1,0 +1,51 @@
+//# Imports
+
+import @vibe/compiler/core {
+  Expr, Pat, Stmt, TypeExpr
+}
+
+import @vibe/core {
+  array_empty
+}
+
+//# Functions
+
+/// #2363: `Bytes::new(n)` -> a length-n zero-filled buffer, synthesized as
+/// ordinary AST and lowered through each backend's `ce` (same technique as
+/// int_parse_expr / double_to_string_expr).
+///
+/// SHARED ON PURPOSE, and that is the point of the file. The runtime
+/// `bytes_new` takes NO operands -- the registry declares it `reg_p0()` -- so a
+/// backend that lets the generic call path emit `n` and then call it anyway
+/// strands the argument on the value stack. The linear lane synthesized this
+/// inline and the wasm-gc lane had no counterpart, which made the one-argument
+/// overload LINEAR-ONLY: it type-checked on both lanes, the emitted module
+/// passed `wasmtime compile`, and it failed at run time on one of them, with
+/// nothing in the source naming a backend.
+///
+/// Two hand-written lowerings of one overload is what let those lanes drift, so
+/// there is exactly one now and each backend's arm is a single call to it. A
+/// future backend gets the behaviour by calling this, not by reimplementing it.
+///
+/// Pinned on both lanes by fixtures/bytes_alloc_backend_parity_test.vibe.
+export fn sized_bytes_new_expr(n_expr: Expr) -> Expr {
+  let n = EIdent("__bn_n", -1)
+  let b = EIdent("__bn_b", -1)
+  let i = EIdent("__bn_i", -1)
+  let push = ECall(EIdent("Bytes::push", -1), [b, EInt(0)], -1)
+  let step = EAssign("__bn_i", EBinOp("+", i, EInt(1)), EUnit)
+  let fill = EWhile(EBinOp("<", i, n), ESeq(push, step))
+  let ret = ESeq(fill, b)
+  let mk = ECall(EIdent("Bytes::new", -1), array_empty(), -1)
+  let z = EInt(0)
+  // The three binders below are FIXED, and match the linear lane exactly.
+  // Gensyming here would reintroduce per-lane divergence, which is the bug
+  // this file exists to prevent. `__bn_*` is reserved-prefix and cannot
+  // collide with a user binding.
+  let body = ELetMut("__bn_i", z, ret, -1)
+  // review-lint: allow-fixed-synthetic-name -- matches linear
+  let alloc = ELet("__bn_b", mk, body, -1)
+  // review-lint: allow-fixed-synthetic-name -- matches linear
+  ELet("__bn_n", n_expr, alloc, -1)
+  // review-lint: allow-fixed-synthetic-name -- matches linear
+}

--- a/lib/@vibe/compiler/codegen/expr/compile_call.vibe
+++ b/lib/@vibe/compiler/codegen/expr/compile_call.vibe
@@ -104,6 +104,7 @@ import @vibe/compiler/codegen/common_base {
   region_try_body_ld,
   resolve_func,
   resolve_local,
+  sized_bytes_new_expr,
   struct_field_candidates,
   struct_field_dispatch_cases
 }
@@ -5116,13 +5117,7 @@ fn compile_call_core(buf: Bytes, callee: Expr, args: Array[Expr], local_names: A
       // the argument and then call it anyway — the operand stayed stranded on
       // the value stack and the whole module failed validation at
       // instantiation time. Synthesize new() + a zero-push loop instead.
-      let n_expr = Array::get(args, 0)
-      let loop_body = ESeq(ECall(EIdent("Bytes::push", -1), [
-        EIdent("__bn_b", -1),
-        EInt(0)
-      ], -1), EAssign("__bn_i", EBinOp("+", EIdent("__bn_i", -1), EInt(1)), EUnit))
-      let synth = ELet("__bn_n", n_expr, ELet("__bn_b", ECall(EIdent("Bytes::new", -1), array_empty(), -1), ELetMut("__bn_i", EInt(0), ESeq(EWhile(EBinOp("<", EIdent("__bn_i", -1), EIdent("__bn_n", -1)), loop_body), EIdent("__bn_b", -1)), -1), -1), -1)
-      ce(buf, synth, local_names, next_local, ctx, ld)
+      ce(buf, sized_bytes_new_expr(Array::get(args, 0)), local_names, next_local, ctx, ld)
     }
     else {
       // #875: a name that is BOTH a func_table entry (some unrelated

--- a/lib/@vibe/compiler/codegen/gc/backend_call.vibe
+++ b/lib/@vibe/compiler/codegen/gc/backend_call.vibe
@@ -74,6 +74,7 @@ import @vibe/compiler/codegen/common_base {
   region_try_body_ld,
   resolve_func,
   resolve_local,
+  sized_bytes_new_expr,
   struct_field_candidates,
   struct_field_dispatch_cases
 }
@@ -2080,6 +2081,26 @@ fn compile_call_gc(buf: Bytes, callee: Expr, args: Array[Expr], local_names: Arr
           emit_i64_const(buf, 0)
         }
         nl
+      }
+      // review-lint: allow-gc-direct-abi-unlisted
+      else if fname == "Bytes::new" && Array::length(args) == 1 && !gc_name_is_user_defined(ctx, local_names, fname) {
+        // Bytes::new(n): length-n zero-filled buffer. The runtime bytes_new
+        // takes NO operands, so the generic path emits `n` and then calls the
+        // zero-parameter body anyway, stranding the argument. This lane had no
+        // counterpart to the linear lane's synthesis, which made the
+        // one-argument overload linear-only -- clean under `vibe check` on both
+        // lanes, past `wasmtime compile`, failing at run time on one (#2363).
+        // The synthesis is SHARED now (common_base/sized_bytes_new_expr.vibe),
+        // so this arm and the linear one are the same single call and cannot
+        // drift apart again.
+        //
+        // The guard is gc_name_is_user_defined, NOT `!source_is_bound`: on this
+        // backend the generated builtin BODIES live in ctx.func_table, so
+        // `source_is_bound` is true for every builtin and the `!source_is_bound`
+        // arms further up are reachable only for region-surface names that have
+        // no body (MutList::/MutBytes::). Guarding this arm that way compiled,
+        // linked, and simply never fired -- measured, not reasoned.
+        ce(buf, sized_bytes_new_expr(Array::get(args, 0)), local_names, next_local, ld)
       }
       else if fname == "eq" && !gc_name_is_user_defined(ctx, local_names, fname) {
         // #2309 (Codex review on #2312): unconditional until now, so a program

--- a/lib/@vibe/compiler/compiler_sources_manifest.tsv
+++ b/lib/@vibe/compiler/compiler_sources_manifest.tsv
@@ -124,6 +124,7 @@ codegen	codegen/expr/compile_lambda.vibe
 codegen	codegen/common_base/double_to_string_expr.vibe
 codegen	codegen/common_base/int_parse_expr.vibe
 codegen	codegen/common_base/double_parse_expr.vibe
+codegen	codegen/common_base/sized_bytes_new_expr.vibe
 codegen	codegen/expr/compile_call.vibe
 codegen	codegen/expr/compile_expr_tail7.vibe
 codegen	codegen/expr/compile_expr_tail6.vibe

--- a/lib/@vibe/core/hashmap.vibe
+++ b/lib/@vibe/core/hashmap.vibe
@@ -70,16 +70,20 @@ export struct MutMap[K, V] {
 ///   >= 128   occupied, low 7 bits = fingerprint (see `ctrl_tag`)
 ///
 /// EMPTY is 0 so that allocating a table needs no separate initialisation pass.
-/// This is `Bytes::new()` + `Bytes::fill`, NOT the sized `Bytes::new(cap)`
-/// overload, which is **linear-backend only**: `compile_call.vibe` synthesises
-/// the fill loop for a one-argument `Bytes::new`, and `codegen/gc/backend_call.vibe`
-/// has no counterpart, so on wasm-gc the argument is emitted and then the
-/// zero-parameter runtime body is called. Measured on a self-contained file,
-/// `Bytes::new(n)` passes on linear and FAILS on gc, while this spelling passes
-/// on both. Tracked as its own compiler gap; until it is closed, MutMap must not
-/// use the sized overload, since a `MutMap` reached on the gc lane would break
-/// for a reason nothing in this file mentions. Tracked as #2363; the both-lane
-/// spelling is pinned by fixtures/bytes_alloc_backend_parity_test.vibe.
+/// This is `Bytes::new()` + `Bytes::fill`, not the one-argument `Bytes::new(cap)`
+/// overload. The overload was LINEAR-ONLY when this was written -- the gc call
+/// path had no counterpart to the linear lane's synthesis, so it type-checked
+/// on both lanes and failed at run time on one (#2363).
+///
+/// #2363 is FIXED: `codegen/gc/backend_call.vibe` now carries the same
+/// synthesis, and both spellings are pinned on both lanes by
+/// `fixtures/bytes_alloc_backend_parity_test.vibe`. This still does not use the
+/// overload, because the COMMITTED SEED predates the fix and `vibe test` /
+/// `vibe fmt` compile `lib/**` with the seed (CLAUDE.md, "Which compiler
+/// answered?"). Switching here before the next bootstrap bump would break the
+/// gc lane for a reason that is already fixed in the source. Worth revisiting
+/// after the bump: measured, the overload is worth about 2% on table build
+/// (1.033x -> 1.053x against the pre-#2346 baseline), and nothing else.
 fn alloc_ctrl(cap: Int) -> Bytes {
   let b = Bytes::new()
   Bytes::fill(b, 0, cap)

--- a/scripts/lint_review_regressions.sh
+++ b/scripts/lint_review_regressions.sh
@@ -195,28 +195,18 @@ else
   # branch merges main, the AST backend above takes over automatically.
   violations="$(printf '%s\n' "$diff" \
   | awk '
-      # A binder is allowed by a marker on its OWN line or on the line AFTER
-      # it, matching is_allowed() in review_lint.vibex -- `pkf run fmt` moves a
-      # trailing comment onto the next line, so the documented form never
-      # survives in lib/**. Resolving one line late is what the `pending` state
-      # is for. Deliberately NOT the line before: that direction would let one
-      # marker cover two adjacent binders. Keep these two tiers in step; a
-      # bootstrap checkout with no stage2 runs THIS one, and a mismatch means
-      # code that commits with a stage2 and is rejected without one.
-      function flush_pending() {
-        if (pending) {
-          printf "%s:%d:%s\n", p_path, p_line, p_text
-          pending = 0
-        }
-      }
+      # Emit a CANDIDATE for every added binder whose own line carries no
+      # marker. The next-line case is settled below against the physical file,
+      # not against the diff -- a marker that already existed is unchanged
+      # context and never appears in `git diff --unified=0`, so deciding it
+      # here would reject a binder whose suppression is sitting one line down.
+      # That is the shape is_allowed() reads, and the two tiers have to agree.
       /^\+\+\+ / {
-        flush_pending()
         path = $2
         sub(/^[^\/]*\//, "", path)
         next
       }
       /^@@ / {
-        flush_pending()
         if (match($0, /\+[0-9]+/)) {
           line = substr($0, RSTART + 1, RLENGTH - 1) + 0
         }
@@ -224,28 +214,35 @@ else
       }
       /^\+/ && !/^\+\+\+/ {
         text = substr($0, 2)
-        marked = text ~ /review-lint: allow-fixed-synthetic-name/
-        if (pending) {
-          if (marked) {
-            pending = 0
-          } else {
-            flush_pending()
-          }
-        }
         in_transform = path ~ /^lib\/@vibe\/compiler\/(normalize|codegen|loader)\/.*\.vibe$/
         is_binder = in_transform && (text ~ /E(Let|LetMut|LetRec)\("__[A-Za-z0-9_]+"/ \
           || text ~ /PBind\("__[A-Za-z0-9_]+"/ \
           || text ~ /SLet\([^)]*"__[A-Za-z0-9_]+"/)
+        marked = text ~ /review-lint: allow-fixed-synthetic-name/
         if (is_binder && !marked) {
-          pending = 1
-          p_path = path
-          p_line = line
-          p_text = text
+          printf "%s:%d:%s\n", path, line, text
         }
         line++
       }
-      END { flush_pending() }
-    ')"
+    ' \
+  | while IFS= read -r candidate; do
+      [ -n "$candidate" ] || continue
+      cand_path="${candidate%%:*}"
+      cand_rest="${candidate#*:}"
+      cand_line="${cand_rest%%:*}"
+      # `pkf run fmt` moves a trailing marker onto the following line, so the
+      # suppression is one line BELOW the binder. Read it from the file, which
+      # sees pre-existing markers as well as newly added ones. Never the line
+      # above: that would let one marker cover two adjacent binders.
+      next_line=""
+      if [ -f "$PROJECT_ROOT/$cand_path" ]; then
+        next_line="$(sed -n "$((cand_line + 1))p" "$PROJECT_ROOT/$cand_path" 2>/dev/null || true)"
+      fi
+      case "$next_line" in
+        *"review-lint: allow-fixed-synthetic-name"*) ;;
+        *) printf '%s\n' "$candidate" ;;
+      esac
+    done)"
 fi
 
 if [ -n "$violations" ] || [ "$ast_tool_error" -eq 1 ]; then

--- a/scripts/lint_review_regressions.sh
+++ b/scripts/lint_review_regressions.sh
@@ -231,13 +231,16 @@ else
       cand_rest="${candidate#*:}"
       cand_line="${cand_rest%%:*}"
       # `pkf run fmt` moves a trailing marker onto the following line, so the
-      # suppression is one line BELOW the binder. Read it from the file, which
-      # sees pre-existing markers as well as newly added ones. Never the line
-      # above: that would let one marker cover two adjacent binders.
-      next_line=""
-      if [ -f "$PROJECT_ROOT/$cand_path" ]; then
-        next_line="$(sed -n "$((cand_line + 1))p" "$PROJECT_ROOT/$cand_path" 2>/dev/null || true)"
-      fi
+      # suppression is one line BELOW the binder. Read it from the SAME
+      # SNAPSHOT the candidates came from -- `git show "$SHOW_REF:path"`, the
+      # index when linting `--cached` and HEAD in range mode, exactly what the
+      # AST tier materializes. Reading `$PROJECT_ROOT` instead would read the
+      # working tree, and a marker added as an UNSTAGED edit would then
+      # suppress a staged binder: the lint would pass while the committed
+      # snapshot still violates it. Never the line above: that would let one
+      # marker cover two adjacent binders.
+      next_line="$(git -C "$PROJECT_ROOT" show "$SHOW_REF:$cand_path" 2>/dev/null \
+        | sed -n "$((cand_line + 1))p" || true)"
       case "$next_line" in
         *"review-lint: allow-fixed-synthetic-name"*) ;;
         *) printf '%s\n' "$candidate" ;;

--- a/scripts/lint_review_regressions.sh
+++ b/scripts/lint_review_regressions.sh
@@ -195,12 +195,28 @@ else
   # branch merges main, the AST backend above takes over automatically.
   violations="$(printf '%s\n' "$diff" \
   | awk '
+      # A binder is allowed by a marker on its OWN line or on the line AFTER
+      # it, matching is_allowed() in review_lint.vibex -- `pkf run fmt` moves a
+      # trailing comment onto the next line, so the documented form never
+      # survives in lib/**. Resolving one line late is what the `pending` state
+      # is for. Deliberately NOT the line before: that direction would let one
+      # marker cover two adjacent binders. Keep these two tiers in step; a
+      # bootstrap checkout with no stage2 runs THIS one, and a mismatch means
+      # code that commits with a stage2 and is rejected without one.
+      function flush_pending() {
+        if (pending) {
+          printf "%s:%d:%s\n", p_path, p_line, p_text
+          pending = 0
+        }
+      }
       /^\+\+\+ / {
+        flush_pending()
         path = $2
         sub(/^[^\/]*\//, "", path)
         next
       }
       /^@@ / {
+        flush_pending()
         if (match($0, /\+[0-9]+/)) {
           line = substr($0, RSTART + 1, RLENGTH - 1) + 0
         }
@@ -208,16 +224,27 @@ else
       }
       /^\+/ && !/^\+\+\+/ {
         text = substr($0, 2)
+        marked = text ~ /review-lint: allow-fixed-synthetic-name/
+        if (pending) {
+          if (marked) {
+            pending = 0
+          } else {
+            flush_pending()
+          }
+        }
         in_transform = path ~ /^lib\/@vibe\/compiler\/(normalize|codegen|loader)\/.*\.vibe$/
         is_binder = in_transform && (text ~ /E(Let|LetMut|LetRec)\("__[A-Za-z0-9_]+"/ \
           || text ~ /PBind\("__[A-Za-z0-9_]+"/ \
           || text ~ /SLet\([^)]*"__[A-Za-z0-9_]+"/)
-        allowed = text ~ /review-lint: allow-fixed-synthetic-name/
-        if (is_binder && !allowed) {
-          printf "%s:%d:%s\n", path, line, text
+        if (is_binder && !marked) {
+          pending = 1
+          p_path = path
+          p_line = line
+          p_text = text
         }
         line++
       }
+      END { flush_pending() }
     ')"
 fi
 

--- a/scripts/lint_review_regressions_test.sh
+++ b/scripts/lint_review_regressions_test.sh
@@ -58,6 +58,113 @@ EOF
 git -C "$TMP_ROOT" add .
 VIBE_REVIEW_LINT_PROJECT_ROOT="$TMP_ROOT" "$CHECK_SCRIPT" >/dev/null
 
+# --- the marker on the line AFTER the binder (#2363) --------------------------
+# `pkf run fmt` moves a trailing comment onto the next line, so this is the
+# shape the suppression actually has everywhere lib/** is formatted. An
+# exact-line test made the documented form unusable; this case is why the
+# check accepts line + 1.
+git -C "$TMP_ROOT" reset -q HEAD -- .
+git -C "$TMP_ROOT" restore .
+cat >> "$TMP_ROOT/lib/@vibe/compiler/normalize/pass.vibe" <<'EOF'
+fn formatted(e: Expr) -> Expr {
+  ELet("__fmt_tmp", e, e, -1)
+  // review-lint: allow-fixed-synthetic-name -- marker moved down by the formatter
+}
+EOF
+git -C "$TMP_ROOT" add .
+if ! VIBE_REVIEW_LINT_PROJECT_ROOT="$TMP_ROOT" "$CHECK_SCRIPT" >"$TMP_ROOT/fmt.out" 2>&1; then
+  echo "review-regressions lint self-test: a marker on the NEXT line must suppress" >&2
+  cat "$TMP_ROOT/fmt.out" >&2
+  exit 1
+fi
+
+# --- ADJACENCY: one marker must not cover two binders (#2366 review) ----------
+# Two binders, but only the FIRST is marked. Accepting `line - 1` would let the
+# first binder's marker suppress the second, so an unreviewed fixed synthetic
+# binder would evade the lint entirely. The second binder MUST still be
+# reported.
+git -C "$TMP_ROOT" reset -q HEAD -- .
+git -C "$TMP_ROOT" restore .
+cat >> "$TMP_ROOT/lib/@vibe/compiler/normalize/pass.vibe" <<'EOF'
+fn adjacent(e: Expr) -> Expr {
+  ELet("__adj_marked", e, e, -1)
+  // review-lint: allow-fixed-synthetic-name -- belongs to __adj_marked only
+  ELet("__adj_unmarked", e, e, -1)
+}
+EOF
+git -C "$TMP_ROOT" add .
+if VIBE_REVIEW_LINT_PROJECT_ROOT="$TMP_ROOT" "$CHECK_SCRIPT" >"$TMP_ROOT/adj.out" 2>&1; then
+  echo "review-regressions lint self-test: an unmarked binder next to a marked one must still be reported" >&2
+  cat "$TMP_ROOT/adj.out" >&2
+  exit 1
+fi
+if ! grep -q '__adj_unmarked' "$TMP_ROOT/adj.out"; then
+  echo "review-regressions lint self-test: adjacency case reported the wrong binder" >&2
+  cat "$TMP_ROOT/adj.out" >&2
+  exit 1
+fi
+if grep -q '__adj_marked' "$TMP_ROOT/adj.out"; then
+  echo "review-regressions lint self-test: the MARKED binder must stay suppressed" >&2
+  cat "$TMP_ROOT/adj.out" >&2
+  exit 1
+fi
+
+# --- ADJACENCY on the AST tier (#2366 review) --------------------------------
+# The case above exercises the AWK fallback. The AST backend resolves the
+# suppression in review_lint.vibex::is_allowed -- a DIFFERENT implementation of
+# the same rule -- so it needs its own case, or the two tiers can disagree.
+# That split is exactly what made this fix necessary: the .vibex tier accepted
+# the formatted marker while the fallback still rejected it.
+#
+# Shape (post-formatter):
+#   ELet("__ast_adj_marked", ...)
+#   // review-lint: allow-fixed-synthetic-name   <- belongs to the line ABOVE
+#   ELet("__ast_adj_unmarked", ...)
+# Accepting `line - 1` would let that one marker cover the SECOND binder too.
+git -C "$TMP_ROOT" reset -q HEAD -- .
+git -C "$TMP_ROOT" restore .
+cat >> "$TMP_ROOT/lib/@vibe/compiler/normalize/pass.vibe" <<'ADJEOF'
+fn ast_adjacent(e: Expr) -> Expr {
+  ELet("__ast_adj_marked", e, e, -1)
+  // review-lint: allow-fixed-synthetic-name -- belongs to __ast_adj_marked only
+  ELet("__ast_adj_unmarked", e, e, -1)
+}
+ADJEOF
+git -C "$TMP_ROOT" add .
+
+cat > "$TMP_ROOT/fake-vibe-adjacency" <<'FAKEEOF'
+#!/usr/bin/env bash
+root="${@: -1}"
+f="$root/lib/@vibe/compiler/normalize/pass.vibe"
+if [[ "$*" == *'SLet('* || "$*" == *'EAssignOp('* || "$*" == *'String::contains('* ]]; then
+  echo '[]'; exit 0
+fi
+m=$(grep -n '__ast_adj_marked' "$f" | head -1 | cut -d: -f1)
+u=$(grep -n '__ast_adj_unmarked' "$f" | head -1 | cut -d: -f1)
+jq -n --arg path "$f" --argjson m "$m" --argjson u "$u" \
+  '[{path:$path,line:$m,col:1,start:1,end:2,text:"ELet(\"__ast_adj_marked\", e, e, -1)",captures:{ctor:{text:"ELet",start:1},name:{text:"\"__ast_adj_marked\"",start:2},rest:{text:"e, e, -1",start:3}}},
+    {path:$path,line:$u,col:1,start:1,end:2,text:"ELet(\"__ast_adj_unmarked\", e, e, -1)",captures:{ctor:{text:"ELet",start:1},name:{text:"\"__ast_adj_unmarked\"",start:2},rest:{text:"e, e, -1",start:3}}}]'
+FAKEEOF
+chmod +x "$TMP_ROOT/fake-vibe-adjacency"
+
+if VIBE_REVIEW_LINT_PROJECT_ROOT="$TMP_ROOT" \
+  VIBE_REVIEW_LINT_GREP_BIN="$TMP_ROOT/fake-vibe-adjacency" \
+  "$CHECK_SCRIPT" >"$TMP_ROOT/ast-adj.out" 2>&1; then
+  echo "review-regressions lint self-test: AST tier let an unmarked adjacent binder through" >&2
+  cat "$TMP_ROOT/ast-adj.out" >&2
+  exit 1
+fi
+if ! grep -q '__ast_adj_unmarked' "$TMP_ROOT/ast-adj.out"; then
+  echo "review-regressions lint self-test: AST adjacency case reported the wrong binder" >&2
+  cat "$TMP_ROOT/ast-adj.out" >&2
+  exit 1
+fi
+if grep -q '__ast_adj_marked' "$TMP_ROOT/ast-adj.out"; then
+  echo "review-regressions lint self-test: AST tier must keep the MARKED binder suppressed" >&2
+  cat "$TMP_ROOT/ast-adj.out" >&2
+  exit 1
+fi
+
 git -C "$TMP_ROOT" reset -q HEAD -- .
 git -C "$TMP_ROOT" restore .
 cat >> "$TMP_ROOT/lib/@vibe/compiler/normalize/pass.vibe" <<'EOF'

--- a/scripts/lint_review_regressions_test.sh
+++ b/scripts/lint_review_regressions_test.sh
@@ -557,4 +557,32 @@ if ! grep -q '__preexisting_new' "$TMP_ROOT/preexisting-gone.out"; then
 fi
 git -C "$TMP_ROOT" reset -q --hard HEAD
 
+# --- the marker must be in the SNAPSHOT, not just the working tree ----------
+# Candidates come from `git diff --cached`, so the suppression has to be read
+# from the index too. Reading $PROJECT_ROOT instead let a developer stage an
+# unsuppressed binder and add the marker as an UNSTAGED edit: the lint passed
+# while the committed snapshot still violated it -- certifying something
+# untrue, which is worse than a false positive.
+git -C "$TMP_ROOT" reset -q --hard HEAD
+cat >> "$TMP_ROOT/lib/@vibe/compiler/normalize/pass.vibe" <<'SNAPEOF'
+fn staged_only(e: Expr) -> Expr {
+  ELet("__staged_only", e, e, -1)
+}
+SNAPEOF
+git -C "$TMP_ROOT" add .
+# the marker exists ONLY in the working tree, never staged
+perl -0pi -e 's/(  ELet\("__staged_only", e, e, -1\)\n)/$1  \/\/ review-lint: allow-fixed-synthetic-name\n/' \
+  "$TMP_ROOT/lib/@vibe/compiler/normalize/pass.vibe"
+if VIBE_REVIEW_LINT_PROJECT_ROOT="$TMP_ROOT" "$CHECK_SCRIPT" >"$TMP_ROOT/snap.out" 2>&1; then
+  echo "review-regressions lint self-test: an UNSTAGED marker must not suppress a STAGED binder" >&2
+  cat "$TMP_ROOT/snap.out" >&2
+  exit 1
+fi
+if ! grep -q '__staged_only' "$TMP_ROOT/snap.out"; then
+  echo "review-regressions lint self-test: snapshot case reported the wrong binder" >&2
+  cat "$TMP_ROOT/snap.out" >&2
+  exit 1
+fi
+git -C "$TMP_ROOT" reset -q --hard HEAD
+
 echo "review-regressions lint self-test: ok"

--- a/scripts/lint_review_regressions_test.sh
+++ b/scripts/lint_review_regressions_test.sh
@@ -512,4 +512,49 @@ if VIBE_REVIEW_LINT_PROJECT_ROOT="$TMP_ROOT" \
   exit 1
 fi
 
+
+# --- an EDITED binder whose marker already existed (#2366 review, 2nd round) --
+# The fallback reads a diff, and `git diff --unified=0` shows only changed
+# lines. A marker that was already there is unchanged context and never appears
+# in it. Resolving the suppression from the DIFF therefore rejected a binder
+# whose marker is sitting one line below it in the file -- while is_allowed(),
+# which reads the file, accepted the same staged source. The fallback reads the
+# physical next line now, so both tiers answer the same question.
+git -C "$TMP_ROOT" reset -q HEAD -- .
+git -C "$TMP_ROOT" restore .
+cat >> "$TMP_ROOT/lib/@vibe/compiler/normalize/pass.vibe" <<'EDITEOF'
+fn preexisting(e: Expr) -> Expr {
+  ELet("__preexisting_old", e, e, -1)
+  // review-lint: allow-fixed-synthetic-name -- committed before the edit
+}
+EDITEOF
+git -C "$TMP_ROOT" add .
+git -C "$TMP_ROOT" -c user.email=selftest@example.com -c user.name=selftest commit -qm "marker committed"
+
+# rename the binder, leaving the marker line untouched
+sed -i.bak 's/__preexisting_old/__preexisting_new/' "$TMP_ROOT/lib/@vibe/compiler/normalize/pass.vibe"
+rm -f "$TMP_ROOT/lib/@vibe/compiler/normalize/pass.vibe.bak"
+git -C "$TMP_ROOT" add .
+if ! VIBE_REVIEW_LINT_PROJECT_ROOT="$TMP_ROOT" "$CHECK_SCRIPT" >"$TMP_ROOT/preexisting.out" 2>&1; then
+  echo "review-regressions lint self-test: an UNCHANGED next-line marker must still suppress" >&2
+  cat "$TMP_ROOT/preexisting.out" >&2
+  exit 1
+fi
+
+# and deleting that marker must bring the violation back
+sed -i.bak '/review-lint: allow-fixed-synthetic-name -- committed before the edit/d' "$TMP_ROOT/lib/@vibe/compiler/normalize/pass.vibe"
+rm -f "$TMP_ROOT/lib/@vibe/compiler/normalize/pass.vibe.bak"
+git -C "$TMP_ROOT" add .
+if VIBE_REVIEW_LINT_PROJECT_ROOT="$TMP_ROOT" "$CHECK_SCRIPT" >"$TMP_ROOT/preexisting-gone.out" 2>&1; then
+  echo "review-regressions lint self-test: deleting the marker must re-report the binder" >&2
+  cat "$TMP_ROOT/preexisting-gone.out" >&2
+  exit 1
+fi
+if ! grep -q '__preexisting_new' "$TMP_ROOT/preexisting-gone.out"; then
+  echo "review-regressions lint self-test: wrong binder reported after marker deletion" >&2
+  cat "$TMP_ROOT/preexisting-gone.out" >&2
+  exit 1
+fi
+git -C "$TMP_ROOT" reset -q --hard HEAD
+
 echo "review-regressions lint self-test: ok"

--- a/scripts/review_lint.vibex
+++ b/scripts/review_lint.vibex
@@ -70,17 +70,28 @@ fn source_line(path: String, line: Int) -> String with Fs {
 }
 
 fn is_allowed(path: String, line: Int) -> Bool with Fs {
-  // line +-1, exactly like gc_drift_suppressed below, and for a concrete
-  // reason: `pkf run fmt` MOVES A TRAILING COMMENT ONTO THE NEXT LINE. The
-  // documented form -- `ELet("__x", ...) // review-lint: allow-fixed-synthetic-name`
-  // -- therefore never survives in lib/**, which vibe-fmt-check enforces, so
-  // an exact-line test made this suppression unusable everywhere it applies.
-  // The lint's own self-test passes only because its fixture is a shell
-  // heredoc that the formatter never sees.
+  // The binder's own line, or the line AFTER it -- and deliberately NOT the
+  // line before.
+  //
+  // After it, because `pkf run fmt` MOVES A TRAILING COMMENT ONTO THE NEXT
+  // LINE. The documented form -- `ELet("__x", ...) // review-lint:
+  // allow-fixed-synthetic-name` -- therefore never survives in lib/**, which
+  // vibe-fmt-check enforces, so an exact-line test made this suppression
+  // unusable everywhere it applies. The lint's own self-test passes only
+  // because its fixture is a shell heredoc the formatter never sees.
+  //
+  // NOT before it, because that direction lets ONE marker cover TWO binders.
+  // Formatted output interleaves them --
+  //   45  let body  = ELetMut("__bn_i", ...)
+  //   46  // review-lint: allow-fixed-synthetic-name     <- 45's marker
+  //   47  let alloc = ELet("__bn_b", ...)
+  // -- so a `line - 1` test lets 46 suppress 47 as well, and deleting 47's own
+  // marker leaves it silently allowed. One-directional keeps each marker bound
+  // to exactly one binder. Pinned by the adjacency case in
+  // scripts/lint_review_regressions_test.sh.
   let marker = "review-lint: allow-fixed-synthetic-name"
   String::contains(source_line(path, line), marker) ||
-  String::contains(source_line(path, line + 1), marker) ||
-  String::contains(source_line(path, line - 1), marker)
+  String::contains(source_line(path, line + 1), marker)
 }
 
 fn is_transform_path(path: String) -> Bool {

--- a/scripts/review_lint.vibex
+++ b/scripts/review_lint.vibex
@@ -70,7 +70,17 @@ fn source_line(path: String, line: Int) -> String with Fs {
 }
 
 fn is_allowed(path: String, line: Int) -> Bool with Fs {
-  String::contains(source_line(path, line), "review-lint: allow-fixed-synthetic-name")
+  // line +-1, exactly like gc_drift_suppressed below, and for a concrete
+  // reason: `pkf run fmt` MOVES A TRAILING COMMENT ONTO THE NEXT LINE. The
+  // documented form -- `ELet("__x", ...) // review-lint: allow-fixed-synthetic-name`
+  // -- therefore never survives in lib/**, which vibe-fmt-check enforces, so
+  // an exact-line test made this suppression unusable everywhere it applies.
+  // The lint's own self-test passes only because its fixture is a shell
+  // heredoc that the formatter never sees.
+  let marker = "review-lint: allow-fixed-synthetic-name"
+  String::contains(source_line(path, line), marker) ||
+  String::contains(source_line(path, line + 1), marker) ||
+  String::contains(source_line(path, line - 1), marker)
 }
 
 fn is_transform_path(path: String) -> Bool {


### PR DESCRIPTION
Closes #2363. Also carries step 1 of #2345.

Both commits are the same shape of change: **one implementation, called by both backends, replacing two hand-written copies.**

---

## #2363 — sized `Bytes::new` was linear-only

`Bytes::new(n)` — the one-argument overload yielding a zero-filled buffer of length `n` — worked on linear and **failed on wasm-gc**. The linear lane special-cased it and synthesised `new()` + a zero-push loop; the gc call path had no counterpart, and the registry declares `Bytes::new` with `reg_p0()`, so on gc the argument was pushed and the zero-parameter body called anyway.

**Why P1 rather than P2.** `vibe check` is clean on *both* lanes, the emitted module *passes* `wasmtime compile`, and it breaks at run time on one of them. Nothing in the source names a backend, so every obvious check says the code is fine.

Measured on two stage2 builds from the same tree, differing only by this change:

| | linear | wasm-gc |
| :--- | :--- | :--- |
| before | 1 passed, 0 failed | **0 passed, 1 FAILED** |
| after | 1 passed, 0 failed | **1 passed, 0 failed** |

The synthesis now lives in `codegen/common_base/sized_bytes_new_expr.vibe`, following the `int_parse_expr` / `double_parse_expr` precedent, and both arms are one call to it. Mirroring linear's code into gc would have fixed the symptom and left the cause: two hand-written lowerings of one overload is *what let the lanes drift*.

**Compiler output unchanged**: `size_ratchet` reports **0 B delta on all five samples**. stage2 itself shrinks 1,959 B.

### The first attempt compiled, linked, and never fired

It guarded on `!source_is_bound`, copied from the `MutList::`/`MutBytes::` arms above. That predicate uses `func_table_index_of` over the **whole** table, and on gc the generated builtin *bodies* are in that table — so `source_is_bound` is true for every builtin, and those arms fire only for region-surface names with no body. The arm needs `gc_name_is_user_defined`, as the `eq` / `not` / `assert` arms use. Caught only because the after-measurement still showed gc failing with a change provably present in the built compiler.

---

## #2345 step 1 — extract the windowed substring search

Pure code motion: the emitter calls inline in `gen_string_index_of_body` now live in `emit_windowed_substring_search`, called from the same place.

**Verified byte-identical**, which is the only reason to believe "pure code motion" — same program, stage2 from before and after:

| | output hash | size |
| :--- | :--- | ---: |
| before | `8e3b565f9a105d21` | 7803 B |
| after | `8e3b565f9a105d21` | 7803 B |

covering `String::index_of`, `String::contains` and `String::last_index_of`, which share the body.

The interface is the finding, not the refactor: four i32 locals the caller populates (2/3 lengths, 5/6 data pointers, 8 last valid start). Everything above unpacks a handle; every byte below is representation-independent. `String` fills them from a packed `(ptr << 32) | len` fat value, `Bytes` from a heap handle (`i32.load offset=8` data, `offset=4` length) — two types with nothing else in common, one search.

This adds **no** `Bytes` API. #2345 as filed proposed routing `String::*` through new `Bytes` primitives, which had it backwards: `String::index_of` is *already* a SIMD memchr (ADR-0054 measures the window at ~5.1×), so an independently-written `Bytes` search would be the slow one and routing five already-SIMD functions through it could only regress them. Extracting first makes the routing question moot — once both call this, they are the same loop.

---

## Lint mechanism fix (from this PR's review)

`review_lint.vibex`'s `is_allowed` now accepts the marker on the binder's own line **or the line after it, never the line before**, and the AWK bootstrap fallback in `lint_review_regressions.sh` matches.

`pkf run fmt` moves a trailing comment onto the next line, so the documented suppression form — the one the lint's own self-test demonstrates — never survived in `lib/**`, which `vibe-fmt-check` enforces. Accepting `line - 1` instead would have let one marker cover two adjacent binders.

Three cases added, each verified to fail without its fix: `formatted-marker` and `adjacency` on the fallback tier, `adjacency` on the AST tier. The AST case needs its own fixture because `is_allowed` is a *second* implementation of the same rule — a divergence between the tiers is exactly what this fix is about.

**My original red test could not have caught the adjacency bug**: it stripped all three markers at once, so every binder lost its own marker and its neighbour's together. A red test that removes everything proves *something* is checked, not that each thing is.

---

## Tests

`fixtures/bytes_alloc_backend_parity_test.vibe` pins **both** spellings on **both** lanes and asserts they agree element for element; red-tested against the pre-fix compiler (passes on linear, fails on gc). The full enforced gc fixture list (12 files) and the MutMap suites pass on the rebuilt compiler.

## Docs corrected, not appended to

The cheatsheet row goes back to `linear / gc`. `MutMap`'s control array **keeps** the portable spelling, and its comment says why: the committed seed predates this fix and `vibe test` / `vibe fmt` compile `lib/**` with the seed, so switching before the next bootstrap bump would break the gc lane for a reason already fixed in source. Worth ~2% on table build once that bump lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FYMVd6D2o82suTfTwoJPMf