### PR TITLE
Fix wasm-gc handle result slot accounting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -874,6 +874,8 @@ jobs:
             fixtures/float_return_review_gc.vibe \
             fixtures/int_bit_primitives_test.vibe \
             fixtures/bytes_alloc_backend_parity_test.vibe \
+            fixtures/gc_handle_aggregate_test.vibe \
+            fixtures/constructor_indexed_map_gc_test.vibe \
             fixtures/constructor_indexed_async_iter_gc_test.vibe
 
   # The 467-file selfhost unit-test battery (#531/#535), weight-balanced into

--- a/fixtures/gc_handle_aggregate_test.vibe
+++ b/fixtures/gc_handle_aggregate_test.vibe
@@ -6,12 +6,14 @@ test "non-firing handler preserves an array" {
   let values = handle {
     [1, 2]
   } with { Exception::Throw(_) => [] }
-  assert_eq(values, [1, 2])
+  inspect(Array::length(values), "2")
+  inspect(Array::get(values, 0), "1")
+  inspect(Array::get(values, 1), "2")
 }
 
 test "non-firing handler preserves a scalar control" {
   let value = handle {
     42
   } with { Exception::Throw(_) => 0 }
-  assert_eq(value, 42)
+  inspect(value, "42")
 }

--- a/fixtures/gc_handle_aggregate_test.vibe
+++ b/fixtures/gc_handle_aggregate_test.vibe
@@ -1,0 +1,17 @@
+// Regression for #2356: a non-firing abortive handler must preserve the
+// handled expression value on every backend. The handler is deliberately
+// independent of trait/dictionary lowering.
+
+test "non-firing handler preserves an array" {
+  let values = handle {
+    [1, 2]
+  } with { Exception::Throw(_) => [] }
+  assert_eq(values, [1, 2])
+}
+
+test "non-firing handler preserves a scalar control" {
+  let value = handle {
+    42
+  } with { Exception::Throw(_) => 0 }
+  assert_eq(value, 42)
+}

--- a/lib/@vibe/compiler/codegen/gc/backend_expr.vibe
+++ b/lib/@vibe/compiler/codegen/gc/backend_expr.vibe
@@ -2226,6 +2226,16 @@ fn compile_expr_gc(buf: Bytes, expr: Expr, local_names: Array[String], next_loca
         if nl_h2 > nl_h {
           nl_h = nl_h2
         }
+        // #2356: the handler arm is a sibling control-flow path, but its
+        // locals still contribute to the function frame high-water mark.
+        // Keep local_names aligned with that returned mark after dropping the
+        // arm scope. Otherwise the next binding records its source name at
+        // the first unpadded slot while emitting local.set at nl_h. Later
+        // lookups then read the never-executed catch-arm local instead of the
+        // successful handle result (observed as a corrupted Array on wasm-gc).
+        while Array::length(local_names) < nl_h {
+          Array::push(local_names, "")
+        }
         nl_h
       }
     },

--- a/scripts/test_gc_selfbuild.sh
+++ b/scripts/test_gc_selfbuild.sh
@@ -317,6 +317,8 @@ if VIBE_TEST_CLI_WASM="$CLI_WASM" VIBE_TEST_BACKEND=gc \
     fixtures/float_return_review_gc.vibe \
     fixtures/int_bit_primitives_test.vibe \
     fixtures/bytes_alloc_backend_parity_test.vibe \
+    fixtures/gc_handle_aggregate_test.vibe \
+    fixtures/constructor_indexed_map_gc_test.vibe \
     fixtures/constructor_indexed_async_iter_gc_test.vibe > "$gcfx_log" 2>&1; then
   sed 's/^/[gc-selfbuild]   /' "$gcfx_log"
   echo "[gc-selfbuild] gc runtime fixtures ok"


### PR DESCRIPTION
Closes #2356
Closes #2369

## Summary

- keep the wasm-gc local name table aligned with the EHandle frame high-water mark after handler-arm scope cleanup
- pin non-firing aggregate handler results with a backend-independent regression fixture
- run both the focused regression and the constructor-indexed map regression in the required gc-gate and mirrored selfbuild list

## Validation

- PATH=/Users/mz/brew/bin:$PATH pkf run full-gate
- pkf run test-affected (1064/1064 active unit-test files passed)
- explicit wasm-gc runtime fixture list (11/11 files passed)
- bash scripts/vibe_fmt.sh --check on both changed .vibe files
- pkf run lint-architecture
- pkf run check-gate-portability
- git diff --check