### PR TITLE
Migrate canonical eager combinator calls to Iterator

### DIFF
--- a/.github/workflows/book-pages.yml
+++ b/.github/workflows/book-pages.yml
@@ -1,9 +1,9 @@
 # Deploy The Vibe Book to GitHub Pages.
 #
-# Build is seed-driven (same as scripts/vibe_book.sh default). The book
-# generator is ordinary vibe; it does not need a fresh stage2. Deploy only
-# from main so a PR cannot overwrite the live site. PRs still build the
-# artifact so a broken generator fails the PR.
+# The book generator resolves the current standard-library closure, so the
+# script builds a current stage2 from the pinned seed before compiling it.
+# Deploy only from main so a PR cannot overwrite the live site. PRs still
+# build the artifact so a broken generator fails the PR.
 name: book-pages
 
 on:

--- a/Taskfile.pkl
+++ b/Taskfile.pkl
@@ -665,6 +665,21 @@ local checkMethodStyleNaming =
   scriptTask("check-method-naming", "scripts/lint_method_style_naming.sh")
 local testCheckMethodStyleNaming =
   scriptTask("test-check-method-naming", "scripts/lint_method_style_naming_test.sh")
+local checkCanonicalIteratorCalls = new Task {
+  name = "check-canonical-iterator-calls"
+  description = "tutorials and examples use the imported Iterator namespace"
+  cmd = "bash scripts/check_canonical_iterator_calls.sh"
+  inputs {
+    "book/**/*.vibe.md"
+    "examples/*.vibe"
+    "scripts/check_canonical_iterator_calls.sh"
+  }
+}
+local testCheckCanonicalIteratorCalls =
+  scriptTask(
+    "test-check-canonical-iterator-calls",
+    "scripts/check_canonical_iterator_calls_test.sh",
+  )
 local testGenerateSelfhostBundle =
   scriptTask("test-generate-bundle", "scripts/generate_bundle_test.sh")
 
