### PR TITLE
Record why the prune pass has no dead-fraction threshold (#2359)

### DIFF
--- a/lib/@vibe/compiler/codegen/wasi/linked_compile.vibe
+++ b/lib/@vibe/compiler/codegen/wasi/linked_compile.vibe
@@ -4283,13 +4283,14 @@ fn lc_pf_prune_with_layout(mod_bytes: Bytes, cell: Array[Int], failed: Array[Boo
       // purpose is output size. At the selfcompile KPI input -- 2.3% dead,
       // 180 of 4305 bodies, 89752 B of 3.85 MB -- the rate is 29848504 heap
       // bytes saved for 104420 output bytes added, and not worth taking
-      // while the heap gate still has 4.2% of headroom.
+      // while the heap gate still allows 14.8% of growth (its ceiling is
+      // the committed baseline + 10%, ci.yml).
       //
       // That rate is not constant, so do not extrapolate this one point. The
       // re-emit's cost tracks module size while the saving tracks
       // dead_fraction * module size, so skipping gets relatively cheaper as
       // the dead fraction falls: the compiler's own module (0.4% dead) costs
-      // 10374 output bytes to skip, a twentieth of the KPI's. A threshold is
+      // 10374 output bytes to skip, a tenth of the KPI's. A threshold is
       // therefore unmeasured here, not refuted -- justifying one needs heap
       // numbers from the barely-dead inputs that motivate it. What is settled
       // is the direction: skipping never saves output bytes, so the only free

--- a/lib/@vibe/compiler/codegen/wasi/linked_compile.vibe
+++ b/lib/@vibe/compiler/codegen/wasi/linked_compile.vibe
@@ -4273,6 +4273,18 @@ fn lc_pf_prune_with_layout(mod_bytes: Bytes, cell: Array[Int], failed: Array[Boo
     if Array::length(keep) == nbodies {
       // Nothing to drop: leave the bytes untouched rather than re-emitting
       // an identical module.
+      //
+      // This early-out is deliberately exact and NOT a dead-fraction
+      // threshold. A threshold looks attractive because the re-emit costs
+      // compile-time heap in proportion to module size while the saving is
+      // only the dead bodies' bytes, so skipping a barely-dead module looks
+      // free. Measured, it is not: the selfcompile KPI input sits at 2.3%
+      // dead (180 of 4305 bodies, 89752 B of 3.85 MB), and skipping its
+      // re-emit trades 2.79% of OUTPUT size for 1.92% of transient compile
+      // heap. That is backwards for a pass whose whole purpose is output
+      // size, and it holds at every dead fraction, since both sides of the
+      // trade scale together. Skipping is only free when there is nothing to
+      // drop at all -- which is exactly the test above.
       mod_bytes
     } else {
       // --- rebuilt code + function sections --------------------------------

--- a/lib/@vibe/compiler/codegen/wasi/linked_compile.vibe
+++ b/lib/@vibe/compiler/codegen/wasi/linked_compile.vibe
@@ -4278,13 +4278,22 @@ fn lc_pf_prune_with_layout(mod_bytes: Bytes, cell: Array[Int], failed: Array[Boo
       // threshold. A threshold looks attractive because the re-emit costs
       // compile-time heap in proportion to module size while the saving is
       // only the dead bodies' bytes, so skipping a barely-dead module looks
-      // free. Measured, it is not: the selfcompile KPI input sits at 2.3%
-      // dead (180 of 4305 bodies, 89752 B of 3.85 MB), and skipping its
-      // re-emit trades 2.79% of OUTPUT size for 1.92% of transient compile
-      // heap. That is backwards for a pass whose whole purpose is output
-      // size, and it holds at every dead fraction, since both sides of the
-      // trade scale together. Skipping is only free when there is nothing to
-      // drop at all -- which is exactly the test above.
+      // free. It is not free: skipping always buys transient compile heap
+      // with permanent OUTPUT size, which is backwards for a pass whose
+      // purpose is output size. At the selfcompile KPI input -- 2.3% dead,
+      // 180 of 4305 bodies, 89752 B of 3.85 MB -- the rate is 29848504 heap
+      // bytes saved for 104420 output bytes added, and not worth taking
+      // while the heap gate still has 4.2% of headroom.
+      //
+      // That rate is not constant, so do not extrapolate this one point. The
+      // re-emit's cost tracks module size while the saving tracks
+      // dead_fraction * module size, so skipping gets relatively cheaper as
+      // the dead fraction falls: the compiler's own module (0.4% dead) costs
+      // 10374 output bytes to skip, a twentieth of the KPI's. A threshold is
+      // therefore unmeasured here, not refuted -- justifying one needs heap
+      // numbers from the barely-dead inputs that motivate it. What is settled
+      // is the direction: skipping never saves output bytes, so the only free
+      // case is nothing to drop at all, which is the test above.
       mod_bytes
     } else {
       // --- rebuilt code + function sections --------------------------------


### PR DESCRIPTION
Answers the open question left on #2415, and answers it against the proposal I made there.

## The proposal, and why it looked right

#2359's re-emit copies the whole module, so its cost scales with module size while the saving is only the dead bodies' bytes. On a barely-dead module that trade inverts, which is a real effect — the compiler's own module is 0.4% dead (49 of 5859 bodies, 9,887 B of 2.8 MB). I proposed a dead-fraction threshold there, claiming it "keeps every win and skips exactly the pathological case".

The claim had an unchecked step in it: I generalized from the compiler's own module to the selfcompile KPI, which does not compile the compiler. It compiles `lib/@vibe/compiler/tests/codegen_lexer_test.vibe`.

## What measurement says

I built three stage2s — `main`, a 2% threshold, and a 5% threshold — and measured all of them against one identical source tree with an isolated cold `VIBE_BUILD_CACHE_DIR`. `heap_ptr_bytes` is byte-deterministic for a fixed (stage2, input) pair, so one run each is exact, not a sample.

| variant | KPI compile heap | KPI output size |
|---|---:|---:|
| `main` (prune always) | 1,551,740,640 | 3,747,705 |
| 2% threshold | 1,551,741,552 (+0.00006%) | 3,747,705 (identical) |
| 5% threshold | 1,521,892,136 (−1.92%) | 3,852,125 (+2.79%) |

The KPI input's module is **2.3% dead** (180 of 4305 bodies, 89,752 B of 3.85 MB) — just above a 2% threshold, which is why that variant moved nothing while still costing 10,374 B on the compiler's own shipped artifact. The 5% variant does engage, and buys 29,848,504 bytes of *transient* compile heap for 104,420 bytes of *output* size.

That is a bad trade at this point, for a pass whose entire purpose is output size, and while the heap gate still has capacity: `ci.yml` sets the ceiling to the committed baseline + 10% (1,619,751,744 → 1,781,726,918), so from `main`'s 1,551,740,640 the gate allows 14.8% of growth.

**It is a point, not a law** ([review](https://github.com/mizchi/vibe-lang/pull/2417#discussion_r3889128400), fixed in `eddc0bec1`). The re-emit's cost tracks module size while the saving tracks `dead_fraction × module_size`, so the exchange rate is not constant — skipping gets relatively cheaper as the dead fraction falls, and my own data shows it: the compiler's own module at 0.4% dead costs only 10,374 output bytes to skip, a tenth of the KPI's. So a threshold is **unmeasured here rather than refuted**; justifying one needs heap numbers from the barely-dead inputs, which this PR did not take. The one dead-fraction-independent claim that survives is the direction: skipping never *saves* output bytes, so "nothing to drop at all" is the only free case — which is the exact test the pass already has.

Under either threshold all five `bench/binary_size` samples stay byte-identical to the committed baseline (1887 / 648 / 1247 / 684 / 3309), confirming the pass's real wins are nowhere near the line and were never what a threshold would have touched.

## What this changes

Comment only — no behavior change. The measured result goes next to the exact `keep == nbodies` early-out, which is where the generalization is tempting, so the next reader gets the numbers and their limits instead of the intuition.

The +1.4–3% compile-heap cost of #2359 therefore stands as an accepted trade for now.

## Review corrections

Three findings, all correct, all against the note's own evidence rather than the code:

- over-generalizing the trade to every dead fraction (`eddc0bec1`)
- "a twentieth" where 104,420 / 10,374 = 10.07 (`f771196e4`)
- reporting the distance *below* the baseline as gate headroom; the gate's actual capacity is 14.8% growth (`f771196e4`)

After the second round I re-derived every remaining figure from its source rather than waiting for a third: dead counts and fractions from the reachability scan, 29,848,504 and 104,420 from the three stage2 variants, 10,374 from the stage2 size difference. Those hold.

## Verification

- `bash scripts/compiler_gate.sh` — green, 124/124
- `bash scripts/vibe_fmt.sh --check` on the edited file — clean
- `vibe check` on the edited file — no diagnostics (confirmed against an untouched control file, since the runner prints the same line either way)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FYMVd6D2o82suTfTwoJPMf