### PR TITLE
Say which declarations are reachable, and check the claim — #2343

### DIFF
--- a/lib/@vibe/compiler/builtins/declarations.vibe
+++ b/lib/@vibe/compiler/builtins/declarations.vibe
@@ -1,6 +1,16 @@
 // lib/@vibe/compiler/builtins/declarations.vibe
-// Single Source of Truth for all builtin function signatures.
-// This file is parsed by the binary encoder to generate builtin_table.bin.
+// Single source of truth for builtin SIGNATURES. It is parsed by the binary
+// encoder to generate builtin_table.bin.
+//
+// It is NOT the source of truth for REACHABILITY. A declaration here says what
+// a name's type is if it resolves, not that user code can spell it: what the
+// checker sees is decided by `core/builtin_registry.vibe` (a checker_visible
+// row) and the per-namespace checker lookups. The two differ block by block --
+// `simd_skip_ws` below resolves, and every name under "WASM intrinsics
+// (low-level)" does not -- and the file used to record neither, so a reader
+// looking for "how do I get a ctz" found a declaration, wrote the name, and
+// got `unknown name` (#2343). Each block that is codegen-internal now says so,
+// and `tests/gates/early/run.sh` (section 4g) checks that the claim is true.
 
 //# Operators (internal)
 declare __add(T, T) -> T
@@ -160,6 +170,17 @@ declare Double::floor(Double) -> Double
 declare Double::ceil(Double) -> Double
 
 //# WASM intrinsics (low-level)
+// CODEGEN-INTERNAL: not reachable from user code. These are the raw wasm
+// opcodes the backends emit through; they have no checker_visible registry row
+// and no namespace lookup, so spelling one in vibe source is `unknown name`.
+// Measured: all 49 of them, uniformly.
+//
+// Wanting one of these is a real need (#2344 wants ctz and popcount) -- the
+// answer is a designed `Int::` surface with defined edge cases, routed through
+// the registry the way `simd_skip_ws` is, NOT un-hiding the raw opcode name.
+//
+// `//#` starts a section and `//` does not: the gate reads this block by
+// banner, so these lines must stay plain comments.
 declare i32_eqz(Int) -> Int
 declare i32_shr_u(Int, Int) -> Int
 declare i32_eq(Int, Int) -> Int

--- a/tests/gates/early/run.sh
+++ b/tests/gates/early/run.sh
@@ -360,31 +360,40 @@ if printf '%s\n' "$intrinsic_names" | grep -qx "simd_skip_ws"; then
   echo "[compiler-gate] FAIL: the #2343 scan ran past the WASM-intrinsics block -- it collected simd_skip_ws, which is declared under a later banner" >&2
   exit 1
 fi
+# The CHECK lane, and the diagnostic itself -- not "was a wasm produced?".
+# Those differ: a name that becomes checker-visible but has no linear
+# function-table entry RESOLVES and still emits no wasm, so an
+# artifact-existence test would file it under "unreachable" -- a false pass on
+# exactly the state this section exists to catch (Codex review). `unknown
+# name: <n>` is the checker saying it, and nothing else produces that line.
 reachable=""
 for n in $intrinsic_names; do
+  rm -f "$dcldir/p.out" "$dcldir/p.out.diag"
   printf 'fn probe() -> Int {\n  let _x = %s\n  0\n}\n' "$n" > "$dcldir/p.vibe"
   VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
     bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
-    "$dcldir/p.vibe" "$dcldir/p.wasm" __no_entry__ >/dev/null 2>&1 || true
-  if [ -s "$dcldir/p.wasm" ]; then
+    "$dcldir/p.vibe" "$dcldir/p.out" __no_entry__ check >/dev/null 2>&1 || true
+  if ! grep -qF "unknown name: $n" "$dcldir/p.out.diag" 2>/dev/null; then
     reachable="$reachable $n"
   fi
-  rm -f "$dcldir/p.wasm" "$dcldir/p.wasm.diag"
 done
