### PR TITLE
Type inline wasm operand stacks in the assembler (#2401)

### DIFF
--- a/docs/cheatsheet.md
+++ b/docs/cheatsheet.md
@@ -2249,6 +2249,24 @@ fn simd_add(a: Int, b: Int) -> Int = wasm
   check errs toward rejecting: `unreachable` / `return` / `br` are
   stack-polymorphic and wasm would accept them there, and `select` is not
   typed.
+- **Operand types and stack depth are checked** (#2401): the assembler walks
+  an abstract value stack, so a body that is not valid wasm is a located error
+  from `vibe check` rather than a module that fails when a runtime loads it.
+  `(i64.add (i32.const 1) (i64.const 2))` and
+  `(block (result i64) (i32.const 1))` both used to assemble. What is checked:
+  each instruction's operands against its signature (a lane shift takes an
+  i32 amount, a load/store addresses through an i32, `replace_lane` takes the
+  shape's scalar, a comparison yields i32 whatever its operand width); a
+  `block` / `loop` / `if` actually leaving what its `(result T)` declares, and
+  leaving nothing without one; an `if` with a `(result T)` having an `(else
+  ...)`; and the depth, in both directions — too few operands for an
+  instruction, and a body that leaves other than the single i64 an
+  inline-wasm fn returns. A block's frame is a floor, so an instruction inside
+  it cannot consume a value produced outside it. Dead code after
+  `unreachable` / `br` / `return` is stack-polymorphic but still typed, which
+  is what wasm does too. Two deliberate gaps, both erring toward accepting: a
+  numeric `local.get 3` types as unknown (the locals table is keyed by name)
+  and an unknown matches anything, and `br_table` is not in the slice at all.
 - **Locals**: the fn's own params (`$name` or index), plus `(local $name
   TYPE)` declarations at the START of the body — types `i32`/`i64`/`v128`,
   grouped in that order (a located error enforces the grouping); declared

--- a/docs/cheatsheet.md
+++ b/docs/cheatsheet.md
@@ -2264,7 +2264,9 @@ fn simd_add(a: Int, b: Int) -> Int = wasm
   inline-wasm fn returns. A block's frame is a floor, so an instruction inside
   it cannot consume a value produced outside it. Dead code after
   `unreachable` / `br` / `return` is stack-polymorphic but still typed, which
-  is what wasm does too. Two deliberate gaps, both erring toward accepting: a
+  is what wasm does too — polymorphism lets a frame's declared result come
+  from the floor, it does not let values pushed afterwards survive to the
+  frame's `end`. Two deliberate gaps, both erring toward accepting: a
   numeric `local.get 3` types as unknown (the locals table is keyed by name)
   and an unknown matches anything, and `br_table` is not in the slice at all.
 - **Locals**: the fn's own params (`$name` or index), plus `(local $name

--- a/lib/@vibe/compiler/codegen/codegen.vibe
+++ b/lib/@vibe/compiler/codegen/codegen.vibe
@@ -40,6 +40,7 @@ export ./common_base {
   exn_kind_read_expr,
   exn_msg_read_expr,
   inject_trait_method_generics,
+  inline_wat_unclassified_instructions,
   unbox_tuple_loop_params
 }
 

--- a/lib/@vibe/compiler/codegen/common_base/index.vpkg
+++ b/lib/@vibe/compiler/codegen/common_base/index.vpkg
@@ -238,6 +238,7 @@ fn sized_bytes_new_expr(n_expr: Expr) -> Expr
 fn compile_inline_wat(fn_name: String, wat: String, param_names: Array[String]) -> Bytes with Exception
 fn compile_inline_wat_full(fn_name: String, wat: String, param_names: Array[String], extra_base: Int) -> (Bytes, Int, Int, Int) with Exception
 fn compile_inline_wat_calls(fn_name: String, wat: String, param_names: Array[String], extra_base: Int, callees: Array[(String, Int, Int)]) -> (Bytes, Int, Int, Int) with Exception
+fn inline_wat_unclassified_instructions() -> Array[String]
 
 // --- normalize/desugar_trait_dict.vibe (cross-package facade re-export;
 // the checker imports its three pre-check transforms directly from normalize,

--- a/lib/@vibe/compiler/codegen/common_base/inline_wat.vibe
+++ b/lib/@vibe/compiler/codegen/common_base/inline_wat.vibe
@@ -1575,13 +1575,17 @@ fn iw_stack_effect(st: IwStack, fn_name: String, kinds: Array[Int], texts: Array
   let off = Array::get(offs, pos)
   if name == "local.get" {
     iw_st_push(st, iw_local_valtype(locals, Array::get(texts, pos + 1)))
-  } else if name == "local.set" || name == "local.tee" {
+  } else if name == "local.set" {
+    iw_apply(st, fn_name, name, iw_params1(iw_local_valtype(locals, Array::get(texts, pos + 1))), 0, off)
+  } else if name == "local.tee" {
+    // `local.tee` always leaves its operand, so the push is unconditional.
+    // It cannot go through iw_apply's `result`, where 0 means "pushes
+    // nothing" -- a different thing from the 0 a numeric `local.tee 0` gets
+    // back from iw_local_valtype, which means "pushes a value of unknown
+    // type". Conflating the two rejected that valid body for leaving nothing.
     let lt = iw_local_valtype(locals, Array::get(texts, pos + 1))
-    iw_apply(st, fn_name, name, iw_params1(lt), if name == "local.tee" {
-      lt
-    } else {
-      0
-    }, off)
+    iw_apply(st, fn_name, name, iw_params1(lt), 0, off)
+    iw_st_push(st, lt)
   } else if name == "br" || name == "br_if" {
     let rel = iw_label_rel(fn_name, lbl_names, lbl_depths, Array::get(texts, pos + 1), depth, Array::get(offs, pos + 1))
     let ti = Array::length(st.frames) - 1 - rel

--- a/lib/@vibe/compiler/codegen/common_base/inline_wat.vibe
+++ b/lib/@vibe/compiler/codegen/common_base/inline_wat.vibe
@@ -1330,27 +1330,47 @@ fn iw_apply(st: IwStack, fn_name: String, name: String, params: Array[Int], resu
 
 /// #2401: close the innermost frame, checking it leaves exactly what it
 /// declared, then drop back to its floor. The caller pushes the result.
+///
+/// Same two steps, in the same order, as the spec's `pop_ctrl`: pop the
+/// declared result, then require the stack to be back AT the floor.
+/// Polymorphism relaxes only the first step -- a frame whose values a `br` or
+/// `unreachable` carried away can supply a missing result from the floor. It
+/// does NOT excuse the second: values pushed after that point are live at
+/// `end`, and wasm rejects `(block unreachable (i64.const 1))` for the extra
+/// i64 exactly as it rejects `(block (i64.const 1))`. Skipping the whole
+/// check when the flag was set is what this used to do.
 fn iw_st_close(st: IwStack, fn_name: String, what: String, hint: String, off: Int) -> Unit with Exception {
   let n = Array::length(st.frames) - 1
   let (base, res, _l, poly) = Array::get(st.frames, n)
-  let h = Array::length(st.vals)
-  if poly == 1 {
-    ()
-  } else if res == 0 {
-    if h != base {
-      throw(iw_err(fn_name, "\{what} declares no result but leaves \{h - base} value(s) on the stack\{hint}", off))
+  if res != 0 {
+    let h0 = Array::length(st.vals)
+    if h0 <= base {
+      if poly == 1 {
+        ()
+      } else {
+        throw(iw_err(fn_name, "\{what} must leave exactly one \{iw_valtype_name(res)} but leaves 0 value(s) on the stack\{hint}", off))
+      }
     } else {
-      ()
+      let got = Array::get(st.vals, h0 - 1)
+      Array::truncate(st.vals, h0 - 1)
+      if got != 0 && got != res {
+        throw(iw_err(fn_name, "\{what} must leave \{iw_valtype_name(res)} but leaves \{iw_valtype_name(got)}\{hint}", off))
+      } else {
+        ()
+      }
     }
-  } else if h != base + 1 {
-    throw(iw_err(fn_name, "\{what} must leave exactly one \{iw_valtype_name(res)} but leaves \{h - base} value(s) on the stack\{hint}", off))
   } else {
-    let got = Array::get(st.vals, h - 1)
-    if got != 0 && got != res {
-      throw(iw_err(fn_name, "\{what} must leave \{iw_valtype_name(res)} but leaves \{iw_valtype_name(got)}\{hint}", off))
+    ()
+  }
+  let left = Array::length(st.vals) - base
+  if left != 0 {
+    if res == 0 {
+      throw(iw_err(fn_name, "\{what} declares no result but leaves \{left} value(s) on the stack\{hint}", off))
     } else {
-      ()
+      throw(iw_err(fn_name, "\{what} must leave exactly one \{iw_valtype_name(res)} but leaves \{left + 1} value(s) on the stack\{hint}", off))
     }
+  } else {
+    ()
   }
   Array::truncate(st.vals, base)
   Array::truncate(st.frames, n)

--- a/lib/@vibe/compiler/codegen/common_base/inline_wat.vibe
+++ b/lib/@vibe/compiler/codegen/common_base/inline_wat.vibe
@@ -63,6 +63,16 @@ import @vibe/core {
 //     not be checked
 //   - NOT supported (clear errors): flat-form call / call_indirect /
 //     return_call / br_table / global.get/set / f32.const / f64.const
+//
+// #2401: the assembler also TYPES the body. It walks an abstract value stack
+// (IwStack below) checking each instruction's operands against its signature,
+// each block/loop/if against its declared `(result T)`, and the depth in both
+// directions -- including that the body leaves the single i64 the fn returns.
+// Before that, `(i64.add (i32.const 1) (i64.const 2))` assembled, `vibe check`
+// reported the file clean, and the mismatch surfaced only when a runtime
+// validated the module. Everything else in this file already worked that way
+// (#2341: a located error, not a broken artifact); the operand stacks were
+// the hole.
 
 fn iw_err(fn_name: String, msg: String, off: Int) -> String {
   "inline wasm (fn \{fn_name}): \{msg} (WAT offset \{off})"
@@ -1218,6 +1228,500 @@ fn iw_operand_valtype(kinds: Array[Int], texts: Array[String], pos: Int, end: In
   }
 }
 
+/// #2401: the assembler's abstract value stack.
+///
+/// `vals` holds one wasm valtype byte per value currently on the stack. 0
+/// means "a value whose type the assembler could not determine" -- today only
+/// a numeric `local.get 3`, or a `select` over two such values -- and it
+/// matches any expected type, so an unknown never manufactures an error.
+///
+/// `frames` holds one entry per enclosing block/loop/if PLUS one for the
+/// function body itself, so it is never empty:
+/// `(stack height at frame entry, result valtype or 0, 1 for a loop, 1 once
+/// the frame is stack-polymorphic)`. The height is a FLOOR, not just a
+/// bookkeeping number: it is what stops an instruction inside a block from
+/// consuming a value produced outside it, which wasm forbids and this
+/// assembler used to emit.
+struct IwStack {
+  vals: Array[Int];
+  frames: Array[(Int, Int, Int, Int)]
+}
+
+fn iw_fresh_frames() -> Array[(Int, Int, Int, Int)] {
+  array_empty()
+}
+
+/// A fresh stack whose function-body frame declares `result_ty`.
+fn iw_st_new(result_ty: Int) -> IwStack {
+  let fr = iw_fresh_frames()
+  Array::push(fr, (0, result_ty, 0, 0))
+  IwStack::{ vals: iw_fresh_ints(), frames: fr }
+}
+
+fn iw_st_base(st: IwStack) -> Int {
+  let (b, _r, _l, _p) = Array::get(st.frames, Array::length(st.frames) - 1)
+  b
+}
+
+fn iw_st_poly(st: IwStack) -> Bool {
+  let (_b, _r, _l, p) = Array::get(st.frames, Array::length(st.frames) - 1)
+  p == 1
+}
+
+/// Enter the stack-polymorphic state, exactly as the spec's validation
+/// algorithm does after `unreachable` / `br` / `return`: drop back to the
+/// frame's floor and set the flag. Instructions AFTER this point are still
+/// type-checked against what they push themselves -- wasm rejects
+/// `unreachable i32.const 1 i64.add` too -- but they may pop values the frame
+/// never had.
+fn iw_st_mark_poly(st: IwStack) -> Unit {
+  let n = Array::length(st.frames) - 1
+  let (b, r, l, _p) = Array::get(st.frames, n)
+  Array::set(st.frames, n, (b, r, l, 1))
+  Array::truncate(st.vals, b)
+}
+
+fn iw_st_push(st: IwStack, ty: Int) -> Unit {
+  Array::push(st.vals, ty)
+}
+
+/// Pop one value, or 0 when the frame's floor is already reached -- which
+/// only happens in the polymorphic state, since `iw_apply` refuses to
+/// underflow otherwise.
+fn iw_st_pop_raw(st: IwStack) -> Int {
+  let h = Array::length(st.vals)
+  if h <= iw_st_base(st) {
+    0
+  } else {
+    let v = Array::get(st.vals, h - 1)
+    Array::truncate(st.vals, h - 1)
+    v
+  }
+}
+
+/// #2401: apply one instruction's stack effect -- pop `params` (listed
+/// DEEPEST first, i.e. the order they were pushed) and push `result` unless
+/// it is 0.
+fn iw_apply(st: IwStack, fn_name: String, name: String, params: Array[Int], result: Int, off: Int) -> Unit with Exception {
+  let n = Array::length(params)
+  let avail = Array::length(st.vals) - iw_st_base(st)
+  if avail < n && !iw_st_poly(st) {
+    throw(iw_err(fn_name, "'\{name}' takes \{n} operand(s), but only \{avail} value(s) are on the stack here", off))
+  } else {
+    ()
+  }
+  let mut i = n - 1
+  while i >= 0 {
+    let want = Array::get(params, i)
+    let got = iw_st_pop_raw(st)
+    if want != 0 && got != 0 && got != want {
+      throw(iw_err(fn_name, "'\{name}' expects \{iw_valtype_name(want)} for operand \{i + 1} of \{n}, but the value there is \{iw_valtype_name(got)}", off))
+    } else {
+      ()
+    }
+    i = i - 1
+  }
+  if result != 0 {
+    iw_st_push(st, result)
+  } else {
+    ()
+  }
+}
+
+/// #2401: close the innermost frame, checking it leaves exactly what it
+/// declared, then drop back to its floor. The caller pushes the result.
+fn iw_st_close(st: IwStack, fn_name: String, what: String, hint: String, off: Int) -> Unit with Exception {
+  let n = Array::length(st.frames) - 1
+  let (base, res, _l, poly) = Array::get(st.frames, n)
+  let h = Array::length(st.vals)
+  if poly == 1 {
+    ()
+  } else if res == 0 {
+    if h != base {
+      throw(iw_err(fn_name, "\{what} declares no result but leaves \{h - base} value(s) on the stack\{hint}", off))
+    } else {
+      ()
+    }
+  } else if h != base + 1 {
+    throw(iw_err(fn_name, "\{what} must leave exactly one \{iw_valtype_name(res)} but leaves \{h - base} value(s) on the stack\{hint}", off))
+  } else {
+    let got = Array::get(st.vals, h - 1)
+    if got != 0 && got != res {
+      throw(iw_err(fn_name, "\{what} must leave \{iw_valtype_name(res)} but leaves \{iw_valtype_name(got)}\{hint}", off))
+    } else {
+      ()
+    }
+  }
+  Array::truncate(st.vals, base)
+  Array::truncate(st.frames, n)
+}
+
+/// #2401: index of the first '.' in an instruction name, or -1.
+fn iw_dot_pos(name: String) -> Int {
+  let n = String::length(name)
+  let mut i = 0
+  let mut found = 0 - 1
+  while i < n {
+    if String::char_code_at(name, i) == '.' {
+      found = i
+      i = n
+    } else {
+      i = i + 1
+    }
+  }
+  found
+}
+
+/// #2401: the valtype an `iNN.` / `fNN.` name prefix denotes, or 0.
+fn iw_prefix_valtype(name: String) -> Int {
+  if String::starts_with(name, "i32.") {
+    0x7F
+  } else if String::starts_with(name, "i64.") {
+    0x7E
+  } else if String::starts_with(name, "f32.") {
+    0x7D
+  } else if String::starts_with(name, "f64.") {
+    0x7C
+  } else {
+    0
+  }
+}
+
+/// #2401: the SOURCE valtype named inside a conversion mnemonic --
+/// `wrap_i64`, `trunc_f32_s`, `extend_i32_u`, `convert_i64_s`, `demote_f64`,
+/// `promote_f32`, `reinterpret_f64`. 0 when the mnemonic names no source
+/// type: `extend8_s` / `extend16_s` / `extend32_s` widen from their own
+/// prefix type, and "8" / "16" / "32" are not type names.
+fn iw_conv_source_valtype(mn: String) -> Int {
+  if String::contains(mn, "_i32") {
+    0x7F
+  } else if String::contains(mn, "_i64") {
+    0x7E
+  } else if String::contains(mn, "_f32") {
+    0x7D
+  } else if String::contains(mn, "_f64") {
+    0x7C
+  } else {
+    0
+  }
+}
+
+/// #2401: core mnemonics taking ONE operand of the name's prefix type.
+fn iw_core_unary_mnemonic(mn: String) -> Bool {
+  mn == "eqz" || mn == "clz" || mn == "ctz" || mn == "popcnt" || mn == "abs" || mn == "neg" || mn == "ceil" || mn == "floor" || mn == "trunc" || mn == "nearest" || mn == "sqrt" || mn == "extend8_s" || mn == "extend16_s" || mn == "extend32_s"
+}
+
+/// #2401: core mnemonics taking TWO operands of the name's prefix type.
+/// Comparisons are here too -- they consume the prefix width and yield i32,
+/// which is what `iw_core_result_valtype` already encodes.
+fn iw_core_binary_mnemonic(mn: String) -> Bool {
+  mn == "eq" || mn == "ne" || mn == "lt_s" || mn == "lt_u" || mn == "gt_s" || mn == "gt_u" || mn == "le_s" || mn == "le_u" || mn == "ge_s" || mn == "ge_u" || mn == "lt" || mn == "gt" || mn == "le" || mn == "ge" || mn == "add" || mn == "sub" || mn == "mul" || mn == "div" || mn == "div_s" || mn == "div_u" || mn == "rem_s" || mn == "rem_u" || mn == "and" || mn == "or" || mn == "xor" || mn == "shl" || mn == "shr_s" || mn == "shr_u" || mn == "rotl" || mn == "rotr" || mn == "min" || mn == "max" || mn == "copysign"
+}
+
+/// #2401: the operand valtypes a core-table instruction pops, deepest first.
+///
+/// THROWS for a name it cannot classify. That is the point: a row added to
+/// `iw_core_table` with no signature here must fail loudly rather than skip
+/// the operand check and go back to emitting a module the runtime rejects.
+/// `inline_wat_unclassified_instructions` reports exactly the names that
+/// reach this throw, and the compiler test asserts that list is empty.
+fn iw_core_op_params(fn_name: String, name: String, off: Int) -> Array[Int] with Exception {
+  let out = iw_fresh_ints()
+  if name == "unreachable" || name == "nop" {
+    out
+  } else if name == "return" {
+    // The fn's single i64 result; the rest of the frame is polymorphic.
+    Array::push(out, 0x7E)
+    out
+  } else if name == "drop" {
+    Array::push(out, 0)
+    out
+  } else if name == "select" {
+    // Handled specially by iw_stack_effect (its result is its operands'
+    // type); the shape is here so the coverage self-check sees it typed.
+    Array::push(out, 0)
+    Array::push(out, 0)
+    Array::push(out, 0x7F)
+    out
+  } else {
+    let t = iw_prefix_valtype(name)
+    let d = iw_dot_pos(name)
+    if t == 0 || d < 0 {
+      throw(iw_err(fn_name, "the assembler has no operand signature for '\{name}'", off))
+    } else {
+      let mn = String::substring(name, d + 1, String::length(name))
+      let src = iw_conv_source_valtype(mn)
+      if src != 0 {
+        Array::push(out, src)
+        out
+      } else if iw_core_unary_mnemonic(mn) {
+        Array::push(out, t)
+        out
+      } else if iw_core_binary_mnemonic(mn) {
+        Array::push(out, t)
+        Array::push(out, t)
+        out
+      } else {
+        throw(iw_err(fn_name, "the assembler has no operand signature for '\{name}'", off))
+      }
+    }
+  }
+}
+
+/// #2401: the scalar valtype a SIMD shape's lanes hold.
+fn iw_shape_scalar_valtype(name: String) -> Int {
+  if String::starts_with(name, "i8x16.") || String::starts_with(name, "i16x8.") || String::starts_with(name, "i32x4.") {
+    0x7F
+  } else if String::starts_with(name, "i64x2.") {
+    0x7E
+  } else if String::starts_with(name, "f32x4.") {
+    0x7D
+  } else if String::starts_with(name, "f64x2.") {
+    0x7C
+  } else {
+    0
+  }
+}
+
+/// #2401: SIMD mnemonics taking ONE v128.
+fn iw_simd_unary_mnemonic(mn: String) -> Bool {
+  mn == "not" || mn == "any_true" || mn == "all_true" || mn == "bitmask" || mn == "abs" || mn == "neg" || mn == "popcnt" || mn == "sqrt"
+}
+
+/// #2401: SIMD mnemonics taking TWO v128.
+fn iw_simd_binary_mnemonic(mn: String) -> Bool {
+  mn == "eq" || mn == "ne" || mn == "lt_s" || mn == "lt_u" || mn == "gt_s" || mn == "gt_u" || mn == "le_s" || mn == "le_u" || mn == "ge_s" || mn == "ge_u" || mn == "lt" || mn == "gt" || mn == "le" || mn == "ge" || mn == "and" || mn == "andnot" || mn == "or" || mn == "xor" || mn == "add" || mn == "add_sat_s" || mn == "add_sat_u" || mn == "sub" || mn == "sub_sat_s" || mn == "sub_sat_u" || mn == "mul" || mn == "div" || mn == "min" || mn == "max" || mn == "min_s" || mn == "min_u" || mn == "max_s" || mn == "max_u" || mn == "avgr_u" || mn == "dot_i16x8_s" || mn == "swizzle"
+}
+
+/// #2401: the operand valtypes an `iw_simd_table` instruction pops. Same
+/// fail-loud contract as `iw_core_op_params`.
+fn iw_simd_op_params(fn_name: String, name: String, off: Int) -> Array[Int] with Exception {
+  let out = iw_fresh_ints()
+  let d = iw_dot_pos(name)
+  if d < 0 {
+    throw(iw_err(fn_name, "the assembler has no operand signature for '\{name}'", off))
+  } else {
+    let mn = String::substring(name, d + 1, String::length(name))
+    if mn == "splat" {
+      Array::push(out, iw_shape_scalar_valtype(name))
+      out
+    } else if mn == "shl" || mn == "shr_s" || mn == "shr_u" {
+      // A lane shift takes the vector and an i32 shift amount.
+      Array::push(out, 0x7B)
+      Array::push(out, 0x7F)
+      out
+    } else if mn == "bitselect" {
+      Array::push(out, 0x7B)
+      Array::push(out, 0x7B)
+      Array::push(out, 0x7B)
+      out
+    } else if iw_simd_unary_mnemonic(mn) {
+      Array::push(out, 0x7B)
+      out
+    } else if iw_simd_binary_mnemonic(mn) {
+      Array::push(out, 0x7B)
+      Array::push(out, 0x7B)
+      out
+    } else {
+      throw(iw_err(fn_name, "the assembler has no operand signature for '\{name}'", off))
+    }
+  }
+}
+
+/// #2401: one v128 operand, for the shorthand used by several arms below.
+fn iw_params1(a: Int) -> Array[Int] {
+  let out = iw_fresh_ints()
+  Array::push(out, a)
+  out
+}
+
+fn iw_params2(a: Int, b: Int) -> Array[Int] {
+  let out = iw_fresh_ints()
+  Array::push(out, a)
+  Array::push(out, b)
+  out
+}
+
+/// #2401: apply the stack effect of the plain instruction whose name word is
+/// at `pos`. Dispatch mirrors `iw_plain_op` arm for arm; that function runs
+/// FIRST and rejects every unknown or unsupported spelling, so the trailing
+/// throw here is reached only if the two ever drift apart.
+///
+/// Folded form calls this AFTER walking the operand expressions (the operands
+/// are on the stack by then, which is the whole point); flat form calls it at
+/// the instruction, where the operands are already on the stack too.
+fn iw_stack_effect(st: IwStack, fn_name: String, kinds: Array[Int], texts: Array[String], offs: Array[Int], pos: Int, end: Int, locals: Array[(String, Int, Int)], lbl_names: Array[String], lbl_depths: Array[Int], depth: Int) -> Unit with Exception {
+  let name = Array::get(texts, pos)
+  let off = Array::get(offs, pos)
+  if name == "local.get" {
+    iw_st_push(st, iw_local_valtype(locals, Array::get(texts, pos + 1)))
+  } else if name == "local.set" || name == "local.tee" {
+    let lt = iw_local_valtype(locals, Array::get(texts, pos + 1))
+    iw_apply(st, fn_name, name, iw_params1(lt), if name == "local.tee" {
+      lt
+    } else {
+      0
+    }, off)
+  } else if name == "br" || name == "br_if" {
+    let rel = iw_label_rel(fn_name, lbl_names, lbl_depths, Array::get(texts, pos + 1), depth, Array::get(offs, pos + 1))
+    let ti = Array::length(st.frames) - 1 - rel
+    if ti < 0 {
+      throw(iw_err(fn_name, "'\{name}' targets a label \{rel} level(s) out, which is outside this function body", off))
+    } else {
+      ()
+    }
+    // A `br` to a loop restarts it, so the loop's label takes no value; a
+    // block/if label takes the block's declared result.
+    let (_tb, tres, tloop, _tp) = Array::get(st.frames, ti)
+    let arity = if tloop == 1 {
+      0
+    } else {
+      tres
+    }
+    if name == "br_if" {
+      iw_apply(st, fn_name, name, iw_params1(0x7F), 0, off)
+      // The branch value must be there, and stays there for the fallthrough.
+      if arity != 0 {
+        iw_apply(st, fn_name, name, iw_params1(arity), arity, off)
+      } else {
+        ()
+      }
+    } else {
+      if arity != 0 {
+        iw_apply(st, fn_name, name, iw_params1(arity), 0, off)
+      } else {
+        ()
+      }
+      iw_st_mark_poly(st)
+    }
+  } else if name == "i32.const" {
+    iw_st_push(st, 0x7F)
+  } else if name == "i64.const" {
+    iw_st_push(st, 0x7E)
+  } else if name == "memory.size" {
+    iw_st_push(st, 0x7F)
+  } else if name == "memory.grow" {
+    iw_apply(st, fn_name, name, iw_params1(0x7F), 0x7F, off)
+  } else if name == "v128.const" {
+    iw_st_push(st, 0x7B)
+  } else if name == "v128.load" {
+    iw_apply(st, fn_name, name, iw_params1(0x7F), 0x7B, off)
+  } else if name == "v128.store" {
+    iw_apply(st, fn_name, name, iw_params2(0x7F, 0x7B), 0, off)
+  } else if name == "i8x16.shuffle" {
+    iw_apply(st, fn_name, name, iw_params2(0x7B, 0x7B), 0x7B, off)
+  } else if iw_lookup(iw_core_table(), name) >= 0 {
+    if name == "select" {
+      // `select`'s result is its operands' type, so it is the one core
+      // instruction whose signature is not a constant.
+      iw_apply(st, fn_name, name, iw_params1(0x7F), 0, off)
+      if Array::length(st.vals) - iw_st_base(st) < 2 && !iw_st_poly(st) {
+        throw(iw_err(fn_name, "'select' takes 3 operand(s), but only \{Array::length(st.vals) - iw_st_base(st) + 1} value(s) are on the stack here", off))
+      } else {
+        ()
+      }
+      let b = iw_st_pop_raw(st)
+      let a = iw_st_pop_raw(st)
+      if a != 0 && b != 0 && a != b {
+        throw(iw_err(fn_name, "'select' needs both value operands to have the same type, got \{iw_valtype_name(a)} and \{iw_valtype_name(b)}", off))
+      } else {
+        ()
+      }
+      iw_st_push(st, if a != 0 {
+        a
+      } else {
+        b
+      })
+    } else {
+      iw_apply(st, fn_name, name, iw_core_op_params(fn_name, name, off), iw_core_result_valtype(name), off)
+      if name == "unreachable" || name == "return" {
+        iw_st_mark_poly(st)
+      } else {
+        ()
+      }
+    }
+  } else if iw_lookup(iw_simd_lane_table(), name) >= 0 {
+    if String::contains(name, ".extract_lane") {
+      iw_apply(st, fn_name, name, iw_params1(0x7B), iw_simd_result_valtype(name), off)
+    } else {
+      iw_apply(st, fn_name, name, iw_params2(0x7B, iw_shape_scalar_valtype(name)), 0x7B, off)
+    }
+  } else {
+    let (mem_opc, _mem_align) = iw_mem_lookup(name)
+    if mem_opc >= 0 {
+      let vt = iw_prefix_valtype(name)
+      if String::contains(name, ".store") {
+        iw_apply(st, fn_name, name, iw_params2(0x7F, vt), 0, off)
+      } else {
+        iw_apply(st, fn_name, name, iw_params1(0x7F), vt, off)
+      }
+    } else if iw_lookup(iw_simd_table(), name) >= 0 {
+      iw_apply(st, fn_name, name, iw_simd_op_params(fn_name, name, off), iw_simd_result_valtype(name), off)
+    } else {
+      throw(iw_err(fn_name, "the assembler has no operand signature for '\{name}'", off))
+    }
+  }
+}
+
+/// #2401 coverage self-check: the instruction names this file assembles but
+/// cannot give an operand signature, i.e. the ones whose operands would go
+/// unchecked. It must stay EMPTY -- a new row in one of the tables without a
+/// matching signature rule shows up here, and
+/// `inline wasm assembler: every table instruction has an operand signature`
+/// in lib/@vibe/compiler/tests/inline_wasm_test.vibe fails.
+///
+/// This is exported rather than tested through a synthesized body because the
+/// body would need the very signature under test to be written correctly.
+export fn inline_wat_unclassified_instructions() -> Array[String] {
+  let out = iw_fresh_strings()
+  let core = iw_core_table()
+  let mut i = 0
+  while i < Array::length(core) {
+    let (cn, _co) = Array::get(core, i)
+    handle {
+      let _ = iw_core_op_params("probe", cn, 0)
+      ()
+    } with { Exception::Throw(_) => Array::push(out, cn) }
+    i = i + 1
+  }
+  let simd = iw_simd_table()
+  let mut j = 0
+  while j < Array::length(simd) {
+    let (sn, _so) = Array::get(simd, j)
+    handle {
+      let _ = iw_simd_op_params("probe", sn, 0)
+      ()
+    } with { Exception::Throw(_) => Array::push(out, sn) }
+    j = j + 1
+  }
+  // The lane and memory tables are typed from their shape/prefix alone, so a
+  // new row there can still be unclassified: a shape this file does not know
+  // types its scalar as 0 ("any"), which silently disables the check.
+  let lane = iw_simd_lane_table()
+  let mut k = 0
+  while k < Array::length(lane) {
+    let (ln, _lo) = Array::get(lane, k)
+    if iw_shape_scalar_valtype(ln) == 0 {
+      Array::push(out, ln)
+    } else {
+      ()
+    }
+    k = k + 1
+  }
+  let mem = iw_mem_table()
+  let mut m = 0
+  while m < Array::length(mem) {
+    let (mn, _mo, _ma) = Array::get(mem, m)
+    if iw_prefix_valtype(mn) == 0 {
+      Array::push(out, mn)
+    } else {
+      ()
+    }
+    m = m + 1
+  }
+  out
+}
+
 /// #2348: folded `(call $f <operand exprs...>)` to another inline-wasm fn in
 /// the same module.
 ///
@@ -1233,7 +1737,7 @@ fn iw_operand_valtype(kinds: Array[Int], texts: Array[String], pos: Int, end: In
 /// the whole reason `call` is folded-only: in the flat spelling the count is
 /// not knowable here, and an unchecked call would surface as a wasm validation
 /// failure at module load instead of a located error.
-fn iw_folded_call(out: Bytes, fn_name: String, kinds: Array[Int], texts: Array[String], offs: Array[Int], pos: Int, end: Int, locals: Array[(String, Int, Int)], lbl_names: Array[String], lbl_depths: Array[Int], depth: Int, callees: Array[(String, Int, Int)]) -> Int with Exception {
+fn iw_folded_call(out: Bytes, fn_name: String, kinds: Array[Int], texts: Array[String], offs: Array[Int], pos: Int, end: Int, locals: Array[(String, Int, Int)], lbl_names: Array[String], lbl_depths: Array[Int], depth: Int, callees: Array[(String, Int, Int)], st: IwStack) -> Int with Exception {
   let head_off = Array::get(offs, pos)
   if pos + 2 >= end || Array::get(kinds, pos + 2) != 3 {
     throw(iw_err(fn_name, "'call' needs a callee name: (call $f ...)", head_off))
@@ -1275,7 +1779,7 @@ fn iw_folded_call(out: Bytes, fn_name: String, kinds: Array[Int], texts: Array[S
       } else {
         ()
       }
-      p = iw_item(out, fn_name, kinds, texts, offs, p, end, locals, lbl_names, lbl_depths, depth, callees)
+      p = iw_item(out, fn_name, kinds, texts, offs, p, end, locals, lbl_names, lbl_depths, depth, callees, st)
       argc = argc + 1
     } else {
       throw(iw_err(fn_name, "unexpected '\{Array::get(texts, p)}' inside '(call $\{callee}' — operands must be parenthesized", Array::get(offs, p)))
@@ -1286,6 +1790,15 @@ fn iw_folded_call(out: Bytes, fn_name: String, kinds: Array[Int], texts: Array[S
   } else {
     ()
   }
+  // #2401: the arguments are on the stack now. Every inline-wasm parameter
+  // and result is an i64, so the effect is `carity` i64s in, one i64 out.
+  let cps = iw_fresh_ints()
+  let mut cpi = 0
+  while cpi < carity {
+    Array::push(cps, 0x7E)
+    cpi = cpi + 1
+  }
+  iw_apply(st, fn_name, "call $\{callee}", cps, 0x7E, head_off)
   // The closure-env slot: every user function's last wasm param.
   bytebuf_push(out, 0x42)
   leb128_encode_s64(out, 0)
@@ -1296,10 +1809,14 @@ fn iw_folded_call(out: Bytes, fn_name: String, kinds: Array[Int], texts: Array[S
 
 /// One sequence item at `pos`: either a folded `(...)` expression or a plain
 /// instruction word. Returns the position after the item.
-fn iw_item(out: Bytes, fn_name: String, kinds: Array[Int], texts: Array[String], offs: Array[Int], pos: Int, end: Int, locals: Array[(String, Int, Int)], lbl_names: Array[String], lbl_depths: Array[Int], depth: Int, callees: Array[(String, Int, Int)]) -> Int with Exception {
+fn iw_item(out: Bytes, fn_name: String, kinds: Array[Int], texts: Array[String], offs: Array[Int], pos: Int, end: Int, locals: Array[(String, Int, Int)], lbl_names: Array[String], lbl_depths: Array[Int], depth: Int, callees: Array[(String, Int, Int)], st: IwStack) -> Int with Exception {
   let k = Array::get(kinds, pos)
   if k == 3 {
-    iw_plain_op(out, fn_name, kinds, texts, offs, pos, end, locals, lbl_names, lbl_depths, depth)
+    // #2401: flat form -- the operands are already on the stack, so the
+    // instruction's effect applies right here.
+    let next = iw_plain_op(out, fn_name, kinds, texts, offs, pos, end, locals, lbl_names, lbl_depths, depth)
+    iw_stack_effect(st, fn_name, kinds, texts, offs, pos, end, locals, lbl_names, lbl_depths, depth)
+    next
   } else if k == 1 {
     if pos + 1 >= end || Array::get(kinds, pos + 1) != 3 {
       throw(iw_err(fn_name, "expected an instruction name after '('", Array::get(offs, pos)))
@@ -1308,15 +1825,15 @@ fn iw_item(out: Bytes, fn_name: String, kinds: Array[Int], texts: Array[String],
     }
     let head = Array::get(texts, pos + 1)
     if head == "call" {
-      iw_folded_call(out, fn_name, kinds, texts, offs, pos, end, locals, lbl_names, lbl_depths, depth, callees)
+      iw_folded_call(out, fn_name, kinds, texts, offs, pos, end, locals, lbl_names, lbl_depths, depth, callees, st)
     } else if head == "block" || head == "loop" {
-      iw_folded_block(out, fn_name, kinds, texts, offs, pos, end, locals, lbl_names, lbl_depths, depth, callees)
+      iw_folded_block(out, fn_name, kinds, texts, offs, pos, end, locals, lbl_names, lbl_depths, depth, callees, st)
     } else if head == "if" {
-      iw_folded_if(out, fn_name, kinds, texts, offs, pos, end, locals, lbl_names, lbl_depths, depth, callees)
+      iw_folded_if(out, fn_name, kinds, texts, offs, pos, end, locals, lbl_names, lbl_depths, depth, callees, st)
     } else if head == "then" || head == "else" || head == "result" {
       throw(iw_err(fn_name, "misplaced '(\{head} ...)' clause", Array::get(offs, pos)))
     } else {
-      iw_folded_op(out, fn_name, kinds, texts, offs, pos, end, locals, lbl_names, lbl_depths, depth, callees)
+      iw_folded_op(out, fn_name, kinds, texts, offs, pos, end, locals, lbl_names, lbl_depths, depth, callees, st)
     }
   } else {
     throw(iw_err(fn_name, "unexpected ')'", Array::get(offs, pos)))
@@ -1324,7 +1841,7 @@ fn iw_item(out: Bytes, fn_name: String, kinds: Array[Int], texts: Array[String],
 }
 
 /// A sequence of items up to (not consuming) a closing ')' or the end.
-fn iw_seq(out: Bytes, fn_name: String, kinds: Array[Int], texts: Array[String], offs: Array[Int], pos: Int, end: Int, locals: Array[(String, Int, Int)], lbl_names: Array[String], lbl_depths: Array[Int], depth: Int, callees: Array[(String, Int, Int)]) -> Int with Exception {
+fn iw_seq(out: Bytes, fn_name: String, kinds: Array[Int], texts: Array[String], offs: Array[Int], pos: Int, end: Int, locals: Array[(String, Int, Int)], lbl_names: Array[String], lbl_depths: Array[Int], depth: Int, callees: Array[(String, Int, Int)], st: IwStack) -> Int with Exception {
   let mut p = pos
   let mut done = false
   while !done {
@@ -1333,7 +1850,7 @@ fn iw_seq(out: Bytes, fn_name: String, kinds: Array[Int], texts: Array[String], 
     } else if Array::get(kinds, p) == 2 {
       done = true
     } else {
-      p = iw_item(out, fn_name, kinds, texts, offs, p, end, locals, lbl_names, lbl_depths, depth, callees)
+      p = iw_item(out, fn_name, kinds, texts, offs, p, end, locals, lbl_names, lbl_depths, depth, callees, st)
     }
   }
   p
@@ -1341,7 +1858,7 @@ fn iw_seq(out: Bytes, fn_name: String, kinds: Array[Int], texts: Array[String], 
 
 /// Folded `(op <immediates> <operand exprs...>)`: real folded-form semantics —
 /// the operand expressions are emitted FIRST, then the op itself.
-fn iw_folded_op(out: Bytes, fn_name: String, kinds: Array[Int], texts: Array[String], offs: Array[Int], pos: Int, end: Int, locals: Array[(String, Int, Int)], lbl_names: Array[String], lbl_depths: Array[Int], depth: Int, callees: Array[(String, Int, Int)]) -> Int with Exception {
+fn iw_folded_op(out: Bytes, fn_name: String, kinds: Array[Int], texts: Array[String], offs: Array[Int], pos: Int, end: Int, locals: Array[(String, Int, Int)], lbl_names: Array[String], lbl_depths: Array[Int], depth: Int, callees: Array[(String, Int, Int)], st: IwStack) -> Int with Exception {
   let opb = bytebuf_new()
   let after_imm = iw_plain_op(opb, fn_name, kinds, texts, offs, pos + 1, end, locals, lbl_names, lbl_depths, depth)
   let mut p = after_imm
@@ -1352,17 +1869,21 @@ fn iw_folded_op(out: Bytes, fn_name: String, kinds: Array[Int], texts: Array[Str
     } else if Array::get(kinds, p) == 2 {
       done = true
     } else if Array::get(kinds, p) == 1 {
-      p = iw_item(out, fn_name, kinds, texts, offs, p, end, locals, lbl_names, lbl_depths, depth, callees)
+      p = iw_item(out, fn_name, kinds, texts, offs, p, end, locals, lbl_names, lbl_depths, depth, callees, st)
     } else {
       throw(iw_err(fn_name, "unexpected '\{Array::get(texts, p)}' inside folded '\{Array::get(texts, pos + 1)}' — operands must be parenthesized", Array::get(offs, p)))
     }
   }
+  // #2401: the operands are on the stack only now, which is where a folded
+  // op's effect belongs -- the iw_plain_op call above consumed its immediates
+  // and emitted its opcode into a side buffer, nothing more.
+  iw_stack_effect(st, fn_name, kinds, texts, offs, pos + 1, end, locals, lbl_names, lbl_depths, depth)
   bytebuf_push_buf(out, opb)
   p + 1
 }
 
 /// Folded `(block $l? (result T)? ...)` / `(loop $l? (result T)? ...)`.
-fn iw_folded_block(out: Bytes, fn_name: String, kinds: Array[Int], texts: Array[String], offs: Array[Int], pos: Int, end: Int, locals: Array[(String, Int, Int)], lbl_names: Array[String], lbl_depths: Array[Int], depth: Int, callees: Array[(String, Int, Int)]) -> Int with Exception {
+fn iw_folded_block(out: Bytes, fn_name: String, kinds: Array[Int], texts: Array[String], offs: Array[Int], pos: Int, end: Int, locals: Array[(String, Int, Int)], lbl_names: Array[String], lbl_depths: Array[Int], depth: Int, callees: Array[(String, Int, Int)], st: IwStack) -> Int with Exception {
   let head = Array::get(texts, pos + 1)
   bytebuf_push(out, if head == "loop" {
     0x03
@@ -1380,13 +1901,29 @@ fn iw_folded_block(out: Bytes, fn_name: String, kinds: Array[Int], texts: Array[
   }
   let (bt, after_bt) = iw_blocktype(fn_name, kinds, texts, offs, q, end)
   bytebuf_push(out, bt)
-  let bq = iw_seq(out, fn_name, kinds, texts, offs, after_bt, end, locals, lbl_names, lbl_depths, depth + 1, callees)
+  let bres = if bt == 0x40 {
+    0
+  } else {
+    bt
+  }
+  Array::push(st.frames, (Array::length(st.vals), bres, if head == "loop" {
+    1
+  } else {
+    0
+  }, 0))
+  let bq = iw_seq(out, fn_name, kinds, texts, offs, after_bt, end, locals, lbl_names, lbl_depths, depth + 1, callees, st)
   if bq >= end || Array::get(kinds, bq) != 2 {
     throw(iw_err(fn_name, "missing ')' closing '\{head}'", Array::get(offs, pos)))
   } else {
     ()
   }
   bytebuf_push(out, 0x0B)
+  iw_st_close(st, fn_name, "'\{head}'", "", Array::get(offs, pos))
+  if bres != 0 {
+    iw_st_push(st, bres)
+  } else {
+    ()
+  }
   Array::truncate(lbl_names, lbl_mark)
   Array::truncate(lbl_depths, lbl_mark)
   bq + 1
@@ -1394,7 +1931,7 @@ fn iw_folded_block(out: Bytes, fn_name: String, kinds: Array[Int], texts: Array[
 
 /// Folded `(if $l? (result T)? <cond exprs...> (then ...) (else ...)?)`.
 /// The condition is emitted first, then 0x04 + blocktype, then the branches.
-fn iw_folded_if(out: Bytes, fn_name: String, kinds: Array[Int], texts: Array[String], offs: Array[Int], pos: Int, end: Int, locals: Array[(String, Int, Int)], lbl_names: Array[String], lbl_depths: Array[Int], depth: Int, callees: Array[(String, Int, Int)]) -> Int with Exception {
+fn iw_folded_if(out: Bytes, fn_name: String, kinds: Array[Int], texts: Array[String], offs: Array[Int], pos: Int, end: Int, locals: Array[(String, Int, Int)], lbl_names: Array[String], lbl_depths: Array[Int], depth: Int, callees: Array[(String, Int, Int)], st: IwStack) -> Int with Exception {
   let lbl_mark = Array::length(lbl_names)
   let mut q = pos + 2
   if q < end && Array::get(kinds, q) == 3 && String::length(Array::get(texts, q)) > 0 && String::char_code_at(Array::get(texts, q), 0) == '$' {
@@ -1414,30 +1951,51 @@ fn iw_folded_if(out: Bytes, fn_name: String, kinds: Array[Int], texts: Array[Str
     } else if Array::get(kinds, p) == 1 && p + 1 < end && Array::get(kinds, p + 1) == 3 && Array::get(texts, p + 1) == "then" {
       cond_done = true
     } else if Array::get(kinds, p) == 1 {
-      p = iw_item(out, fn_name, kinds, texts, offs, p, end, locals, lbl_names, lbl_depths, depth, callees)
+      p = iw_item(out, fn_name, kinds, texts, offs, p, end, locals, lbl_names, lbl_depths, depth, callees, st)
     } else {
       throw(iw_err(fn_name, "unexpected token in folded 'if' condition (condition operands must be parenthesized)", Array::get(offs, p)))
     }
   }
+  // #2401: the condition is on the stack now, and the two branches type
+  // against a frame whose floor sits BELOW it.
+  iw_apply(st, fn_name, "if", iw_params1(0x7F), 0, Array::get(offs, pos))
   bytebuf_push(out, 0x04)
   bytebuf_push(out, bt)
+  let bres = if bt == 0x40 {
+    0
+  } else {
+    bt
+  }
   // then branch: p is at '(' of (then ...)
-  let tq = iw_seq(out, fn_name, kinds, texts, offs, p + 2, end, locals, lbl_names, lbl_depths, depth + 1, callees)
+  Array::push(st.frames, (Array::length(st.vals), bres, 0, 0))
+  let tq = iw_seq(out, fn_name, kinds, texts, offs, p + 2, end, locals, lbl_names, lbl_depths, depth + 1, callees, st)
   if tq >= end || Array::get(kinds, tq) != 2 {
     throw(iw_err(fn_name, "missing ')' closing '(then ...)'", Array::get(offs, p)))
   } else {
     ()
   }
+  iw_st_close(st, fn_name, "the 'then' branch", "", Array::get(offs, p))
   let mut r = tq + 1
   if r + 1 < end && Array::get(kinds, r) == 1 && Array::get(kinds, r + 1) == 3 && Array::get(texts, r + 1) == "else" {
     bytebuf_push(out, 0x05)
-    let eq = iw_seq(out, fn_name, kinds, texts, offs, r + 2, end, locals, lbl_names, lbl_depths, depth + 1, callees)
+    Array::push(st.frames, (Array::length(st.vals), bres, 0, 0))
+    let eq = iw_seq(out, fn_name, kinds, texts, offs, r + 2, end, locals, lbl_names, lbl_depths, depth + 1, callees, st)
     if eq >= end || Array::get(kinds, eq) != 2 {
       throw(iw_err(fn_name, "missing ')' closing '(else ...)'", Array::get(offs, r)))
     } else {
       ()
     }
+    iw_st_close(st, fn_name, "the 'else' branch", "", Array::get(offs, r))
     r = eq + 1
+  } else {
+    if bres != 0 {
+      throw(iw_err(fn_name, "a folded 'if' declaring (result \{iw_valtype_name(bres)}) needs an (else ...) branch, so the value exists on both paths", Array::get(offs, pos)))
+    } else {
+      ()
+    }
+  }
+  if bres != 0 {
+    iw_st_push(st, bres)
   } else {
     ()
   }
@@ -1564,12 +2122,16 @@ export fn compile_inline_wat_calls(fn_name: String, wat: String, param_names: Ar
   } else {
     ()
   }
-  let final_pos = iw_seq(out, fn_name, kinds, texts, offs, body_start, end, locals, lbl_names, lbl_depths, 0, callees)
+  // #2401: the body's own frame. The parser admits only `-> Int`, so the
+  // body must leave exactly one i64.
+  let st = iw_st_new(0x7E)
+  let final_pos = iw_seq(out, fn_name, kinds, texts, offs, body_start, end, locals, lbl_names, lbl_depths, 0, callees, st)
   if final_pos != end {
     throw(iw_err(fn_name, "unbalanced ')'", Array::get(offs, final_pos)))
   } else {
     ()
   }
+  iw_st_close(st, fn_name, "the inline wasm body", " (an inline-wasm fn returns Int, so its body leaves one i64)", 0)
   (out, n32, n64, nv)
 }
 
@@ -1583,5 +2145,5 @@ export fn compile_inline_wat(fn_name: String, wat: String, param_names: Array[St
 //# Misc
 
 export {
-  compile_inline_wat, compile_inline_wat_calls, compile_inline_wat_full
+  compile_inline_wat, compile_inline_wat_calls, compile_inline_wat_full, inline_wat_unclassified_instructions
 }

--- a/lib/@vibe/compiler/codegen/index.vpkg
+++ b/lib/@vibe/compiler/codegen/index.vpkg
@@ -70,6 +70,7 @@ fn compile_wasi_module_break(stmts: Array[Stmt], entry_name: String, prov: DbgPr
 fn compile_inline_wat(fn_name: String, wat: String, param_names: Array[String]) -> Bytes with Exception
 fn compile_inline_wat_full(fn_name: String, wat: String, param_names: Array[String], extra_base: Int) -> (Bytes, Int, Int, Int) with Exception
 fn compile_inline_wat_calls(fn_name: String, wat: String, param_names: Array[String], extra_base: Int, callees: Array[(String, Int, Int)]) -> (Bytes, Int, Int, Int) with Exception
+fn inline_wat_unclassified_instructions() -> Array[String]
 
 // --- normalize/desugar_trait_dict.vibe (re-exported through
 // codegen/common_base for compatibility; see that package's index.vpkg header)

--- a/lib/@vibe/compiler/tests/inline_wasm_test.vibe
+++ b/lib/@vibe/compiler/tests/inline_wasm_test.vibe
@@ -570,6 +570,10 @@ test "#2401 inline wasm: operands are typed against the instruction" {
   assert(String::contains(wat_err("(i64.add (i64.eq (local.get $a) (local.get $b)) (local.get $b))"), "the value there is i32"))
   // A declared local's type is the one that counts.
   assert(String::contains(wat_err("(local $p i32) (local.set $p (local.get $a)) (local.get $a)"), "'local.set' expects i32"))
+  assert(String::contains(wat_err("(local $p i32) (i64.extend_i32_s (local.tee $p (i64.const 1)))"), "'local.tee' expects i32"))
+  // ... and `local.tee` leaves that type, not an unknown that matches
+  // anything: an i32 local's tee cannot be the body's i64 result.
+  assert(String::contains(wat_err("(local $p i32) (local.tee $p (i32.const 1))"), "the inline wasm body must leave i64 but leaves i32"))
   // `return` and `select` are the two whose signature is not a plain table row.
   assert(String::contains(wat_err("(return (i32.const 1))"), "'return' expects i64 for operand 1 of 1"))
   assert(String::contains(wat_err("(select (local.get $a) (i32.const 1) (i32.const 1))"), "'select' needs both value operands to have the same type, got i64 and i32"))
@@ -653,4 +657,10 @@ test "#2401 inline wasm: the ordinary shapes still assemble" {
   // guessed: `locals` is keyed by name, and an unknown matches any expected
   // type, so it can never manufacture an error.
   assert(wat_err("(i64.add (local.get 0) (local.get 1))") == "")
+  assert(wat_err("(local.set 0 (i64.const 1)) (local.get $a)") == "")
+  // `local.tee` always leaves its operand, so it pushes even when the local's
+  // type is unknown. The first cut routed that push through iw_apply's
+  // `result`, where 0 means "pushes nothing" rather than "pushes an unknown",
+  // and rejected this valid body for leaving nothing (Codex on #2418).
+  assert(wat_err("(local.tee 0 (i64.const 1))") == "")
 }

--- a/lib/@vibe/compiler/tests/inline_wasm_test.vibe
+++ b/lib/@vibe/compiler/tests/inline_wasm_test.vibe
@@ -27,7 +27,7 @@ import ../codegen_gc.vibe {
 }
 
 import @vibe/compiler/codegen {
-  compile_inline_wat, compile_inline_wat_calls, compile_inline_wat_full
+  compile_inline_wat, compile_inline_wat_calls, compile_inline_wat_full, inline_wat_unclassified_instructions
 }
 
 import @vibe/compiler/codegen/common_base {
@@ -119,9 +119,13 @@ test "inline wasm assembler: flat sequence equals folded form" {
 }
 
 test "inline wasm assembler: simd 0xFD prefix" {
-  // i64x2.splat = 0xFD 18
-  let bytes = compile_inline_wat("probe", "(i64x2.splat (local.get $a))", ["a"])
-  assert(Bytes::length(bytes) == 4)
+  // i64x2.splat = 0xFD 18. The extract_lane wrapper is what brings the body
+  // back to the single i64 an inline-wasm fn returns (#2401); the bytes under
+  // test are still the first four.
+  let bytes = compile_inline_wat("probe", "(i64x2.extract_lane 0 (i64x2.splat (local.get $a)))", [
+    "a"
+  ])
+  assert(Bytes::length(bytes) == 7)
   assert(bytes[0] == 0x20)
   assert(bytes[1] == 0x00)
   assert(bytes[2] == 0xFD)
@@ -172,16 +176,22 @@ test "inline wasm assembler: integer immediates accept both spellings (#2341)" {
   // to be LEB-encoded verbatim as an out-of-range s32: `vibe check` reported
   // the file CLEAN and the module then failed at LOAD with a wasmtime
   // backtrace naming a function index the author never wrote.
-  let unsigned_spelling = compile_inline_wat("probe", "(i32.const 2654435761)", [
+  // The i64.extend_i32_s wrapper only brings the body back to the single i64
+  // an inline-wasm fn returns (#2401); the i32.const encoding under test is
+  // still the leading bytes.
+  let unsigned_spelling = compile_inline_wat("probe", "(i64.extend_i32_s (i32.const 2654435761))", [
     "a"
   ])
-  let signed_spelling = compile_inline_wat("probe", "(i32.const -1640531535)", [
+  let signed_spelling = compile_inline_wat("probe", "(i64.extend_i32_s (i32.const -1640531535))", [
     "a"
   ])
   assert(unsigned_spelling == signed_spelling)
-  assert(Bytes::length(unsigned_spelling) == 6)
+  assert(Bytes::length(unsigned_spelling) == 7)
   assert(unsigned_spelling[0] == 0x41)
-  let hex_spelling = compile_inline_wat("probe", "(i32.const 0x9E3779B1)", ["a"])
+  assert(unsigned_spelling[6] == 0xAC)
+  let hex_spelling = compile_inline_wat("probe", "(i64.extend_i32_s (i32.const 0x9E3779B1))", [
+    "a"
+  ])
   assert(hex_spelling == signed_spelling)
   // ... and out of range is a LOCATED error, not a truncation and not a
   // load-time failure.
@@ -196,10 +206,10 @@ test "inline wasm assembler: integer immediates accept both spellings (#2341)" {
 test "inline wasm assembler: v128.const lanes are range-checked (#2341)" {
   // `(v >> bi * 8) & 255` truncated an out-of-range lane silently, so
   // `v128.const i8x16 300 ...` assembled as 44.
-  let ok = compile_inline_wat("probe", "(v128.const i8x16 200 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0)", [
+  let ok = compile_inline_wat("probe", "(i64x2.extract_lane 0 (v128.const i8x16 200 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0))", [
     "a"
   ])
-  assert(Bytes::length(ok) == 18)
+  assert(Bytes::length(ok) == 21)
   assert(ok[0] == 0xFD)
   assert(ok[1] == 12)
   assert(ok[2] == 200)
@@ -209,10 +219,10 @@ test "inline wasm assembler: v128.const lanes are range-checked (#2341)" {
   let e2 = wat_err("(v128.const i16x8 70000 0 0 0 0 0 0 0)")
   assert(String::contains(e2, "is out of range for i16"))
   // i64x2 needs no check: every vibe Int already fits in an i64.
-  let wide = compile_inline_wat("probe", "(v128.const i64x2 4611686018427387903 -1)", [
+  let wide = compile_inline_wat("probe", "(i64x2.extract_lane 0 (v128.const i64x2 4611686018427387903 -1))", [
     "a"
   ])
-  assert(Bytes::length(wide) == 18)
+  assert(Bytes::length(wide) == 21)
 }
 
 test "inline wasm assembler: an over-long integer literal is a located error (#2341)" {
@@ -263,12 +273,13 @@ test "inline wasm assembler: (local ...) misuse is a located error" {
 }
 
 test "inline wasm assembler: i8x16.shuffle encodes 16 lane bytes" {
-  let bytes = compile_inline_wat("probe", "(i8x16.shuffle 0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 (i64x2.splat (local.get $a)) (i64x2.splat (local.get $b)))", [
+  let bytes = compile_inline_wat("probe", "(i64x2.extract_lane 0 (i8x16.shuffle 0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 (i64x2.splat (local.get $a)) (i64x2.splat (local.get $b))))", [
     "a",
     "b"
   ])
-  // 2 * (local.get + splat) = 2 * 4 bytes, then 0xFD 13 + 16 lane bytes
-  assert(Bytes::length(bytes) == 8 + 2 + 16)
+  // 2 * (local.get + splat) = 2 * 4 bytes, then 0xFD 13 + 16 lane bytes, then
+  // the extract_lane that brings the body back to one i64 (#2401)
+  assert(Bytes::length(bytes) == 8 + 2 + 16 + 3)
   assert(bytes[8] == 0xFD)
   assert(bytes[9] == 13)
   assert(bytes[10] == 0)
@@ -492,7 +503,7 @@ test "#2348 inline wasm: a call operand of the wrong result type is rejected" {
   assert(String::contains(call_result("(call $dbl (i64.eq (local.get $a) (local.get $b)))"), "produces i32"))
   assert(String::contains(call_result("(call $dbl (f64.abs (f64.reinterpret_i64 (local.get $a))))"), "produces f64"))
   // A SIMD reduction is i32; a lane extract is the lane's scalar type.
-  assert(String::contains(call_result("(call $dbl (i8x16.all_true (v128.load (local.get $a))))"), "produces i32"))
+  assert(String::contains(call_result("(call $dbl (i8x16.all_true (v128.load (i32.wrap_i64 (local.get $a)))))"), "produces i32"))
   assert(String::contains(call_result("(call $dbl (block (result i32) (i32.const 1)))"), "produces i32"))
 }
 
@@ -510,12 +521,122 @@ test "#2348 inline wasm: i64 call operands still assemble" {
   // ordinary shapes. A local, an arithmetic head, a nested call, a block WITH
   // an i64 result, a load, local.tee, an i64 lane extract, and a widening
   // conversion.
+  //
+  // The two loads address through `i32.wrap_i64` because a wasm load takes an
+  // i32 address. They used to pass `(local.get $a)` -- an i64 -- straight in:
+  // this "the check must not reject the ordinary shapes" control was itself
+  // two modules a validator rejects, which is exactly the gap #2401 closed and
+  // exactly why an operand check has to see inside the operand.
   assert(call_result("(call $dbl (local.get $a))") == "ok")
   assert(call_result("(call $dbl (i64.add (local.get $a) (local.get $b)))") == "ok")
   assert(call_result("(call $dbl (call $dbl (local.get $a)))") == "ok")
   assert(call_result("(call $dbl (block (result i64) (i64.const 1)))") == "ok")
-  assert(call_result("(call $dbl (i64.load (local.get $a)))") == "ok")
+  assert(call_result("(call $dbl (i64.load (i32.wrap_i64 (local.get $a))))") == "ok")
   assert(call_result("(call $dbl (local.tee $a (i64.const 2)))") == "ok")
-  assert(call_result("(call $dbl (i64x2.extract_lane 0 (v128.load (local.get $a))))") == "ok")
+  assert(call_result("(call $dbl (i64x2.extract_lane 0 (v128.load (i32.wrap_i64 (local.get $a)))))") == "ok")
   assert(call_result("(call $dbl (i64.extend_i32_s (i32.const 1)))") == "ok")
+}
+
+test "#2401 inline wasm: every table instruction has an operand signature" {
+  // The coverage gate for the operand check. A row added to one of the four
+  // instruction tables without a matching signature rule lands in this list,
+  // and an unsigned instruction is one whose operands go UNCHECKED -- the very
+  // hole #2401 closed. Empty is the only acceptable answer.
+  let unclassified = inline_wat_unclassified_instructions()
+  assert(Array::length(unclassified) == 0)
+}
+
+test "#2401 inline wasm: the two measured cases from the issue are rejected" {
+  // Both assembled cleanly before this, `vibe check` said the file was fine,
+  // and the module failed only when a runtime validated it. Neither involves
+  // `call`, so #2399's call-boundary check could not see them.
+  let mistyped = wat_err("(i64.add (i32.const 1) (i64.const 2))")
+  assert(String::contains(mistyped, "'i64.add' expects i64 for operand 1 of 2, but the value there is i32"))
+  let block_result = wat_err("(block (result i64) (i32.const 1))")
+  assert(String::contains(block_result, "'block' must leave i64 but leaves i32"))
+}
+
+test "#2401 inline wasm: operands are typed against the instruction" {
+  // A shift amount is an i32 even when the lanes are i64.
+  assert(String::contains(wat_err("(i64x2.extract_lane 0 (i64x2.shl (i64x2.splat (local.get $a)) (i64.const 1)))"), "'i64x2.shl' expects i32 for operand 2 of 2"))
+  // A load/store addresses through an i32.
+  assert(String::contains(wat_err("(i64.load (local.get $a))"), "'i64.load' expects i32 for operand 1 of 1"))
+  assert(String::contains(wat_err("(i64.store (i32.wrap_i64 (local.get $a)) (i32.const 1)) (local.get $a)"), "'i64.store' expects i64 for operand 2 of 2"))
+  // replace_lane takes the shape's scalar, shuffle takes two vectors.
+  assert(String::contains(wat_err("(i64x2.extract_lane 0 (i64x2.replace_lane 1 (i64x2.splat (local.get $a)) (i32.const 1)))"), "'i64x2.replace_lane' expects i64 for operand 2 of 2"))
+  assert(String::contains(wat_err("(i64x2.extract_lane 0 (i8x16.shuffle 0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 (local.get $a) (i64x2.splat (local.get $b))))"), "'i8x16.shuffle' expects v128 for operand 1 of 2"))
+  // A comparison yields i32 whatever its operand width, so feeding one to an
+  // i64 operator is a type error and a prefix rule alone would miss it.
+  assert(String::contains(wat_err("(i64.add (i64.eq (local.get $a) (local.get $b)) (local.get $b))"), "the value there is i32"))
+  // A declared local's type is the one that counts.
+  assert(String::contains(wat_err("(local $p i32) (local.set $p (local.get $a)) (local.get $a)"), "'local.set' expects i32"))
+  // `return` and `select` are the two whose signature is not a plain table row.
+  assert(String::contains(wat_err("(return (i32.const 1))"), "'return' expects i64 for operand 1 of 1"))
+  assert(String::contains(wat_err("(select (local.get $a) (i32.const 1) (i32.const 1))"), "'select' needs both value operands to have the same type, got i64 and i32"))
+}
+
+test "#2401 inline wasm: stack depth is tracked, in both directions" {
+  // Under-supply: a folded operator with too few operands used to assemble and
+  // silently take a value from whatever happened to be underneath.
+  assert(String::contains(wat_err("(i64.add (local.get $a))"), "'i64.add' takes 2 operand(s), but only 1 value(s) are on the stack here"))
+  assert(String::contains(wat_err("drop (local.get $a)"), "'drop' takes 1 operand(s), but only 0 value(s) are on the stack here"))
+  // Over-supply: an inline-wasm fn returns Int, so its body leaves ONE i64.
+  assert(String::contains(wat_err("(local.get $a) (local.get $b)"), "the inline wasm body must leave exactly one i64 but leaves 2 value(s)"))
+  assert(String::contains(wat_err("(i32.const 5)"), "the inline wasm body must leave i64 but leaves i32"))
+  // A block's frame is a FLOOR: an instruction inside it cannot reach a value
+  // produced outside it, which is what wasm says and what this used to emit.
+  assert(String::contains(wat_err("(local.get $a) (block (result i64) (i64.add (local.get $b)))"), "'i64.add' takes 2 operand(s), but only 1 value(s) are on the stack here"))
+}
+
+test "#2401 inline wasm: block, loop and if frames are checked" {
+  // A block with no (result T) must leave nothing.
+  assert(String::contains(wat_err("(block (i64.const 1))"), "'block' declares no result but leaves 1 value(s) on the stack"))
+  // Each branch of an `if` produces the declared result...
+  assert(String::contains(wat_err("(if (result i64) (i32.const 1) (then (i32.const 1)) (else (local.get $b)))"), "the 'then' branch must leave i64 but leaves i32"))
+  assert(String::contains(wat_err("(if (result i64) (i32.const 1) (then (local.get $a)) (else (i32.const 1)))"), "the 'else' branch must leave i64 but leaves i32"))
+  // ... which needs both branches to exist.
+  assert(String::contains(wat_err("(if (result i64) (i32.const 1) (then (local.get $a)))"), "needs an (else ...) branch"))
+  // The condition is an i32.
+  assert(String::contains(wat_err("(if (result i64) (local.get $a) (then (local.get $a)) (else (local.get $b)))"), "'if' expects i32 for operand 1 of 1"))
+  assert(String::contains(wat_err("(block (result i64) (br_if 0 (local.get $a) (local.get $b)))"), "'br_if' expects i32 for operand 1 of 1"))
+}
+
+test "#2401 inline wasm: unreachable code is polymorphic but still typed" {
+  // `unreachable` satisfies the frame's declared result -- rejecting this
+  // would reject a program wasm accepts.
+  assert(wat_err("(block (result i64) unreachable)") == "")
+  assert(wat_err("(loop $l (br $l)) (local.get $a)") == "")
+  // ... but wasm still types what FOLLOWS it, and so does this.
+  assert(String::contains(wat_err("unreachable (i32.const 1) (i64.add (i64.const 2))"), "'i64.add' expects i64 for operand 1 of 2"))
+}
+
+test "#2401 inline wasm: the ordinary shapes still assemble" {
+  // The control. Every case above rejects something; these must not be
+  // rejected, or the check has simply broken inline wasm.
+  assert(wat_err("(i64.add (local.get $a) (local.get $b))") == "")
+  assert(wat_err("local.get $a local.get $b i64.add") == "")
+  assert(wat_err("(i64.and (local.get $a) (i64.const 0x1FE))") == "")
+  assert(wat_err("(block (result i64) (local.get $a))") == "")
+  assert(wat_err("(loop (result i64) (local.get $a))") == "")
+  assert(wat_err("(block (result i64) (block (result i64) (local.get $a)))") == "")
+  assert(wat_err("(if (result i64) (i32.const 1) (then (local.get $a)) (else (local.get $b)))") == "")
+  // A br carries the target block's result; a br to a LOOP carries nothing,
+  // because a loop label restarts the loop rather than leaving it.
+  assert(wat_err("(block (result i64) (br 0 (local.get $a)))") == "")
+  assert(wat_err("(block (result i64) (br_if 0 (local.get $a) (i32.const 1)))") == "")
+  assert(wat_err("(loop $l (br_if $l (i32.const 1))) (local.get $a)") == "")
+  assert(wat_err("(select (local.get $a) (local.get $b) (i32.const 1))") == "")
+  assert(wat_err("(drop (local.get $a)) (local.get $b)") == "")
+  assert(wat_err("(local.tee $a (local.get $b))") == "")
+  assert(wat_err("(return (local.get $a))") == "")
+  assert(wat_err("(i64.extend_i32_s (memory.grow (i32.const 1)))") == "")
+  assert(wat_err("(i64.reinterpret_f64 (f64.abs (f64.reinterpret_i64 (local.get $a))))") == "")
+  assert(wat_err("(i64.shl (i64.extend_i32_u (i32.load offset=4 (i32.wrap_i64 (local.get $a)))) (i64.const 1))") == "")
+  assert(wat_err("(v128.store (i32.wrap_i64 (local.get $a)) (i64x2.splat (local.get $b))) (local.get $a)") == "")
+  assert(wat_err("(i64x2.extract_lane 0 (v128.bitselect (i64x2.splat (local.get $a)) (i64x2.splat (local.get $b)) (i64x2.splat (local.get $a))))") == "")
+  assert(wat_err("(i64x2.extract_lane 0 (i64x2.shl (i64x2.splat (local.get $a)) (i32.const 1)))") == "")
+  // A numeric local index is deliberately typed as unknown rather than
+  // guessed: `locals` is keyed by name, and an unknown matches any expected
+  // type, so it can never manufacture an error.
+  assert(wat_err("(i64.add (local.get 0) (local.get 1))") == "")
 }

--- a/lib/@vibe/compiler/tests/inline_wasm_test.vibe
+++ b/lib/@vibe/compiler/tests/inline_wasm_test.vibe
@@ -608,6 +608,20 @@ test "#2401 inline wasm: unreachable code is polymorphic but still typed" {
   assert(wat_err("(loop $l (br $l)) (local.get $a)") == "")
   // ... but wasm still types what FOLLOWS it, and so does this.
   assert(String::contains(wat_err("unreachable (i32.const 1) (i64.add (i64.const 2))"), "'i64.add' expects i64 for operand 1 of 2"))
+  // Polymorphism relaxes only the POP at a frame's end -- a missing result can
+  // come from the floor. Values pushed after the `unreachable` are live at
+  // `end`, and wasm rejects those exactly as it would without it. The first
+  // cut of this pass skipped the whole end-of-frame check once the flag was
+  // set, so each of these assembled (Codex on #2418).
+  assert(String::contains(wat_err("(block unreachable (i64.const 1)) (local.get $a)"), "'block' declares no result but leaves 1 value(s) on the stack"))
+  assert(String::contains(wat_err("(loop $l (br $l) (i64.const 1)) (local.get $a)"), "'loop' declares no result but leaves 1 value(s) on the stack"))
+  assert(String::contains(wat_err("(block (result i64) unreachable (i64.const 1) (i64.const 2))"), "'block' must leave exactly one i64 but leaves 2 value(s)"))
+  assert(String::contains(wat_err("unreachable (i32.const 1)"), "the inline wasm body must leave i64 but leaves i32"))
+  // The other side of the same rule: one value of the declared type after an
+  // `unreachable` is what the frame asked for, and stays accepted.
+  assert(wat_err("(block (result i64) unreachable (i64.const 1))") == "")
+  assert(wat_err("unreachable") == "")
+  assert(wat_err("(if (result i64) (i32.const 1) (then unreachable) (else (local.get $b)))") == "")
 }
 
 test "#2401 inline wasm: the ordinary shapes still assemble" {


### PR DESCRIPTION
Closes #2401.

`inline_wat.vibe` checked locals, labels, immediates, lane indices and `(local ...)` grouping, but never checked that an instruction's **operands** have the types it requires. The bytes were emitted, the module was written, and the mismatch surfaced only when a runtime validated it — `vibe check` clean, artifact broken. Both cases measured on the issue assembled before this, and neither involves `call`, so #2399's call-boundary check could not see them:

```
fn f(a: Int, b: Int) -> Int = wasm"(i64.add (i32.const 1) (i64.const 2))"
fn g(a: Int, b: Int) -> Int = wasm"(block (result i64) (i32.const 1))"
```

Took route 1 from the issue (type the assembler) over route 2 (shell out to an external validator): it keeps the located-error standard #2341 set for this file, and adds no dependency.

## What is checked

The assembler walks an abstract value stack (`IwStack`): one valtype per value, one frame per enclosing block/loop/if plus one for the function body. A frame's entry height is a **floor**, which is what stops an instruction inside a block from consuming a value produced outside it.

- **Operand types** against each instruction's signature — a lane shift takes an i32 amount, a load/store addresses through an i32, `replace_lane` takes the shape's scalar, a comparison yields i32 whatever its operand width.
- **Frames** — a `block`/`loop`/`if` leaves what its `(result T)` declares, and nothing without one; an `if` with a `(result T)` has an `(else ...)`.
- **Depth, both directions** — too few operands for an instruction, and a body that leaves other than the single i64 an inline-wasm fn returns.
- Dead code after `unreachable` / `br` / `return` is stack-polymorphic but still typed, as in the spec's own validation algorithm: `(block (result i64) unreachable)` is accepted, `unreachable (i32.const 1) (i64.add (i64.const 2))` is not.

Deliberate conservatism, erring toward accepting: a numeric `local.get 3` types as unknown (the locals table is keyed by name), and an unknown matches any expected type, so it can never manufacture an error.

## The tables cannot silently outgrow the checker

Signatures are derived from the instruction tables by name rules rather than kept in a parallel table, and **a name the rules cannot classify throws instead of skipping the check**. `inline_wat_unclassified_instructions` reports exactly those names, and `#2401 inline wasm: every table instruction has an operand signature` asserts the list is empty.

Red-tested rather than assumed: a bogus row planted in each of the four tables (`i64.frobnicate`, `f64x2.frobnicate`, `i128x1.replace_lane`, `v256.store`) makes that list non-empty in every case, so the assertion can fail.

## Two existing test controls were themselves invalid wasm

In the #2348 tests, `assert(call_result("(call $dbl (i64.load (local.get $a)))") == "ok")` passes an i64 address to an instruction taking i32; the `v128.load` line next to it did the same. They sat under the comment "the check must not reject the ordinary shapes" — the gap in miniature, since #2399's lookahead deliberately does not look inside an operand. Fixed here, with the reason recorded next to them.

Four byte-probe bodies that left an i32 or a v128 (`(i32.const N)`, `(v128.const ...)`, `(i8x16.shuffle ...)`, `(i64x2.splat ...)`) now carry a conversion so the body leaves the i64 the fn returns. The bytes each probe asserts are unchanged; only the lengths move.

## Verification

- `lib/@vibe/compiler/tests/inline_wasm_test.vibe` — 38 tests pass (31 before; 7 new for #2401, each with its control)
- `scripts/vibe_fmt.sh --check` — clean on every edited file
- `scripts/compiler_gate.sh` — full operation gate

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FYMVd6D2o82suTfTwoJPMf

---
_Generated by [Claude Code](https://claude.ai/code/session_01FYMVd6D2o82suTfTwoJPMf)_