### PR TITLE
Say why a compile failed instead of exiting 1 in silence — #2361

### DIFF
--- a/Taskfile.pkl
+++ b/Taskfile.pkl
@@ -1684,6 +1684,12 @@ local releaseCheck = new Task {
     // copy is the gc-gate job in .github/workflows/ci.yml, which installs
     // wasm-tools; a task that is only registered runs nowhere.
     testWasmValidateParity
+    // Registered since it was written and depended on by nothing, so it ran
+    // nowhere -- the same shape the two comments above describe. #2361 added
+    // the assertion that a program which does not compile explains itself on
+    // stderr, which is worth exactly as much as the number of places that
+    // assertion runs.
+    testVibeRun
   }
 }
 

--- a/lib/@vibe/cli/dispatch.vibe
+++ b/lib/@vibe/cli/dispatch.vibe
@@ -998,7 +998,7 @@ fn profile_callstack_env() -> String with Env {
 
 export fn selfhost_cli_low_level_args_profiled(input_path: String, output_path: String, entry_name: String, mode: String, profile_tsv_path: String, profile_callstack_path: String) -> Int with Exception + Fs + Env + Profiler {
   if !input_file_exists(input_path) {
-    1
+    throw(String::concat("no such input file: ", input_path))
   } else {
     let total_start = profiler_now_us()
     let (bytes, load_us, type_us, bundle_us, parse_us, compile_us, _compile_total_us) = compile_release_file_mode_for_cli_profiled(input_path, entry_name, mode)
@@ -1028,22 +1028,36 @@ fn low_level_compile_release_profiled(input_path: String, output_path: String, e
   }
 }
 
+/// What the positional low-level form takes, and what to type instead. Named
+/// here rather than in a wrapper script so it cannot drift from the dispatch
+/// `match` a few lines below, which is the only place the subcommands exist.
+fn low_level_usage() -> String {
+  "usage: <input> <output> <entry> [mode], or a subcommand: build, check, compile, compile-lite, profile, serve"
+}
+
+/// `deps foo.vibe` is not a subcommand, so dispatch reads it as the positional
+/// form and `deps` becomes the input path. Say what was read as what, so a
+/// mistyped or unported verb is visible instead of being an exit code (#2361).
+fn low_level_read_as(input_path: String, output_path: String, entry_name: String) -> String {
+  String::concat(String::concat(String::concat("read `", input_path), "` as the input path, `"), String::concat(String::concat(output_path, "` as the output path, `"), String::concat(entry_name, "` as the entry name")))
+}
+
 export fn selfhost_cli_low_level_args(input_path: String, output_path: String, entry_name: String, mode: String) -> Int with Exception + Fs + Env + Profiler {
   if input_path == "" {
-    1
+    throw(String::concat("no input path -- ", low_level_usage()))
   }
   else if output_path == "" {
-    1
+    throw(String::concat(String::concat("no output path (", low_level_read_as(input_path, output_path, entry_name)), String::concat(") -- ", low_level_usage())))
   }
   else if entry_name == "" {
-    1
+    throw(String::concat(String::concat("no entry name (", low_level_read_as(input_path, output_path, entry_name)), String::concat(") -- ", low_level_usage())))
   }
   else if is_vibex_path(input_path) && entry_name != "main" {
     throw(".vibex executable entry is always main; arbitrary entry names are not allowed")
   }
   else if mode == "" || mode == "release" || mode == "no-dce" || mode == "mvp" {
     if !input_file_exists(input_path) {
-      1
+      throw(String::concat(String::concat("no such input file: ", input_path), String::concat(" -- ", low_level_usage())))
     } else {
       let profile_tsv_path = profile_tsv_env()
       let profile_callstack_path = profile_callstack_env()
@@ -1076,7 +1090,7 @@ export fn selfhost_cli_low_level_args(input_path: String, output_path: String, e
     status
   }
   else {
-    1
+    throw(String::concat(String::concat("unknown mode `", mode), "`: expected one of release, no-dce, mvp, debug, check"))
   }
 }
 

--- a/lib/@vibe/cli/dispatch_test.vibe
+++ b/lib/@vibe/cli/dispatch_test.vibe
@@ -9,6 +9,7 @@ import ./dispatch.vibe {
   selfhost_cli_check_args,
   selfhost_cli_compile_args,
   selfhost_cli_compile_lite_args,
+  selfhost_cli_low_level_args,
   selfhost_cli_low_level_args_profiled,
   selfhost_cli_profile_plan_args
 }
@@ -695,6 +696,62 @@ test "cli_main nesting: check usage throw is a printable String and exits 1" {
   assert(thrown == "check: expected <file...>")
   let status = run_cli_main_with_args(["check"])
   assert(status == 1)
+}
+
+/// #2361: the positional low-level form returned a bare `1` for every way of
+/// being wrong -- no input, no output, no entry, a file that is not there, an
+/// unrecognized mode. The exit code is unchanged; what was missing is the
+/// reason, and "the file is broken", "this verb is not supported" and "the
+/// toolchain is not built" were indistinguishable from the output.
+///
+/// The unknown-verb case arrives here because dispatch falls through to the
+/// positional form for anything that is not a subcommand, so `vibe_cli.sh deps
+/// foo.vibe` compiles a file named `deps`. Saying what was read as what is what
+/// makes that visible.
+fn low_level_throw(input_path: String, output_path: String, entry_name: String, mode: String) -> String with Env + Exception + Fs + Profiler {
+  handle {
+    let _ = selfhost_cli_low_level_args(input_path, output_path, entry_name, mode)
+    "OK"
+  } with { Exception::Throw(e) => e }
+}
+
+test "low-level form names what it read when an argument is missing" {
+  assert(String::contains(low_level_throw("", "", "", ""), "no input path"))
+  let no_output = low_level_throw("deps", "", "", "")
+  assert(String::contains(no_output, "no output path"))
+  assert(String::contains(no_output, "read `deps` as the input path"))
+  // `vibe_cli.sh deps foo.vibe`: not a subcommand, so `deps` became the input.
+  let no_entry = low_level_throw("deps", "lib/x.vibe", "", "")
+  assert(String::contains(no_entry, "no entry name"))
+  assert(String::contains(no_entry, "read `deps` as the input path"))
+  assert(String::contains(no_entry, "`lib/x.vibe` as the output path"))
+  // Every one of them points at the two things that ARE accepted.
+  for message in [no_output, no_entry] {
+    assert(String::contains(message, "<input> <output> <entry> [mode]"))
+    assert(String::contains(message, "build, check, compile, compile-lite, profile, serve"))
+  }
+}
+
+test "low-level form names a missing input file and an unknown mode" {
+  let missing = low_level_throw("/tmp/vibe_no_such_input_2361.vibe", "/tmp/vibe_2361_out.wasm", "main", "")
+  assert(String::contains(missing, "no such input file: /tmp/vibe_no_such_input_2361.vibe"))
+  let real_path = "/tmp/vibe_selfhost_cli_2361_mode.vibe"
+  Fs::write_bytes(real_path, string_to_bytes("export let answer: () -> Int = () -> { 42 }\n"))
+  let bad_mode = low_level_throw(real_path, "/tmp/vibe_2361_out.wasm", "answer", "frobnicate")
+  assert(String::contains(bad_mode, "unknown mode `frobnicate`"))
+  assert(String::contains(bad_mode, "release, no-dce, mvp, debug, check"))
+  // The control: the same call with a mode that IS recognized does not throw.
+  assert(low_level_throw(real_path, "/tmp/vibe_2361_out.wasm", "answer", "release") == "OK")
+}
+
+/// The exit code these carry is the one they always had -- 1, via the entry
+/// wrapper's Exception arm. Only the printed reason is new.
+test "an unexplained low-level failure still exits 1" {
+  assert(run_cli_main_with_args([
+    "/tmp/vibe_no_such_input_2361.vibe",
+    "/tmp/vibe_2361_out.wasm",
+    "main"
+  ]) == 1)
 }
 
 /// Same framing as `runtime/vibe` `emit_check_diagnostics`: `error: ` on a

--- a/scripts/vibe_run.sh
+++ b/scripts/vibe_run.sh
@@ -77,11 +77,44 @@ mkdir -p "$ROOT_DIR/_build/vibe_run"
 
 # 1. compile (FS import resolution) via the seed. VIBE_COVERAGE=$coverage selects
 #    the instrumented codegen when --coverage.
+#
+# The compile step says WHY it failed in two places, neither of them the
+# program's stdout: `cli_main` writes its diagnostics to the `<output>.diag`
+# sidecar (emit_compile_diag), and a runner-level failure (bad wasm, missing
+# host import, a node stack) lands on the invoke's stdout, which is otherwise
+# just the result code. Both are reported below on failure -- #2361, where this
+# wrapper sent stdout to /dev/null and exited 1 having explained nothing.
+#
+# Delete last run's artifacts first. A stale `.diag` would otherwise be printed
+# as this run's reason, and a stale wasm would satisfy the emptiness check below.
+compile_out="$ROOT_DIR/$out_rel"
+compile_diag="$compile_out.diag"
+rm -f "$compile_out" "$compile_diag"
+
+compile_log="$ROOT_DIR/_build/vibe_run/$(basename "${src_rel%.vibex}").compile.log"
+compile_status=0
 VIBE_COVERAGE="$coverage" VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   bash "$ROOT_DIR/scripts/run_wasm_vibe_host_runner.sh" \
-  --invoke cli_main "$seed" "$src_rel" "$out_rel" "$entry" >/dev/null
+  --invoke cli_main "$seed" "$src_rel" "$out_rel" "$entry" >"$compile_log" || compile_status=$?
 
-[ -s "$ROOT_DIR/$out_rel" ] || { echo "vibe_run.sh: compile produced no wasm" >&2; exit 1; }
+if [ "$compile_status" -ne 0 ] || [ ! -s "$compile_out" ]; then
+  # `awk`, not `sed`: emit_compile_diag ends the sidecar WITHOUT a trailing
+  # newline, and sed would leave the last diagnostic glued to the summary line
+  # below. awk terminates every record it prints.
+  if [ -s "$compile_diag" ]; then
+    awk '{ print "error: " $0 }' "$compile_diag" >&2
+  elif [ -s "$compile_log" ]; then
+    # No diagnostic: the compiler did not reach the point of writing one, so
+    # relay whatever the invoke printed rather than exiting silently.
+    awk '{ print "vibe_run.sh: compile output: " $0 }' "$compile_log" >&2
+  fi
+  if [ "$compile_status" -ne 0 ]; then
+    echo "vibe_run.sh: compilation failed: $src_rel" >&2
+  else
+    echo "vibe_run.sh: compile produced no wasm: $out_rel" >&2
+  fi
+  exit 1
+fi
 
 # 2. execute the compiled program. Under --coverage, VIBE_COV_OUT makes the runner
 #    dump the hit bitmap (functions + branches) after the run, before it exits —

--- a/scripts/vibe_run.sh
+++ b/scripts/vibe_run.sh
@@ -98,11 +98,17 @@ VIBE_COVERAGE="$coverage" VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IM
   --invoke cli_main "$seed" "$src_rel" "$out_rel" "$entry" >"$compile_log" || compile_status=$?
 
 if [ "$compile_status" -ne 0 ] || [ ! -s "$compile_out" ]; then
+  # Framed the same way `runtime/vibe` and `format_check_report`
+  # (lib/@vibe/cli/entry.vibe) frame it: `error: ` starts a diagnostic, and a
+  # `hint:` or already-indented line is a CONTINUATION of the one above, so it
+  # is indented rather than prefixed. Prefixing every line turned one
+  # two-line diagnostic into two, which is what `grep -c '^error: '` counts.
+  #
   # `awk`, not `sed`: emit_compile_diag ends the sidecar WITHOUT a trailing
   # newline, and sed would leave the last diagnostic glued to the summary line
   # below. awk terminates every record it prints.
   if [ -s "$compile_diag" ]; then
-    awk '{ print "error: " $0 }' "$compile_diag" >&2
+    awk '{ if ($0 ~ /^hint:/ || $0 ~ /^[[:space:]]/) print "  " $0; else print "error: " $0 }' "$compile_diag" >&2
   elif [ -s "$compile_log" ]; then
     # No diagnostic: the compiler did not reach the point of writing one, so
     # relay whatever the invoke printed rather than exiting silently.

--- a/scripts/vibe_run_smoke.sh
+++ b/scripts/vibe_run_smoke.sh
@@ -43,4 +43,43 @@ grep -q ".vibex entry is always main" "$entry_err" || {
   echo "[vibe-run-smoke] FAIL: missing custom-entry rejection diagnostic" >&2; exit 1
 }
 
-echo "[vibe-run-smoke] ok (single=10, multi-file=42)"
+# #2361: a program that does not compile must say WHY on stderr. The compile
+# step's reason lives in the `<output>.diag` sidecar, and the wrapper used to
+# send its stdout to /dev/null and exit 1 having printed nothing -- "the file is
+# broken", "the wrapper does not support this" and "the toolchain is not built"
+# were indistinguishable from the output.
+#
+# Two shapes, because they are produced by different parts of the compiler and
+# a wrapper can lose one while relaying the other.
+check_explains() { # <label> <source text> <expected substring>
+  local label="$1" src="$2" needle="$3" err="$WORK/$1.err"
+  printf '%s' "$src" > "$WORK/$label.vibex"
+  if bash "$ROOT_DIR/scripts/vibe_run.sh" "$WORK/$label.vibex" > /dev/null 2> "$err"; then
+    echo "[vibe-run-smoke] FAIL $label: a program that does not compile exited 0" >&2; exit 1
+  fi
+  grep -q "$needle" "$err" || {
+    echo "[vibe-run-smoke] FAIL $label: the failure was not explained on stderr (#2361)" >&2
+    echo "    expected substring: $needle" >&2
+    echo "    stderr was:" >&2
+    sed 's/^/      /' "$err" >&2
+    exit 1
+  }
+}
+
+# A checker diagnostic.
+check_explains missing_effect_row \
+  'fn main() -> Unit {
+  println("hi")
+}
+' \
+  "requires an explicit effect row"
+
+# A parse error, which is reported by an earlier phase.
+check_explains parse_error \
+  'fn main() -> Unit with () {
+  let x = (
+}
+' \
+  "unexpected token"
+
+echo "[vibe-run-smoke] ok (single=10, multi-file=42, compile failures explained)"

--- a/scripts/vibe_run_smoke.sh
+++ b/scripts/vibe_run_smoke.sh
@@ -82,4 +82,21 @@ check_explains parse_error \
 ' \
   "unexpected token"
 
+# A diagnostic with a `hint:` continuation is ONE diagnostic. `runtime/vibe` and
+# `format_check_report` both frame it that way so `grep -c '^error: '` is an
+# exact count; prefixing every relayed line would make this program look like
+# two errors.
+printf 'fn helper() -> Unit with () {\n  println("hi")\n}\nfn main() -> Unit with Stdout {\n  helper()\n}\n' > "$WORK/hint_shape.vibex"
+hint_err="$WORK/hint_shape.err"
+if bash "$ROOT_DIR/scripts/vibe_run.sh" "$WORK/hint_shape.vibex" > /dev/null 2> "$hint_err"; then
+  echo "[vibe-run-smoke] FAIL hint_shape: a program that does not compile exited 0" >&2; exit 1
+fi
+starts="$(grep -c '^error: ' "$hint_err" || true)"
+hints="$(grep -c '^  hint: ' "$hint_err" || true)"
+if [ "$starts" != "1" ] || [ "$hints" != "1" ]; then
+  echo "[vibe-run-smoke] FAIL hint_shape: expected 1 diagnostic start and 1 indented hint, got $starts and $hints (#2361)" >&2
+  sed 's/^/      /' "$hint_err" >&2
+  exit 1
+fi
+
 echo "[vibe-run-smoke] ok (single=10, multi-file=42, compile failures explained)"


### PR DESCRIPTION
Closes #2361.

## The finding

`scripts/vibe_run.sh` exited 1 having printed nothing about why:

```console
$ bash scripts/vibe_run.sh _scratch/bad.vibex; echo "exit=$?"
[ensure-seed] already present and verified: bootstrap/seed/compiler.wasm (sha256=7ab896...)
exit=1
```

"The file is broken", "the wrapper does not support this" and "the toolchain is not built" are indistinguishable from that output.

The issue attributed this to the `>/dev/null` on the compile step, on the premise that stdout is where the compiler writes diagnostics. Measured, that is not where they were: **`cli_main` writes them to the `<output>.diag` sidecar** (`emit_compile_diag`), and the invoke's stdout carries the result code — `0` or `1` — plus, when the runner itself dies, a node stack. So the redirect was hiding the second one and the first was never being read at all.

| | stdout | `<out>.wasm.diag` | exit |
|---|---|---|---|
| compiles | `0` | not written | 0 |
| effect-row error | `1` | `.vibex fn main requires an explicit effect row; write 'with ()' for a pure entry` | 1 |
| parse error | `1` | `unexpected token: }` | 1 |

## What this does

**`vibe_run.sh` reports whichever it has.** The sidecar when there is one, the captured stdout otherwise, so a runner-level failure is not silent either:

```console
$ bash scripts/vibe_run.sh _scratch/bad.vibex
error: _scratch/bad.vibex: .vibex fn main requires an explicit effect row; write 'with ()' for a pure entry
vibe_run.sh: compilation failed: _scratch/bad.vibex
```

Two details that are not incidental:

- **Last run's wasm and `.diag` are deleted first.** A stale `.diag` would otherwise be printed as this run's reason, and a stale wasm would satisfy the `[ -s ... ]` emptiness check — so the fix does not introduce running yesterday's binary.
- **`awk`, not `sed`.** The sidecar ends without a trailing newline, and `sed` left the last diagnostic glued to the summary line (`...for a pure entryvibe_run.sh: compilation failed:`).

**The same silence had a second home.** An unknown verb is not rejected by `scripts/vibe_cli.sh` — dispatch falls through to the positional low-level form, so `vibe_cli.sh deps foo.vibe` sets out to compile a file named `deps` — and `selfhost_cli_low_level_args` returned a bare `1` for every way of being wrong. Five of those now speak:

```console
$ bash scripts/vibe_cli.sh deps lib/@vibe/core/list.vibe
error: no entry name (read `deps` as the input path, `lib/@vibe/core/list.vibe` as the output path, `` as the entry name) -- usage: <input> <output> <entry> [mode], or a subcommand: build, check, compile, compile-lite, profile, serve

$ bash scripts/vibe_cli.sh no_such_file.vibe /tmp/out.wasm main
error: no such input file: no_such_file.vibe -- usage: ...

$ bash scripts/vibe_cli.sh lib/@vibe/core/list.vibe /tmp/out.wasm main frobnicate
error: unknown mode `frobnicate`: expected one of release, no-dce, mvp, debug, check
```

This lives in the CLI, not in the shell wrapper: a verb list in `vibe_cli.sh` would be a second copy of the dispatch `match` and would drift from it. The list is now a function three lines above that `match`. Exit codes are unchanged — the entry wrapper's `Exception` arm prints and returns 1, which is what these returned before.

## Verification

- `bash scripts/compiler_gate.sh` — **ok**, 835 lines, 0 FAIL
- `lib/@vibe/cli/dispatch_test.vibe` — 49 tests pass (3 new)
- `vibe fmt --check` clean on both changed `.vibe` files

**Red-tested, with the mutation verified present before its failure was trusted:**

| mutation | result |
|---|---|
| `vibe_run.sh` back to `>/dev/null` with no relay | `vibe_run_smoke.sh` FAILS, naming the missing substring and printing the stderr it did get |
| the silent `1` restored for a missing input file | exactly **one** of the 49 dispatch tests fails — the one asserting the message |

In both cases the pre-existing assertions stayed green under the mutation, so the new ones are what discriminate.

## One thing found on the way

`scripts/vibe_run_smoke.sh` was registered as a pkfire task and **depended on by nothing**, so it ran nowhere — the shape `Taskfile.pkl`'s own comments call out twice ("Registered but depended on by nothing until #2252, so it ran nowhere", "a task that is only registered runs nowhere"). Adding a red test to a script that never runs would have been the #2248 failure exactly, so `test-vibe-run` is now in `release-check`.

It is not the only one in that state — `test-vibe-test` and several siblings are registered-only too. Wiring them all is a separate change; this PR wires the one it depends on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FYMVd6D2o82suTfTwoJPMf

---
_Generated by [Claude Code](https://claude.ai/code/session_01FYMVd6D2o82suTfTwoJPMf)_