-# The control: a name from the same file that IS reachable.
+# The control: a name from the same file that IS reachable -- it must produce
+# NO diagnostic. Without it, a harness whose probes all failed to run would
+# report every name unreachable and pass.
+rm -f "$dcldir/ctl.out" "$dcldir/ctl.out.diag"
 printf 'fn probe(b: Bytes) -> Int {\n  simd_skip_ws(b, 0, 1)\n}\n' > "$dcldir/ctl.vibe"
 VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
-  "$dcldir/ctl.vibe" "$dcldir/ctl.wasm" __no_entry__ >/dev/null 2>&1 || true
-if [ ! -s "$dcldir/ctl.wasm" ]; then
-  echo "[compiler-gate] FAIL: the #2343 control did not compile -- simd_skip_ws is declared in $decl_src and must resolve, so this harness is reporting 'unreachable' for everything" >&2
-  cat "$dcldir/ctl.wasm.diag" >&2 2>/dev/null || true
+  "$dcldir/ctl.vibe" "$dcldir/ctl.out" __no_entry__ check >/dev/null 2>&1 || true
+if [ -s "$dcldir/ctl.out.diag" ]; then
+  echo "[compiler-gate] FAIL: the #2343 control reported a diagnostic -- simd_skip_ws is declared in $decl_src and must resolve, so this harness is calling everything unreachable" >&2
+  cat "$dcldir/ctl.out.diag" >&2 2>/dev/null || true
   rm -rf "$dcldir"
   exit 1
 fi
 rm -rf "$dcldir"
 if [ -n "$reachable" ]; then
-  echo "[compiler-gate] FAIL: these names are under the codegen-internal WASM-intrinsics banner in $decl_src but DO resolve from user code:$reachable" >&2
+  echo "[compiler-gate] FAIL: these names are under the codegen-internal WASM-intrinsics banner in $decl_src but the checker did NOT report them unknown:$reachable" >&2
   echo "    Either move them out of that block, or drop the claim. The banner says the block is unreachable (#2343)." >&2
   exit 1
 fi

--- a/tests/gates/early/run.sh
+++ b/tests/gates/early/run.sh
@@ -322,6 +322,74 @@ if ! printf '%s\n' "$hm_out" | grep -qF "filling"; then
 fi
 echo "[compiler-gate] insert_raw bounded probe ok (terminated, rc=$hm_rc)"
 
