### PR TITLE
Give `ts_known_int` the bare-ident arm it never had (#2406)

### DIFF
--- a/fixtures/to_string_let_bound_int_test.vibe
+++ b/fixtures/to_string_let_bound_int_test.vibe
@@ -1,0 +1,96 @@
+// #2406 regression: an `Int` reaching `__to_string` THROUGH A `let` BINDING
+// must stringify as an integer, exactly as the same expression written
+// inline already did.
+//
+// `__to_string` has no runtime type tag to consult, so it guesses: a value
+// that looks like the packed `(ptr << 32) | len` string encoding is returned
+// unchanged. `ts_known_int`
+// (lib/@vibe/compiler/codegen/expr/compile_call.vibe) is the static override
+// that keeps known integers off that heuristic -- and it had no bare-ident
+// arm, so a `let`-bound integer with a zero low word (the shape a real hash
+// or packed offset takes) was emitted as the EMPTY STRING while the identical
+// expression written inline printed correctly. The classification was already
+// being computed and logged per slot at every `let` site; nothing read it.
+//
+// Linear lane. The gc lane's `gc_expr_is_intish` takes no locals, so it
+// cannot classify an ident even in principle (#2406 fix 2), and a
+// pathological value additionally traps `__to_string` there (#2405).
+
+fn idf(s: String) -> String {
+  s
+}
+
+test "#2406 a let-bound Int with a zero low word stringifies as an Int" {
+  let via_let = ((0 - (64<<32)) - 1)^(0 - 1)
+  assert(__to_string(via_let) == "274877906944")
+  assert("\{via_let}" == "274877906944")
+}
+
+test "#2406 let-bound and inline agree" {
+  let a = ((0 - (64<<32)) - 1)^(0 - 1)
+  let b = ((0 - (65<<32)) - 1)^(0 - 1)
+  assert(__to_string(a) == __to_string(((0 - (64<<32)) - 1)^(0 - 1)))
+  assert(__to_string(b) == __to_string(((0 - (65<<32)) - 1)^(0 - 1)))
+  assert(__to_string(a) != __to_string(b))
+}
+
+test "#2406 ordinary let-bound ints are unchanged" {
+  let n = 42
+  let m = 1<<40
+  assert(__to_string(n) == "42")
+  assert(__to_string(m) == "1099511627776")
+  assert("\{n}-\{m}" == "42-1099511627776")
+}
+
+// The three guards below are what stops the ident arm from being written as
+// `slot_is_intish` (the "bit 0 set" test `expr_is_intish` uses for `==`).
+// That predicate is TRUE for kind 3 (Bool) as well as kind 1 (Int), because
+// Bool and Int share the tagged-int runtime representation -- correct for
+// `==`, wrong for `__to_string`, which must print "false" and not "0".
+// `ts_known_int` reads the kind exactly.
+
+test "#2406 a bool-bound ident still prints true/false" {
+  let f = 1 == 2
+  let t = 1 < 2
+  assert(__to_string(f) == "false")
+  assert(__to_string(t) == "true")
+  assert("\{f}/\{t}" == "false/true")
+}
+
+test "#2406 a string-bound ident still prints itself" {
+  let j = String::join([], "-")
+  let s = "hi"
+  assert(__to_string(j) == "")
+  assert(__to_string(s) == "hi")
+  assert("[\{j}]" == "[]")
+}
+
+test "#2406 a float-bound ident still prints as a double" {
+  let d = 1.5
+  assert(__to_string(d) == "1.5")
+}
+
+// D/E/F below are the discriminating guards for the ident arm, not decoration.
+// The arm reads `ctx.int_local_slots`, and `expr_is_intish` -- the predicate
+// that fills that log -- returns true for `EBinOp("+", ..)` whenever neither
+// operand is floatish, which reads on paper as though a String `+` would be
+// logged kind 1 and then forced down the integer path by this very fix.
+// Measured against main's stage2 before the change: it is not. A String-typed
+// `let` gets no kind-1 entry, which `E` and `F` pin from the other side --
+// they would answer `false` (an i64.eq on two distinct string fat-pointers)
+// the moment one did.
+
+test "#2406 a concat-bound ident still prints the string" {
+  let cat = "a" + "b"
+  assert(__to_string(cat) == "ab")
+}
+
+test "#2406 a concat-bound ident still compares by content" {
+  let cat = "a" + "b"
+  assert(cat == "ab")
+}
+
+test "#2406 a call-concat-bound ident still compares by content" {
+  let cat2 = idf("a") + idf("b")
+  assert(cat2 == "ab")
+}

--- a/fixtures/to_string_let_bound_int_test.vibe
+++ b/fixtures/to_string_let_bound_int_test.vibe
@@ -16,14 +16,21 @@
 // cannot classify an ident even in principle (#2406 fix 2), and a
 // pathological value additionally traps `__to_string` there (#2405).
 
+// Expected renderings are `inspect(value, content)` snapshots, per #1571 --
+// `vibe test --update` can rewrite them if the rendering contract changes.
+// The relational checks stay `assert`: "let-bound agrees with inline" and
+// "two different values render differently" are properties, not snapshots,
+// and a snapshot of either would record the answer while dropping the
+// comparison that makes it mean something.
+
 fn idf(s: String) -> String {
   s
 }
 
 test "#2406 a let-bound Int with a zero low word stringifies as an Int" {
   let via_let = ((0 - (64<<32)) - 1)^(0 - 1)
-  assert(__to_string(via_let) == "274877906944")
-  assert("\{via_let}" == "274877906944")
+  inspect(via_let, "274877906944")
+  inspect("\{via_let}", "274877906944")
 }
 
 test "#2406 let-bound and inline agree" {
@@ -37,9 +44,9 @@ test "#2406 let-bound and inline agree" {
 test "#2406 ordinary let-bound ints are unchanged" {
   let n = 42
   let m = 1<<40
-  assert(__to_string(n) == "42")
-  assert(__to_string(m) == "1099511627776")
-  assert("\{n}-\{m}" == "42-1099511627776")
+  inspect(n, "42")
+  inspect(m, "1099511627776")
+  inspect("\{n}-\{m}", "42-1099511627776")
 }
 
 // The three guards below are what stops the ident arm from being written as
@@ -52,22 +59,22 @@ test "#2406 ordinary let-bound ints are unchanged" {
 test "#2406 a bool-bound ident still prints true/false" {
   let f = 1 == 2
   let t = 1 < 2
-  assert(__to_string(f) == "false")
-  assert(__to_string(t) == "true")
-  assert("\{f}/\{t}" == "false/true")
+  inspect(f, "false")
+  inspect(t, "true")
+  inspect("\{f}/\{t}", "false/true")
 }
 
 test "#2406 a string-bound ident still prints itself" {
   let j = String::join([], "-")
   let s = "hi"
-  assert(__to_string(j) == "")
-  assert(__to_string(s) == "hi")
-  assert("[\{j}]" == "[]")
+  inspect(j, "")
+  inspect(s, "hi")
+  inspect("[\{j}]", "[]")
 }
 
 test "#2406 a float-bound ident still prints as a double" {
   let d = 1.5
-  assert(__to_string(d) == "1.5")
+  inspect(d, "1.5")
 }
 
 // D/E/F below are the discriminating guards for the ident arm, not decoration.
@@ -82,7 +89,7 @@ test "#2406 a float-bound ident still prints as a double" {
 
 test "#2406 a concat-bound ident still prints the string" {
   let cat = "a" + "b"
-  assert(__to_string(cat) == "ab")
+  inspect(cat, "ab")
 }
 
 test "#2406 a concat-bound ident still compares by content" {

--- a/lib/@vibe/compiler/codegen/expr/compile_call.vibe
+++ b/lib/@vibe/compiler/codegen/expr/compile_call.vibe
@@ -787,6 +787,51 @@ export fn cc_builtin_call_ret_kind(e: Expr, local_names: Array[String], ctx: Com
   }
 }
 
+/// #769 encoding, read as a whole: the per-slot kind logged in
+/// `ctx.int_local_slots` (`slot*4 + kind`, most-recent entry wins) for the
+/// local a bare ident names -- 0 = cleared, 1 = Int, 2 = String, 3 = Bool --
+/// or -1 when `e` is not an ident, names no local, or that slot has no entry.
+///
+/// The slot_is_* family in compile_expr_tail answers one kind each; this
+/// returns the kind itself so a caller that must distinguish Int from Bool
+/// (`ts_known_int`, #2406) can, and so the three ident arms in this file share
+/// one scan. Duplicated from compile_expr_tail rather than imported: that file
+/// imports this one, so importing back would be circular.
+fn cc_ident_slot_kind(e: Expr, local_names: Array[String], ctx: CompileCtx) -> Int with Exception {
+  if expr_tag(e) != 4 {
+    -1
+  } else {
+    let nm = get_eident_name(e)
+    let mut i = Array::length(local_names) - 1
+    let mut slot = -1
+    while i >= 0 {
+      if Array::get(local_names, i) == nm {
+        slot = i
+        i = -1
+      } else {
+        i = i - 1
+      }
+    }
+    if slot < 0 {
+      -1
+    } else {
+      let arr = ctx.int_local_slots
+      let mut j = Array::length(arr) - 1
+      let mut kind = -1
+      while j >= 0 {
+        let entry = Array::get(arr, j)
+        if entry / 4 == slot {
+          kind = entry % 4
+          j = -1
+        } else {
+          j = j - 1
+        }
+      }
+      kind
+    }
+  }
+}
+
 /// #950: is `e` statically a String? The stringish sibling of
 /// cc_expr_is_boolish below (same structure, same slot-log discipline: kind-2
 /// entries in ctx.int_local_slots track `let`-bound strings, see
@@ -801,36 +846,8 @@ export fn cc_expr_is_stringish(e: Expr, local_names: Array[String], ctx: Compile
     true
   } else if tag == 4 {
     // A bare ident `let`-bound to a stringish value — kind-2 entry in
-    // ctx.int_local_slots (slot*4 + kind). Same scan as the boolish kind-3
-    // lookup below.
-    let nm = get_eident_name(e)
-    let mut i = Array::length(local_names) - 1
-    let mut slot = -1
-    while i >= 0 {
-      if Array::get(local_names, i) == nm {
-        slot = i
-        i = -1
-      } else {
-        i = i - 1
-      }
-    }
-    if slot >= 0 {
-      let arr = ctx.int_local_slots
-      let mut j = Array::length(arr) - 1
-      let mut result = false
-      while j >= 0 {
-        let entry = Array::get(arr, j)
-        if entry / 4 == slot {
-          result = (entry % 4) == 2
-          j = -1
-        } else {
-          j = j - 1
-        }
-      }
-      result
-    } else {
-      false
-    }
+    // ctx.int_local_slots (slot*4 + kind).
+    cc_ident_slot_kind(e, local_names, ctx) == 2
   } else if tag == 9 {
     cc_expr_is_stringish(get_elet_body(e), local_names, ctx)
   } else if tag == 10 {
@@ -906,37 +923,8 @@ fn cc_expr_is_boolish(e: Expr, local_names: Array[String], ctx: CompileCtx) -> B
     // #769: a bare ident `let`-bound to a boolish value -- kind-3 entry in
     // ctx.int_local_slots (slot*4 + kind, see compile_expr_tail's
     // slot_is_intish). Closes the documented #785-P2 gap where
-    // `let b = true; "\{b}"` printed the raw integer. Duplicated slot scan
-    // (expr_is_boolish lives in compile_expr_tail, which imports this file --
-    // importing back would be circular).
-    let nm = get_eident_name(e)
-    let mut i = Array::length(local_names) - 1
-    let mut slot = -1
-    while i >= 0 {
-      if Array::get(local_names, i) == nm {
-        slot = i
-        i = -1
-      } else {
-        i = i - 1
-      }
-    }
-    if slot >= 0 {
-      let arr = ctx.int_local_slots
-      let mut j = Array::length(arr) - 1
-      let mut result = false
-      while j >= 0 {
-        let entry = Array::get(arr, j)
-        if entry / 4 == slot {
-          result = (entry % 4) == 3
-          j = -1
-        } else {
-          j = j - 1
-        }
-      }
-      result
-    } else {
-      false
-    }
+    // `let b = true; "\{b}"` printed the raw integer.
+    cc_ident_slot_kind(e, local_names, ctx) == 3
   } else if tag == 5 {
     let op = get_ebinop_op(e)
     op == "==" || op == "!=" || op == "<" || op == ">" || op == "<=" || op == ">=" || op == "&&" || op == "||"
@@ -1133,16 +1121,36 @@ fn cc_retain_stored_arg(buf: Bytes, carg: Expr, local_names: Array[String], nl: 
   }
 }
 
-/// #664/#678: is `e` statically — BY SHAPE — a known integer that must NOT be run
-/// through `__to_string`'s string-pointer heuristic (which misreads a large int
-/// as an empty string)? An Int literal, or a bitwise/shift/mod expression (those
-/// operators are never float or string). Bare idents are deliberately excluded:
-/// a per-slot "is int" log is unsound because slots are reused across scopes
-/// without updating it. Covers `"\{1 << 40}"` and integer-literal interpolation.
+/// #664/#678: is `e` statically a known integer that must NOT be run through
+/// `__to_string`'s string-pointer heuristic (which misreads a large int as an
+/// empty string)? An Int literal, a bitwise/shift/mod expression (those
+/// operators are never float or string), unary `~`, a direct call to a known
+/// Int-returning builtin, or a bare ident whose slot was `let`-bound to an Int.
+/// Covers `"\{1 << 40}"` and integer-literal interpolation.
+///
+/// #2406: the ident arm reads the kind EXACTLY (kind 1), not slot_is_intish's
+/// looser "bit 0 set" test. That predicate is also true for kind 3 (Bool),
+/// which shares Int's tagged runtime representation -- right for `==`, wrong
+/// here, where a bool must print "false" and not "0". The `__to_string` chain
+/// does try cc_expr_is_boolish before reaching this, so a kind-3 ident does not
+/// arrive today; reading the kind exactly is what keeps that ordering from
+/// being load-bearing.
+///
+/// Idents were excluded until #2406 on the grounds that a per-slot log is
+/// "unsound because slots are reused across scopes without updating it".
+/// Measured false: the log IS updated -- every `let`/`let mut` site relogs a
+/// reused slot (kind 0 clears it), and int_log_reset_above prunes at branch and
+/// arm boundaries. That is the same soundness argument expr_is_intish has
+/// relied on for its own ident arm since #678; this classifier just never
+/// asked. The consequence of not asking was silent: a `let`-bound integer with
+/// a zero low word rendered as the EMPTY STRING while the identical expression
+/// written inline rendered correctly.
 fn ts_known_int(e: Expr, local_names: Array[String], ctx: CompileCtx) -> Bool with Exception {
   let tag = expr_tag(e)
   if tag == 0 {
     true
+  } else if tag == 4 {
+    cc_ident_slot_kind(e, local_names, ctx) == 1
   } else if tag == 5 {
     let op = get_ebinop_op(e)
     op == "&" || op == "|" || op == "^" || op == "<<" || op == ">>" || op == "%"


### PR DESCRIPTION
Fixes #2406 (P0, silently wrong). Fix 1 of the three the issue weighs — the linear lane.

## The defect

An `Int` reaching `__to_string` **through a `let` binding** was rendered as the empty string when its bit pattern resembled the packed `(ptr << 32) | len` string encoding. The identical expression written inline rendered correctly.

```
let x = ((0 - (64 << 32)) - 1) ^ (0 - 1)
__to_string(x)                                  // ""
__to_string(((0 - (64 << 32)) - 1) ^ (0 - 1))   // "274877906944"
```

`__to_string` has no runtime type tag to consult, so it guesses, and `ts_known_int` is the static override that keeps known integers off that guess. It handled literals, a list of binops, `~`, and Int-returning builtin calls — but had **no bare-ident arm at all**, and never consulted the per-slot kind log that every `let` site was already filling in. The classification was computed and thrown away.

## Measured, through the right compiler

Baseline is a stage2 built from this checkout, not the committed seed — the two are indistinguishable from a passing result, and only one of them contains the change.

| case | before | after |
|---|---|---|
| A `let`-bound pathological Int → `__to_string` | **fail** | pass |
| B bool-bound ident | pass | pass |
| C `String::join([], _)`-bound ident | pass | pass |
| D/E/F string-`+`-bound ident (`__to_string`, `==`, call operands) | pass | pass |
| G float-bound ident | pass | pass |
| H same expression as A, inline | pass | pass |

The committed fixture fails against the pre-fix stage2 and passes against the fixed one, so it can actually fail.

## The change

`ts_known_int` gains a `tag == 4` arm reading the slot kind **exactly** (kind 1 = Int), not `slot_is_intish`'s looser "bit 0 set" test — that predicate is also true for kind 3 (Bool), which shares Int's tagged representation. The loose test is right for `==` and wrong here, where a bool must print `false` and not `0`. The `__to_string` chain does try the boolish classifier first, so a kind-3 ident does not reach this today; reading the kind exactly is what keeps that ordering from being load-bearing. The doc says so rather than implying the guard is currently doing work.

Three duplicated inline slot scans in this file (stringish kind 2, boolish kind 3, and the new int kind 1) fold into one `cc_ident_slot_kind` helper that returns the kind instead of answering a single-kind question.

## A false statement removed, not left standing

The old doc gave a reason for the exclusion:

> Bare idents are deliberately excluded: a per-slot "is int" log is unsound because slots are reused across scopes without updating it.

Measured false at the source. Every `let`/`let mut` site relogs a reused slot (kind 0 clears it), and `int_log_reset_above` (`common_base.vibe:1663`) compacts the log at each `if` boundary (`compile_expr.vibe:1453`) and both match boundaries (`compile_match.vibe:1034,1376`). That is the same soundness argument `expr_is_intish` has relied on for its own ident arm since #678 — this classifier just never asked. Left in place, the sentence would have kept justifying the bug to the next reader.

## Why three of the nine tests are about string concatenation

`expr_is_intish` returns true for `EBinOp("+", ..)` whenever neither operand is floatish, which reads as though a String `+` would be logged kind 1 and then forced down the integer path by this very fix. I expected exactly that regression and was wrong: measured against main's stage2, no String-typed `let` carries a kind-1 entry. `E` and `F` pin it from the other side — they compare by content today and would answer `false` (an `i64.eq` on two distinct string fat-pointers) the moment one did. They are marked load-bearing in the fixture, because the next reader will re-derive the same wrong prediction from the same code.

## It fires on real programs

The five `bench/binary_size` samples move ±0, so the size ratchet is untouched and no rebaseline is owed. That is a fact about those five samples, not about the change — real programs do bind ints to locals and interpolate them, and there the ~30-byte runtime heuristic collapses to a 1-byte constant. From the perf report:

| scenario | Δ wasm (linear) | Δ wasm (gc) |
|---|---|---|
| json_scan | **−3.94%** | ±0 |
| sieve | **−2.97%** | ±0 |
| records_pipeline | **−2.93%** | ±0 |
| expr_eval | −1.55% | ±0 |
| sort_ints / string_ops / int_wrap / base64 | −0.74 … −1.30% | ±0 |
| higher_order | ±0 | ±0 |

Output checks 9/9 (linear against golden, gc against linear) — which is the property that matters for a change that alters emitted code. Fuel is flat (≤0.05%). The gc lane is ±0 on every scenario, independently corroborating the scope claim below.

## Scope

The linear lane only. The gc lane's `gc_expr_is_intish` takes no `local_names` and no context, so it cannot classify an ident even in principle — that is fix 2 in the issue, a separate change, and this does not cover it. An `Int`-typed **parameter** is also still unclassified (`linked_compile.vibe` seeds slots for `Float`/`Double`/`Bool` but not `Int`), so a pathological value arriving as a param keeps the old behavior; also not covered here.

## Verification

- Red→green on the committed fixture, both directions, against purpose-built stage2s — re-run after the `inspect` conversion, not assumed safe because it was a test-only edit.
- `vibe fmt --check` clean on both files.
- `scripts/compiler_gate.sh` green locally (exit 0), and `check_fixture_execution.sh` accounts for all 514 test-block fixtures.
- Note for anyone reproducing locally: `pkf run release-check` fails in some containers on a broken nix `sort` (`GLIBC_ABI_DT_X86_64_PLT not found`) that has nothing to do with this diff. The same steps pass when the gate script is run directly.

## Review

Codex raised one P1: new tests must record expectations as `inspect(value, content)` snapshots (#1571) so `vibe test --update` can maintain them. Correct, and fixed in `41803388e` — 14 expectations converted. `inspect` desugars to `__to_string` before the checker, so the converted tests exercise exactly the path this PR fixes, and they report better: `actual: ` / `expected: 274877906944` where the `assert` form gave only a bare `trap: RuntimeError: unreachable`. Five relational assertions stay assertions, with the reason written into the fixture.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FYMVd6D2o82suTfTwoJPMf