### PR TITLE
Compiler perf: −34% wall on a full-closure compile, plus dead-code cleanup

### DIFF
--- a/lib/@vibe/compiler/checker/canonical_checked_type_state.vibe
+++ b/lib/@vibe/compiler/checker/canonical_checked_type_state.vibe
@@ -412,6 +412,16 @@ fn canonical_name_seen(names: Array[String], name: String) -> Bool {
   string_in(names, name)
 }
 
+/// Checker-internal entries that must not surface in a semantic environment
+/// snapshot: per-function return markers, and every `#`-prefixed sentinel --
+/// `#` is rejected in identifiers, so no parsed source can bind such a name
+/// and its presence is pure checker bookkeeping (e.g. the negative
+/// #active_region entry env_cache seeds into every acceleration index).
+/// Filtering here keeps cached and uncached environments canonically equal.
+fn canonical_env_name_is_internal(name: String) -> Bool {
+  String::starts_with(name, "__fn_ret__:") || String::starts_with(name, "#")
+}
+
 fn canonical_collect_effective_bindings(env: TypeEnv) -> Array[(String, Type)] {
   let out = array_empty()
   let seen = array_empty()
@@ -425,7 +435,7 @@ fn canonical_collect_effective_bindings(env: TypeEnv) -> Array[(String, Type)] {
       EnvBind(name, binding, rest) => {
         if !canonical_name_seen(seen, name) {
           Array::push(seen, name)
-          if !String::starts_with(name, "__fn_ret__:") {
+          if !canonical_env_name_is_internal(name) {
             Array::push(out, (name, binding.ty))
           }
         }
@@ -452,7 +462,7 @@ fn canonical_collect_effective_bindings(env: TypeEnv) -> Array[(String, Type)] {
           let (name, binding) = Array::get(bindings, i)
           if !canonical_name_seen(seen, name) {
             Array::push(seen, name)
-            if !String::starts_with(name, "__fn_ret__:") {
+            if !canonical_env_name_is_internal(name) {
               Array::push(out, (name, binding.ty))
             }
           }
@@ -466,7 +476,7 @@ fn canonical_collect_effective_bindings(env: TypeEnv) -> Array[(String, Type)] {
           let name = Array::get(names, i)
           if !canonical_name_seen(seen, name) {
             Array::push(seen, name)
-            if !String::starts_with(name, "__fn_ret__:") {
+            if !canonical_env_name_is_internal(name) {
               Array::push(out, (name, Array::get(types, i).ty))
             }
           }

--- a/lib/@vibe/compiler/checker/checker.vibe
+++ b/lib/@vibe/compiler/checker/checker.vibe
@@ -1880,64 +1880,6 @@ fn resolve_qualified_ctor_ident(name: String, env: TypeEnv, defs: Array[TypeDef]
   }
 }
 
-/// Legacy carrier decoder path retained for compatibility with its isolated
-/// codec tests. No checker/import path calls it; EnvTypeDefs is authoritative.
-fn resolve_qualified_parameterized_ctor(ename: String, params: Array[String], member: String, env: TypeEnv, c: Int) -> Option[Type] {
-  match env_lookup(env, enum_def_env_name(ename)) {
-    Some(carrier) => match decode_enum_def(carrier) {
-      Some((carrier_params, carrier_variants)) => {
-        // The carrier and the `TDEnum` must agree on the arity, or the
-        // substitution below would leave a formal unbound. They disagree only
-        // if the two were written by different declarations of the same name,
-        // which is exactly when guessing is wrong.
-        if Array::length(carrier_params) != Array::length(params) {
-          env_lookup(env, member)
-        } else {
-          let param_var_ids = array_empty()
-          let param_var_types = array_empty()
-          let mut pi = 0
-          while pi < Array::length(carrier_params) {
-            Array::push(param_var_ids, c + pi)
-            Array::push(param_var_types, CtVar(c + pi))
-            pi = pi + 1
-          }
-          let result_ty = CtNamed(ename, param_var_types)
-          let mut found = false
-          let mut payloads = array_empty()
-          let mut vi = 0
-          while vi < Array::length(carrier_variants) {
-            let (vname, vtypes) = Array::get(carrier_variants, vi)
-            if vname == member {
-              found = true
-              payloads = vtypes
-            } else {
-              ()
-            }
-            vi = vi + 1
-          }
-          if found {
-            let subst_payloads = for pt in payloads {
-              subst_type_params(pt, carrier_params, param_var_types)
-            }
-            let ctor_ty = if Array::length(subst_payloads) == 0 {
-              result_ty
-            } else {
-              CtFn(subst_payloads, result_ty, None)
-            }
-            Some(CtForAll(param_var_ids, array_empty(), ctor_ty))
-          } else {
-            // The `TDEnum` says the variant exists but the carrier does not
-            // list it. Do not invent a scheme for it.
-            None
-          }
-        }
-      },
-      None => env_lookup(env, member)
-    },
-    None => env_lookup(env, member)
-  }
-}
-
 fn expr_ident_name_or_empty(expr: Expr) -> String {
   match expr {
     EIdent(name, _) => name,
@@ -3231,8 +3173,16 @@ export fn bind_function_dependency_contracts(env: TypeEnv, name: String, value: 
 }
 
 fn env_has_active_region(env: TypeEnv) -> Bool {
+  // Only the real region skolem (a CtNamed bound by the `region` checker path)
+  // counts as active. env_cache seeds every acceleration index with a negative
+  // CtUnit-typed `__active_region__` entry so this common query answers from
+  // the index instead of walking the whole chain on a miss; that marker (and
+  // any other non-CtNamed value) means NO active region.
   match env_lookup(env, "__active_region__") {
-    Some(_) => true,
+    Some(ty) => match ty {
+      CtNamed(_, _) => true,
+      _ => false
+    },
     None => false
   }
 }

--- a/lib/@vibe/compiler/checker/checker.vibe
+++ b/lib/@vibe/compiler/checker/checker.vibe
@@ -2791,7 +2791,7 @@ fn closure_capture_row(effect: Option[String], body: Expr, params: Array[(String
 fn type_mentions_active_region(ty: Type, env: TypeEnv) -> Bool {
   match env {
     EnvEmpty => false,
-    EnvBind(name, binding, rest) => if name == "__active_region__" {
+    EnvBind(name, binding, rest) => if name == "#active_region" {
       match binding.ty {
         CtNamed(region_name, _) => type_mentions_named(ty, region_name) || type_mentions_active_region(ty, rest),
         _ => type_mentions_active_region(ty, rest)
@@ -2816,7 +2816,7 @@ fn assignment_crosses_region(name: String, ty: Type, env: TypeEnv) -> Bool {
     EnvEmpty => false,
     EnvBind(n, binding, rest) => if n == name {
       false
-    } else if n == "__active_region__" {
+    } else if n == "#active_region" {
       match binding.ty {
         CtNamed(region_name, _) => type_mentions_named(ty, region_name) || assignment_crosses_region(name, ty, rest),
         _ => assignment_crosses_region(name, ty, rest)
@@ -2863,7 +2863,7 @@ fn binding_predates_active_region(name: String, env: TypeEnv) -> Bool {
     EnvEmpty => false,
     EnvBind(n, _, rest) => if n == name {
       false
-    } else if n == "__active_region__" {
+    } else if n == "#active_region" {
       match env_lookup(rest, name) {
         Some(_) => true,
         None => false
@@ -3175,10 +3175,10 @@ export fn bind_function_dependency_contracts(env: TypeEnv, name: String, value: 
 fn env_has_active_region(env: TypeEnv) -> Bool {
   // Only the real region skolem (a CtNamed bound by the `region` checker path)
   // counts as active. env_cache seeds every acceleration index with a negative
-  // CtUnit-typed `__active_region__` entry so this common query answers from
+  // CtUnit-typed `#active_region` entry so this common query answers from
   // the index instead of walking the whole chain on a miss; that marker (and
   // any other non-CtNamed value) means NO active region.
-  match env_lookup(env, "__active_region__") {
+  match env_lookup(env, "#active_region") {
     Some(ty) => match ty {
       CtNamed(_, _) => true,
       _ => false
@@ -6725,7 +6725,7 @@ fn tail_named_record_mentions_region(expr: Expr, env: TypeEnv, defs: Array[TypeD
 fn expression_mentions_active_region_scan(expr: Expr, cur: TypeEnv, full: TypeEnv, defs: Array[TypeDef], s: Subst, c: Int, ce: (Expr, TypeEnv, Array[TypeDef], Subst, Int, Array[String], Array[(Int, Type)]) -> (Type, Subst, Int)) -> Bool {
   match cur {
     EnvEmpty => false,
-    EnvBind(name, binding, rest) => if name == "__active_region__" {
+    EnvBind(name, binding, rest) => if name == "#active_region" {
       match binding.ty {
         CtNamed(region_name, _) => tail_named_record_mentions_region(expr, full, defs, s, c, region_name, ce) || expression_mentions_active_region_scan(expr, rest, full, defs, s, c, ce),
         _ => expression_mentions_active_region_scan(expr, rest, full, defs, s, c, ce)
@@ -8823,8 +8823,8 @@ fn check_expr_capture_impl(expr: Expr, env: TypeEnv, defs: Array[TypeDef], s: Su
               // existing indexed TypeEnv lookup instead of rescanning every
               // lexical binding. env_bind keeps this cache at the head for
               // ordinary region-local names, and a nested region rebuilds it.
-              let env_body_uncached = env_bind(env_bind(env_bind(env, "__capture_boundary__", CtUnit), binder_name, region_ty), "__active_region__", region_ty)
-              let env_body = env_cache_binding(env_body_uncached, "__active_region__", region_ty)
+              let env_body_uncached = env_bind(env_bind(env_bind(env, "__capture_boundary__", CtUnit), binder_name, region_ty), "#active_region", region_ty)
+              let env_body = env_cache_binding(env_body_uncached, "#active_region", region_ty)
               // The specialized region path checks the literal lambda body
               // directly. Preserve both structural edges from the outer call:
               // argument child 1, then EFn body child 0.

--- a/lib/@vibe/compiler/checker/checker_effects.vibe
+++ b/lib/@vibe/compiler/checker/checker_effects.vibe
@@ -3177,39 +3177,6 @@ fn collect_unhandled_entry_ops(root: Expr) -> Array[String] {
   out
 }
 
-fn collect_expr_handle_effects(root: Expr) -> Array[String] {
-  let out = no_str_labels()
-  let stack = Array::slice([root], 0, 1)
-  while Array::length(stack) > 0 {
-    let n = Array::length(stack)
-    let expr = Array::get(stack, n - 1)
-    Array::truncate(stack, n - 1)
-    match expr {
-      EHandle(_, arms) => {
-        let discharged = collect_handle_effects(arms)
-        let mut i = 0
-        while i < Array::length(discharged) {
-          let lab = Array::get(discharged, i)
-          if effect_row_has_label(Some(out), lab) {
-            ()
-          } else {
-            Array::push(out, lab)
-          }
-          i = i + 1
-        }
-      },
-      _ => ()
-    }
-    let children = expr_children(expr)
-    let mut ci = 0
-    while ci < Array::length(children) {
-      Array::push(stack, Array::get(children, ci))
-      ci = ci + 1
-    }
-  }
-  out
-}
-
 fn label_is_handled(label: String, handled: Array[String]) -> Bool {
   if effect_row_has_label(Some(handled), label) {
     true
@@ -4764,7 +4731,6 @@ export fn typing_semantics_seed() -> String {
 /// reach the two `STest` / `SBench` arms below without widening either node.
 let test_effect_row_tbl: Array[(String, String)] = array_empty()
 
-///|
 fn test_row_has_label(labels: Array[String], target: String) -> Bool {
   let mut i = 0
   let mut found = false
@@ -4779,7 +4745,6 @@ fn test_row_has_label(labels: Array[String], target: String) -> Bool {
   found
 }
 
-///|
 fn set_test_effect_rows(stmts: Array[Stmt]) -> Unit {
   Array::truncate(test_effect_row_tbl, 0)
   let mut i = 0
@@ -5617,31 +5582,6 @@ fn labels_are_entry_cache_safe(row: Array[String]) -> Bool {
   let mut ok = true
   while i < Array::length(row) {
     if !is_entry_cache_safe_operation(Array::get(row, i)) {
-      ok = false
-    } else {
-      ()
-    }
-    i = i + 1
-  }
-  ok
-}
-
-fn array_is_subset_of_str(row: Array[String], safe: Array[String]) -> Bool {
-  let mut i = 0
-  let mut ok = true
-  while i < Array::length(row) {
-    let eff = effect_name_of_op(Array::get(row, i))
-    let mut j = 0
-    let mut found = false
-    while j < Array::length(safe) {
-      if Array::get(safe, j) == eff {
-        found = true
-      } else {
-        ()
-      }
-      j = j + 1
-    }
-    if !found {
       ok = false
     } else {
       ()

--- a/lib/@vibe/compiler/cli_support.vibe
+++ b/lib/@vibe/compiler/cli_support.vibe
@@ -626,40 +626,6 @@ fn owner_locating_source(path: String, source: String) -> Option[String] with Ex
   }
 }
 
-/// The entry's snapshot EXACTLY as the linked check consumed it -- ingested,
-/// markers and all, with no remap to the physical file. `checked_entry_source`
-/// does that remap so ordinary warnings cite lines a reader can visit; a
-/// VERDICT must not, or an inherited `.vpkg` import is invisible to it while
-/// the build rejects the same entry.
-///
-/// Unique-or-nothing, like `checked_entry_source`: describing text that was not
-/// the text checked is worse than saying nothing.
-fn checked_entry_snapshot(input_path: String, source_groups: Array[(String, Array[(String, String)])]) -> Option[String] {
-  let mut found: Option[String] = None
-  let mut count = 0
-  let mut gi = 0
-  while gi < Array::length(source_groups) {
-    let (_, sources) = Array::get(source_groups, gi)
-    let mut si = 0
-    while si < Array::length(sources) {
-      let (path, source) = Array::get(sources, si)
-      if path == input_path {
-        found = Some(source)
-        count = count + 1
-      } else {
-        ()
-      }
-      si = si + 1
-    }
-    gi = gi + 1
-  }
-  if count == 1 {
-    found
-  } else {
-    None
-  }
-}
-
 fn checked_entry_source(input_path: String, source_groups: Array[(String, Array[(String, String)])]) -> Option[String] with Exception + Fs {
   let mut found: Option[String] = None
   let mut count = 0

--- a/lib/@vibe/compiler/codegen/builtin_bodies/bodies_core_a1a1_str_eq.vibe
+++ b/lib/@vibe/compiler/codegen/builtin_bodies/bodies_core_a1a1_str_eq.vibe
@@ -213,8 +213,20 @@ import @vibe/compiler/codegen/wasm_emit {
 /// Params 0=a 1=b (packed (ptr<<32)|len i64). Locals (all i32, meta_i32=6):
 /// 2=len_a 3=len_b 4=ptr_a 5=ptr_b 6=i 7=chunk_limit (len-15, or 0 when
 /// len < 16 so the unsigned loop guard skips the chunk phase entirely).
+///
+/// Identity fast path: equal packed values mean same ptr AND same len, so the
+/// bytes are trivially equal -- answer 1 without touching memory. Same-object
+/// compares are common (e.g. table-verification scans over arrays sharing
+/// their element strings), and the check is one i64.eq before anything else.
 export fn gen_str_eq_body() -> Bytes {
   let b = bytebuf_new()
+  emit_local_get(b, 0)
+  emit_local_get(b, 1)
+  emit_i64_eq(b)
+  emit_if_void(b)
+  emit_i64_const(b, 1)
+  emit_return(b)
+  emit_end(b)
   emit_local_get(b, 0)
   emit_i64_const(b, 4294967295)
   emit_i64_and(b)

--- a/lib/@vibe/compiler/codegen/builtin_bodies/bodies_core_a1a1_str_eq.vibe
+++ b/lib/@vibe/compiler/codegen/builtin_bodies/bodies_core_a1a1_str_eq.vibe
@@ -217,16 +217,12 @@ import @vibe/compiler/codegen/wasm_emit {
 /// Identity fast path: equal packed values mean same ptr AND same len, so the
 /// bytes are trivially equal -- answer 1 without touching memory. Same-object
 /// compares are common (e.g. table-verification scans over arrays sharing
-/// their element strings), and the check is one i64.eq before anything else.
+/// their element strings). The check sits INSIDE the equal-length branch so
+/// the unequal-length miss -- the majority of misses in name-table scans --
+/// pays nothing for it; an equal-length compare pays one i64.eq before the
+/// SIMD loop it would otherwise always run.
 export fn gen_str_eq_body() -> Bytes {
   let b = bytebuf_new()
-  emit_local_get(b, 0)
-  emit_local_get(b, 1)
-  emit_i64_eq(b)
-  emit_if_void(b)
-  emit_i64_const(b, 1)
-  emit_return(b)
-  emit_end(b)
   emit_local_get(b, 0)
   emit_i64_const(b, 4294967295)
   emit_i64_and(b)
@@ -243,6 +239,13 @@ export fn gen_str_eq_body() -> Bytes {
   emit_if_i64(b)
   emit_i64_const(b, 0)
   emit_else(b)
+  emit_local_get(b, 0)
+  emit_local_get(b, 1)
+  emit_i64_eq(b)
+  emit_if_void(b)
+  emit_i64_const(b, 1)
+  emit_return(b)
+  emit_end(b)
   emit_local_get(b, 0)
   emit_i64_const(b, 32)
   emit_i64_shr_s(b)

--- a/lib/@vibe/compiler/codegen/common_analysis/common_analysis.vibe
+++ b/lib/@vibe/compiler/codegen/common_analysis/common_analysis.vibe
@@ -4294,20 +4294,6 @@ fn all_returns_definitely_int(e: Expr) -> Bool {
   }
 }
 
-/// `names` plus `n`, as a NEW array. The shadow set must not leak between
-/// sibling subtrees -- pushing in place would let a binder inside one `if`
-/// branch mask a call in the other.
-fn name_list_with(names: Array[String], n: String) -> Array[String] {
-  let out: Array[String] = []
-  let mut i = 0
-  while i < Array::length(names) {
-    Array::push(out, Array::get(names, i))
-    i = i + 1
-  }
-  Array::push(out, n)
-  out
-}
-
 /// The type table `compute_float_returning_names` resolves against.
 ///
 /// It mirrors what `check_stmts` has in `defs` when it resolves a return

--- a/lib/@vibe/compiler/codegen/gc/backend_expr.vibe
+++ b/lib/@vibe/compiler/codegen/gc/backend_expr.vibe
@@ -513,20 +513,6 @@ fn emit_gc_eq_value(buf: Bytes, lhs: Expr, rhs: Expr, local_names: Array[String]
   }
 }
 
-fn gc_direct_abi_expr_index(ctx: CompileCtxGc, name: String) -> Int {
-  let mut i = 0
-  let mut found = -1
-  while i < Array::length(ctx.gc_direct_abi_names) {
-    if found < 0 && Array::get(ctx.gc_direct_abi_names, i) == name {
-      found = i
-    } else {
-      ()
-    }
-    i = i + 1
-  }
-  found
-}
-
 /// Conservative escape gate for native locals, extended in #1541 to admit a
 /// reference in a proven direct-call parameter position and in the tail of a
 /// proven reference-result body. `allow_tail` is reset for ordinary children,

--- a/lib/@vibe/compiler/codegen/wasi/linked_compile.vibe
+++ b/lib/@vibe/compiler/codegen/wasi/linked_compile.vibe
@@ -2343,28 +2343,6 @@ fn lc_option_name_equals(opt: Option[String], target: String) -> Bool {
   }
 }
 
-fn lc_stmts_mention_name(stmts: Array[Stmt], target: String) -> Bool {
-  let mut i = 0
-  let mut hit = false
-  while i < Array::length(stmts) {
-    let mentioned = match Array::get(stmts, i) {
-      SLet(_, _, n, _, e) => n == target || lc_expr_mentions_name(e, target),
-      SLetMut(n, _, e) => n == target || lc_expr_mentions_name(e, target),
-      SExpr(e) => lc_expr_mentions_name(e, target),
-      STest(_, e) => lc_expr_mentions_name(e, target),
-      SBench(_, e) => lc_expr_mentions_name(e, target),
-      _ => false
-    }
-    if mentioned {
-      hit = true
-    } else {
-      ()
-    }
-    i = i + 1
-  }
-  hit
-}
-
 /// ADR-0089 (#1218, resolve -> direct wake): can this program call the
 /// @vibe/concurrent direct-wake await hooks? Both names must be callable
 /// -- as linked imports (the auto-want in linked_artifacts registers them

--- a/lib/@vibe/compiler/codegen/wasm_emit/simd_test.vibe
+++ b/lib/@vibe/compiler/codegen/wasm_emit/simd_test.vibe
@@ -17,8 +17,6 @@ import ./simd.vibe {
   emit_v128_store
 }
 
-///|
-
 test "emit_v128_const emits prefix + opcode + 16 bytes" {
   let buf = bytebuf_new()
   emit_v128_const(buf, [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16])
@@ -34,8 +32,6 @@ test "emit_v128_const emits prefix + opcode + 16 bytes" {
   // last data byte
 }
 
-///|
-
 test "emit_v128_const pads short array with zeros" {
   let buf = bytebuf_new()
   emit_v128_const(buf, [42])
@@ -48,8 +44,6 @@ test "emit_v128_const pads short array with zeros" {
   // padded zero
 }
 
-///|
-
 test "emit_i8x16_splat emits prefix + opcode" {
   let buf = bytebuf_new()
   emit_i8x16_splat(buf)
@@ -58,8 +52,6 @@ test "emit_i8x16_splat emits prefix + opcode" {
   assert_eq(Bytes::get(buf, 1), 15)
   // i8x16.splat = 0x0F
 }
-
-///|
 
 test "emit_i8x16_le_u emits prefix + correct opcode (not lt_u)" {
   let buf = bytebuf_new()
@@ -70,8 +62,6 @@ test "emit_i8x16_le_u emits prefix + correct opcode (not lt_u)" {
   // i8x16.le_u = 0x2A (NOT 38 = lt_u)
 }
 
-///|
-
 test "emit_i8x16_ge_u emits prefix + correct opcode (not gt_u)" {
   let buf = bytebuf_new()
   emit_i8x16_ge_u(buf)
@@ -80,8 +70,6 @@ test "emit_i8x16_ge_u emits prefix + correct opcode (not gt_u)" {
   assert_eq(Bytes::get(buf, 1), 44)
   // i8x16.ge_u = 0x2C (NOT 40 = gt_u)
 }
-
-///|
 
 test "emit_i8x16_eq emits prefix + opcode" {
   let buf = bytebuf_new()
@@ -92,8 +80,6 @@ test "emit_i8x16_eq emits prefix + opcode" {
   // 0x23
 }
 
-///|
-
 test "emit_v128_any_true emits prefix + opcode" {
   let buf = bytebuf_new()
   emit_v128_any_true(buf)
@@ -102,8 +88,6 @@ test "emit_v128_any_true emits prefix + opcode" {
   assert_eq(Bytes::get(buf, 1), 83)
   // 0x53
 }
-
-///|
 
 test "emit_v128_load emits prefix + opcode + memarg" {
   let buf = bytebuf_new()
@@ -119,8 +103,6 @@ test "emit_v128_load emits prefix + opcode + memarg" {
   // offset
 }
 
-///|
-
 test "emit_v128_load with large offset uses LEB128" {
   let buf = bytebuf_new()
   emit_v128_load(buf, 4, 256)
@@ -134,8 +116,6 @@ test "emit_v128_load with large offset uses LEB128" {
   assert_eq(Bytes::get(buf, 4), 2)
 }
 
-///|
-
 test "emit_i8x16_swizzle emits prefix + opcode" {
   let buf = bytebuf_new()
   emit_i8x16_swizzle(buf)
@@ -144,8 +124,6 @@ test "emit_i8x16_swizzle emits prefix + opcode" {
   assert_eq(Bytes::get(buf, 1), 14)
   // 0x0E
 }
-
-///|
 
 test "emit_v128_store emits prefix + opcode + memarg" {
   let buf = bytebuf_new()
@@ -160,8 +138,6 @@ test "emit_v128_store emits prefix + opcode + memarg" {
   // offset
 }
 
-///|
-
 test "emit_v128_not emits prefix + opcode" {
   let buf = bytebuf_new()
   emit_v128_not(buf)
@@ -170,8 +146,6 @@ test "emit_v128_not emits prefix + opcode" {
   assert_eq(Bytes::get(buf, 1), 77)
   // 0x4D
 }
-
-///|
 
 test "emit_v128_and emits prefix + opcode" {
   let buf = bytebuf_new()
@@ -182,8 +156,6 @@ test "emit_v128_and emits prefix + opcode" {
   // 0x4E
 }
 
-///|
-
 test "emit_i8x16_sub emits prefix + opcode" {
   let buf = bytebuf_new()
   emit_i8x16_sub(buf)
@@ -192,8 +164,6 @@ test "emit_i8x16_sub emits prefix + opcode" {
   assert_eq(Bytes::get(buf, 1), 113)
   // 0x71
 }
-
-///|
 
 test "emit_i8x16_min_u emits prefix + opcode" {
   let buf = bytebuf_new()

--- a/lib/@vibe/compiler/core/builtin_registry.vibe
+++ b/lib/@vibe/compiler/core/builtin_registry.vibe
@@ -716,19 +716,26 @@ export fn builtin_allocates(name: String) -> Bool {
 /// interior view, a silent double-free caught only by review (#1932). Add new
 /// borrow-returning builtins HERE and nowhere else.
 ///
+/// The one spelling of the set. Module-level so `is_borrow_ret_builtin` --
+/// called once per call site across the whole program -- does not rebuild it
+/// per query (it was the profiled top __rt_arr_push producer of the codegen
+/// phase). Never hand this array itself to a caller that mutates it; that is
+/// what the slice in `borrow_ret_builtin_names` is for.
+let borrow_ret_builtin_name_table: Array[String] = [
+  "Array::get",
+  "MutList::get",
+  "Map::get",
+  "Map::iter_get",
+  "Map::__iter_get_unchecked",
+  "__index",
+  "__rec_field"
+]
+
 /// Returns a fresh array on each call because
 /// compute_borrow_returning_names' fixed-point worklist pushes discovered user
 /// functions into the one it is given.
 export fn borrow_ret_builtin_names() -> Array[String] {
-  [
-    "Array::get",
-    "MutList::get",
-    "Map::get",
-    "Map::iter_get",
-    "Map::__iter_get_unchecked",
-    "__index",
-    "__rec_field"
-  ]
+  Array::slice(borrow_ret_builtin_name_table, 0, Array::length(borrow_ret_builtin_name_table))
 }
 
 /// Membership in `borrow_ret_builtin_names`, before source ownership is
@@ -739,10 +746,11 @@ export fn borrow_ret_builtin_names() -> Array[String] {
 /// other silently reintroduced exactly the drift this consolidation exists to
 /// remove -- and the two partial updates fail in opposite directions (miss it
 /// in the list and wrappers of it classify as owned; miss it in the predicate
-/// and direct calls do). Five string compares over a five-element array is the
-/// same work the chain did, plus the array.
+/// and direct calls do). Scans the shared module-level table directly: this
+/// predicate runs once per call site across the whole program, so it must not
+/// allocate a fresh copy per query.
 export fn is_borrow_ret_builtin(name: String) -> Bool {
-  let names = borrow_ret_builtin_names()
+  let names = borrow_ret_builtin_name_table
   let mut i = 0
   let mut found = false
   while i < Array::length(names) {

--- a/lib/@vibe/compiler/core/import_alias_rewrite.vibe
+++ b/lib/@vibe/compiler/core/import_alias_rewrite.vibe
@@ -852,20 +852,6 @@ fn alias_map_without_pat(aliases: Array[(String, String)], pat: Pat) -> Array[(S
   }
 }
 
-fn param_binds_name(params: Array[(String, Option[TypeExpr])], name: String) -> Bool {
-  let mut found = false
-  let mut i = 0
-  while i < Array::length(params) && !found {
-    let (param_name, _) = Array::get(params, i)
-    if param_name == name {
-      found = true
-    } else {
-      i = i + 1
-    }
-  }
-  found
-}
-
 /// Parameter-list counterpart of pat_shadows_alias -- same rewrite, same
 /// reasoning (see that function's note).
 fn params_shadow_alias(params: Array[(String, Option[TypeExpr])], alias: String) -> Bool {
@@ -2487,29 +2473,6 @@ fn namespace_private_stmt(stmt: Stmt, ram: AliasIdx) -> Stmt {
     SLetPat(pat, body) => SLetPat(pat, rewrite_alias_expr_ix(body, ram)),
     SModule(exported, name, stmts) => SModule(exported, name, namespace_private_value_stmts(name, stmts)),
     _ => stmt
-  }
-}
-
-fn namespace_private_value_stmts_legacy_ordered(path: String, stmts: Array[Stmt]) -> Array[Stmt] {
-  let namespace_suffix_box = [""]
-  let exported = collect_exported_value_names(stmts)
-  let renames = collect_private_value_renames(path, stmts, namespace_suffix_box, exported)
-  let value_renamed = if Array::length(renames) == 0 {
-    stmts
-  } else {
-    let ram = aliasidx_build(renames)
-    for stmt in stmts {
-      namespace_private_stmt(stmt, ram)
-    }
-  }
-  let type_renames = collect_private_type_renames(path, value_renamed, namespace_suffix_box, exported)
-  let ctor_renames = collect_private_ctor_renames(path, value_renamed, type_renames, namespace_suffix_box, exported)
-  if Array::length(type_renames) == 0 && Array::length(ctor_renames) == 0 {
-    value_renamed
-  } else {
-    for stmt in value_renamed {
-      namespace_private_type_ctor_stmt(stmt, type_renames, ctor_renames)
-    }
   }
 }
 

--- a/lib/@vibe/compiler/core/types.vibe
+++ b/lib/@vibe/compiler/core/types.vibe
@@ -530,7 +530,7 @@ export fn env_cache(env: TypeEnv) -> TypeEnv {
     }
     let na = ArrayBuilder::freeze(names)
     let ta = ArrayBuilder::freeze(types)
-    // Negative `__active_region__` marker (perf): env_has_active_region asks
+    // Negative `#active_region` marker (perf): env_has_active_region asks
     // for this sentinel once per region-sensitive check, and outside a region
     // the answer used to be a MISS -- a walk over the entire chain, measured
     // as the single largest env_lookup consumer in a full-closure compile.
@@ -544,13 +544,13 @@ export fn env_cache(env: TypeEnv) -> TypeEnv {
     let mut has_region_marker = false
     let mut mi = 0
     while mi < Array::length(na) {
-      if Array::get(na, mi) == "__active_region__" {
+      if Array::get(na, mi) == "#active_region" {
         has_region_marker = true
       }
       mi = mi + 1
     }
     if !has_region_marker {
-      Array::push(na, "__active_region__")
+      Array::push(na, "#active_region")
       Array::push(ta, env_value_binding(CtUnit))
     }
     // `na`/`ta` are collected innermost-binding-first (the traversal above

--- a/lib/@vibe/compiler/core/types.vibe
+++ b/lib/@vibe/compiler/core/types.vibe
@@ -530,6 +530,29 @@ export fn env_cache(env: TypeEnv) -> TypeEnv {
     }
     let na = ArrayBuilder::freeze(names)
     let ta = ArrayBuilder::freeze(types)
+    // Negative `__active_region__` marker (perf): env_has_active_region asks
+    // for this sentinel once per region-sensitive check, and outside a region
+    // the answer used to be a MISS -- a walk over the entire chain, measured
+    // as the single largest env_lookup consumer in a full-closure compile.
+    // Appending a CtUnit-typed entry turns the miss into an O(log n) bsearch
+    // hit; env_has_active_region treats only the real CtNamed skolem as
+    // active. Appended LAST (= outermost), so a real region marker collected
+    // from the chain stays leftmost and wins the bsearch. The chain itself is
+    // untouched: the manual region walks (type_mentions_active_region,
+    // assignment_crosses_region, binding_predates_active_region) read only
+    // EnvBind nodes and never see this entry.
+    let mut has_region_marker = false
+    let mut mi = 0
+    while mi < Array::length(na) {
+      if Array::get(na, mi) == "__active_region__" {
+        has_region_marker = true
+      }
+      mi = mi + 1
+    }
+    if !has_region_marker {
+      Array::push(na, "__active_region__")
+      Array::push(ta, env_value_binding(CtUnit))
+    }
     // `na`/`ta` are collected innermost-binding-first (the traversal above
     // walks `cur = rest` outward from the head). A STABLE sort keeps that
     // relative order among same-named entries, and bsearch_leftmost returns
@@ -3745,7 +3768,6 @@ fn char_int_compatible(ta: Type, tb: Type) -> Bool {
   }
 }
 
-///|
 export fn unify(a: Type, b: Type, s: Subst) -> Option[Subst] {
   let ta = subst_apply(s, a)
   let tb = subst_apply(s, b)

--- a/lib/@vibe/compiler/entry/source_compile/wasi_only/component_codegen.vibe
+++ b/lib/@vibe/compiler/entry/source_compile/wasi_only/component_codegen.vibe
@@ -4057,43 +4057,6 @@ fn emit_comp_wit_payload_type(content: Bytes, payload: String) -> Int with Excep
   }
 }
 
-/// Aggregate payload types live inside the imported interface type. Defining
-/// them at the root and aliasing a future that refers back to the root record
-/// is not a valid import type in the component model.
-fn emit_comp_wit_async_aggregate_instance_type(buf: Bytes, payload: String, func_names: Array[String]) -> Unit with Exception {
-  bytebuf_push(buf, section_type)
-  let content = bytebuf_new()
-  leb128_encode_u32(content, 1)
-  bytebuf_push(content, 66)
-  let nfuncs = Array::length(func_names)
-  leb128_encode_u32(content, 2 + nfuncs + nfuncs)
-  let _ = emit_comp_wit_payload_type(content, payload)
-  // local type 1 = future<local payload type 0>
-  bytebuf_push(content, 1)
-  bytebuf_push(content, 101)
-  bytebuf_push(content, 1)
-  leb128_encode_u32(content, 0)
-  let mut ti = 0
-  while ti < nfuncs {
-    bytebuf_push(content, 1)
-    bytebuf_push(content, 67)
-    bytebuf_push(content, 0)
-    bytebuf_push(content, 0)
-    leb128_encode_u32(content, 1)
-    ti = ti + 1
-  }
-  let mut ei = 0
-  while ei < nfuncs {
-    bytebuf_push(content, 4)
-    bytebuf_push(content, 0)
-    emit_name(content, Array::get(func_names, ei))
-    bytebuf_push(content, comp_extern_func)
-    leb128_encode_u32(content, 2 + ei)
-    ei = ei + 1
-  }
-  emit_raw_content(buf, content)
-}
-
 fn comp_wit_types_interface_id(interface_id: String) -> String with Exception {
   let mut slash = 0 - 1
   let mut at = 0 - 1

--- a/lib/@vibe/compiler/loader/loader.vibe
+++ b/lib/@vibe/compiler/loader/loader.vibe
@@ -507,25 +507,6 @@ fn strip_trailing_cr(line: String) -> String {
   }
 }
 
-fn string_to_bytes(s: String) -> Bytes {
-  let out = Bytes::new()
-  let len = String::length(s)
-  let mut i = 0
-  while i < len {
-    Bytes::push(out, String::char_code_at(s, i))
-    i = i + 1
-  }
-  out
-}
-
-fn special_bundle_header(path: String) -> Option[(Array[String], Array[String])] {
-  if String::ends_with(path, "compiler_sources_bundle.vibe") {
-    Some((array_empty(), ["compiler_sources", "compiler_source_groups"]))
-  } else {
-    None
-  }
-}
-
 fn split_tsv_fields(line: String) -> Array[String] {
   let fields = array_empty()
   let len = String::length(line)
@@ -544,47 +525,6 @@ fn split_tsv_fields(line: String) -> Array[String] {
     i = i + 1
   }
   fields
-}
-
-let header_value_separator = String::from_char_code(31)
-
-fn join_header_values(values: Array[String]) -> String {
-  // O(N) via StringBuilder (previous accumulator was O(N^2)).
-  let sb = StringBuilder::new()
-  let mut i = 0
-  while i < Array::length(values) {
-    if i > 0 {
-      StringBuilder::push(sb, header_value_separator)
-    }
-    StringBuilder::push(sb, Array::get(values, i))
-    i = i + 1
-  }
-  StringBuilder::freeze(sb)
-}
-
-fn split_header_values(text: String) -> Array[String] {
-  let values = array_empty()
-  if String::length(text) == 0 {
-    values
-  } else {
-    let sep = String::char_code_at(header_value_separator, 0)
-    let len = String::length(text)
-    let mut start = 0
-    let mut i = 0
-    while i <= len {
-      let at_value_end = if i == len {
-        true
-      } else {
-        String::char_code_at(text, i) == sep
-      }
-      if at_value_end {
-        Array::push(values, text[start: i])
-        start = i + 1
-      }
-      i = i + 1
-    }
-    values
-  }
 }
 
 fn empty_source_specs() -> Array[(String, String)] {
@@ -1696,32 +1636,6 @@ fn manifest_path_of(manifest: Option[(String, String, String)]) -> Option[String
   }
 }
 
-fn load_persistent_sources_from_group_cache_if_valid(entry_path: String) -> Option[(Option[String], Array[(String, String)])] with Exception + Fs {
-  let cache_path = persistent_source_group_cache_path(entry_path)
-  if !(Fs::exists(cache_path)) {
-    None
-  } else {
-    let (_, manifest, rows, resctx) = parse_persistent_source_group_cache(normalize_persistent_cache_text(Fs::read_file(cache_path)))
-    if !(resolution_context_is_valid(resctx, entry_path, group_cache_row_paths(rows))) {
-      None
-    } else if !(manifest_cache_is_valid(manifest)) {
-      None
-    } else {
-      let specs = empty_source_cache_specs()
-      let mut i = 0
-      while i < Array::length(rows) {
-        let (_, path, stat_token_text, source_fingerprint) = Array::get(rows, i)
-        Array::push(specs, (path, stat_token_text, source_fingerprint))
-        i = i + 1
-      }
-      match load_cached_sources_rec(specs, 0, empty_source_specs()) {
-        Some(sources) => Some((manifest_path_of(manifest), sources)),
-        None => None
-      }
-    }
-  }
-}
-
 fn load_persistent_source_groups_from_source_list_cache_if_valid(entry_path: String) -> Option[(Option[String], Array[(String, Array[(String, String)])])] with Exception + Fs {
   let cache_path = persistent_source_list_cache_path(entry_path)
   if !(Fs::exists(cache_path)) {
@@ -1891,22 +1805,6 @@ fn build_persistent_source_groups_cache_text(entry_path: String, manifest_path: 
   StringBuilder::freeze(sb)
 }
 
-fn collect_import_deps_from_stmts(stmts: Array[Stmt], base_dir: String) -> Array[String] with Fs {
-  let deps = array_empty()
-  let mut i = 0
-  while i < Array::length(stmts) {
-    match Array::get(stmts, i) {
-      SImport(raw_path, _) => if !is_builtin_iterator_serialized_boundary_path(raw_path) {
-        Array::push(deps, resolve_path_fs(base_dir, raw_path))
-      },
-      SReExport(raw_path, _) => Array::push(deps, resolve_path_fs(base_dir, raw_path)),
-      _ => ()
-    }
-    i = i + 1
-  }
-  deps
-}
-
 export fn load_or_parse_module_header_fs(path: String, source: String, parse_count: Int) -> (Array[String], Array[String], Int) with Exception + Fs {
   load_or_parse_module_header_fs_impl(path, source, parse_count)
 }
@@ -1944,64 +1842,6 @@ fn flatten_group_sources(groups: Array[(String, Array[(String, String)])]) -> Ar
     gi = gi + 1
   }
   out
-}
-
-fn filter_group_sources(groups: Array[(String, Array[(String, String)])], ordered_sources: Array[(String, String)]) -> Array[(String, Array[(String, String)])] {
-  let filtered = empty_grouped_sources()
-  let mut gi = 0
-  while gi < Array::length(groups) {
-    let (group_name, sources) = Array::get(groups, gi)
-    let next_sources = empty_source_specs()
-    let mut si = 0
-    while si < Array::length(sources) {
-      let pair = Array::get(sources, si)
-      let (path, _) = pair
-      match source_lookup(ordered_sources, path) {
-        Some(_) => Array::push(next_sources, pair),
-        None => ()
-      }
-      si = si + 1
-    }
-    if Array::length(next_sources) > 0 {
-      Array::push(filtered, (group_name, next_sources))
-    }
-    gi = gi + 1
-  }
-  filtered
-}
-
-fn special_bundle_source_groups(entry_path: String) -> Option[Array[(String, Array[(String, String)])]] {
-  let _ = entry_path
-  None
-}
-
-fn normalize_bundle_source_groups(groups: Array[(String, Array[(String, String)])], main_path: String, main_source: String) -> Array[(String, Array[(String, String)])] {
-  let normalized = empty_grouped_sources()
-  let mut found = false
-  let mut gi = 0
-  while gi < Array::length(groups) {
-    let (group_name, sources) = Array::get(groups, gi)
-    let next_sources = empty_source_specs()
-    let mut si = 0
-    while si < Array::length(sources) {
-      let (path, source) = Array::get(sources, si)
-      if path == main_path {
-        Array::push(next_sources, (path, main_source))
-        found = true
-      } else {
-        Array::push(next_sources, (path, source))
-      }
-      si = si + 1
-    }
-    Array::push(normalized, (group_name, next_sources))
-    gi = gi + 1
-  }
-  if !found {
-    let entry_sources = empty_source_specs()
-    Array::push(entry_sources, (main_path, main_source))
-    Array::push(normalized, ("entry", entry_sources))
-  }
-  normalized
 }
 
 fn special_manifest_sources(entry_path: String) -> Option[(String, Array[(String, String)])] {

--- a/lib/@vibe/compiler/monoify.vibe
+++ b/lib/@vibe/compiler/monoify.vibe
@@ -215,20 +215,6 @@ export fn collect_call_sites(expr: Expr, fn_name: String) -> Array[Array[Expr]] 
   collect_call_sites_expr(expr, fn_name)
 }
 
-fn collect_call_sites_from_stmt(stmt: Stmt, fn_name: String) -> Array[Array[Expr]] {
-  match stmt {
-    SLet(_exported, _is_rec, _name, _ty, body) =>
-    collect_call_sites_expr(body, fn_name),
-    SLetMut(_name, _ty, body) =>
-    collect_call_sites_expr(body, fn_name),
-    STest(_name, body) =>
-    collect_call_sites_expr(body, fn_name),
-    SExpr(body) =>
-    collect_call_sites_expr(body, fn_name),
-    _ => empty_expr_arrays()
-  }
-}
-
 export fn collect_call_sites_stmts(stmts: Array[Stmt], fn_name: String) -> Array[Array[Expr]] {
   let out = empty_expr_arrays()
   let mut i = 0

--- a/lib/@vibe/compiler/normalize/desugar_trait_dict.vibe
+++ b/lib/@vibe/compiler/normalize/desugar_trait_dict.vibe
@@ -14539,7 +14539,6 @@ fn struct_decl_exists(stmts: Array[Stmt], name: String) -> Bool {
   found
 }
 
-///|
 /// ===== #786: hoist non-capturing effectful local lambdas to top-level =====
 /// A `let f = () -> { perform ... }` bound INSIDE a block compiles to a closure
 /// value; calling it inside `handle` drives a miscompiled effect+closure lowering
@@ -14567,14 +14566,12 @@ fn dlh_name_ok(n: String) -> Bool {
   }
 }
 
-///|
 fn dlh_with(arr: Array[String], name: String) -> Array[String] {
   let out = Array::slice(arr, 0, Array::length(arr))
   Array::push(out, name)
   out
 }
 
-///|
 fn dlh_strip_tilde(n: String) -> String {
   let ln = String::length(n)
   if ln > 0 && n[ln - 1: ln] == "~" {
@@ -14584,7 +14581,6 @@ fn dlh_strip_tilde(n: String) -> String {
   }
 }
 
-///|
 /// #786 targets `perform` inside a local lambda that is later called under a
 /// `handle`. Hoisting is gated on the body containing a `perform` specifically —
 /// NOT `throw`. A `throw(SubErr(..))` lambda (see effect_handler_test) has no
@@ -14796,7 +14792,6 @@ fn dlh_join_comma(names: Array[String]) -> String {
   out
 }
 
-///|
 fn dlh_has_perform_arms(arms: Array[(Pat, Expr)]) -> Bool {
   let mut i = 0
   let mut found = false
@@ -14812,7 +14807,6 @@ fn dlh_has_perform_arms(arms: Array[(Pat, Expr)]) -> Bool {
   found
 }
 
-///|
 /// Append to `bad` any free identifier of `expr` that is not `dlh_name_ok` and
 /// not in `bound`. Non-empty `bad` => the lambda references a bare lowercase
 /// non-top-level name (capture or bare-helper call) and must not be hoisted.
@@ -14967,7 +14961,6 @@ fn dlh_scan_free(expr: Expr, bound: Array[String], bad: Array[String]) -> Unit {
   }
 }
 
-///|
 fn dlh_scan_arms(arms: Array[(Pat, Expr)], bound: Array[String], bad: Array[String]) -> Unit {
   let mut i = 0
   while i < Array::length(arms) {
@@ -14985,7 +14978,6 @@ fn dlh_scan_arms(arms: Array[(Pat, Expr)], bound: Array[String], bad: Array[Stri
   }
 }
 
-///|
 /// Capture-safe substitution: EIdent(from) -> EIdent(to), stopping in subtrees
 /// that rebind `from`.
 fn dlh_subst(expr: Expr, from: String, to: String) -> Expr {
@@ -15112,7 +15104,6 @@ fn dlh_subst(expr: Expr, from: String, to: String) -> Expr {
   }
 }
 
-///|
 fn dlh_subst_arms(arms: Array[(Pat, Expr)], from: String, to: String) -> Array[(Pat, Expr)] {
   let out = array_empty()
   let mut i = 0
@@ -15131,7 +15122,6 @@ fn dlh_subst_arms(arms: Array[(Pat, Expr)], from: String, to: String) -> Array[(
   out
 }
 
-///|
 /// #1069 follow-up: closure-conversion for a CAPTURING local effectful
 /// lambda (`dlh_scan_free` found a non-empty `bad`). The plain rename
 /// dlh_hoist_expr already does for the non-capturing case (dlh_subst,
@@ -15313,7 +15303,6 @@ fn dlh_row_is_effectful(eff: Option[String]) -> Bool {
   }
 }
 
-///|
 /// Only ever matches an EFFECTFUL literal (dlh_has_perform on its body) --
 /// found via a live regression (2026-07-23, fixtures/eq_array_option_fields_test.vibe
 /// trapping "unreachable" in a derive(Eq)-generated equality helper, bisected
@@ -15361,7 +15350,6 @@ fn dlh_args_have_literal_efn(args: Array[Expr]) -> Bool {
   found
 }
 
-///|
 /// Rewrites `callee(args...)` so every DIRECT `EFn` literal in `args` --
 /// bare, or one layer inside an `ELabeledArg` wrapper (`f = () -> ...`) --
 /// is let-bound immediately before the call, left-to-right (same evaluation
@@ -15414,7 +15402,6 @@ fn dlh_letbind_literal_args(callee: Expr, args: Array[Expr], off: Int, ctr: Arra
   wrapped
 }
 
-///|
 fn dlh_hoist_expr(expr: Expr, hoisted: Array[Stmt], ctr: Array[Int]) -> Expr {
   match expr {
     ELet(name, v, b, soff) => match v {
@@ -15618,7 +15605,6 @@ fn dlh_hoist_expr(expr: Expr, hoisted: Array[Stmt], ctr: Array[Int]) -> Expr {
   }
 }
 
-///|
 fn dlh_hoist_arms(arms: Array[(Pat, Expr)], hoisted: Array[Stmt], ctr: Array[Int]) -> Array[(Pat, Expr)] {
   let out = array_empty()
   let mut i = 0
@@ -15630,7 +15616,6 @@ fn dlh_hoist_arms(arms: Array[(Pat, Expr)], hoisted: Array[Stmt], ctr: Array[Int
   out
 }
 
-///|
 fn dlh_hoist_stmt(stmt: Stmt, hoisted: Array[Stmt], ctr: Array[Int]) -> Stmt {
   match stmt {
     SLet(ex, rc, name, ty, body) => SLet(ex, rc, name, ty, dlh_hoist_expr(body, hoisted, ctr)),
@@ -15643,7 +15628,6 @@ fn dlh_hoist_stmt(stmt: Stmt, hoisted: Array[Stmt], ctr: Array[Int]) -> Stmt {
   }
 }
 
-///|
 /// In-place hoisting of non-capturing effectful local lambdas across the program.
 export fn desugar_hoist_local_lambdas(stmts: Array[Stmt]) -> Unit {
   let hoisted = array_empty()
@@ -15661,7 +15645,6 @@ export fn desugar_hoist_local_lambdas(stmts: Array[Stmt]) -> Unit {
   }
 }
 
-///|
 /// Labeled-argument reordering. Named args are order-independent — `f(y=2, x=1)`
 /// binds x=1, y=2 (cheatsheet "Labeled arguments"). Codegen strips ELabeledArg
 /// labels and binds positionally, so a call given out of declared order used to
@@ -15688,7 +15671,6 @@ fn strip_label_tilde(n: String) -> String {
   }
 }
 
-///|
 /// fname -> ordered param base names, for every top-level `let f = (..) -> ..`
 /// (#986: labeled or not — see the pass comment above).
 fn collect_fn_param_labels(stmts: Array[Stmt]) -> Array[(String, Array[String])] {
@@ -15716,20 +15698,17 @@ fn collect_fn_param_labels(stmts: Array[Stmt]) -> Array[(String, Array[String])]
   out
 }
 
-///|
 /// #1500: `fname -> per-parameter "is optional"` flags, consulted by the ECall
 /// arm of `relabel_expr`. A module cell rather than another threaded parameter
 /// because `relabel_expr` recurses from ~30 sites; same shape as the other
 /// per-program tables in this file (`afe_field_types_cell`, `throw_kind_cell`).
 let optional_param_tbl_cell: Array[Array[(String, Array[Bool])]] = array_empty()
 
-///|
 fn optional_param_tbl_set(tbl: Array[(String, Array[Bool])]) -> Unit {
   Array::truncate(optional_param_tbl_cell, 0)
   Array::push(optional_param_tbl_cell, tbl)
 }
 
-///|
 fn optional_param_flags(fname: String) -> Option[Array[Bool]] {
   if Array::length(optional_param_tbl_cell) == 0 {
     None
@@ -15875,7 +15854,6 @@ fn stmts_have_optional_fn(_stmts: Array[Stmt]) -> Bool {
   true
 }
 
-///|
 /// #1899/#1952: the labels and optional flags of lambdas bound by a `let`
 /// INSIDE a block, which the two top-level tables above cannot see.
 ///
@@ -15901,7 +15879,6 @@ fn stmts_have_optional_fn(_stmts: Array[Stmt]) -> Bool {
 /// completely unrelated value that happens to reuse its name.
 let local_fn_tbl_cell: Array[(String, Array[String], Array[Bool], Int)] = array_empty()
 
-///|
 /// Record a `let`-bound lambda's parameter shape. Non-lambda bindings are
 /// deliberately not recorded: they have no labels, and their presence in
 /// `shadows` is what masks any outer entry.
@@ -15984,12 +15961,10 @@ fn local_fn_tbl_replace(name: String, v: Expr, shadows: Array[String]) -> Unit {
   }
 }
 
-///|
 fn local_fn_tbl_truncate(mark: Int) -> Unit {
   Array::truncate(local_fn_tbl_cell, mark)
 }
 
-///|
 /// A lambda's parameter labels, in declared order, or None for anything else.
 fn efn_param_labels(v: Expr) -> Option[Array[String]] {
   match v {
@@ -16007,7 +15982,6 @@ fn efn_param_labels(v: Expr) -> Option[Array[String]] {
   }
 }
 
-///|
 fn str_arrays_equal(a: Array[String], b: Array[String]) -> Bool {
   if Array::length(a) != Array::length(b) {
     false
@@ -16026,7 +16000,6 @@ fn str_arrays_equal(a: Array[String], b: Array[String]) -> Bool {
   }
 }
 
-///|
 fn params_bind_name(params: Array[(String, Option[TypeExpr])], name: String) -> Bool {
   let mut i = 0
   let mut hit = false
@@ -16042,14 +16015,12 @@ fn params_bind_name(params: Array[(String, Option[TypeExpr])], name: String) -> 
   hit
 }
 
-///|
 fn pat_binds_name(p: Pat, name: String) -> Bool {
   let binders = empty_str_array()
   collect_pat_binders(p, binders)
   str_array_contains(binders, name)
 }
 
-///|
 /// The arms whose pattern does NOT take `name` over -- the only ones whose body
 /// can still assign to the binding being scanned.
 fn arms_not_binding(arms: Array[(Pat, Expr)], name: String, labels: Array[String]) -> Bool {
@@ -16067,7 +16038,6 @@ fn arms_not_binding(arms: Array[(Pat, Expr)], name: String, labels: Array[String
   broken
 }
 
-///|
 fn loop_binds_broken(binds: Array[(String, Expr)], name: String, labels: Array[String]) -> Bool {
   let mut i = 0
   let mut broken = false
@@ -16083,7 +16053,6 @@ fn loop_binds_broken(binds: Array[(String, Expr)], name: String, labels: Array[S
   broken
 }
 
-///|
 fn loop_binds_name(binds: Array[(String, Expr)], name: String) -> Bool {
   let mut i = 0
   let mut hit = false
@@ -16099,7 +16068,6 @@ fn loop_binds_name(binds: Array[(String, Expr)], name: String) -> Bool {
   hit
 }
 
-///|
 /// #1994: can every value `name` holds inside `body` be described by `labels`?
 ///
 /// A `let mut` binding is the one local shape whose value is not its
@@ -16127,7 +16095,6 @@ fn mut_binding_labels_stable(body: Expr, name: String, labels: Array[String]) ->
   !mut_binding_labels_broken(body, name, labels)
 }
 
-///|
 fn mut_binding_labels_broken(e: Expr, name: String, labels: Array[String]) -> Bool {
   match e {
     // A binder's initializer is evaluated in the OUTER scope, so it is still
@@ -16180,7 +16147,6 @@ fn mut_binding_labels_broken(e: Expr, name: String, labels: Array[String]) -> Bo
   }
 }
 
-///|
 /// #1994: `let mut` lambda bindings whose scope does NOT agree on the labels,
 /// with the index the name occupies in `shadows` -- same innermost-binding
 /// discipline as `local_fn_tbl_cell` above. A labeled call to one of these has
@@ -16188,7 +16154,6 @@ fn mut_binding_labels_broken(e: Expr, name: String, labels: Array[String]) -> Bo
 /// written order, which is right only by luck.
 let unstable_mut_tbl_cell: Array[(String, Int)] = array_empty()
 
-///|
 /// Every assignment that CHANGED a binding's labels, as (name, index in
 /// `shadows`). A subtree whose walk does not dominate what follows notes the
 /// length on entry and hands what its walk appended to
@@ -16197,7 +16162,6 @@ let unstable_mut_tbl_cell: Array[(String, Int)] = array_empty()
 /// observe, so it must not cost the binding its labels.
 let relabel_assigned_cell: Array[(String, Int)] = array_empty()
 
-///|
 fn innermost_shadow_index(name: String, shadows: Array[String]) -> Int {
   let mut innermost = 0 - 1
   let mut i = 0
@@ -16210,7 +16174,6 @@ fn innermost_shadow_index(name: String, shadows: Array[String]) -> Int {
   innermost
 }
 
-///|
 fn labels_equal(a: Array[String], b: Array[String]) -> Bool {
   if Array::length(a) != Array::length(b) {
     false
@@ -16229,7 +16192,6 @@ fn labels_equal(a: Array[String], b: Array[String]) -> Bool {
   }
 }
 
-///|
 fn local_fn_tbl_remove(name: String, at: Int) -> Unit {
   let kept = array_empty()
   let mut i = 0
@@ -16251,7 +16213,6 @@ fn local_fn_tbl_remove(name: String, at: Int) -> Unit {
   }
 }
 
-///|
 /// Leaving a subtree whose walk does not dominate what follows -- an `if` arm,
 /// a loop body, a closure body. Every binding it re-labelled and did not itself
 /// introduce (`at < mark`, the length of `shadows` on entry) loses its entry,
@@ -16273,22 +16234,18 @@ fn poison_branch_assignments(from: Int, mark: Int) -> Unit {
   Array::truncate(relabel_assigned_cell, from)
 }
 
-///|
 fn unstable_mut_tbl_push(name: String, at: Int) -> Unit {
   Array::push(unstable_mut_tbl_cell, (name, at))
 }
 
-///|
 fn unstable_mut_tbl_truncate(mark: Int) -> Unit {
   Array::truncate(unstable_mut_tbl_cell, mark)
 }
 
-///|
 /// Call sites drained by the checker (`unresolved_mut_labeled_calls`), as
 /// (callee name, callee offset).
 let unresolved_mut_labeled_cell: Array[(String, Int)] = array_empty()
 
-///|
 /// The labeled calls this pass could not resolve because their callee is a
 /// `let mut` binding whose scope disagrees about its parameter names. Drained
 /// by `check_program` right after `desugar_labeled_args`, which is the only
@@ -16304,7 +16261,6 @@ export fn unresolved_mut_labeled_calls() -> Array[(String, Int)] {
   out
 }
 
-///|
 /// Is `fname`'s innermost binding an unstable `let mut` lambda?
 fn unstable_mut_tbl_lookup(fname: String, shadows: Array[String]) -> Bool {
   let mut innermost = 0 - 1
@@ -16333,7 +16289,6 @@ fn unstable_mut_tbl_lookup(fname: String, shadows: Array[String]) -> Bool {
   }
 }
 
-///|
 /// The entry for `fname`, but only when it is still the innermost binding of
 /// that name. Returns (labels, optional flags).
 fn local_fn_tbl_lookup(fname: String, shadows: Array[String]) -> Option[(Array[String], Array[Bool])] {
@@ -16363,7 +16318,6 @@ fn local_fn_tbl_lookup(fname: String, shadows: Array[String]) -> Option[(Array[S
   }
 }
 
-///|
 /// Every top-level function that declares at least one optional (`z?`)
 /// parameter, with one flag per parameter. Functions with no optional
 /// parameter are left out so the ECall arm's lookup misses immediately for
@@ -16405,7 +16359,6 @@ fn collect_optional_param_fns(stmts: Array[Stmt]) -> Array[(String, Array[Bool])
   out
 }
 
-///|
 /// True when `e` already denotes an `Option` at the syntax level, so a second
 /// run of this pass would not double-wrap. The pass is called exactly once
 /// (checker_stmt.vibe, right after desugar_labeled_args) -- this is a belt for
@@ -16425,7 +16378,6 @@ fn opt_arg_already_option(e: Expr) -> Bool {
   }
 }
 
-///|
 /// #1500 call-site lowering: an optional parameter is declared `Option[T]`, so
 /// a supplied argument becomes `Some(v)` and an omitted trailing one becomes
 /// `None`. After this the call has exactly as many arguments as the function
@@ -17517,7 +17469,6 @@ fn relabel_stmt_paired(stmt: Stmt, tbl: Array[(String, Array[String])], node: Bi
   }
 }
 
-///|
 /// #986: allocation-free containment scan used to gate the allocating
 /// relabel_stmt rebuild per top-level statement,
 /// since collect_fn_param_labels now indexes EVERY top-level function and the
@@ -17565,7 +17516,6 @@ fn stmt_has_labeled_arg(stmt: Stmt) -> Bool {
 ///
 /// Enumerated (no `_ =>` catch-all for the recursive shapes) so a new `Expr`
 /// variant is a compile error here instead of a silently unscanned subtree.
-///|
 /// True when any parameter is declared optional (`z?`). The marker survives on
 /// the parameter NAME at this stage -- see parse_one_param_with_binder_context.
 fn dinsp_params_optional(params: Array[(String, Option[TypeExpr])]) -> Bool {
@@ -18494,7 +18444,6 @@ export fn normalize_labeled_args_with_binder_authority(source: LocatedProgramBin
   }
 }
 
-///|
 /// #790: lower array-literal spreads `[a, ...xs, b]` into an `Array::concat` chain
 /// of segments (`Array::concat(Array::concat([a], xs), [b])`). The parser accepts
 /// `...expr` inside an array literal (ESpread), but the active desugar pipeline
@@ -18619,7 +18568,6 @@ fn das_expr(expr: Expr) -> Expr {
   }
 }
 
-///|
 fn das_arms(arms: Array[(Pat, Expr)]) -> Array[(Pat, Expr)] {
   let out = array_empty()
   let mut i = 0
@@ -18631,7 +18579,6 @@ fn das_arms(arms: Array[(Pat, Expr)]) -> Array[(Pat, Expr)] {
   out
 }
 
-///|
 fn das_stmt(stmt: Stmt) -> Stmt {
   match stmt {
     SLet(ex, rc, name, ty, body) => SLet(ex, rc, name, ty, das_expr(body)),
@@ -18644,7 +18591,6 @@ fn das_stmt(stmt: Stmt) -> Stmt {
   }
 }
 
-///|
 /// In-place lowering of array-literal spreads across the whole program (#790).
 export fn desugar_array_spread(stmts: Array[Stmt]) -> Unit {
   let n = Array::length(stmts)
@@ -18655,7 +18601,6 @@ export fn desugar_array_spread(stmts: Array[Stmt]) -> Unit {
   }
 }
 
-///|
 fn dtpw_exprs_bind_name(es: Array[Expr], name: String) -> Bool {
   let mut i = 0
   let mut found = false
@@ -18670,7 +18615,6 @@ fn dtpw_exprs_bind_name(es: Array[Expr], name: String) -> Bool {
   found
 }
 
-///|
 /// Does `expr` bind (shadow) `name` ANYWHERE within it -- as an EFn
 /// parameter, a `let`/`let mut`/`let rec` name, a match/handle arm's
 /// pattern binder, a for-loop's item/index name, or a `loop` parameter?
@@ -18801,7 +18745,6 @@ fn dtpw_expr_binds_name(expr: Expr, name: String) -> Bool {
   }
 }
 
-///|
 /// #1070 (narrow slice): a "trivial pass-through wrapper" is a top-level
 /// `let name = (param) -> T with <row> { param() }` -- exactly one
 /// parameter, body is EXACTLY a zero-arg call to that same parameter and
@@ -18978,7 +18921,6 @@ fn dtpw_inline_trivial_wrappers(stmts: Array[Stmt]) -> Unit {
   }
 }
 
-///|
 /// Entry point: in-place dictionary-passing desugaring. No-op unless the program
 /// declares at least one method-bearing trait. Idempotent: re-running (the
 /// single-file pipeline desugars before generic-stripping and codegen re-runs on

--- a/lib/@vibe/compiler/normalize/desugar_trait_dict.vibe
+++ b/lib/@vibe/compiler/normalize/desugar_trait_dict.vibe
@@ -2182,16 +2182,18 @@ fn lookup_var_type(var_types: Array[(String, String)], name: String) -> Option[S
   // entry for the same name. Return the LAST match (the innermost binding in
   // scope) so `let r = record { a }; ...; let r = record { c }; r.c` resolves
   // against the inner shape rather than the stale outer one (#760(4)).
-  let mut i = 0
+  // Scanned BACKWARD so the innermost binding -- the common query -- answers
+  // without walking the whole environment.
+  let mut i = Array::length(var_types) - 1
   let mut result = None
-  while i < Array::length(var_types) {
+  while i >= 0 {
     let (vn, vt) = Array::get(var_types, i)
     if vn == name {
       result = Some(vt)
+      i = -1
     } else {
-      ()
+      i = i - 1
     }
-    i = i + 1
   }
   result
 }
@@ -4195,12 +4197,7 @@ fn infer_impl_target_key(arg: Expr, struct_sets: Array[(String, Array[String])],
 fn bind_impl_target_key(var_types: Array[(String, String)], name: String, value: Expr, struct_sets: Array[(String, Array[String])], fn_returns: Array[(String, String)]) -> Array[(String, String)] {
   match infer_impl_target_key(value, struct_sets, var_types, fn_returns) {
     Some(key) => {
-      let out = array_empty()
-      let mut i = 0
-      while i < Array::length(var_types) {
-        Array::push(out, Array::get(var_types, i))
-        i = i + 1
-      }
+      let out = clone_var_types(var_types)
       Array::push(out, (impl_target_var_key(name), key))
       out
     },
@@ -5202,8 +5199,7 @@ fn array_elem_type_of(var_types: Array[(String, String)], name: String) -> Optio
 fn mask_stale_array_elem(var_types: Array[(String, String)], name: String) -> Array[(String, String)] {
   match array_elem_type_of(var_types, name) {
     Some(_) => {
-      let out = array_empty()
-      push_all_var_types(out, var_types)
+      let out = clone_var_types(var_types)
       Array::push(out, (array_elem_key(name), ""))
       out
     },
@@ -5295,8 +5291,7 @@ fn array_elem_bind(var_types: Array[(String, String)], name: String, val: Expr, 
   // an annotated binding has to reach it too.
   match dtd_array_elem_of_ann_opt(dtd_ascribed_type(val)) {
     Some(elem) => {
-      let out = array_empty()
-      push_all_var_types(out, var_types)
+      let out = clone_var_types(var_types)
       Array::push(out, (array_elem_key(name), elem))
       out
     },
@@ -5390,12 +5385,12 @@ fn ctor_payload_key(pname: String, ctor: String) -> String {
   String::concat("__ctorpay$", String::concat(ctor, String::concat("$", pname)))
 }
 
-fn push_all_var_types(out: Array[(String, String)], var_types: Array[(String, String)]) -> Unit {
-  let mut i = 0
-  while i < Array::length(var_types) {
-    Array::push(out, Array::get(var_types, i))
-    i = i + 1
-  }
+/// Independent copy of the rewrite environment, made once per extension.
+/// `Array::slice` is one allocation + one guarded-dup copy; the push-per-element
+/// version this replaces was the single largest __rt_arr_push caller in a
+/// full-closure compile profile (same finding as perceus.vibe's copy_ints).
+fn clone_var_types(var_types: Array[(String, String)]) -> Array[(String, String)] {
+  Array::slice(var_types, 0, Array::length(var_types))
 }
 
 /// Split a `tuple_shape_key` value back into its per-element type names.
@@ -5497,8 +5492,7 @@ fn tuple_shape_bind(var_types: Array[(String, String)], name: String, val: Expr,
   // NOTHING and `t.0 < t.1` stayed an address comparison.
   match dtd_tuple_elem_names_of_ann(dtd_ascribed_type(val)) {
     Some(sentinel) => {
-      let out = array_empty()
-      push_all_var_types(out, var_types)
+      let out = clone_var_types(var_types)
       Array::push(out, (tuple_shape_key(name), sentinel))
       return out
     },
@@ -5510,8 +5504,7 @@ fn tuple_shape_bind(var_types: Array[(String, String)], name: String, val: Expr,
   // types are in the ARRAY's own `__shape$` record.
   let from_elem = dtd_tuple_elem_names_of_array_get(val, var_types)
   if String::length(from_elem) > 0 {
-    let out = array_empty()
-    push_all_var_types(out, var_types)
+    let out = clone_var_types(var_types)
     Array::push(out, (tuple_shape_key(name), from_elem))
     return out
   } else {
@@ -5533,8 +5526,7 @@ fn tuple_shape_bind(var_types: Array[(String, String)], name: String, val: Expr,
         }
         i = i + 1
       }
-      let out = array_empty()
-      push_all_var_types(out, var_types)
+      let out = clone_var_types(var_types)
       Array::push(out, (tuple_shape_key(name), acc))
       out
     } else {
@@ -5552,8 +5544,7 @@ fn ctor_payload_bind(var_types: Array[(String, String)], name: String, val: Expr
   match val {
     ECall(callee, cargs, _) => match callee {
       EIdent(cn, _) => if Array::length(cargs) >= 1 && starts_upper(cn) {
-        let out = array_empty()
-        push_all_var_types(out, var_types)
+        let out = clone_var_types(var_types)
         let mut i = 0
         let mut wrote = false
         while i < Array::length(cargs) {
@@ -5806,8 +5797,7 @@ fn dtd_elem_projecting_shape(fname: String, cargs: Array[Expr], struct_sets: Arr
 /// reads back as unknown here because `dtd_scalar_shape`'s `EIdent` arm returns
 /// the looked-up string as-is.
 fn dtd_mask_var_type(var_types: Array[(String, String)], name: String) -> Array[(String, String)] {
-  let out = array_empty()
-  push_all_var_types(out, var_types)
+  let out = clone_var_types(var_types)
   Array::push(out, (name, ""))
   out
 }
@@ -6029,8 +6019,7 @@ fn infer_shape_by_syntax(e: Expr, struct_sets: Array[(String, Array[String])], v
 /// composites are stored.
 fn shape_bind(var_types: Array[(String, String)], name: String, val: Expr, struct_sets: Array[(String, Array[String])], fn_returns: Array[(String, String)]) -> Array[(String, String)] {
   let sh = infer_shape(val, struct_sets, var_types, fn_returns)
-  let out = array_empty()
-  push_all_var_types(out, var_types)
+  let out = clone_var_types(var_types)
   // ALWAYS record, even for a non-composite binding (recording ""). Skipping
   // those would leave a SHADOWED name's old shape as the live answer:
   // `extend_var_types` appends and `lookup_var_type` returns the LAST match
@@ -6109,8 +6098,7 @@ fn eq_shape_bind(var_types: Array[(String, String)], name: String, val: Expr, st
       _ => infer_eq_shape(val, struct_sets, var_types, fn_returns)
     }
   }
-  let out = array_empty()
-  push_all_var_types(out, var_types)
+  let out = clone_var_types(var_types)
   Array::push(out, (eq_shape_key(name), if shape_is_composite(sh) {
     sh
   } else {
@@ -6674,8 +6662,7 @@ fn empty_array_shape_from_body(var_types: Array[(String, String)], name: String,
     if String::length(elem) == 0 {
       var_types
     } else {
-      let out = array_empty()
-      push_all_var_types(out, var_types)
+      let out = clone_var_types(var_types)
       Array::push(out, (eq_shape_key(name), String::concat("[", String::concat(elem, "]"))))
       out
     }
@@ -6871,8 +6858,7 @@ fn arm_binder_var_types_env(scrut: Expr, p: Pat, var_types: Array[(String, Strin
                   // A NESTED tuple: record it under the binder's own tuple key
                   // so `inner.0` resolves, instead of putting a shape where a
                   // type name belongs.
-                  let nested = array_empty()
-                  push_all_var_types(nested, eacc)
+                  let nested = clone_var_types(eacc)
                   Array::push(nested, (tuple_shape_key(ev), dtd_join_shape_parts(shape_split(shape_inner(ety)))))
                   eacc = nested
                 } else {
@@ -6912,8 +6898,7 @@ fn arm_binder_var_types_env(scrut: Expr, p: Pat, var_types: Array[(String, Strin
                   // A composite payload goes in as a SHAPE, so the arm body's
                   // interpolation takes the recursive path rather than the
                   // head-name one.
-                  let out = array_empty()
-                  push_all_var_types(out, acc)
+                  let out = clone_var_types(acc)
                   Array::push(out, (shape_key(v), sh))
                   acc = out
                 } else {
@@ -8401,12 +8386,7 @@ fn constructor_match_arm_var_types(scrut: Expr, pat: Pat, gens: Array[DictGen], 
 fn extend_var_types(var_types: Array[(String, String)], name: String, inferred: Option[String]) -> Array[(String, String)] {
   match inferred {
     Some(tname) => {
-      let out = array_empty()
-      let mut i = 0
-      while i < Array::length(var_types) {
-        Array::push(out, Array::get(var_types, i))
-        i = i + 1
-      }
+      let out = clone_var_types(var_types)
       Array::push(out, (name, tname))
       out
     },

--- a/lib/@vibe/compiler/perceus/perceus.vibe
+++ b/lib/@vibe/compiler/perceus/perceus.vibe
@@ -57,16 +57,20 @@ struct PCtx {
   // reclamation guard), while a view-returning callee's binding must not
   // release a reference it never acquired. Same COPY discipline.
   view_ret_user: Array[String];
-  uses: Array[Int];
-  borrows: Array[Int];
-  scalar: Array[Bool];
-  remaining: Array[Int];
+  // The per-plan working state below is `mut` so a cached PCtx (see
+  // pctx_cache) can be reset between plan builds by assigning fresh empty
+  // arrays -- assignment drops the previous plan's arrays instead of leaking
+  // their elements the way an in-place truncate would.
+  mut uses: Array[Int];
+  mut borrows: Array[Int];
+  mut scalar: Array[Bool];
+  mut remaining: Array[Int];
   // True for a let-binding whose VALUE is a call to a borrow-arg0 fn (user
   // set or builtin list) -- the class whose result may be an unowned
   // interior view. With the borrow set empty this is never set, so the fix
   // is inert while lc_borrow_arg0_enabled is off.
-  view_call_let: Array[Bool];
-  actions: Array[PerceusAction]
+  mut view_call_let: Array[Bool];
+  mut actions: Array[PerceusAction]
 }
 
 struct HeapInferCtx {
@@ -162,6 +166,79 @@ fn pctx_new(borrow_ret_names: Array[String], borrow_param_fns: Array[String], bo
     view_call_let: [],
     actions: [],
   }
+}
+
+/// The PCtx built for the most recent whole-program table set, reused across
+/// plan builds. pctx_new's four Array::slice copies were the single largest
+/// __rt_arr_slice caller in a full-closure compile profile (~7% of total CPU):
+/// one plan is built per top-level function AND per lambda, and each paid a
+/// fresh copy of the same four program-wide tables. The cache is keyed by
+/// CONTENT: build_perceus_plan_with_params_split verifies all four incoming
+/// tables element-by-element against the cached copies (cheap -- the elements
+/// are the same string objects, so __rt_str_eq answers on its identity fast
+/// path) and falls back to a fresh PCtx on any mismatch. Correctness therefore
+/// never depends on a set/reset discipline; a stale or half-built cache entry
+/// can only cause a miss, never a wrong table.
+let pctx_cache: Array[PCtx] = []
+
+fn same_str_table(a: Array[String], b: Array[String]) -> Bool {
+  let la = Array::length(a)
+  if la != Array::length(b) {
+    false
+  } else {
+    let mut i = 0
+    let mut same = true
+    while same && i < la {
+      if Array::get(a, i) == Array::get(b, i) {
+        i = i + 1
+      } else {
+        same = false
+      }
+    }
+    same
+  }
+}
+
+fn same_int_table(a: Array[Int], b: Array[Int]) -> Bool {
+  let la = Array::length(a)
+  if la != Array::length(b) {
+    false
+  } else {
+    let mut i = 0
+    let mut same = true
+    while same && i < la {
+      if Array::get(a, i) == Array::get(b, i) {
+        i = i + 1
+      } else {
+        same = false
+      }
+    }
+    same
+  }
+}
+
+fn pctx_cache_matches(ctx: PCtx, borrow_ret_names: Array[String], borrow_param_fns: Array[String], borrow_param_masks: Array[Int], view_ret_fns: Array[String]) -> Bool {
+  same_str_table(ctx.pctx_names, borrow_ret_names) && same_str_table(ctx.borrow_param_user, borrow_param_fns) && same_int_table(ctx.borrow_param_mask, borrow_param_masks) && same_str_table(ctx.view_ret_user, view_ret_fns)
+}
+
+/// Clear the per-plan working state of a cached PCtx. Fresh empty arrays (not
+/// truncates): assignment drops the previous plan's arrays and their elements.
+fn pctx_reset(ctx: PCtx) -> Int {
+  ctx.next_id = 0
+  ctx.seq_id = 0
+  let uses0: Array[Int] = []
+  ctx.uses = uses0
+  let borrows0: Array[Int] = []
+  ctx.borrows = borrows0
+  let scalar0: Array[Bool] = []
+  ctx.scalar = scalar0
+  let remaining0: Array[Int] = []
+  ctx.remaining = remaining0
+  let view0: Array[Bool] = []
+  ctx.view_call_let = view0
+  let actions0: Array[PerceusAction] = []
+  ctx.actions = actions0
+  0
 }
 
 /// Perf: this snapshot runs in every branch/match arm of the perceus plan --
@@ -2680,7 +2757,19 @@ export fn param_is_heap_in_body(name: String, otype: Option[TypeExpr], body: Exp
 /// one used in multiple owning positions. Heap-ness comes from the param's type
 /// annotation (scalar params get scalar=true so they are never dropped).
 export fn build_perceus_plan_with_params_split(params: Array[(String, Option[TypeExpr])], body: Expr, borrow_ret_names: Array[String], borrow_param_fns: Array[String], borrow_param_masks: Array[Int], view_ret_fns: Array[String], out_param_drop_start: Array[Int]) -> Array[PerceusAction] {
-  let ctx = pctx_new(borrow_ret_names, borrow_param_fns, borrow_param_masks, view_ret_fns)
+  // Reuse the cached PCtx when the caller's four whole-program tables are
+  // content-identical to the cached copies (the per-program common case: one
+  // plan per function/lambda, all against the same tables); otherwise build a
+  // fresh one and make it the cache. Either way `ctx` is read back out of the
+  // cache cell so it is uniformly a borrowed view of the cache-owned PCtx.
+  if Array::length(pctx_cache) == 0 {
+    Array::push(pctx_cache, pctx_new(borrow_ret_names, borrow_param_fns, borrow_param_masks, view_ret_fns))
+  } else if pctx_cache_matches(Array::get(pctx_cache, 0), borrow_ret_names, borrow_param_fns, borrow_param_masks, view_ret_fns) {
+    pctx_reset(Array::get(pctx_cache, 0))
+  } else {
+    Array::set(pctx_cache, 0, pctx_new(borrow_ret_names, borrow_param_fns, borrow_param_masks, view_ret_fns))
+  }
+  let ctx = Array::get(pctx_cache, 0)
   let mut scope: Map[String, Int] = Map::new()
   let mut pi = 0
   while pi < Array::length(params) {
@@ -2718,7 +2807,10 @@ export fn build_perceus_plan_with_params_split(params: Array[(String, Option[Typ
     pe_scope_end(ctx, Array::get(param_ids, pk), pname)
     pk = pk + 1
   }
-  ctx.actions
+  // An owned copy, NOT ctx.actions itself: the cached PCtx keeps (and later
+  // resets) its own actions array, while callers hold the returned plan
+  // across subsequent plan builds.
+  Array::slice(ctx.actions, 0, Array::length(ctx.actions))
 }
 
 /// The plan without the param-drop split index, for callers that do not

--- a/lib/@vibe/compiler/perceus/perceus.vibe
+++ b/lib/@vibe/compiler/perceus/perceus.vibe
@@ -37,17 +37,22 @@ export enum PerceusActionKind {
 struct PCtx {
   mut next_id: Int;
   mut seq_id: Int;
-  pctx_names: Array[String];
+  // The four table fields are `mut` for one reason only: on a pctx_cache
+  // mismatch the cached PCtx is refilled in place by field assignment, which
+  // drops the previous tables -- replacing the whole PCtx through Array::set
+  // would leak it (the linear lane's arr_set stores without releasing the old
+  // element).
+  mut pctx_names: Array[String];
   // ADR-0092 borrow-inference: sorted whole-program names with aligned borrow
   // masks (compute_borrow_param_user_fns, common_analysis.vibe). A
   // source-owned shadowable builtin is retained even with mask zero so its
   // source ABI overrides the builtin contract. Same COPY discipline as
   // pctx_names -- see pctx_new's doc comment.
-  borrow_param_user: Array[String];
+  mut borrow_param_user: Array[String];
   // Aligned to borrow_param_user: bit i of entry k says parameter i of
   // borrow_param_user[k] is borrowed. One bsearch on the names indexes
   // straight into this. Same COPY discipline.
-  borrow_param_mask: Array[Int];
+  mut borrow_param_mask: Array[Int];
   // User fns whose RETURN may be an unowned interior view
   // (compute_may_return_view_fns; NOT intersected with borrow_param_user --
   // see the linked_compile gate comment for why that intersection was a
@@ -56,7 +61,7 @@ struct PCtx {
   // fresh-returning callee's binding leaks its result (compiler-gate RC
   // reclamation guard), while a view-returning callee's binding must not
   // release a reference it never acquired. Same COPY discipline.
-  view_ret_user: Array[String];
+  mut view_ret_user: Array[String];
   // The per-plan working state below is `mut` so a cached PCtx (see
   // pctx_cache) can be reset between plan builds by assigning fresh empty
   // arrays -- assignment drops the previous plan's arrays instead of leaking
@@ -2767,7 +2772,16 @@ export fn build_perceus_plan_with_params_split(params: Array[(String, Option[Typ
   } else if pctx_cache_matches(Array::get(pctx_cache, 0), borrow_ret_names, borrow_param_fns, borrow_param_masks, view_ret_fns) {
     pctx_reset(Array::get(pctx_cache, 0))
   } else {
-    Array::set(pctx_cache, 0, pctx_new(borrow_ret_names, borrow_param_fns, borrow_param_masks, view_ret_fns))
+    // Refill the cached PCtx IN PLACE: field assignment drops the previous
+    // tables and working state. Replacing the element via Array::set would
+    // leak the whole old context -- the linear lane's arr_set stores without
+    // releasing the replaced element.
+    let stale = Array::get(pctx_cache, 0)
+    pctx_reset(stale)
+    stale.pctx_names = Array::slice(borrow_ret_names, 0, Array::length(borrow_ret_names))
+    stale.borrow_param_user = Array::slice(borrow_param_fns, 0, Array::length(borrow_param_fns))
+    stale.borrow_param_mask = Array::slice(borrow_param_masks, 0, Array::length(borrow_param_masks))
+    stale.view_ret_user = Array::slice(view_ret_fns, 0, Array::length(view_ret_fns))
   }
   let ctx = Array::get(pctx_cache, 0)
   let mut scope: Map[String, Int] = Map::new()

--- a/lib/@vibe/compiler/tests/types_test.vibe
+++ b/lib/@vibe/compiler/tests/types_test.vibe
@@ -348,15 +348,15 @@ test "re-export surface bindings block older locals and survive caches" {
       // marker's name starts with '#', which no parsed identifier can spell,
       // so it is unreachable from ordinary source-level lookups.
       inspect(Array::length(names), "3")
-      let mut has_marker = false
+      let mut has_marker = "absent"
       let mut i = 0
       while i < Array::length(names) {
         if Array::get(names, i) == "#active_region" {
-          has_marker = true
+          has_marker = "present"
         }
         i = i + 1
       }
-      inspect(has_marker, "true")
+      inspect(has_marker, "present")
     },
     _ => assert(false)
   }

--- a/lib/@vibe/compiler/tests/types_test.vibe
+++ b/lib/@vibe/compiler/tests/types_test.vibe
@@ -341,7 +341,23 @@ test "re-export surface bindings block older locals and survive caches" {
     ("local", env_value_binding(CtInt))
   ])
   match env_cache(flat_surface) {
-    EnvCached(names, _, _) => inspect(Array::length(names), "2"),
+    EnvCached(names, _, _) => {
+      // Two flattened bindings plus the negative #active_region marker that
+      // env_cache seeds into every index (perf: the no-active-region query
+      // answers from the bsearch instead of a full-chain miss walk). The
+      // marker's name starts with '#', which no parsed identifier can spell,
+      // so it is unreachable from ordinary source-level lookups.
+      inspect(Array::length(names), "3")
+      let mut has_marker = false
+      let mut i = 0
+      while i < Array::length(names) {
+        if Array::get(names, i) == "#active_region" {
+          has_marker = true
+        }
+        i = i + 1
+      }
+      inspect(has_marker, "true")
+    },
     _ => assert(false)
   }
 }


### PR DESCRIPTION
Profiled a real selfhost compile per the `compiler-perf-profiling` skill
(`scripts/profile_compile.sh` on `lib/@vibe/compiler/tests/codegen_lexer_test.vibe`,
stage2 built with `VIBE_WASM_NAMES=1`), then knocked down the measured hotspots
in order. Continues #1848 (the linear-scan / allocation-churn hot path).

## Measured result (same corpus, same machine, before → after)

| metric | before | after | Δ |
|---|---:|---:|---:|
| wall | 12.19s | 8.09s | **−34%** |
| CPU total | 11.10s | 7.66s | −31% |
| bump-heap high water | 1.44GB | 1.25GB | −13% |
| linear memory pages | 28768 | 19179 | −33% |
| `__rt_arr_slice` self | 1073ms | 111ms | −90% |
| `__rt_arr_push` self | 1343ms | 406ms | −70% |

## The five perf changes, in profile order

1. **Perceus whole-program table cache** (`perceus/perceus.vibe`) — `pctx_new`
   copied the four program-wide borrow tables into every plan's PCtx (one plan
   per top-level fn AND per lambda): ~7% of total CPU in `__rt_arr_slice`
   alone, and the dominant allocation source. A module-level cache now holds
   the PCtx for the current table set; every plan build **content-verifies**
   all four incoming tables against the cached copies and falls back to a
   fresh PCtx on any mismatch, so correctness never depends on a set/reset
   discipline — a stale entry can only cause a miss, never a wrong table. The
   returned plan is an owned slice, so callers keep valid plans across builds.
2. **`__rt_str_eq` identity fast path** (`bodies_core_a1a1_str_eq.vibe`) —
   equal packed `(ptr<<32)|len` values are trivially equal: one `i64.eq`
   before touching memory. This is also what makes the table verification in
   (1) cheap (both sides hold the same string objects).
3. **Trait-dict rewrite environment copies** (`normalize/desugar_trait_dict.vibe`)
   — every `var_types` extension cloned the environment with per-element
   pushes; `push_all_var_types` was the largest single `__rt_arr_push` caller.
   All twelve sites plus `extend_var_types` / `bind_impl_target_key` now clone
   via one `Array::slice`, and `lookup_var_type` scans backward with an early
   exit (same LAST-match answer, #760(4)).
4. **`is_borrow_ret_builtin` allocation** (`core/builtin_registry.vibe`) —
   ran once per call site and rebuilt the 7-name table per query. The set now
   lives in one module-level table (still the single spelling, #1979);
   `borrow_ret_builtin_names()` keeps returning a fresh copy for the
   fixed-point worklist that mutates its result.
5. **No-active-region query** (`core/types.vibe`, `checker/checker.vibe`) —
   `env_has_active_region` was a full-chain miss walk outside regions (the
   largest env_lookup consumer, ~265ms). `env_cache` now seeds every
   acceleration index with a negative CtUnit-typed `__active_region__` entry;
   only the real CtNamed skolem counts as active. The chain is untouched, so
   the manual region walks are unaffected, and pre-existing cached envs just
   keep the slow-but-correct path.

## Dead-code cleanup (separate commits)

~510 lines removed, every function verified zero-reference across
`lib/ scripts/ tests/ fixtures/ tools/ bench/ docs/` (generated bundles
excluded): nine orphaned private loader helpers, the self-described legacy
`resolve_qualified_parameterized_ctor`, `checked_entry_snapshot` (identical
sibling of `checked_entry_source`), `namespace_private_value_stmts_legacy_ordered`,
and seven more single-file orphans — plus the remaining `.mbt`-era `///|`
block separators (CLAUDE.md: delete on sight).

## Validation

- `bash scripts/generations.sh build --stage3` fixpoint: **stage2 == stage3**
  byte-identical, after each round.
- `scripts/unit_test_runner.sh` full suite against the new stage2:
  **1079/1079 passed** (round 1; round 2 result in the PR checks).
- `pkf run test` (operation gate).
- `scripts/vibe_fmt.sh --check` clean on every touched file.
- Re-profiled after each round; the targeted hotspots are gone from the top
  of the self-time table.

The RC-sensitive change (1) was validated the way #1980 prescribes: full unit
suite + self-compile fixpoint, not just the compiler gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0159xd5111g8KFt2CGyNyZvA

---
_Generated by [Claude Code](https://claude.ai/code/session_0159xd5111g8KFt2CGyNyZvA)_