### PR TITLE
inline wasm: let a kernel call another kernel in the same module (#2348)

### DIFF
--- a/docs/cheatsheet.md
+++ b/docs/cheatsheet.md
@@ -2220,7 +2220,20 @@ fn simd_add(a: Int, b: Int) -> Int = wasm
   layout: length at `obj+4`, data pointer at `obj+8`) — the body can
   `i32.load offset=8` the data pointer and feed `v128.load`/`v128.store`
   (the pointer is only valid while the Bytes is alive and un-grown). No
-  `call` / `global.*` / `br_table` / `f32.const` / `f64.const`.
+  `call_indirect` / `return_call` / `global.*` / `br_table` / `f32.const` /
+  `f64.const`.
+- **Calling another kernel** (#2348): a body may `call` another inline-wasm
+  `fn` in the same module — `(call $other (local.get $a) (local.get $b))`.
+  Write only the real arguments: the assembler adds the closure-env slot
+  every user function carries as its last wasm param, then the call. The
+  callee may be declared anywhere in the module, before or after the caller.
+  Two limits, both deliberate: the callee must itself be an inline-wasm `fn`
+  (an ordinary vibe `fn` has an effect row, RC accounting and a real closure
+  env that this assembler does not model), and `call` is **folded-form only**
+  — the flat spelling's operand count is not knowable in the assembler, so
+  its arity could not be checked and a mismatch would surface as a wasm
+  validation failure at module load instead of a located error. The operand
+  count IS checked against the callee's declared params.
 - **Locals**: the fn's own params (`$name` or index), plus `(local $name
   TYPE)` declarations at the START of the body — types `i32`/`i64`/`v128`,
   grouped in that order (a located error enforces the grouping); declared
@@ -2243,7 +2256,8 @@ fn simd_add(a: Int, b: Int) -> Int = wasm
   sequences (`local.get $a local.get $b i64.add`) also work. Structured
   control (`block`/`loop`/`if`) is folded-form only:
   `(block $l (result i64) ...)`, `(if (result i64) <cond> (then ...) (else ...))`,
-  `br`/`br_if` with `$label` or relative depth.
+  `br`/`br_if` with `$label` or relative depth. `call` is folded-form only for
+  the same reason (see above).
 - SIMD (0xFD prefix) is supported: `v128.const i64x2 1 2`, splat /
   extract_lane / replace_lane, `i8x16.shuffle` (16 lane-byte immediates
   0..31), lane arithmetic, bitwise, `all_true` / `any_true` / `bitmask`,

--- a/docs/cheatsheet.md
+++ b/docs/cheatsheet.md
@@ -2233,7 +2233,13 @@ fn simd_add(a: Int, b: Int) -> Int = wasm
   — the flat spelling's operand count is not knowable in the assembler, so
   its arity could not be checked and a mismatch would surface as a wasm
   validation failure at module load instead of a located error. The operand
-  count IS checked against the callee's declared params.
+  count IS checked against the callee's declared params, and each operand
+  must itself **yield one value**: `(call $f (drop (local.get $a)))` counts
+  as one operand but pushes nothing, so it is rejected with a located error
+  rather than assembled a value short. A `(block ...)` / `(if ...)` operand
+  therefore needs an explicit `(result ...)`. The check errs toward
+  rejecting — `unreachable` / `return` / `br` are stack-polymorphic and wasm
+  would accept them there.
 - **Locals**: the fn's own params (`$name` or index), plus `(local $name
   TYPE)` declarations at the START of the body — types `i32`/`i64`/`v128`,
   grouped in that order (a located error enforces the grouping); declared

--- a/docs/cheatsheet.md
+++ b/docs/cheatsheet.md
@@ -2234,12 +2234,16 @@ fn simd_add(a: Int, b: Int) -> Int = wasm
   its arity could not be checked and a mismatch would surface as a wasm
   validation failure at module load instead of a located error. The operand
   count IS checked against the callee's declared params, and each operand
-  must itself **yield one value**: `(call $f (drop (local.get $a)))` counts
-  as one operand but pushes nothing, so it is rejected with a located error
-  rather than assembled a value short. A `(block ...)` / `(if ...)` operand
-  therefore needs an explicit `(result ...)`. The check errs toward
-  rejecting — `unreachable` / `return` / `br` are stack-polymorphic and wasm
-  would accept them there.
+  must itself **yield one i64** — every inline-wasm parameter is an i64 slot.
+  Both halves are located errors rather than a module that fails at load:
+  `(call $f (drop (local.get $a)))` counts as one operand but pushes nothing,
+  and `(call $f (i32.const 1))` pushes the wrong width. So a `(block ...)` /
+  `(if ...)` operand needs an explicit `(result i64)`, a comparison
+  (`i64.eq`, `f64.lt`) is i32 and is rejected, and `local.get` of a declared
+  `(local $p i32)` is rejected while a parameter — always i64 — is fine. The
+  check errs toward rejecting: `unreachable` / `return` / `br` are
+  stack-polymorphic and wasm would accept them there, and `select` is not
+  typed.
 - **Locals**: the fn's own params (`$name` or index), plus `(local $name
   TYPE)` declarations at the START of the body — types `i32`/`i64`/`v128`,
   grouped in that order (a located error enforces the grouping); declared

--- a/fixtures/inline_wasm_test.vibe
+++ b/fixtures/inline_wasm_test.vibe
@@ -100,6 +100,33 @@ fn wasm_reverse16(buf: Bytes) -> Int = wasm
 "  (i8x16.shuffle 15 14 13 12 11 10 9 8 7 6 5 4 3 2 1 0 (local.get $v) (local.get $v)))"
 "(i64.const 0)"
 
+// #2348: a kernel may `call` another inline-wasm fn in the SAME module, in
+// folded form. The assembler emits the operands, then `i64.const 0` for the
+// closure-env slot every user function carries as its last wasm param, then
+// the call -- the WAT author writes only the real arguments. Only inline-wasm
+// fns are callable: an ordinary vibe fn's effect row, RC accounting and real
+// closure env are not modelled here.
+//
+// Subtraction, not addition, so an operand-order bug cannot pass this
+// (CLAUDE.md: never test argument order with a commutative operator).
+fn wasm_sub(a: Int, b: Int) -> Int = wasm"(i64.sub (local.get $a) (local.get $b))"
+
+fn wasm_sub3(a: Int, b: Int, c: Int) -> Int = wasm
+"(call $wasm_sub (call $wasm_sub (local.get $a) (local.get $b)) (local.get $c))"
+
+// One shared kernel, two call sites, inside a folded `if` -- the duplication
+// #2348 exists to remove.
+fn wasm_abs_diff(a: Int, b: Int) -> Int = wasm
+"(if (result i64) (i64.gt_s (local.get $a) (local.get $b))"
+"  (then (call $wasm_sub (local.get $a) (local.get $b)))"
+"  (else (call $wasm_sub (local.get $b) (local.get $a))))"
+
+// The callee table is the MODULE's, not a prefix of it: this one calls a
+// kernel declared further down the file.
+fn wasm_calls_forward(a: Int) -> Int = wasm"(call $wasm_declared_later (local.get $a))"
+
+fn wasm_declared_later(a: Int) -> Int = wasm"(i64.sub (i64.const 0) (local.get $a))"
+
 //# Misc
 
 test "inline wasm: tagged add" {
@@ -173,4 +200,15 @@ test "inline wasm: i8x16.shuffle reverses through v128.load/store" {
     assert(Bytes::get(b, j) == 15 - j)
     j = j + 1
   }
+}
+
+test "#2348 inline wasm: a kernel calls another kernel in the same module" {
+  assert(wasm_sub(10, 3) == 7)
+  assert(wasm_sub3(10, 3, 2) == 5)
+  assert(wasm_sub3(0, 1, 2) == -3)
+  assert(wasm_abs_diff(3, 10) == 7)
+  assert(wasm_abs_diff(10, 3) == 7)
+  assert(wasm_abs_diff(4, 4) == 0)
+  assert(wasm_calls_forward(41) == -41)
+  assert(wasm_calls_forward(-41) == 41)
 }

--- a/lib/@vibe/compiler/codegen/codegen.vibe
+++ b/lib/@vibe/compiler/codegen/codegen.vibe
@@ -29,6 +29,7 @@ import @vibe/compiler/codegen/wasi {
 // same lower-level contract directly.
 export ./common_base {
   compile_inline_wat,
+  compile_inline_wat_calls,
   compile_inline_wat_full,
   desugar_labeled_args,
   desugar_railway_binds,

--- a/lib/@vibe/compiler/codegen/common_base/index.vpkg
+++ b/lib/@vibe/compiler/codegen/common_base/index.vpkg
@@ -237,6 +237,7 @@ fn sized_bytes_new_expr(n_expr: Expr) -> Expr
 // --- inline_wat.vibe (relocated here, see #897 header note above)
 fn compile_inline_wat(fn_name: String, wat: String, param_names: Array[String]) -> Bytes with Exception
 fn compile_inline_wat_full(fn_name: String, wat: String, param_names: Array[String], extra_base: Int) -> (Bytes, Int, Int, Int) with Exception
+fn compile_inline_wat_calls(fn_name: String, wat: String, param_names: Array[String], extra_base: Int, callees: Array[(String, Int, Int)]) -> (Bytes, Int, Int, Int) with Exception
 
 // --- normalize/desugar_trait_dict.vibe (cross-package facade re-export;
 // the checker imports its three pre-check transforms directly from normalize,

--- a/lib/@vibe/compiler/codegen/common_base/inline_wat.vibe
+++ b/lib/@vibe/compiler/codegen/common_base/inline_wat.vibe
@@ -76,7 +76,10 @@ fn iw_fresh_strings() -> Array[String] {
   array_empty()
 }
 
-fn iw_fresh_locals() -> Array[(String, Int)] {
+/// #2348: `(name, wasm local index, wasm valtype byte)`. The type is what
+/// lets a folded `call` reject `(call $f (local.get $v))` when `$v` is an
+/// i32 or v128 local -- every inline-wasm parameter slot is an i64.
+fn iw_fresh_locals() -> Array[(String, Int, Int)] {
   array_empty()
 }
 
@@ -663,14 +666,38 @@ fn iw_mem_lookup(name: String) -> (Int, Int) {
 /// (indexed from the caller's extra_base past the closure-env slot) — or a
 /// bare numeric index (indices between the params and extra_base are the
 /// codegen's own, e.g. the env slot — named access is the safe spelling).
-fn iw_local_idx(fn_name: String, locals: Array[(String, Int)], tok: String, off: Int) -> Int with Exception {
+/// #2348: the wasm valtype byte of `$name`, or 0 when it is not a known local
+/// (a numeric index, or an unknown name -- both refuse to answer rather than
+/// guess).
+fn iw_local_valtype(locals: Array[(String, Int, Int)], tok: String) -> Int {
+  if String::length(tok) > 0 && String::char_code_at(tok, 0) == 36 {
+    let want = String::substring(tok, 1, String::length(tok))
+    let n = Array::length(locals)
+    let mut i = 0
+    let mut found = 0
+    while i < n {
+      let (ln, _li, lt) = Array::get(locals, i)
+      if ln == want {
+        found = lt
+        i = n
+      } else {
+        i = i + 1
+      }
+    }
+    found
+  } else {
+    0
+  }
+}
+
+fn iw_local_idx(fn_name: String, locals: Array[(String, Int, Int)], tok: String, off: Int) -> Int with Exception {
   if String::length(tok) > 0 && String::char_code_at(tok, 0) == '$' {
     let want = String::substring(tok, 1, String::length(tok))
     let n = Array::length(locals)
     let mut i = 0
     let mut found = 0 - 1
     while i < n {
-      let (ln, li) = Array::get(locals, i)
+      let (ln, li, _lt) = Array::get(locals, i)
       if ln == want {
         found = li
         i = n
@@ -836,7 +863,7 @@ fn iw_v128_const(buf: Bytes, fn_name: String, kinds: Array[Int], texts: Array[St
 
 /// Emit ONE plain (non-control) instruction word at `pos` plus its immediates
 /// into `buf`. Returns the position after the instruction + immediates.
-fn iw_plain_op(buf: Bytes, fn_name: String, kinds: Array[Int], texts: Array[String], offs: Array[Int], pos: Int, end: Int, locals: Array[(String, Int)], lbl_names: Array[String], lbl_depths: Array[Int], depth: Int) -> Int with Exception {
+fn iw_plain_op(buf: Bytes, fn_name: String, kinds: Array[Int], texts: Array[String], offs: Array[Int], pos: Int, end: Int, locals: Array[(String, Int, Int)], lbl_names: Array[String], lbl_depths: Array[Int], depth: Int) -> Int with Exception {
   let name = Array::get(texts, pos)
   let off = Array::get(offs, pos)
   if name == "block" || name == "loop" || name == "if" || name == "else" || name == "end" || name == "then" {
@@ -1029,50 +1056,164 @@ fn iw_callee_names(callees: Array[(String, Int, Int)]) -> String {
   }
 }
 
-/// #2348: does the folded operand starting at `pos` (its `(`) push exactly one
-/// value?
+/// #2348: is `name` one of the comparison instructions, whose result is i32
+/// whatever its operand width? `i64.eq` and `f64.lt` yield i32, not i64/f64,
+/// so a prefix rule alone would type them wrong.
+/// #2348: the spelling of a wasm valtype byte, for a diagnostic.
+fn iw_valtype_name(code: Int) -> String {
+  if code == 0x7F {
+    "i32"
+  } else if code == 0x7E {
+    "i64"
+  } else if code == 0x7D {
+    "f32"
+  } else if code == 0x7C {
+    "f64"
+  } else if code == 0x7B {
+    "v128"
+  } else {
+    "nothing"
+  }
+}
+
+fn iw_is_compare_op(name: String) -> Bool {
+  String::ends_with(name, ".eq") || String::ends_with(name, ".ne") || String::ends_with(name, ".eqz") || String::ends_with(name, ".lt_s") || String::ends_with(name, ".lt_u") || String::ends_with(name, ".gt_s") || String::ends_with(name, ".gt_u") || String::ends_with(name, ".le_s") || String::ends_with(name, ".le_u") || String::ends_with(name, ".ge_s") || String::ends_with(name, ".ge_u") || String::ends_with(name, ".lt") || String::ends_with(name, ".gt") || String::ends_with(name, ".le") || String::ends_with(name, ".ge")
+}
+
+/// #2348: the wasm valtype byte a core-table instruction leaves on the stack,
+/// or 0 for the four that leave nothing. Comparisons are i32 regardless of
+/// width; otherwise the `iNN.` / `fNN.` prefix is the result type, which holds
+/// for every remaining entry (arithmetic, conversions, reinterprets, the
+/// sign-extensions -- a conversion is named for what it produces).
+fn iw_core_result_valtype(name: String) -> Int {
+  if name == "unreachable" || name == "nop" || name == "return" || name == "drop" {
+    0
+  } else if iw_is_compare_op(name) {
+    0x7F
+  } else if String::starts_with(name, "i32.") {
+    0x7F
+  } else if String::starts_with(name, "i64.") {
+    0x7E
+  } else if String::starts_with(name, "f32.") {
+    0x7D
+  } else if String::starts_with(name, "f64.") {
+    0x7C
+  } else {
+    // `select` is the only one left, and its result type is its operands'.
+    // Refusing to answer costs a rejected `(call $f (select ...))` and keeps
+    // the classifier from guessing.
+    0
+  }
+}
+
+/// #2348: the wasm valtype byte a SIMD instruction leaves, or 0.
+fn iw_simd_result_valtype(name: String) -> Int {
+  if String::ends_with(name, ".all_true") || String::ends_with(name, ".any_true") || String::ends_with(name, ".bitmask") {
+    0x7F
+  } else if String::contains(name, ".extract_lane") {
+    // The lane's scalar type, named by the shape.
+    if String::starts_with(name, "i8x16.") || String::starts_with(name, "i16x8.") || String::starts_with(name, "i32x4.") {
+      0x7F
+    } else if String::starts_with(name, "i64x2.") {
+      0x7E
+    } else if String::starts_with(name, "f32x4.") {
+      0x7D
+    } else if String::starts_with(name, "f64x2.") {
+      0x7C
+    } else {
+      0
+    }
+  } else if String::ends_with(name, ".store") {
+    0
+  } else {
+    // Everything else in the SIMD tables -- lane arithmetic, bitwise,
+    // splat, replace_lane, shuffle, swizzle, shifts, v128.load -- is v128.
+    0x7B
+  }
+}
+
+/// #2348: the wasm valtype byte the folded operand starting at `pos` (its `(`)
+/// leaves on the stack, or 0 when it leaves nothing, is stack-polymorphic, or
+/// is not recognized.
 ///
 /// A folded call counts parenthesized operands, and counting alone is not an
-/// arity check: `(call $f (drop (local.get $a)))` has one operand that leaves
-/// NOTHING on the stack, so the call would be assembled one value short and
-/// the module would fail wasm validation at load -- clean `vibe check`,
-/// broken artifact, the #2341 shape this section exists to avoid.
+/// arity check, nor is "it pushes something" a type check. Both were measured
+/// as modules that pass `vibe check` and fail wasm validation at load:
+/// `(call $f (drop (local.get $a)))` assembles one value short, and
+/// `(call $f (i32.const 1))` assembles an i32 into an i64 parameter slot. That
+/// is the #2341 shape this section exists to avoid.
 ///
-/// Answers true only for heads it recognizes as one-result, so an unknown or
-/// newly added instruction is rejected rather than assumed. Two deliberate
-/// conservatisms: `unreachable` / `return` / `br` are stack-polymorphic and
-/// wasm would accept them here, and a result-less `block` / `loop` / `if` is
-/// rejected rather than analyzed. Both reject a program wasm would take; the
-/// opposite direction is what produces the broken module.
-fn iw_operand_yields_value(kinds: Array[Int], texts: Array[String], pos: Int, end: Int) -> Bool {
+/// Answers 0 for anything it does not recognize, so an unknown or newly added
+/// instruction is rejected rather than assumed. Two deliberate conservatisms:
+/// `unreachable` / `return` / `br` are stack-polymorphic and wasm would accept
+/// them here, and a result-less `block` / `loop` / `if` is rejected rather
+/// than analyzed. Both reject a program wasm would take; the opposite
+/// direction is what produces the broken module.
+fn iw_operand_valtype(kinds: Array[Int], texts: Array[String], pos: Int, end: Int, locals: Array[(String, Int, Int)]) -> Int {
   if pos + 1 >= end || Array::get(kinds, pos + 1) != 3 {
-    false
+    0
   } else {
     let head = Array::get(texts, pos + 1)
     if head == "block" || head == "loop" || head == "if" {
-      // One value only with an explicit `(result T)`, after an optional label.
+      // A value only with an explicit `(result T)`, after an optional label.
       let mut q = pos + 2
       if q < end && Array::get(kinds, q) == 3 && String::length(Array::get(texts, q)) > 0 && String::char_code_at(Array::get(texts, q), 0) == 36 {
         q = q + 1
       } else {
         ()
       }
-      q + 1 < end && Array::get(kinds, q) == 1 && Array::get(kinds, q + 1) == 3 && Array::get(texts, q + 1) == "result"
-    } else if head == "unreachable" || head == "nop" || head == "return" || head == "drop" || head == "br" || head == "br_if" || head == "local.set" || head == "v128.store" || head == "global.set" {
-      false
-    } else if head == "local.get" || head == "local.tee" || head == "i32.const" || head == "i64.const" || head == "v128.const" || head == "memory.size" || head == "memory.grow" || head == "v128.load" || head == "i8x16.shuffle" || head == "call" {
-      true
+      if q + 2 < end && Array::get(kinds, q) == 1 && Array::get(kinds, q + 1) == 3 && Array::get(texts, q + 1) == "result" && Array::get(kinds, q + 2) == 3 {
+        match Array::get(texts, q + 2) {
+          "i32" => 0x7F,
+          "i64" => 0x7E,
+          "f32" => 0x7D,
+          "f64" => 0x7C,
+          "v128" => 0x7B,
+          _ => 0
+        }
+      } else {
+        0
+      }
+    } else if head == "local.get" || head == "local.tee" {
+      if pos + 2 < end && Array::get(kinds, pos + 2) == 3 {
+        iw_local_valtype(locals, Array::get(texts, pos + 2))
+      } else {
+        0
+      }
+    } else if head == "call" {
+      // Every inline-wasm fn returns Int, a raw tagged i64 (parser-enforced).
+      0x7E
+    } else if head == "br" || head == "br_if" || head == "local.set" || head == "global.set" || head == "global.get" {
+      0
+    } else if head == "i32.const" {
+      0x7F
+    } else if head == "i64.const" {
+      0x7E
+    } else if head == "v128.const" || head == "v128.load" || head == "i8x16.shuffle" {
+      0x7B
+    } else if head == "v128.store" {
+      0
+    } else if head == "memory.size" || head == "memory.grow" {
+      0x7F
     } else if iw_lookup(iw_core_table(), head) >= 0 {
-      // Everything left in the core table pushes one value; the four that do
-      // not are named above.
-      true
+      iw_core_result_valtype(head)
     } else if iw_lookup(iw_simd_lane_table(), head) >= 0 || iw_lookup(iw_simd_table(), head) >= 0 {
-      true
+      iw_simd_result_valtype(head)
     } else {
       let (mem_opc, _mem_align) = iw_mem_lookup(head)
-      // Loads push one, stores push none. `.store` is the only distinction the
-      // memory table draws, and it is in the spelling.
-      mem_opc >= 0 && !String::contains(head, ".store")
+      if mem_opc < 0 || String::contains(head, ".store") {
+        0
+      } else if String::starts_with(head, "i32.") {
+        0x7F
+      } else if String::starts_with(head, "i64.") {
+        0x7E
+      } else if String::starts_with(head, "f32.") {
+        0x7D
+      } else if String::starts_with(head, "f64.") {
+        0x7C
+      } else {
+        0
+      }
     }
   }
 }
@@ -1092,7 +1233,7 @@ fn iw_operand_yields_value(kinds: Array[Int], texts: Array[String], pos: Int, en
 /// the whole reason `call` is folded-only: in the flat spelling the count is
 /// not knowable here, and an unchecked call would surface as a wasm validation
 /// failure at module load instead of a located error.
-fn iw_folded_call(out: Bytes, fn_name: String, kinds: Array[Int], texts: Array[String], offs: Array[Int], pos: Int, end: Int, locals: Array[(String, Int)], lbl_names: Array[String], lbl_depths: Array[Int], depth: Int, callees: Array[(String, Int, Int)]) -> Int with Exception {
+fn iw_folded_call(out: Bytes, fn_name: String, kinds: Array[Int], texts: Array[String], offs: Array[Int], pos: Int, end: Int, locals: Array[(String, Int, Int)], lbl_names: Array[String], lbl_depths: Array[Int], depth: Int, callees: Array[(String, Int, Int)]) -> Int with Exception {
   let head_off = Array::get(offs, pos)
   if pos + 2 >= end || Array::get(kinds, pos + 2) != 3 {
     throw(iw_err(fn_name, "'call' needs a callee name: (call $f ...)", head_off))
@@ -1123,8 +1264,14 @@ fn iw_folded_call(out: Bytes, fn_name: String, kinds: Array[Int], texts: Array[S
     } else if Array::get(kinds, p) == 2 {
       done = true
     } else if Array::get(kinds, p) == 1 {
-      if !iw_operand_yields_value(kinds, texts, p, end) {
-        throw(iw_err(fn_name, "argument \{argc + 1} of '(call $\{callee}' does not produce a value, so the call would be assembled with too few arguments; every operand must be an expression that yields one (a `(block ...)`/`(if ...)` operand needs an explicit `(result ...)`)", Array::get(offs, p)))
+      let operand_ty = iw_operand_valtype(kinds, texts, p, end, locals)
+      if operand_ty != 0x7E {
+        let why = if operand_ty == 0 {
+          "does not produce an i64 value (it leaves nothing on the stack, or the assembler cannot type it; a `(block ...)`/`(if ...)` operand needs an explicit `(result i64)`)"
+        } else {
+          "produces \{iw_valtype_name(operand_ty)}, but every inline-wasm parameter is an i64 slot"
+        }
+        throw(iw_err(fn_name, "argument \{argc + 1} of '(call $\{callee}' \{why}", Array::get(offs, p)))
       } else {
         ()
       }
@@ -1149,7 +1296,7 @@ fn iw_folded_call(out: Bytes, fn_name: String, kinds: Array[Int], texts: Array[S
 
 /// One sequence item at `pos`: either a folded `(...)` expression or a plain
 /// instruction word. Returns the position after the item.
-fn iw_item(out: Bytes, fn_name: String, kinds: Array[Int], texts: Array[String], offs: Array[Int], pos: Int, end: Int, locals: Array[(String, Int)], lbl_names: Array[String], lbl_depths: Array[Int], depth: Int, callees: Array[(String, Int, Int)]) -> Int with Exception {
+fn iw_item(out: Bytes, fn_name: String, kinds: Array[Int], texts: Array[String], offs: Array[Int], pos: Int, end: Int, locals: Array[(String, Int, Int)], lbl_names: Array[String], lbl_depths: Array[Int], depth: Int, callees: Array[(String, Int, Int)]) -> Int with Exception {
   let k = Array::get(kinds, pos)
   if k == 3 {
     iw_plain_op(out, fn_name, kinds, texts, offs, pos, end, locals, lbl_names, lbl_depths, depth)
@@ -1177,7 +1324,7 @@ fn iw_item(out: Bytes, fn_name: String, kinds: Array[Int], texts: Array[String],
 }
 
 /// A sequence of items up to (not consuming) a closing ')' or the end.
-fn iw_seq(out: Bytes, fn_name: String, kinds: Array[Int], texts: Array[String], offs: Array[Int], pos: Int, end: Int, locals: Array[(String, Int)], lbl_names: Array[String], lbl_depths: Array[Int], depth: Int, callees: Array[(String, Int, Int)]) -> Int with Exception {
+fn iw_seq(out: Bytes, fn_name: String, kinds: Array[Int], texts: Array[String], offs: Array[Int], pos: Int, end: Int, locals: Array[(String, Int, Int)], lbl_names: Array[String], lbl_depths: Array[Int], depth: Int, callees: Array[(String, Int, Int)]) -> Int with Exception {
   let mut p = pos
   let mut done = false
   while !done {
@@ -1194,7 +1341,7 @@ fn iw_seq(out: Bytes, fn_name: String, kinds: Array[Int], texts: Array[String], 
 
 /// Folded `(op <immediates> <operand exprs...>)`: real folded-form semantics —
 /// the operand expressions are emitted FIRST, then the op itself.
-fn iw_folded_op(out: Bytes, fn_name: String, kinds: Array[Int], texts: Array[String], offs: Array[Int], pos: Int, end: Int, locals: Array[(String, Int)], lbl_names: Array[String], lbl_depths: Array[Int], depth: Int, callees: Array[(String, Int, Int)]) -> Int with Exception {
+fn iw_folded_op(out: Bytes, fn_name: String, kinds: Array[Int], texts: Array[String], offs: Array[Int], pos: Int, end: Int, locals: Array[(String, Int, Int)], lbl_names: Array[String], lbl_depths: Array[Int], depth: Int, callees: Array[(String, Int, Int)]) -> Int with Exception {
   let opb = bytebuf_new()
   let after_imm = iw_plain_op(opb, fn_name, kinds, texts, offs, pos + 1, end, locals, lbl_names, lbl_depths, depth)
   let mut p = after_imm
@@ -1215,7 +1362,7 @@ fn iw_folded_op(out: Bytes, fn_name: String, kinds: Array[Int], texts: Array[Str
 }
 
 /// Folded `(block $l? (result T)? ...)` / `(loop $l? (result T)? ...)`.
-fn iw_folded_block(out: Bytes, fn_name: String, kinds: Array[Int], texts: Array[String], offs: Array[Int], pos: Int, end: Int, locals: Array[(String, Int)], lbl_names: Array[String], lbl_depths: Array[Int], depth: Int, callees: Array[(String, Int, Int)]) -> Int with Exception {
+fn iw_folded_block(out: Bytes, fn_name: String, kinds: Array[Int], texts: Array[String], offs: Array[Int], pos: Int, end: Int, locals: Array[(String, Int, Int)], lbl_names: Array[String], lbl_depths: Array[Int], depth: Int, callees: Array[(String, Int, Int)]) -> Int with Exception {
   let head = Array::get(texts, pos + 1)
   bytebuf_push(out, if head == "loop" {
     0x03
@@ -1247,7 +1394,7 @@ fn iw_folded_block(out: Bytes, fn_name: String, kinds: Array[Int], texts: Array[
 
 /// Folded `(if $l? (result T)? <cond exprs...> (then ...) (else ...)?)`.
 /// The condition is emitted first, then 0x04 + blocktype, then the branches.
-fn iw_folded_if(out: Bytes, fn_name: String, kinds: Array[Int], texts: Array[String], offs: Array[Int], pos: Int, end: Int, locals: Array[(String, Int)], lbl_names: Array[String], lbl_depths: Array[Int], depth: Int, callees: Array[(String, Int, Int)]) -> Int with Exception {
+fn iw_folded_if(out: Bytes, fn_name: String, kinds: Array[Int], texts: Array[String], offs: Array[Int], pos: Int, end: Int, locals: Array[(String, Int, Int)], lbl_names: Array[String], lbl_depths: Array[Int], depth: Int, callees: Array[(String, Int, Int)]) -> Int with Exception {
   let lbl_mark = Array::length(lbl_names)
   let mut q = pos + 2
   if q < end && Array::get(kinds, q) == 3 && String::length(Array::get(texts, q)) > 0 && String::char_code_at(Array::get(texts, q), 0) == '$' {
@@ -1310,7 +1457,7 @@ fn iw_folded_if(out: Bytes, fn_name: String, kinds: Array[Int], texts: Array[Str
 /// encodes one run per type, so interleaved declarations would silently
 /// renumber). Each declared local joins `locals` at wasm index
 /// `extra_base + running position`. Returns (body_start, n_i32, n_i64, n_v128).
-fn iw_parse_local_decls(fn_name: String, kinds: Array[Int], texts: Array[String], offs: Array[Int], end: Int, locals: Array[(String, Int)], extra_base: Int) -> (Int, Int, Int, Int) with Exception {
+fn iw_parse_local_decls(fn_name: String, kinds: Array[Int], texts: Array[String], offs: Array[Int], end: Int, locals: Array[(String, Int, Int)], extra_base: Int) -> (Int, Int, Int, Int) with Exception {
   let mut p = 0
   let mut n32 = 0
   let mut n64 = 0
@@ -1340,10 +1487,17 @@ fn iw_parse_local_decls(fn_name: String, kinds: Array[Int], texts: Array[String]
       if rank < last_rank {
         throw(iw_err(fn_name, "(local ...) declarations must be grouped by type in the order i32, i64, v128", decl_off))
       }
+      let ty = if rank == 0 {
+        0x7F
+      } else if rank == 1 {
+        0x7E
+      } else {
+        0x7B
+      }
       let want = String::substring(name_tok, 1, String::length(name_tok))
       let mut di = 0
       while di < Array::length(locals) {
-        let (dn, _dx) = Array::get(locals, di)
+        let (dn, _dx, _dt) = Array::get(locals, di)
         if dn == want {
           throw(iw_err(fn_name, "duplicate local name '\{name_tok}'", decl_off))
         } else {
@@ -1351,7 +1505,7 @@ fn iw_parse_local_decls(fn_name: String, kinds: Array[Int], texts: Array[String]
         }
         di = di + 1
       }
-      Array::push(locals, (want, extra_base + n32 + n64 + nv))
+      Array::push(locals, (want, extra_base + n32 + n64 + nv, ty))
       if rank == 0 {
         n32 = n32 + 1
       } else if rank == 1 {
@@ -1401,7 +1555,7 @@ export fn compile_inline_wat_calls(fn_name: String, wat: String, param_names: Ar
   let locals = iw_fresh_locals()
   let mut pi = 0
   while pi < Array::length(param_names) {
-    Array::push(locals, (Array::get(param_names, pi), pi))
+    Array::push(locals, (Array::get(param_names, pi), pi, 0x7E))
     pi = pi + 1
   }
   let (body_start, n32, n64, nv) = iw_parse_local_decls(fn_name, kinds, texts, offs, end, locals, extra_base)

--- a/lib/@vibe/compiler/codegen/common_base/inline_wat.vibe
+++ b/lib/@vibe/compiler/codegen/common_base/inline_wat.vibe
@@ -1029,6 +1029,54 @@ fn iw_callee_names(callees: Array[(String, Int, Int)]) -> String {
   }
 }
 
+/// #2348: does the folded operand starting at `pos` (its `(`) push exactly one
+/// value?
+///
+/// A folded call counts parenthesized operands, and counting alone is not an
+/// arity check: `(call $f (drop (local.get $a)))` has one operand that leaves
+/// NOTHING on the stack, so the call would be assembled one value short and
+/// the module would fail wasm validation at load -- clean `vibe check`,
+/// broken artifact, the #2341 shape this section exists to avoid.
+///
+/// Answers true only for heads it recognizes as one-result, so an unknown or
+/// newly added instruction is rejected rather than assumed. Two deliberate
+/// conservatisms: `unreachable` / `return` / `br` are stack-polymorphic and
+/// wasm would accept them here, and a result-less `block` / `loop` / `if` is
+/// rejected rather than analyzed. Both reject a program wasm would take; the
+/// opposite direction is what produces the broken module.
+fn iw_operand_yields_value(kinds: Array[Int], texts: Array[String], pos: Int, end: Int) -> Bool {
+  if pos + 1 >= end || Array::get(kinds, pos + 1) != 3 {
+    false
+  } else {
+    let head = Array::get(texts, pos + 1)
+    if head == "block" || head == "loop" || head == "if" {
+      // One value only with an explicit `(result T)`, after an optional label.
+      let mut q = pos + 2
+      if q < end && Array::get(kinds, q) == 3 && String::length(Array::get(texts, q)) > 0 && String::char_code_at(Array::get(texts, q), 0) == 36 {
+        q = q + 1
+      } else {
+        ()
+      }
+      q + 1 < end && Array::get(kinds, q) == 1 && Array::get(kinds, q + 1) == 3 && Array::get(texts, q + 1) == "result"
+    } else if head == "unreachable" || head == "nop" || head == "return" || head == "drop" || head == "br" || head == "br_if" || head == "local.set" || head == "v128.store" || head == "global.set" {
+      false
+    } else if head == "local.get" || head == "local.tee" || head == "i32.const" || head == "i64.const" || head == "v128.const" || head == "memory.size" || head == "memory.grow" || head == "v128.load" || head == "i8x16.shuffle" || head == "call" {
+      true
+    } else if iw_lookup(iw_core_table(), head) >= 0 {
+      // Everything left in the core table pushes one value; the four that do
+      // not are named above.
+      true
+    } else if iw_lookup(iw_simd_lane_table(), head) >= 0 || iw_lookup(iw_simd_table(), head) >= 0 {
+      true
+    } else {
+      let (mem_opc, _mem_align) = iw_mem_lookup(head)
+      // Loads push one, stores push none. `.store` is the only distinction the
+      // memory table draws, and it is in the spelling.
+      mem_opc >= 0 && !String::contains(head, ".store")
+    }
+  }
+}
+
 /// #2348: folded `(call $f <operand exprs...>)` to another inline-wasm fn in
 /// the same module.
 ///
@@ -1075,6 +1123,11 @@ fn iw_folded_call(out: Bytes, fn_name: String, kinds: Array[Int], texts: Array[S
     } else if Array::get(kinds, p) == 2 {
       done = true
     } else if Array::get(kinds, p) == 1 {
+      if !iw_operand_yields_value(kinds, texts, p, end) {
+        throw(iw_err(fn_name, "argument \{argc + 1} of '(call $\{callee}' does not produce a value, so the call would be assembled with too few arguments; every operand must be an expression that yields one (a `(block ...)`/`(if ...)` operand needs an explicit `(result ...)`)", Array::get(offs, p)))
+      } else {
+        ()
+      }
       p = iw_item(out, fn_name, kinds, texts, offs, p, end, locals, lbl_names, lbl_depths, depth, callees)
       argc = argc + 1
     } else {

--- a/lib/@vibe/compiler/codegen/common_base/inline_wat.vibe
+++ b/lib/@vibe/compiler/codegen/common_base/inline_wat.vibe
@@ -55,8 +55,14 @@ import @vibe/core {
 //     replace_lane, i8x16.shuffle (16 lane-byte immediates 0..31), integer
 //     lane arithmetic + compares, bitwise, all_true / any_true / bitmask,
 //     swizzle, shifts
-//   - NOT supported (clear errors): call / call_indirect / br_table /
-//     global.get/set / f32.const / f64.const
+//   - folded `(call $f <operands...>)` to another inline-wasm fn in the SAME
+//     module (#2348), arity-checked against the callee's declared params.
+//     The closure-env slot and the call opcode are emitted by the assembler;
+//     the WAT author writes only the real arguments. Folded form only --
+//     the flat spelling's operand count is not knowable here, so it could
+//     not be checked
+//   - NOT supported (clear errors): flat-form call / call_indirect /
+//     return_call / br_table / global.get/set / f32.const / f64.const
 
 fn iw_err(fn_name: String, msg: String, off: Int) -> String {
   "inline wasm (fn \{fn_name}): \{msg} (WAT offset \{off})"
@@ -71,6 +77,11 @@ fn iw_fresh_strings() -> Array[String] {
 }
 
 fn iw_fresh_locals() -> Array[(String, Int)] {
+  array_empty()
+}
+
+/// #2348: the empty callee table — a body that may not `call` anything.
+fn iw_fresh_callees() -> Array[(String, Int, Int)] {
   array_empty()
 }
 
@@ -894,8 +905,16 @@ fn iw_plain_op(buf: Bytes, fn_name: String, kinds: Array[Int], texts: Array[Stri
     leb128_encode_u32(buf, align)
     leb128_encode_u32(buf, offset)
     next
-  } else if name == "call" || name == "call_indirect" || name == "return_call" {
-    throw(iw_err(fn_name, "'\{name}' is not supported in inline wasm (v0.3 slice: bodies cannot reference other functions)", off))
+  } else if name == "call" {
+    // #2348: `call` is FOLDED-FORM ONLY, and iw_item routes `(call ...)` to
+    // iw_folded_call before this arm is reached. Reaching it means the flat
+    // spelling, whose operand count the assembler cannot know -- so it could
+    // not check the callee's arity and would hand a wasm validator the
+    // mismatch instead (the #2341 shape: passes `vibe check`, fails at module
+    // load). Structured control is folded-only for the same reason.
+    throw(iw_err(fn_name, "'call' must be written in folded form so its arity can be checked: (call $f (local.get $a) ...)", off))
+  } else if name == "call_indirect" || name == "return_call" {
+    throw(iw_err(fn_name, "'\{name}' is not supported in inline wasm (v0.3 slice: only a direct `call` to another inline-wasm fn in the same module)", off))
   } else if name == "global.get" || name == "global.set" {
     throw(iw_err(fn_name, "'\{name}' is not supported in inline wasm (v0.3 slice: runtime globals are not addressable)", off))
   } else if name == "br_table" {
@@ -965,9 +984,119 @@ fn iw_plain_op(buf: Bytes, fn_name: String, kinds: Array[Int], texts: Array[Stri
   }
 }
 
+/// #2348: position of `name` in the module's inline-wasm callee table, or -1.
+/// Entries are `(source name without `$`, wasm function index, declared param
+/// count)`; the table holds ONLY inline-wasm fns, so a `call` can never reach
+/// an ordinary vibe fn (whose effect row, RC accounting and closure env this
+/// assembler does not model).
+fn iw_callee_find(callees: Array[(String, Int, Int)], name: String) -> Int {
+  let n = Array::length(callees)
+  let mut i = 0
+  let mut found = 0 - 1
+  while i < n {
+    let (cn, _ci, _ca) = Array::get(callees, i)
+    if cn == name {
+      found = i
+      i = n
+    } else {
+      i = i + 1
+    }
+  }
+  found
+}
+
+/// #2348: the callable names, comma-joined, for a "no such callee" error.
+/// An empty table prints as `(none)` rather than an empty tail, so the
+/// message reads the same whether the module defines no other kernel or the
+/// caller passed no table at all.
+fn iw_callee_names(callees: Array[(String, Int, Int)]) -> String {
+  let n = Array::length(callees)
+  if n == 0 {
+    "(none)"
+  } else {
+    let mut out = ""
+    let mut i = 0
+    while i < n {
+      let (cn, _ci, _ca) = Array::get(callees, i)
+      out = if i == 0 {
+        cn
+      } else {
+        String::concat(out, String::concat(", ", cn))
+      }
+      i = i + 1
+    }
+    out
+  }
+}
+
+/// #2348: folded `(call $f <operand exprs...>)` to another inline-wasm fn in
+/// the same module.
+///
+/// Operands are emitted first (folded-form semantics, same as iw_folded_op),
+/// then the closure-env slot every user function carries as its LAST wasm
+/// param, then the call itself -- exactly the sequence compile_call.vibe emits
+/// for a static call (args, `i64.const 0` when needs_env, `call`). Every
+/// inline-wasm fn is a user function, so needs_env is true and the result is
+/// one i64; there is no arm here for the other shapes because the parser does
+/// not admit them.
+///
+/// The operand count is checked against the callee's declared arity. That is
+/// the whole reason `call` is folded-only: in the flat spelling the count is
+/// not knowable here, and an unchecked call would surface as a wasm validation
+/// failure at module load instead of a located error.
+fn iw_folded_call(out: Bytes, fn_name: String, kinds: Array[Int], texts: Array[String], offs: Array[Int], pos: Int, end: Int, locals: Array[(String, Int)], lbl_names: Array[String], lbl_depths: Array[Int], depth: Int, callees: Array[(String, Int, Int)]) -> Int with Exception {
+  let head_off = Array::get(offs, pos)
+  if pos + 2 >= end || Array::get(kinds, pos + 2) != 3 {
+    throw(iw_err(fn_name, "'call' needs a callee name: (call $f ...)", head_off))
+  } else {
+    ()
+  }
+  let tok = Array::get(texts, pos + 2)
+  let name_off = Array::get(offs, pos + 2)
+  if String::length(tok) < 2 || String::char_code_at(tok, 0) != 36 {
+    throw(iw_err(fn_name, "'call' callee must be written as $name, not '\{tok}'", name_off))
+  } else {
+    ()
+  }
+  let callee = String::substring(tok, 1, String::length(tok))
+  let slot = iw_callee_find(callees, callee)
+  if slot < 0 {
+    throw(iw_err(fn_name, "no inline-wasm fn named '\{callee}' in this module; inline wasm can only call another `fn ... = wasm` here (callable: \{iw_callee_names(callees)})", name_off))
+  } else {
+    ()
+  }
+  let (_cn, cidx, carity) = Array::get(callees, slot)
+  let mut p = pos + 3
+  let mut argc = 0
+  let mut done = false
+  while !done {
+    if p >= end {
+      throw(iw_err(fn_name, "missing ')' closing '(call $\{callee}'", head_off))
+    } else if Array::get(kinds, p) == 2 {
+      done = true
+    } else if Array::get(kinds, p) == 1 {
+      p = iw_item(out, fn_name, kinds, texts, offs, p, end, locals, lbl_names, lbl_depths, depth, callees)
+      argc = argc + 1
+    } else {
+      throw(iw_err(fn_name, "unexpected '\{Array::get(texts, p)}' inside '(call $\{callee}' — operands must be parenthesized", Array::get(offs, p)))
+    }
+  }
+  if argc != carity {
+    throw(iw_err(fn_name, "'\{callee}' takes \{carity} argument(s), called with \{argc}", head_off))
+  } else {
+    ()
+  }
+  // The closure-env slot: every user function's last wasm param.
+  bytebuf_push(out, 0x42)
+  leb128_encode_s64(out, 0)
+  bytebuf_push(out, 0x10)
+  leb128_encode_u32(out, cidx)
+  p + 1
+}
+
 /// One sequence item at `pos`: either a folded `(...)` expression or a plain
 /// instruction word. Returns the position after the item.
-fn iw_item(out: Bytes, fn_name: String, kinds: Array[Int], texts: Array[String], offs: Array[Int], pos: Int, end: Int, locals: Array[(String, Int)], lbl_names: Array[String], lbl_depths: Array[Int], depth: Int) -> Int with Exception {
+fn iw_item(out: Bytes, fn_name: String, kinds: Array[Int], texts: Array[String], offs: Array[Int], pos: Int, end: Int, locals: Array[(String, Int)], lbl_names: Array[String], lbl_depths: Array[Int], depth: Int, callees: Array[(String, Int, Int)]) -> Int with Exception {
   let k = Array::get(kinds, pos)
   if k == 3 {
     iw_plain_op(out, fn_name, kinds, texts, offs, pos, end, locals, lbl_names, lbl_depths, depth)
@@ -978,14 +1107,16 @@ fn iw_item(out: Bytes, fn_name: String, kinds: Array[Int], texts: Array[String],
       ()
     }
     let head = Array::get(texts, pos + 1)
-    if head == "block" || head == "loop" {
-      iw_folded_block(out, fn_name, kinds, texts, offs, pos, end, locals, lbl_names, lbl_depths, depth)
+    if head == "call" {
+      iw_folded_call(out, fn_name, kinds, texts, offs, pos, end, locals, lbl_names, lbl_depths, depth, callees)
+    } else if head == "block" || head == "loop" {
+      iw_folded_block(out, fn_name, kinds, texts, offs, pos, end, locals, lbl_names, lbl_depths, depth, callees)
     } else if head == "if" {
-      iw_folded_if(out, fn_name, kinds, texts, offs, pos, end, locals, lbl_names, lbl_depths, depth)
+      iw_folded_if(out, fn_name, kinds, texts, offs, pos, end, locals, lbl_names, lbl_depths, depth, callees)
     } else if head == "then" || head == "else" || head == "result" {
       throw(iw_err(fn_name, "misplaced '(\{head} ...)' clause", Array::get(offs, pos)))
     } else {
-      iw_folded_op(out, fn_name, kinds, texts, offs, pos, end, locals, lbl_names, lbl_depths, depth)
+      iw_folded_op(out, fn_name, kinds, texts, offs, pos, end, locals, lbl_names, lbl_depths, depth, callees)
     }
   } else {
     throw(iw_err(fn_name, "unexpected ')'", Array::get(offs, pos)))
@@ -993,7 +1124,7 @@ fn iw_item(out: Bytes, fn_name: String, kinds: Array[Int], texts: Array[String],
 }
 
 /// A sequence of items up to (not consuming) a closing ')' or the end.
-fn iw_seq(out: Bytes, fn_name: String, kinds: Array[Int], texts: Array[String], offs: Array[Int], pos: Int, end: Int, locals: Array[(String, Int)], lbl_names: Array[String], lbl_depths: Array[Int], depth: Int) -> Int with Exception {
+fn iw_seq(out: Bytes, fn_name: String, kinds: Array[Int], texts: Array[String], offs: Array[Int], pos: Int, end: Int, locals: Array[(String, Int)], lbl_names: Array[String], lbl_depths: Array[Int], depth: Int, callees: Array[(String, Int, Int)]) -> Int with Exception {
   let mut p = pos
   let mut done = false
   while !done {
@@ -1002,7 +1133,7 @@ fn iw_seq(out: Bytes, fn_name: String, kinds: Array[Int], texts: Array[String], 
     } else if Array::get(kinds, p) == 2 {
       done = true
     } else {
-      p = iw_item(out, fn_name, kinds, texts, offs, p, end, locals, lbl_names, lbl_depths, depth)
+      p = iw_item(out, fn_name, kinds, texts, offs, p, end, locals, lbl_names, lbl_depths, depth, callees)
     }
   }
   p
@@ -1010,7 +1141,7 @@ fn iw_seq(out: Bytes, fn_name: String, kinds: Array[Int], texts: Array[String], 
 
 /// Folded `(op <immediates> <operand exprs...>)`: real folded-form semantics —
 /// the operand expressions are emitted FIRST, then the op itself.
-fn iw_folded_op(out: Bytes, fn_name: String, kinds: Array[Int], texts: Array[String], offs: Array[Int], pos: Int, end: Int, locals: Array[(String, Int)], lbl_names: Array[String], lbl_depths: Array[Int], depth: Int) -> Int with Exception {
+fn iw_folded_op(out: Bytes, fn_name: String, kinds: Array[Int], texts: Array[String], offs: Array[Int], pos: Int, end: Int, locals: Array[(String, Int)], lbl_names: Array[String], lbl_depths: Array[Int], depth: Int, callees: Array[(String, Int, Int)]) -> Int with Exception {
   let opb = bytebuf_new()
   let after_imm = iw_plain_op(opb, fn_name, kinds, texts, offs, pos + 1, end, locals, lbl_names, lbl_depths, depth)
   let mut p = after_imm
@@ -1021,7 +1152,7 @@ fn iw_folded_op(out: Bytes, fn_name: String, kinds: Array[Int], texts: Array[Str
     } else if Array::get(kinds, p) == 2 {
       done = true
     } else if Array::get(kinds, p) == 1 {
-      p = iw_item(out, fn_name, kinds, texts, offs, p, end, locals, lbl_names, lbl_depths, depth)
+      p = iw_item(out, fn_name, kinds, texts, offs, p, end, locals, lbl_names, lbl_depths, depth, callees)
     } else {
       throw(iw_err(fn_name, "unexpected '\{Array::get(texts, p)}' inside folded '\{Array::get(texts, pos + 1)}' — operands must be parenthesized", Array::get(offs, p)))
     }
@@ -1031,7 +1162,7 @@ fn iw_folded_op(out: Bytes, fn_name: String, kinds: Array[Int], texts: Array[Str
 }
 
 /// Folded `(block $l? (result T)? ...)` / `(loop $l? (result T)? ...)`.
-fn iw_folded_block(out: Bytes, fn_name: String, kinds: Array[Int], texts: Array[String], offs: Array[Int], pos: Int, end: Int, locals: Array[(String, Int)], lbl_names: Array[String], lbl_depths: Array[Int], depth: Int) -> Int with Exception {
+fn iw_folded_block(out: Bytes, fn_name: String, kinds: Array[Int], texts: Array[String], offs: Array[Int], pos: Int, end: Int, locals: Array[(String, Int)], lbl_names: Array[String], lbl_depths: Array[Int], depth: Int, callees: Array[(String, Int, Int)]) -> Int with Exception {
   let head = Array::get(texts, pos + 1)
   bytebuf_push(out, if head == "loop" {
     0x03
@@ -1049,7 +1180,7 @@ fn iw_folded_block(out: Bytes, fn_name: String, kinds: Array[Int], texts: Array[
   }
   let (bt, after_bt) = iw_blocktype(fn_name, kinds, texts, offs, q, end)
   bytebuf_push(out, bt)
-  let bq = iw_seq(out, fn_name, kinds, texts, offs, after_bt, end, locals, lbl_names, lbl_depths, depth + 1)
+  let bq = iw_seq(out, fn_name, kinds, texts, offs, after_bt, end, locals, lbl_names, lbl_depths, depth + 1, callees)
   if bq >= end || Array::get(kinds, bq) != 2 {
     throw(iw_err(fn_name, "missing ')' closing '\{head}'", Array::get(offs, pos)))
   } else {
@@ -1063,7 +1194,7 @@ fn iw_folded_block(out: Bytes, fn_name: String, kinds: Array[Int], texts: Array[
 
 /// Folded `(if $l? (result T)? <cond exprs...> (then ...) (else ...)?)`.
 /// The condition is emitted first, then 0x04 + blocktype, then the branches.
-fn iw_folded_if(out: Bytes, fn_name: String, kinds: Array[Int], texts: Array[String], offs: Array[Int], pos: Int, end: Int, locals: Array[(String, Int)], lbl_names: Array[String], lbl_depths: Array[Int], depth: Int) -> Int with Exception {
+fn iw_folded_if(out: Bytes, fn_name: String, kinds: Array[Int], texts: Array[String], offs: Array[Int], pos: Int, end: Int, locals: Array[(String, Int)], lbl_names: Array[String], lbl_depths: Array[Int], depth: Int, callees: Array[(String, Int, Int)]) -> Int with Exception {
   let lbl_mark = Array::length(lbl_names)
   let mut q = pos + 2
   if q < end && Array::get(kinds, q) == 3 && String::length(Array::get(texts, q)) > 0 && String::char_code_at(Array::get(texts, q), 0) == '$' {
@@ -1083,7 +1214,7 @@ fn iw_folded_if(out: Bytes, fn_name: String, kinds: Array[Int], texts: Array[Str
     } else if Array::get(kinds, p) == 1 && p + 1 < end && Array::get(kinds, p + 1) == 3 && Array::get(texts, p + 1) == "then" {
       cond_done = true
     } else if Array::get(kinds, p) == 1 {
-      p = iw_item(out, fn_name, kinds, texts, offs, p, end, locals, lbl_names, lbl_depths, depth)
+      p = iw_item(out, fn_name, kinds, texts, offs, p, end, locals, lbl_names, lbl_depths, depth, callees)
     } else {
       throw(iw_err(fn_name, "unexpected token in folded 'if' condition (condition operands must be parenthesized)", Array::get(offs, p)))
     }
@@ -1091,7 +1222,7 @@ fn iw_folded_if(out: Bytes, fn_name: String, kinds: Array[Int], texts: Array[Str
   bytebuf_push(out, 0x04)
   bytebuf_push(out, bt)
   // then branch: p is at '(' of (then ...)
-  let tq = iw_seq(out, fn_name, kinds, texts, offs, p + 2, end, locals, lbl_names, lbl_depths, depth + 1)
+  let tq = iw_seq(out, fn_name, kinds, texts, offs, p + 2, end, locals, lbl_names, lbl_depths, depth + 1, callees)
   if tq >= end || Array::get(kinds, tq) != 2 {
     throw(iw_err(fn_name, "missing ')' closing '(then ...)'", Array::get(offs, p)))
   } else {
@@ -1100,7 +1231,7 @@ fn iw_folded_if(out: Bytes, fn_name: String, kinds: Array[Int], texts: Array[Str
   let mut r = tq + 1
   if r + 1 < end && Array::get(kinds, r) == 1 && Array::get(kinds, r + 1) == 3 && Array::get(texts, r + 1) == "else" {
     bytebuf_push(out, 0x05)
-    let eq = iw_seq(out, fn_name, kinds, texts, offs, r + 2, end, locals, lbl_names, lbl_depths, depth + 1)
+    let eq = iw_seq(out, fn_name, kinds, texts, offs, r + 2, end, locals, lbl_names, lbl_depths, depth + 1, callees)
     if eq >= end || Array::get(kinds, eq) != 2 {
       throw(iw_err(fn_name, "missing ')' closing '(else ...)'", Array::get(offs, r)))
     } else {
@@ -1194,6 +1325,16 @@ fn iw_parse_local_decls(fn_name: String, kinds: Array[Int], texts: Array[String]
 /// `extra_base` is the wasm-local index the FIRST declared local lands on —
 /// the caller's total param-slot count including the closure-env slot.
 export fn compile_inline_wat_full(fn_name: String, wat: String, param_names: Array[String], extra_base: Int) -> (Bytes, Int, Int, Int) with Exception {
+  compile_inline_wat_calls(fn_name, wat, param_names, extra_base, iw_fresh_callees())
+}
+
+/// #2348 entry: same as `compile_inline_wat_full`, plus the module's
+/// inline-wasm callee table — `(source name, wasm function index, declared
+/// param count)` per entry — that a folded `(call $f ...)` in this body may
+/// name. An empty table means "this body may not call anything", which is
+/// what the two back-compat entries above pass and what the assembler
+/// reported for every `call` before this issue.
+export fn compile_inline_wat_calls(fn_name: String, wat: String, param_names: Array[String], extra_base: Int, callees: Array[(String, Int, Int)]) -> (Bytes, Int, Int, Int) with Exception {
   let (kinds, texts, offs) = iw_tokenize(fn_name, wat)
   let out = bytebuf_new()
   let lbl_names = iw_fresh_strings()
@@ -1216,7 +1357,7 @@ export fn compile_inline_wat_full(fn_name: String, wat: String, param_names: Arr
   } else {
     ()
   }
-  let final_pos = iw_seq(out, fn_name, kinds, texts, offs, body_start, end, locals, lbl_names, lbl_depths, 0)
+  let final_pos = iw_seq(out, fn_name, kinds, texts, offs, body_start, end, locals, lbl_names, lbl_depths, 0, callees)
   if final_pos != end {
     throw(iw_err(fn_name, "unbalanced ')'", Array::get(offs, final_pos)))
   } else {
@@ -1235,5 +1376,5 @@ export fn compile_inline_wat(fn_name: String, wat: String, param_names: Array[St
 //# Misc
 
 export {
-  compile_inline_wat, compile_inline_wat_full
+  compile_inline_wat, compile_inline_wat_calls, compile_inline_wat_full
 }

--- a/lib/@vibe/compiler/codegen/index.vpkg
+++ b/lib/@vibe/compiler/codegen/index.vpkg
@@ -68,6 +68,7 @@ fn compile_wasi_module_break(stmts: Array[Stmt], entry_name: String, prov: DbgPr
 // header note above).
 fn compile_inline_wat(fn_name: String, wat: String, param_names: Array[String]) -> Bytes with Exception
 fn compile_inline_wat_full(fn_name: String, wat: String, param_names: Array[String], extra_base: Int) -> (Bytes, Int, Int, Int) with Exception
+fn compile_inline_wat_calls(fn_name: String, wat: String, param_names: Array[String], extra_base: Int, callees: Array[(String, Int, Int)]) -> (Bytes, Int, Int, Int) with Exception
 
 // --- normalize/desugar_trait_dict.vibe (re-exported through
 // codegen/common_base for compatibility; see that package's index.vpkg header)

--- a/lib/@vibe/compiler/codegen/wasi/linked_compile.vibe
+++ b/lib/@vibe/compiler/codegen/wasi/linked_compile.vibe
@@ -165,7 +165,7 @@ import @vibe/compiler/codegen/common_base {
   codegen_body_cache_new,
   codegen_body_cache_record,
   codegen_body_cache_replay,
-  compile_inline_wat_full,
+  compile_inline_wat_calls,
   compute_agg_returning,
   ctor_sorted_index,
   desugar_trait_dicts,
@@ -672,6 +672,11 @@ fn push_ctor_float_fields(out: Array[Int], ctor_idx: Int, field_types: Array[Typ
   }
 }
 
+/// #2348: the inline-wasm callee table (name, wasm index, declared arity).
+fn lc_fresh_iw_callees() -> Array[(String, Int, Int)] {
+  array_empty()
+}
+
 fn lc_fresh_string_matrix() -> Array[Array[String]] {
   ArrayBuilder::freeze(ArrayBuilder::new())
 }
@@ -689,7 +694,7 @@ fn gen_heap_grow_check_body() -> Bytes {
 /// scalar-return classification, string-table collection, coverage) sees an
 /// ordinary trivial body and the WAT text never leaks into the data section.
 /// The per-fn codegen loop then splices the assembled instruction bytes
-/// (compile_inline_wat) instead of running compile_expr for these names.
+/// (compile_inline_wat_calls) instead of running compile_expr for these names.
 fn lc_extract_inline_wasm(stmts: Array[Stmt], names: Array[String], wats: Array[String]) -> Unit {
   let mut i = 0
   while i < Array::length(stmts) {
@@ -721,6 +726,40 @@ fn lc_extract_inline_wasm(stmts: Array[Stmt], names: Array[String], wats: Array[
   }
 }
 
+/// #2348: the callee table a `(call $f ...)` inside an inline-wasm body may
+/// name — one `(source name, wasm function index, declared param count)` per
+/// inline-wasm fn in this module.
+///
+/// Only inline-wasm fns are listed, deliberately: calling an ordinary vibe fn
+/// would need this assembler to model an effect row, RC accounting and a real
+/// closure env, none of which it does. The scan is over the USER prefix of the
+/// func table (`[0, num_user_funcs)`, the layout func_table_user_index_of
+/// documents), so a builtin registered under the same name can never be
+/// resolved instead.
+fn lc_build_iw_callees(iw_names: Array[String], ft_names: Array[String], ft_indices: Array[Int], ft_params: Array[Int], num_user_funcs: Int) -> Array[(String, Int, Int)] {
+  let out = lc_fresh_iw_callees()
+  let limit = if num_user_funcs < Array::length(ft_names) {
+    num_user_funcs
+  } else {
+    Array::length(ft_names)
+  }
+  let mut i = 0
+  while i < Array::length(iw_names) {
+    let want = Array::get(iw_names, i)
+    let mut j = 0
+    while j < limit {
+      if Array::get(ft_names, j) == want {
+        Array::push(out, (want, Array::get(ft_indices, j), Array::get(ft_params, j)))
+        j = limit
+      } else {
+        j = j + 1
+      }
+    }
+    i = i + 1
+  }
+  out
+}
+
 /// #805 SIMD locals: assemble an inline-wasm fn's body bytes into `body_buf`
 /// and write its extra-local counts (i32, i64, v128) into the 3-slot
 /// `iw_extra_cell` -- zeros when the function is not inline wasm (iw_found
@@ -730,7 +769,7 @@ fn lc_extract_inline_wasm(stmts: Array[Stmt], names: Array[String], wats: Array[
 /// depth of the flattened module source ("unknown name" on every later
 /// reference, tuple/mut/plain-Int alike), while reads through an
 /// already-in-scope array provably survive (meta_i32 itself is one).
-fn lc_compile_iw_body(body_buf: Bytes, fn_name_dbg: String, iw_wats: Array[String], iw_found: Int, iw_param_names: Array[String], param_count: Int, iw_extra_cell: Array[Int]) -> Unit with Exception {
+fn lc_compile_iw_body(body_buf: Bytes, fn_name_dbg: String, iw_wats: Array[String], iw_found: Int, iw_param_names: Array[String], param_count: Int, iw_extra_cell: Array[Int], iw_callees: Array[(String, Int, Int)]) -> Unit with Exception {
   Array::set(iw_extra_cell, 0, 0)
   Array::set(iw_extra_cell, 1, 0)
   Array::set(iw_extra_cell, 2, 0)
@@ -740,7 +779,7 @@ fn lc_compile_iw_body(body_buf: Bytes, fn_name_dbg: String, iw_wats: Array[Strin
     // Declared `(local ...)` runs index from param_count (params + the
     // closure-env slot), matching the i32/i64/v128 header runs the meta
     // arrays receive at the code-section assembly.
-    let (iw_bytes, iw_n32, iw_n64, iw_nv) = compile_inline_wat_full(fn_name_dbg, Array::get(iw_wats, iw_found), iw_param_names, param_count)
+    let (iw_bytes, iw_n32, iw_n64, iw_nv) = compile_inline_wat_calls(fn_name_dbg, Array::get(iw_wats, iw_found), iw_param_names, param_count, iw_callees)
     bytebuf_push_buf(body_buf, iw_bytes)
     Array::set(iw_extra_cell, 0, iw_n32)
     Array::set(iw_extra_cell, 1, iw_n64)
@@ -5896,6 +5935,9 @@ export fn compile_wasi_module_linked_impl_with_float_offsets(stmts: Array[Stmt],
   // would re-sort this same, unchanging array on every iteration) for
   // func_table_index_of's O(log N) lookups.
   let (all_fn_names_sorted, all_fn_names_sorted_pos) = ctor_sorted_index(all_fn_names_list)
+  // #2348: built once here, from the finalized func-table lists, and shared
+  // by every inline-wasm body the loop below assembles.
+  let iw_callees = lc_build_iw_callees(iw_names, all_fn_names_list, all_fn_indices_list, all_fn_param_counts, num_user_funcs)
   let num_base_types = 9
   let lt_w = LambdaTable::{
     bodies: lc_fresh_bytes_array(),
@@ -6850,7 +6892,7 @@ export fn compile_wasi_module_linked_impl_with_float_offsets(stmts: Array[Stmt],
             Array::push(iw_param_names, iw_pn)
             iw_pi = iw_pi + 1
           }
-          lc_compile_iw_body(body_buf, fn_name_dbg, iw_wats, iw_found, iw_param_names, param_count, iw_extra_cell)
+          lc_compile_iw_body(body_buf, fn_name_dbg, iw_wats, iw_found, iw_param_names, param_count, iw_extra_cell, iw_callees)
           let final_nl = if iw_found >= 0 {
             param_count
           } else {

--- a/lib/@vibe/compiler/compiler_sources_manifest.tsv
+++ b/lib/@vibe/compiler/compiler_sources_manifest.tsv
@@ -22,6 +22,7 @@ core	core/polyfill.vibe
 core	core/bytebuf.vibe
 core	core/ast.vibe
 core	core/types.vibe
+core	core/inline_wasm_marker.vibe
 core	core/dce.vibe
 core	core/expr_children.vibe
 core	core/exception_effect.vibe

--- a/lib/@vibe/compiler/core/core.vibe
+++ b/lib/@vibe/compiler/core/core.vibe
@@ -30,6 +30,10 @@ export ./bytebuf.vibe {
   leb128_encode_u32
 }
 
+export ./inline_wasm_marker.vibe {
+  inline_wasm_marker_name, wat_callee_names, wat_rewrite_callees
+}
+
 export ./dce.vibe {
   dce_keep_flags, dce_stmts
 }

--- a/lib/@vibe/compiler/core/dce.vibe
+++ b/lib/@vibe/compiler/core/dce.vibe
@@ -4,6 +4,10 @@ import ./ast.vibe {
   Expr, Pat, Stmt, TypeExpr
 }
 
+import ./inline_wasm_marker.vibe {
+  inline_wasm_marker_name, wat_callee_names
+}
+
 import @vibe/core {
   array_empty, struct MutMap, struct MutSet
 }
@@ -89,6 +93,30 @@ fn collect_pat_bindings(pat: Pat, bound: Array[String]) -> Int {
   }
 }
 
+/// #2348: add the `call $name` callees of an inline-wasm marker call
+/// (`%wasm("<WAT>")`) to `out`. A no-op for every other call.
+fn collect_wat_callee_refs(callee: Expr, args: Array[Expr], bound: Array[String], out: Array[String]) -> Int {
+  match callee {
+    EIdent(cname, _) => if cname == inline_wasm_marker_name() && Array::length(args) == 1 {
+      match Array::get(args, 0) {
+        EString(wat) => {
+          let names = wat_callee_names(wat)
+          let mut i = 0
+          while i < Array::length(names) {
+            let _ = add_ref(out, bound, Array::get(names, i))
+            i = i + 1
+          }
+          0
+        },
+        _ => 0
+      }
+    } else {
+      0
+    },
+    _ => 0
+  }
+}
+
 fn collect_refs_into(expr: Expr, bound: Array[String], out: Array[String]) -> Int {
   match expr {
     EIdent(name, _) => add_ref(out, bound, name),
@@ -133,6 +161,13 @@ fn collect_refs_into(expr: Expr, bound: Array[String], out: Array[String]) -> In
     },
     ECall(callee, args, _) => {
       collect_refs_into(callee, bound, out)
+      // #2348: an inline-wasm body reaches here as `%wasm("<WAT text>")`, and
+      // the text is an EString, which contributes nothing below. A
+      // `(call $helper ...)` inside it is a real reference, so without this
+      // arm DCE prunes a helper that only a kernel calls and codegen then
+      // reports it missing -- while `vibe check`, which runs on the unpruned
+      // statements, reports clean.
+      collect_wat_callee_refs(callee, args, bound, out)
       let mut i = 0
       while i < Array::length(args) {
         collect_refs_into(Array::get(args, i), bound, out)

--- a/lib/@vibe/compiler/core/dce.vibe
+++ b/lib/@vibe/compiler/core/dce.vibe
@@ -103,7 +103,16 @@ fn collect_wat_callee_refs(callee: Expr, args: Array[Expr], bound: Array[String]
           let names = wat_callee_names(wat)
           let mut i = 0
           while i < Array::length(names) {
-            let _ = add_ref(out, bound, Array::get(names, i))
+            // NOT add_ref: `bound` holds the expression's value binders, and a
+            // WAT `$name` callee is a wasm FUNCTION name, a namespace of its
+            // own. `fn caller(helper: Int) = wasm"(call $helper (local.get
+            // $helper))"` calls the fn and reads the param, and the assembler
+            // already keeps those apart -- filtering by `bound` here dropped
+            // the call edge and DCE then pruned the live helper.
+            let name = Array::get(names, i)
+            if not(dce_array_contains_str(out, name)) {
+              Array::push(out, name)
+            }
             i = i + 1
           }
           0

--- a/lib/@vibe/compiler/core/import_alias_rewrite.vibe
+++ b/lib/@vibe/compiler/core/import_alias_rewrite.vibe
@@ -16,6 +16,10 @@ import ./module_graph_path.vibe {
   dir_of_path, is_contract_ext, resolve_import_path_candidates
 }
 
+import ./inline_wasm_marker.vibe {
+  inline_wasm_marker_name, wat_callee_names, wat_rewrite_callees
+}
+
 //# Functions
 
 fn empty_aliases() -> Array[(String, String)] {
@@ -1124,6 +1128,48 @@ fn rewrite_alias_param_types(params: Array[(String, Option[TypeExpr])], am: Alia
   }
 }
 
+/// #2348: is this call the parser's inline-wasm marker, `%wasm("<WAT>")`?
+fn is_inline_wasm_marker(callee: Expr, args: Array[Expr]) -> Bool {
+  match callee {
+    EIdent(cname, _) => if cname == inline_wasm_marker_name() && Array::length(args) == 1 {
+      match Array::get(args, 0) {
+        EString(_) => true,
+        _ => false
+      }
+    } else {
+      false
+    },
+    _ => false
+  }
+}
+
+/// #2348: rename the `call $name` callees inside an inline-wasm marker's WAT
+/// text with the same map the surrounding rewrite applies to identifiers, so
+/// a kernel keeps calling the helper it named after the helper is renamed.
+fn rewrite_wat_marker_args(args: Array[Expr], am: AliasIdx) -> Array[Expr] {
+  match Array::get(args, 0) {
+    EString(wat) => {
+      let names = wat_callee_names(wat)
+      let from = array_empty()
+      let to = array_empty()
+      let mut i = 0
+      while i < Array::length(names) {
+        let name = Array::get(names, i)
+        match MutMap::get(am.idx, name) {
+          Some(renamed) => {
+            Array::push(from, name)
+            Array::push(to, renamed)
+          },
+          None => ()
+        }
+        i = i + 1
+      }
+      [EString(wat_rewrite_callees(wat, from, to))]
+    },
+    _ => args
+  }
+}
+
 fn rewrite_alias_expr_ix(expr: Expr, am: AliasIdx) -> Expr {
   // Perf: with no aliases the rewrite is the identity, but the match below
   // still rebuilt EVERY node of the tree. Alias maps only shrink on the way
@@ -1195,9 +1241,18 @@ fn rewrite_alias_expr_ix(expr: Expr, am: AliasIdx) -> Expr {
         }
         EForIn(name, index_name, rewrite_alias_expr_ix(iter, am), rewrite_alias_expr_ix(body, body_aliases))
       },
-      ECall(callee, args, off) => ECall(rewrite_alias_expr_ix(callee, am), for arg in args {
-        rewrite_alias_expr_ix(arg, am)
-      }, off),
+      // #2348: an inline-wasm body is `%wasm("<WAT text>")`, and a
+      // `(call $helper ...)` inside that text names a fn of this module. The
+      // generic rewrite below cannot see it -- the text is an EString -- so a
+      // private helper's DEFINITION was renamed by the merge while the
+      // `$helper` token was left pointing at a name that no longer existed.
+      ECall(callee, args, off) => if is_inline_wasm_marker(callee, args) {
+        ECall(rewrite_alias_expr_ix(callee, am), rewrite_wat_marker_args(args, am), off)
+      } else {
+        ECall(rewrite_alias_expr_ix(callee, am), for arg in args {
+          rewrite_alias_expr_ix(arg, am)
+        }, off)
+      },
       EBinOp(op, left, right) => EBinOp(op, rewrite_alias_expr_ix(left, am), rewrite_alias_expr_ix(right, am)),
       EUnaryOp(op, value) => EUnaryOp(op, rewrite_alias_expr_ix(value, am)),
       EFn(type_params, bounds, params, ret_ty, effect, body) => {

--- a/lib/@vibe/compiler/core/import_alias_rewrite.vibe
+++ b/lib/@vibe/compiler/core/import_alias_rewrite.vibe
@@ -1128,6 +1128,14 @@ fn rewrite_alias_param_types(params: Array[(String, Option[TypeExpr])], am: Alia
   }
 }
 
+/// #2348: is this expression an inline-wasm marker call, `%wasm("<WAT>")`?
+fn is_inline_wasm_marker_body(body: Expr) -> Bool {
+  match body {
+    ECall(callee, args, _) => is_inline_wasm_marker(callee, args),
+    _ => false
+  }
+}
+
 /// #2348: is this call the parser's inline-wasm marker, `%wasm("<WAT>")`?
 fn is_inline_wasm_marker(callee: Expr, args: Array[Expr]) -> Bool {
   match callee {
@@ -1261,7 +1269,18 @@ fn rewrite_alias_expr_ix(expr: Expr, am: AliasIdx) -> Expr {
         // namespaces while canonicalizing imported contract aliases in fn
         // parameter and return annotations (#1539 StdinStream as S).
         let type_am = aliasidx_without_names(am, type_params)
-        EFn(type_params, rewrite_alias_bounds(bounds, type_am), rewrite_alias_param_types(params, type_am), rewrite_alias_type_opt(ret_ty, type_am), effect, rewrite_alias_expr_ix(body, aliasidx_without_params(am, params)))
+        // #2348: a WAT body's `$name` callees are wasm FUNCTION names, a
+        // namespace of their own -- `fn caller(helper: Int) = wasm"(call
+        // $helper (local.get $helper))"` calls the fn and reads the param, and
+        // the assembler already keeps those apart. So the marker body is
+        // rewritten with the UNSHADOWED map: passing it the params-removed one
+        // left the callee spelled for a definition the merge had renamed.
+        let body_am = if is_inline_wasm_marker_body(body) {
+          am
+        } else {
+          aliasidx_without_params(am, params)
+        }
+        EFn(type_params, rewrite_alias_bounds(bounds, type_am), rewrite_alias_param_types(params, type_am), rewrite_alias_type_opt(ret_ty, type_am), effect, rewrite_alias_expr_ix(body, body_am))
       },
       // #897: `mod.x` written against a qualified-import namespace (`import
       // ... as mod only { x }`) is encoded as the alias key "mod.x" -- see

--- a/lib/@vibe/compiler/core/index.vpkg
+++ b/lib/@vibe/compiler/core/index.vpkg
@@ -339,6 +339,13 @@ fn bsearch_leftmost(sorted: Array[String], name: String) -> Int
 // consumer list)
 fn is_contract_ext(path: String) -> Bool
 fn dir_of_path(file_path: String) -> String
+
+// #2348: inline-wasm marker text -- the `call $name` callees a WAT body
+// references, and the rename of those callee tokens. See
+// inline_wasm_marker.vibe for why the scan over-reports rather than misses.
+fn inline_wasm_marker_name() -> String
+fn wat_callee_names(wat: String) -> Array[String]
+fn wat_rewrite_callees(wat: String, from: Array[String], to: Array[String]) -> String
 fn ensure_regular_source_fs(path: String) -> Unit with Exception + Fs
 fn path_in_dir(dir: String, basename: String) -> String
 fn vpkg_path_in_dir(dir: String) -> String

--- a/lib/@vibe/compiler/core/inline_wasm_marker.vibe
+++ b/lib/@vibe/compiler/core/inline_wasm_marker.vibe
@@ -13,8 +13,12 @@ export fn inline_wasm_marker_name() -> String {
   "%wasm"
 }
 
+/// The assembler's own word terminators: whitespace, `(`, `)` and `;`
+/// (inline_wat.vibe's tokenizer ends a word at any of these). `;` matters:
+/// `(call $helper;; why` is valid WAT whose callee is `helper`, and a scan
+/// that stopped only at whitespace read `helper;;` and matched nothing.
 fn wat_is_delim(c: Int) -> Bool {
-  c == 32 || c == 9 || c == 10 || c == 13 || c == 40 || c == 41
+  c == 32 || c == 9 || c == 10 || c == 13 || c == 40 || c == 41 || c == 59
 }
 
 fn wat_token_end(wat: String, start: Int, len: Int) -> Int {
@@ -25,10 +29,48 @@ fn wat_token_end(wat: String, start: Int, len: Int) -> Int {
   i
 }
 
+/// Advance past delimiters AND comments, the two forms the assembler accepts:
+/// `;;` to end of line and `(; ... ;)`. Skipping them is what lets the `call`
+/// keyword be recognized after one, and keeps a `call $x` written INSIDE a
+/// comment from being recorded as an edge.
 fn wat_skip_delims(wat: String, start: Int, len: Int) -> Int {
   let mut i = start
-  while i < len && wat_is_delim(String::char_code_at(wat, i)) {
-    i = i + 1
+  let mut moving = true
+  while moving {
+    if i >= len {
+      moving = false
+    } else if wat_is_delim(String::char_code_at(wat, i)) {
+      // `;;` runs to the end of the line; a lone `;` is just a terminator.
+      if String::char_code_at(wat, i) == 59 && i + 1 < len && String::char_code_at(wat, i + 1) == 59 {
+        let mut j = i + 2
+        while j < len && String::char_code_at(wat, j) != 10 {
+          j = j + 1
+        }
+        i = j
+      } else if String::char_code_at(wat, i) == 40 && i + 1 < len && String::char_code_at(wat, i + 1) == 59 {
+        // `(; ... ;)`. An unterminated one is the assembler's error to
+        // report, not this scan's: treat the rest of the text as comment.
+        let mut j = i + 2
+        let mut closed = false
+        while j + 1 < len && !closed {
+          if String::char_code_at(wat, j) == 59 && String::char_code_at(wat, j + 1) == 41 {
+            closed = true
+            j = j + 2
+          } else {
+            j = j + 1
+          }
+        }
+        i = if closed {
+          j
+        } else {
+          len
+        }
+      } else {
+        i = i + 1
+      }
+    } else {
+      moving = false
+    }
   }
   i
 }

--- a/lib/@vibe/compiler/core/inline_wasm_marker.vibe
+++ b/lib/@vibe/compiler/core/inline_wasm_marker.vibe
@@ -99,13 +99,19 @@ fn wat_name_index(names: Array[String], name: String) -> Int {
 /// helper's DEFINITION and leave the `$helper` token in the caller pointing
 /// at a name that no longer exists.
 ///
-/// The scan is deliberately looser than the assembler's: it tracks neither
-/// comments nor nesting, so it can report a name the assembler would never
-/// resolve. That direction is safe for both callers — DCE keeps a function it
-/// did not have to, and a rename rewrites a token inside a comment, which
-/// changes nothing. The other direction is not: a MISSED name is a function
-/// DCE drops out from under a live call, or a callee the merge leaves
-/// dangling. When in doubt this over-reports.
+/// It reads the same tokens the assembler does — a word ends at whitespace,
+/// `(`, `)` or `;`, and both comment forms (`;;` to end of line, `(; ... ;)`)
+/// are skipped. That is not cosmetic: `(call $helper;; why` is valid WAT whose
+/// callee is `helper`, and a scan that stopped only at whitespace read
+/// `helper;;`, matched nothing, and let DCE prune the live helper.
+///
+/// Nesting is the one thing it does not track, and does not need to: it keys
+/// on the `call` keyword, and `call` is only ever an instruction. Where it
+/// still differs from the assembler it errs toward reporting a name — DCE
+/// keeps a function it did not have to, a rename rewrites a token that was
+/// already spelled right. The other direction is not safe: a MISSED name is a
+/// function DCE drops out from under a live call, or a callee the merge leaves
+/// dangling.
 export fn wat_callee_names(wat: String) -> Array[String] {
   let out = array_empty()
   let len = String::length(wat)

--- a/lib/@vibe/compiler/core/inline_wasm_marker.vibe
+++ b/lib/@vibe/compiler/core/inline_wasm_marker.vibe
@@ -1,0 +1,145 @@
+//# Imports
+
+import @vibe/core {
+  array_empty
+}
+
+//# Functions
+
+/// #805 (ADR-0072): the marker call the parser emits for an inline-wasm fn
+/// body, `%wasm("<WAT text>")`. A `%`-ident can never be parsed in expression
+/// position, so user source cannot forge it.
+export fn inline_wasm_marker_name() -> String {
+  "%wasm"
+}
+
+fn wat_is_delim(c: Int) -> Bool {
+  c == 32 || c == 9 || c == 10 || c == 13 || c == 40 || c == 41
+}
+
+fn wat_token_end(wat: String, start: Int, len: Int) -> Int {
+  let mut i = start
+  while i < len && !wat_is_delim(String::char_code_at(wat, i)) {
+    i = i + 1
+  }
+  i
+}
+
+fn wat_skip_delims(wat: String, start: Int, len: Int) -> Int {
+  let mut i = start
+  while i < len && wat_is_delim(String::char_code_at(wat, i)) {
+    i = i + 1
+  }
+  i
+}
+
+fn wat_name_index(names: Array[String], name: String) -> Int {
+  let n = Array::length(names)
+  let mut i = 0
+  let mut found = 0 - 1
+  while i < n {
+    if Array::get(names, i) == name {
+      found = i
+      i = n
+    } else {
+      i = i + 1
+    }
+  }
+  found
+}
+
+/// #2348: the fn names a WAT body references through `call $name`.
+///
+/// The WAT text reaches every AST pass as an opaque `EString`, so a pass that
+/// needs to know what a kernel depends on has to read the names out of the
+/// text: DCE, whose reachability would otherwise drop a helper only a `call`
+/// mentions, and the merge rename plan, which would otherwise mangle a
+/// helper's DEFINITION and leave the `$helper` token in the caller pointing
+/// at a name that no longer exists.
+///
+/// The scan is deliberately looser than the assembler's: it tracks neither
+/// comments nor nesting, so it can report a name the assembler would never
+/// resolve. That direction is safe for both callers — DCE keeps a function it
+/// did not have to, and a rename rewrites a token inside a comment, which
+/// changes nothing. The other direction is not: a MISSED name is a function
+/// DCE drops out from under a live call, or a callee the merge leaves
+/// dangling. When in doubt this over-reports.
+export fn wat_callee_names(wat: String) -> Array[String] {
+  let out = array_empty()
+  let len = String::length(wat)
+  let mut i = 0
+  while i < len {
+    let start = wat_skip_delims(wat, i, len)
+    if start >= len {
+      i = len
+    } else {
+      let stop = wat_token_end(wat, start, len)
+      if String::substring(wat, start, stop) == "call" {
+        let name_start = wat_skip_delims(wat, stop, len)
+        if name_start < len && String::char_code_at(wat, name_start) == 36 {
+          let name_stop = wat_token_end(wat, name_start, len)
+          if name_stop > name_start + 1 {
+            Array::push(out, String::substring(wat, name_start + 1, name_stop))
+          } else {
+            ()
+          }
+        } else {
+          ()
+        }
+      } else {
+        ()
+      }
+      i = stop
+    }
+  }
+  out
+}
+
+/// #2348: `wat` with every `call $name` callee that appears in `from`
+/// replaced by the matching entry of `to`. Only the callee token is touched —
+/// a local or label spelled the same way is left alone, which is why this
+/// looks for the `call` keyword rather than for `$name` anywhere.
+export fn wat_rewrite_callees(wat: String, from: Array[String], to: Array[String]) -> String {
+  if Array::length(from) == 0 {
+    wat
+  } else {
+    let len = String::length(wat)
+    let mut out = ""
+    let mut copied = 0
+    let mut i = 0
+    while i < len {
+      let start = wat_skip_delims(wat, i, len)
+      if start >= len {
+        i = len
+      } else {
+        let stop = wat_token_end(wat, start, len)
+        if String::substring(wat, start, stop) == "call" {
+          let name_start = wat_skip_delims(wat, stop, len)
+          if name_start < len && String::char_code_at(wat, name_start) == 36 {
+            let name_stop = wat_token_end(wat, name_start, len)
+            let slot = wat_name_index(from, String::substring(wat, name_start + 1, name_stop))
+            if slot >= 0 {
+              out = String::concat(out, String::substring(wat, copied, name_start + 1))
+              out = String::concat(out, Array::get(to, slot))
+              copied = name_stop
+            } else {
+              ()
+            }
+            i = name_stop
+          } else {
+            i = stop
+          }
+        } else {
+          i = stop
+        }
+      }
+    }
+    String::concat(out, String::substring(wat, copied, len))
+  }
+}
+
+//# Misc
+
+export {
+  inline_wasm_marker_name, wat_callee_names, wat_rewrite_callees
+}

--- a/lib/@vibe/compiler/runtime/typecheck_fs.vibe
+++ b/lib/@vibe/compiler/runtime/typecheck_fs.vibe
@@ -77,7 +77,7 @@ import @vibe/compiler/core {
 // #946(4): inline-wasm codegen validation (lane/align/etc. errors) runs as
 // part of `collect_all_diagnostics` too — see check_inline_wasm_fns below.
 import @vibe/compiler/codegen {
-  compile_inline_wat
+  compile_inline_wat_calls
 }
 
 // #1948: the same Show-interpolation contract `vibe check` runs via
@@ -5600,7 +5600,21 @@ fn collect_inline_wasm_fns(stmts: Array[Stmt]) -> Array[(String, String, Array[S
   }
   out
 }
-/// #946(4): validate every inline-wasm fn body (compile_inline_wat — the same
+/// #2348: the callee table for the CHECK lane -- one entry per inline-wasm fn
+/// in this module, carrying its position where codegen carries a wasm function
+/// index (see check_inline_wasm_fns for why that is sound here).
+fn check_iw_callee_table(fns: Array[(String, String, Array[String])]) -> Array[(String, Int, Int)] {
+  let out = array_empty()
+  let mut i = 0
+  while i < Array::length(fns) {
+    let (fn_name, _wat, pnames) = Array::get(fns, i)
+    Array::push(out, (fn_name, i, Array::length(pnames)))
+    i = i + 1
+  }
+  out
+}
+
+/// #946(4): validate every inline-wasm fn body (compile_inline_wat_calls — the same
 /// assembler codegen uses) and return the FIRST located error, or None when
 /// every inline-wasm fn assembles cleanly. `compile` surfaced these (e.g. a bad
 /// SIMD lane index) as a located error while `vibe diagnostics` reported clean
@@ -5610,6 +5624,14 @@ fn collect_inline_wasm_fns(stmts: Array[Stmt]) -> Array[(String, String, Array[S
 export fn check_inline_wasm_fns(stmts: Array[Stmt]) -> Option[String] {
   let fns = collect_inline_wasm_fns(stmts)
   let n = Array::length(fns)
+  // #2348: the same callee table codegen builds, so `vibe check` accepts
+  // exactly the `(call $f ...)` bodies codegen accepts. The wasm function
+  // INDEX is not knowable here -- module layout is decided in
+  // linked_compile.vibe -- so each entry carries its position in this list.
+  // That is sound because the assembled bytes are discarded below (`let _`):
+  // this lane checks that the callee resolves and the arity matches, and
+  // nothing reads the index it encoded.
+  let iw_callees = check_iw_callee_table(fns)
   let mut i = 0
   let mut result = None
   let mut done = false
@@ -5619,7 +5641,7 @@ export fn check_inline_wasm_fns(stmts: Array[Stmt]) -> Option[String] {
     } else {
       let (fn_name, wat, pnames) = Array::get(fns, i)
       let outcome = handle {
-        let _ = compile_inline_wat(fn_name, wat, pnames)
+        let _ = compile_inline_wat_calls(fn_name, wat, pnames, Array::length(pnames) + 1, iw_callees)
         None
       } with { Exception::Throw(msg) => Some(msg) }
       match outcome {

--- a/lib/@vibe/compiler/tests/dce_test.vibe
+++ b/lib/@vibe/compiler/tests/dce_test.vibe
@@ -155,3 +155,63 @@ test "SBench expression refs are kept" {
   let result = dce_stmts(stmts, array_empty())
   assert(eq(Array::length(result), 2))
 }
+
+//# #2348: a WAT body's `call $name` edges
+
+/// The parser's inline-wasm marker: `fn <name>(...) = wasm "<wat>"` reaches
+/// every AST pass as `SFnDecl(.., EFn(.., ECall(EIdent("%wasm"), [EString])))`.
+fn iw_marker_fn(name: String, wat: String) -> Stmt {
+  SFnDecl(false, name, EFn(array_empty(), array_empty(), array_empty(), no_ty(), None, ECall(EIdent("%wasm", -1), [
+    EString(wat)
+  ], -1)), array_empty(), array_empty())
+}
+
+test "#2348 dce: a helper only a WAT `call` names is reachable" {
+  // Before the WAT scan, `collect_refs_into` answered `EString(_) => 0` and
+  // this dropped `helper` -- out from under a live call. Codegen then reported
+  // it missing while `vibe check`, which runs on the UNPRUNED statements,
+  // reported clean.
+  let stmts = [
+    iw_marker_fn("helper", "(i64.sub (local.get $a) (local.get $b))"),
+    iw_marker_fn("caller", "(call $helper (local.get $a) (i64.const 8))"),
+    SLet(false, false, "main", no_ty(), ECall(EIdent("caller", -1), [EInt(10)], -1))
+  ]
+  let result = dce_stmts(stmts, ["main"])
+  assert(eq(Array::length(result), 3))
+}
+
+test "#2348 dce: an inline-wasm fn nothing calls is still pruned" {
+  // The control. Without it the test above would pass just as well if the
+  // scan had been replaced by "never prune an inline-wasm fn".
+  let stmts = [
+    iw_marker_fn("helper", "(i64.sub (local.get $a) (local.get $b))"),
+    iw_marker_fn("caller", "(i64.add (local.get $a) (i64.const 8))"),
+    SLet(false, false, "main", no_ty(), ECall(EIdent("caller", -1), [EInt(10)], -1))
+  ]
+  let result = dce_stmts(stmts, ["main"])
+  assert(eq(Array::length(result), 2))
+}
+
+test "#2348 dce: a local spelled like a fn is not a reference" {
+  // The scan keys on the `call` keyword, not on `$name` anywhere, so
+  // `(local.get $helper)` does not keep `helper` alive.
+  let stmts = [
+    iw_marker_fn("helper", "(i64.sub (local.get $a) (local.get $b))"),
+    iw_marker_fn("caller", "(i64.add (local.get $helper) (i64.const 8))"),
+    SLet(false, false, "main", no_ty(), ECall(EIdent("caller", -1), [EInt(10)], -1))
+  ]
+  let result = dce_stmts(stmts, ["main"])
+  assert(eq(Array::length(result), 2))
+}
+
+test "#2348 dce: every callee of a multi-call body is reachable" {
+  let stmts = [
+    iw_marker_fn("h1", "(i64.sub (local.get $a) (local.get $b))"),
+    iw_marker_fn("h2", "(i64.add (local.get $a) (local.get $b))"),
+    iw_marker_fn("unused", "(i64.mul (local.get $a) (local.get $b))"),
+    iw_marker_fn("caller", "(call $h1 (call $h2 (local.get $a) (i64.const 2)) (i64.const 8))"),
+    SLet(false, false, "main", no_ty(), ECall(EIdent("caller", -1), [EInt(10)], -1))
+  ]
+  let result = dce_stmts(stmts, ["main"])
+  assert(eq(Array::length(result), 4))
+}

--- a/lib/@vibe/compiler/tests/dce_test.vibe
+++ b/lib/@vibe/compiler/tests/dce_test.vibe
@@ -1,7 +1,7 @@
 //# Imports
 
 import @vibe/compiler/core {
-  Expr, ImportItem, Pat, Stmt, TypeExpr, dce_stmts
+  Expr, ImportItem, Pat, Stmt, TypeExpr, dce_stmts, wat_callee_names
 }
 
 import @vibe/core {
@@ -214,4 +214,52 @@ test "#2348 dce: every callee of a multi-call body is reachable" {
   ]
   let result = dce_stmts(stmts, ["main"])
   assert(eq(Array::length(result), 4))
+}
+
+/// Like `iw_marker_fn`, with declared parameters -- the shadowing case.
+fn iw_marker_fn_params(name: String, params: Array[String], wat: String) -> Stmt {
+  let ps = array_empty()
+  let mut i = 0
+  while i < Array::length(params) {
+    Array::push(ps, (Array::get(params, i), no_ty()))
+    i = i + 1
+  }
+  SFnDecl(false, name, EFn(array_empty(), array_empty(), ps, no_ty(), None, ECall(EIdent("%wasm", -1), [
+    EString(wat)
+  ], -1)), array_empty(), array_empty())
+}
+
+test "#2348 dce: a callee followed straight by a `;;` comment is an edge" {
+  // `(call $helper;; why` is valid WAT -- the assembler ends a word at `;`
+  // too. A scan that stopped only at whitespace read `helper;;`, matched
+  // nothing, and DCE pruned the live helper.
+  let names = wat_callee_names("(call $helper;; why\n (local.get $a))")
+  assert(eq(Array::length(names), 1))
+  assert(eq(Array::get(names, 0), "helper"))
+  let stmts = [
+    iw_marker_fn("helper", "(i64.sub (local.get $a) (local.get $b))"),
+    iw_marker_fn("caller", "(call $helper;; why\n (local.get $a) (i64.const 8))"),
+    SLet(false, false, "main", no_ty(), ECall(EIdent("caller", -1), [EInt(10)], -1))
+  ]
+  assert(eq(Array::length(dce_stmts(stmts, ["main"])), 3))
+}
+
+test "#2348 dce: a call written inside a comment is not an edge" {
+  // Both comment forms the assembler accepts. Recording these would only
+  // over-keep, but the scan can be exact here, so it is.
+  assert(eq(Array::length(wat_callee_names(";; (call $ghost)\n(i64.const 1)")), 0))
+  assert(eq(Array::length(wat_callee_names("(; (call $ghost) ;)(i64.const 1)")), 0))
+  assert(eq(Array::length(wat_callee_names("(call ;; between\n $real (i64.const 1))")), 1))
+}
+
+test "#2348 dce: a parameter named like the callee does not hide the edge" {
+  // `$helper` as a callee and `$helper` as a local are different namespaces,
+  // and the assembler already keeps them apart. Filtering the callee through
+  // the expression's value binders dropped the edge and pruned the helper.
+  let stmts = [
+    iw_marker_fn("helper", "(i64.sub (local.get $a) (local.get $b))"),
+    iw_marker_fn_params("caller", ["helper"], "(call $helper (local.get $helper) (i64.const 8))"),
+    SLet(false, false, "main", no_ty(), ECall(EIdent("caller", -1), [EInt(10)], -1))
+  ]
+  assert(eq(Array::length(dce_stmts(stmts, ["main"])), 3))
 }

--- a/lib/@vibe/compiler/tests/import_alias_rewrite_test.vibe
+++ b/lib/@vibe/compiler/tests/import_alias_rewrite_test.vibe
@@ -16,6 +16,7 @@ import @vibe/compiler/core {
   collect_import_value_renames,
   export_plan_renames_for,
   namespace_exported_name,
+  namespace_private_value_stmts,
   trait_import_local_operation_renames
 }
 
@@ -478,4 +479,46 @@ test "later aliased re-export blocks an earlier import reference rename" {
   ], main_path)
   let renames = collect_import_value_renames(plan, facade_path, facade_stmts)
   assert(Array::length(renames) == 0)
+}
+
+//# #2348: a WAT body's `call $name` survives the merge rename
+
+/// The name a top-level value statement binds, however it is spelled.
+fn iw_stmt_binding_name(stmt: Stmt) -> String {
+  match stmt {
+    SFnDecl(_, name, _, _, _) => name,
+    SLet(_, _, name, _, _) => name,
+    _ => ""
+  }
+}
+
+test "#2348 merge: a WAT callee is renamed together with its definition" {
+  // A private inline-wasm helper gets a namespaced name when its file is
+  // merged. The `$helper` token lives inside an EString, so the generic
+  // rewrite could not see it and the caller was left naming a fn that no
+  // longer existed -- a program whose per-file `vibe check` is clean.
+  let stmts = parse_program(lex("fn helper(a: Int, b: Int) -> Int = wasm\"(i64.sub (local.get $a) (local.get $b))\"\nexport fn caller(a: Int) -> Int = wasm\"(call $helper (local.get $a) (i64.const 8))\"\n"))
+  let renamed = namespace_private_value_stmts("dep.vibe", stmts)
+  let helper_name = iw_stmt_binding_name(Array::get(renamed, 0))
+  // The definition really was renamed; without this the assertion below
+  // would hold vacuously on a build where nothing is namespaced at all.
+  assert(helper_name != "helper")
+  assert(String::length(helper_name) > 6)
+  let printed = print_program(renamed)
+  // The callee token now names exactly the renamed definition ...
+  assert(String::contains(printed, String::concat("call $", helper_name)))
+  // ... and no longer the original spelling. The trailing space matters:
+  // `call $helper` is a prefix of `call $helper_dep_vibe`.
+  assert(!String::contains(printed, "call $helper "))
+}
+
+test "#2348 merge: a local spelled like a private fn is left alone" {
+  // The rewrite keys on the `call` keyword, not on `$name` anywhere, so a
+  // local or label that happens to share a renamed fn's name keeps its
+  // spelling -- renaming it would silently change which slot the body reads.
+  let stmts = parse_program(lex("fn helper(a: Int, b: Int) -> Int = wasm\"(i64.sub (local.get $a) (local.get $b))\"\nexport fn caller(a: Int) -> Int = wasm\"(i64.add (local.get $helper) (i64.const 8))\"\n"))
+  let renamed = namespace_private_value_stmts("dep.vibe", stmts)
+  assert(iw_stmt_binding_name(Array::get(renamed, 0)) != "helper")
+  let printed = print_program(renamed)
+  assert(String::contains(printed, "local.get $helper)"))
 }

--- a/lib/@vibe/compiler/tests/import_alias_rewrite_test.vibe
+++ b/lib/@vibe/compiler/tests/import_alias_rewrite_test.vibe
@@ -522,3 +522,16 @@ test "#2348 merge: a local spelled like a private fn is left alone" {
   let printed = print_program(renamed)
   assert(String::contains(printed, "local.get $helper)"))
 }
+
+test "#2348 merge: a parameter named like the callee does not block the rename" {
+  // The enclosing EFn removes its parameter names from the alias map before
+  // the body is rewritten. A WAT `$name` callee is a wasm FUNCTION name, a
+  // namespace of its own, so it must not inherit that shadowing -- it did,
+  // and the caller was left naming a definition the merge had renamed.
+  let renamed = namespace_private_value_stmts("dep.vibe", parse_program(lex("fn helper(a: Int, b: Int) -> Int = wasm\"(i64.sub (local.get $a) (local.get $b))\"\nexport fn caller(helper: Int) -> Int = wasm\"(call $helper (local.get $helper) (i64.const 8))\"\n")))
+  assert(iw_stmt_binding_name(Array::get(renamed, 0)) != "helper")
+  let printed = print_program(renamed)
+  assert(!String::contains(printed, "call $helper "))
+  // ... while the parameter read keeps its own spelling.
+  assert(String::contains(printed, "local.get $helper)"))
+}

--- a/lib/@vibe/compiler/tests/inline_wasm_test.vibe
+++ b/lib/@vibe/compiler/tests/inline_wasm_test.vibe
@@ -469,20 +469,47 @@ test "#2348 inline wasm: a call operand that leaves nothing on the stack is reje
   // `(drop ...)` is one operand that pushes NOTHING, so the call would be
   // assembled a value short and the module would fail wasm validation at load
   // -- clean `vibe check`, broken artifact.
-  assert(String::contains(call_result("(call $dbl (drop (local.get $a)))"), "does not produce a value"))
-  assert(String::contains(call_result("(call $dbl (nop))"), "does not produce a value"))
-  assert(String::contains(call_result("(call $dbl (local.set $a (i64.const 2)))"), "does not produce a value"))
-  assert(String::contains(call_result("(call $dbl (i64.store (local.get $a) (local.get $b)))"), "does not produce a value"))
+  assert(String::contains(call_result("(call $dbl (drop (local.get $a)))"), "does not produce an i64"))
+  assert(String::contains(call_result("(call $dbl (nop))"), "does not produce an i64"))
+  assert(String::contains(call_result("(call $dbl (local.set $a (i64.const 2)))"), "does not produce an i64"))
+  assert(String::contains(call_result("(call $dbl (i64.store (local.get $a) (local.get $b)))"), "does not produce an i64"))
   // A block yields a value only with an explicit `(result ...)`.
-  assert(String::contains(call_result("(call $dbl (block (i64.const 1)))"), "does not produce a value"))
+  assert(String::contains(call_result("(call $dbl (block (i64.const 1)))"), "does not produce an i64"))
   // The message names WHICH argument.
   assert(String::contains(call_result("(call $sub2 (local.get $a) (drop (local.get $b)))"), "argument 2"))
 }
 
-test "#2348 inline wasm: value-producing call operands still assemble" {
-  // The control for the test above: the check must not reject the ordinary
-  // shapes. Covers a local, an arithmetic head, a nested call, a block WITH a
-  // result, a load, local.tee, and a SIMD lane extract.
+test "#2348 inline wasm: a call operand of the wrong result type is rejected" {
+  // "pushes something" is not a type check either: every inline-wasm parameter
+  // is an i64 slot, so an i32 or v128 operand assembles a module that fails
+  // validation at load just as surely as a missing one. The message names the
+  // type it found.
+  assert(String::contains(call_result("(call $dbl (i32.const 1))"), "produces i32"))
+  assert(String::contains(call_result("(call $dbl (v128.const i32x4 0 0 0 0))"), "produces v128"))
+  assert(String::contains(call_result("(call $dbl (i32.wrap_i64 (local.get $a)))"), "produces i32"))
+  // A comparison is i32 whatever its operand width -- a prefix rule alone
+  // would type `i64.eq` as i64.
+  assert(String::contains(call_result("(call $dbl (i64.eq (local.get $a) (local.get $b)))"), "produces i32"))
+  assert(String::contains(call_result("(call $dbl (f64.abs (f64.reinterpret_i64 (local.get $a))))"), "produces f64"))
+  // A SIMD reduction is i32; a lane extract is the lane's scalar type.
+  assert(String::contains(call_result("(call $dbl (i8x16.all_true (v128.load (local.get $a))))"), "produces i32"))
+  assert(String::contains(call_result("(call $dbl (block (result i32) (i32.const 1)))"), "produces i32"))
+}
+
+test "#2348 inline wasm: a declared local's type decides, not just its name" {
+  // Params are i64 by construction (the parser admits only Int and Bytes), but
+  // a declared `(local $p i32)` is not -- the locals table carries the type so
+  // `local.get` can be typed instead of assumed.
+  assert(call_result("(local $t i64) (call $dbl (local.get $t))") == "ok")
+  assert(String::contains(call_result("(local $p i32) (call $dbl (local.get $p))"), "produces i32"))
+  assert(String::contains(call_result("(local $v v128) (call $dbl (local.get $v))"), "produces v128"))
+}
+
+test "#2348 inline wasm: i64 call operands still assemble" {
+  // The control for the three tests above: the check must not reject the
+  // ordinary shapes. A local, an arithmetic head, a nested call, a block WITH
+  // an i64 result, a load, local.tee, an i64 lane extract, and a widening
+  // conversion.
   assert(call_result("(call $dbl (local.get $a))") == "ok")
   assert(call_result("(call $dbl (i64.add (local.get $a) (local.get $b)))") == "ok")
   assert(call_result("(call $dbl (call $dbl (local.get $a)))") == "ok")
@@ -490,4 +517,5 @@ test "#2348 inline wasm: value-producing call operands still assemble" {
   assert(call_result("(call $dbl (i64.load (local.get $a)))") == "ok")
   assert(call_result("(call $dbl (local.tee $a (i64.const 2)))") == "ok")
   assert(call_result("(call $dbl (i64x2.extract_lane 0 (v128.load (local.get $a))))") == "ok")
+  assert(call_result("(call $dbl (i64.extend_i32_s (i32.const 1)))") == "ok")
 }

--- a/lib/@vibe/compiler/tests/inline_wasm_test.vibe
+++ b/lib/@vibe/compiler/tests/inline_wasm_test.vibe
@@ -448,3 +448,46 @@ test "#2348 late dce: the lane compiles a kernel nobody calls too" {
   // them, and also compiles.
   assert(late_dce_compile("fn helper(a: Int, b: Int) -> Int = wasm\"(i64.sub (local.get $a) (local.get $b))\"\nfn caller(a: Int) -> Int = wasm\"(i64.add (local.get $a) (i64.const 8))\"\nfn main() -> Int { caller(10) }\n") == "ok")
 }
+
+/// #2348: assemble with the two-entry callee table; "ok" or the thrown error.
+fn call_result(wat: String) -> String {
+  handle {
+    let (out, _n32, _n64, _nv) = compile_inline_wat_calls("probe", wat, [
+      "a",
+      "b"
+    ], 3, iw_test_callees())
+    if Bytes::length(out) > 0 {
+      "ok"
+    } else {
+      "empty"
+    }
+  } with { Exception::Throw(msg) => msg }
+}
+
+test "#2348 inline wasm: a call operand that leaves nothing on the stack is rejected" {
+  // Counting parenthesized operands is not an arity check on its own:
+  // `(drop ...)` is one operand that pushes NOTHING, so the call would be
+  // assembled a value short and the module would fail wasm validation at load
+  // -- clean `vibe check`, broken artifact.
+  assert(String::contains(call_result("(call $dbl (drop (local.get $a)))"), "does not produce a value"))
+  assert(String::contains(call_result("(call $dbl (nop))"), "does not produce a value"))
+  assert(String::contains(call_result("(call $dbl (local.set $a (i64.const 2)))"), "does not produce a value"))
+  assert(String::contains(call_result("(call $dbl (i64.store (local.get $a) (local.get $b)))"), "does not produce a value"))
+  // A block yields a value only with an explicit `(result ...)`.
+  assert(String::contains(call_result("(call $dbl (block (i64.const 1)))"), "does not produce a value"))
+  // The message names WHICH argument.
+  assert(String::contains(call_result("(call $sub2 (local.get $a) (drop (local.get $b)))"), "argument 2"))
+}
+
+test "#2348 inline wasm: value-producing call operands still assemble" {
+  // The control for the test above: the check must not reject the ordinary
+  // shapes. Covers a local, an arithmetic head, a nested call, a block WITH a
+  // result, a load, local.tee, and a SIMD lane extract.
+  assert(call_result("(call $dbl (local.get $a))") == "ok")
+  assert(call_result("(call $dbl (i64.add (local.get $a) (local.get $b)))") == "ok")
+  assert(call_result("(call $dbl (call $dbl (local.get $a)))") == "ok")
+  assert(call_result("(call $dbl (block (result i64) (i64.const 1)))") == "ok")
+  assert(call_result("(call $dbl (i64.load (local.get $a)))") == "ok")
+  assert(call_result("(call $dbl (local.tee $a (i64.const 2)))") == "ok")
+  assert(call_result("(call $dbl (i64x2.extract_lane 0 (v128.load (local.get $a))))") == "ok")
+}

--- a/lib/@vibe/compiler/tests/inline_wasm_test.vibe
+++ b/lib/@vibe/compiler/tests/inline_wasm_test.vibe
@@ -19,7 +19,7 @@ import @vibe/compiler/checker {
 }
 
 import @vibe/compiler/codegen/wasi {
-  compile_wasi_module_impl
+  compile_wasi_module_impl, compile_wasi_module_linked_impl
 }
 
 import ../codegen_gc.vibe {
@@ -28,6 +28,10 @@ import ../codegen_gc.vibe {
 
 import @vibe/compiler/codegen {
   compile_inline_wat, compile_inline_wat_calls, compile_inline_wat_full
+}
+
+import @vibe/compiler/codegen/common_base {
+  codegen_body_cache_new, empty_dbg_prov
 }
 
 //# Functions
@@ -410,4 +414,37 @@ test "#2348 inline wasm: call_indirect and return_call stay unsupported" {
   assert(String::contains(ci, "'call_indirect' is not supported"))
   let rc = call_err("return_call $dbl")
   assert(String::contains(rc, "'return_call' is not supported"))
+}
+
+/// #2348: compile through the LATE-DCE lane -- `enable_late_dce = true`, the
+/// argument `compile_file_wasi_linked_artifacts` passes. Returns "ok" or the
+/// thrown message.
+fn late_dce_compile(src: String) -> String {
+  handle {
+    let stmts = parse_program(lex(src))
+    let wasm = compile_wasi_module_linked_impl(stmts, "main", array_empty(), array_empty(), false, false, false, false, false, false, true, empty_dbg_prov(), codegen_body_cache_new(), codegen_body_cache_new(), 0, 0 - 1)
+    if Bytes::length(wasm) > 0 {
+      "ok"
+    } else {
+      "empty wasm"
+    }
+  } with { Exception::Throw(msg) => msg }
+}
+
+test "#2348 late dce: a helper only a WAT call names survives the post-extraction pass" {
+  // `effect_lowering_prelude` replaces every WAT body with a neutral EInt(0)
+  // BEFORE the late `dce_stmts` runs, so that pass cannot see the call edge
+  // the early one reads out of the marker. It does not need to:
+  // `lc_late_dce_roots` roots every top-level name except the pipeline's own
+  // derive helpers (#1666). This pins that -- if the late pass ever starts
+  // pruning user functions, the assembler throws `no inline-wasm fn named
+  // 'helper'` here instead of at someone's `vibe run`.
+  assert(late_dce_compile("fn helper(a: Int, b: Int) -> Int = wasm\"(i64.sub (local.get $a) (local.get $b))\"\nfn caller(a: Int) -> Int = wasm\"(call $helper (local.get $a) (i64.const 8))\"\nfn main() -> Int { caller(10) }\n") == "ok")
+}
+
+test "#2348 late dce: the lane compiles a kernel nobody calls too" {
+  // The control: "ok" above must not be an artifact of the lane accepting
+  // anything -- this variant has the same two kernels with no `call` between
+  // them, and also compiles.
+  assert(late_dce_compile("fn helper(a: Int, b: Int) -> Int = wasm\"(i64.sub (local.get $a) (local.get $b))\"\nfn caller(a: Int) -> Int = wasm\"(i64.add (local.get $a) (i64.const 8))\"\nfn main() -> Int { caller(10) }\n") == "ok")
 }

--- a/lib/@vibe/compiler/tests/inline_wasm_test.vibe
+++ b/lib/@vibe/compiler/tests/inline_wasm_test.vibe
@@ -27,7 +27,7 @@ import ../codegen_gc.vibe {
 }
 
 import @vibe/compiler/codegen {
-  compile_inline_wat, compile_inline_wat_full
+  compile_inline_wat, compile_inline_wat_calls, compile_inline_wat_full
 }
 
 //# Functions
@@ -66,6 +66,24 @@ fn wat_err(wat: String) -> String {
     let _ = compile_inline_wat("probe", wat, ["a", "b"])
     ""
   } with { Exception::Throw(msg) => msg }
+}
+
+/// #2348: a two-entry callee table -- `dbl` at wasm index 7 taking 1 param,
+/// `sub2` at wasm index 9 taking 2.
+fn iw_test_callees() -> Array[(String, Int, Int)] {
+  [("dbl", 7, 1), ("sub2", 9, 2)]
+}
+
+fn call_err(wat: String) -> String {
+  handle {
+    let _ = compile_inline_wat_calls("probe", wat, ["a", "b"], 3, iw_test_callees())
+    ""
+  } with { Exception::Throw(msg) => msg }
+}
+
+fn call_bytes(wat: String) -> Bytes with Exception {
+  let (out, _n32, _n64, _nv) = compile_inline_wat_calls("probe", wat, ["a", "b"], 3, iw_test_callees())
+  out
 }
 
 //# Misc
@@ -116,8 +134,13 @@ test "inline wasm assembler: malformed WAT is a located error" {
   assert(String::contains(e3, "missing ')'"))
   let e4 = wat_err("(br $nowhere)")
   assert(String::contains(e4, "unknown label '$nowhere'"))
+  // #2348: `call` resolves against the module's inline-wasm fns. `wat_err`
+  // passes no callee table, so nothing is callable and the error says so --
+  // this used to read "not supported", when no body could call anything.
   let e5 = wat_err("(call $f)")
-  assert(String::contains(e5, "not supported"))
+  assert(String::contains(e5, "no inline-wasm fn named 'f'"))
+  let e5b = wat_err("(call_indirect (local.get $a))")
+  assert(String::contains(e5b, "not supported"))
   let e6 = wat_err("block")
   assert(String::contains(e6, "folded form"))
 }
@@ -297,4 +320,94 @@ test "inline wasm: printer round-trips the = wasm form" {
   // and the printed form re-parses to the same print
   let stmts2 = parse_program_preserving(lex(printed))
   assert(print_stmt(Array::get(stmts2, 0)) == printed)
+}
+
+test "#2348 inline wasm: folded call emits operands, the env slot, then the call" {
+  // `(call $dbl (local.get $a))` is the same sequence compile_call.vibe emits
+  // for a static call: the argument, `i64.const 0` for the closure-env slot
+  // every user function carries as its last wasm param, then `call <idx>`.
+  let bytes = call_bytes("(call $dbl (local.get $a))")
+  assert(Bytes::length(bytes) == 6)
+  assert(bytes[0] == 0x20)
+  assert(bytes[1] == 0x00)
+  assert(bytes[2] == 0x42)
+  assert(bytes[3] == 0x00)
+  assert(bytes[4] == 0x10)
+  assert(bytes[5] == 7)
+}
+
+test "#2348 inline wasm: call operands keep source order" {
+  // Deliberately a NON-commutative callee: `sub2` would assemble identically
+  // under a swap if this used an add, and an argument-order bug would survive
+  // the test (CLAUDE.md, "never test argument order with a commutative
+  // operator").
+  let bytes = call_bytes("(call $sub2 (local.get $a) (local.get $b))")
+  assert(Bytes::length(bytes) == 8)
+  assert(bytes[0] == 0x20)
+  assert(bytes[1] == 0x00)
+  assert(bytes[2] == 0x20)
+  assert(bytes[3] == 0x01)
+  assert(bytes[4] == 0x42)
+  assert(bytes[5] == 0x00)
+  assert(bytes[6] == 0x10)
+  assert(bytes[7] == 9)
+}
+
+test "#2348 inline wasm: a call nests inside another call and inside an operator" {
+  let nested = call_bytes("(call $dbl (call $dbl (local.get $a)))")
+  assert(Bytes::length(nested) == 10)
+  assert(nested[4] == 0x10)
+  assert(nested[5] == 7)
+  assert(nested[8] == 0x10)
+  assert(nested[9] == 7)
+  let inside = call_bytes("(i64.add (call $dbl (local.get $a)) (local.get $b))")
+  assert(Bytes::length(inside) == 9)
+  assert(inside[8] == 0x7C)
+}
+
+test "#2348 inline wasm: call arity is checked against the callee" {
+  let too_few = call_err("(call $sub2 (local.get $a))")
+  assert(String::contains(too_few, "'sub2' takes 2 argument(s), called with 1"))
+  let too_many = call_err("(call $dbl (local.get $a) (local.get $b))")
+  assert(String::contains(too_many, "'dbl' takes 1 argument(s), called with 2"))
+}
+
+test "#2348 inline wasm: an unknown callee names what IS callable" {
+  let e = call_err("(call $nope (local.get $a))")
+  assert(String::contains(e, "no inline-wasm fn named 'nope'"))
+  assert(String::contains(e, "callable: dbl, sub2"))
+}
+
+test "#2348 inline wasm: with no callee table nothing is callable" {
+  // What the two back-compat entries pass, and what every `call` met before
+  // this issue.
+  let e = handle {
+    let _ = compile_inline_wat("probe", "(call $dbl (local.get $a))", ["a", "b"])
+    ""
+  } with { Exception::Throw(msg) => msg }
+  assert(String::contains(e, "no inline-wasm fn named 'dbl'"))
+  assert(String::contains(e, "callable: (none)"))
+}
+
+test "#2348 inline wasm: flat-form call is rejected, with the fix in the message" {
+  // Folded-only on purpose: the flat spelling's operand count is not knowable
+  // in the assembler, so its arity could not be checked and the mismatch
+  // would surface as a wasm validation failure at module load.
+  let e = call_err("local.get $a call $dbl")
+  assert(String::contains(e, "'call' must be written in folded form"))
+  assert(String::contains(e, "(call $f (local.get $a) ...)"))
+}
+
+test "#2348 inline wasm: the callee must be spelled $name" {
+  let e = call_err("(call dbl (local.get $a))")
+  assert(String::contains(e, "'call' callee must be written as $name"))
+  let bare = call_err("(call)")
+  assert(String::contains(bare, "'call' needs a callee name"))
+}
+
+test "#2348 inline wasm: call_indirect and return_call stay unsupported" {
+  let ci = call_err("(call_indirect (local.get $a))")
+  assert(String::contains(ci, "'call_indirect' is not supported"))
+  let rc = call_err("return_call $dbl")
+  assert(String::contains(rc, "'return_call' is not supported"))
 }


### PR DESCRIPTION
Closes the first half of #2348.

## The problem

Inline-wasm bodies could not reference any function, so every structure re-inlined its own hash, its own probe and its own tail handling, and every constant was spelled twice — once in vibe, once inside the WAT text. `lib/@vibe/blake3/simd.vibe` is one 28 KB kernel for that reason, and in `bench/bench_simd_hash_probe.vibe` `simd_has` is `simd_count_hits` with the outer loop deleted.

## What changed

A body may now write `(call $other ...)` naming another inline-wasm `fn` in the same module:

```
fn wasm_sub(a: Int, b: Int) -> Int = wasm"(i64.sub (local.get $a) (local.get $b))"

fn wasm_abs_diff(a: Int, b: Int) -> Int = wasm
"(if (result i64) (i64.gt_s (local.get $a) (local.get $b))"
"  (then (call $wasm_sub (local.get $a) (local.get $b)))"
"  (else (call $wasm_sub (local.get $b) (local.get $a))))"
```

The assembler emits the operands, then `i64.const 0` for the closure-env slot every user function carries as its last wasm param, then the call — the same sequence `compile_call.vibe` emits for a static call. The author writes only the real arguments. The callee may be declared anywhere in the module, before or after the caller.

## The contract at the call boundary

Everything below is a **located error at check time**, never a module that fails validation at load — the standard #2341 set for this file.

| the body writes | result |
| :--- | :--- |
| `(call $k (local.get $a) (i64.const 2))`, `k` declared | ok |
| `(call $nope ...)` | `no inline-wasm fn named 'nope' in this module; ... (callable: k, c)` |
| `(call $k (local.get $a))`, `k` takes 2 | `'k' takes 2 argument(s), called with 1` |
| `(call $ordinary ...)` where `ordinary` is an ordinary vibe fn | `no inline-wasm fn named 'ordinary' ...` |
| `local.get $a i64.const 2 call $k` (flat form) | `'call' must be written in folded form so its arity can be checked` |
| `(call $k (drop (local.get $a)))` | `argument 1 ... does not produce an i64 value` |
| `(call $k (i32.const 1))` | `argument 1 ... produces i32, but every inline-wasm parameter is an i64 slot` |

Three limits, all deliberate:

**Only an inline-wasm fn is callable.** The callee table is built from the inline-wasm fns alone, scanned over the func table's user prefix so a builtin registered under the same name can never be resolved instead. An ordinary vibe `fn` has an effect row, RC accounting and a real closure env that this assembler does not model — the issue scopes that out explicitly.

**`call` is folded-form only.** In the flat spelling the operand count is not knowable in the assembler, so the callee's arity could not be checked. Structured control is folded-only for the same reason.

**Each operand must yield an i64.** Counting operands is not an arity check and "it pushes something" is not a type check — both were measured as modules that pass `vibe check` and fail validation at load. The operand's head is classified to a wasm valtype and must be i64. Unrecognized heads are rejected, so adding an instruction fails closed. Two conservatisms: `unreachable` / `return` / `br` are stack-polymorphic and wasm would accept them, and `select` is not typed.

## The call edge outside the assembler

A WAT body reaches every AST pass as `%wasm("<text>")`, an opaque `EString`, so two passes that need to know what a kernel depends on were reading nothing:

- **DCE** pruned a helper that only a `(call $helper ...)` names — measured, `dce_stmts` took a three-statement program to two — while `vibe check`, which runs unpruned, reported clean.
- **The merge rename** renamed a private helper's definition and left the `$helper` token in the caller pointing at a name that no longer existed, so a two-file program with a clean per-file `vibe check` failed to compile.

`core/inline_wasm_marker.vibe` reads the callees out of the text using the assembler's own token rules — a word ends at whitespace, `(`, `)` or `;`, and both comment forms are skipped — and both passes use it. A WAT `$name` callee is a **wasm function name, a namespace of its own**: `fn caller(helper: Int) = wasm"(call $helper (local.get $helper))"` calls the function and reads the parameter, and the assembler already keeps those apart, so neither pass applies vibe's binder shadowing to it.

`vibe check` runs the same assembler over every inline-wasm body and builds the same callee table, so it accepts exactly what codegen accepts.

## Verification

| check | result |
| :--- | :--- |
| `fixtures/inline_wasm_test.vibe` | 10 tests — the kernels compile, link and run |
| the same fixture on the **pre-change** compiler | `'call' is not supported in inline wasm (v0.3 slice: bodies cannot reference other functions)` |
| assembler unit tests | 31 |
| `dce_test.vibe` / `import_alias_rewrite_test.vibe` | 22 / 26 |
| `scripts/compiler_gate.sh` | ok, 843 lines, 0 FAIL |

Every fix here was reproduced before it was written and red-tested after, with each mutation verified present first. The end-to-end fixture uses **subtraction**, not addition — `wasm_sub3(10, 3, 2) == 5` is order-sensitive, so an operand-reordering bug cannot pass it (CLAUDE.md: never test argument order with a commutative operator) — and covers one kernel shared by both arms of a folded `if` plus a forward reference to a kernel declared later in the file.

One existing assertion changed rather than being added to: `wat_err("(call $f)")` asserted `"not supported"`, which was the old contract. With no callee table nothing is callable, so it now asserts the new message, and `call_indirect` picks up the `"not supported"` assertion it vacated.

## Not in this PR

**Part 2 of #2348** — `Array[T]` as an inline-wasm param — is untouched. The value's tagging and RC treatment at the boundary differ from `Bytes`, getting it wrong is silent-wrong rather than a diagnostic, and the issue lists competing options for it.

**#2401** — the assembler does not type its operand *stacks*. `(i64.add (i32.const 1) (i64.const 2))` assembles with no `call` anywhere, and did so before inline-wasm `call` existed; this PR closes the call boundary, not that general gap. Filed rather than folded in, because closing it means a value-type stack with per-instruction operand signatures and block frames.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FYMVd6D2o82suTfTwoJPMf