### PR TITLE
Prune unreachable functions and renumber (#2359)

### DIFF
--- a/bench/perf/size_baseline.txt
+++ b/bench/perf/size_baseline.txt
@@ -174,8 +174,36 @@
 # The wasm-gc lane is the opposite and is NOT gated here: it links builtins
 # unconditionally, so these four cost it +2.2..3.1% on every perf scenario
 # including programs that never search bytes. That is #2359, not this file.
-closure_indirect 2681
-fib 1020
-fizzbuzz 1609
-hello_world 1056
-variant_float 4513
+
+# 2026-08-30 rebaseline (#2359, whole-module function pruning): the linear
+# lane now DROPS unreachable functions and renumbers, instead of shrinking
+# their bodies to a 3-byte `unreachable` stub and keeping the index slot.
+# closure_indirect 2701->1887, fib 1026->648, fizzbuzz 1615->1247,
+# hello_world 1062->684, variant_float 4530->3309. Ratcheted DOWN per this
+# file's header so the gate protects the win.
+#
+# Note the "before" column is the CURRENT measured size, not the row that was
+# committed below (fib 1020, hello_world 1056, fizzbuzz 1609,
+# closure_indirect 2681, variant_float 4513). Those were stale: #2403 (`~`)
+# moved every sample +6..+20 B without rebaselining, which the gate allowed
+# because each stayed inside +2%. Ratcheting from the stale numbers would
+# have quietly credited this change with #2403's drift.
+#
+# The tax this removes is the one the NOTE above predicted. That note tracked
+# fib 755 -> 1000 across five rebaselines and attributed 230 of the 245 bytes
+# to builtins linked unconditionally that the sample never calls. Measured
+# exactly, it was larger than the note estimated: 75 of fib's 79 functions are
+# unreachable, 378 B = 36.8% of the file. Four of the five samples were more
+# than a fifth index slots for functions that can never run.
+#
+# Two of those bytes-per-sample figures are NOT stub slots. The older
+# body-stubbing pass finds call targets by scanning body bytes for 0x10/0xd2,
+# which over-approximates: measured, it leaves 9 dead functions with real
+# bodies in variant_float (909 B) and 5 in closure_indirect (467 B). The new
+# pass decodes instructions properly, so it finds those too.
+
+closure_indirect 1887
+fib 648
+fizzbuzz 1247
+hello_world 684
+variant_float 3309

--- a/lib/@vibe/compiler/codegen/wasi/linked_compile.vibe
+++ b/lib/@vibe/compiler/codegen/wasi/linked_compile.vibe
@@ -3718,6 +3718,712 @@ fn lc_derive_helper_names(stmts: Array[Stmt]) -> Array[String] {
   names
 }
 
+//# ---------------------------------------------------------------------------
+//# #2359: whole-module function pruning (exact decode + renumber)
+//#
+//# The older pass below (search "Binary-size: replace the bodies") shrinks an
+//# unreachable generated helper's BODY to `unreachable` but must leave its
+//# function index in place, because every call site references indices fixed
+//# far earlier. Measured on `bench/binary_size`, that leftover index block is
+//# the dominant term in a small module: 74 of `fib`'s 79 functions are
+//# byte-identical 3-byte stubs, 371 B = 36% of the file.
+//#
+//# Removing the slots means renumbering, and renumbering is exactly what that
+//# pass's safety argument does not support. It finds call targets by scanning
+//# body bytes for `call`(0x10) / `ref.func`(0xd2) and decoding whatever
+//# follows as a LEB. A byte that merely LOOKS like an opcode -- one inside
+//# another instruction's immediate -- can only ever KEEP a helper that is
+//# actually dead, which is harmless when the answer is "stub or not". Rewrite
+//# the same byte and the module is corrupt.
+//#
+//# So this pass decodes instructions properly instead of scanning for them.
+//# Every immediate is skipped by its own encoding, so a call opcode is only
+//# recognized where an instruction actually starts, and the byte offset of
+//# each call immediate is known exactly rather than guessed.
+//#
+//# The decode carries its own proof: a body is only accepted when the walk
+//# lands EXACTLY on its final byte. A mis-decoded immediate desynchronizes the
+//# walk, which then overshoots or stops short -- so "my opcode table is
+//# incomplete" surfaces as a refusal, never as a wrong rewrite. Any unknown
+//# opcode, any desync, any construct below that is not handled (a `ref.func`
+//# in a global initializer, an unexpected element-segment encoding) abandons
+//# pruning for the WHOLE module and returns the input unchanged. The cost of
+//# being wrong about the encoding is the optimization, not the program.
+//#
+//# Gated to the same builds as the older pass, plus `enable_late_dce`: the
+//# `compile_wasi_module_no_dce_impl` lane contracts not to prune, and this
+//# honors that rather than making it prune by a different route.
+//# ---------------------------------------------------------------------------
+
+/// Read a LEB128 at `p`, returning the decoded value; `cell[0]` receives the
+/// position just past it. Unsigned and signed LEBs share a terminator (the
+/// first byte with bit 7 clear), so the SAME walk skips both -- only call and
+/// ref.func immediates are read for their value, and those are unsigned.
+fn lc_pf_leb(b: Bytes, p: Int, cell: Array[Int]) -> Int {
+  let mut q = p
+  let mut v = 0
+  let mut shift = 0
+  let mut more = true
+  let len = Bytes::length(b)
+  while more && q < len {
+    let byte = Bytes::get(b, q)
+    if shift < 35 {
+      v = v|((byte&127)<<shift)
+    } else {
+      ()
+    }
+    q = q + 1
+    if (byte&128) == 0 {
+      more = false
+    } else {
+      shift = shift + 7
+    }
+  }
+  Array::set(cell, 0, q)
+  v
+}
+
+/// Skip a LEB128 at `p`, returning the position just past it.
+fn lc_pf_skip_leb(b: Bytes, p: Int) -> Int {
+  let mut q = p
+  let mut more = true
+  let len = Bytes::length(b)
+  while more && q < len {
+    let byte = Bytes::get(b, q)
+    q = q + 1
+    if (byte&128) == 0 {
+      more = false
+    } else {
+      ()
+    }
+  }
+  q
+}
+
+/// Skip a blocktype: `0x40` (empty), a single-byte value type, or a negative
+/// LEB type index.
+fn lc_pf_skip_blocktype(b: Bytes, p: Int) -> Int {
+  let t = Bytes::get(b, p)
+  if t == 64 || t == 127 || t == 126 || t == 125 || t == 124 || t == 123 || t == 112 || t == 111 {
+    p + 1
+  } else {
+    lc_pf_skip_leb(b, p)
+  }
+}
+
+/// Decode one function body's instructions, recording the byte range and
+/// target of every `call` / `return_call` / `ref.func` immediate into the
+/// three parallel sink arrays. Returns true only when the walk lands EXACTLY
+/// on `body_end` -- see the header note: that equality is what makes an
+/// incomplete opcode table refuse rather than corrupt.
+fn lc_pf_decode_body(b: Bytes, instr_start: Int, body_end: Int, cell: Array[Int], sink_pos: Array[Int], sink_end: Array[Int], sink_val: Array[Int]) -> Bool {
+  let mut p = instr_start
+  let mut ok = true
+  while ok && p < body_end {
+    let op = Bytes::get(b, p)
+    p = p + 1
+    if op == 16 || op == 18 || op == 210 {
+      // call / return_call / ref.func -- the immediates this pass rewrites.
+      let ipos = p
+      let v = lc_pf_leb(b, p, cell)
+      p = Array::get(cell, 0)
+      Array::push(sink_pos, ipos)
+      Array::push(sink_end, p)
+      Array::push(sink_val, v)
+    } else if op == 2 || op == 3 || op == 4 || op == 6 {
+      p = lc_pf_skip_blocktype(b, p)
+    } else if op == 31 {
+      // try_table: blocktype, then a vector of catch clauses (kinds 0/1 carry
+      // a tag index AND a label, kinds 2/3 only a label).
+      p = lc_pf_skip_blocktype(b, p)
+      let nc = lc_pf_leb(b, p, cell)
+      p = Array::get(cell, 0)
+      let mut ci = 0
+      while ci < nc && p < body_end {
+        let kind = Bytes::get(b, p)
+        p = p + 1
+        p = lc_pf_skip_leb(b, p)
+        if kind == 0 || kind == 1 {
+          p = lc_pf_skip_leb(b, p)
+        } else {
+          ()
+        }
+        ci = ci + 1
+      }
+    } else if op == 14 {
+      // br_table: vector of labels plus the default.
+      let n = lc_pf_leb(b, p, cell)
+      p = Array::get(cell, 0)
+      let mut bi = 0
+      while bi <= n && p < body_end {
+        p = lc_pf_skip_leb(b, p)
+        bi = bi + 1
+      }
+    } else if op == 28 {
+      // select with an explicit result-type vector.
+      let n = lc_pf_leb(b, p, cell)
+      p = Array::get(cell, 0) + n
+    } else if op == 12 || op == 13 || op == 7 || op == 8 || op == 9 || op == 24 || op == 32 || op == 33 || op == 34 || op == 35 || op == 36 || op == 37 || op == 38 || op == 63 || op == 64 || op == 208 {
+      p = lc_pf_skip_leb(b, p)
+    } else if op == 17 || op == 19 {
+      // call_indirect / return_call_indirect: type index then table index.
+      // The callee is dynamic, so the funcref table's own entries are roots.
+      p = lc_pf_skip_leb(b, p)
+      p = lc_pf_skip_leb(b, p)
+    } else if op >= 40 && op <= 62 {
+      p = lc_pf_skip_leb(b, p)
+      p = lc_pf_skip_leb(b, p)
+    } else if op == 65 || op == 66 {
+      p = lc_pf_skip_leb(b, p)
+    } else if op == 67 {
+      p = p + 4
+    } else if op == 68 {
+      p = p + 8
+    } else if op == 252 {
+      // misc prefix (memory.copy/fill, table ops, saturating truncs)
+      let sub = lc_pf_leb(b, p, cell)
+      p = Array::get(cell, 0)
+      if sub == 8 || sub == 10 || sub == 12 || sub == 14 {
+        p = lc_pf_skip_leb(b, p)
+        p = lc_pf_skip_leb(b, p)
+      } else if sub == 9 || sub == 11 || sub == 13 || sub == 15 || sub == 16 || sub == 17 {
+        p = lc_pf_skip_leb(b, p)
+      } else {
+        ()
+      }
+    } else if op == 253 {
+      // SIMD prefix
+      let sub = lc_pf_leb(b, p, cell)
+      p = Array::get(cell, 0)
+      if sub == 12 || sub == 13 {
+        p = p + 16
+      } else if sub >= 84 && sub <= 91 {
+        p = lc_pf_skip_leb(b, p)
+        p = lc_pf_skip_leb(b, p)
+        p = p + 1
+      } else if sub <= 11 || sub == 92 || sub == 93 {
+        p = lc_pf_skip_leb(b, p)
+        p = lc_pf_skip_leb(b, p)
+      } else if sub >= 21 && sub <= 34 {
+        p = p + 1
+      } else {
+        ()
+      }
+    } else if op == 0 || op == 1 || op == 5 || op == 11 || op == 15 || op == 25 || op == 26 || op == 27 || op == 209 {
+      ()
+    } else if op >= 69 && op <= 196 {
+      ()
+    } else {
+      // Unknown opcode: refuse rather than guess (header note).
+      ok = false
+    }
+  }
+  ok && p == body_end
+}
+
+/// Copy `[from, to)` of `src` onto `dst`.
+fn lc_pf_copy_range(dst: Bytes, src: Bytes, from: Int, to: Int) -> Unit {
+  let mut i = from
+  while i < to {
+    bytebuf_push(dst, Bytes::get(src, i))
+    i = i + 1
+  }
+}
+
+/// Rewrite the "name" custom section's function-name subsection (id 1) through
+/// `newidx`, dropping entries for pruned functions. Other subsections are
+/// copied verbatim. Returns the rebuilt payload, or an empty buffer when the
+/// layout is not the one this understands (caller then abandons the prune --
+/// a name section left pointing at old indices would mislabel every frame in
+/// a backtrace, which is worse than not shrinking).
+fn lc_pf_remap_name_section(payload: Bytes, newidx: Array[Int], cell: Array[Int], failed: Array[Bool]) -> Bytes {
+  let out = bytebuf_new()
+  let len = Bytes::length(payload)
+  // section name ("name"), copied as-is
+  let nlen = lc_pf_leb(payload, 0, cell)
+  let mut p = Array::get(cell, 0)
+  lc_pf_copy_range(out, payload, 0, p + nlen)
+  p = p + nlen
+  while p < len {
+    let sub_id = Bytes::get(payload, p)
+    p = p + 1
+    let sub_len = lc_pf_leb(payload, p, cell)
+    let sub_body = Array::get(cell, 0)
+    let sub_end = sub_body + sub_len
+    if sub_id == 1 {
+      let names = bytebuf_new()
+      let cnt = lc_pf_leb(payload, sub_body, cell)
+      let mut q = Array::get(cell, 0)
+      let kept = bytebuf_new()
+      let mut kept_n = 0
+      let mut ni = 0
+      while ni < cnt && q < sub_end {
+        let idx = lc_pf_leb(payload, q, cell)
+        q = Array::get(cell, 0)
+        let slen = lc_pf_leb(payload, q, cell)
+        let sstart = Array::get(cell, 0)
+        q = sstart + slen
+        if idx < Array::length(newidx) && Array::get(newidx, idx) >= 0 {
+          leb128_encode_u32(kept, Array::get(newidx, idx))
+          leb128_encode_u32(kept, slen)
+          lc_pf_copy_range(kept, payload, sstart, sstart + slen)
+          kept_n = kept_n + 1
+        } else {
+          ()
+        }
+        ni = ni + 1
+      }
+      if q != sub_end {
+        Array::set(failed, 0, true)
+      } else {
+        ()
+      }
+      bytebuf_push_vec_header(names, kept_n)
+      bytebuf_push_buf(names, kept)
+      bytebuf_push(out, 1)
+      leb128_encode_u32(out, bytebuf_length(names))
+      bytebuf_push_buf(out, names)
+    } else {
+      bytebuf_push(out, sub_id)
+      leb128_encode_u32(out, sub_len)
+      lc_pf_copy_range(out, payload, sub_body, sub_end)
+    }
+    p = sub_end
+  }
+  out
+}
+
+/// #2359: drop every function the module cannot reach and renumber what is
+/// left. Roots are the exported functions plus every funcref-table entry (a
+/// `call_indirect` target is only known dynamically, so a table slot is a
+/// root, not an edge). Returns `mod_bytes` unchanged whenever anything is not
+/// understood -- see the header note on why refusing is the safe answer.
+fn lc_pf_prune_module(mod_bytes: Bytes) -> Bytes {
+  let cell = lc_fresh_int_array()
+  Array::push(cell, 0)
+  let failed = lc_fresh_bool_array()
+  Array::push(failed, false)
+  let total = Bytes::length(mod_bytes)
+  if total < 8 {
+    mod_bytes
+  } else {
+    // --- section table -------------------------------------------------
+    let sec_id = lc_fresh_int_array()
+    let sec_start = lc_fresh_int_array()
+    let sec_len = lc_fresh_int_array()
+    let mut p = 8
+    let mut walk_ok = true
+    while walk_ok && p < total {
+      let sid = Bytes::get(mod_bytes, p)
+      let n = lc_pf_leb(mod_bytes, p + 1, cell)
+      let body = Array::get(cell, 0)
+      if body + n > total {
+        walk_ok = false
+      } else {
+        Array::push(sec_id, sid)
+        Array::push(sec_start, body)
+        Array::push(sec_len, n)
+        p = body + n
+      }
+    }
+    if !walk_ok {
+      mod_bytes
+    } else {
+      let nsec = Array::length(sec_id)
+      // --- imported function count, function types, bodies ---------------
+      let mut num_imported = 0
+      let ftypes = lc_fresh_int_array()
+      let mut code_i = -1
+      let body_instr = lc_fresh_int_array()
+      let body_end = lc_fresh_int_array()
+      let body_start = lc_fresh_int_array()
+      let roots = lc_fresh_int_array()
+      let mut si = 0
+      while si < nsec && !Array::get(failed, 0) {
+        let sid = Array::get(sec_id, si)
+        let sstart = Array::get(sec_start, si)
+        let send = sstart + Array::get(sec_len, si)
+        if sid == 2 {
+          let c = lc_pf_leb(mod_bytes, sstart, cell)
+          let mut q = Array::get(cell, 0)
+          let mut ii = 0
+          while ii < c && q < send {
+            let ml = lc_pf_leb(mod_bytes, q, cell)
+            q = Array::get(cell, 0) + ml
+            let nl = lc_pf_leb(mod_bytes, q, cell)
+            q = Array::get(cell, 0) + nl
+            let kind = Bytes::get(mod_bytes, q)
+            q = q + 1
+            if kind == 0 {
+              q = lc_pf_skip_leb(mod_bytes, q)
+              num_imported = num_imported + 1
+            } else if kind == 1 {
+              q = q + 1
+              let lim = Bytes::get(mod_bytes, q)
+              q = lc_pf_skip_leb(mod_bytes, q + 1)
+              if lim == 1 {
+                q = lc_pf_skip_leb(mod_bytes, q)
+              } else {
+                ()
+              }
+            } else if kind == 2 {
+              let lim2 = Bytes::get(mod_bytes, q)
+              q = lc_pf_skip_leb(mod_bytes, q + 1)
+              if lim2 == 1 {
+                q = lc_pf_skip_leb(mod_bytes, q)
+              } else {
+                ()
+              }
+            } else {
+              q = q + 2
+            }
+            ii = ii + 1
+          }
+        } else if sid == 3 {
+          let c = lc_pf_leb(mod_bytes, sstart, cell)
+          let mut q = Array::get(cell, 0)
+          let mut ti = 0
+          while ti < c {
+            let t = lc_pf_leb(mod_bytes, q, cell)
+            q = Array::get(cell, 0)
+            Array::push(ftypes, t)
+            ti = ti + 1
+          }
+        } else if sid == 6 {
+          // A `ref.func` in a global initializer would be an extra root this
+          // pass does not model. None is emitted today; refuse if that changes.
+          let mut gi = sstart
+          while gi < send {
+            if Bytes::get(mod_bytes, gi) == 210 {
+              Array::set(failed, 0, true)
+            } else {
+              ()
+            }
+            gi = gi + 1
+          }
+        } else if sid == 7 {
+          let c = lc_pf_leb(mod_bytes, sstart, cell)
+          let mut q = Array::get(cell, 0)
+          let mut ei = 0
+          while ei < c && q < send {
+            let nl = lc_pf_leb(mod_bytes, q, cell)
+            q = Array::get(cell, 0) + nl
+            let kind = Bytes::get(mod_bytes, q)
+            q = q + 1
+            let idx = lc_pf_leb(mod_bytes, q, cell)
+            q = Array::get(cell, 0)
+            if kind == 0 {
+              Array::push(roots, idx)
+            } else {
+              ()
+            }
+            ei = ei + 1
+          }
+        } else if sid == 9 {
+          let c = lc_pf_leb(mod_bytes, sstart, cell)
+          let mut q = Array::get(cell, 0)
+          let mut gi2 = 0
+          while gi2 < c && q < send && !Array::get(failed, 0) {
+            let flag = lc_pf_leb(mod_bytes, q, cell)
+            q = Array::get(cell, 0)
+            if flag != 0 {
+              // Only the active-table-0 form is emitted today.
+              Array::set(failed, 0, true)
+            } else {
+              while q < send && Bytes::get(mod_bytes, q) != 11 {
+                let iop = Bytes::get(mod_bytes, q)
+                q = q + 1
+                if iop == 65 || iop == 35 {
+                  q = lc_pf_skip_leb(mod_bytes, q)
+                } else {
+                  ()
+                }
+              }
+              q = q + 1
+              let nf = lc_pf_leb(mod_bytes, q, cell)
+              q = Array::get(cell, 0)
+              let mut fi = 0
+              while fi < nf {
+                let f = lc_pf_leb(mod_bytes, q, cell)
+                q = Array::get(cell, 0)
+                Array::push(roots, f)
+                fi = fi + 1
+              }
+            }
+            gi2 = gi2 + 1
+          }
+        } else if sid == 8 {
+          // A start function would be another root; none is emitted today.
+          Array::set(failed, 0, true)
+        } else if sid == 10 {
+          code_i = si
+          let c = lc_pf_leb(mod_bytes, sstart, cell)
+          let mut q = Array::get(cell, 0)
+          let mut bi = 0
+          while bi < c && q < send {
+            let sz = lc_pf_leb(mod_bytes, q, cell)
+            let bstart = Array::get(cell, 0)
+            let bend = bstart + sz
+            let nl = lc_pf_leb(mod_bytes, bstart, cell)
+            let mut r = Array::get(cell, 0)
+            let mut li = 0
+            while li < nl {
+              r = lc_pf_skip_leb(mod_bytes, r)
+              r = r + 1
+              li = li + 1
+            }
+            Array::push(body_start, bstart)
+            Array::push(body_instr, r)
+            Array::push(body_end, bend)
+            q = bend
+            bi = bi + 1
+          }
+        } else {
+          ()
+        }
+        si = si + 1
+      }
+      let nbodies = Array::length(body_end)
+      if Array::get(failed, 0) || code_i < 0 || nbodies == 0 || Array::length(ftypes) != nbodies {
+        mod_bytes
+      } else {
+        lc_pf_prune_with_layout(mod_bytes, cell, failed, sec_id, sec_start, sec_len, num_imported, ftypes, body_start, body_instr, body_end, roots, code_i)
+      }
+    }
+  }
+}
+
+/// Second half of lc_pf_prune_module: decode every body, close reachability
+/// over the call graph, then re-emit the module with the survivors renumbered.
+/// Split out only because the section walk above already fills a screen.
+fn lc_pf_prune_with_layout(mod_bytes: Bytes, cell: Array[Int], failed: Array[Bool], sec_id: Array[Int], sec_start: Array[Int], sec_len: Array[Int], num_imported: Int, ftypes: Array[Int], body_start: Array[Int], body_instr: Array[Int], body_end: Array[Int], roots: Array[Int], code_i: Int) -> Bytes {
+  let nbodies = Array::length(body_end)
+  // --- decode every body once; remember each call immediate ---------------
+  // Sites are stored flat with a per-body [begin, end) window into them, so
+  // the whole pass allocates a fixed number of arrays regardless of module
+  // size.
+  let site_pos = lc_fresh_int_array()
+  let site_end = lc_fresh_int_array()
+  let site_val = lc_fresh_int_array()
+  let site_from = lc_fresh_int_array()
+  let site_to = lc_fresh_int_array()
+  let mut bi = 0
+  let mut all_ok = true
+  while bi < nbodies && all_ok {
+    Array::push(site_from, Array::length(site_pos))
+    all_ok = lc_pf_decode_body(mod_bytes, Array::get(body_instr, bi), Array::get(body_end, bi), cell, site_pos, site_end, site_val)
+    Array::push(site_to, Array::length(site_pos))
+    bi = bi + 1
+  }
+  if !all_ok {
+    mod_bytes
+  } else {
+    // --- reachability -----------------------------------------------------
+    let seen = lc_fresh_bool_array()
+    let mut szi = 0
+    while szi < num_imported + nbodies {
+      Array::push(seen, false)
+      szi = szi + 1
+    }
+    let stack = lc_fresh_int_array()
+    let mut ri = 0
+    while ri < Array::length(roots) {
+      Array::push(stack, Array::get(roots, ri))
+      ri = ri + 1
+    }
+    let mut sp = 0
+    while sp < Array::length(stack) {
+      let f = Array::get(stack, sp)
+      sp = sp + 1
+      if f >= 0 && f < Array::length(seen) && !Array::get(seen, f) {
+        Array::set(seen, f, true)
+        if f >= num_imported {
+          let fb = f - num_imported
+          let mut k = Array::get(site_from, fb)
+          let kend = Array::get(site_to, fb)
+          while k < kend {
+            Array::push(stack, Array::get(site_val, k))
+            k = k + 1
+          }
+        } else {
+          ()
+        }
+      } else {
+        ()
+      }
+    }
+    // --- old -> new index map (imports keep their indices) ----------------
+    let newidx = lc_fresh_int_array()
+    let mut mi = 0
+    while mi < num_imported {
+      Array::push(newidx, mi)
+      mi = mi + 1
+    }
+    let keep = lc_fresh_int_array()
+    let mut ki = 0
+    while ki < nbodies {
+      if Array::get(seen, ki + num_imported) {
+        Array::push(newidx, num_imported + Array::length(keep))
+        Array::push(keep, ki)
+      } else {
+        Array::push(newidx, -1)
+      }
+      ki = ki + 1
+    }
+    if Array::length(keep) == nbodies {
+      // Nothing to drop: leave the bytes untouched rather than re-emitting
+      // an identical module.
+      mod_bytes
+    } else {
+      // --- rebuilt code + function sections --------------------------------
+      let code_content = bytebuf_new()
+      bytebuf_push_vec_header(code_content, Array::length(keep))
+      let func_content = bytebuf_new()
+      bytebuf_push_vec_header(func_content, Array::length(keep))
+      let mut kj = 0
+      while kj < Array::length(keep) && !Array::get(failed, 0) {
+        let b = Array::get(keep, kj)
+        leb128_encode_u32(func_content, Array::get(ftypes, b))
+        let nb = bytebuf_new()
+        let mut prev = Array::get(body_start, b)
+        let mut k = Array::get(site_from, b)
+        let kend = Array::get(site_to, b)
+        while k < kend {
+          lc_pf_copy_range(nb, mod_bytes, prev, Array::get(site_pos, k))
+          let target = Array::get(site_val, k)
+          if target < 0 || target >= Array::length(newidx) || Array::get(newidx, target) < 0 {
+            // A kept body calls something the walk pruned: the reachability
+            // closure and the rewrite disagree, so trust neither.
+            Array::set(failed, 0, true)
+          } else {
+            leb128_encode_u32(nb, Array::get(newidx, target))
+          }
+          prev = Array::get(site_end, k)
+          k = k + 1
+        }
+        lc_pf_copy_range(nb, mod_bytes, prev, Array::get(body_end, b))
+        leb128_encode_u32(code_content, bytebuf_length(nb))
+        bytebuf_push_buf(code_content, nb)
+        kj = kj + 1
+      }
+      if Array::get(failed, 0) {
+        mod_bytes
+      } else {
+        lc_pf_reemit(mod_bytes, cell, failed, sec_id, sec_start, sec_len, newidx, func_content, code_content)
+      }
+    }
+  }
+}
+
+/// Final step: write the module back out, substituting the rebuilt function
+/// and code sections and remapping every function index the other sections
+/// carry (exports, element segments, the name section).
+fn lc_pf_reemit(mod_bytes: Bytes, cell: Array[Int], failed: Array[Bool], sec_id: Array[Int], sec_start: Array[Int], sec_len: Array[Int], newidx: Array[Int], func_content: Bytes, code_content: Bytes) -> Bytes {
+  let out = bytebuf_new()
+  lc_pf_copy_range(out, mod_bytes, 0, 8)
+  let mut si = 0
+  while si < Array::length(sec_id) && !Array::get(failed, 0) {
+    let sid = Array::get(sec_id, si)
+    let sstart = Array::get(sec_start, si)
+    let send = sstart + Array::get(sec_len, si)
+    if sid == 3 {
+      bytebuf_push_section(out, 3, func_content)
+    } else if sid == 10 {
+      bytebuf_push_section(out, 10, code_content)
+    } else if sid == 7 {
+      let ec = bytebuf_new()
+      let c = lc_pf_leb(mod_bytes, sstart, cell)
+      let mut q = Array::get(cell, 0)
+      bytebuf_push_vec_header(ec, c)
+      let mut ei = 0
+      while ei < c && q < send {
+        let nl = lc_pf_leb(mod_bytes, q, cell)
+        let nstart = Array::get(cell, 0)
+        leb128_encode_u32(ec, nl)
+        lc_pf_copy_range(ec, mod_bytes, nstart, nstart + nl)
+        q = nstart + nl
+        let kind = Bytes::get(mod_bytes, q)
+        bytebuf_push(ec, kind)
+        q = q + 1
+        let idx = lc_pf_leb(mod_bytes, q, cell)
+        q = Array::get(cell, 0)
+        if kind == 0 {
+          if Array::get(newidx, idx) < 0 {
+            Array::set(failed, 0, true)
+          } else {
+            leb128_encode_u32(ec, Array::get(newidx, idx))
+          }
+        } else {
+          leb128_encode_u32(ec, idx)
+        }
+        ei = ei + 1
+      }
+      bytebuf_push_section(out, 7, ec)
+    } else if sid == 9 {
+      let el = bytebuf_new()
+      let c = lc_pf_leb(mod_bytes, sstart, cell)
+      let mut q = Array::get(cell, 0)
+      bytebuf_push_vec_header(el, c)
+      let mut gi = 0
+      while gi < c && q < send && !Array::get(failed, 0) {
+        let flag = lc_pf_leb(mod_bytes, q, cell)
+        q = Array::get(cell, 0)
+        leb128_encode_u32(el, flag)
+        let expr_from = q
+        while q < send && Bytes::get(mod_bytes, q) != 11 {
+          let iop = Bytes::get(mod_bytes, q)
+          q = q + 1
+          if iop == 65 || iop == 35 {
+            q = lc_pf_skip_leb(mod_bytes, q)
+          } else {
+            ()
+          }
+        }
+        q = q + 1
+        lc_pf_copy_range(el, mod_bytes, expr_from, q)
+        let nf = lc_pf_leb(mod_bytes, q, cell)
+        q = Array::get(cell, 0)
+        leb128_encode_u32(el, nf)
+        let mut fi = 0
+        while fi < nf {
+          let f = lc_pf_leb(mod_bytes, q, cell)
+          q = Array::get(cell, 0)
+          if Array::get(newidx, f) < 0 {
+            Array::set(failed, 0, true)
+          } else {
+            leb128_encode_u32(el, Array::get(newidx, f))
+          }
+          fi = fi + 1
+        }
+        gi = gi + 1
+      }
+      bytebuf_push_section(out, 9, el)
+    } else if sid == 0 {
+      let payload = bytebuf_new()
+      lc_pf_copy_range(payload, mod_bytes, sstart, send)
+      let nlen = lc_pf_leb(mod_bytes, sstart, cell)
+      let nstart = Array::get(cell, 0)
+      let is_name = nlen == 4 && Bytes::get(mod_bytes, nstart) == 110 && Bytes::get(mod_bytes, nstart + 1) == 97 && Bytes::get(mod_bytes, nstart + 2) == 109 && Bytes::get(mod_bytes, nstart + 3) == 101
+      if is_name {
+        let remapped = lc_pf_remap_name_section(bytebuf_to_bytes(payload), newidx, cell, failed)
+        bytebuf_push_section(out, 0, remapped)
+      } else {
+        bytebuf_push_section(out, 0, payload)
+      }
+    } else {
+      let raw = bytebuf_new()
+      lc_pf_copy_range(raw, mod_bytes, sstart, send)
+      bytebuf_push_section(out, sid, raw)
+    }
+    si = si + 1
+  }
+  if Array::get(failed, 0) {
+    mod_bytes
+  } else {
+    bytebuf_to_bytes(out)
+  }
+}
+
 fn lc_is_derive_helper_name(derive_names: Array[String], name: String) -> Bool {
   String::starts_with(name, "__arr_equals__") || String::starts_with(name, "__arr_to_string__") || array_contains_str(derive_names, name)
 }
@@ -9091,7 +9797,14 @@ export fn compile_wasi_module_linked_impl_with_float_offsets(stmts: Array[Stmt],
   Array::push(name_sec_names, "_start")
   Array::push(name_sec_names, "run")
   emit_function_name_section(out, name_sec_names, num_imported_funcs)
-  bytebuf_to_bytes(out)
+  // #2359: drop unreachable functions and renumber. Same build gating as the
+  // body-stubbing pass above (instrumented builds must see unmodified
+  // bodies), plus `enable_late_dce` so the no-DCE lane keeps its contract.
+  if enable_late_dce && !coverage && !debug_trace && !debug_break && !rc_shadow {
+    lc_pf_prune_module(bytebuf_to_bytes(out))
+  } else {
+    bytebuf_to_bytes(out)
+  }
 }
 
 /// #2158: the historical signature. Every caller that has no checker offsets to


### PR DESCRIPTION
Fixes #2359.

| sample | before | after | Δ |
|---|---:|---:|---:|
| fib | 1026 | 648 | **−36.8%** |
| hello_world | 1062 | 684 | **−35.6%** |
| closure_indirect | 2701 | 1887 | −30.1% |
| variant_float | 4530 | 3309 | −27.0% |
| fizzbuzz | 1615 | 1247 | −22.8% |
| stage2.wasm | 2800980 | 2797370 | −0.1% |

## What was actually costing the bytes

The issue's framing — "every builtin's body is part of every module" — is not what happens, and I corrected that [in the issue](https://github.com/mizchi/vibe-lang/issues/2359#issuecomment-5466591809) before implementing. The existing pass already shrinks an unreachable helper's **body** to a 3-byte `unreachable` stub. What it cannot remove is the **index slot**, because every call site references indices fixed far earlier. Measured exactly: 75 of `fib`'s 79 functions are unreachable, 378 B = 36.8% of the file.

So the whole task is the one thing the issue listed as a sub-problem: renumbering.

## Why the existing scan cannot do it, and what replaces it

The current pass finds call targets by scanning body bytes for `call`(0x10) / `ref.func`(0xd2) and decoding whatever follows as a LEB. Its safety argument is explicit in the source: a byte that merely *looks* like an opcode — one sitting inside another instruction's immediate — can only ever **keep** a helper that is already dead. That is harmless when the answer is "stub or not". Rewrite that same byte and the module is corrupt.

This pass decodes instructions properly instead of scanning for them. Every immediate is skipped by its own encoding, so a call opcode is recognized only where an instruction actually starts, and each immediate's offset is known rather than guessed.

**The decode carries its own proof.** A body is accepted only when the walk lands *exactly* on its final byte. A mis-decoded immediate desynchronizes the walk, which then overshoots or stops short — so "my opcode table is incomplete" surfaces as a refusal, never as a wrong rewrite. This is not theoretical: I prototyped the decoder in Python first and it hit exactly this twice (`throw`, `try_table`), failing loudly both times instead of silently mis-parsing.

Anything not understood — unknown opcode, desync, a `ref.func` in a global initializer, a start section, an unexpected element-segment encoding, or a kept body calling something pruned — abandons pruning for the **whole module** and returns the input unchanged. The cost of being wrong about the encoding is the optimization, not the program.

## A second finding: the old scan leaves real dead code

Because it over-approximates, the byte-scan does not merely fail to remove slots — it leaves whole live bodies that nothing can reach:

| sample | dead fns | stubbed by the old pass | **missed** |
|---|---:|---:|---:|
| variant_float | 67 | 58 | **9 = 909 B** |
| closure_indirect | 72 | 67 | **5 = 467 B** |
| fib / hello_world / fizzbuzz | 73–75 | 72–74 | 1 = 6 B |

That is why `variant_float` and `closure_indirect` gain more than their stub-slot count alone predicts.

## The lane that contracts not to prune

Gated to the same builds as the stubbing pass (instrumented builds must see unmodified bodies), **plus `enable_late_dce`** — so `compile_wasi_module_no_dce_impl` keeps its contract rather than being made to prune by a different route. `size_baseline.txt`'s #1666 note records a gate that was written and then removed for demanding pruning from exactly that lane.

## Verification

- **Full `compiler_gate.sh` green** (exit 0, 124/124 sections) including the stage2==stage3 fixpoint. That is the strongest test available here: the compiler compiles *itself* through this lane, so the pass ran over a 5,860-function module, and the resulting stage2 then compiled everything else.
- All five samples produce **identical output** through `run_wasm_vibe_host_runner.sh`.
- Sizes match an **independently written Python prototype to the byte** on all five. Agreement on one number is luck; five exact byte counts from two separate implementations is not.

## Baseline ratcheted DOWN, from measured numbers

Per `size_baseline.txt`'s own header. The "before" column is the **currently measured** size, not the committed rows (fib 1020, hello_world 1056, fizzbuzz 1609, closure_indirect 2681, variant_float 4513). Those were stale: #2403 moved every sample +6…+20 B without rebaselining, allowed because each stayed inside +2%. Ratcheting from them would have quietly credited this change with #2403's drift.

**Red/green on the ratchet itself**, because a gate that has not been shown to fail is not protecting anything:

```
pre-change compiler vs the new baseline  -> FAIL on all five (+29% .. +58%)
this compiler        vs the new baseline -> ok, 0 B on every sample
```

That is also what catches a silent refusal: every bail-out path returns the unpruned module, so the sizes jump straight back over tolerance rather than quietly reverting to the old behavior.

## Expected in the perf report

Every linear-lane scenario loses its dead function slots, so the nine execution scenarios will move substantially too. Those are this change; the small pre-existing drift in the committed baseline rows was #2403's, and the entry in `size_baseline.txt` says so rather than letting the two be conflated again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FYMVd6D2o82suTfTwoJPMf

---
_Generated by [Claude Code](https://claude.ai/code/session_01FYMVd6D2o82suTfTwoJPMf)_