### PR TITLE
Bump seed for applied trait impl syntax

### DIFF
--- a/bootstrap/seed.json
+++ b/bootstrap/seed.json
@@ -2,14 +2,14 @@
   "schema": 1,
   "policy": "rust-style-stage0-stage1-stage2",
   "seed": {
-    "name": "qualified-handler-syntax-2026-08-22",
-    "tag": "seed/qualified-handler-syntax-2026-08-22",
-    "source_commit": "475b8761d0e185cb11b8dc0acbce7aa40a1c0c64",
+    "name": "applied-trait-impl-2026-08-28",
+    "tag": "seed/applied-trait-impl-2026-08-28",
+    "source_commit": "ad26d5b486a01eec07676f63a4107629bb59f6b9",
     "entry": "lib/@vibe/compiler/cli_support.vibe",
     "entry_name": "cli_main",
     "artifact": {
       "path": "bootstrap/seed/compiler.wasm",
-      "sha256": "77c4f98ee523d933c60f4c38c8051db246323dca0253ccbc8b6cc4cf4b6e8d9d"
+      "sha256": "7ab89633ccf158691f9898e48afd0f89e1d2022d4bff287a8925a6c7baceb360"
     },
     "runtime": {
       "runner": "node",


### PR DESCRIPTION
## Summary

- adopt a clean `main` stage2 compiler as the next bootstrap seed
- unlock applied trait impl heads such as `impl [T] Iterator[T] for Array[T]` in compiler-owned source
- keep the Iterator ownership change itself out of this prerequisite PR

## Verification

- `pkf run generation -- --stage3`
- stage2 SHA = stage3 SHA = `7ab89633ccf158691f9898e48afd0f89e1d2022d4bff287a8925a6c7baceb360`
- seed release workflow: https://github.com/mizchi/vibe-lang/actions/runs/33176957186
- release: https://github.com/mizchi/vibe-lang/releases/tag/seed/applied-trait-impl-2026-08-28

Prerequisite for #2357.