### PR TITLE
Perceus wide reuse admits pure-borrow binds (#2389 borrow-callee slice)

### DIFF
--- a/docs/perceus-reuse.md
+++ b/docs/perceus-reuse.md
@@ -191,16 +191,26 @@ claim and the tail leaks without corrupting, the same window the narrow
 fusion's spine calls have always had and the "safe leak, never
 use-after-free" class ADR-0055 accepts on unwind paths.
 
-Two deliberate exclusions, both measured against the compiler's own plan
-output rather than guessed:
+Per-bind admission (the borrow-callee slice, follow-up on the first #2389
+round): a payload bind is admitted at consume count **1** — ownership
+transfers raw and the single consume releases it — or **0**, a bind whose
+every use borrows (e.g. all its callees are borrow-classified, the shape
+the first slice declined and where the compiler's own arms mostly live).
+For a consume-0 bind the codegen compensates on both paths of the SAME
+compiled body: the shared path's staging dup gives the bind its own
+reference (a borrowed view would depend on the OTHER reference surviving
+the arm, which arm code can release — the scrutinee's ref is dropped at
+staging), and an unconditional arm-end drop releases that ref on the
+shared path and the raw-transferred child on the unique path, where
+nothing in the body consumes it and the token overwrite would otherwise
+leak it. Consume counts 2+ decline (dup-per-consume has no raw-transfer
+equivalent), as does an alias-bound name (aliasing can hide an owner the
+consume count does not see). The fusion inside a borrow-classified
+FUNCTION stays impossible by construction — its parameter carries no
+plan drop, so the scrutinee gate never opens on a block the caller owns.
 
-- **Borrow-classified callees decline.** `let a2 = walk(a)` where `walk`
-  is in the borrow-param ABI leaves the pattern bind `a` a plan-side
-  scope-end drop the raw ownership transfer would not honor; both the
-  planner (action-free-binds requirement) and the codegen (bind not in
-  rc_drop/dup/alias names) refuse, so the accounting the plan committed to
-  is never broken. Extending the transfer to emit those drops at arm end is
-  the next slice — it is where the compiler's own arms mostly live.
+One deliberate exclusion, measured against the compiler's own plan
+output rather than guessed:
 - **Scalar-payload rebuilds pair when the bind is consumed once, decline
   when it is not.** Measured (this section previously claimed the
   opposite): `Leaf(v) => Leaf(v + 1)` reads a consume count of 1 for `v`

--- a/lib/@vibe/compiler/codegen/expr/compile_match.vibe
+++ b/lib/@vibe/compiler/codegen/expr/compile_match.vibe
@@ -651,12 +651,18 @@ fn mr_reuse_wide_eligible(p: Pat, body: Expr, scrutinee: Expr, ctx: CompileCtx) 
             if ctor_field_is_float(ctx, src_ci, fj) {
               shape_ok = false
             } else if is_pbind(pa) {
-              // Consumed exactly once AND action-free in the plan: a
-              // borrow-classified callee leaves the bind a scope-end drop
-              // the raw ownership transfer below would not honor (the
-              // borrow-callee extension is a separate slice).
+              // Consume count 1: ownership transfers raw and the single
+              // consume releases it. Consume count 0 (every use borrows --
+              // e.g. borrow-classified callees): the staging compensates,
+              // dup-skipping it on the shared path (it stays a view of the
+              // still-live block) and the arm end drops it when the block
+              // was unique (the raw transfer's ref nobody consumed). 2+
+              // declines -- the normal path's dup-per-consume has no
+              // raw-transfer equivalent. An alias-bound name declines:
+              // aliasing can hide an owner the consume count doesn't see.
               let __wbn = get_pbind_name(pa)
-              if md_consume_count_pre(body, __wbn, ctx.borrow_param_user, mr_bmasks) != 1 || array_contains_str(ctx.rc_drop_names, __wbn) || array_contains_str(ctx.rc_dup_names, __wbn) || array_contains_str(ctx.rc_alias_dup_names, __wbn) {
+              let __wcc = md_consume_count_pre(body, __wbn, ctx.borrow_param_user, mr_bmasks)
+              if (__wcc != 0 && __wcc != 1) || array_contains_str(ctx.rc_alias_dup_names, __wbn) {
                 shape_ok = false
               } else {
                 ()
@@ -702,6 +708,31 @@ fn mr_reuse_wide_eligible(p: Pat, body: Expr, scrutinee: Expr, ctx: CompileCtx) 
 /// means the eligibility and the emission disagree, never a user error.
 fn mr_compile_reuse_arm_wide(buf: Bytes, body: Expr, pat: Pat, scrut_local: Int, flag_local: Int, arity: Int, local_names: Array[String], ctx: CompileCtx, ld: Int, ce: (Bytes, Expr, Array[String], Int, CompileCtx, Int) -> Int with Exception) -> Int with Exception {
   let pargs = get_pctor_args(pat)
+  // Per-bind consume counts (0 or 1, eligibility guarantees it), indexed by
+  // PATTERN position. A consume-1 bind's raw-transferred ref is released by
+  // its one consume; a consume-0 bind's is released by the arm-end
+  // conditional drop below (unique path) or never taken (shared path: the
+  // bind stays a borrowed view of the block the other reference keeps
+  // alive, exactly like bind_match_pat's dup-per-consume model with n=0).
+  let __wcc_bmasks = md_shadow_zeroed_bmasks(body, ctx.borrow_param_user, ctx.borrow_param_mask)
+  let bind_consumes: Array[Int] = []
+  let mut has_borrow_bind = false
+  let mut ci = 0
+  while ci < arity {
+    let cpa = Array::get(pargs, ci)
+    if is_pbind(cpa) {
+      let __cn = md_consume_count_pre(body, get_pbind_name(cpa), ctx.borrow_param_user, __wcc_bmasks)
+      Array::push(bind_consumes, __cn)
+      if __cn == 0 {
+        has_borrow_bind = true
+      } else {
+        ()
+      }
+    } else {
+      Array::push(bind_consumes, 0 - 1)
+    }
+    ci = ci + 1
+  }
   let mut bi = 0
   while bi < arity {
     let pa = Array::get(pargs, bi)
@@ -756,6 +787,12 @@ fn mr_compile_reuse_arm_wide(buf: Bytes, body: Expr, pat: Pat, scrut_local: Int,
   let mut dj = 0
   while dj < arity {
     if is_pbind(Array::get(pargs, dj)) {
+      // EVERY bind is dup'd into ownership on the shared path -- including
+      // a consume-0 one. The scrutinee's reference is dropped right below,
+      // so a bind left as a borrowed view would depend on the OTHER
+      // reference surviving the whole arm, which arm code can release (a
+      // container the arm mutates, say). Owning the ref makes the bind
+      // self-sufficient; the arm-end drop below releases it on both paths.
       let nbinds_before = mr_binds_before(pargs, dj)
       emit_rc_dup_guarded(buf, tk - mr_bind_count(pargs) + nbinds_before, ctx.rc_shadow, ctx.rc_dup_func_idx)
     } else {
@@ -774,6 +811,26 @@ fn mr_compile_reuse_arm_wide(buf: Bytes, body: Expr, pat: Pat, scrut_local: Int,
   Array::push(ctx.reuse_tok_arities, arity)
   Array::push(ctx.reuse_tok_emitted, 0)
   let nl2 = ce(buf, body, local_names, Array::length(local_names), ctx, ld)
+  // Arm-end release of every consume-0 bind's owned ref (raw-transferred on
+  // the unique path, dup'd on the shared path -- both exactly one). Nothing
+  // in the body consumed it; without this the token overwrite leaks the
+  // child on the unique path. Emitted after the body value, which stays on
+  // the wasm stack untouched (rc_drop returns nothing). A scalar payload
+  // no-ops inside rc_drop (even tag).
+  if has_borrow_bind {
+    let mut fj = 0
+    while fj < arity {
+      if is_pbind(Array::get(pargs, fj)) && Array::get(bind_consumes, fj) == 0 {
+        emit_local_get(buf, tk - mr_bind_count(pargs) + mr_binds_before(pargs, fj))
+        emit_call(buf, ctx.rc_drop_func_idx)
+      } else {
+        ()
+      }
+      fj = fj + 1
+    }
+  } else {
+    ()
+  }
   let __rt_at = Array::length(ctx.reuse_tok_emitted) - 1
   let __rt_emitted = Array::get(ctx.reuse_tok_emitted, __rt_at)
   Array::truncate(ctx.reuse_tok_locals, __rt_at)

--- a/lib/@vibe/compiler/perceus/perceus.vibe
+++ b/lib/@vibe/compiler/perceus/perceus.vibe
@@ -2794,8 +2794,11 @@ export fn param_is_heap_in_body(name: String, otype: Option[TypeExpr], body: Exp
 //
 // Post-pass over the function body: every `match <ident>` whose scrutinee
 // has a planned drop is scanned for arms that (a) decompose the value with
-// an all-PBind/PWild `PCtor` pattern whose every PBind is consumed exactly
-// once, (b) never mention the scrutinee again, (c) contain no control
+// an all-PBind/PWild `PCtor` pattern whose every PBind is consumed at most
+// once (consume 1 transfers raw; consume 0 -- a bind only borrow-read by
+// its uses, e.g. every callee borrow-classified -- is compensated by the
+// codegen and aliased binds decline), (b) never mention the scrutinee
+// again, (c) contain no control
 // transfer that could skip the arm's tail (return/break/continue/perform
 // -- a lambda's interior is exempt: its body runs in its own frame), and
 // (d) end (through any let spine) in a call of the SAME arity as the
@@ -2871,7 +2874,7 @@ export fn reuse_arm_has_blocker(e: Expr) -> Bool {
   }
 }
 
-fn reuse_arm_candidate_arity(sname: String, pat: Pat, arm_body: Expr, borrow_param_fns: Array[String], borrow_param_masks: Array[Int], action_names: Array[String]) -> Int {
+fn reuse_arm_candidate_arity(sname: String, pat: Pat, arm_body: Expr, borrow_param_fns: Array[String], borrow_param_masks: Array[Int], alias_names: Array[String]) -> Int {
   match pat {
     PCtor(_, pargs) => {
       let arity = Array::length(pargs)
@@ -2889,17 +2892,24 @@ fn reuse_arm_candidate_arity(sname: String, pat: Pat, arm_body: Expr, borrow_par
         let mut i = 0
         while ok && i < arity {
           match Array::get(pargs, i) {
-            // A payload bind must be consumed EXACTLY once AND owe the plan
-            // no action of its own (a borrow-classified callee leaves the
-            // bind with a scope-end drop; raw ownership transfer would then
-            // break the accounting the plan already committed to -- the
-            // borrow-callee extension is a separate slice). Name-keyed
-            // against the whole fn's action names, so a same-named binding
+            // A payload bind is admitted at consume count 1 (ownership
+            // transfers raw and the single consume releases it) or 0 (pure
+            // borrow reads; the codegen compensates -- on the unique path
+            // the arm-end conditional drop releases the raw-transferred
+            // child, on the shared path the bind stays a borrowed view of
+            // the still-live block). 2+ declines: the normal path's
+            // dup-per-consume has no raw-transfer equivalent. An
+            // alias-bound name (PaAliasDup row anywhere in the fn) also
+            // declines -- aliasing can hide an extra owner the consume
+            // count does not see; name-keyed, so a same-named alias
             // elsewhere declines conservatively.
-            PBind(bn) => if md_consume_count_pre(arm_body, bn, borrow_param_fns, bmasks) != 1 || name_in(action_names, bn) {
-              ok = false
-            } else {
-              ()
+            PBind(bn) => {
+              let __cc = md_consume_count_pre(arm_body, bn, borrow_param_fns, bmasks)
+              if (__cc != 0 && __cc != 1) || name_in(alias_names, bn) {
+                ok = false
+              } else {
+                ()
+              }
             },
             PWild => (),
             _ => ok = false
@@ -2921,7 +2931,7 @@ fn reuse_arm_candidate_arity(sname: String, pat: Pat, arm_body: Expr, borrow_par
   }
 }
 
-fn plan_reuse_pairs_walk(e: Expr, drop_names: Array[String], action_names: Array[String], actions: Array[PerceusAction], borrow_param_fns: Array[String], borrow_param_masks: Array[Int]) -> Unit {
+fn plan_reuse_pairs_walk(e: Expr, drop_names: Array[String], alias_names: Array[String], actions: Array[PerceusAction], borrow_param_fns: Array[String], borrow_param_masks: Array[Int]) -> Unit {
   match e {
     // A nested lambda's body plans in its OWN frame (compile_lambda builds
     // a separate plan whose post-pass pairs its matches there), exactly as
@@ -2937,7 +2947,7 @@ fn plan_reuse_pairs_walk(e: Expr, drop_names: Array[String], action_names: Array
           let mut ai = 0
           while ai < Array::length(arms) {
             let (apat, abody) = Array::get(arms, ai)
-            let arity = reuse_arm_candidate_arity(sname, apat, abody, borrow_param_fns, borrow_param_masks, action_names)
+            let arity = reuse_arm_candidate_arity(sname, apat, abody, borrow_param_fns, borrow_param_masks, alias_names)
             if arity >= 1 {
               pr_push_reuse(actions, PaReuseToken, sname, arity)
               pr_push_reuse(actions, PaReuseAlloc, sname, arity)
@@ -2954,7 +2964,7 @@ fn plan_reuse_pairs_walk(e: Expr, drop_names: Array[String], action_names: Array
       let kids = expr_children(e)
       let mut i = 0
       while i < Array::length(kids) {
-        plan_reuse_pairs_walk(Array::get(kids, i), drop_names, action_names, actions, borrow_param_fns, borrow_param_masks)
+        plan_reuse_pairs_walk(Array::get(kids, i), drop_names, alias_names, actions, borrow_param_fns, borrow_param_masks)
         i = i + 1
       }
     },
@@ -2962,7 +2972,7 @@ fn plan_reuse_pairs_walk(e: Expr, drop_names: Array[String], action_names: Array
       let kids = expr_children(e)
       let mut i = 0
       while i < Array::length(kids) {
-        plan_reuse_pairs_walk(Array::get(kids, i), drop_names, action_names, actions, borrow_param_fns, borrow_param_masks)
+        plan_reuse_pairs_walk(Array::get(kids, i), drop_names, alias_names, actions, borrow_param_fns, borrow_param_masks)
         i = i + 1
       }
     }
@@ -2971,7 +2981,7 @@ fn plan_reuse_pairs_walk(e: Expr, drop_names: Array[String], action_names: Array
 
 fn plan_reuse_pairs(body: Expr, actions: Array[PerceusAction], borrow_param_fns: Array[String], borrow_param_masks: Array[Int]) -> Unit {
   let drop_names: Array[String] = []
-  let action_names: Array[String] = []
+  let alias_names: Array[String] = []
   let mut i = 0
   while i < Array::length(actions) {
     let a = Array::get(actions, i)
@@ -2980,15 +2990,15 @@ fn plan_reuse_pairs(body: Expr, actions: Array[PerceusAction], borrow_param_fns:
     } else {
       ()
     }
-    if !name_in(action_names, a.name) {
-      Array::push(action_names, a.name)
+    if pa_is_alias_dup(a) && !name_in(alias_names, a.name) {
+      Array::push(alias_names, a.name)
     } else {
       ()
     }
     i = i + 1
   }
   if Array::length(drop_names) > 0 {
-    plan_reuse_pairs_walk(body, drop_names, action_names, actions, borrow_param_fns, borrow_param_masks)
+    plan_reuse_pairs_walk(body, drop_names, alias_names, actions, borrow_param_fns, borrow_param_masks)
   } else {
     ()
   }

--- a/lib/@vibe/compiler/tests/perceus_reuse_e2e_test.vibe
+++ b/lib/@vibe/compiler/tests/perceus_reuse_e2e_test.vibe
@@ -108,6 +108,41 @@ test "tracked-spine arm: interior consumer plus dropped intermediate stays corre
   assert(!contains_token_test(bump_wasm))
 }
 
+test "a pure-borrow bind fuses: raw-transferred child released at arm end" {
+  // `a` is only ever BORROW-read (total is borrow-classified: every call
+  // site passes an ident), so its consume count is 0 -- the shape the
+  // first slice declined. The wide fusion now admits it: on the unique
+  // path the raw-transferred child is dropped at arm end (nothing in the
+  // body consumes it; without that drop the token overwrite leaks it), on
+  // the shared path the staging dup gives the bind its own ref and the
+  // same arm-end drop releases it. `reshape(Leaf(0))` keeps reshape
+  // owning; b stays a plain consume-1 transfer in the same arm.
+  let src = String::concat(tree_prelude(), "let rec reshape: (Node) -> Node = (n) -> {\n  match n {\n    Pair(a, b) => {\n      let w = total(a)\n      let b2 = reshape(b)\n      Pair(Leaf(w), b2)\n    },\n    Leaf(v) => Leaf(v + 1)\n  }\n}\nfn main() -> Int {\n  let t = build(4)\n  let r = reshape(t)\n  let z = reshape(Leaf(0))\n  total(r) * 10 + total(z)\n}")
+  assert_bump_rc_agree(src, "borrow_bind_unique", "171")
+  // Two fused arms: the Pair arm through the WIDE path (a's consume count
+  // is 0, so the narrow tier declines), the Leaf arm narrowly.
+  let rc_wasm = compile_wasi_rc(src, "main")
+  inspect(count_token_tests(rc_wasm), content = "2")
+}
+
+test "a shared source survives a pure-borrow-bind rebuild untouched" {
+  // Same reshape, but the source tree stays live across the rebuild: the
+  // shared path must leave t's structure intact while the consume-0 bind
+  // (dup'd at staging, dropped at arm end) reads through it.
+  let src = String::concat(tree_prelude(), "let rec reshape: (Node) -> Node = (n) -> {\n  match n {\n    Pair(a, b) => {\n      let w = total(a)\n      let b2 = reshape(b)\n      Pair(Leaf(w), b2)\n    },\n    Leaf(v) => Leaf(v + 1)\n  }\n}\nfn main() -> Int {\n  let t = build(3)\n  let r = reshape(t)\n  let z = reshape(Leaf(0))\n  total(t) * 1000 + total(r) + total(z)\n}")
+  assert_bump_rc_agree(src, "borrow_bind_shared", "8010")
+}
+
+test "a bind both borrowed and consumed still transfers cleanly" {
+  // `a` is read by borrow-classified total AND consumed by the recursive
+  // incr2 -- consume count 1 with extra borrow reads. The transfer hands
+  // the child to the consume; the borrow reads happen before it.
+  let src = String::concat(tree_prelude(), "let rec incr2: (Node) -> Node = (n) -> {\n  match n {\n    Pair(a, b) => {\n      let w = total(a)\n      let a2 = incr2(a)\n      let b2 = incr2(b)\n      Pair(a2, b2)\n    },\n    Leaf(v) => Leaf(v + 1)\n  }\n}\nfn main() -> Int {\n  let t = build(3)\n  let r = incr2(t)\n  let z = incr2(Leaf(9))\n  total(r) * 100 + total(z)\n}")
+  assert_bump_rc_agree(src, "borrow_and_consume", "1610")
+  let rc_wasm = compile_wasi_rc(src, "main")
+  inspect(count_token_tests(rc_wasm), content = "2")
+}
+
 test "a sibling arm with a conditional return is never authorized by the eligible arm's plan row" {
   // The plan's reuse row is keyed (scrutinee, arity). `B(y)` and
   // `L(v) => L(v + d)` are eligible arity-1 rebuilds (a scalar payload

--- a/lib/@vibe/compiler/tests/perceus_reuse_plan_test.vibe
+++ b/lib/@vibe/compiler/tests/perceus_reuse_plan_test.vibe
@@ -38,6 +38,19 @@ test "rows carry the arity the codegen authorizes by" {
   assert(String::contains(plan, "walk n reuse_alloc:2 1"))
 }
 
+test "a pure-borrow bind pairs; a doubly-consumed bind does not" {
+  // In reshape's Pair arm, `a` is only borrow-read (total3 is
+  // borrow-classified) -- consume count 0, admitted since the
+  // borrow-callee slice; the codegen compensates with a staging dup on
+  // the shared path and an arm-end drop. In dbl's arm `a` is consumed
+  // TWICE by the owning `own` -- no raw-transfer equivalent exists for
+  // dup-per-consume, so it must stay unpaired.
+  let src = "enum Node {\n  Leaf(Int);\n  Pair(Node, Node)\n}\nlet rec total3: (Node) -> Int = (n) -> {\n  match n {\n    Pair(a, b) => total3(a) + total3(b),\n    Leaf(v) => v\n  }\n}\nlet own: (Node) -> Node = (m) -> Pair(m, Leaf(0))\nlet rec reshape: (Node) -> Node = (n) -> {\n  match n {\n    Pair(a, b) => {\n      let w = total3(a)\n      let b2 = reshape(b)\n      Pair(Leaf(w), b2)\n    },\n    _ => Leaf(1)\n  }\n}\nlet dbl: (Node) -> Node = (n) -> {\n  match n {\n    Pair(a, _) => Pair(own(a), own(a)),\n    _ => Leaf(1)\n  }\n}\nlet main: () -> Int = () -> {\n  match reshape(Leaf(0)) {\n    _ => match dbl(own(Leaf(1))) {\n      _ => 0\n    }\n  }\n}"
+  let plan = plan_of(src)
+  assert(String::contains(plan, "reshape n reuse_token:2 1"))
+  assert(!String::contains(plan, "dbl n reuse_token"))
+}
+
 test "arms that keep the scrutinee alive or change arity stay unpaired" {
   // `keep` mentions the scrutinee in the arm body; `shrink`'s constructor
   // arm rebuilds at a DIFFERENT arity and its other arm is a wildcard


### PR DESCRIPTION
Second slice of #2389 (follow-up to #2411): the wide reuse fusion admits payload binds at consume count **0** — a bind whose every use borrows, e.g. all its callees borrow-classified. That was the first slice's recorded exclusion and is the compiler's dominant rebuild-arm shape.

## What changed

**Planner** (`perceus/perceus.vibe`)
- `reuse_arm_candidate_arity` admits a `PBind` at consume count 0 or 1 (was: exactly 1 with no plan actions). Counts 2+ decline — dup-per-consume has no raw-transfer equivalent — and so does an alias-bound name (aliasing can hide an owner the consume count does not see); the eligibility now keys on the plan's alias rows instead of all action names.

**Wide codegen** (`codegen/expr/compile_match.vibe`)
- Eligibility mirrors the planner (consume 0/1, alias guard) and the staging compiles ONE body that balances both paths for a consume-0 bind:
  - **shared path**: the staging dup gives the bind its own reference. A borrowed view would depend on the *other* reference surviving the arm — which arm code can release (the scrutinee's ref is dropped at staging) — so the bind owns its ref outright.
  - **unique path**: the raw-transferred child is released by a new unconditional arm-end drop; nothing in the body consumes it, and the token overwrite would otherwise leak it. The same arm-end drop releases the shared path's dup, so no per-path branching is needed.
- Fusion inside a borrow-classified *function* stays impossible by construction: its parameter carries no plan drop, so the scrutinee gate never opens on a caller-owned block.

## Validation

- Red-tested by mutation on both sides: narrowing either window back to `consume == 1` fails the new tests (planner: the pure-borrow plan row disappears; codegen: the token-test count drops 2 → 1).
- New e2e cases with exact-value and token-test-count assertions: unique-path consume-0 rebuild (`171`), shared source surviving the rebuild untouched (`8010`), and a bind both borrowed and consumed (`1610`) — bump and RC lanes agree on all.
- `stage2 == stage3` fixpoint (the compiler self-compiles byte-identically through the broadened fusion), full unit suite, full compiler gate, RC heap e2e battery (163), `vibe fmt --check` clean.

## Measurements (honest: wall-flat, deterministic-positive)

- Self-compile RC/bump KPI (interleaved paired, runs=3): **flat within noise** — 2.8343 (main, pairs 2.797–2.870) vs 2.8303 (this branch, pairs 2.829–2.916). Consistent with prior findings that the allocator (post bounded-walk/bins) no longer dominates.
- Targeted consume-0 rebuild shape (depth-10 tree × 200, viberun fuel — deterministic): fuel **−0.54%** (117,829,609 → 117,196,469), allocation high-water **−1.0%**, identical answer. The shape's arm work is dominated by the borrow traversal itself, so the saved alloc+free cycle per node is real but small.
- `bench/exec` corpus: byte-identical wasm (no borrow-bind rebuild arms in it). stage2: +452 bytes.

#2389 remains open for the remaining exclusion (consume-count 2+) and any further KPI work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0159xd5111g8KFt2CGyNyZvA

---
_Generated by [Claude Code](https://claude.ai/code/session_0159xd5111g8KFt2CGyNyZvA)_