### PR TITLE
Persist per-function codegen output across compiles (#2388 step 3)

### DIFF
--- a/lib/@vibe/cache/cache.vibe
+++ b/lib/@vibe/cache/cache.vibe
@@ -128,17 +128,38 @@ export fn decode_persistent_artifact(env: Bytes) -> Option[Bytes] {
   }
 }
 
-/// #1326: publish atomically — write "<path>.tmp", then Fs::rename over the
-/// final path — so readers never observe a mid-write final file. Racing
-/// writers of the same key produce identical bytes, so rename-over is safe;
-/// any residual torn read is caught by the envelope length check above.
+/// #1326: publish atomically — write a temporary file, then Fs::rename over
+/// the final path — so readers never observe a mid-write final file. The
+/// temporary name carries a checksum of the PAYLOAD (#2402): most artifact
+/// keys are content-derived, so racing writers of one key produce identical
+/// bytes and share one temporary file harmlessly, exactly as before — but a
+/// self-describing artifact (the #2388 codegen body cache) re-publishes
+/// DIFFERENT bytes under one fixed key, and with a shared temporary name one
+/// writer could rename the other's half-written file out from under it and
+/// abort an otherwise valid compile. Distinct payloads now write distinct
+/// temporary files; last rename wins, and any residual torn read is caught
+/// by the envelope length check above.
 export fn store_persistent_artifact(version_tag: String, kind: String, entry_name: String, fingerprint: String, bytes: Bytes) -> Unit with Exception + Fs {
   let path = persistent_artifact_cache_path(version_tag, kind, entry_name, fingerprint)
   store_artifact_envelope_at(path, bytes)
 }
 
+fn artifact_payload_stamp(bytes: Bytes) -> String {
+  let mut h1 = 17
+  let mut h2 = 29
+  let n = Bytes::length(bytes)
+  let mut i = 0
+  while i < n {
+    let byte = Bytes::get(bytes, i)
+    h1 = (h1 * 131 + byte) % 2147483647
+    h2 = (h2 * 137 + byte) % 2147483629
+    i = i + 1
+  }
+  String::concat(__to_string(h1), String::concat("-", __to_string(h2)))
+}
+
 export fn store_artifact_envelope_at(path: String, bytes: Bytes) -> Unit with Exception + Fs {
-  let tmp = String::concat(path, ".tmp")
+  let tmp = String::concat(path, String::concat(".", String::concat(artifact_payload_stamp(bytes), ".tmp")))
   Fs::write_bytes(tmp, encode_persistent_artifact(bytes))
   Fs::rename(tmp, path)
 }

--- a/lib/@vibe/cache/cache.vibe
+++ b/lib/@vibe/cache/cache.vibe
@@ -128,50 +128,25 @@ export fn decode_persistent_artifact(env: Bytes) -> Option[Bytes] {
   }
 }
 
-/// #1326: publish atomically — write a temporary file, then Fs::rename over
-/// the final path — so readers never observe a mid-write final file. The
-/// temporary name carries a checksum of the PAYLOAD (#2402): most artifact
-/// keys are content-derived, so racing writers of one key produce identical
-/// bytes and share one temporary file harmlessly, exactly as before — but a
-/// self-describing artifact (the #2388 codegen body cache) re-publishes
-/// DIFFERENT bytes under one fixed key, and with a shared temporary name one
-/// writer could rename the other's half-written file out from under it and
-/// abort an otherwise valid compile. Distinct payloads now write distinct
-/// temporary files; last rename wins, and any residual torn read is caught
-/// by the envelope length check above.
+/// Publish in one host call. `Fs::write_bytes` is ATOMIC on both hosts --
+/// scripts/wasm_vibe_host_runner.js `atomicWriteFileSync` and
+/// runtime/viberun `vibe_atomic_write` each write a pid+nonce-unique
+/// same-directory temporary file and rename it over the target -- so a
+/// concurrent reader never observes a mid-write file and concurrent
+/// writers (identical or differing payloads alike) last-write-win as
+/// complete files. The guest-level tmp+rename this used to layer on top
+/// (#1326) predates that host guarantee and was itself the only shared
+/// mutable temporary in the picture: two guest writers of one key could
+/// rename each other's temporary away and abort an otherwise valid
+/// compile (#2402 review, three escalations of the same race). Any
+/// residual torn read is still caught by the envelope length check above.
 export fn store_persistent_artifact(version_tag: String, kind: String, entry_name: String, fingerprint: String, bytes: Bytes) -> Unit with Exception + Fs {
   let path = persistent_artifact_cache_path(version_tag, kind, entry_name, fingerprint)
   store_artifact_envelope_at(path, bytes)
 }
 