+# 4g. #2343: `declarations.vibe` declares ~50 low-level wasm opcodes that user
+#     code cannot spell. The file called itself "Single Source of Truth for all
+#     builtin function signatures" and recorded nothing about reachability, so
+#     a reader looking for a ctz found `declare int_ctz(Int) -> Int`, wrote it,
+#     and got `unknown name`. The block now says it is codegen-internal; this
+#     checks the claim rather than trusting the comment.
+#
+#     The oracle is the CHECKER, one probe per name -- not a lookup in
+#     `core/builtin_registry.vibe`, which decides only some names (the rest go
+#     through per-namespace checker lookups), so a registry cross-reference
+#     would answer a different question than the one the comment makes.
+#
+#     A control runs alongside: `simd_skip_ws`, declared in the same file two
+#     blocks down, MUST resolve. Without it, a probe harness that silently
+#     failed to compile anything would report all-unreachable and pass.
+echo "[compiler-gate] 4g the WASM-intrinsics block is codegen-internal, as it claims (#2343)"
+dcldir="_build/_gate_declarations_reach"
+rm -rf "$dcldir"; mkdir -p "$dcldir"
+decl_src="lib/@vibe/compiler/builtins/declarations.vibe"
+# The block runs from its own banner to the next one.
+intrinsic_names="$(awk '
+  /^\/\/# WASM intrinsics/ { inblock = 1; next }
+  inblock && /^\/\/#/ { inblock = 0; next }
+  inblock && /^declare / { sub(/^declare /, ""); sub(/\(.*$/, ""); print }
+' "$decl_src")"
+intrinsic_count="$(printf '%s\n' "$intrinsic_names" | grep -c .)"
+if [ "$intrinsic_count" -lt 40 ]; then
+  echo "[compiler-gate] FAIL: found only $intrinsic_count names under the WASM-intrinsics banner in $decl_src -- the block moved or the scan broke, and an empty scan would pass this section vacuously (#2343)" >&2
+  exit 1
+fi
+# A floor catches an empty scan; it does not catch one that runs PAST the block
+# and swallows the reachable names below it (which is what the first version of
+# this scan did, reporting Fs:: and Env:: as unreachable intrinsics). The
+# control name lives two blocks down, so its presence here means exactly that.
+if printf '%s\n' "$intrinsic_names" | grep -qx "simd_skip_ws"; then
+  echo "[compiler-gate] FAIL: the #2343 scan ran past the WASM-intrinsics block -- it collected simd_skip_ws, which is declared under a later banner" >&2
+  exit 1
+fi
+reachable=""
+for n in $intrinsic_names; do
+  printf 'fn probe() -> Int {\n  let _x = %s\n  0\n}\n' "$n" > "$dcldir/p.vibe"
+  VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
+    bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
+    "$dcldir/p.vibe" "$dcldir/p.wasm" __no_entry__ >/dev/null 2>&1 || true
+  if [ -s "$dcldir/p.wasm" ]; then
+    reachable="$reachable $n"
+  fi
+  rm -f "$dcldir/p.wasm" "$dcldir/p.wasm.diag"
+done
+# The control: a name from the same file that IS reachable.
+printf 'fn probe(b: Bytes) -> Int {\n  simd_skip_ws(b, 0, 1)\n}\n' > "$dcldir/ctl.vibe"
+VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
+  bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
+  "$dcldir/ctl.vibe" "$dcldir/ctl.wasm" __no_entry__ >/dev/null 2>&1 || true
+if [ ! -s "$dcldir/ctl.wasm" ]; then
+  echo "[compiler-gate] FAIL: the #2343 control did not compile -- simd_skip_ws is declared in $decl_src and must resolve, so this harness is reporting 'unreachable' for everything" >&2
+  cat "$dcldir/ctl.wasm.diag" >&2 2>/dev/null || true
+  rm -rf "$dcldir"
+  exit 1
+fi
+rm -rf "$dcldir"
+if [ -n "$reachable" ]; then
+  echo "[compiler-gate] FAIL: these names are under the codegen-internal WASM-intrinsics banner in $decl_src but DO resolve from user code:$reachable" >&2
+  echo "    Either move them out of that block, or drop the claim. The banner says the block is unreachable (#2343)." >&2
+  exit 1
+fi
+echo "[compiler-gate] declarations.vibe reachability claim ok ($intrinsic_count intrinsics unreachable, control resolves)"
+
 # 5. test-block regression (#594): a file with only `test {}` blocks (no entry)
 #    must compile to a valid module whose `_start` runs every test; a passing
 #    file exits clean and a failing assert traps. Guards the codegen fix that

--- a/tests/gates/early/run.sh
+++ b/tests/gates/early/run.sh
@@ -334,20 +334,47 @@ echo "[compiler-gate] insert_raw bounded probe ok (terminated, rc=$hm_rc)"
 #     through per-namespace checker lookups), so a registry cross-reference
 #     would answer a different question than the one the comment makes.
 #
-#     A control runs alongside: `simd_skip_ws`, declared in the same file two
-#     blocks down, MUST resolve. Without it, a probe harness that silently
-#     failed to compile anything would report all-unreachable and pass.
+#     Each name is probed in BOTH the value form (`let _x = n`) and the call
+#     form (`n(a0, ...)` at the declared arity). They are not the same question:
+#     the checker's `ECall` arm resolves the callee through `direct_call_return`
+#     and does not re-check the callee `EIdent`, so a name reached only by that
+#     fast path type-checks as a call while the value form still reports
+#     `unknown name`. Measured on `__len`, which is in `direct_builtin_return`:
+#     `let _x = __len` gives `unknown name: __len`, `__len(a)` gives no
+#     diagnostic at all. A value-only probe therefore certifies as unreachable
+#     a name user code can call -- exactly the state this section exists to
+#     catch (Codex review). A name counts as unreachable only when BOTH forms
+#     report it unknown.
+#
+#     The call probe spells each declared parameter type verbatim as an
+#     annotation. If that spelling is ever wrong (a parameter type containing a
+#     top-level comma would split badly), the checker answers with some OTHER
+#     diagnostic, not `unknown name`, and the name is reported reachable -- the
+#     section fails loudly rather than passing on a probe that never compiled.
+#
+#     Controls run alongside: `simd_skip_ws`, declared in the same file two
+#     blocks down, MUST resolve in both forms. Without them, a probe harness
+#     that silently failed to compile anything would report all-unreachable and
+#     pass.
 echo "[compiler-gate] 4g the WASM-intrinsics block is codegen-internal, as it claims (#2343)"
 dcldir="_build/_gate_declarations_reach"
 rm -rf "$dcldir"; mkdir -p "$dcldir"
 decl_src="lib/@vibe/compiler/builtins/declarations.vibe"
-# The block runs from its own banner to the next one.
-intrinsic_names="$(awk '
+# The block runs from its own banner to the next one. `name|T0,T1,...`.
+intrinsic_decls="$(awk '
   /^\/\/# WASM intrinsics/ { inblock = 1; next }
   inblock && /^\/\/#/ { inblock = 0; next }
-  inblock && /^declare / { sub(/^declare /, ""); sub(/\(.*$/, ""); print }
+  inblock && /^declare / {
+    line = $0
+    sub(/^declare /, "", line)
+    name = line; sub(/\(.*$/, "", name)
+    params = line; sub(/^[^(]*\(/, "", params); sub(/\).*$/, "", params)
+    gsub(/ /, "", params)
+    print name "|" params
+  }
 ' "$decl_src")"
-intrinsic_count="$(printf '%s\n' "$intrinsic_names" | grep -c .)"
+intrinsic_names="$(printf '%s\n' "$intrinsic_decls" | sed 's/|.*$//' | grep . || true)"
+intrinsic_count="$(printf '%s\n' "$intrinsic_names" | grep -c . || true)"
 if [ "$intrinsic_count" -lt 40 ]; then
   echo "[compiler-gate] FAIL: found only $intrinsic_count names under the WASM-intrinsics banner in $decl_src -- the block moved or the scan broke, and an empty scan would pass this section vacuously (#2343)" >&2
   exit 1
@@ -366,38 +393,68 @@ fi
 # artifact-existence test would file it under "unreachable" -- a false pass on
 # exactly the state this section exists to catch (Codex review). `unknown
 # name: <n>` is the checker saying it, and nothing else produces that line.
-reachable=""
-for n in $intrinsic_names; do
-  rm -f "$dcldir/p.out" "$dcldir/p.out.diag"
-  printf 'fn probe() -> Int {\n  let _x = %s\n  0\n}\n' "$n" > "$dcldir/p.vibe"
+decl_probe_reports_unknown() { # <probe-source> <name>
+  local src="$1" name="$2"
+  rm -f "$dcldir/p.vibe" "$dcldir/p.out" "$dcldir/p.out.diag"
+  cp "$src" "$dcldir/p.vibe"
   VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
     bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
     "$dcldir/p.vibe" "$dcldir/p.out" __no_entry__ check >/dev/null 2>&1 || true
-  if ! grep -qF "unknown name: $n" "$dcldir/p.out.diag" 2>/dev/null; then
+  grep -qF "unknown name: $name" "$dcldir/p.out.diag" 2>/dev/null
+}
+reachable=""
+while IFS='|' read -r n params; do
+  [ -n "$n" ] || continue
+  printf 'fn probe() -> Int {\n  let _x = %s\n  0\n}\n' "$n" > "$dcldir/value.vibe"
+  sig=""; args=""; argno=0
+  if [ -n "$params" ]; then
+    saved_ifs="$IFS"
+    IFS=','
+    for pty in $params; do
+      if [ -n "$sig" ]; then sig="$sig, "; args="$args, "; fi
+      sig="${sig}a${argno}: ${pty}"
+      args="${args}a${argno}"
+      argno=$((argno + 1))
+    done
+    IFS="$saved_ifs"
+  fi
+  printf 'fn probe(%s) -> Int {\n  let _r = %s(%s)\n  0\n}\n' "$sig" "$n" "$args" > "$dcldir/call.vibe"
+  if decl_probe_reports_unknown "$dcldir/value.vibe" "$n" \
+     && decl_probe_reports_unknown "$dcldir/call.vibe" "$n"; then
+    :
+  else
     reachable="$reachable $n"
   fi
+done <<DECLS
+$intrinsic_decls
+DECLS
+# The controls: a name from the same file that IS reachable -- both forms must
+# produce NO diagnostic. Without them, a harness whose probes all failed to run
+# would report every name unreachable and pass.
+for ctl_form in value call; do
+  if [ "$ctl_form" = "value" ]; then
+    printf 'fn probe() -> Int {\n  let _x = simd_skip_ws\n  0\n}\n' > "$dcldir/ctl.vibe"
+  else
+    printf 'fn probe(b: Bytes) -> Int {\n  simd_skip_ws(b, 0, 1)\n}\n' > "$dcldir/ctl.vibe"
+  fi
+  rm -f "$dcldir/ctl.out" "$dcldir/ctl.out.diag"
+  VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
+    bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
+    "$dcldir/ctl.vibe" "$dcldir/ctl.out" __no_entry__ check >/dev/null 2>&1 || true
+  if [ -s "$dcldir/ctl.out.diag" ]; then
+    echo "[compiler-gate] FAIL: the #2343 $ctl_form-form control reported a diagnostic -- simd_skip_ws is declared in $decl_src and must resolve, so this harness is calling everything unreachable" >&2
+    cat "$dcldir/ctl.out.diag" >&2 2>/dev/null || true
+    rm -rf "$dcldir"
+    exit 1
+  fi
 done
-# The control: a name from the same file that IS reachable -- it must produce
-# NO diagnostic. Without it, a harness whose probes all failed to run would
-# report every name unreachable and pass.
-rm -f "$dcldir/ctl.out" "$dcldir/ctl.out.diag"
-printf 'fn probe(b: Bytes) -> Int {\n  simd_skip_ws(b, 0, 1)\n}\n' > "$dcldir/ctl.vibe"
-VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
-  bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
-  "$dcldir/ctl.vibe" "$dcldir/ctl.out" __no_entry__ check >/dev/null 2>&1 || true
-if [ -s "$dcldir/ctl.out.diag" ]; then
-  echo "[compiler-gate] FAIL: the #2343 control reported a diagnostic -- simd_skip_ws is declared in $decl_src and must resolve, so this harness is calling everything unreachable" >&2
-  cat "$dcldir/ctl.out.diag" >&2 2>/dev/null || true
-  rm -rf "$dcldir"
-  exit 1
-fi
 rm -rf "$dcldir"
 if [ -n "$reachable" ]; then
-  echo "[compiler-gate] FAIL: these names are under the codegen-internal WASM-intrinsics banner in $decl_src but the checker did NOT report them unknown:$reachable" >&2
+  echo "[compiler-gate] FAIL: these names are under the codegen-internal WASM-intrinsics banner in $decl_src but the checker resolved them in the value form, the call form, or both:$reachable" >&2
   echo "    Either move them out of that block, or drop the claim. The banner says the block is unreachable (#2343)." >&2
   exit 1
 fi
-echo "[compiler-gate] declarations.vibe reachability claim ok ($intrinsic_count intrinsics unreachable, control resolves)"
+echo "[compiler-gate] declarations.vibe reachability claim ok ($intrinsic_count intrinsics unreachable in both value and call form, controls resolve)"
 
 # 5. test-block regression (#594): a file with only `test {}` blocks (no entry)
 #    must compile to a valid module whose `_start` runs every test; a passing

--- a/tests/gates/registry.tsv
+++ b/tests/gates/registry.tsv
@@ -19,6 +19,7 @@ x-parser-binder-context-spine	bootstrap	parser binder-context spine
 4d	early	4d derive(Show) source-name rendering across merge rename (#2205)
 4e	early	4e OOB abort names the operation, index, and length (#2199)
 4f	early	4f insert_raw's probe walk is bounded (#2362)
+4g	early	4g the WASM-intrinsics block is codegen-internal, as it claims (#2343)
 5/5	early	5/5 test-block compile+run regression
 6/6	early	6/6 normalize compile+run regression
 6b	early	6b contract package + boundary regression (#729)


### PR DESCRIPTION
Closes #2343.

`declarations.vibe` called itself *"Single Source of Truth for all builtin function signatures"* and recorded nothing about reachability, so its `//# WASM intrinsics (low-level)` block reads as an offer:

```console
$ cat probe.vibe
fn f(x: Int) -> Int { let _ = int_ctz; 0 }
$ vibe check probe.vibe
unknown name: int_ctz
```

Measured on `1dcdab3`: **all 49** names in that block, uniformly — no partial state.

## What changed

The header now says the file is the source of truth for **signatures**, not for reachability (what the checker sees is decided by a `checker_visible` registry row or a per-namespace lookup), and the block says it is codegen-internal.

**A comment that says so is worth what checks it**, so `tests/gates/early/run.sh` gains section `4g`: one probe per name, through the checker, asserting none resolve.

The oracle is the **checker**, not a lookup in `builtin_registry.vibe`. The registry decides only some names — the rest go through per-namespace checker lookups — so cross-referencing it would answer a different question than the one the comment makes.

## Two things stop it passing vacuously

- **A control.** `simd_skip_ws`, declared in the same file two blocks down, must *resolve*. Without it, a harness that silently compiled nothing would report all-unreachable and pass.
- **A bound on the scan.** The first version ran past the block, collecting `Fs::` and `Env::` names and reporting them as unreachable intrinsics, because the block-end pattern never matched the banner that follows. Continuation comments inside the block are plain `//` now so `//#` unambiguously means "section", and the section fails if the control name turns up among the scanned ones.

## Red-tested, three directions

| mutation | result |
|---|---|
| a reachable declaration (`Env::get`) moved into the block | **FAIL**, naming it |
| the banner renamed | **FAIL** (scan found nothing) |
| the control name replaced with a bogus one | **FAIL** (harness is broken) |

Each mutation was verified present before its failure was trusted — and **the first attempt at the first one did not fire**, which is worth recording: it added a registry row, but the gate runs against a *prebuilt* stage2, so the compiler answering did not contain the edit. Moving an already-reachable declaration into the block tests the same assertion with no rebuild.

## A note on the issue's examples

They had drifted. #2343 cites `v128_any_true` in a `//# SIMD V128` block as the contrast that resolves; neither the name, the type `V128`, nor that block exists now. The contrast today is `simd_skip_ws` under `//# Fused SIMD scanners` — which is what the control uses. The issue's *claim* — same file, block-by-block difference, unrecorded — holds exactly.

#2344 wants ctz and popcount, and this does not un-hide them: the block's note says the answer is a designed `Int::` surface routed through the registry, not a raw opcode name.

## Verification

- `bash scripts/compiler_gate.sh` — **ok**, 843 lines, 0 FAIL, including `4g`
- section registered in `tests/gates/registry.tsv`; `check_gate_registry.sh` ok
- `check_gate_portability.sh` ok

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FYMVd6D2o82suTfTwoJPMf

---
_Generated by [Claude Code](https://claude.ai/code/session_01FYMVd6D2o82suTfTwoJPMf)_