### PR TITLE
Restore `type_is_ground_except`'s doc comment (#2412 follow-up)

### DIFF
--- a/lib/@vibe/compiler/checker/checker.vibe
+++ b/lib/@vibe/compiler/checker/checker.vibe
@@ -2463,12 +2463,6 @@ fn type_is_ground(t: Type) -> Bool {
   }
 }
 
-/// #1340 (ADR-0071): ground modulo a set of rigid names — a generic effect's
-/// declared op return type is usable as the perform's value type when its
-/// only non-ground parts are the effect's OWN type params (which the caller
-/// substitutes with fresh inference vars before use). Any other CtNamed /
-/// CtVar / CtForAll keeps the conservative fresh-var fallback, exactly like
-/// type_is_ground does for non-generic effects.
 /// True when a UNARY operator's operand is concrete enough to reject: the
 /// operand cannot be the primitive the operator needs, whatever else is still
 /// unresolved about it. Shared by `!`, unary `-` and `~` (#2408) -- they take
@@ -2512,6 +2506,12 @@ fn unary_operand_is_definitely_wrong(t: Type, defs: Array[TypeDef]) -> Bool {
   }
 }
 
+/// #1340 (ADR-0071): ground modulo a set of rigid names — a generic effect's
+/// declared op return type is usable as the perform's value type when its
+/// only non-ground parts are the effect's OWN type params (which the caller
+/// substitutes with fresh inference vars before use). Any other CtNamed /
+/// CtVar / CtForAll keeps the conservative fresh-var fallback, exactly like
+/// type_is_ground does for non-generic effects.
 fn type_is_ground_except(t: Type, allowed: Array[String]) -> Bool {
   match t {
     CtNamed(nm, targs) => if Array::length(targs) == 0 {


### PR DESCRIPTION
Follow-up to #2412, which **merged one commit before this fix**. The review finding on that PR ([discussion_r3888497614](https://github.com/mizchi/vibe-lang/pull/2412#discussion_r3888497614)) was correct and I fixed it, but the merge took head `8d196e1e1` and my fix was `d51a1dea6` — so the defect is currently on `main`.

## What is wrong on main

`#2412` added `unary_operand_is_definitely_wrong` by anchoring the insertion on `fn type_is_ground_except`, which placed it **between** that function and its `/// #1340 (ADR-0071)` doc block. `///` binds to the following declaration, so on `main` right now:

```
unary_operand_is_definitely_wrong ... #1340 (ADR-0071): ground modulo
type_is_ground_except             ... (4 fields — no doc at all)
```

That is `vibe symbols` output against `main`'s tree: a generic-effect explanation reported as the API doc of an unrelated type predicate, and a documented function reporting none. `vibe doc-at` and editor hover read the same table.

After this change:

```
unary_operand_is_definitely_wrong ... True when a UNARY operator's operand is
type_is_ground_except             ... #1340 (ADR-0071): ground modulo
```

## The change

Pure reordering — the helper block moves above the `#1340` block. Six lines each way, no text altered, no behavior touched.

Full gate green. The 7 unary tests and 18 `~` tests pass (they are unaffected by construction, but the gate runs them anyway).

## Why this is a new PR

The branch's PR had already merged, so per the repo's branch rules this is a fresh change rather than more commits on merged history: the branch was restarted from `main` (`0d0c61fd6`) and the fix cherry-picked onto it.

**The generalizable lesson is about the edit, not the code.** Anchoring an insertion on a `fn` line silently steals whatever doc comment sits above it, and nothing at the insertion point looks wrong in review — you have to look *up* from the diff. Anchoring on the doc block, or on the blank line before it, cannot do this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FYMVd6D2o82suTfTwoJPMf

---
_Generated by [Claude Code](https://claude.ai/code/session_01FYMVd6D2o82suTfTwoJPMf)_