@@ -1652,6 +1667,8 @@ local releaseCheck = new Task {
     testPreCommit
     testCheckMethodStyleNaming
     checkMethodStyleNaming
+    testCheckCanonicalIteratorCalls
+    checkCanonicalIteratorCalls
     testCheckFreezeSurface
     checkFreezeSurface
     testCheckVersionLadder
@@ -1737,6 +1754,8 @@ tasks {
   checkFixtureExecution
   checkMethodStyleNaming
   testCheckMethodStyleNaming
+  checkCanonicalIteratorCalls
+  testCheckCanonicalIteratorCalls
   checkFreezeSurface
   testCheckFreezeSurface
   checkVersionLadder

--- a/Taskfile.pkl
+++ b/Taskfile.pkl
@@ -671,7 +671,7 @@ local checkCanonicalIteratorCalls = new Task {
   cmd = "bash scripts/check_canonical_iterator_calls.sh"
   inputs {
     "book/**/*.vibe.md"
-    "examples/*.vibe"
+    "examples/**/*.vibe"
     "scripts/check_canonical_iterator_calls.sh"
   }
 }

--- a/book/en/03_values_functions.vibe.md
+++ b/book/en/03_values_functions.vibe.md
@@ -182,14 +182,14 @@ covers the type properly.
 operator wide:
 
 ```vibe run
+import @vibe/builtin {
+  trait Iterator
+}
+
 fn main with Console {
-  let xs = [
-    1,
-    2,
-    3
-  ]
-  let doubled = Array::map(xs, _ * 2)
-  let total = Array::fold(xs, 0, _ + _)
+  let xs = [1, 2, 3]
+  let doubled = Iterator::map(xs, _ * 2)
+  let total = Iterator::fold(xs, 0, _ + _)
   println("doubled = [\{Array::get(doubled, 0)}, \{Array::get(doubled, 1)}, \{Array::get(doubled, 2)}]")
   println("fold sum = \{total}")
 }

--- a/book/en/04_control_flow.vibe.md
+++ b/book/en/04_control_flow.vibe.md
@@ -109,17 +109,10 @@ body's results. Add a name before the element to get the index:
 
 ```vibe run
 fn main with Console {
-  let doubled = for x in [
-    1,
-    2,
-    3
-  ] {
+  let doubled = for x in [1, 2, 3] {
     x * 2
   }
-  let with_index = for i, x in [
-    10,
-    20
-  ] {
+  let with_index = for i, x in [10, 20] {
     i + x
   }
   println("doubled = [\{Array::get(doubled, 0)}, \{Array::get(doubled, 1)}, \{Array::get(doubled, 2)}]")
@@ -138,22 +131,18 @@ with_index = [10, 21]
 instead of inside out:
 
 ```vibe run
+import @vibe/builtin {
+  trait Iterator
+}
+
 fn pair(a: Int, b: Int) -> Int {
   a * 10 + b
 }
 
 fn main with Console {
   let trimmed_len = "  hi  " |> String::trim |> String::length
-  let arr_len = [
-    1,
-    2,
-    3
-  ] |> Array::length
-  let mapped = [
-    1,
-    2,
-    3
-  ] |> Array::map(_, _ * 2)
+  let arr_len = [1, 2, 3] |> Array::length
+  let mapped = [1, 2, 3] |> Iterator::map(_, _ * 2)
   let repeated = 7 |> pair(_, _)
   println("trimmed_len = \{trimmed_len}")
   println("arr_len = \{arr_len}")
@@ -174,7 +163,7 @@ somewhere else, mark the position with a bare `_`: `x |> f(a, _)` is
 `f(a, x)`, and a slot may repeat, so `7 |> pair(_, _)` is `pair(7, 7)`.
 
 A `_` inside a larger expression is a different thing — the lambda
-shorthand from the last chapter. That is why `Array::map(_, _ * 2)` has
+shorthand from the last chapter. That is why `Iterator::map(_, _ * 2)` has
 two of them doing unrelated jobs: the first is the pipe slot, the second
 is `(v) -> v * 2`.
 

--- a/book/en/13_collections.vibe.md
+++ b/book/en/13_collections.vibe.md
@@ -13,15 +13,15 @@ the end of this chapter.
 `Array` is the primitive sequence: index it, map over it, push to it.
 
 ```vibe run
+import @vibe/builtin {
+  trait Iterator
+}
+
 fn main with Console {
-  let xs = [
-    1,
-    2,
-    3
-  ]
+  let xs = [1, 2, 3]
   println("xs[0] = \{xs[0]}")
   println("length = \{Array::length(xs)}")
-  let doubled = Array::map(xs, _ * 2)
+  let doubled = Iterator::map(xs, _ * 2)
   println("doubled[2] = \{Array::get(doubled, 2)}")
   Array::push(xs, 4)
   println("after push, length = \{Array::length(xs)}")
@@ -88,7 +88,9 @@ and `::new_int` pick a key specialization, so the common cases need no
 hash or equality closure from you.
 
 ```vibe run
-import @vibe/core { struct MutMap }
+import @vibe/core {
+  struct MutMap
+}
 
 fn unwrap_or(o: Option[Int], fallback: Int) -> Int {
   match o {

--- a/book/en/14_iteration.vibe.md
+++ b/book/en/14_iteration.vibe.md
@@ -12,17 +12,16 @@ hold.
 ## One pass over an array
 
 ```vibe run
+import @vibe/builtin {
+  trait Iterator
+}
+
 fn main with Console {
-  let xs = [
-    1,
-    2,
-    3,
-    4
-  ]
-  let evens = Array::filter(xs, (n) -> {
+  let xs = [1, 2, 3, 4]
+  let evens = Iterator::filter(xs, (n) -> {
     n % 2 == 0
   })
-  let sum = Array::fold(xs, 0, _ + _)
+  let sum = Iterator::fold(xs, 0, _ + _)
   let doubled = for x in xs {
     x * 2
   }
@@ -43,9 +42,10 @@ builtin collection, the loop is an expression whose value is `Array[T]` —
 which is why `doubled` can be indexed. `for i, x in xs` binds the index
 too.
 
-`Array::map`, `Array::filter` and `Array::fold` do the same work as
-plain functions. Pick whichever reads better at the call site; both are
-the same single pass.
+`Iterator::map`, `Iterator::filter`, and `Iterator::fold` are eager operations
+provided by the imported trait. `Array` implements `Iterator`, and statically
+known Array receivers compile to the same direct loops as the Array
+specializations, without dictionary-dispatch overhead.
 
 ## Piping
 
@@ -53,14 +53,14 @@ the same single pass.
 unless a bare `_` marks the slot:
 
 ```vibe run
+import @vibe/builtin {
+  trait Iterator
+}
+
 fn main with Console {
   let n = "  vibe  " |> String::trim |> String::length
-  let xs = [
-    1,
-    2,
-    3
-  ]
-  let ys = xs |> Array::map(_, _ * 10)
+  let xs = [1, 2, 3]
+  let ys = xs |> Iterator::map(_, _ * 10)
   println("trimmed length = \{n}")
   println("ys[1] = \{Array::get(ys, 1)}")
 }
@@ -71,13 +71,14 @@ trimmed length = 4
 ys[1] = 20
 ```
 
-`xs |> Array::map(_, _ * 10)` reads as `Array::map(xs, (v) -> v * 10)`.
+`xs |> Iterator::map(_, _ * 10)` reads as
+`Iterator::map(xs, (v) -> v * 10)`.
 The two underscores are different things: the first is the pipe slot,
 the second is a section — shorthand for a lambda over that argument.
 
 ## When it is not an array
 
-There is no lazy combinator chain to assemble. An `Array::*` call and a
+There is no lazy combinator chain to assemble. An `Iterator::*` call and a
 `for` are the eager layer, and they are the whole of it.
 
 The second layer is for values that arrive over time — a stream, a

--- a/book/ja/03_values_functions.vibe.md
+++ b/book/ja/03_values_functions.vibe.md
@@ -178,14 +178,14 @@ hi x3
 `_` は引数の代わりに置けます。ラムダが演算子1つ分の幅なら読みやすくなります:
 
 ```vibe run
+import @vibe/builtin {
+  trait Iterator
+}
+
 fn main with Console {
-  let xs = [
-    1,
-    2,
-    3
-  ]
-  let doubled = Array::map(xs, _ * 2)
-  let total = Array::fold(xs, 0, _ + _)
+  let xs = [1, 2, 3]
+  let doubled = Iterator::map(xs, _ * 2)
+  let total = Iterator::fold(xs, 0, _ + _)
   println("doubled = [\{Array::get(doubled, 0)}, \{Array::get(doubled, 1)}, \{Array::get(doubled, 2)}]")
   println("fold sum = \{total}")
 }

--- a/book/ja/04_control_flow.vibe.md
+++ b/book/ja/04_control_flow.vibe.md
@@ -106,17 +106,10 @@ r = (3, 3)
 
 ```vibe run
 fn main with Console {
-  let doubled = for x in [
-    1,
-    2,
-    3
-  ] {
+  let doubled = for x in [1, 2, 3] {
     x * 2
   }
-  let with_index = for i, x in [
-    10,
-    20
-  ] {
+  let with_index = for i, x in [10, 20] {
     i + x
   }
   println("doubled = [\{Array::get(doubled, 0)}, \{Array::get(doubled, 1)}, \{Array::get(doubled, 2)}]")
@@ -134,22 +127,18 @@ with_index = [10, 21]
 `x |> f` は `f(x)` です。変換を内側から外側へではなく、左から右へ読ませます:
 
 ```vibe run
+import @vibe/builtin {
+  trait Iterator
+}
+
 fn pair(a: Int, b: Int) -> Int {
   a * 10 + b
 }
 
 fn main with Console {
   let trimmed_len = "  hi  " |> String::trim |> String::length
-  let arr_len = [
-    1,
-    2,
-    3
-  ] |> Array::length
-  let mapped = [
-    1,
-    2,
-    3
-  ] |> Array::map(_, _ * 2)
+  let arr_len = [1, 2, 3] |> Array::length
+  let mapped = [1, 2, 3] |> Iterator::map(_, _ * 2)
   let repeated = 7 |> pair(_, _)
   println("trimmed_len = \{trimmed_len}")
   println("arr_len = \{arr_len}")
@@ -170,7 +159,7 @@ repeated = 77
 `7 |> pair(_, _)` は `pair(7, 7)` です。
 
 もっと大きな式の中の `_` は別物で、前章のラムダ略記です。だから
-`Array::map(_, _ * 2)` には無関係な仕事をする `_` が2つあります — 最初が
+`Iterator::map(_, _ * 2)` には無関係な仕事をする `_` が2つあります — 最初が
 パイプのスロット、次が `(v) -> v * 2` です。
 
 次: [型と文字列](05_types_strings.vibe.md)。

--- a/book/ja/13_collections.vibe.md
+++ b/book/ja/13_collections.vibe.md
@@ -12,15 +12,15 @@ English version: [13_collections.vibe.md](../en/13_collections.vibe.md)
 `Array` は基本の列。添字で読み、map をかけ、push する。
 
 ```vibe run
+import @vibe/builtin {
+  trait Iterator
+}
+
 fn main with Console {
-  let xs = [
-    1,
-    2,
-    3
-  ]
+  let xs = [1, 2, 3]
   println("xs[0] = \{xs[0]}")
   println("length = \{Array::length(xs)}")
-  let doubled = Array::map(xs, _ * 2)
+  let doubled = Iterator::map(xs, _ * 2)
   println("doubled[2] = \{Array::get(doubled, 2)}")
   Array::push(xs, 4)
   println("after push, length = \{Array::length(xs)}")
@@ -84,7 +84,9 @@ hello vibe
 渡す必要はない。
 
 ```vibe run
-import @vibe/core { struct MutMap }
+import @vibe/core {
+  struct MutMap
+}
 
 fn unwrap_or(o: Option[Int], fallback: Int) -> Int {
   match o {

--- a/book/ja/14_iteration.vibe.md
+++ b/book/ja/14_iteration.vibe.md
@@ -11,17 +11,16 @@ vibe の反復はほとんどが「配列を一度なめる eager な一巡」�
 ## 配列を一度なめる
 
 ```vibe run
+import @vibe/builtin {
+  trait Iterator
+}
+
 fn main with Console {
-  let xs = [
-    1,
-    2,
-    3,
-    4
-  ]
-  let evens = Array::filter(xs, (n) -> {
+  let xs = [1, 2, 3, 4]
+  let evens = Iterator::filter(xs, (n) -> {
     n % 2 == 0
   })
-  let sum = Array::fold(xs, 0, _ + _)
+  let sum = Iterator::fold(xs, 0, _ + _)
   let doubled = for x in xs {
     x * 2
   }
@@ -41,8 +40,10 @@ doubled[3] = 8
 コレクション）なら、このループは式で、その値は `Array[T]` になる。だから
 `doubled` は添字で引ける。`for i, x in xs` と書けば添字も束縛される。
 
-`Array::map` / `Array::filter` / `Array::fold` は同じ仕事を関数として
-行う。呼び出し側で読みやすい方を選べばよく、どちらも同じ一巡。
+`Iterator::map` / `Iterator::filter` / `Iterator::fold` は import した
+trait が提供する eager operation。`Array` は `Iterator` を実装しており、
+receiver が静的に Array と分かる場合は dictionary dispatch を経由せず、
+Array 専用処理と同じ直接ループへコンパイルされる。
 
 ## パイプ
 
@@ -50,14 +51,14 @@ doubled[3] = 8
 そこに入る。
 
 ```vibe run
+import @vibe/builtin {
+  trait Iterator
+}
+
 fn main with Console {
   let n = "  vibe  " |> String::trim |> String::length
-  let xs = [
-    1,
-    2,
-    3
-  ]
-  let ys = xs |> Array::map(_, _ * 10)
+  let xs = [1, 2, 3]
+  let ys = xs |> Iterator::map(_, _ * 10)
   println("trimmed length = \{n}")
   println("ys[1] = \{Array::get(ys, 1)}")
 }
@@ -68,13 +69,14 @@ trimmed length = 4
 ys[1] = 20
 ```
 
-`xs |> Array::map(_, _ * 10)` は `Array::map(xs, (v) -> v * 10)` と読む。
+`xs |> Iterator::map(_, _ * 10)` は
+`Iterator::map(xs, (v) -> v * 10)` と読む。
 2つの `_` は別物で、1つ目はパイプの差し込み位置、2つ目はセクション —
 その引数についてのラムダの略記。
 
 ## 配列でない場合
 
-組み立てるべき遅延コンビネータの鎖は無い。`Array::*` の呼び出しと `for`
+組み立てるべき遅延コンビネータの鎖は無い。`Iterator::*` の呼び出しと `for`
 が eager 層であり、それで全部。
 
 もう一つの層は、値が時間をかけて届く場合 — ストリーム、ソケット、分割して

--- a/docs/cheatsheet.md
+++ b/docs/cheatsheet.md
@@ -378,9 +378,13 @@ let b = greet("hi", 3)     // => "hi x3"
 
 <!-- doctest-skip: 未定義名 (xs) を参照する構文提示の断片 -->
 ```vibe skip
-Array::map(xs, x -> x * 2)
-Array::map(xs, _ * 2)         // placeholder
-Array::fold(xs, 0, _ + _)
+import @vibe/builtin {
+  trait Iterator
+}
+
+Iterator::map(xs, x -> x * 2)
+Iterator::map(xs, _ * 2)         // placeholder
+Iterator::fold(xs, 0, _ + _)
 ```
 
 ## Operators (precedence: high to low)
@@ -538,8 +542,9 @@ s |> String::trim |> String::length
 Without a `_`, the piped value becomes the **first** argument. A bare `_` in
 the call's arguments substitutes the value at that position instead (no
 prepend). A *compound* placeholder such as `_ * 2` is a section lambda
-(`(v) -> v * 2`), not a pipe slot — so `xs |> Array::map(_, _ * 2)` reads as
-`Array::map(xs, (v) -> v * 2)`.
+(`(v) -> v * 2`), not a pipe slot — so
+`xs |> Iterator::map(_, _ * 2)` reads as
+`Iterator::map(xs, (v) -> v * 2)` after importing `trait Iterator`.
 
 Every method-bearing trait exposes its operations through the trait namespace:
 `Trait::operation(value, args)` or `value |> Trait::operation(args)`. The
@@ -554,7 +559,9 @@ Implementing `iter_length` and `iter_get` activates its eager operations
 (ADR-0110):
 
 ```vibe
-import @vibe/builtin { trait Iterator }
+import @vibe/builtin {
+  trait Iterator
+}
 
 let arrays = [1, 2]
   |> Iterator::map((x) -> { x + 1 })
@@ -635,11 +642,15 @@ import them before use (`import ./func.vibe { compose, identity, flip }`).
 
 <!-- doctest-skip: 未定義名 (f / g / xs / parse / render) を参照する構文提示の断片 -->
 ```vibe skip
+import @vibe/builtin {
+  compose, flip, identity, trait Iterator
+}
+
 // vibe has no `>>` compose operator (`>>` is arithmetic shift) — use functions
 compose(f, g)            // (x) -> g(f(x))   apply f then g
 identity                 // (x) -> x         no-op stage / default
 flip(f)                  // (b, a) -> f(a, b)
-Array::map(xs, compose(parse, render))
+Iterator::map(xs, compose(parse, render))
 ```
 
 > Runnable reference for the pipe `_` slot, combinators, `let*`, and `tap`:
@@ -952,6 +963,10 @@ selects a witness for the constructor itself, while `F[A]` and `F[B]` remain
 ordinary applied value types:
 
 ```vibe
+import @vibe/builtin {
+  trait Iterator
+}
+
 trait LocalFunctor[F[_]] {
   map[A, B](F[A], (A) -> B) -> F[B]
 }
@@ -992,11 +1007,15 @@ both targets.
 ## Collections
 
 ```vibe
+import @vibe/builtin {
+  trait Iterator
+}
+
 // Array
 let a = [1, 2, 3]
 let first = a[0]              // index
 let len = Array::length(a)
-let doubled = Array::map(a, _ * 2)
+let doubled = Iterator::map(a, _ * 2)
 
 // Tuple
 let t = (1, "two", true)
@@ -1698,9 +1717,10 @@ resolves as one.
 - **Array**: `length`, `get`, `slice`, `concat`
 
 `Map::get` / `has_key` / `keys` / `values` / `set` / `size` and the Array
-HOFs (`map`, `filter`, `fold`, `find`, `any`, `all`, `reverse`) are call-only
-operations, not first-class values (`Array::map(xs, f)`, not
-`let g = Array::map`). They live in the Signature reference; they are not
+compatibility operations (`map`, `filter`, `fold`, `find`, `any`, `all`,
+`reverse`) are call-only, not first-class values. New generic code imports
+`trait Iterator` and calls `Iterator::*`; the `Array::*` spellings remain a
+compatibility surface. They live in the Signature reference; they are not
 indexed here because the freeze probe is a bare reference.
 
 `String` is a byte string: `length`, indexes and slices use byte counts and
@@ -1902,7 +1922,10 @@ different, currently nonexistent function.
 `slice: (Array[T], Int, Int) -> Array[T]`,
 `concat: (Array[T], Array[T]) -> Array[T]`, `reverse: (Array[T]) -> Array[T]`.
 
-**Array** (prelude; collection first, function last):
+**Array compatibility operations** (prelude; collection first, function
+last). New generic code should import `trait Iterator` and use the matching
+`Iterator::*` operation. These direct Array specializations remain available
+for compatibility:
 
 | function | signature |
 |---|---|
@@ -2029,6 +2052,10 @@ test "shell" {
 その結果を vibe の関数へ繋ぐ:
 
 ```vibe
+import @vibe/builtin {
+  trait Iterator
+}
+
 let pipes: () -> Array[String] with Process = () -> {
   let a = sh_lines("echo hello | cat")
   let b = sh_lines("printf 'a\\nb\\nc' | sort -r")
@@ -2037,7 +2064,7 @@ let pipes: () -> Array[String] with Process = () -> {
 
 let count_txt: () -> Int with Process = () -> {
   sh_lines("ls /tmp")
-  |> Array::filter((s) -> { String::contains(s, ".txt") })
+  |> Iterator::filter((s) -> { String::contains(s, ".txt") })
   |> Array::length
 }
 // Works because |> inserts value as first arg, matching collection-first order
@@ -2068,6 +2095,10 @@ note: posix-mode command-head desugar: ls -> sh_lines("ls")
 
 <!-- doctest-skip: 未定義名 (read_config / parse / process / risky / xs / parse_int 等) を参照するイディオム断片 -->
 ```vibe skip
+import @vibe/builtin {
+  trait Iterator
+}
+
 // Failure composition: the row carries it, so stages just chain
 // (fn read_config() -> Config with Exception[String] etc.)
 let result = read_config() |> parse |> process
@@ -2090,7 +2121,7 @@ let doubled = for x in xs { x * 2 }
 input
   |> String::trim
   |> String::split(",")
-  |> Array::map(_, parse_int)
+  |> Iterator::map(_, parse_int)
 ```
 
 ## Conditional Compilation (`#cfg`)

--- a/docs/spec/structured-shell-design.md
+++ b/docs/spec/structured-shell-design.md
@@ -1,95 +1,99 @@
-# Structured Shell Design: shellscript superset + nushell-style data pipelines
+# Structured Shell Design: Shell-Script Superset with Nushell-Style Data Pipelines
 
-## ビジョン
+## Vision
 
-vibe shell の posix mode は **shellscript のスーパーセット** として設計する。
+Vibe shell's POSIX mode is designed as a **superset of shell script**.
 
-1. **既存の shellscript がそのまま動く** — 認識できないコマンドは `sh_lines()` にフォールバック
-2. **認識できるコマンドは構造化データで返す** — `ls` → `Array[FileEntry]`, `cat` → `String`
-3. **vibe 式で拡張できる** — `|>`, `match`, `if`, `let`, lambda はそのまま使える
+1. **Existing shell scripts keep working** — unrecognized commands fall back to `sh_lines()`.
+2. **Recognized commands return structured data** — `ls` returns `Array[FileEntry]`, and `cat` returns `String`.
+3. **Vibe expressions extend the shell** — `|>`, `match`, `if`, `let`, and lambdas remain available.
 
-つまり: `bash の全コマンド + vibe の型付きパイプライン + nushell の構造化データ`
+In short: `all bash commands + typed Vibe pipelines + Nushell-style structured data`.
 
-## 設計原則
+## Design Principles
 
-### 1. shellscript 互換 (フォールバック)
+### 1. Shell-script compatibility through fallback
 
 ```bash
-# 全て動く — 認識できないコマンドは sh_lines() 経由で /bin/sh に委譲
+# All of these work: unrecognized commands delegate to /bin/sh through sh_lines().
 git status
 docker build -t myapp .
 curl -s https://api.example.com
 grep -r "TODO" src/
 ```
 
-### 2. 認識コマンドは構造化データに昇格
+### 2. Recognized commands produce structured data
 
 ```bash
-# ls は Array[FileEntry] を返す (テーブル表示)
+# ls returns Array[FileEntry] and displays it as a table.
 ls .
 
-# cat は String を返す (そのまま表示)
+# cat returns String and displays it directly.
 cat README.md
 
-# env は String を返す
+# env returns String.
 env HOME
 ```
 
-### 3. vibe 式でシームレスに拡張
+### 3. Vibe expressions extend pipelines directly
 
 ```bash
-# パイプで構造化フィルタ
+# Filter structured data through a pipeline.
 ls . |> where_entry(e -> e.is_dir)
 
-# let 束縛
+# Bind a result with let.
 let files = ls .
 Array::length(files)
 
-# if/match も混在可能
+# if and match can coexist with shell expressions.
 if exists "package.json" { cat package.json |> jq .name } else { "no package" }
 ```
 
-### 4. 段階的に認識コマンドを増やす
+### 4. Add recognized commands incrementally
 
-将来的に `grep`, `find`, `sort`, `head`, `tail` 等も vibe 実装で置き換え可能。
-ただし **常にフォールバックが動く** ので、未実装コマンドでもブロックされない。
+Commands such as `grep`, `find`, `sort`, `head`, and `tail` can eventually be
+replaced by Vibe implementations. The fallback always remains available, so an
+unimplemented command does not block the user.
 
-## 現状
+## Current State
 
-### 既存の基盤
+### Existing foundation
+
 - `vibe/shell/types.vibe`: `FileEntry { name, path, is_dir }`
-- `vibe/shell/pipeline.vibe`: grep, cut, lines, split, jq, where_entry, filter_str 等
-- `vibe/shell/commands.vibe`: ls → `Array[FileEntry]`, cat → `String`
-- vibe の `|>` パイプ演算子: `expr |> f` = `f(expr)`
-- posix preprocessor: `ls /tmp` → `Fs::readdir("/tmp")`
+- `vibe/shell/pipeline.vibe`: grep, cut, lines, split, jq, where_entry, filter_str, and related helpers
+- `vibe/shell/commands.vibe`: ls returns `Array[FileEntry]`; cat returns `String`
+- Vibe's `|>` pipeline operator: `expr |> f` is `f(expr)`
+- POSIX preprocessor: `ls /tmp` becomes `Fs::readdir("/tmp")`
 
-### ギャップ
-- `|>` は compiled WASM で動くが、shell の posix preprocessor がパイプを解釈しない
-- `where` は関数呼び出しだが、posix 風の `ls | where is_dir` 構文がない
-- 表示 (table format) がない
+### Gaps
 
-## 設計
+- `|>` works in compiled Wasm, but the shell's POSIX preprocessor does not interpret pipelines.
+- `where` exists as a function call, but there is no POSIX-style `ls | where is_dir` syntax.
+- There is no table formatter.
 
-### Phase 1: パイプライン式の posix preprocessor 対応
+## Design
+
+### Phase 1: Pipeline expressions in the POSIX preprocessor
 
 ```bash
-# 現在の vibe 式 (動作する)
+# Current Vibe expression; this works.
 Fs::readdir(".") |> where_entry(e -> e.is_dir)
 
-# 目標: posix 風の構文
+# Target POSIX-style syntax.
 ls . |> where is_dir
 ls . |> where name == "src"
 ls . |> sort_by name |> take 5
 cat data.csv |> from_csv |> where age > 30
 ```
 
-posix preprocessor が `ls . |> where is_dir` を以下に変換:
+The POSIX preprocessor transforms `ls . |> where is_dir` into:
+
 ```vibe skip
 // doctest-skip: design sketch: the syntax below is not implemented (preprocessor output sketch)
 Fs::readdir(".") |> where_entry(e -> e.is_dir)
 ```
 
-### Phase 2: テーブル表示
+### Phase 2: Table display
 
 ```
 vibe> ls .
@@ -102,38 +106,38 @@ vibe> ls .
 └─────┴──────────┴───────┘
 ```
 
-`Array[FileEntry]` や `Array[Record]` を自動的にテーブル形式で表示。
+Values such as `Array[FileEntry]` and `Array[Record]` display automatically as tables.
 
-### Phase 3: 構造化データ変換
+### Phase 3: Structured-data conversion
 
 ```
-# JSON → テーブル
+# JSON to table
 cat package.json |> jq .dependencies |> from_json
 
-# CSV → テーブル
+# CSV to table
 cat data.csv |> from_csv
 
-# YAML → テーブル
+# YAML to table
 cat config.yaml |> from_yaml
 
-# テーブル → JSON
+# Table to JSON
 ls . |> to_json
 
-# テーブルの列選択
+# Select table columns
 ls . |> select name, is_dir
 
-# テーブルのソート
+# Sort a table
 ls . |> sort_by name
 
-# テーブルの集約
+# Aggregate a table
 ls . |> group_by is_dir |> count
 ```
 
-## パイプライン変換ルール
+## Pipeline Transformation Rules
 
-posix preprocessor の拡張:
+The POSIX preprocessor gains these transformations:
 
-| 入力 | 変換 |
+| Input | Transformation |
 |------|------|
 | `ls .` | `Fs::readdir(".")` |
 | `ls . \|> where is_dir` | `Fs::readdir(".") \|> where_entry(e -> e.is_dir)` |
@@ -143,11 +147,11 @@ posix preprocessor の拡張:
 | `cat f.csv \|> from_csv` | `from_csv(Fs::read_file("f.csv"))` |
 | `cat f.json \|> jq .name` | `jq(Fs::read_file("f.json"), ".name")` |
 
-## ワークフロー: REPL → ファイル → リファクタ
+## Workflow: REPL to File to Refactoring
 
-vibe shell の典型的な開発ワークフロー:
+A typical Vibe shell development workflow is:
 
-### 1. REPL で探索的にコードを書く
+### 1. Explore in the REPL
 
 ```
 vibe> import @vibe/builtin { trait Iterator }
@@ -160,27 +164,27 @@ vibe> let avg = Iterator::fold(filtered |> select age, 0, (acc, x) -> acc + x) /
 last: 42
 ```
 
-### 2. セッションを `.vibe` ファイルに吐き出す
+### 2. Save the session as a `.vibe` file
 
 ```
 vibe> :save analysis.vibe
 saved: analysis.vibe (6 bindings)
 ```
 
-`:save` コマンドが scratch_source の全バインディングを normalize してファイルに書き出す。
+The `:save` command normalizes every binding in `scratch_source` and writes the result to a file.
 
-### 3. normalize でクリーンアップ
+### 3. Clean up with normalize
 
 ```bash
 vibe normalize analysis.vibe
 ```
 
-- import の整理・ソート
-- 未使用バインディングの除去
-- 関数定義の並び替え (トポロジカルソート)
-- フォーマット統一
+- Organize and sort imports.
+- Remove unused bindings.
+- Topologically sort function definitions.
+- Apply consistent formatting.
 
-### 4. エディタでリファクタ
+### 4. Refactor in an editor
 
 ```bash
 vim analysis.vibex   # or vscode with vibe extension
@@ -188,55 +192,56 @@ vibe check analysis.vibex
 vibe run analysis.vibex
 ```
 
-### 5. テストを追加して品質保証
+### 5. Add tests for confidence
 
 ```bash
-# analysis.vibex の末尾にテストブロックを追加
+# Add test blocks to the end of analysis.vibex.
 vibe test analysis.vibe
 ```
 
-### 設計上の要件
+### Design requirements
 
-- **scratch_source はバインディングを蓄積**: `let x = ...` は後続行から参照可能
-- **`:save` コマンド**: 現在の scratch_source を normalize してファイルに書き出す
-- **`:load` コマンド**: ファイルを scratch_source に読み込んで REPL で継続
-- **`:clear` コマンド**: scratch_source をリセット
-- **normalize との統合**: `:save` は `vibe normalize` と同等の整形を適用
+- **`scratch_source` accumulates bindings**: `let x = ...` remains visible to later lines.
+- **`:save` command**: normalize the current `scratch_source` and write it to a file.
+- **`:load` command**: load a file into `scratch_source` and continue in the REPL.
+- **`:clear` command**: reset `scratch_source`.
+- **Normalize integration**: `:save` applies formatting equivalent to `vibe normalize`.
 
-## フォールバック戦略
+## Fallback Strategy
 
 ```
-入力行
+input line
   │
-  ├─ vibe keyword (let, if, match, ...) → vibe 式としてコンパイル
-  ├─ 関数呼び出し f(...) → vibe 式としてコンパイル
-  ├─ 認識コマンド (cat, ls, cd, ...) → vibe builtin 呼び出しに変換
-  └─ 不明コマンド → sh_lines("...") でシステムシェルに委譲
+  ├─ Vibe keyword (let, if, match, ...) → compile as a Vibe expression
+  ├─ function call f(...) → compile as a Vibe expression
+  ├─ recognized command (cat, ls, cd, ...) → transform into a Vibe builtin call
+  └─ unknown command → delegate to the system shell through sh_lines("...")
 ```
 
-これにより:
-- `git push` → そのまま動く (sh_lines)
-- `cat file.txt |> lines |> grep "TODO"` → 構造化パイプライン
-- `let count = ls . |> where_entry(e -> e.is_dir) |> Array::length` → 型安全
+As a result:
 
-## 実装計画
+- `git push` runs unchanged through `sh_lines`.
+- `cat file.txt |> lines |> grep "TODO"` is a structured pipeline.
+- `let count = ls . |> where_entry(e -> e.is_dir) |> Array::length` is type-safe.
 
-| Phase | 内容 | 依存 |
+## Implementation Plan
+
+| Phase | Scope | Dependency |
 |-------|------|------|
-| Phase 0 | `ls .` が動く (fs_host_imports) | #44 |
-| Phase 1 | `ls . \|> where is_dir` パイプライン変換 | posix preprocessor 拡張 |
-| Phase 2 | テーブル表示 (Array[FileEntry] の format) | Show trait / REPL display |
-| Phase 3 | from_csv/from_yaml/to_json 変換 | 既存 vibe/shell/from_*.vibe |
-| Phase 4 | grep/find/sort 等の vibe native 実装 | 段階的 |
+| Phase 0 | Make `ls .` work through `fs_host_imports` | #44 |
+| Phase 1 | Transform the `ls . \|> where is_dir` pipeline | POSIX preprocessor extension |
+| Phase 2 | Format `Array[FileEntry]` as a table | Show trait / REPL display |
+| Phase 3 | Add from_csv/from_yaml/to_json conversion | Existing vibe/shell/from_*.vibe modules |
+| Phase 4 | Implement grep/find/sort and related commands in Vibe | Incremental |
 
-## 既存ライブラリとの対応
+## Mapping to the Existing Library
 
-| nushell | vibe/shell |
+| Nushell | vibe/shell |
 |---------|-----------|
 | `ls` | `ls(dir)` → `Array[FileEntry]` |
 | `where` | `where_entry(pred)` / `filter_str(pred)` |
-| `sort-by` | (未実装) `sort_entries_by(key_fn)` |
-| `select` | (未実装) `select_fields(fields)` |
+| `sort-by` | Not implemented: `sort_entries_by(key_fn)` |
+| `select` | Not implemented: `select_fields(fields)` |
 | `get` | `jq(data, expr)` |
 | `from csv` | `from_csv(text)` |
 | `from yaml` | `from_yaml(text)` |

--- a/docs/spec/structured-shell-design.md
+++ b/docs/spec/structured-shell-design.md
@@ -150,12 +150,13 @@ vibe shell の典型的な開発ワークフロー:
 ### 1. REPL で探索的にコードを書く
 
 ```
+vibe> import @vibe/builtin { trait Iterator }
 vibe> let data = cat data.csv |> from_csv
 vibe> let filtered = data |> where age > 30
 vibe> let names = filtered |> select name
 vibe> Array::length(names)
 last: 5
-vibe> let avg = Array::fold(filtered |> select age, 0, (acc, x) -> acc + x) / 5
+vibe> let avg = Iterator::fold(filtered |> select age, 0, (acc, x) -> acc + x) / 5
 last: 42
 ```
 

--- a/docs/spec/syntax.md
+++ b/docs/spec/syntax.md
@@ -58,7 +58,7 @@ Rules:
 - `r#keyword` forces identifier interpretation for reserved words. Exception:
   `fn` has no raw-identifier escape (#1280) — `r#fn` still lexes as the `fn`
   keyword, so no binding/parameter/type/member can be named `fn`.
-- Qualified names use `::`: `Array::map`, `Module::name`, `Point::{ ... }`.
+- Qualified names use `::`: `Iterator::map`, `Module::name`, `Point::{ ... }`.
 - Field and tuple access use `.`: `record.name`, `tuple.0`.
 - Package/module refs after `@` may contain `/` and `-`: `@pkg/path`.
 
@@ -486,9 +486,13 @@ Rules:
 
 ```vibe skip
 // doctest-skip: form catalogue: bare surface forms, not a compilable program
+import @vibe/builtin {
+  trait Iterator
+}
+
 f(x)
 f(x=1, y=2)
-Array::map(xs, _ * 2)
+Iterator::map(xs, _ * 2)
 point.x
 tuple.0
 arr[0]

--- a/examples/basics.vibe
+++ b/examples/basics.vibe
@@ -1,3 +1,7 @@
+import @vibe/builtin {
+  trait Iterator
+}
+
 //# Types
 
 type Pair = (Int, Int)
@@ -41,11 +45,7 @@ let pair_value: (Int, Int) = (10, 20)
 
 let pipe_value: Int = mul(add(1, 2), 3)
 
-let array_value: Array[Int] = [
-  1,
-  2,
-  3
-]
+let array_value: Array[Int] = [1, 2, 3]
 
 let block_value: Int = {
   let base = 40
@@ -118,17 +118,8 @@ test "while and mut" {
 }
 
 test "lambda and placeholder" {
-  let doubled = Array::map([
-    1,
-    2,
-    3
-  ], x -> x * 2)
-  let total = Array::fold([
-    1,
-    2,
-    3,
-    4
-  ], 0, _ + _)
+  let doubled = Iterator::map([1, 2, 3], x -> x * 2)
+  let total = Iterator::fold([1, 2, 3, 4], 0, _ + _)
   assert(doubled[0] == 2)
   assert(doubled[2] == 6)
   assert(total == 10)

--- a/examples/syntax.vibe
+++ b/examples/syntax.vibe
@@ -1,3 +1,7 @@
+import @vibe/builtin {
+  trait Iterator
+}
+
 //# Types
 
 enum Result[T] {
@@ -8,7 +12,8 @@ enum Result[T] {
 type IntResult = Result[Int]
 
 struct Point {
-  x: Int; y: Int
+  x: Int;
+  y: Int
 }
 
 enum Color {
@@ -63,7 +68,8 @@ fn fact(n: Int) -> Int {
 let pair = (1, 2)
 
 let point = Point::{
-  x: 3, y: 4
+  x: 3,
+  y: 4
 }
 
 fn add_i32(a: Int, b: Int) -> Int {
@@ -100,14 +106,12 @@ fn make_pair[A, B](a: A, b: B) -> (A, B) {
   (a, b)
 }
 
-let map_value = Map::from_pairs([
-  ("a", 1),
-  ("b", 2)
-])
+let map_value = Map::from_pairs([("a", 1), ("b", 2)])
 
 let point_sum = match point {
   Point::{
-    x, y
+    x,
+    y
   } => add(x, y),
   _ => 0
 }
@@ -132,11 +136,7 @@ fn trait_keep[T: Eq](x: T) -> T {
   x
 }
 
-let array_value = [
-  1,
-  2,
-  3
-]
+let array_value = [1, 2, 3]
 
 let block_value = {
   let x = 1
@@ -173,9 +173,7 @@ let match_value = match Ok(1) {
 fn safe_div_or(a: Int, b: Int, fallback: Int) -> Int {
   handle {
     safe_div(a, b)
-  } with {
-    Exception::Throw(_) => fallback
-  }
+  } with { Exception::Throw(_) => fallback }
 }
 
 fn trait_keep2[T: Eq + Show](x: T) -> T {
@@ -214,11 +212,7 @@ fn trait_measured_keep[T: Measured](x: T) -> T {
   x
 }
 
-let trait_array = trait_measured_keep([
-  1,
-  2,
-  3
-])
+let trait_array = trait_measured_keep([1, 2, 3])
 
 let trait_value = trait_identity(42)
 
@@ -388,52 +382,32 @@ test "half_int" {
 }
 
 test "Array::concat" {
-  let a = Array::concat([
-    1,
-    2
-  ], [
-    3,
-    4
-  ])
+  let a = Array::concat([1, 2], [3, 4])
   assert(Array::length(a) == 4)
   assert(Array::get(a, 0) == 1)
   assert(Array::get(a, 3) == 4)
 }
 
 test "Array::reverse" {
-  let r = Array::reverse([
-    1,
-    2,
-    3
-  ])
+  let r = Array::reverse([1, 2, 3])
   assert(Array::get(r, 0) == 3)
   assert(Array::get(r, 2) == 1)
 }
 
 test "Map::keys" {
-  let m = Map::from_pairs([
-    ("a", 1),
-    ("b", 2)
-  ])
+  let m = Map::from_pairs([("a", 1), ("b", 2)])
   let k = Map::keys(m)
   assert(Array::length(k) == 2)
 }
 
 test "Map::has_key" {
-  let m = Map::from_pairs([
-    ("x", 10)
-  ])
+  let m = Map::from_pairs([("x", 10)])
   assert(Map::has_key(m, "x"))
   assert(not(Map::has_key(m, "y")))
 }
 
 test "Array::slice" {
-  let s = Array::slice([
-    10,
-    20,
-    30,
-    40
-  ], 1, 3)
+  let s = Array::slice([10, 20, 30, 40], 1, 3)
   assert(Array::length(s) == 2)
   assert(Array::get(s, 0) == 20)
   assert(Array::get(s, 1) == 30)
@@ -455,49 +429,24 @@ test "line_comment" {
   assert(x == 1)
 }
 
-test "Array::any" {
-  assert(Array::any([
-    1,
-    2,
-    4
-  ], x -> x > 3))
-  assert(not(Array::any([
-    1,
-    2,
-    3
-  ], x -> x > 5)))
+test "Iterator::any with Array" {
+  assert(Iterator::any([1, 2, 4], x -> x > 3))
+  assert(not(Iterator::any([1, 2, 3], x -> x > 5)))
 }
 
-test "Array::all" {
-  assert(Array::all([
-    1,
-    2,
-    3
-  ], x -> x > 0))
-  assert(not(Array::all([
-    1,
-    2,
-    3
-  ], x -> x > 1)))
+test "Iterator::all with Array" {
+  assert(Iterator::all([1, 2, 3], x -> x > 0))
+  assert(not(Iterator::all([1, 2, 3], x -> x > 1)))
 }
 
-test "Array::find" {
-  let found = Array::find([
-    1,
-    2,
-    3,
-    4
-  ], x -> x > 2)
+test "Iterator::find with Array" {
+  let found = Iterator::find([1, 2, 3, 4], x -> x > 2)
   if found is Some(v) {
     assert(v == 3)
   } else {
     assert(false)
   }
-  let not_found = Array::find([
-    1,
-    2,
-    3
-  ], x -> x > 10)
+  let not_found = Iterator::find([1, 2, 3], x -> x > 10)
   assert(not_found is None)
 }
 
@@ -588,26 +537,13 @@ test "method_chain" {
 }
 
 test "index_array" {
-  let a = [
-    10,
-    20,
-    30
-  ]
+  let a = [10, 20, 30]
   assert(a[0] == 10)
   assert(a[2] == 30)
 }
 
 test "index_chain" {
-  let a = [
-    [
-      1,
-      2
-    ],
-    [
-      3,
-      4
-    ]
-  ]
+  let a = [[1, 2], [3, 4]]
   let b = a[1]
   assert(b[0] == 3)
 }

--- a/fixtures/iterator_trait_operations_test.vibe
+++ b/fixtures/iterator_trait_operations_test.vibe
@@ -44,3 +44,16 @@ test "a user Iterator impl gains the same operation family" {
   })
   assert_eq(values, [10, 20, 30])
 }
+
+test "the receiver determines an unconstrained Iterator element type" {
+  let words: Array[String] = ["vibe", "lang"]
+  let selected = Iterator::filter(words, (word) -> {
+    String::contains(word, "v")
+  })
+  assert_eq(selected, ["vibe"])
+  let lengths = Triple::{ first: "a", second: "bb", third: "ccc" }
+  |> Iterator::map((word) -> {
+    String::length(word)
+  })
+  assert_eq(lengths, [1, 2, 3])
+}

--- a/lib/@vibe/builtin/func.vibe
+++ b/lib/@vibe/builtin/func.vibe
@@ -5,7 +5,8 @@
 // NOTE: vibe has no dedicated composition *operator* — `>>` is the
 // arithmetic right-shift token — so composition is expressed as a function.
 // Use it to build reusable pipeline stages or to compose inside higher-order
-// calls, e.g. `Array::map(xs, compose(parse, render))`.
+// calls, e.g. `Iterator::map(xs, compose(parse, render))` after importing the
+// `Iterator` trait.
 
 /// Left-to-right composition: `compose(f, g)` is `(x) -> g(f(x))` — apply `f`
 /// then `g`, matching the reading order of a `|>` pipeline. Pure (composes

--- a/lib/@vibe/compiler/checker/checker.vibe
+++ b/lib/@vibe/compiler/checker/checker.vibe
@@ -33,6 +33,7 @@ import @vibe/compiler/core {
   is_exception_throw_handler_name,
   is_exception_throw_operation,
   is_hkt_app,
+  refine_trait_bounds_from_receiver,
   registry_builtin_arity,
   registry_builtin_param_type,
   resolve_builtin,
@@ -9141,6 +9142,10 @@ fn check_expr_capture_impl(expr: Expr, env: TypeEnv, defs: Array[TypeDef], s: Su
                       None => check_expr_capture(EIdent(name, callee_off), env, defs, s, c, errors, tytab, capture, lane)
                     }
                   }
+                  let inferred_param_tys = match ct {
+                    CtFn(params, _, _) => params,
+                    _ => array_empty()
+                  }
                   let alen = Array::length(args)
                   let arg_tys = array_empty()
                   let mut ai = 0
@@ -9149,7 +9154,11 @@ fn check_expr_capture_impl(expr: Expr, env: TypeEnv, defs: Array[TypeDef], s: Su
                   while ai < alen {
                     let (at, ns, nc) = check_expr_capture(Array::get(args, ai), env, defs, s2, c2, errors, tytab, capture, lane)
                     Array::push(arg_tys, at)
-                    s2 = ns
+                    if ai < Array::length(inferred_param_tys) {
+                      s2 = refine_trait_bounds_from_receiver(env, ns, Array::get(inferred_param_tys, ai), at)
+                    } else {
+                      s2 = ns
+                    }
                     c2 = nc
                     ai = ai + 1
                   }

--- a/lib/@vibe/compiler/core/core.vibe
+++ b/lib/@vibe/compiler/core/core.vibe
@@ -100,6 +100,7 @@ export ./types.vibe {
   impls_overlap_for,
   instantiate,
   occurs_in,
+  refine_trait_bounds_from_receiver,
   resolve_builtin,
   subst_add_bound,
   subst_apply,

--- a/lib/@vibe/compiler/core/index.vpkg
+++ b/lib/@vibe/compiler/core/index.vpkg
@@ -271,6 +271,7 @@ fn overlapping_impl_target_for(env: TypeEnv, trait_name: String, new_params: Arr
 fn collect_subst_bounds_pairs(s: Subst) -> Array[(Int, Array[String])]
 fn generalize(s: Subst, ty: Type) -> Type
 fn type_implements_trait(env: TypeEnv, s: Subst, ty: Type, trait_name: String) -> Bool
+fn refine_trait_bounds_from_receiver(env: TypeEnv, s: Subst, param: Type, receiver: Type) -> Subst
 fn trait_impl_declared_for_ctor(e: TypeEnv, trait_name: String, resolved: Type) -> Bool
 fn trait_is_marker(env: TypeEnv, trait_name: String) -> Bool
 fn type_constructor_name(ty: Type) -> String

--- a/lib/@vibe/compiler/core/types.vibe
+++ b/lib/@vibe/compiler/core/types.vibe
@@ -4316,6 +4316,13 @@ fn erased_impl_ctor_matches(target: Type, resolved: Type) -> Bool {
   }
 }
 
+/// Apply the shared receiver-matching rule for a non-generic impl. Bare
+/// constructor impls cover the constructor family only for method-bearing
+/// traits; marker traits retain their stricter representation-safety gate.
+fn concrete_trait_impl_target_matches(full: TypeEnv, trait_name: String, target: Type, resolved: Type) -> Bool {
+  types_equal(target, resolved) || struct_impl_target_matches(target, resolved) || (erased_impl_ctor_matches(target, resolved) && trait_is_method_bearing(full, trait_name))
+}
+
 fn type_implements_check_env(e: TypeEnv, full: TypeEnv, trait_name: String, resolved: Type) -> Bool {
   match e {
     EnvEmpty => false,
@@ -4328,7 +4335,7 @@ fn type_implements_check_env(e: TypeEnv, full: TypeEnv, trait_name: String, reso
       // builtin `==` / `<`, and those are reference equality on `Array` /
       // `Bytes`, so honouring `impl Eq for Array[Int]` would make `==` silently
       // wrong on the very type the bound was written for.
-      if types_equal(target, resolved) || struct_impl_target_matches(target, resolved) || (erased_impl_ctor_matches(target, resolved) && trait_is_method_bearing(full, trait_name)) {
+      if concrete_trait_impl_target_matches(full, trait_name, target, resolved) {
         true
       }
       else type_implements_check_env(rest, full, trait_name, resolved)
@@ -4451,7 +4458,7 @@ fn type_implements_check_super(e2: TypeEnv, full_env: TypeEnv, s: Subst, trait_n
     EnvBind(_, _, rest) => type_implements_check_super(rest, full_env, s, trait_name, resolved),
     EnvMutCell(_, _, rest) => type_implements_check_super(rest, full_env, s, trait_name, resolved),
     EnvTraitDef(_, _, _, _, rest, _, _) => type_implements_check_super(rest, full_env, s, trait_name, resolved),
-    EnvTraitImpl(tname, target, rest) => if types_equal(target, resolved) || struct_impl_target_matches(target, resolved) || (erased_impl_ctor_matches(target, resolved) && trait_is_method_bearing(full_env, trait_name)) {
+    EnvTraitImpl(tname, target, rest) => if concrete_trait_impl_target_matches(full_env, trait_name, target, resolved) {
       if trait_is_subtrait(full_env, tname, trait_name) {
         true
       }
@@ -4882,7 +4889,7 @@ fn trait_bound_receiver_refinements(scan: TypeEnv, full: TypeEnv, s: Subst, boun
     EnvCached(_, _, rest) => trait_bound_receiver_refinements(rest, full, s, bound, receiver)
   }
   let current = match scan {
-    EnvTraitImpl(itrait, target, _) => if trait_ref_name(itrait) == trait_ref_name(bound) && types_equal(subst_apply(s, target), receiver) {
+    EnvTraitImpl(itrait, target, _) => if trait_ref_name(itrait) == trait_ref_name(bound) && concrete_trait_impl_target_matches(full, trait_ref_name(bound), subst_apply(s, target), receiver) {
       unify(trait_key_type_for_bound(bound), trait_key_type_for_generic_impl(itrait, array_empty(), array_empty()), s)
     } else {
       None

--- a/lib/@vibe/compiler/core/types.vibe
+++ b/lib/@vibe/compiler/core/types.vibe
@@ -4781,6 +4781,168 @@ fn generic_impl_satisfies(scan: TypeEnv, full: TypeEnv, s: Subst, trait_name: St
   }
 }
 
+/// Decode an instantiated bound reference while preserving its fresh type
+/// variables. The serialized `#tpvid.N` spelling is checker provenance, not a
+/// nominal type name.
+fn instantiated_bound_ref_type(expr: TypeExpr) -> Type {
+  match expr {
+    TyName(name) => match parse_trait_bound_vid(name) {
+      Some(id) => CtVar(id),
+      None => trait_ref_type_expr_type(expr)
+    },
+    TyApp(name, nested) => {
+      let args = for item in nested {
+        instantiated_bound_ref_type(item)
+      }
+      match parse_trait_bound_vid(name) {
+        Some(id) => apply_type_constructor(CtVar(id), args),
+        None => if name == "Array" && Array::length(args) == 1 {
+          CtArray(Array::get(args, 0))
+        } else if name == "Option" && Array::length(args) == 1 {
+          CtOption(Array::get(args, 0))
+        } else {
+          CtNamed(name, args)
+        }
+      }
+    },
+    TyTuple(items) => CtTuple(for item in items {
+      instantiated_bound_ref_type(item)
+    }),
+    TyFn(params, ret, effect) => CtFn(for param in params {
+      instantiated_bound_ref_type(param)
+    }, instantiated_bound_ref_type(ret), effect),
+    TyUnit => CtUnit
+  }
+}
+
+/// Instantiate the trait reference written on a generic impl using the type
+/// arguments recovered by matching its target against the receiver.
+fn generic_impl_ref_type(expr: TypeExpr, tparams: Array[String], args: Array[Type]) -> Type {
+  match expr {
+    TyName(name) => {
+      let pi = generic_param_index(tparams, name)
+      if pi >= 0 && pi < Array::length(args) {
+        Array::get(args, pi)
+      } else {
+        trait_ref_type_expr_type(expr)
+      }
+    },
+    TyApp(name, nested) => {
+      let resolved = for item in nested {
+        generic_impl_ref_type(item, tparams, args)
+      }
+      let pi = generic_param_index(tparams, name)
+      if pi >= 0 && pi < Array::length(args) {
+        apply_type_constructor(Array::get(args, pi), resolved)
+      } else if name == "Array" && Array::length(resolved) == 1 {
+        CtArray(Array::get(resolved, 0))
+      } else if name == "Option" && Array::length(resolved) == 1 {
+        CtOption(Array::get(resolved, 0))
+      } else {
+        CtNamed(name, resolved)
+      }
+    },
+    TyTuple(items) => CtTuple(for item in items {
+      generic_impl_ref_type(item, tparams, args)
+    }),
+    TyFn(params, ret, effect) => CtFn(for param in params {
+      generic_impl_ref_type(param, tparams, args)
+    }, generic_impl_ref_type(ret, tparams, args), effect),
+    TyUnit => CtUnit
+  }
+}
+
+fn trait_key_type_for_bound(key: String) -> Type {
+  match trait_ref_from_key(key) {
+    Some(reference) => instantiated_bound_ref_type(reference),
+    None => CtNamed(key, array_empty())
+  }
+}
+
+fn trait_key_type_for_generic_impl(key: String, tparams: Array[String], args: Array[Type]) -> Type {
+  match trait_ref_from_key(key) {
+    Some(reference) => generic_impl_ref_type(reference, tparams, args),
+    None => CtNamed(key, array_empty())
+  }
+}
+
+/// Count impls that can determine the type arguments of `bound` from a
+/// concrete receiver. A count above one is deliberately ambiguous and the
+/// caller leaves the variables unresolved.
+fn trait_bound_receiver_refinements(scan: TypeEnv, full: TypeEnv, s: Subst, bound: String, receiver: Type) -> (Int, Subst) {
+  let (rest_count, rest_subst) = match scan {
+    EnvEmpty => (0, s),
+    EnvBind(_, _, rest) => trait_bound_receiver_refinements(rest, full, s, bound, receiver),
+    EnvTraitDef(_, _, _, _, rest, _, _) => trait_bound_receiver_refinements(rest, full, s, bound, receiver),
+    EnvTraitImpl(_, _, rest) => trait_bound_receiver_refinements(rest, full, s, bound, receiver),
+    EnvMutCell(_, _, rest) => trait_bound_receiver_refinements(rest, full, s, bound, receiver),
+    EnvTraitImplGen(_, _, _, _, rest) => trait_bound_receiver_refinements(rest, full, s, bound, receiver),
+    EnvTypeDefs(_, _, rest) => trait_bound_receiver_refinements(rest, full, s, bound, receiver),
+    EnvFlat(_) => (0, s),
+    EnvCached(_, _, rest) => trait_bound_receiver_refinements(rest, full, s, bound, receiver)
+  }
+  let current = match scan {
+    EnvTraitImpl(itrait, target, _) => if trait_ref_name(itrait) == trait_ref_name(bound) && types_equal(subst_apply(s, target), receiver) {
+      unify(trait_key_type_for_bound(bound), trait_key_type_for_generic_impl(itrait, array_empty(), array_empty()), s)
+    } else {
+      None
+    },
+    EnvTraitImplGen(itrait, tparams, bounds, target, _) => if trait_ref_name(itrait) == trait_ref_name(bound) {
+      match generic_target_args(tparams, target, receiver) {
+        Some(args) => if generic_bounds_hold(full, s, tparams, bounds, args) {
+          unify(trait_key_type_for_bound(bound), trait_key_type_for_generic_impl(itrait, tparams, args), s)
+        } else {
+          None
+        },
+        None => None
+      }
+    } else {
+      None
+    },
+    _ => None
+  }
+  match current {
+    Some(current_subst) => {
+      if rest_count == 0 {
+        (1, current_subst)
+      } else if rest_count == 1 && types_equal(subst_apply(current_subst, trait_key_type_for_bound(bound)), subst_apply(rest_subst, trait_key_type_for_bound(bound))) {
+        // Import projection may retain the same impl through more than one
+        // facade layer. Equal answers are duplicates, not an ambiguous choice.
+        (1, current_subst)
+      } else {
+        (rest_count + 1, s)
+      }
+    },
+    None => (rest_count, rest_subst)
+  }
+}
+
+/// Refine type variables mentioned by a parameter's applied trait bounds from
+/// the unique visible impl for its concrete receiver. This lets a signature
+/// such as `[A, C: Iterator[A]] (C, (A) -> B)` infer `A` from `Array[A]`
+/// before checking the callback, without making an ambiguous impl choice.
+export fn refine_trait_bounds_from_receiver(env: TypeEnv, s: Subst, param: Type, receiver: Type) -> Subst {
+  match param {
+    CtVar(id) => {
+      let bounds = subst_bounds_for(s, id)
+      let mut out = s
+      let mut i = 0
+      while i < Array::length(bounds) {
+        let bound = Array::get(bounds, i)
+        let (count, refined) = trait_bound_receiver_refinements(env, env, out, bound, subst_apply(out, receiver))
+        if count == 1 {
+          out = refined
+        } else {
+          ()
+        }
+        i = i + 1
+      }
+      out
+    },
+    _ => s
+  }
+}
+
 /// Every non-empty per-parameter bound is satisfied by every concrete type
 /// argument. Empty bound lists (Increment A) hold trivially.
 fn generic_bounds_hold(full: TypeEnv, s: Subst, tparams: Array[String], bounds: Array[(String, Array[String])], args: Array[Type]) -> Bool {

--- a/lib/@vibe/compiler/tests/checker_trait_test.vibe
+++ b/lib/@vibe/compiler/tests/checker_trait_test.vibe
@@ -13,7 +13,17 @@ import @vibe/core {
 }
 
 import @vibe/compiler/core {
-  Subst, Type, TypeEnv, overlapping_impl_target_for, trait_defined, trait_supers, type_implements_trait
+  Subst,
+  Type,
+  TypeEnv,
+  overlapping_impl_target_for,
+  refine_trait_bounds_from_receiver,
+  subst_add_bound,
+  subst_apply,
+  trait_defined,
+  trait_supers,
+  type_implements_trait,
+  types_equal
 }
 
 //# Functions
@@ -195,6 +205,17 @@ test "generic applied trait impls match builtin Array targets" {
   let actual = trait_ref_key(TyApp("Value", [TyName("Int")]))
   let env = EnvTraitImplGen(template, ["T"], [], CtArray(CtNamed("T", [])), base)
   assert(type_implements_trait(env, SubstEmpty, CtArray(CtInt), actual))
+}
+
+test "a unique applied impl refines bound arguments from its receiver" {
+  let methods = [("value", [TyName("Self")], TyName("A"))]
+  let base = EnvTraitDef("Value", ["A"], false, methods, EnvEmpty, [], [])
+  let template = trait_ref_key(TyApp("Value", [TyName("T")]))
+  let env = EnvTraitImplGen(template, ["T"], [], CtArray(CtNamed("T", [])), base)
+  let bound = trait_ref_key(TyApp("Value", [TyName("#tpvid.1")]))
+  let s = subst_add_bound(SubstEmpty, 0, [bound])
+  let refined = refine_trait_bounds_from_receiver(env, s, CtVar(0), CtArray(CtString))
+  assert(types_equal(subst_apply(refined, CtVar(1)), CtString))
 }
 
 test "i64 implements Add after registration" {

--- a/lib/@vibe/compiler/tests/checker_trait_test.vibe
+++ b/lib/@vibe/compiler/tests/checker_trait_test.vibe
@@ -218,6 +218,19 @@ test "a unique applied impl refines bound arguments from its receiver" {
   assert(types_equal(subst_apply(refined, CtVar(1)), CtString))
 }
 
+test "a bare constructor impl refines applied bound arguments from its receiver" {
+  let methods = [("value", [TyName("Self")], TyName("A"))]
+  let base = EnvTraitDef("Value", ["A"], false, methods, EnvEmpty, [], [])
+  let actual = trait_ref_key(TyApp("Value", [TyName("Int")]))
+  let env = EnvTraitImpl(actual, CtStruct("Box"), base)
+  let receiver = CtNamed("Box", [CtString])
+  assert(type_implements_trait(env, SubstEmpty, receiver, actual))
+  let bound = trait_ref_key(TyApp("Value", [TyName("#tpvid.1")]))
+  let s = subst_add_bound(SubstEmpty, 0, [bound])
+  let refined = refine_trait_bounds_from_receiver(env, s, CtVar(0), receiver)
+  assert(types_equal(subst_apply(refined, CtVar(1)), CtInt))
+}
+
 test "i64 implements Add after registration" {
   let env = register_builtin_traits(EnvEmpty)
   assert(type_implements_trait(env, SubstEmpty, CtNamed("i64", no_type_args()), "Add"))

--- a/scripts/check_canonical_iterator_calls.sh
+++ b/scripts/check_canonical_iterator_calls.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_ROOT="${VIBE_CANONICAL_ITERATOR_ROOT:-$(dirname "$SCRIPT_DIR")}"
+
+tmp_dir="$(mktemp -d "${TMPDIR:-/tmp}/vibe_iterator_calls.XXXXXX")"
+trap 'rm -rf "$tmp_dir"' EXIT
+files="$tmp_dir/files"
+findings="$tmp_dir/findings"
+: > "$files"
+: > "$findings"
+
+if [ -d "$PROJECT_ROOT/book" ]; then
+  find "$PROJECT_ROOT/book" -type f -name '*.vibe.md' >> "$files"
+fi
+if [ -d "$PROJECT_ROOT/examples" ]; then
+  find "$PROJECT_ROOT/examples" -type f -name '*.vibe' >> "$files"
+fi
+sort -u "$files" -o "$files"
+while IFS= read -r file; do
+  [ -n "$file" ] || continue
+  relative="${file#"$PROJECT_ROOT"/}"
+  grep -nE 'Array::(map|filter|flatmap|fold|find|any|all)([^A-Za-z0-9_]|$)' "$file" |
+    sed "s|^|$relative:|" >> "$findings" || true
+done < "$files"
+
+if [ -s "$findings" ]; then
+  echo "canonical Iterator calls: tutorials and examples must use Iterator::* and import trait Iterator:" >&2
+  cat "$findings" >&2
+  exit 1
+fi
+
+echo "canonical Iterator calls: ok"

--- a/scripts/check_canonical_iterator_calls.sh
+++ b/scripts/check_canonical_iterator_calls.sh
@@ -21,7 +21,7 @@ sort -u "$files" -o "$files"
 while IFS= read -r file; do
   [ -n "$file" ] || continue
   relative="${file#"$PROJECT_ROOT"/}"
-  grep -nE 'Array::(map|filter|flatmap|fold|find|any|all)([^A-Za-z0-9_]|$)' "$file" |
+  grep -nE 'Array::(iter|map|filter|flatmap|fold|find|any|all)([^A-Za-z0-9_]|$)' "$file" |
     sed "s|^|$relative:|" >> "$findings" || true
 done < "$files"
 

--- a/scripts/check_canonical_iterator_calls_test.sh
+++ b/scripts/check_canonical_iterator_calls_test.sh
@@ -6,9 +6,10 @@ CHECK="$SCRIPT_DIR/check_canonical_iterator_calls.sh"
 tmp_root="$(mktemp -d "${TMPDIR:-/tmp}/vibe_iterator_calls_test.XXXXXX")"
 trap 'rm -rf "$tmp_root"' EXIT
 
-mkdir -p "$tmp_root/book/en" "$tmp_root/examples" "$tmp_root/bench/exec" "$tmp_root/fixtures"
+mkdir -p "$tmp_root/book/en" "$tmp_root/examples/wasm" "$tmp_root/bench/exec" "$tmp_root/fixtures"
 printf '%s\n' 'Array::map(xs, f)' > "$tmp_root/book/en/chapter.vibe.md"
 printf '%s\n' 'Array::filter(xs, pred)' > "$tmp_root/examples/example.vibe"
+printf '%s\n' 'Array::iter(xs, f)' > "$tmp_root/examples/wasm/nested.vibe"
 printf '%s\n' 'Array::fold(xs, 0, add)' > "$tmp_root/bench/exec/scenario.vibe"
 printf '%s\n' 'Array::map(xs, f)' > "$tmp_root/fixtures/compatibility_test.vibe"
 
@@ -20,14 +21,15 @@ if [ "$red_status" -eq 0 ]; then
   echo "canonical Iterator calls self-test: expected legacy tutorial and example calls to fail" >&2
   exit 1
 fi
-if [ "$(grep -c 'Array::' "$tmp_root/red.out")" -ne 2 ]; then
-  echo "canonical Iterator calls self-test: expected one finding in each canonical scope" >&2
+if [ "$(grep -c 'Array::' "$tmp_root/red.out")" -ne 3 ]; then
+  echo "canonical Iterator calls self-test: expected all canonical calls, including nested iter, to be found" >&2
   cat "$tmp_root/red.out" >&2
   exit 1
 fi
 
 printf '%s\n' 'Iterator::map(xs, f)' > "$tmp_root/book/en/chapter.vibe.md"
 printf '%s\n' 'Iterator::filter(xs, pred)' > "$tmp_root/examples/example.vibe"
+printf '%s\n' 'Iterator::iter(xs, f)' > "$tmp_root/examples/wasm/nested.vibe"
 printf '%s\n' 'Iterator::fold(xs, 0, add)' > "$tmp_root/bench/exec/scenario.vibe"
 VIBE_CANONICAL_ITERATOR_ROOT="$tmp_root" bash "$CHECK" > "$tmp_root/green.out"
 grep -q '^canonical Iterator calls: ok$' "$tmp_root/green.out"

--- a/scripts/check_canonical_iterator_calls_test.sh
+++ b/scripts/check_canonical_iterator_calls_test.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+CHECK="$SCRIPT_DIR/check_canonical_iterator_calls.sh"
+tmp_root="$(mktemp -d "${TMPDIR:-/tmp}/vibe_iterator_calls_test.XXXXXX")"
+trap 'rm -rf "$tmp_root"' EXIT
+
+mkdir -p "$tmp_root/book/en" "$tmp_root/examples" "$tmp_root/bench/exec" "$tmp_root/fixtures"
+printf '%s\n' 'Array::map(xs, f)' > "$tmp_root/book/en/chapter.vibe.md"
+printf '%s\n' 'Array::filter(xs, pred)' > "$tmp_root/examples/example.vibe"
+printf '%s\n' 'Array::fold(xs, 0, add)' > "$tmp_root/bench/exec/scenario.vibe"
+printf '%s\n' 'Array::map(xs, f)' > "$tmp_root/fixtures/compatibility_test.vibe"
+
+set +e
+VIBE_CANONICAL_ITERATOR_ROOT="$tmp_root" bash "$CHECK" > "$tmp_root/red.out" 2>&1
+red_status=$?
+set -e
+if [ "$red_status" -eq 0 ]; then
+  echo "canonical Iterator calls self-test: expected legacy tutorial and example calls to fail" >&2
+  exit 1
+fi
+if [ "$(grep -c 'Array::' "$tmp_root/red.out")" -ne 2 ]; then
+  echo "canonical Iterator calls self-test: expected one finding in each canonical scope" >&2
+  cat "$tmp_root/red.out" >&2
+  exit 1
+fi
+
+printf '%s\n' 'Iterator::map(xs, f)' > "$tmp_root/book/en/chapter.vibe.md"
+printf '%s\n' 'Iterator::filter(xs, pred)' > "$tmp_root/examples/example.vibe"
+printf '%s\n' 'Iterator::fold(xs, 0, add)' > "$tmp_root/bench/exec/scenario.vibe"
+VIBE_CANONICAL_ITERATOR_ROOT="$tmp_root" bash "$CHECK" > "$tmp_root/green.out"
+grep -q '^canonical Iterator calls: ok$' "$tmp_root/green.out"
+
+echo "canonical Iterator calls self-test: ok"

--- a/scripts/doctest_extract_run.sh
+++ b/scripts/doctest_extract_run.sh
@@ -340,8 +340,12 @@ export -f trace_begin trace_end trace_rand_hex trace_now_ns trace_json_escape
 
 # awk rather than `grep -v`: grep exits 1 when it filters everything out, and
 # under `set -o pipefail` that would kill an all-skip run.
-awk -F'\t' '$4 != "skip"' "$worklist" \
-  | xargs -r -P "$JOBS" -I{} bash -c 'doctest_block "$1"' _ {}
+# BSD xargs normalizes tabs in `-I` input before substitution, which destroys
+# the work-list record and makes the worker treat the complete line as seq_no.
+# NUL-delimit each record so tabs reach `doctest_block` unchanged on both BSD
+# and GNU xargs.
+awk -F'\t' '$4 != "skip" { printf "%s%c", $0, 0 }' "$worklist" \
+  | xargs -0 -r -P "$JOBS" -I{} bash -c 'doctest_block "$1"' _ {}
 
 # Phase 3 (serial): replay the work list in source order. Output is identical
 # to the serial version's, whatever order the workers finished in.

--- a/scripts/vibe_book.sh
+++ b/scripts/vibe_book.sh
@@ -18,7 +18,11 @@ cd "$ROOT_DIR"
 compiler="${VIBE_BOOK_COMPILER:-}"
 if [ -z "$compiler" ]; then
   echo "vibe_book.sh: building current stage2"
-  VIBE_REGEN_MODULE_SOURCE=1 bash scripts/generations.sh build
+  # The tool compile and `_start` run below are the executable validation for
+  # this lane. Skip generations.sh's additional sample run so the standalone
+  # book workflow does not also require a wasmtime installation.
+  VIBE_REGEN_MODULE_SOURCE=1 VIBE_GENERATION_VALIDATE_RUN=0 \
+    bash scripts/generations.sh build
   for gen in $(ls -td _build/selfhost/generations/*/ 2>/dev/null); do
     if [ -s "${gen}stage2.wasm" ]; then
       compiler="${gen}stage2.wasm"

--- a/scripts/vibe_book.sh
+++ b/scripts/vibe_book.sh
@@ -5,6 +5,10 @@
 #
 # Writes _build/book/*.html. Uses the same compile-once tool cache pattern
 # as scripts/vibe_md.sh. Invokes `_start` directly so main runs once.
+#
+# The book package resolves the current @vibe/builtin closure. Build a current
+# stage2 before compiling the tool: the pinned seed is a stage0 compiler and
+# may predate intrinsics used by that closure.
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -13,15 +17,14 @@ cd "$ROOT_DIR"
 
 compiler="${VIBE_BOOK_COMPILER:-}"
 if [ -z "$compiler" ]; then
+  echo "vibe_book.sh: building current stage2"
+  VIBE_REGEN_MODULE_SOURCE=1 bash scripts/generations.sh build
   for gen in $(ls -td _build/selfhost/generations/*/ 2>/dev/null); do
     if [ -s "${gen}stage2.wasm" ]; then
       compiler="${gen}stage2.wasm"
       break
     fi
   done
-  if [ -z "$compiler" ]; then
-    compiler="bootstrap/seed/compiler.wasm"
-  fi
 fi
 if [ ! -s "$compiler" ]; then
   echo "vibe_book.sh: compiler wasm not found: $compiler" >&2


### PR DESCRIPTION
Follow-up to #2379.

## Summary

- infer applied trait arguments from a concrete receiver before checking later callback arguments, so `Iterator::filter(Array[String], unannotated_lambda)` and the same shape on user-defined iterators type-check
- use the same constructor-family matching rule for receiver inference and normal trait satisfaction, including deliberately bare impls such as `impl Value[Int] for Box`
- migrate the English/Japanese book, examples, cheatsheet, and syntax documentation from canonical `Array::*` combinator calls to `Iterator::*` with an explicit `trait Iterator` import
- retain `Array::*` as the compatibility/intrinsic implementation surface and keep raw single-file performance fixtures on that surface
- add a release-check lint that prevents legacy combinator spellings, including `Array::iter`, from returning to tutorials and nested examples
- translate the edited structured-shell internal design document to English
- preserve work-list tabs in the parallel doctest harness on BSD/macOS `xargs`
- build the book generator with a current stage2 because its package resolves the current stdlib closure, which may use intrinsics newer than the pinned stage0 seed

## Validation

- `pkf run test-affected`: 1,078/1,078 active unit-test files passed (FULL battery)
- docs doctest: 65 pass, 0 fail, 68 skip
- tutorial: 112 pass, 0 fail, 14 skip
- examples typecheck: 16/16
- tutorial translation parity: 20/20 chapter pairs
- canonical Iterator lint and self-test passed
- default `scripts/vibe_book.sh`: 57 entries rendered and `_build/book/index.html` produced
- Taskfile format and `git diff --check` passed
- final CI: 29 successful, 0 failing, 2 expected skips
- final Codex review: no major issues; all review threads resolved

## Performance

- the existing Array/Iterator devirtualization regression test passes in the full battery, so statically known Array receivers still lower to the direct Array loop without dictionary dispatch
- CI perf report: self-compile heap +0.17%, stage2 wasm size +0.14%, and no fuel/heap/wasm-size drift in the execution scenarios