### PR TITLE
An alias constructor's binders belong to the alias, not to the signature

### DIFF
--- a/lib/@vibe/compiler/checker/checker.vibe
+++ b/lib/@vibe/compiler/checker/checker.vibe
@@ -28,6 +28,7 @@ import @vibe/compiler/core {
   generalize,
   hkt_apply_ctor,
   instantiate,
+  is_alias_constructor,
   is_exception_effect_name,
   is_exception_label,
   is_exception_throw_handler_name,
@@ -678,12 +679,23 @@ fn collect_all_formals_in_type(ty: Type, formals: Array[String], out: Array[Stri
     // unkinded spelling was caught all along ("return type mismatch"), which is
     // what hid it (Codex review).
     CtApplied(head, args) => {
-      push_unique_formal(type_constructor_name(head), formals, out)
-      collect_all_formals_in_type(head, formals, out)
-      let mut i = 0
-      while i < Array::length(args) {
-        collect_all_formals_in_type(Array::get(args, i), formals, out)
-        i = i + 1
+      // Everything after the body of an `#alias_ctor` is the ALIAS's own
+      // binder names, which have nothing to do with this signature's formals.
+      // Walking them marked an unrelated formal of the same name rigid:
+      // measured, `type Pair[A, B]` vs `type Pair[P, Q]` was the only
+      // difference between a program that compiled and one rejected with
+      // "binding type mismatch for a local let: expected Int, got A"
+      // (Codex review).
+      if is_alias_constructor(ty) {
+        ()
+      } else {
+        push_unique_formal(type_constructor_name(head), formals, out)
+        collect_all_formals_in_type(head, formals, out)
+        let mut i = 0
+        while i < Array::length(args) {
+          collect_all_formals_in_type(Array::get(args, i), formals, out)
+          i = i + 1
+        }
       }
     },
     CtConstructor(name, _) => push_unique_formal(name, formals, out),
@@ -765,8 +777,15 @@ fn collect_hkt_related_formals_in_type(ty: Type, formals: Array[String], out: Ar
     // An applied head that IS one of the formals is exactly the HKT use this
     // function classifies, so its arguments are collected in full.
     CtApplied(head, args) => {
-      let head_name = type_constructor_name(head)
-      if formals_contain_source_name(formals, head_name) && Array::length(args) > 0 {
+      // Same alias-binder metadata as in collect_all_formals_in_type above.
+      let head_name = if is_alias_constructor(ty) {
+        ""
+      } else {
+        type_constructor_name(head)
+      }
+      if is_alias_constructor(ty) {
+        ()
+      } else if formals_contain_source_name(formals, head_name) && Array::length(args) > 0 {
         push_unique_formal(head_name, formals, out)
         let mut i = 0
         while i < Array::length(args) {

--- a/lib/@vibe/compiler/core/index.vpkg
+++ b/lib/@vibe/compiler/core/index.vpkg
@@ -274,6 +274,7 @@ fn type_implements_trait(env: TypeEnv, s: Subst, ty: Type, trait_name: String) -
 fn refine_trait_bounds_from_receiver(env: TypeEnv, s: Subst, param: Type, receiver: Type) -> Subst
 fn trait_impl_declared_for_ctor(e: TypeEnv, trait_name: String, resolved: Type) -> Bool
 fn trait_is_marker(env: TypeEnv, trait_name: String) -> Bool
+fn is_alias_constructor(ty: Type) -> Bool
 fn type_constructor_name(ty: Type) -> String
 
 // --- import_alias_rewrite

--- a/lib/@vibe/compiler/core/types.vibe
+++ b/lib/@vibe/compiler/core/types.vibe
@@ -2565,6 +2565,22 @@ export fn apply_type_constructor(head: Type, args: Array[Type]) -> Type {
 
 let alias_ctor_tag = "#alias_ctor"
 
+/// A bare parameterized alias passed to a higher-kinded slot, encoded as
+/// `CtApplied(CtNamed("#alias_ctor", []), [body, <binder>...])`. Everything
+/// after the body is the ALIAS DECLARATION's own binder names, which belong to
+/// that declaration and not to whatever signature the value appears in -- a
+/// scan that walks them conflates them with same-named formals of the enclosing
+/// function.
+export fn is_alias_constructor(ty: Type) -> Bool {
+  match ty {
+    CtApplied(head, meta) => match head {
+      CtNamed(n, ha) => n == alias_ctor_tag && Array::length(ha) == 0 && Array::length(meta) > 0,
+      _ => false
+    },
+    _ => false
+  }
+}
+
 fn make_alias_constructor(params: Array[String], body: Type) -> Type {
   let meta = array_empty()
   Array::push(meta, type_clone(body))

--- a/lib/@vibe/compiler/tests/hkt_rigid_formals_test.vibe
+++ b/lib/@vibe/compiler/tests/hkt_rigid_formals_test.vibe
@@ -211,6 +211,18 @@ test "a method generic shadows a same-named trait parameter" {
   assert(String::contains(unshadowed, "constructor parameter `A` is applied"))
 }
 
+/// A bare parameterized alias in a higher-kinded slot is encoded as
+/// `CtApplied(CtNamed("#alias_ctor", []), [body, <binder>...])`, and those
+/// binders belong to the ALIAS declaration. Walking them marked an unrelated
+/// formal of the same name rigid: the only difference between these two
+/// programs is whether the alias spells its own binder `A` (Codex review).
+test "an alias constructor's own binders are not this signature's formals" {
+  let collide = "type Pair[A, B] = (A, B)\nstruct Holder[H[_, _]] {\n  value: Int\n}\nfn coerce[G[_], A](x: G[Holder[Pair]], y: A) -> Int {\n  let z: Int = y\n  z\n}\nfn main { () }\n"
+  let renamed = "type Pair[P, Q] = (P, Q)\nstruct Holder[H[_, _]] {\n  value: Int\n}\nfn coerce[G[_], A](x: G[Holder[Pair]], y: A) -> Int {\n  let z: Int = y\n  z\n}\nfn main { () }\n"
+  assert(checks(renamed))
+  assert(checks(collide))
+}
+
 /// A header parameter's kind is aggregated across the whole trait, so it has to
 /// be aggregated over the methods that MENTION it. Pooling a method generic of
 /// the same name -- a different binder, with its own kind -- reported a valid


### PR DESCRIPTION
Follow-up to #2364, which merged at `0f0b784` while this fix was still in review. The commit was validated on that PR's branch and never reached main, so **main currently carries the regression** — verified against the compiler main shipped, below.

## The regression

#2364's `CtApplied` traversal walks the arguments of every application. A bare parameterized alias passed to a higher-kinded slot is encoded as

```
CtApplied(CtNamed("#alias_ctor", []), [body, <binder>...])
```

where everything after the body is the **alias declaration's own binder names**. Walking them marks a formal of the enclosing signature that happens to share a name as rigid, which rejects the local annotation a plain formal is meant to permit.

Measured on the same program, with only the alias's binder spelling changed:

```vibe
type Pair[A, B] = (A, B)      // vs  type Pair[P, Q] = (P, Q)
struct Holder[H[_, _]] { value: Int }

fn coerce[G[_], A](x: G[Holder[Pair]], y: A) -> Int {
  let z: Int = y
  z
}
```

| compiler | `Pair[A, B]` | `Pair[P, Q]` |
|---|---|---|
| what main shipped (`0f0b784`) | `binding type mismatch for a local let: expected Int, got A` | ok |
| this branch | ok | ok |

The alias's private choice of binder name decides whether an unrelated function compiles.

## The fix

Both scans stop at the encoding, via `is_alias_constructor` exported from `types.vibe` rather than a second copy of the `#alias_ctor` tag string in the checker.

Credit to the Codex review on #2364, which found this a commit after the traversal that caused it. Its own example (`h: Holder[Apply]` for `type Apply[F[_], A] = F[A]`) does not reproduce — `Apply` has a nested constructor parameter, so it cannot fill `H[_, _]` at all and is rejected earlier and independently. The shape above reaches the scan because `Holder[Pair]` is a *complete* type and can therefore be the argument of a kinded formal, which is what puts the metadata under `collect_all_formals_in_type`.

## Verification

- `bash scripts/compiler_gate.sh` — **ok**, 834 lines, 0 FAIL, on this branch rebased onto current main
- `lib/@vibe/compiler/tests/hkt_rigid_formals_test.vibe` — 33 tests pass
- the before/after table above, measured on two stage2 builds: the generation main shipped and this branch's
- Red-tested: disabling the guard fails the new test — `an alias constructor's own binders are not this signature's formals` — and no other, with the mutation verified present before its failure was trusted. The test asserts **both** spellings compile, so the renamed control cannot carry it alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FYMVd6D2o82suTfTwoJPMf

---
_Generated by [Claude Code](https://claude.ai/code/session_01FYMVd6D2o82suTfTwoJPMf)_