-fn artifact_payload_stamp(bytes: Bytes) -> String {
-  let mut h1 = 17
-  let mut h2 = 29
-  let n = Bytes::length(bytes)
-  let mut i = 0
-  while i < n {
-    let byte = Bytes::get(bytes, i)
-    h1 = (h1 * 131 + byte) % 2147483647
-    h2 = (h2 * 137 + byte) % 2147483629
-    i = i + 1
-  }
-  String::concat(__to_string(h1), String::concat("-", __to_string(h2)))
-}
-
 export fn store_artifact_envelope_at(path: String, bytes: Bytes) -> Unit with Exception + Fs {
-  let tmp = String::concat(path, String::concat(".", String::concat(artifact_payload_stamp(bytes), ".tmp")))
-  Fs::write_bytes(tmp, encode_persistent_artifact(bytes))
-  // Two writers of IDENTICAL bytes share this temporary name; the first
-  // rename consumes it, and the loser must tolerate the loss -- the final
-  // path already holds exactly the bytes it meant to publish, so skipping
-  // is correct, and aborting an otherwise valid compile is not. The check
-  // narrows rather than eliminates the window; a store is best-effort by
-  // contract (a lost write costs a future cache miss, never wrong bytes).
-  if Fs::exists(tmp) {
-    Fs::rename(tmp, path)
-  } else {
-    ()
-  }
+  Fs::write_bytes(path, encode_persistent_artifact(bytes))
 }
 
 export fn load_artifact_envelope_at(path: String) -> Option[Bytes] with Exception + Fs {

--- a/lib/@vibe/cache/cache.vibe
+++ b/lib/@vibe/cache/cache.vibe
@@ -161,7 +161,17 @@ fn artifact_payload_stamp(bytes: Bytes) -> String {
 export fn store_artifact_envelope_at(path: String, bytes: Bytes) -> Unit with Exception + Fs {
   let tmp = String::concat(path, String::concat(".", String::concat(artifact_payload_stamp(bytes), ".tmp")))
   Fs::write_bytes(tmp, encode_persistent_artifact(bytes))
-  Fs::rename(tmp, path)
+  // Two writers of IDENTICAL bytes share this temporary name; the first
+  // rename consumes it, and the loser must tolerate the loss -- the final
+  // path already holds exactly the bytes it meant to publish, so skipping
+  // is correct, and aborting an otherwise valid compile is not. The check
+  // narrows rather than eliminates the window; a store is best-effort by
+  // contract (a lost write costs a future cache miss, never wrong bytes).
+  if Fs::exists(tmp) {
+    Fs::rename(tmp, path)
+  } else {
+    ()
+  }
 }
 
 export fn load_artifact_envelope_at(path: String) -> Option[Bytes] with Exception + Fs {

--- a/lib/@vibe/compiler/cli_adapter.vibe
+++ b/lib/@vibe/compiler/cli_adapter.vibe
@@ -79,6 +79,7 @@ import @vibe/compiler/entry/compiler/file_compile {
   compile_file_fs_mode_coverage,
   compile_file_fs_mode_gc,
   compile_file_fs_mode_rc,
+  compile_file_fs_mode_rc_body_cached,
   compile_file_fs_mode_rc_heap_marked,
   compile_file_fs_mode_rc_shadow,
   compile_file_fs_mode_testmeta,
@@ -1460,7 +1461,16 @@ export fn cli_main() -> Int with Exception + Fs + Env + Stdin + Stdout {
         if mark_memory {
           (compile_file_fs_mode_rc_heap_marked(input_path, entry_name), "")
         } else {
-          (compile_file_fs_mode_rc(input_path, entry_name), "")
+          // #2388 step 3: opt-in cross-compile codegen body cache. "verify"
+          // double-compiles and byte-compares (trust building); "on" replays
+          // persisted bodies. Env is read here, keeping file_compile Env-free
+          // (#634). Any other value keeps the exact production lane.
+          let body_cache_mode = Env::get("VIBE_CODEGEN_BODY_CACHE")
+          if body_cache_mode == "verify" || body_cache_mode == "on" {
+            (compile_file_fs_mode_rc_body_cached(input_path, entry_name, body_cache_mode), "")
+          } else {
+            (compile_file_fs_mode_rc(input_path, entry_name), "")
+          }
         }
       } else {
         // Legacy bump path (VIBE_RC=0). #634 (ADR-0026): only when `vibe test`

--- a/lib/@vibe/compiler/codegen/codegen.vibe
+++ b/lib/@vibe/compiler/codegen/codegen.vibe
@@ -5,7 +5,7 @@ import @vibe/compiler/core {
 }
 
 import @vibe/compiler/codegen/common_base {
-  DbgProv, erase_railway_origin_markers, unbox_tuple_loop_params
+  CodegenBodyCache, DbgProv, erase_railway_origin_markers, unbox_tuple_loop_params
 }
 
 import @vibe/compiler/codegen/expr {
@@ -16,6 +16,7 @@ import @vibe/compiler/codegen/wasi {
   compile_wasi_module_break_impl,
   compile_wasi_module_coverage_impl,
   compile_wasi_module_impl,
+  compile_wasi_module_rc_cached_impl,
   compile_wasi_module_rc_impl,
   compile_wasi_module_rc_shadow_impl,
   compile_wasi_module_replayed_impl,
@@ -81,6 +82,12 @@ export fn compile_wasi_module_sliced(stmts: Array[Stmt], entry_name: String) -> 
 /// silently using the bump path. Same merged stmts as compile_wasi_module.
 export fn compile_wasi_module_rc(stmts: Array[Stmt], entry_name: String) -> Bytes with Exception {
   compile_wasi_module_rc_impl(stmts, entry_name)
+}
+
+/// #2388 step 3: RC codegen with body-cache threading for the cross-compile
+/// persistence layer. `body_cache_in` replays, `body_cache_out` harvests.
+export fn compile_wasi_module_rc_body_cached(stmts: Array[Stmt], entry_name: String, body_cache_in: CodegenBodyCache, body_cache_out: CodegenBodyCache) -> Bytes with Exception {
+  compile_wasi_module_rc_cached_impl(stmts, entry_name, body_cache_in, body_cache_out)
 }
 
 /// #715/#768 debug variant: RC codegen + shadow-liveness double-free traps

--- a/lib/@vibe/compiler/codegen/common_base/common_base.vibe
+++ b/lib/@vibe/compiler/codegen/common_base/common_base.vibe
@@ -1,7 +1,19 @@
 //# Imports
 
 import @vibe/compiler/core {
-  Expr, Pat, Stmt, TypeExpr, __to_string, apply_perm_strings, bsearch_leftmost, bytebuf_push, leb128_encode_u32, sort_perm_by_names
+  Expr,
+  Pat,
+  Stmt,
+  TypeExpr,
+  __to_string,
+  apply_perm_strings,
+  bsearch_leftmost,
+  bytebuf_new,
+  bytebuf_push,
+  bytebuf_push_buf,
+  bytebuf_to_bytes,
+  leb128_encode_u32,
+  sort_perm_by_names
 }
 
 import @vibe/ast {
@@ -145,7 +157,30 @@ export struct CodegenBodyCache {
   /// section than a compiled one. The consumer builds a flag set, so order and
   /// duplicates do not matter, which is what lets slices merge freely.
   slot_owner: Array[Int];
-  slot_values: Array[Int]
+  slot_values: Array[Int];
+  /// #2388 step 3: the merged-statement index each cached function was
+  /// compiled from, parallel to fn_indices (-1 when the recording site has
+  /// no statement, e.g. tests that record synthetic entries). Replay ignores
+  /// it; the cross-compile persistence layer uses it to keep only the
+  /// entries whose source-group prefix is unchanged.
+  fn_src_stmts: Array[Int];
+  /// #2388 step 3 guards. Cross-compile replay is only sound while the
+  /// layout facts every cached body's immediates were emitted against still
+  /// hold in the consuming compile. `guard_meta` is exactly
+  /// `[pin_src_n, pin_capacity, lambda_slot_base]` when the recording
+  /// compile ran the #2388 step-2 pin reorder, and empty otherwise -- an
+  /// empty guard makes the cache in-process-only (the consumer treats it as
+  /// unusable across compiles). `guard_synth_names`/`guard_synth_stmts` are
+  /// the synthesized region's function names and their merged-statement
+  /// positions: a prelude whose synthesized output changed in CONTENT keeps
+  /// name and position, so synthesized entries are never replayed across
+  /// compiles at all -- these lists exist to pin their count, order, and
+  /// insertion positions, which is what keeps every pre-pass table
+  /// (string pool, signatures) and the synth index region aligned for the
+  /// source bodies that ARE replayed.
+  guard_meta: Array[Int];
+  guard_synth_names: Array[String];
+  guard_synth_stmts: Array[Int]
 }
 
 /// An empty cache. Threading one of these in means "compile everything, cache
@@ -165,7 +200,11 @@ export fn codegen_body_cache_new() -> CodegenBodyCache {
     lam_meta_i32: array_empty(),
     lam_meta_i64: array_empty(),
     slot_owner: array_empty(),
-    slot_values: array_empty()
+    slot_values: array_empty(),
+    fn_src_stmts: array_empty(),
+    guard_meta: array_empty(),
+    guard_synth_names: array_empty(),
+    guard_synth_stmts: array_empty()
   }
 }
 
@@ -190,12 +229,13 @@ export fn codegen_body_cache_find(cache: CodegenBodyCache, fn_index: Int) -> Int
 /// Reads the LAST entry of `bodies` / `meta_i32` / `meta_i64` -- the loop has
 /// just pushed them -- and the lambda table slice `[lam_lo, lam_hi)`, which is
 /// exactly the range the plan assigned this function.
-export fn codegen_body_cache_record(cache: CodegenBodyCache, fn_index: Int, bodies: Array[Bytes], meta_i32: Array[Int], meta_i64: Array[Int], meta_v128: Array[Int], lt: LambdaTable, lam_lo: Int, lam_hi: Int, slots: Array[Int], slot_lo: Int, slot_hi: Int) -> Unit {
+export fn codegen_body_cache_record(cache: CodegenBodyCache, fn_index: Int, src_stmt: Int, bodies: Array[Bytes], meta_i32: Array[Int], meta_i64: Array[Int], meta_v128: Array[Int], lt: LambdaTable, lam_lo: Int, lam_hi: Int, slots: Array[Int], slot_lo: Int, slot_hi: Int) -> Unit {
   let n = Array::length(bodies)
   if n == 0 {
     ()
   } else {
     Array::push(cache.fn_indices, fn_index)
+    Array::push(cache.fn_src_stmts, src_stmt)
     Array::push(cache.fn_bodies, Array::get(bodies, n - 1))
     Array::push(cache.fn_meta_i32, Array::get(meta_i32, Array::length(meta_i32) - 1))
     Array::push(cache.fn_meta_i64, Array::get(meta_i64, Array::length(meta_i64) - 1))
@@ -242,6 +282,7 @@ export fn codegen_body_cache_merge(a: CodegenBodyCache, b: CodegenBodyCache) -> 
     let mut i = 0
     while i < fn_n {
       Array::push(out.fn_indices, Array::get(src.fn_indices, i))
+      Array::push(out.fn_src_stmts, Array::get(src.fn_src_stmts, i))
       Array::push(out.fn_bodies, Array::get(src.fn_bodies, i))
       Array::push(out.fn_meta_i32, Array::get(src.fn_meta_i32, i))
       Array::push(out.fn_meta_i64, Array::get(src.fn_meta_i64, i))
@@ -269,7 +310,52 @@ export fn codegen_body_cache_merge(a: CodegenBodyCache, b: CodegenBodyCache) -> 
     }
     si = si + 1
   }
+  // Guards are compile-level facts, not per-entry data: slices harvested
+  // from the same compile carry identical guards, so take one side's
+  // (preferring a non-empty one) rather than concatenating.
+  let gsrc = if Array::length(a.guard_meta) > 0 {
+    a
+  } else {
+    b
+  }
+  bcc_copy_guards(gsrc, out)
   out
+}
+
+/// #2388 step 3: does `cache`'s recorded synthesized region match the
+/// current compile's -- same names in the same order at the same merged-
+/// statement positions? `names`/`stmt_indices` are the post-reorder
+/// function lists, `[lo, hi)` the synthesized region.
+export fn bcc_guard_synth_matches(cache: CodegenBodyCache, names: Array[String], stmt_indices: Array[Int], lo: Int, hi: Int) -> Bool {
+  let mut ok = Array::length(cache.guard_synth_names) == hi - lo
+  let mut i = lo
+  while ok && i < hi {
+    if Array::get(cache.guard_synth_names, i - lo) != Array::get(names, i) || Array::get(cache.guard_synth_stmts, i - lo) != Array::get(stmt_indices, i) {
+      ok = false
+    } else {
+      ()
+    }
+    i = i + 1
+  }
+  ok
+}
+
+fn bcc_copy_guards(src: CodegenBodyCache, out: CodegenBodyCache) -> Unit {
+  let mut gi = 0
+  while gi < Array::length(src.guard_meta) {
+    Array::push(out.guard_meta, Array::get(src.guard_meta, gi))
+    gi = gi + 1
+  }
+  let mut gj = 0
+  while gj < Array::length(src.guard_synth_names) {
+    Array::push(out.guard_synth_names, Array::get(src.guard_synth_names, gj))
+    gj = gj + 1
+  }
+  let mut gk = 0
+  while gk < Array::length(src.guard_synth_stmts) {
+    Array::push(out.guard_synth_stmts, Array::get(src.guard_synth_stmts, gk))
+    gk = gk + 1
+  }
 }
 
 /// Replay cache entry `at` into the whole-program accumulators, in place of
@@ -309,6 +395,446 @@ export fn codegen_body_cache_replay(cache: CodegenBodyCache, at: Int, bodies: Ar
       ()
     }
     si = si + 1
+  }
+}
+
+/// #2388 step 3: the subset of `cache` whose recorded merged-statement index
+/// is below `limit` -- the caller's proven-unchanged source prefix. Entries
+/// past the limit (edited modules, capacity pads, appended derived lets)
+/// are dropped and recompile. Prelude-synthesized functions can sit BELOW
+/// the limit (trait dispatchers are inserted after the last impl, which may
+/// be mid-prefix) while their content depends on the WHOLE program, so the
+/// filter also requires the entry to be in the recorded source-function
+/// region (`fn_index < guard_meta[0]`); a cache with no recorded guards
+/// filters to empty -- it was never meant to cross compiles. Returns a
+/// fresh cache carrying the input's guards; the input is not mutated.
+export fn codegen_body_cache_filter_src_below(cache: CodegenBodyCache, limit: Int) -> CodegenBodyCache {
+  let out = codegen_body_cache_new()
+  let keep_fn = array_empty()
+  let src_region_n = if Array::length(cache.guard_meta) == 3 {
+    Array::get(cache.guard_meta, 0)
+  } else {
+    0
+  }
+  let mut i = 0
+  while i < Array::length(cache.fn_indices) {
+    let src_stmt = Array::get(cache.fn_src_stmts, i)
+    if src_stmt >= 0 && src_stmt < limit && Array::get(cache.fn_indices, i) < src_region_n {
+      let fni = Array::get(cache.fn_indices, i)
+      Array::push(keep_fn, fni)
+      Array::push(out.fn_indices, fni)
+      Array::push(out.fn_src_stmts, src_stmt)
+      Array::push(out.fn_bodies, Array::get(cache.fn_bodies, i))
+      Array::push(out.fn_meta_i32, Array::get(cache.fn_meta_i32, i))
+      Array::push(out.fn_meta_i64, Array::get(cache.fn_meta_i64, i))
+      Array::push(out.fn_meta_v128, Array::get(cache.fn_meta_v128, i))
+    } else {
+      ()
+    }
+    i = i + 1
+  }
+  let mut j = 0
+  while j < Array::length(cache.lam_owner) {
+    let owner = Array::get(cache.lam_owner, j)
+    if array_contains_int_bcc(keep_fn, owner) {
+      Array::push(out.lam_owner, owner)
+      Array::push(out.lam_indices, Array::get(cache.lam_indices, j))
+      Array::push(out.lam_bodies, Array::get(cache.lam_bodies, j))
+      Array::push(out.lam_param_counts, Array::get(cache.lam_param_counts, j))
+      Array::push(out.lam_captures, Array::get(cache.lam_captures, j))
+      Array::push(out.lam_meta_i32, Array::get(cache.lam_meta_i32, j))
+      Array::push(out.lam_meta_i64, Array::get(cache.lam_meta_i64, j))
+    } else {
+      ()
+    }
+    j = j + 1
+  }
+  let mut k = 0
+  while k < Array::length(cache.slot_owner) {
+    let sowner = Array::get(cache.slot_owner, k)
+    if array_contains_int_bcc(keep_fn, sowner) {
+      Array::push(out.slot_owner, sowner)
+      Array::push(out.slot_values, Array::get(cache.slot_values, k))
+    } else {
+      ()
+    }
+    k = k + 1
+  }
+  bcc_copy_guards(cache, out)
+  out
+}
+
+fn array_contains_int_bcc(xs: Array[Int], v: Int) -> Bool {
+  let mut i = 0
+  let mut found = false
+  while !found && i < Array::length(xs) {
+    if Array::get(xs, i) == v {
+      found = true
+    } else {
+      ()
+    }
+    i = i + 1
+  }
+  found
+}
+
+//# CodegenBodyCache codec (#2388 step 3)
+
+// Length-prefixed binary layout, "VBC1" magic. Every integer is LEB128 of
+// (value + 1), so -1 (a recording site with no statement) round-trips and
+// any other negative -- which no field legitimately holds -- fails loudly at
+// encode time instead of corrupting the stream. Deserialize is fail-safe:
+// anything malformed returns None and the caller compiles from scratch; a
+// damaged artifact can cost a cache miss, never a wrong body.
+
+fn bcc_push_int(buf: Bytes, v: Int) -> Unit with Exception {
+  if v < 0 - 1 {
+    throw(String::concat("body-cache codec: negative field ", __to_string(v)))
+  } else {
+    ()
+  }
+  leb128_encode_u32(buf, v + 1)
+}
+
+fn bcc_push_int_array(buf: Bytes, xs: Array[Int]) -> Unit with Exception {
+  bcc_push_int(buf, Array::length(xs))
+  let mut i = 0
+  while i < Array::length(xs) {
+    bcc_push_int(buf, Array::get(xs, i))
+    i = i + 1
+  }
+}
+
+fn bcc_push_bytes(buf: Bytes, b: Bytes) -> Unit with Exception {
+  bcc_push_int(buf, Bytes::length(b))
+  bytebuf_push_buf(buf, b)
+}
+
+fn bcc_push_bytes_array(buf: Bytes, xs: Array[Bytes]) -> Unit with Exception {
+  bcc_push_int(buf, Array::length(xs))
+  let mut i = 0
+  while i < Array::length(xs) {
+    bcc_push_bytes(buf, Array::get(xs, i))
+    i = i + 1
+  }
+}
+
+fn bcc_push_string(buf: Bytes, s: String) -> Unit with Exception {
+  bcc_push_int(buf, String::length(s))
+  let mut i = 0
+  while i < String::length(s) {
+    bytebuf_push(buf, String::char_code_at(s, i))
+    i = i + 1
+  }
+}
+
+fn bcc_push_string_array(buf: Bytes, xs: Array[String]) -> Unit with Exception {
+  bcc_push_int(buf, Array::length(xs))
+  let mut i = 0
+  while i < Array::length(xs) {
+    bcc_push_string(buf, Array::get(xs, i))
+    i = i + 1
+  }
+}
+
+fn bcc_push_string_arrays(buf: Bytes, xs: Array[Array[String]]) -> Unit with Exception {
+  bcc_push_int(buf, Array::length(xs))
+  let mut i = 0
+  while i < Array::length(xs) {
+    let inner = Array::get(xs, i)
+    bcc_push_int(buf, Array::length(inner))
+    let mut j = 0
+    while j < Array::length(inner) {
+      bcc_push_string(buf, Array::get(inner, j))
+      j = j + 1
+    }
+    i = i + 1
+  }
+}
+
+export fn codegen_body_cache_to_bytes(cache: CodegenBodyCache) -> Bytes with Exception {
+  let buf = bytebuf_new()
+  bytebuf_push(buf, 'V')
+  bytebuf_push(buf, 'B')
+  bytebuf_push(buf, 'C')
+  bytebuf_push(buf, '1')
+  bcc_push_int_array(buf, cache.fn_indices)
+  bcc_push_int_array(buf, cache.fn_src_stmts)
+  bcc_push_bytes_array(buf, cache.fn_bodies)
+  bcc_push_int_array(buf, cache.fn_meta_i32)
+  bcc_push_int_array(buf, cache.fn_meta_i64)
+  bcc_push_int_array(buf, cache.fn_meta_v128)
+  bcc_push_int_array(buf, cache.lam_owner)
+  bcc_push_int_array(buf, cache.lam_indices)
+  bcc_push_bytes_array(buf, cache.lam_bodies)
+  bcc_push_int_array(buf, cache.lam_param_counts)
+  bcc_push_string_arrays(buf, cache.lam_captures)
+  bcc_push_int_array(buf, cache.lam_meta_i32)
+  bcc_push_int_array(buf, cache.lam_meta_i64)
+  bcc_push_int_array(buf, cache.slot_owner)
+  bcc_push_int_array(buf, cache.slot_values)
+  bcc_push_int_array(buf, cache.guard_meta)
+  bcc_push_string_array(buf, cache.guard_synth_names)
+  bcc_push_int_array(buf, cache.guard_synth_stmts)
+  bytebuf_to_bytes(buf)
+}
+
+// Reader state: (value, next_pos), pos = -1 on malformed input. Every reader
+// checks bounds before consuming; a bad stream degrades to None at the top.
+fn bcc_read_int(b: Bytes, pos: Int) -> (Int, Int) {
+  let n = Bytes::length(b)
+  let mut p = pos
+  let mut shift = 0
+  let mut acc = 0
+  let mut done = false
+  let mut bad = false
+  while !done && !bad {
+    if p >= n || shift > 34 {
+      bad = true
+    } else {
+      let byte = Bytes::get(b, p)
+      p = p + 1
+      acc = acc|((byte&127)<<shift)
+      shift = shift + 7
+      if (byte&128) == 0 {
+        done = true
+      } else {
+        ()
+      }
+    }
+  }
+  if bad {
+    (0, 0 - 1)
+  } else {
+    (acc - 1, p)
+  }
+}
+
+fn bcc_read_int_array(b: Bytes, pos: Int, out: Array[Int]) -> Int {
+  let (count, p0) = bcc_read_int(b, pos)
+  if p0 < 0 || count < 0 {
+    0 - 1
+  } else {
+    let mut p = p0
+    let mut i = 0
+    while p >= 0 && i < count {
+      let (v, np) = bcc_read_int(b, p)
+      if np < 0 {
+        p = 0 - 1
+      } else {
+        Array::push(out, v)
+        p = np
+      }
+      i = i + 1
+    }
+    p
+  }
+}
+
+fn bcc_read_bytes(b: Bytes, pos: Int) -> (Bytes, Int) {
+  let (len, p0) = bcc_read_int(b, pos)
+  if p0 < 0 || len < 0 || p0 + len > Bytes::length(b) {
+    (bytebuf_new(), 0 - 1)
+  } else {
+    (Bytes::slice(b, p0, p0 + len), p0 + len)
+  }
+}
+
+fn bcc_read_bytes_array(b: Bytes, pos: Int, out: Array[Bytes]) -> Int {
+  let (count, p0) = bcc_read_int(b, pos)
+  if p0 < 0 || count < 0 {
+    0 - 1
+  } else {
+    let mut p = p0
+    let mut i = 0
+    while p >= 0 && i < count {
+      let (v, np) = bcc_read_bytes(b, p)
+      if np < 0 {
+        p = 0 - 1
+      } else {
+        Array::push(out, v)
+        p = np
+      }
+      i = i + 1
+    }
+    p
+  }
+}
+
+fn bcc_read_string(b: Bytes, pos: Int) -> (String, Int) {
+  let (len, p0) = bcc_read_int(b, pos)
+  if p0 < 0 || len < 0 || p0 + len > Bytes::length(b) {
+    ("", 0 - 1)
+  } else {
+    let parts = array_empty()
+    let mut i = 0
+    while i < len {
+      Array::push(parts, String::from_byte(Bytes::get(b, p0 + i)))
+      i = i + 1
+    }
+    (String::join(parts, ""), p0 + len)
+  }
+}
+
+fn bcc_read_string_array(b: Bytes, pos: Int, out: Array[String]) -> Int {
+  let (count, p0) = bcc_read_int(b, pos)
+  if p0 < 0 || count < 0 {
+    0 - 1
+  } else {
+    let mut p = p0
+    let mut i = 0
+    while p >= 0 && i < count {
+      let (s, np) = bcc_read_string(b, p)
+      if np < 0 {
+        p = 0 - 1
+      } else {
+        Array::push(out, s)
+        p = np
+      }
+      i = i + 1
+    }
+    p
+  }
+}
+
+fn bcc_read_string_arrays(b: Bytes, pos: Int, out: Array[Array[String]]) -> Int {
+  let (count, p0) = bcc_read_int(b, pos)
+  if p0 < 0 || count < 0 {
+    0 - 1
+  } else {
+    let mut p = p0
+    let mut i = 0
+    while p >= 0 && i < count {
+      let (ilen, np0) = bcc_read_int(b, p)
+      if np0 < 0 || ilen < 0 {
+        p = 0 - 1
+      } else {
+        let inner = array_empty()
+        let mut p2 = np0
+        let mut j = 0
+        while p2 >= 0 && j < ilen {
+          let (s, np) = bcc_read_string(b, p2)
+          if np < 0 {
+            p2 = 0 - 1
+          } else {
+            Array::push(inner, s)
+            p2 = np
+          }
+          j = j + 1
+        }
+        if p2 < 0 {
+          p = 0 - 1
+        } else {
+          Array::push(out, inner)
+          p = p2
+        }
+      }
+      i = i + 1
+    }
+    p
+  }
+}
+
+export fn codegen_body_cache_from_bytes(b: Bytes) -> Option[CodegenBodyCache] {
+  if Bytes::length(b) < 4 || Bytes::get(b, 0) != 'V' || Bytes::get(b, 1) != 'B' || Bytes::get(b, 2) != 'C' || Bytes::get(b, 3) != '1' {
+    None
+  } else {
+    let out = codegen_body_cache_new()
+    let mut p = 4
+    p = bcc_read_int_array(b, p, out.fn_indices)
+    if p >= 0 {
+      p = bcc_read_int_array(b, p, out.fn_src_stmts)
+    } else {
+      ()
+    }
+    if p >= 0 {
+      p = bcc_read_bytes_array(b, p, out.fn_bodies)
+    } else {
+      ()
+    }
+    if p >= 0 {
+      p = bcc_read_int_array(b, p, out.fn_meta_i32)
+    } else {
+      ()
+    }
+    if p >= 0 {
+      p = bcc_read_int_array(b, p, out.fn_meta_i64)
+    } else {
+      ()
+    }
+    if p >= 0 {
+      p = bcc_read_int_array(b, p, out.fn_meta_v128)
+    } else {
+      ()
+    }
+    if p >= 0 {
+      p = bcc_read_int_array(b, p, out.lam_owner)
+    } else {
+      ()
+    }
+    if p >= 0 {
+      p = bcc_read_int_array(b, p, out.lam_indices)
+    } else {
+      ()
+    }
+    if p >= 0 {
+      p = bcc_read_bytes_array(b, p, out.lam_bodies)
+    } else {
+      ()
+    }
+    if p >= 0 {
+      p = bcc_read_int_array(b, p, out.lam_param_counts)
+    } else {
+      ()
+    }
+    if p >= 0 {
+      p = bcc_read_string_arrays(b, p, out.lam_captures)
+    } else {
+      ()
+    }
+    if p >= 0 {
+      p = bcc_read_int_array(b, p, out.lam_meta_i32)
+    } else {
+      ()
+    }
+    if p >= 0 {
+      p = bcc_read_int_array(b, p, out.lam_meta_i64)
+    } else {
+      ()
+    }
+    if p >= 0 {
+      p = bcc_read_int_array(b, p, out.slot_owner)
+    } else {
+      ()
+    }
+    if p >= 0 {
+      p = bcc_read_int_array(b, p, out.slot_values)
+    } else {
+      ()
+    }
+    if p >= 0 {
+      p = bcc_read_int_array(b, p, out.guard_meta)
+    } else {
+      ()
+    }
+    if p >= 0 {
+      p = bcc_read_string_array(b, p, out.guard_synth_names)
+    } else {
+      ()
+    }
+    if p >= 0 {
+      p = bcc_read_int_array(b, p, out.guard_synth_stmts)
+    } else {
+      ()
+    }
+    let fn_n = Array::length(out.fn_indices)
+    let lam_n = Array::length(out.lam_owner)
+    let guard_n = Array::length(out.guard_meta)
+    if p < 0 || Array::length(out.fn_src_stmts) != fn_n || Array::length(out.fn_bodies) != fn_n || Array::length(out.fn_meta_i32) != fn_n || Array::length(out.fn_meta_i64) != fn_n || Array::length(out.fn_meta_v128) != fn_n || Array::length(out.lam_indices) != lam_n || Array::length(out.lam_bodies) != lam_n || Array::length(out.lam_param_counts) != lam_n || Array::length(out.lam_captures) != lam_n || Array::length(out.lam_meta_i32) != lam_n || Array::length(out.lam_meta_i64) != lam_n || Array::length(out.slot_owner) != Array::length(out.slot_values) || (guard_n != 0 && guard_n != 3) || Array::length(out.guard_synth_names) != Array::length(out.guard_synth_stmts) {
+      None
+    } else {
+      Some(out)
+    }
   }
 }
 

--- a/lib/@vibe/compiler/codegen/common_base/common_base.vibe
+++ b/lib/@vibe/compiler/codegen/common_base/common_base.vibe
@@ -185,10 +185,27 @@ export struct CodegenBodyCache {
   /// `Map::has_key(used_builtin_names, ...)` tests, so set equality (not
   /// merely count equality -- two different sets of the same size assign
   /// DIFFERENT indices to each import) pins the whole import vector.
+  /// `guard_borrow_names`/`guard_borrow_masks` are the ADR-0092 program-wide
+  /// borrow-parameter inference (sorted names, masks aligned): it is
+  /// CALL-SITE sensitive -- a position ever passed a non-ident argument is
+  /// disqualified -- so an edit anywhere can flip an unchanged function's
+  /// owned/borrowed parameter ABI, changing both its own drop obligations
+  /// and every caller's dup obligations. Replay is only sound while the
+  /// whole vector is unchanged.
+  /// `guard_unmangled_names` closes the global name-membership class:
+  /// compile_call's `prefer_bound_call` and the func-table name lookups are
+  /// cross-file matches on the spelled name, and only builtin-spelled names
+  /// take those branches. Prefix defs are #716 path-mangled, so the names
+  /// that can flip such a branch are the unmangled source-region ones;
+  /// `__test_`/`__bench_` blocks are excluded (nothing calls them by name),
+  /// which is what keeps the append-a-test edit inside the cache.
   guard_meta: Array[Int];
   guard_synth_names: Array[String];
   guard_synth_stmts: Array[Int];
-  guard_import_names: Array[String]
+  guard_import_names: Array[String];
+  guard_borrow_names: Array[String];
+  guard_borrow_masks: Array[Int];
+  guard_unmangled_names: Array[String]
 }
 
 /// An empty cache. Threading one of these in means "compile everything, cache
@@ -213,7 +230,10 @@ export fn codegen_body_cache_new() -> CodegenBodyCache {
     guard_meta: array_empty(),
     guard_synth_names: array_empty(),
     guard_synth_stmts: array_empty(),
-    guard_import_names: array_empty()
+    guard_import_names: array_empty(),
+    guard_borrow_names: array_empty(),
+    guard_borrow_masks: array_empty(),
+    guard_unmangled_names: array_empty()
   }
 }
 
@@ -370,6 +390,36 @@ fn bcc_copy_guards(src: CodegenBodyCache, out: CodegenBodyCache) -> Unit {
     Array::push(out.guard_import_names, Array::get(src.guard_import_names, gm))
     gm = gm + 1
   }
+  let mut gb = 0
+  while gb < Array::length(src.guard_borrow_names) {
+    Array::push(out.guard_borrow_names, Array::get(src.guard_borrow_names, gb))
+    gb = gb + 1
+  }
+  let mut gc = 0
+  while gc < Array::length(src.guard_borrow_masks) {
+    Array::push(out.guard_borrow_masks, Array::get(src.guard_borrow_masks, gc))
+    gc = gc + 1
+  }
+  let mut gu = 0
+  while gu < Array::length(src.guard_unmangled_names) {
+    Array::push(out.guard_unmangled_names, Array::get(src.guard_unmangled_names, gu))
+    gu = gu + 1
+  }
+}
+
+/// #2388 step 3: exact int-list equality, the mask half of the borrow guard.
+export fn bcc_int_lists_equal(a: Array[Int], b: Array[Int]) -> Bool {
+  let mut ok = Array::length(a) == Array::length(b)
+  let mut i = 0
+  while ok && i < Array::length(a) {
+    if Array::get(a, i) != Array::get(b, i) {
+      ok = false
+    } else {
+      ()
+    }
+    i = i + 1
+  }
+  ok
 }
 
 /// #2388 step 3: exact string-list equality, used by the guard validation
@@ -607,6 +657,9 @@ export fn codegen_body_cache_to_bytes(cache: CodegenBodyCache) -> Bytes with Exc
   bcc_push_string_array(buf, cache.guard_synth_names)
   bcc_push_int_array(buf, cache.guard_synth_stmts)
   bcc_push_string_array(buf, cache.guard_import_names)
+  bcc_push_string_array(buf, cache.guard_borrow_names)
+  bcc_push_int_array(buf, cache.guard_borrow_masks)
+  bcc_push_string_array(buf, cache.guard_unmangled_names)
   bytebuf_to_bytes(buf)
 }
 
@@ -863,10 +916,25 @@ export fn codegen_body_cache_from_bytes(b: Bytes) -> Option[CodegenBodyCache] {
     } else {
       ()
     }
+    if p >= 0 {
+      p = bcc_read_string_array(b, p, out.guard_borrow_names)
+    } else {
+      ()
+    }
+    if p >= 0 {
+      p = bcc_read_int_array(b, p, out.guard_borrow_masks)
+    } else {
+      ()
+    }
+    if p >= 0 {
+      p = bcc_read_string_array(b, p, out.guard_unmangled_names)
+    } else {
+      ()
+    }
     let fn_n = Array::length(out.fn_indices)
     let lam_n = Array::length(out.lam_owner)
     let guard_n = Array::length(out.guard_meta)
-    if p < 0 || Array::length(out.fn_src_stmts) != fn_n || Array::length(out.fn_bodies) != fn_n || Array::length(out.fn_meta_i32) != fn_n || Array::length(out.fn_meta_i64) != fn_n || Array::length(out.fn_meta_v128) != fn_n || Array::length(out.lam_indices) != lam_n || Array::length(out.lam_bodies) != lam_n || Array::length(out.lam_param_counts) != lam_n || Array::length(out.lam_captures) != lam_n || Array::length(out.lam_meta_i32) != lam_n || Array::length(out.lam_meta_i64) != lam_n || Array::length(out.slot_owner) != Array::length(out.slot_values) || (guard_n != 0 && guard_n != 5) || Array::length(out.guard_synth_names) != Array::length(out.guard_synth_stmts) {
+    if p < 0 || Array::length(out.fn_src_stmts) != fn_n || Array::length(out.fn_bodies) != fn_n || Array::length(out.fn_meta_i32) != fn_n || Array::length(out.fn_meta_i64) != fn_n || Array::length(out.fn_meta_v128) != fn_n || Array::length(out.lam_indices) != lam_n || Array::length(out.lam_bodies) != lam_n || Array::length(out.lam_param_counts) != lam_n || Array::length(out.lam_captures) != lam_n || Array::length(out.lam_meta_i32) != lam_n || Array::length(out.lam_meta_i64) != lam_n || Array::length(out.slot_owner) != Array::length(out.slot_values) || (guard_n != 0 && guard_n != 5) || Array::length(out.guard_synth_names) != Array::length(out.guard_synth_stmts) || Array::length(out.guard_borrow_names) != Array::length(out.guard_borrow_masks) {
       None
     } else {
       Some(out)

--- a/lib/@vibe/compiler/codegen/common_base/common_base.vibe
+++ b/lib/@vibe/compiler/codegen/common_base/common_base.vibe
@@ -167,20 +167,28 @@ export struct CodegenBodyCache {
   /// #2388 step 3 guards. Cross-compile replay is only sound while the
   /// layout facts every cached body's immediates were emitted against still
   /// hold in the consuming compile. `guard_meta` is exactly
-  /// `[pin_src_n, pin_capacity, lambda_slot_base]` when the recording
-  /// compile ran the #2388 step-2 pin reorder, and empty otherwise -- an
-  /// empty guard makes the cache in-process-only (the consumer treats it as
-  /// unusable across compiles). `guard_synth_names`/`guard_synth_stmts` are
-  /// the synthesized region's function names and their merged-statement
+  /// `[pin_src_n, pin_capacity, lambda_slot_base, num_imported_funcs,
+  /// num_generated]` when the recording compile ran the #2388 step-2 pin
+  /// reorder, and empty otherwise -- an empty guard makes the cache
+  /// in-process-only (the consumer treats it as unusable across compiles).
+  /// The import/generated counts pin `func_offset`, the base every user
+  /// call immediate is built on. `guard_synth_names`/`guard_synth_stmts`
+  /// are the synthesized region's function names and their merged-statement
   /// positions: a prelude whose synthesized output changed in CONTENT keeps
   /// name and position, so synthesized entries are never replayed across
   /// compiles at all -- these lists exist to pin their count, order, and
   /// insertion positions, which is what keeps every pre-pass table
   /// (string pool, signatures) and the synth index region aligned for the
-  /// source bodies that ARE replayed.
+  /// source bodies that ARE replayed. `guard_import_names` is the sorted
+  /// used-builtin-name set plus the linked-import names: the gated host
+  /// imports are assigned indices by a fixed code sequence of
+  /// `Map::has_key(used_builtin_names, ...)` tests, so set equality (not
+  /// merely count equality -- two different sets of the same size assign
+  /// DIFFERENT indices to each import) pins the whole import vector.
   guard_meta: Array[Int];
   guard_synth_names: Array[String];
-  guard_synth_stmts: Array[Int]
+  guard_synth_stmts: Array[Int];
+  guard_import_names: Array[String]
 }
 
 /// An empty cache. Threading one of these in means "compile everything, cache
@@ -204,7 +212,8 @@ export fn codegen_body_cache_new() -> CodegenBodyCache {
     fn_src_stmts: array_empty(),
     guard_meta: array_empty(),
     guard_synth_names: array_empty(),
-    guard_synth_stmts: array_empty()
+    guard_synth_stmts: array_empty(),
+    guard_import_names: array_empty()
   }
 }
 
@@ -356,6 +365,27 @@ fn bcc_copy_guards(src: CodegenBodyCache, out: CodegenBodyCache) -> Unit {
     Array::push(out.guard_synth_stmts, Array::get(src.guard_synth_stmts, gk))
     gk = gk + 1
   }
+  let mut gm = 0
+  while gm < Array::length(src.guard_import_names) {
+    Array::push(out.guard_import_names, Array::get(src.guard_import_names, gm))
+    gm = gm + 1
+  }
+}
+
+/// #2388 step 3: exact string-list equality, used by the guard validation
+/// (synth-name and import-name lists must match elementwise, in order).
+export fn bcc_string_lists_equal(a: Array[String], b: Array[String]) -> Bool {
+  let mut ok = Array::length(a) == Array::length(b)
+  let mut i = 0
+  while ok && i < Array::length(a) {
+    if Array::get(a, i) != Array::get(b, i) {
+      ok = false
+    } else {
+      ()
+    }
+    i = i + 1
+  }
+  ok
 }
 
 /// Replay cache entry `at` into the whole-program accumulators, in place of
@@ -411,7 +441,7 @@ export fn codegen_body_cache_replay(cache: CodegenBodyCache, at: Int, bodies: Ar
 export fn codegen_body_cache_filter_src_below(cache: CodegenBodyCache, limit: Int) -> CodegenBodyCache {
   let out = codegen_body_cache_new()
   let keep_fn = array_empty()
-  let src_region_n = if Array::length(cache.guard_meta) == 3 {
+  let src_region_n = if Array::length(cache.guard_meta) == 5 {
     Array::get(cache.guard_meta, 0)
   } else {
     0
@@ -576,6 +606,7 @@ export fn codegen_body_cache_to_bytes(cache: CodegenBodyCache) -> Bytes with Exc
   bcc_push_int_array(buf, cache.guard_meta)
   bcc_push_string_array(buf, cache.guard_synth_names)
   bcc_push_int_array(buf, cache.guard_synth_stmts)
+  bcc_push_string_array(buf, cache.guard_import_names)
   bytebuf_to_bytes(buf)
 }
 
@@ -827,10 +858,15 @@ export fn codegen_body_cache_from_bytes(b: Bytes) -> Option[CodegenBodyCache] {
     } else {
       ()
     }
+    if p >= 0 {
+      p = bcc_read_string_array(b, p, out.guard_import_names)
+    } else {
+      ()
+    }
     let fn_n = Array::length(out.fn_indices)
     let lam_n = Array::length(out.lam_owner)
     let guard_n = Array::length(out.guard_meta)
-    if p < 0 || Array::length(out.fn_src_stmts) != fn_n || Array::length(out.fn_bodies) != fn_n || Array::length(out.fn_meta_i32) != fn_n || Array::length(out.fn_meta_i64) != fn_n || Array::length(out.fn_meta_v128) != fn_n || Array::length(out.lam_indices) != lam_n || Array::length(out.lam_bodies) != lam_n || Array::length(out.lam_param_counts) != lam_n || Array::length(out.lam_captures) != lam_n || Array::length(out.lam_meta_i32) != lam_n || Array::length(out.lam_meta_i64) != lam_n || Array::length(out.slot_owner) != Array::length(out.slot_values) || (guard_n != 0 && guard_n != 3) || Array::length(out.guard_synth_names) != Array::length(out.guard_synth_stmts) {
+    if p < 0 || Array::length(out.fn_src_stmts) != fn_n || Array::length(out.fn_bodies) != fn_n || Array::length(out.fn_meta_i32) != fn_n || Array::length(out.fn_meta_i64) != fn_n || Array::length(out.fn_meta_v128) != fn_n || Array::length(out.lam_indices) != lam_n || Array::length(out.lam_bodies) != lam_n || Array::length(out.lam_param_counts) != lam_n || Array::length(out.lam_captures) != lam_n || Array::length(out.lam_meta_i32) != lam_n || Array::length(out.lam_meta_i64) != lam_n || Array::length(out.slot_owner) != Array::length(out.slot_values) || (guard_n != 0 && guard_n != 5) || Array::length(out.guard_synth_names) != Array::length(out.guard_synth_stmts) {
       None
     } else {
       Some(out)

--- a/lib/@vibe/compiler/codegen/common_base/index.vpkg
+++ b/lib/@vibe/compiler/codegen/common_base/index.vpkg
@@ -289,6 +289,7 @@ fn codegen_body_cache_replay(cache: CodegenBodyCache, at: Int, bodies: Array[Byt
 fn codegen_body_cache_filter_src_below(cache: CodegenBodyCache, limit: Int) -> CodegenBodyCache
 fn bcc_guard_synth_matches(cache: CodegenBodyCache, names: Array[String], stmt_indices: Array[Int], lo: Int, hi: Int) -> Bool
 fn bcc_string_lists_equal(a: Array[String], b: Array[String]) -> Bool
+fn bcc_int_lists_equal(a: Array[Int], b: Array[Int]) -> Bool
 fn codegen_body_cache_to_bytes(cache: CodegenBodyCache) -> Bytes with Exception
 fn codegen_body_cache_from_bytes(b: Bytes) -> Option[CodegenBodyCache]
 // --- await_poll_pass (#1230, docs/spec/wasi-p3-async.md M1b-3c;

--- a/lib/@vibe/compiler/codegen/common_base/index.vpkg
+++ b/lib/@vibe/compiler/codegen/common_base/index.vpkg
@@ -283,9 +283,13 @@ fn suspend_cps_pass(stmts: Array[Stmt]) -> Array[String]
 // programs that call compile_wasi_module). See common_base.vibe.
 fn codegen_body_cache_new() -> CodegenBodyCache
 fn codegen_body_cache_find(cache: CodegenBodyCache, fn_index: Int) -> Int
-fn codegen_body_cache_record(cache: CodegenBodyCache, fn_index: Int, bodies: Array[Bytes], meta_i32: Array[Int], meta_i64: Array[Int], meta_v128: Array[Int], lt: LambdaTable, lam_lo: Int, lam_hi: Int, slots: Array[Int], slot_lo: Int, slot_hi: Int) -> Unit
+fn codegen_body_cache_record(cache: CodegenBodyCache, fn_index: Int, src_stmt: Int, bodies: Array[Bytes], meta_i32: Array[Int], meta_i64: Array[Int], meta_v128: Array[Int], lt: LambdaTable, lam_lo: Int, lam_hi: Int, slots: Array[Int], slot_lo: Int, slot_hi: Int) -> Unit
 fn codegen_body_cache_merge(a: CodegenBodyCache, b: CodegenBodyCache) -> CodegenBodyCache
 fn codegen_body_cache_replay(cache: CodegenBodyCache, at: Int, bodies: Array[Bytes], meta_i32: Array[Int], meta_i64: Array[Int], meta_v128: Array[Int], lt: LambdaTable, slots: Array[Int]) -> Unit
+fn codegen_body_cache_filter_src_below(cache: CodegenBodyCache, limit: Int) -> CodegenBodyCache
+fn bcc_guard_synth_matches(cache: CodegenBodyCache, names: Array[String], stmt_indices: Array[Int], lo: Int, hi: Int) -> Bool
+fn codegen_body_cache_to_bytes(cache: CodegenBodyCache) -> Bytes with Exception
+fn codegen_body_cache_from_bytes(b: Bytes) -> Option[CodegenBodyCache]
 // --- await_poll_pass (#1230, docs/spec/wasi-p3-async.md M1b-3c;
 // host_future key = ADR-0089 step 4, #1218; waiter_hooks key =
 // resolve -> direct wake, routes poll rounds through the library's

--- a/lib/@vibe/compiler/codegen/common_base/index.vpkg
+++ b/lib/@vibe/compiler/codegen/common_base/index.vpkg
@@ -288,6 +288,7 @@ fn codegen_body_cache_merge(a: CodegenBodyCache, b: CodegenBodyCache) -> Codegen
 fn codegen_body_cache_replay(cache: CodegenBodyCache, at: Int, bodies: Array[Bytes], meta_i32: Array[Int], meta_i64: Array[Int], meta_v128: Array[Int], lt: LambdaTable, slots: Array[Int]) -> Unit
 fn codegen_body_cache_filter_src_below(cache: CodegenBodyCache, limit: Int) -> CodegenBodyCache
 fn bcc_guard_synth_matches(cache: CodegenBodyCache, names: Array[String], stmt_indices: Array[Int], lo: Int, hi: Int) -> Bool
+fn bcc_string_lists_equal(a: Array[String], b: Array[String]) -> Bool
 fn codegen_body_cache_to_bytes(cache: CodegenBodyCache) -> Bytes with Exception
 fn codegen_body_cache_from_bytes(b: Bytes) -> Option[CodegenBodyCache]
 // --- await_poll_pass (#1230, docs/spec/wasi-p3-async.md M1b-3c;

--- a/lib/@vibe/compiler/codegen/index.vpkg
+++ b/lib/@vibe/compiler/codegen/index.vpkg
@@ -59,6 +59,7 @@ fn compile_wasi_module(stmts: Array[Stmt], entry_name: String) -> Bytes with Exc
 fn compile_wasi_module_replayed(stmts: Array[Stmt], entry_name: String) -> Bytes with Exception
 fn compile_wasi_module_sliced(stmts: Array[Stmt], entry_name: String) -> Bytes with Exception
 fn compile_wasi_module_rc(stmts: Array[Stmt], entry_name: String) -> Bytes with Exception
+fn compile_wasi_module_rc_body_cached(stmts: Array[Stmt], entry_name: String, body_cache_in: CodegenBodyCache, body_cache_out: CodegenBodyCache) -> Bytes with Exception
 fn compile_wasi_module_rc_shadow(stmts: Array[Stmt], entry_name: String) -> Bytes with Exception
 fn compile_wasi_module_coverage(stmts: Array[Stmt], entry_name: String) -> Bytes with Exception
 fn compile_wasi_module_trace(stmts: Array[Stmt], entry_name: String) -> Bytes with Exception

--- a/lib/@vibe/compiler/codegen/wasi/index.vpkg
+++ b/lib/@vibe/compiler/codegen/wasi/index.vpkg
@@ -59,5 +59,6 @@ fn effect_lowering_prelude(stmts: Array[Stmt], entry_name: String, linked_import
 fn compile_wasi_module_replayed_impl(stmts: Array[Stmt], entry_name: String) -> Bytes with Exception
 fn compile_wasi_module_sliced_impl(stmts: Array[Stmt], entry_name: String) -> Bytes with Exception
 fn compile_wasi_module_rc_impl(stmts_in: Array[Stmt], entry_name: String) -> Bytes with Exception
+fn compile_wasi_module_rc_cached_impl(stmts_in: Array[Stmt], entry_name: String, body_cache_in: CodegenBodyCache, body_cache_out: CodegenBodyCache) -> Bytes with Exception
 fn compile_wasi_module_rc_impl_with_float_offsets(stmts_in: Array[Stmt], entry_name: String, checker_float_call_offsets: Array[Int]) -> Bytes with Exception
 fn compile_wasi_module_rc_shadow_impl(stmts_in: Array[Stmt], entry_name: String) -> Bytes with Exception

--- a/lib/@vibe/compiler/codegen/wasi/linked_compile.vibe
+++ b/lib/@vibe/compiler/codegen/wasi/linked_compile.vibe
@@ -4339,7 +4339,29 @@ export fn compile_wasi_module_linked_impl_with_float_offsets(stmts: Array[Stmt],
   if entry_user_idx < 0 && !library_mode && entry_name != "__no_entry__" {
     throw("entry `\{entry_name}` not found: no exported function named `\{entry_name}` (use __no_entry__ to build a test runner)")
   }
-  let str_strs = collect_strings_stmts(stmts)
+  // #2402: the empty string is seeded at pool slot 0, BEFORE the source
+  // strings. It is the one compiler-materialised string that user bodies
+  // embed (StringBuilder::freeze's join separator, ByteStream::to_string's
+  // accumulator); seeded after the source strings it moved whenever an edit
+  // added a novel literal, shifting the offset inside every unchanged body
+  // that embeds it and defeating cross-compile replay. "" is zero-length,
+  // so fronting it changes no other string's data offset. The remaining
+  // seeded strings (the #2199 OOB fragments below) stay where they are:
+  // only the generated builtin bodies reference them, and those are rebuilt
+  // by every compile.
+  let str_collected = collect_strings_stmts(stmts)
+  let str_strs = lc_fresh_string_array()
+  Array::push(str_strs, "")
+  let mut __sc = 0
+  while __sc < Array::length(str_collected) {
+    let __scs = Array::get(str_collected, __sc)
+    if String::length(__scs) > 0 {
+      Array::push(str_strs, __scs)
+    } else {
+      ()
+    }
+    __sc = __sc + 1
+  }
   let rec add_map_keys_expr: (Expr) -> Unit = (e) -> {
     match e {
       EMap(fields) => {
@@ -4403,13 +4425,8 @@ export fn compile_wasi_module_linked_impl_with_float_offsets(stmts: Array[Stmt],
     }
     __mk = __mk + 1
   }
-  // Always seed the empty string so codegen that materialises "" (e.g.
-  // StringBuilder::freeze's join separator, ByteStream::to_string's accumulator)
-  // can rely on str_table_lookup("") succeeding even when the source never
-  // mentions "" literally.
-  if !array_contains_str(str_strs, "") {
-    Array::push(str_strs, "")
-  }
+  // ("" is seeded at pool slot 0 above -- see the #2402 note at the pool's
+  // construction.)
   // #2199: every bounds-checked builtin's OOB abort prints
   // `<operation>: index <idx> out of bounds for length <len>` before its
   // `unreachable` (a bare trap reads as a compiler bug). Seed the message

--- a/lib/@vibe/compiler/codegen/wasi/linked_compile.vibe
+++ b/lib/@vibe/compiler/codegen/wasi/linked_compile.vibe
@@ -161,6 +161,7 @@ import @vibe/compiler/codegen/common_base {
   append_hidden_attempt_constructors,
   await_poll_pass,
   bcc_guard_synth_matches,
+  bcc_string_lists_equal,
   codegen_body_cache_find,
   codegen_body_cache_merge,
   codegen_body_cache_new,
@@ -4310,47 +4311,6 @@ export fn compile_wasi_module_linked_impl_with_float_offsets(stmts: Array[Stmt],
   // before this change (one added test in the entry): 581 of 4214 function
   // bodies differed, every one only in a slot immediate.
   let lambda_slot_base = ((num_user_funcs + 1023) / 1024) * 1024
-  // #2388 step 3: record the layout facts this compile's bodies are emitted
-  // against, and validate an incoming cross-compile cache against the same
-  // facts. A cached body's immediates assume the pin region's shape, the
-  // lambda-slot base, and the synthesized functions' names AND merged-
-  // statement positions (their positions decide the statement-ordered
-  // pre-pass tables -- string pool, signatures -- every body offset is
-  // computed from). Any mismatch makes replay unsound, so the cache is
-  // dropped wholesale: a miss costs a recompile, never a wrong body.
-  if pin_region_capacity >= 0 {
-    Array::push(body_cache_out.guard_meta, pin_region_src_n)
-    Array::push(body_cache_out.guard_meta, pin_region_capacity)
-    Array::push(body_cache_out.guard_meta, lambda_slot_base)
-    let mut __gsy = pin_region_capacity
-    while __gsy < num_user_funcs {
-      Array::push(body_cache_out.guard_synth_names, Array::get(fn_names_list, __gsy))
-      Array::push(body_cache_out.guard_synth_stmts, Array::get(fn_stmt_indices, __gsy))
-      __gsy = __gsy + 1
-    }
-  }
-  let body_cache_in_ok = if Array::length(body_cache_in.fn_indices) == 0 {
-    true
-  } else if pin_region_capacity < 0 {
-    // This compile did not run the pin reorder. Either the stmts were
-    // already lowered by an earlier compile in this same process (#1259's
-    // replay/sliced lanes re-feed the SAME mutated array, whose layout is
-    // exactly the harvest's -- the earlier compile's pads and synthesized
-    // lets now read as source names, so the reorder is a no-op skip), or
-    // the program has no synthesized functions at all. In both cases the
-    // incoming cache came from this identical layout; the cross-compile
-    // lane never lands here, because a fresh closure compile always
-    // lowers, always synthesizes, and therefore always reorders.
-    true
-  } else if Array::length(body_cache_in.guard_meta) == 0 {
-    // Guard-less but non-empty under a reordering compile: only hand-built
-    // test caches look like this (a real harvest of a reordering compile
-    // records guards, and codegen_body_cache_filter_src_below empties a
-    // guard-less cache before it can cross compiles). Accept unchanged.
-    true
-  } else {
-    Array::length(body_cache_in.guard_meta) == 3 && Array::get(body_cache_in.guard_meta, 0) == pin_region_src_n && Array::get(body_cache_in.guard_meta, 1) == pin_region_capacity && Array::get(body_cache_in.guard_meta, 2) == lambda_slot_base && Array::length(body_cache_in.guard_synth_names) == num_user_funcs - pin_region_capacity && bcc_guard_synth_matches(body_cache_in, fn_names_list, fn_stmt_indices, pin_region_capacity, num_user_funcs)
-  }
   let mut entry_user_idx = -1
   let mut ei = 0
   while ei < num_user_funcs {
@@ -5845,6 +5805,65 @@ export fn compile_wasi_module_linked_impl_with_float_offsets(stmts: Array[Stmt],
   }
   let num_generated = (max_builtin_func_idx - num_imported_funcs) + 1
   let func_offset = num_imported_funcs + num_generated
+  // #2388 step 3: record the layout facts this compile's bodies are emitted
+  // against, and validate an incoming cross-compile cache against the same
+  // facts. A cached body's immediates assume the pin region's shape, the
+  // lambda-slot base, the host-import/generated-builtin index layout below
+  // func_offset, and the synthesized functions' names AND merged-statement
+  // positions (their positions decide the statement-ordered pre-pass tables
+  // -- string pool, signatures -- every body offset is computed from). The
+  // import vector is pinned by the sorted used-builtin-name SET, not its
+  // size: the gated imports are assigned indices by a fixed sequence of
+  // has_key tests, so two different sets of equal size would assign each
+  // import a different index while every count still matched. Any mismatch
+  // makes replay unsound, so the cache is dropped wholesale: a miss costs a
+  // recompile, never a wrong body.
+  let guard_import_names_now = sorted_names_of(Map::keys(used_builtin_names))
+  let mut __gim = 0
+  while __gim < Array::length(linked_import_names) {
+    Array::push(guard_import_names_now, Array::get(linked_import_names, __gim))
+    __gim = __gim + 1
+  }
+  if pin_region_capacity >= 0 {
+    Array::push(body_cache_out.guard_meta, pin_region_src_n)
+    Array::push(body_cache_out.guard_meta, pin_region_capacity)
+    Array::push(body_cache_out.guard_meta, lambda_slot_base)
+    Array::push(body_cache_out.guard_meta, num_imported_funcs)
+    Array::push(body_cache_out.guard_meta, num_generated)
+    let mut __gsy = pin_region_capacity
+    while __gsy < num_user_funcs {
+      Array::push(body_cache_out.guard_synth_names, Array::get(fn_names_list, __gsy))
+      Array::push(body_cache_out.guard_synth_stmts, Array::get(fn_stmt_indices, __gsy))
+      __gsy = __gsy + 1
+    }
+    let mut __gin = 0
+    while __gin < Array::length(guard_import_names_now) {
+      Array::push(body_cache_out.guard_import_names, Array::get(guard_import_names_now, __gin))
+      __gin = __gin + 1
+    }
+  }
+  let body_cache_in_ok = if Array::length(body_cache_in.fn_indices) == 0 {
+    true
+  } else if pin_region_capacity < 0 {
+    // This compile did not run the pin reorder. Either the stmts were
+    // already lowered by an earlier compile in this same process (#1259's
+    // replay/sliced lanes re-feed the SAME mutated array, whose layout is
+    // exactly the harvest's -- the earlier compile's pads and synthesized
+    // lets now read as source names, so the reorder is a no-op skip), or
+    // the program has no synthesized functions at all. In both cases the
+    // incoming cache came from this identical layout; the cross-compile
+    // lane never lands here, because a fresh closure compile always
+    // lowers, always synthesizes, and therefore always reorders.
+    true
+  } else if Array::length(body_cache_in.guard_meta) == 0 {
+    // Guard-less but non-empty under a reordering compile: only hand-built
+    // test caches look like this (a real harvest of a reordering compile
+    // records guards, and codegen_body_cache_filter_src_below empties a
+    // guard-less cache before it can cross compiles). Accept unchanged.
+    true
+  } else {
+    Array::length(body_cache_in.guard_meta) == 5 && Array::get(body_cache_in.guard_meta, 0) == pin_region_src_n && Array::get(body_cache_in.guard_meta, 1) == pin_region_capacity && Array::get(body_cache_in.guard_meta, 2) == lambda_slot_base && Array::get(body_cache_in.guard_meta, 3) == num_imported_funcs && Array::get(body_cache_in.guard_meta, 4) == num_generated && Array::length(body_cache_in.guard_synth_names) == num_user_funcs - pin_region_capacity && bcc_guard_synth_matches(body_cache_in, fn_names_list, fn_stmt_indices, pin_region_capacity, num_user_funcs) && bcc_string_lists_equal(body_cache_in.guard_import_names, guard_import_names_now)
+  }
   let fn_indices_list = lc_fresh_int_array()
   let fn_returns_list = lc_fresh_int_array()
   let mut fi = 0

--- a/lib/@vibe/compiler/codegen/wasi/linked_compile.vibe
+++ b/lib/@vibe/compiler/codegen/wasi/linked_compile.vibe
@@ -161,6 +161,7 @@ import @vibe/compiler/codegen/common_base {
   append_hidden_attempt_constructors,
   await_poll_pass,
   bcc_guard_synth_matches,
+  bcc_int_lists_equal,
   bcc_string_lists_equal,
   codegen_body_cache_find,
   codegen_body_cache_merge,
@@ -3817,7 +3818,16 @@ export fn compile_wasi_module_linked_impl_with_float_offsets(stmts: Array[Stmt],
   //     The gate pins exactly this (ADR-0069 entry hardening), and it is what
   //     caught the first version of this guard, which special-cased only the
   //     sentinel.
+  // #2388 step 3: when late DCE actually removes statements, the statement
+  // index space compacts, and the body cache's file-prefix limit -- summed
+  // in PRE-prelude merged coordinates -- no longer bounds it from below (an
+  // edited entry function can compact DOWN under the limit). A pruned
+  // compile therefore neither records cross-compile guards nor consumes a
+  // persisted cache. The `vibe test` lane (`__no_entry__`) never prunes and
+  // keeps full reuse.
+  let mut late_dce_pruned = false
   if enable_late_dce && late_dce_has_entry {
+    let late_dce_pre_len = Array::length(stmts)
     let dce_pruned = dce_stmts(stmts, late_dce_roots)
     // `stmts` is threaded onward by reference, so the pruned program has to
     // replace its contents rather than rebind the name. `dce_stmts` builds a
@@ -3828,6 +3838,7 @@ export fn compile_wasi_module_linked_impl_with_float_offsets(stmts: Array[Stmt],
       Array::push(stmts, Array::get(dce_pruned, dce_i))
       dce_i = dce_i + 1
     }
+    late_dce_pruned = Array::length(stmts) != late_dce_pre_len
   } else {
     ()
   }
@@ -5824,7 +5835,30 @@ export fn compile_wasi_module_linked_impl_with_float_offsets(stmts: Array[Stmt],
     Array::push(guard_import_names_now, Array::get(linked_import_names, __gim))
     __gim = __gim + 1
   }
-  if pin_region_capacity >= 0 {
+  // Global name-membership guard: compile_call's `prefer_bound_call` and the
+  // func-table lookups match the SPELLED name across the whole program, and
+  // only builtin-spelled names take those branches. Prefix defs are #716
+  // path-mangled (`_exp_`/`_dep_` marker), so the names that can flip such a
+  // branch are the unmangled source-region ones. `__test_`/`__bench_` blocks
+  // are excluded -- nothing calls a test by name -- which is what keeps the
+  // append-a-test edit inside the cache.
+  let guard_unmangled_now = if pin_region_capacity >= 0 {
+    let raw = lc_fresh_string_array()
+    let mut __gun = 0
+    while __gun < pin_region_src_n {
+      let __gname = Array::get(fn_names_list, __gun)
+      if !String::contains(__gname, "_exp_") && !String::contains(__gname, "_dep_") && !String::starts_with(__gname, "__test_") && !String::starts_with(__gname, "__bench_") {
+        Array::push(raw, __gname)
+      } else {
+        ()
+      }
+      __gun = __gun + 1
+    }
+    sorted_names_of(raw)
+  } else {
+    lc_fresh_string_array()
+  }
+  if pin_region_capacity >= 0 && !late_dce_pruned {
     Array::push(body_cache_out.guard_meta, pin_region_src_n)
     Array::push(body_cache_out.guard_meta, pin_region_capacity)
     Array::push(body_cache_out.guard_meta, lambda_slot_base)
@@ -5840,6 +5874,21 @@ export fn compile_wasi_module_linked_impl_with_float_offsets(stmts: Array[Stmt],
     while __gin < Array::length(guard_import_names_now) {
       Array::push(body_cache_out.guard_import_names, Array::get(guard_import_names_now, __gin))
       __gin = __gin + 1
+    }
+    // ADR-0092 borrow-parameter ABI (call-site sensitive: an edit anywhere
+    // can flip an unchanged function's owned/borrowed parameter, changing
+    // its drop obligations and every caller's dup obligations). Names are
+    // sorted with masks aligned by construction.
+    let mut __gbn = 0
+    while __gbn < Array::length(lc_borrow_param_user_srt) {
+      Array::push(body_cache_out.guard_borrow_names, Array::get(lc_borrow_param_user_srt, __gbn))
+      Array::push(body_cache_out.guard_borrow_masks, Array::get(lc_borrow_param_mask, __gbn))
+      __gbn = __gbn + 1
+    }
+    let mut __gum = 0
+    while __gum < Array::length(guard_unmangled_now) {
+      Array::push(body_cache_out.guard_unmangled_names, Array::get(guard_unmangled_now, __gum))
+      __gum = __gum + 1
     }
   }
   let body_cache_in_ok = if Array::length(body_cache_in.fn_indices) == 0 {
@@ -5862,7 +5911,7 @@ export fn compile_wasi_module_linked_impl_with_float_offsets(stmts: Array[Stmt],
     // guard-less cache before it can cross compiles). Accept unchanged.
     true
   } else {
-    Array::length(body_cache_in.guard_meta) == 5 && Array::get(body_cache_in.guard_meta, 0) == pin_region_src_n && Array::get(body_cache_in.guard_meta, 1) == pin_region_capacity && Array::get(body_cache_in.guard_meta, 2) == lambda_slot_base && Array::get(body_cache_in.guard_meta, 3) == num_imported_funcs && Array::get(body_cache_in.guard_meta, 4) == num_generated && Array::length(body_cache_in.guard_synth_names) == num_user_funcs - pin_region_capacity && bcc_guard_synth_matches(body_cache_in, fn_names_list, fn_stmt_indices, pin_region_capacity, num_user_funcs) && bcc_string_lists_equal(body_cache_in.guard_import_names, guard_import_names_now)
+    !late_dce_pruned && Array::length(body_cache_in.guard_meta) == 5 && Array::get(body_cache_in.guard_meta, 0) == pin_region_src_n && Array::get(body_cache_in.guard_meta, 1) == pin_region_capacity && Array::get(body_cache_in.guard_meta, 2) == lambda_slot_base && Array::get(body_cache_in.guard_meta, 3) == num_imported_funcs && Array::get(body_cache_in.guard_meta, 4) == num_generated && Array::length(body_cache_in.guard_synth_names) == num_user_funcs - pin_region_capacity && bcc_guard_synth_matches(body_cache_in, fn_names_list, fn_stmt_indices, pin_region_capacity, num_user_funcs) && bcc_string_lists_equal(body_cache_in.guard_import_names, guard_import_names_now) && bcc_string_lists_equal(body_cache_in.guard_borrow_names, lc_borrow_param_user_srt) && bcc_int_lists_equal(body_cache_in.guard_borrow_masks, lc_borrow_param_mask) && bcc_string_lists_equal(body_cache_in.guard_unmangled_names, guard_unmangled_now)
   }
   let fn_indices_list = lc_fresh_int_array()
   let fn_returns_list = lc_fresh_int_array()

--- a/lib/@vibe/compiler/codegen/wasi/linked_compile.vibe
+++ b/lib/@vibe/compiler/codegen/wasi/linked_compile.vibe
@@ -160,6 +160,7 @@ import @vibe/compiler/codegen/common_base {
   agg_info_of_type_expr,
   append_hidden_attempt_constructors,
   await_poll_pass,
+  bcc_guard_synth_matches,
   codegen_body_cache_find,
   codegen_body_cache_merge,
   codegen_body_cache_new,
@@ -4066,6 +4067,10 @@ export fn compile_wasi_module_linked_impl_with_float_offsets(stmts: Array[Stmt],
   // uncovered functions (measured: a one-test file answered
   // "functions 2/1025"). Coverage is a measurement lane; edit-stable indices
   // buy it nothing.
+  // #2388 step 3: the pin region's shape, exposed for the body-cache guards
+  // below (-1 = the reorder did not run, so no cross-compile reuse).
+  let mut pin_region_src_n = 0 - 1
+  let mut pin_region_capacity = 0 - 1
   if !library_mode && !coverage {
     let __pp_sorted = sorted_names_of(pre_prelude_let_names)
     let __pin_total = Array::length(fn_names_list)
@@ -4083,6 +4088,8 @@ export fn compile_wasi_module_linked_impl_with_float_offsets(stmts: Array[Stmt],
     if Array::length(__pin_synth_idx) > 0 {
       let __pin_src_n = Array::length(__pin_src_idx)
       let __pin_capacity = ((__pin_src_n + 1023) / 1024) * 1024
+      pin_region_src_n = __pin_src_n
+      pin_region_capacity = __pin_capacity
       let __new_names = lc_fresh_string_array()
       let __new_params = lc_fresh_int_array()
       let __new_env = lc_fresh_bool_array()
@@ -4303,6 +4310,47 @@ export fn compile_wasi_module_linked_impl_with_float_offsets(stmts: Array[Stmt],
   // before this change (one added test in the entry): 581 of 4214 function
   // bodies differed, every one only in a slot immediate.
   let lambda_slot_base = ((num_user_funcs + 1023) / 1024) * 1024
+  // #2388 step 3: record the layout facts this compile's bodies are emitted
+  // against, and validate an incoming cross-compile cache against the same
+  // facts. A cached body's immediates assume the pin region's shape, the
+  // lambda-slot base, and the synthesized functions' names AND merged-
+  // statement positions (their positions decide the statement-ordered
+  // pre-pass tables -- string pool, signatures -- every body offset is
+  // computed from). Any mismatch makes replay unsound, so the cache is
+  // dropped wholesale: a miss costs a recompile, never a wrong body.
+  if pin_region_capacity >= 0 {
+    Array::push(body_cache_out.guard_meta, pin_region_src_n)
+    Array::push(body_cache_out.guard_meta, pin_region_capacity)
+    Array::push(body_cache_out.guard_meta, lambda_slot_base)
+    let mut __gsy = pin_region_capacity
+    while __gsy < num_user_funcs {
+      Array::push(body_cache_out.guard_synth_names, Array::get(fn_names_list, __gsy))
+      Array::push(body_cache_out.guard_synth_stmts, Array::get(fn_stmt_indices, __gsy))
+      __gsy = __gsy + 1
+    }
+  }
+  let body_cache_in_ok = if Array::length(body_cache_in.fn_indices) == 0 {
+    true
+  } else if pin_region_capacity < 0 {
+    // This compile did not run the pin reorder. Either the stmts were
+    // already lowered by an earlier compile in this same process (#1259's
+    // replay/sliced lanes re-feed the SAME mutated array, whose layout is
+    // exactly the harvest's -- the earlier compile's pads and synthesized
+    // lets now read as source names, so the reorder is a no-op skip), or
+    // the program has no synthesized functions at all. In both cases the
+    // incoming cache came from this identical layout; the cross-compile
+    // lane never lands here, because a fresh closure compile always
+    // lowers, always synthesizes, and therefore always reorders.
+    true
+  } else if Array::length(body_cache_in.guard_meta) == 0 {
+    // Guard-less but non-empty under a reordering compile: only hand-built
+    // test caches look like this (a real harvest of a reordering compile
+    // records guards, and codegen_body_cache_filter_src_below empties a
+    // guard-less cache before it can cross compiles). Accept unchanged.
+    true
+  } else {
+    Array::length(body_cache_in.guard_meta) == 3 && Array::get(body_cache_in.guard_meta, 0) == pin_region_src_n && Array::get(body_cache_in.guard_meta, 1) == pin_region_capacity && Array::get(body_cache_in.guard_meta, 2) == lambda_slot_base && Array::length(body_cache_in.guard_synth_names) == num_user_funcs - pin_region_capacity && bcc_guard_synth_matches(body_cache_in, fn_names_list, fn_stmt_indices, pin_region_capacity, num_user_funcs)
+  }
   let mut entry_user_idx = -1
   let mut ei = 0
   while ei < num_user_funcs {
@@ -6457,7 +6505,11 @@ export fn compile_wasi_module_linked_impl_with_float_offsets(stmts: Array[Stmt],
       // This is where a parallel body phase pays off: the whole per-function
       // pipeline below -- Perceus plan, locals analysis, ctx construction,
       // compile_expr -- is skipped, not merely discarded.
-      let __cache_hit = codegen_body_cache_find(body_cache_in, bi)
+      let __cache_hit = if body_cache_in_ok {
+        codegen_body_cache_find(body_cache_in, bi)
+      } else {
+        0 - 1
+      }
       if __cache_hit >= 0 {
         codegen_body_cache_replay(body_cache_in, __cache_hit, bodies, meta_i32, meta_i64, meta_v128, lt_w, table_slots_used)
       } else {
@@ -7294,7 +7346,7 @@ export fn compile_wasi_module_linked_impl_with_float_offsets(stmts: Array[Stmt],
         // Harvest is unconditional and cheap (it copies references into parallel
         // arrays, it does not re-encode). The cache is only READ when a caller
         // supplies one.
-        codegen_body_cache_record(body_cache_out, bi, bodies, meta_i32, meta_i64, meta_v128, lt_w, Array::get(lambda_bases, bi), lambda_planned_end, table_slots_used, __slot_lo, Array::length(table_slots_used))
+        codegen_body_cache_record(body_cache_out, bi, Array::get(fn_stmt_indices, bi), bodies, meta_i32, meta_i64, meta_v128, lt_w, Array::get(lambda_bases, bi), lambda_planned_end, table_slots_used, __slot_lo, Array::length(table_slots_used))
       }
     }
     bi = bi + 1
@@ -8967,6 +9019,16 @@ export fn compile_wasi_module_rc_impl(stmts_in: Array[Stmt], entry_name: String)
 export fn compile_wasi_module_rc_impl_with_float_offsets(stmts_in: Array[Stmt], entry_name: String, checker_float_call_offsets: Array[Int]) -> Bytes with Exception {
   let stmts = elaborate_heap_params(stmts_in)
   compile_wasi_module_linked_impl_with_float_offsets(stmts, entry_name, array_empty(), array_empty(), false, true, false, false, false, false, true, empty_dbg_prov(), codegen_body_cache_new(), codegen_body_cache_new(), 0, 0 - 1, checker_float_call_offsets)
+}
+
+/// #2388 step 3: compile_wasi_module_rc_impl with the body caches threaded
+/// through -- `body_cache_in` entries replay instead of compiling (the body
+/// loop already consults it, #1259), and `body_cache_out` harvests this
+/// compile's bodies for the caller to persist. Everything else matches the
+/// plain RC lane flag for flag.
+export fn compile_wasi_module_rc_cached_impl(stmts_in: Array[Stmt], entry_name: String, body_cache_in: CodegenBodyCache, body_cache_out: CodegenBodyCache) -> Bytes with Exception {
+  let stmts = elaborate_heap_params(stmts_in)
+  compile_wasi_module_linked_impl(stmts, entry_name, array_empty(), array_empty(), false, true, false, false, false, false, true, empty_dbg_prov(), body_cache_in, body_cache_out, 0, 0 - 1)
 }
 
 /// Preserve the post-lowering AST for the explicit `no-dce` compile mode.

--- a/lib/@vibe/compiler/entry/compiler/file_compile/file_compile.vibe
+++ b/lib/@vibe/compiler/entry/compiler/file_compile/file_compile.vibe
@@ -50,12 +50,19 @@ import @vibe/compiler/codegen {
   compile_wasi_module_break,
   compile_wasi_module_coverage,
   compile_wasi_module_rc,
+  compile_wasi_module_rc_body_cached,
   compile_wasi_module_rc_shadow,
   compile_wasi_module_trace
 }
 
 import @vibe/compiler/codegen/common_base {
-  DbgProv
+  CodegenBodyCache,
+  DbgProv,
+  codegen_body_cache_filter_src_below,
+  codegen_body_cache_from_bytes,
+  codegen_body_cache_merge,
+  codegen_body_cache_new,
+  codegen_body_cache_to_bytes
 }
 
 import @vibe/compiler/codegen/wasi {
@@ -659,6 +666,278 @@ export fn compile_file_fs_mode_rc(entry_path: String, entry_name: String) -> Byt
   // unset is `"" != "0"`. It is also the lane that cannot afford the
   // checker's offsets today; see compile_file_fs_mode above for the numbers.
   compile_wasi_module_rc(merged_stmts, entry_name)
+}
+
+/// #2388 step 3: like build_grouped_merged_stmts, but ALSO reports, per flat
+/// source file, its path, its content fingerprint, and how many merged
+/// top-level statements it contributed -- measured by length delta around
+/// each append, the same technique build_grouped_merged_stmts_prov uses, so
+/// the counts stay aligned however many statements a file contributes.
+/// `merged` is identical to the normal path's.
+fn build_grouped_merged_stmts_counted(source_groups: Array[(String, Array[(String, String)])]) -> (Array[Stmt], Array[String], Array[String], Array[Int]) with Exception {
+  namespace_rename_originals_reset()
+  let merged = array_empty()
+  let out_paths = array_empty()
+  let out_fps = array_empty()
+  let out_counts = array_empty()
+  let flat_sources = flatten_source_groups_local(source_groups)
+  let (file_paths, file_stmts) = parse_sources_for_merge(flat_sources)
+  let plan_entry = if Array::length(file_paths) > 0 {
+    Array::get(file_paths, Array::length(file_paths) - 1)
+  } else {
+    ""
+  }
+  let plan = build_export_rename_plan(file_paths, file_stmts, plan_entry)
+  let fallback_clone_offset_delta = [0]
+  let mut flat_idx = 0
+  let mut gi = 0
+  while gi < Array::length(source_groups) {
+    let (_, sources) = Array::get(source_groups, gi)
+    let source_count = Array::length(sources)
+    let mut si = 0
+    while si < source_count {
+      let (path, source) = Array::get(sources, si)
+      Array::push(out_paths, path)
+      Array::push(out_fps, compact_string_fingerprint(source))
+      let before = Array::length(merged)
+      append_merged_stmts_for_file(merged, path, Array::get(file_stmts, flat_idx), flat_idx == Array::length(file_paths) - 1, plan, flat_sources, file_stmts, fallback_clone_offset_delta, 0)
+      Array::push(out_counts, Array::length(merged) - before)
+      flat_idx = flat_idx + 1
+      si = si + 1
+    }
+    gi = gi + 1
+  }
+  (merged, out_paths, out_fps, out_counts)
+}
+
+//# #2388 step 3: codegen body-cache artifact (wrapper codec)
+//
+// The stored artifact is self-describing: a per-file table (path, content
+// fingerprint, merged-statement count, in merge order) followed by the
+// CodegenBodyCache blob. It is stored under ONE fixed artifact fingerprint
+// per entry -- the point is to be loadable when the sources DID change --
+// and the per-file table inside decides how much of the cache is still
+// valid. The persistent-cache version tag already keys the store on the
+// compiler's own codegen fingerprint, so an artifact can never cross
+// compiler versions.
+
+fn bcw_push_int(buf: Bytes, v: Int) -> Unit with Exception {
+  if v < 0 {
+    throw(String::concat("body-cache wrapper: negative field ", __to_string(v)))
+  } else {
+    ()
+  }
+  let mut x = v
+  let mut more = true
+  while more {
+    let low = x&127
+    x = x>>7
+    if x == 0 {
+      Bytes::push(buf, low)
+      more = false
+    } else {
+      Bytes::push(buf, low|128)
+    }
+  }
+}
+
+fn bcw_push_string(buf: Bytes, s: String) -> Unit with Exception {
+  bcw_push_int(buf, String::length(s))
+  let mut i = 0
+  while i < String::length(s) {
+    Bytes::push(buf, String::char_code_at(s, i))
+    i = i + 1
+  }
+}
+
+fn bcw_read_int(b: Bytes, pos: Int) -> (Int, Int) {
+  let n = Bytes::length(b)
+  let mut p = pos
+  let mut shift = 0
+  let mut acc = 0
+  let mut done = false
+  let mut bad = false
+  while !done && !bad {
+    if p >= n || shift > 34 {
+      bad = true
+    } else {
+      let byte = Bytes::get(b, p)
+      p = p + 1
+      acc = acc|((byte&127)<<shift)
+      shift = shift + 7
+      if (byte&128) == 0 {
+        done = true
+      } else {
+        ()
+      }
+    }
+  }
+  if bad {
+    (0, 0 - 1)
+  } else {
+    (acc, p)
+  }
+}
+
+fn bcw_read_string(b: Bytes, pos: Int) -> (String, Int) {
+  let (len, p0) = bcw_read_int(b, pos)
+  if p0 < 0 || len < 0 || p0 + len > Bytes::length(b) {
+    ("", 0 - 1)
+  } else {
+    let parts = array_empty()
+    let mut i = 0
+    while i < len {
+      Array::push(parts, String::from_byte(Bytes::get(b, p0 + i)))
+      i = i + 1
+    }
+    (String::join(parts, ""), p0 + len)
+  }
+}
+
+fn encode_body_cache_artifact(paths: Array[String], fps: Array[String], counts: Array[Int], cache: CodegenBodyCache) -> Bytes with Exception {
+  let buf = Bytes::new()
+  Bytes::push(buf, 'V')
+  Bytes::push(buf, 'B')
+  Bytes::push(buf, 'W')
+  Bytes::push(buf, '1')
+  bcw_push_int(buf, Array::length(paths))
+  let mut i = 0
+  while i < Array::length(paths) {
+    bcw_push_string(buf, Array::get(paths, i))
+    bcw_push_string(buf, Array::get(fps, i))
+    bcw_push_int(buf, Array::get(counts, i))
+    i = i + 1
+  }
+  Bytes::append(buf, codegen_body_cache_to_bytes(cache))
+  buf
+}
+
+/// Decode the stored artifact and cut it down to what the CURRENT compile may
+/// replay: the longest leading run of files whose path, content fingerprint,
+/// and merged-statement count all match gives the unchanged merged-statement
+/// prefix, and only cached bodies compiled from below that boundary survive
+/// (codegen_body_cache_filter_src_below also drops synthesized and pad
+/// entries via the recorded guards). Anything malformed answers an empty
+/// cache -- a damaged artifact costs a recompile, never a wrong body.
+fn decode_body_cache_artifact_for(b: Bytes, paths: Array[String], fps: Array[String], counts: Array[Int]) -> CodegenBodyCache {
+  if Bytes::length(b) < 4 || Bytes::get(b, 0) != 'V' || Bytes::get(b, 1) != 'B' || Bytes::get(b, 2) != 'W' || Bytes::get(b, 3) != '1' {
+    codegen_body_cache_new()
+  } else {
+    let (file_n, p0) = bcw_read_int(b, 4)
+    if p0 < 0 {
+      codegen_body_cache_new()
+    } else {
+      let mut p = p0
+      let mut i = 0
+      let mut limit = 0
+      let mut still_matching = true
+      let mut malformed = false
+      while !malformed && i < file_n {
+        let (spath, p1) = bcw_read_string(b, p)
+        let (sfp, p2) = if p1 < 0 {
+          ("", 0 - 1)
+        } else {
+          bcw_read_string(b, p1)
+        }
+        let (scount, p3) = if p2 < 0 {
+          (0, 0 - 1)
+        } else {
+          bcw_read_int(b, p2)
+        }
+        if p3 < 0 {
+          malformed = true
+        } else {
+          p = p3
+          if still_matching && i < Array::length(paths) && spath == Array::get(paths, i) && sfp == Array::get(fps, i) && scount == Array::get(counts, i) {
+            limit = limit + scount
+          } else {
+            still_matching = false
+          }
+        }
+        i = i + 1
+      }
+      if malformed || limit == 0 {
+        codegen_body_cache_new()
+      } else {
+        match codegen_body_cache_from_bytes(Bytes::slice(b, p, Bytes::length(b))) {
+          Some(cache) => codegen_body_cache_filter_src_below(cache, limit),
+          None => codegen_body_cache_new()
+        }
+      }
+    }
+  }
+}
+
+/// #2388 step 3: compile_file_fs_mode_rc with the cross-compile codegen body
+/// cache. `cache_mode` comes from the CLI adapter's VIBE_CODEGEN_BODY_CACHE
+/// read (this layer stays Env-free, #634):
+///
+///   "verify" -- compile everything fresh, then compile AGAIN replaying the
+///     persisted bodies, and throw on the first byte the two outputs differ
+///     at. Proves the replay lane end-to-end on real edits at double compile
+///     cost; the returned bytes are always the fresh compile's.
+///   "on" -- replay persisted bodies directly. The recorded guards
+///     (pin region shape, lambda slot base, synthesized names and
+///     positions) drop the cache wholesale on any layout drift.
+///
+/// Either way the artifact is refreshed with this compile's harvest, under a
+/// fixed per-entry artifact key -- the per-file table INSIDE the artifact is
+/// what decides validity next time, because the whole point is to be usable
+/// when the sources changed (a source-keyed fingerprint would only ever hit
+/// when nothing changed at all).
+export fn compile_file_fs_mode_rc_body_cached(entry_path: String, entry_name: String, cache_mode: String) -> Bytes with Exception + Fs {
+  let source_groups = collect_source_groups_fs(entry_path)
+  let next_db = prepare_file_fs_from_source_groups_persistent_cached(db_new(), entry_path, source_groups)
+  let _ = next_db
+  let (merged_stmts, file_paths, file_fps, file_counts) = build_grouped_merged_stmts_counted(source_groups)
+  let cache_in = match load_persistent_artifact("codegen-body-cache", entry_name, "self-describing") {
+    Some(stored) => decode_body_cache_artifact_for(stored, file_paths, file_fps, file_counts),
+    None => codegen_body_cache_new()
+  }
+  if cache_mode == "verify" {
+    let fresh_out = codegen_body_cache_new()
+    let fresh = compile_wasi_module_rc_body_cached(merged_stmts, entry_name, codegen_body_cache_new(), fresh_out)
+    if Array::length(cache_in.fn_indices) > 0 {
+      // Second compile of the SAME (now already-lowered) stmts: the #1259
+      // replay/sliced gates prove that recompile is byte-identical to the
+      // first, so any difference here is attributable to the persisted
+      // bodies being replayed.
+      let replayed = compile_wasi_module_rc_body_cached(merged_stmts, entry_name, cache_in, codegen_body_cache_new())
+      let fresh_n = Bytes::length(fresh)
+      let rn = Bytes::length(replayed)
+      if fresh_n != rn {
+        throw(String::concat("codegen body-cache verify: length mismatch (fresh ", String::concat(__to_string(fresh_n), String::concat(" B, replayed ", String::concat(__to_string(rn), " B) -- a persisted body replayed wrong; unset VIBE_CODEGEN_BODY_CACHE and report this")))))
+      } else {
+        ()
+      }
+      let mut i = 0
+      let mut bad = 0 - 1
+      while bad < 0 && i < fresh_n {
+        if Bytes::get(fresh, i) != Bytes::get(replayed, i) {
+          bad = i
+        } else {
+          i = i + 1
+        }
+      }
+      if bad >= 0 {
+        throw(String::concat("codegen body-cache verify: byte mismatch at offset ", String::concat(__to_string(bad), " -- a persisted body replayed wrong; unset VIBE_CODEGEN_BODY_CACHE and report this")))
+      } else {
+        ()
+      }
+    } else {
+      ()
+    }
+    store_persistent_artifact("codegen-body-cache", entry_name, "self-describing", encode_body_cache_artifact(file_paths, file_fps, file_counts, fresh_out))
+    fresh
+  } else {
+    let cache_out = codegen_body_cache_new()
+    let bytes = compile_wasi_module_rc_body_cached(merged_stmts, entry_name, cache_in, cache_out)
+    // Replayed entries are not re-recorded, so the refreshed artifact is the
+    // new harvest plus the entries it replayed; merge prefers the new
+    // harvest's guards, which describe this compile's layout.
+    store_persistent_artifact("codegen-body-cache", entry_name, "self-describing", encode_body_cache_artifact(file_paths, file_fps, file_counts, codegen_body_cache_merge(cache_out, cache_in)))
+    bytes
+  }
 }
 
 /// #1553: emit a named heap mark for the FS-compile memory measurement. The

--- a/lib/@vibe/compiler/entry/compiler/file_compile/file_compile.vibe
+++ b/lib/@vibe/compiler/entry/compiler/file_compile/file_compile.vibe
@@ -794,21 +794,49 @@ fn bcw_read_string(b: Bytes, pos: Int) -> (String, Int) {
   }
 }
 
+/// Content checksum over `b[start..)`: the same dual-modulus rolling shape
+/// as compact_string_fingerprint, over bytes. Guards the artifact against
+/// same-length corruption that the length-prefixed framing cannot see -- a
+/// bit flip inside a cached body would otherwise replay as wrong
+/// instructions under `on` mode.
+fn bcw_checksum(b: Bytes, start: Int) -> (Int, Int) {
+  let mut h1 = 17
+  let mut h2 = 29
+  let n = Bytes::length(b)
+  let mut i = start
+  while i < n {
+    let byte = Bytes::get(b, i)
+    h1 = (h1 * 131 + byte) % 2147483647
+    h2 = (h2 * 137 + byte) % 2147483629
+    i = i + 1
+  }
+  (h1, h2)
+}
+
 fn encode_body_cache_artifact(paths: Array[String], fps: Array[String], counts: Array[Int], cache: CodegenBodyCache) -> Bytes with Exception {
+  // Payload first, so the header can carry its checksum. The checksum
+  // covers the WHOLE payload -- the per-file table included, because a
+  // corrupted statement count would corrupt the replay limit just as
+  // silently as a corrupted body.
+  let payload = Bytes::new()
+  bcw_push_int(payload, Array::length(paths))
+  let mut i = 0
+  while i < Array::length(paths) {
+    bcw_push_string(payload, Array::get(paths, i))
+    bcw_push_string(payload, Array::get(fps, i))
+    bcw_push_int(payload, Array::get(counts, i))
+    i = i + 1
+  }
+  Bytes::append(payload, codegen_body_cache_to_bytes(cache))
+  let (h1, h2) = bcw_checksum(payload, 0)
   let buf = Bytes::new()
   Bytes::push(buf, 'V')
   Bytes::push(buf, 'B')
   Bytes::push(buf, 'W')
-  Bytes::push(buf, '1')
-  bcw_push_int(buf, Array::length(paths))
-  let mut i = 0
-  while i < Array::length(paths) {
-    bcw_push_string(buf, Array::get(paths, i))
-    bcw_push_string(buf, Array::get(fps, i))
-    bcw_push_int(buf, Array::get(counts, i))
-    i = i + 1
-  }
-  Bytes::append(buf, codegen_body_cache_to_bytes(cache))
+  Bytes::push(buf, '2')
+  bcw_push_int(buf, h1)
+  bcw_push_int(buf, h2)
+  Bytes::append(buf, payload)
   buf
 }
 
@@ -820,49 +848,69 @@ fn encode_body_cache_artifact(paths: Array[String], fps: Array[String], counts: 
 /// entries via the recorded guards). Anything malformed answers an empty
 /// cache -- a damaged artifact costs a recompile, never a wrong body.
 fn decode_body_cache_artifact_for(b: Bytes, paths: Array[String], fps: Array[String], counts: Array[Int]) -> CodegenBodyCache {
-  if Bytes::length(b) < 4 || Bytes::get(b, 0) != 'V' || Bytes::get(b, 1) != 'B' || Bytes::get(b, 2) != 'W' || Bytes::get(b, 3) != '1' {
+  if Bytes::length(b) < 4 || Bytes::get(b, 0) != 'V' || Bytes::get(b, 1) != 'B' || Bytes::get(b, 2) != 'W' || Bytes::get(b, 3) != '2' {
     codegen_body_cache_new()
   } else {
-    let (file_n, p0) = bcw_read_int(b, 4)
-    if p0 < 0 {
+    let (stored_h1, ph1) = bcw_read_int(b, 4)
+    let (stored_h2, ph2) = if ph1 < 0 {
+      (0, 0 - 1)
+    } else {
+      bcw_read_int(b, ph1)
+    }
+    let checksum_ok = if ph2 < 0 {
+      false
+    } else {
+      let (h1, h2) = bcw_checksum(b, ph2)
+      h1 == stored_h1 && h2 == stored_h2
+    }
+    if !checksum_ok {
       codegen_body_cache_new()
     } else {
-      let mut p = p0
-      let mut i = 0
-      let mut limit = 0
-      let mut still_matching = true
-      let mut malformed = false
-      while !malformed && i < file_n {
-        let (spath, p1) = bcw_read_string(b, p)
-        let (sfp, p2) = if p1 < 0 {
-          ("", 0 - 1)
-        } else {
-          bcw_read_string(b, p1)
-        }
-        let (scount, p3) = if p2 < 0 {
-          (0, 0 - 1)
-        } else {
-          bcw_read_int(b, p2)
-        }
-        if p3 < 0 {
-          malformed = true
-        } else {
-          p = p3
-          if still_matching && i < Array::length(paths) && spath == Array::get(paths, i) && sfp == Array::get(fps, i) && scount == Array::get(counts, i) {
-            limit = limit + scount
-          } else {
-            still_matching = false
-          }
-        }
-        i = i + 1
-      }
-      if malformed || limit == 0 {
-        codegen_body_cache_new()
+      decode_body_cache_payload_for(b, ph2, paths, fps, counts)
+    }
+  }
+}
+
+fn decode_body_cache_payload_for(b: Bytes, payload_start: Int, paths: Array[String], fps: Array[String], counts: Array[Int]) -> CodegenBodyCache {
+  let (file_n, p0) = bcw_read_int(b, payload_start)
+  if p0 < 0 {
+    codegen_body_cache_new()
+  } else {
+    let mut p = p0
+    let mut i = 0
+    let mut limit = 0
+    let mut still_matching = true
+    let mut malformed = false
+    while !malformed && i < file_n {
+      let (spath, p1) = bcw_read_string(b, p)
+      let (sfp, p2) = if p1 < 0 {
+        ("", 0 - 1)
       } else {
-        match codegen_body_cache_from_bytes(Bytes::slice(b, p, Bytes::length(b))) {
-          Some(cache) => codegen_body_cache_filter_src_below(cache, limit),
-          None => codegen_body_cache_new()
+        bcw_read_string(b, p1)
+      }
+      let (scount, p3) = if p2 < 0 {
+        (0, 0 - 1)
+      } else {
+        bcw_read_int(b, p2)
+      }
+      if p3 < 0 {
+        malformed = true
+      } else {
+        p = p3
+        if still_matching && i < Array::length(paths) && spath == Array::get(paths, i) && sfp == Array::get(fps, i) && scount == Array::get(counts, i) {
+          limit = limit + scount
+        } else {
+          still_matching = false
         }
+      }
+      i = i + 1
+    }
+    if malformed || limit == 0 {
+      codegen_body_cache_new()
+    } else {
+      match codegen_body_cache_from_bytes(Bytes::slice(b, p, Bytes::length(b))) {
+        Some(cache) => codegen_body_cache_filter_src_below(cache, limit),
+        None => codegen_body_cache_new()
       }
     }
   }
@@ -880,17 +928,25 @@ fn decode_body_cache_artifact_for(b: Bytes, paths: Array[String], fps: Array[Str
 ///     (pin region shape, lambda slot base, synthesized names and
 ///     positions) drop the cache wholesale on any layout drift.
 ///
-/// Either way the artifact is refreshed with this compile's harvest, under a
-/// fixed per-entry artifact key -- the per-file table INSIDE the artifact is
-/// what decides validity next time, because the whole point is to be usable
-/// when the sources changed (a source-keyed fingerprint would only ever hit
-/// when nothing changed at all).
+/// Either way the artifact is refreshed with this compile's harvest, under
+/// an artifact key scoped to the entry PATH but not to source content --
+/// the per-file table INSIDE the artifact is what decides validity next
+/// time, because the whole point is to be usable when the sources changed
+/// (a source-keyed fingerprint would only ever hit when nothing changed at
+/// all). The artifact carries a payload checksum; any corruption -- a
+/// same-length bit flip in a cached body included -- decodes as an empty
+/// cache and recompiles.
 export fn compile_file_fs_mode_rc_body_cached(entry_path: String, entry_name: String, cache_mode: String) -> Bytes with Exception + Fs {
   let source_groups = collect_source_groups_fs(entry_path)
   let next_db = prepare_file_fs_from_source_groups_persistent_cached(db_new(), entry_path, source_groups)
   let _ = next_db
   let (merged_stmts, file_paths, file_fps, file_counts) = build_grouped_merged_stmts_counted(source_groups)
-  let cache_in = match load_persistent_artifact("codegen-body-cache", entry_name, "self-describing") {
+  // The key is independent of source CONTENT (the point is to hit after an
+  // edit) but scoped to the entry PATH: two roots that share a conventional
+  // entry name (`run`, `main`) must not share one artifact slot, or their
+  // concurrent stores race on the same temp file and one aborts.
+  let artifact_key = String::concat("self-describing-", compact_string_fingerprint(entry_path))
+  let cache_in = match load_persistent_artifact("codegen-body-cache", entry_name, artifact_key) {
     Some(stored) => decode_body_cache_artifact_for(stored, file_paths, file_fps, file_counts),
     None => codegen_body_cache_new()
   }
@@ -927,7 +983,7 @@ export fn compile_file_fs_mode_rc_body_cached(entry_path: String, entry_name: St
     } else {
       ()
     }
-    store_persistent_artifact("codegen-body-cache", entry_name, "self-describing", encode_body_cache_artifact(file_paths, file_fps, file_counts, fresh_out))
+    store_persistent_artifact("codegen-body-cache", entry_name, artifact_key, encode_body_cache_artifact(file_paths, file_fps, file_counts, fresh_out))
     fresh
   } else {
     let cache_out = codegen_body_cache_new()
@@ -935,7 +991,7 @@ export fn compile_file_fs_mode_rc_body_cached(entry_path: String, entry_name: St
     // Replayed entries are not re-recorded, so the refreshed artifact is the
     // new harvest plus the entries it replayed; merge prefers the new
     // harvest's guards, which describe this compile's layout.
-    store_persistent_artifact("codegen-body-cache", entry_name, "self-describing", encode_body_cache_artifact(file_paths, file_fps, file_counts, codegen_body_cache_merge(cache_out, cache_in)))
+    store_persistent_artifact("codegen-body-cache", entry_name, artifact_key, encode_body_cache_artifact(file_paths, file_fps, file_counts, codegen_body_cache_merge(cache_out, cache_in)))
     bytes
   }
 }

--- a/lib/@vibe/compiler/entry/compiler/file_compile/file_compile.vibe
+++ b/lib/@vibe/compiler/entry/compiler/file_compile/file_compile.vibe
@@ -58,6 +58,8 @@ import @vibe/compiler/codegen {
 import @vibe/compiler/codegen/common_base {
   CodegenBodyCache,
   DbgProv,
+  bcc_int_lists_equal,
+  bcc_string_lists_equal,
   codegen_body_cache_filter_src_below,
   codegen_body_cache_from_bytes,
   codegen_body_cache_merge,
@@ -936,6 +938,18 @@ fn decode_body_cache_payload_for(b: Bytes, payload_start: Int, paths: Array[Stri
 /// all). The artifact carries a payload checksum; any corruption -- a
 /// same-length bit flip in a cached body included -- decodes as an empty
 /// cache and recompiles.
+/// #2388 step 3: full guard-set equality between two caches. Used where the
+/// consuming compile's own validation cannot run: the verify lane's second
+/// compile re-feeds the already-lowered stmts, where linked_compile's guard
+/// validation legitimately stands down (the pin reorder is a no-op there),
+/// so expected guard drift from an edit must be turned into a cache miss
+/// HERE, against the fresh harvest's guards -- not left to throw as a
+/// verify mismatch. Also decides whether a consumed cache may be merged
+/// back into the refreshed artifact.
+fn body_cache_guards_equal(a: CodegenBodyCache, b: CodegenBodyCache) -> Bool {
+  Array::length(a.guard_meta) == 5 && bcc_int_lists_equal(a.guard_meta, b.guard_meta) && bcc_string_lists_equal(a.guard_synth_names, b.guard_synth_names) && bcc_int_lists_equal(a.guard_synth_stmts, b.guard_synth_stmts) && bcc_string_lists_equal(a.guard_import_names, b.guard_import_names) && bcc_string_lists_equal(a.guard_borrow_names, b.guard_borrow_names) && bcc_int_lists_equal(a.guard_borrow_masks, b.guard_borrow_masks) && bcc_string_lists_equal(a.guard_unmangled_names, b.guard_unmangled_names)
+}
+
 export fn compile_file_fs_mode_rc_body_cached(entry_path: String, entry_name: String, cache_mode: String) -> Bytes with Exception + Fs {
   let source_groups = collect_source_groups_fs(entry_path)
   let next_db = prepare_file_fs_from_source_groups_persistent_cached(db_new(), entry_path, source_groups)
@@ -953,7 +967,13 @@ export fn compile_file_fs_mode_rc_body_cached(entry_path: String, entry_name: St
   if cache_mode == "verify" {
     let fresh_out = codegen_body_cache_new()
     let fresh = compile_wasi_module_rc_body_cached(merged_stmts, entry_name, codegen_body_cache_new(), fresh_out)
-    if Array::length(cache_in.fn_indices) > 0 {
+    if Array::length(cache_in.fn_indices) > 0 && body_cache_guards_equal(cache_in, fresh_out) {
+      // Guard drift (an edit flipped a whole-program fact the guards pin)
+      // is an EXPECTED cache miss, checked above against the fresh
+      // harvest's guards -- the second compile below re-feeds the
+      // already-lowered stmts, where linked_compile's own validation
+      // stands down, so it must never see a drifted cache.
+      //
       // Second compile of the SAME (now already-lowered) stmts: the #1259
       // replay/sliced gates prove that recompile is byte-identical to the
       // first, so any difference here is attributable to the persisted
@@ -988,10 +1008,18 @@ export fn compile_file_fs_mode_rc_body_cached(entry_path: String, entry_name: St
   } else {
     let cache_out = codegen_body_cache_new()
     let bytes = compile_wasi_module_rc_body_cached(merged_stmts, entry_name, cache_in, cache_out)
-    // Replayed entries are not re-recorded, so the refreshed artifact is the
-    // new harvest plus the entries it replayed; merge prefers the new
-    // harvest's guards, which describe this compile's layout.
-    store_persistent_artifact("codegen-body-cache", entry_name, artifact_key, encode_body_cache_artifact(file_paths, file_fps, file_counts, codegen_body_cache_merge(cache_out, cache_in)))
+    // Replayed entries are not re-recorded, so the refreshed artifact is
+    // the new harvest plus the entries it replayed -- but ONLY when the
+    // cache was actually consumed (its guards match the new harvest's).
+    // Merging a guard-rejected cache would re-persist every entry the
+    // compile just recompiled, growing the artifact by a full duplicate
+    // set on each guard-flipping edit.
+    let refreshed = if Array::length(cache_in.fn_indices) > 0 && body_cache_guards_equal(cache_out, cache_in) {
+      codegen_body_cache_merge(cache_out, cache_in)
+    } else {
+      cache_out
+    }
+    store_persistent_artifact("codegen-body-cache", entry_name, artifact_key, encode_body_cache_artifact(file_paths, file_fps, file_counts, refreshed))
     bytes
   }
 }

--- a/lib/@vibe/compiler/entry/compiler/file_compile/index.vpkg
+++ b/lib/@vibe/compiler/entry/compiler/file_compile/index.vpkg
@@ -38,6 +38,7 @@ fn check_file_fs_mode_from_source_groups(entry_path: String, source_groups: Arra
 fn compile_file_fs_mode(entry_path: String, entry_name: String, mode: String) -> Bytes with Exception + Fs
 fn compile_file_fs_mode_gc(entry_path: String, entry_name: String) -> Bytes with Exception + Fs
 fn compile_file_fs_mode_rc(entry_path: String, entry_name: String) -> Bytes with Exception + Fs
+fn compile_file_fs_mode_rc_body_cached(entry_path: String, entry_name: String, cache_mode: String) -> Bytes with Exception + Fs
 // #1553 observation-only heap-mark lanes (VIBE_PROFILE_MEMORY_MARKS=1); same
 // pipelines as the respective RC/bump FS helpers, Env only for the runner's
 // mark hook.

--- a/lib/@vibe/compiler/tests/codegen_body_cache_persist_test.vibe
+++ b/lib/@vibe/compiler/tests/codegen_body_cache_persist_test.vibe
@@ -1,0 +1,188 @@
+//# Imports
+
+// #2388 step 3: the cross-compile codegen body cache -- codec round-trip,
+// the prefix/guard filter, and the end-to-end persisted lanes ("verify"
+// double-compiles and byte-compares; "on" replays persisted bodies).
+
+import @vibe/compiler/codegen/common_base {
+  CodegenBodyCache, codegen_body_cache_filter_src_below, codegen_body_cache_from_bytes, codegen_body_cache_new, codegen_body_cache_to_bytes
+}
+
+import @vibe/compiler/entry/compiler/file_compile {
+  compile_file_fs_mode_rc, compile_file_fs_mode_rc_body_cached
+}
+
+import @vibe/compiler/cache {
+  persistent_artifact_cache_path
+}
+
+//# Functions
+
+fn string_to_bytes(s: String) -> Bytes {
+  let out = Bytes::new()
+  let len = String::length(s)
+  let mut i = 0
+  while i < len {
+    Bytes::push(out, String::char_code_at(s, i))
+    i = i + 1
+  }
+  out
+}
+
+fn bytes_eq(a: Bytes, b: Bytes) -> Bool {
+  let n = Bytes::length(a)
+  if n != Bytes::length(b) {
+    false
+  } else {
+    let mut i = 0
+    let mut same = true
+    while same && i < n {
+      if Bytes::get(a, i) != Bytes::get(b, i) {
+        same = false
+      } else {
+        i = i + 1
+      }
+    }
+    same
+  }
+}
+
+fn remove_file_if_exists(path: String) -> Unit with Fs {
+  if Fs::exists(path) {
+    Fs::remove(path)
+  } else {
+    ()
+  }
+}
+
+/// A populated cache exercising every field group: one function entry in the
+/// source region (fn_index 0), one outside it (fn_index 3, which the filter
+/// must drop), a lambda with captures, a slot-log entry, and recorded
+/// guards.
+fn sample_cache() -> CodegenBodyCache {
+  let c = codegen_body_cache_new()
+  Array::push(c.fn_indices, 0)
+  Array::push(c.fn_src_stmts, 2)
+  Array::push(c.fn_bodies, string_to_bytes("ab"))
+  Array::push(c.fn_meta_i32, 1)
+  Array::push(c.fn_meta_i64, 2)
+  Array::push(c.fn_meta_v128, 0)
+  Array::push(c.fn_indices, 3)
+  Array::push(c.fn_src_stmts, 7)
+  Array::push(c.fn_bodies, string_to_bytes("cde"))
+  Array::push(c.fn_meta_i32, 4)
+  Array::push(c.fn_meta_i64, 5)
+  Array::push(c.fn_meta_v128, 1)
+  Array::push(c.lam_owner, 0)
+  Array::push(c.lam_indices, 5)
+  Array::push(c.lam_bodies, string_to_bytes("xyz"))
+  Array::push(c.lam_param_counts, 2)
+  Array::push(c.lam_captures, ["a", "bb"])
+  Array::push(c.lam_meta_i32, 9)
+  Array::push(c.lam_meta_i64, 0 - 1)
+  Array::push(c.slot_owner, 0)
+  Array::push(c.slot_values, 1029)
+  Array::push(c.guard_meta, 1)
+  Array::push(c.guard_meta, 1024)
+  Array::push(c.guard_meta, 2048)
+  Array::push(c.guard_synth_names, "Pt::equals")
+  Array::push(c.guard_synth_stmts, 42)
+  c
+}
+
+test "codegen body cache codec round-trips every field group" {
+  let c = sample_cache()
+  let b = codegen_body_cache_to_bytes(c)
+  match codegen_body_cache_from_bytes(b) {
+    Some(d) => {
+      inspect(Array::length(d.fn_indices), content = "2")
+      inspect(Array::get(d.fn_indices, 1), content = "3")
+      inspect(Array::get(d.fn_src_stmts, 0), content = "2")
+      assert(bytes_eq(Array::get(d.fn_bodies, 1), string_to_bytes("cde")))
+      inspect(Array::get(d.fn_meta_v128, 1), content = "1")
+      inspect(Array::length(d.lam_owner), content = "1")
+      assert(bytes_eq(Array::get(d.lam_bodies, 0), string_to_bytes("xyz")))
+      inspect(Array::get(d.lam_param_counts, 0), content = "2")
+      inspect(Array::get(Array::get(d.lam_captures, 0), 1), content = "bb")
+      inspect(Array::get(d.lam_meta_i64, 0), content = "-1")
+      inspect(Array::get(d.slot_values, 0), content = "1029")
+      inspect(Array::get(d.guard_meta, 2), content = "2048")
+      inspect(Array::get(d.guard_synth_names, 0), content = "Pt::equals")
+      inspect(Array::get(d.guard_synth_stmts, 0), content = "42")
+    },
+    None => assert(false)
+  }
+}
+
+test "codegen body cache codec fails safe on damage" {
+  let c = sample_cache()
+  let b = codegen_body_cache_to_bytes(c)
+  // Wrong magic.
+  let wrong_magic = Bytes::concat(string_to_bytes("XBC1"), Bytes::slice(b, 4, Bytes::length(b)))
+  match codegen_body_cache_from_bytes(wrong_magic) {
+    Some(_) => assert(false),
+    None => assert(true)
+  }
+  // Truncation anywhere in the stream degrades to None, never to a partial
+  // cache.
+  match codegen_body_cache_from_bytes(Bytes::slice(b, 0, Bytes::length(b) - 3)) {
+    Some(_) => assert(false),
+    None => assert(true)
+  }
+  match codegen_body_cache_from_bytes(Bytes::slice(b, 0, 6)) {
+    Some(_) => assert(false),
+    None => assert(true)
+  }
+}
+
+test "filter_src_below keeps only guarded source-region entries below the limit" {
+  let c = sample_cache()
+  // limit 7: entry (fn 0, src 2) survives; (fn 3, src 7) is out by limit AND
+  // out of the source region (guard_meta[0] == 1). The kept function's
+  // lambda and slot entries ride along; guards are copied verbatim.
+  let f = codegen_body_cache_filter_src_below(c, 7)
+  inspect(Array::length(f.fn_indices), content = "1")
+  inspect(Array::get(f.fn_indices, 0), content = "0")
+  inspect(Array::length(f.lam_owner), content = "1")
+  inspect(Array::length(f.slot_owner), content = "1")
+  inspect(Array::length(f.guard_meta), content = "3")
+  inspect(Array::get(f.guard_synth_names, 0), content = "Pt::equals")
+  // A guard-less cache never crosses compiles: it filters to empty.
+  let unguarded = sample_cache()
+  Array::truncate(unguarded.guard_meta, 0)
+  let g = codegen_body_cache_filter_src_below(unguarded, 100)
+  inspect(Array::length(g.fn_indices), content = "0")
+}
+
+test "persisted body cache: verify survives an entry edit; on matches a fresh compile" {
+  let helper_path = "/tmp/vibe_codegen_body_cache_helper.vibe"
+  let main_path = "/tmp/vibe_codegen_body_cache_main.vibe"
+  // The helper compares arrays so the closure is guaranteed to synthesize a
+  // derived comparator -- which makes the compile run the #2388 pin reorder
+  // and record guards into the artifact.
+  let helper_source = "export let helper_flag: () -> Bool = () -> { [1, 2] == [1, 2] }"
+  let main_source1 = "import ./vibe_codegen_body_cache_helper.vibe { helper_flag }\nlet run: () -> Int = () -> { if helper_flag() { 40 + 2 } else { 0 } }"
+  let main_source2 = "import ./vibe_codegen_body_cache_helper.vibe { helper_flag }\nlet run: () -> Int = () -> { if helper_flag() { 50 + 3 } else { 1 } }"
+  Fs::write_bytes(helper_path, string_to_bytes(helper_source))
+  Fs::write_bytes(main_path, string_to_bytes(main_source1))
+  remove_file_if_exists(persistent_artifact_cache_path("codegen-body-cache", "run", "self-describing"))
+  // Run 1: no artifact yet -- verify has nothing to replay, compiles fresh
+  // and stores the harvest.
+  let bytes1 = compile_file_fs_mode_rc_body_cached(main_path, "run", "verify")
+  assert(Fs::exists(persistent_artifact_cache_path("codegen-body-cache", "run", "self-describing")))
+  // Run 2, nothing edited: every file matches the stored table, so the
+  // whole harvest replays -- and verify throws if any replayed byte
+  // differs from the fresh compile.
+  let bytes2 = compile_file_fs_mode_rc_body_cached(main_path, "run", "verify")
+  assert(bytes_eq(bytes1, bytes2))
+  // Run 3, entry edited: only the helper prefix may replay; verify again
+  // proves the replayed prefix bytes are what a fresh compile produces.
+  Fs::write_bytes(main_path, string_to_bytes(main_source2))
+  let bytes3 = compile_file_fs_mode_rc_body_cached(main_path, "run", "verify")
+  assert(!bytes_eq(bytes2, bytes3))
+  // "on" mode replays without the double compile; its output must be
+  // byte-identical to the plain production lane's.
+  let on_bytes = compile_file_fs_mode_rc_body_cached(main_path, "run", "on")
+  let fresh_bytes = compile_file_fs_mode_rc(main_path, "run")
+  assert(bytes_eq(on_bytes, fresh_bytes))
+}

--- a/lib/@vibe/compiler/tests/codegen_body_cache_persist_test.vibe
+++ b/lib/@vibe/compiler/tests/codegen_body_cache_persist_test.vibe
@@ -5,7 +5,13 @@
 // double-compiles and byte-compares; "on" replays persisted bodies).
 
 import @vibe/compiler/codegen/common_base {
-  CodegenBodyCache, codegen_body_cache_filter_src_below, codegen_body_cache_from_bytes, codegen_body_cache_new, codegen_body_cache_to_bytes
+  CodegenBodyCache,
+  bcc_int_lists_equal,
+  bcc_string_lists_equal,
+  codegen_body_cache_filter_src_below,
+  codegen_body_cache_from_bytes,
+  codegen_body_cache_new,
+  codegen_body_cache_to_bytes
 }
 
 import @vibe/compiler/entry/compiler/file_compile {
@@ -99,6 +105,9 @@ fn sample_cache() -> CodegenBodyCache {
   Array::push(c.guard_synth_stmts, 42)
   Array::push(c.guard_import_names, "vibe_env_get")
   Array::push(c.guard_import_names, "vibe_http_request_raw")
+  Array::push(c.guard_borrow_names, "peek")
+  Array::push(c.guard_borrow_masks, 5)
+  Array::push(c.guard_unmangled_names, "run")
   c
 }
 
@@ -123,6 +132,9 @@ test "codegen body cache codec round-trips every field group" {
       inspect(Array::get(d.guard_synth_names, 0), content = "Pt::equals")
       inspect(Array::get(d.guard_synth_stmts, 0), content = "42")
       inspect(Array::get(d.guard_import_names, 1), content = "vibe_http_request_raw")
+      inspect(Array::get(d.guard_borrow_names, 0), content = "peek")
+      inspect(Array::get(d.guard_borrow_masks, 0), content = "5")
+      inspect(Array::get(d.guard_unmangled_names, 0), content = "run")
     },
     None => assert(false)
   }
@@ -201,6 +213,27 @@ test "guard validation can fail: a poisoned body replays, a poisoned guard drops
     },
     None => assert(false)
   }
+}
+
+test "a call-shape edit that flips the borrow ABI drops the cache" {
+  // The ADR-0092 borrow-parameter inference is call-site sensitive: passing
+  // a non-ident argument (`use_it(make())`) disqualifies the position that
+  // `use_it(x)` qualifies, flipping the callee's parameter between borrowed
+  // and owned -- a different body under an unchanged name and layout. The
+  // borrow guard must drop the cache, so the replayed compile answers the
+  // same bytes as a fresh one.
+  let shared = "let seed_eq: () -> Bool = () -> { [1] == [1] }\nlet make: () -> Array[Int] = () -> { [1, 2] }\nlet use_it: (Array[Int]) -> Int = (xs) -> { Array::length(xs) }\n"
+  let src_a = String::concat(shared, "let run: () -> Int = () -> { let x = make()\n  use_it(x) }")
+  let src_b = String::concat(shared, "let run: () -> Int = () -> { use_it(make()) }")
+  let out_a = codegen_body_cache_new()
+  let _ = compile_wasi_module_rc_body_cached(parse_program(lex(src_a)), "run", codegen_body_cache_new(), out_a)
+  let out_b = codegen_body_cache_new()
+  let fresh_b = compile_wasi_module_rc_body_cached(parse_program(lex(src_b)), "run", codegen_body_cache_new(), out_b)
+  // Non-vacuity: the two programs must actually record different borrow
+  // guards -- otherwise this test would pass without exercising the drop.
+  assert(!bcc_string_lists_equal(out_a.guard_borrow_names, out_b.guard_borrow_names) || !bcc_int_lists_equal(out_a.guard_borrow_masks, out_b.guard_borrow_masks))
+  let replayed_b = compile_wasi_module_rc_body_cached(parse_program(lex(src_b)), "run", out_a, codegen_body_cache_new())
+  assert(bytes_eq(fresh_b, replayed_b))
 }
 
 test "persisted body cache: verify survives an entry edit; on matches a fresh compile" {

--- a/lib/@vibe/compiler/tests/codegen_body_cache_persist_test.vibe
+++ b/lib/@vibe/compiler/tests/codegen_body_cache_persist_test.vibe
@@ -280,4 +280,13 @@ test "persisted body cache: verify survives an entry edit; on matches a fresh co
   Fs::write_bytes(artifact_path, stored)
   let after_corruption = compile_file_fs_mode_rc_body_cached(main_path, "run", "on")
   assert(bytes_eq(after_corruption, fresh_bytes))
+  // A guard-flipping edit (a new unmangled entry helper changes the global
+  // name-membership guard) under VERIFY: the drift is an expected cache
+  // miss checked against the fresh harvest's guards, never a thrown verify
+  // mismatch -- the second compile re-feeds already-lowered stmts, where
+  // linked_compile's own validation stands down.
+  let main_source3 = String::concat(main_source2, "\nlet spare_helper: () -> Int = () -> { 7 }\nlet run2: () -> Int = () -> { spare_helper() }")
+  Fs::write_bytes(main_path, string_to_bytes(main_source3))
+  let bytes5 = compile_file_fs_mode_rc_body_cached(main_path, "run", "verify")
+  assert(Bytes::length(bytes5) > 0)
 }

--- a/lib/@vibe/compiler/tests/codegen_body_cache_persist_test.vibe
+++ b/lib/@vibe/compiler/tests/codegen_body_cache_persist_test.vibe
@@ -13,7 +13,7 @@ import @vibe/compiler/entry/compiler/file_compile {
 }
 
 import @vibe/compiler/cache {
-  persistent_artifact_cache_path
+  compact_string_fingerprint, persistent_artifact_cache_path
 }
 
 import @vibe/compiler/codegen {
@@ -214,11 +214,15 @@ test "persisted body cache: verify survives an entry edit; on matches a fresh co
   let main_source2 = "import ./vibe_codegen_body_cache_helper.vibe { helper_flag }\nlet run: () -> Int = () -> { if helper_flag() { 50 + 3 } else { 1 } }"
   Fs::write_bytes(helper_path, string_to_bytes(helper_source))
   Fs::write_bytes(main_path, string_to_bytes(main_source1))
-  remove_file_if_exists(persistent_artifact_cache_path("codegen-body-cache", "run", "self-describing"))
+  // Mirrors the lane's own key derivation: content-independent, but scoped
+  // to the entry path so unrelated roots sharing an entry name (`run`)
+  // cannot race on one artifact slot.
+  let artifact_path = persistent_artifact_cache_path("codegen-body-cache", "run", String::concat("self-describing-", compact_string_fingerprint(main_path)))
+  remove_file_if_exists(artifact_path)
   // Run 1: no artifact yet -- verify has nothing to replay, compiles fresh
   // and stores the harvest.
   let bytes1 = compile_file_fs_mode_rc_body_cached(main_path, "run", "verify")
-  assert(Fs::exists(persistent_artifact_cache_path("codegen-body-cache", "run", "self-describing")))
+  assert(Fs::exists(artifact_path))
   // Run 2, nothing edited: every file matches the stored table, so the
   // whole harvest replays -- and verify throws if any replayed byte
   // differs from the fresh compile.
@@ -234,4 +238,13 @@ test "persisted body cache: verify survives an entry edit; on matches a fresh co
   let on_bytes = compile_file_fs_mode_rc_body_cached(main_path, "run", "on")
   let fresh_bytes = compile_file_fs_mode_rc(main_path, "run")
   assert(bytes_eq(on_bytes, fresh_bytes))
+  // On-disk corruption: flip one byte inside the stored artifact's body
+  // region (same length, valid framing). The payload checksum must reject
+  // the whole artifact, so "on" still answers the fresh compile's bytes.
+  let stored = Fs::read_bytes(artifact_path)
+  let flip_at = Bytes::length(stored) / 2
+  Bytes::set(stored, flip_at, (Bytes::get(stored, flip_at) + 1)&255)
+  Fs::write_bytes(artifact_path, stored)
+  let after_corruption = compile_file_fs_mode_rc_body_cached(main_path, "run", "on")
+  assert(bytes_eq(after_corruption, fresh_bytes))
 }

--- a/lib/@vibe/compiler/tests/codegen_body_cache_persist_test.vibe
+++ b/lib/@vibe/compiler/tests/codegen_body_cache_persist_test.vibe
@@ -16,6 +16,14 @@ import @vibe/compiler/cache {
   persistent_artifact_cache_path
 }
 
+import @vibe/compiler/codegen {
+  compile_wasi_module_rc_body_cached
+}
+
+import @vibe/compiler/syntax {
+  lex, parse_program
+}
+
 //# Functions
 
 fn string_to_bytes(s: String) -> Bytes {
@@ -85,8 +93,12 @@ fn sample_cache() -> CodegenBodyCache {
   Array::push(c.guard_meta, 1)
   Array::push(c.guard_meta, 1024)
   Array::push(c.guard_meta, 2048)
+  Array::push(c.guard_meta, 7)
+  Array::push(c.guard_meta, 40)
   Array::push(c.guard_synth_names, "Pt::equals")
   Array::push(c.guard_synth_stmts, 42)
+  Array::push(c.guard_import_names, "vibe_env_get")
+  Array::push(c.guard_import_names, "vibe_http_request_raw")
   c
 }
 
@@ -107,8 +119,10 @@ test "codegen body cache codec round-trips every field group" {
       inspect(Array::get(d.lam_meta_i64, 0), content = "-1")
       inspect(Array::get(d.slot_values, 0), content = "1029")
       inspect(Array::get(d.guard_meta, 2), content = "2048")
+      inspect(Array::get(d.guard_meta, 4), content = "40")
       inspect(Array::get(d.guard_synth_names, 0), content = "Pt::equals")
       inspect(Array::get(d.guard_synth_stmts, 0), content = "42")
+      inspect(Array::get(d.guard_import_names, 1), content = "vibe_http_request_raw")
     },
     None => assert(false)
   }
@@ -145,13 +159,48 @@ test "filter_src_below keeps only guarded source-region entries below the limit"
   inspect(Array::get(f.fn_indices, 0), content = "0")
   inspect(Array::length(f.lam_owner), content = "1")
   inspect(Array::length(f.slot_owner), content = "1")
-  inspect(Array::length(f.guard_meta), content = "3")
+  inspect(Array::length(f.guard_meta), content = "5")
   inspect(Array::get(f.guard_synth_names, 0), content = "Pt::equals")
+  inspect(Array::length(f.guard_import_names), content = "2")
   // A guard-less cache never crosses compiles: it filters to empty.
   let unguarded = sample_cache()
   Array::truncate(unguarded.guard_meta, 0)
   let g = codegen_body_cache_filter_src_below(unguarded, 100)
   inspect(Array::length(g.fn_indices), content = "0")
+}
+
+test "guard validation can fail: a poisoned body replays, a poisoned guard drops the cache" {
+  // Red/green pair for the #2388 guard validation, per the repo's gate
+  // doctrine: a check is only trusted once it has been shown to fail.
+  let src = "let helper: () -> Bool = () -> { [1, 2] == [1, 2] }\nlet run: () -> Int = () -> { if helper() { 42 } else { 0 } }"
+  let out1 = codegen_body_cache_new()
+  let fresh = compile_wasi_module_rc_body_cached(parse_program(lex(src)), "run", codegen_body_cache_new(), out1)
+  // RED (proves replay is live and this test can detect it): copy the
+  // harvest, poison ONE cached body, keep the guards valid. A fresh parse
+  // of the same source revalidates the guards, accepts the cache, and
+  // replays the poisoned bytes -- the output MUST differ.
+  match codegen_body_cache_from_bytes(codegen_body_cache_to_bytes(out1)) {
+    Some(poisoned_body) => {
+      let victim = Array::get(poisoned_body.fn_bodies, 0)
+      Bytes::set(victim, Bytes::length(victim) - 1, (Bytes::get(victim, Bytes::length(victim) - 1) + 1)&255)
+      let replayed = compile_wasi_module_rc_body_cached(parse_program(lex(src)), "run", poisoned_body, codegen_body_cache_new())
+      assert(!bytes_eq(fresh, replayed))
+    },
+    None => assert(false)
+  }
+  // GREEN: the same poisoned body PLUS a poisoned import-name guard. The
+  // validation must now drop the cache wholesale, so the poisoned body
+  // never reaches the output and the compile answers fresh bytes.
+  match codegen_body_cache_from_bytes(codegen_body_cache_to_bytes(out1)) {
+    Some(poisoned_guard) => {
+      let victim2 = Array::get(poisoned_guard.fn_bodies, 0)
+      Bytes::set(victim2, Bytes::length(victim2) - 1, (Bytes::get(victim2, Bytes::length(victim2) - 1) + 1)&255)
+      Array::push(poisoned_guard.guard_import_names, "#never_a_builtin")
+      let dropped = compile_wasi_module_rc_body_cached(parse_program(lex(src)), "run", poisoned_guard, codegen_body_cache_new())
+      assert(bytes_eq(fresh, dropped))
+    },
+    None => assert(false)
+  }
 }
 
 test "persisted body cache: verify survives an entry edit; on matches a fresh compile" {


### PR DESCRIPTION
Step 3 of #2388: persist per-function codegen output across compiles and replay it through the existing `CodegenBodyCache`, behind an env flag with a byte-comparing verify mode as the trust-building default — the plan posted on #2388 after steps 1+2 (#2394, #2400) proved the prefix-stability invariant.

## What lands

`VIBE_CODEGEN_BODY_CACHE` on the `vibe test` / `vibe run` FS lane (`compile_file_fs_mode_rc`), read by the CLI adapter so the production layers stay Env-free (#634):

- **`verify`** — compile everything fresh, then compile AGAIN replaying the persisted bodies, and **throw on the first differing byte**. Double compile cost, zero risk: the returned bytes are always the fresh compile's. Guard drift from an edit is detected up front (against the fresh harvest's guards) and taken as a cache miss, never a false mismatch.
- **`on`** — replay persisted bodies directly. Guarded (below), opt-in experimental.
- unset / anything else — the exact production lane, untouched.

## The mechanism

1. `CodegenBodyCache` (the #1259 replay structure) gains the merged-statement index per cached function, a fail-safe binary codec, and a prefix filter.
2. The artifact is **self-describing, stored under a per-entry-path key** (content-independent — the point is to hit after an edit): a per-file table (path, content fingerprint, merged-statement count) decides how much survives — the longest unchanged leading file run gives the replay limit. The whole artifact is protected by a payload checksum; any corruption, same-length bit flips included, decodes as an empty cache. The persistent store's version tag already keys on the compiler's own codegen fingerprint, so artifacts never cross compiler versions.
3. **Guards make a stale replay a cache miss, never a wrong body.** The recording compile stores every layout and ABI fact bodies are emitted against, and the consuming compile validates all of them, dropping the cache wholesale on any mismatch:
   - pin-region shape and lambda slot base (#2388 steps 1+2);
   - `num_imported_funcs` / `num_generated` (together `func_offset`) plus the **sorted used-builtin-name set** — the gated host imports get indices from a fixed sequence of `has_key` tests, so set equality (not count equality) pins the import vector;
   - the synthesized functions' names AND merged-statement positions (they decide the statement-ordered pre-pass tables — string pool, signatures);
   - the full **borrow-parameter ABI vectors** (`compute_borrow_param_user_fns` is call-site sensitive — an edit anywhere can flip an unchanged callee's owned/borrowed parameter);
   - the sorted **unmangled source-region name set** (global name-membership facts like `prefer_bound_call`);
   - a compile where **late DCE pruned** anything neither records nor consumes cross-compile guards (index spaces no longer align); the `vibe test` lane (`__no_entry__`) never prunes.
   - the compiler-seeded `""` now lives at string-pool slot 0 so its embedded offset is edit-independent (it is zero-length, so no other offset moves).
4. Synthesized functions and capacity pads **never replay across compiles**; the #1259 in-process replay/sliced lanes are preserved bit-for-bit.
5. The generic artifact store dropped its redundant guest-level tmp+rename: `Fs::write_bytes` is already atomic on both hosts with pid+nonce-unique temporaries, which eliminates the concurrent-writer rename races the guest layer itself introduced.

## Tests

`lib/@vibe/compiler/tests/codegen_body_cache_persist_test.vibe` (6 tests): codec round-trip over every field group; damage degrades to `None`; the filter keeps only guarded source-region entries; a **red/green pair** proving the guard validation can fail (a poisoned cached body with valid guards visibly corrupts the output — replay is live — and a poisoned guard drops the cache wholesale); a **borrow-ABI flip** at one call site (with a non-vacuity assertion) shown to drop the cache; and the end-to-end persisted lanes — fresh store, full-replay verify, entry-edit verify, `on` byte-compared against the production lane, on-disk artifact corruption rejected by the checksum, and a guard-flipping edit under verify completing as a miss.

## Validation (head a171cc8)

- `stage2 == stage3` byte-identical fixpoint; prefix-stability probe `ok`; full unit suite **1083/1083** against the new stage2; `compiler_gate.sh` ok; CI green on every commit; Codex review converged (10 findings across 5 rounds, all fixed with regression tests, all threads resolved).
- CI perf report: fuel/output/heap/B-op all ±0; compiler size +0.5% (the new code itself).

## Measured effect (§0.5 protocol, compiler-sized closure)

| scenario | off | on |
|---|---:|---:|
| unedited recompile (full replay) | 4.8–5.0 s | **4.1–4.3 s (~−14%)** |
| append-one-test edit | ~5.6 s | ~5.9 s (±0) |

The edited case gets no gain YET: the guards are deliberately over-strict (an added function changes `pin_src_n`, shifts appended-synth positions, can extend the borrow set — each currently requires exact equality, so the cache drops). A hit-rate limitation, never a correctness one. The follow-up on #2388 is limit-scoped guard comparison (compare positions/ABI entries only below the unchanged-prefix boundary) plus DCE-immune provenance for pruned builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0159xd5111g8KFt2CGyNyZvA