### PR TITLE
Bound insert_raw's probe walk so a full table fails instead of hanging — #2362

### DIFF
--- a/lib/@vibe/core/hashmap.vibe
+++ b/lib/@vibe/core/hashmap.vibe
@@ -167,6 +167,26 @@ fn find_index[K, V](m: MutMap[K, V], k: K) -> Int {
   result
 }
 
+/// The probe is bounded by `cap`, and exceeding it is a violated PRECONDITION,
+/// not a recoverable state: the walk only runs out when the table has no empty
+/// slot AND does not already hold the key, so there is nowhere to put it.
+/// `MutMap::set` is what maintains "there is always a free slot" (it grows
+/// whenever `(size + tombs + 1) / cap` would pass 0.7), so reaching the bound
+/// means that accounting has drifted -- and #2362 measured the consequence:
+/// under-counting `m.tombs` makes the table fill, and this loop then spins
+/// forever, which is the least diagnosable way to fail.
+///
+/// `assert` is the fail-closed mechanism available here. It traps, the way a
+/// bounds-checked builtin does, WITHOUT the message such a builtin prints:
+/// `__rt_oob_abort` is a codegen-level helper that library code cannot reach.
+/// Terminating silently beats hanging; a named abort for library code would be
+/// better still and is not this change to invent.
+///
+/// `find_index`'s bound is deliberately NOT loud, and the asymmetry is real:
+/// there, exhausting the walk over a full table is how a lookup for an ABSENT
+/// key terminates, and `-1` is the correct answer. Here it means the insert
+/// cannot be performed at all.
+///
 /// Insert without growth check. Reuses the first tombstone seen on the probe
 /// path when the key is not already present.
 fn insert_raw[K, V](m: MutMap[K, V], k: K, v: V) -> Unit {
@@ -176,6 +196,7 @@ fn insert_raw[K, V](m: MutMap[K, V], k: K, v: V) -> Unit {
   let mut idx = home_of(h, cap)
   let mut tomb_idx = -1
   let mut inserting = true
+  let mut steps = 0
   while inserting {
     let c = Bytes::get(m.ctrl, idx)
     if c == 0 {
@@ -200,6 +221,8 @@ fn insert_raw[K, V](m: MutMap[K, V], k: K, v: V) -> Unit {
       if idx >= cap {
         idx = 0
       }
+      steps = steps + 1
+      assert(steps <= cap)
     } else {
       let mut matched = false
       if c == tag {
@@ -220,6 +243,8 @@ fn insert_raw[K, V](m: MutMap[K, V], k: K, v: V) -> Unit {
         if idx >= cap {
           idx = 0
         }
+        steps = steps + 1
+        assert(steps <= cap)
       }
     }
   }

--- a/tests/gates/early/run.sh
+++ b/tests/gates/early/run.sh
@@ -259,6 +259,69 @@ if ! printf '%s\n' "$oob_bytes_out" | grep -qF "Bytes::get: index 9 out of bound
 fi
 echo "[compiler-gate] OOB abort messages ok (Array::get, Bytes::get)"
 
+# 4f. #2362: `insert_raw`'s probe walk is BOUNDED. `find_index` has carried a
+#     step guard since it was written; the insert path walking the same chain
+#     under the same invariant did not, so a table with no empty slot spun
+#     forever -- the least diagnosable way to fail. The state is unreachable
+#     through `MutMap::set`, which grows before every insert, so the probe
+#     below reaches it the way an accounting bug would: by under-counting
+#     `m.tombs`, which is exactly what the growth check reads.
+#
+#     The assertion is TERMINATION, timed: before the guard this program ran
+#     until something killed it, so a plain "did it fail?" check passes either
+#     way -- a hang and a trap are both non-zero once a timeout is involved.
+#     `timeout` reports 124 when it had to intervene, and that is the value
+#     this pins against.
+echo "[compiler-gate] 4f insert_raw's probe walk is bounded (#2362)"
+hmdir="_build/_gate_hashmap_bound"
+rm -rf "$hmdir"; mkdir -p "$hmdir"
+cat > "$hmdir/fill.vibe" <<'VEOF'
+import @vibe/core { struct MutMap }
+
+fn main with Console {
+  let m: MutMap[String, Int] = MutMap::with_capacity_string(8)
+  println("filling")
+  let mut i = 0
+  while i < 40 {
+    let k = "k\{i}"
+    MutMap::set(m, k, i)
+    let _ = MutMap::delete(m, k)
+    m.tombs = m.tombs - 1
+    i = i + 1
+  }
+  println("returned")
+}
+VEOF
+VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
+  bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
+  "$hmdir/fill.vibe" "$hmdir/fill.wasm" main >/dev/null 2>&1 || true
+if [ ! -s "$hmdir/fill.wasm" ]; then
+  echo "[compiler-gate] FAIL: #2362 probe did not compile" >&2
+  cat "$hmdir/fill.wasm.diag" >&2 2>/dev/null || true
+  exit 1
+fi
+set +e
+hm_out="$(timeout 60 env VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh --invoke _start "$hmdir/fill.wasm" 2>&1)"
+hm_rc=$?
+set -e
+rm -rf "$hmdir"
+if [ "$hm_rc" -eq 124 ]; then
+  echo "[compiler-gate] FAIL: a full table made insert_raw spin -- the probe had to be killed at the timeout (#2362)" >&2
+  printf '%s\n' "$hm_out" >&2
+  exit 1
+fi
+if [ "$hm_rc" -eq 0 ]; then
+  echo "[compiler-gate] FAIL: insert_raw accepted an insert into a table with no free slot (#2362)" >&2
+  printf '%s\n' "$hm_out" >&2
+  exit 1
+fi
+if ! printf '%s\n' "$hm_out" | grep -qF "filling"; then
+  echo "[compiler-gate] FAIL: the #2362 probe failed before it reached the fill loop, so it proves nothing" >&2
+  printf '%s\n' "$hm_out" >&2
+  exit 1
+fi
+echo "[compiler-gate] insert_raw bounded probe ok (terminated, rc=$hm_rc)"
+
 # 5. test-block regression (#594): a file with only `test {}` blocks (no entry)
 #    must compile to a valid module whose `_start` runs every test; a passing
 #    file exits clean and a failing assert traps. Guards the codegen fix that

--- a/tests/gates/registry.tsv
+++ b/tests/gates/registry.tsv
@@ -18,6 +18,7 @@ x-parser-binder-context-spine	bootstrap	parser binder-context spine
 4c	early	4c missing-import diagnostic regression (#831)
 4d	early	4d derive(Show) source-name rendering across merge rename (#2205)
 4e	early	4e OOB abort names the operation, index, and length (#2199)
+4f	early	4f insert_raw's probe walk is bounded (#2362)
 5/5	early	5/5 test-block compile+run regression
 6/6	early	6/6 normalize compile+run regression
 6b	early	6b contract package + boundary regression (#729)


### PR DESCRIPTION
Closes #2362.

`find_index` has carried a step guard since it was written. `insert_raw` walks the same chain under the same invariant and had none, so a table with no empty slot spun forever.

## Reproduced through the public API

No private access needed, and it is the issue's own causal chain. `MutMap::set` reads `size + tombs` to decide when to grow, so under-counting tombstones makes it grow later than it should, until the table fills:

```vibe
let m: MutMap[String, Int] = MutMap::with_capacity_string(8)
while i < 40 {
  MutMap::set(m, k, i)
  let _ = MutMap::delete(m, k)
  m.tombs = m.tombs - 1        // the drift
}
```

| | result |
|---|---|
| before | killed at a 60 s timeout, having printed only `filling` |
| after | terminates, `rc=1` |

## Not an Exception

The issue asks for "an explicit failure", and my first design put `throw` here. @mizchi pushed back, and was right — it does not survive measurement:

- **The throw is unreachable.** `MutMap::set` grows whenever `(size + tombs + 1) * 10 > cap * 7`, so `insert_raw` always runs with ≥30% of slots free. The issue says as much: *"the invariant holds today."* It would color `MutMap::insert`'s **public** effect row for a case that cannot occur.
- **It would be inconsistent.** Measured, this is how the language already fails:

  | condition | behaviour |
  |---|---|
  | `Array::get(xs, 99)`, len 3 | `Array::get: index 99 out of bounds for length 3`, then **traps** |
  | `Int` overflow (`max + 1`) | **wraps** to `-4611686018427387904` (#1877, deliberate) |

  Nothing puts `Exception` on a public row for a broken invariant, and it would work against the "colorless functions where possible" policy.

Exceeding the bound is a violated **precondition**: the walk runs out only when the table has no empty slot *and* does not already hold the key, so there is nowhere to put it. `insert_raw` is documented "insert without growth check" — its caller owes it a free slot. `assert` is the fail-closed mechanism available to library code and matches how the language already fails a violated precondition.

**One thing it does not do is say so.** `__rt_oob_abort`, which gives bounds-checked builtins their named message, is a codegen-level helper library code cannot reach (and the gc lane has none). Terminating silently beats hanging, but a named abort available to library code is a real gap — filed separately rather than invented here.

## `find_index` stays silent, against the issue's suggestion

#2362 raises whether `find_index`'s guard should also be loud, on the grounds that returning `-1` for a present key is the P0 shape. Measured against the code, it should not: in a full table, exhausting the walk is exactly how a lookup for an **absent** key terminates, and `-1` is then the *correct* answer. Trapping there would kill a correct path. The asymmetry is documented at `insert_raw`.

## Verification

- `bash scripts/compiler_gate.sh` — **ok**, 841 lines, 0 FAIL, including the new `4f` section
- `hashmap_test.vibe` + 4 sibling map/set suites — 5 files, 40 tests, pass
- the before/after table above, same probe both ways

**The test asserts termination, timed.** Before the guard the probe ran until something killed it, so a plain "did it fail?" check passes either way — a hang and a trap are both non-zero once a timeout is involved. The gate pins `timeout`'s 124, `rc=0`, and that the probe reached its fill loop at all.

Red-tested: neutering both guards fails it with `a full table made insert_raw spin -- the probe had to be killed at the timeout`. The first attempt at verifying that mutation **miscounted and did not land** (a 6-space pattern also matched inside the 8-space one), so the "red" run it produced was meaningless; the mutation is counted by whole line now, and was confirmed present before its failure was trusted.

The new gate section is registered in `tests/gates/registry.tsv` — `check_gate_registry.sh` rejected it until it was, which is the registry doing its job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FYMVd6D2o82suTfTwoJPMf

---
_Generated by [Claude Code](https://claude.ai/code/session_01FYMVd6D2o82suTfTwoJPMf)_