### PR TITLE
Reuse fusion refuses mixed consume-plus-borrow binds (both tiers)

### DIFF
--- a/lib/@vibe/compiler/codegen/expr/compile_match.vibe
+++ b/lib/@vibe/compiler/codegen/expr/compile_match.vibe
@@ -29,7 +29,7 @@ import @vibe/compiler/codegen/common_analysis {
 }
 
 import @vibe/compiler/perceus {
-  reuse_arm_has_blocker
+  reuse_arm_has_blocker, reuse_bind_mode
 }
 
 import @vibe/compiler/codegen/common_base {
@@ -330,7 +330,12 @@ fn mr_reuse_eligible(p: Pat, body: Expr, scrutinee: Expr, ctx: CompileCtx) -> In
             if ctor_field_is_float(ctx, ci, fj) || ctor_field_is_float(ctx, src_ci, fj) {
               shape_ok = false
             } else if is_pbind(pa) {
-              if md_consume_count_pre(body, get_pbind_name(pa), ctx.borrow_param_user, mr_bmasks) != 1 {
+              // Mode 1 only for the narrow tier (a raw transfer whose
+              // single consume is the bind's ONLY occurrence): a mixed
+              // consume-plus-borrow bind could be read after the consume
+              // freed the transferred child (PR #2416 review); the wide
+              // tier additionally admits mode 0.
+              if reuse_bind_mode(body, get_pbind_name(pa), ctx.borrow_param_user, mr_bmasks) != 1 {
                 shape_ok = false
               } else {
                 ()
@@ -651,18 +656,16 @@ fn mr_reuse_wide_eligible(p: Pat, body: Expr, scrutinee: Expr, ctx: CompileCtx) 
             if ctor_field_is_float(ctx, src_ci, fj) {
               shape_ok = false
             } else if is_pbind(pa) {
-              // Consume count 1: ownership transfers raw and the single
-              // consume releases it. Consume count 0 (every use borrows --
-              // e.g. borrow-classified callees): the staging compensates,
-              // dup-skipping it on the shared path (it stays a view of the
-              // still-live block) and the arm end drops it when the block
-              // was unique (the raw transfer's ref nobody consumed). 2+
-              // declines -- the normal path's dup-per-consume has no
-              // raw-transfer equivalent. An alias-bound name declines:
-              // aliasing can hide an owner the consume count doesn't see.
+              // Mode 1 (pure consume: the raw transfer's single consume is
+              // the bind's only occurrence) or mode 0 (pure borrow: the
+              // staging dups it on the shared path and the arm end drops
+              // it on both). A mixed consume-plus-borrow bind is refused
+              // -- a read sequenced after the consume would be
+              // use-after-free on the unique path (PR #2416 review) --
+              // and so is an alias-bound name: aliasing can hide an owner
+              // the consume count doesn't see.
               let __wbn = get_pbind_name(pa)
-              let __wcc = md_consume_count_pre(body, __wbn, ctx.borrow_param_user, mr_bmasks)
-              if (__wcc != 0 && __wcc != 1) || array_contains_str(ctx.rc_alias_dup_names, __wbn) {
+              if reuse_bind_mode(body, __wbn, ctx.borrow_param_user, mr_bmasks) < 0 || array_contains_str(ctx.rc_alias_dup_names, __wbn) {
                 shape_ok = false
               } else {
                 ()
@@ -721,7 +724,7 @@ fn mr_compile_reuse_arm_wide(buf: Bytes, body: Expr, pat: Pat, scrut_local: Int,
   while ci < arity {
     let cpa = Array::get(pargs, ci)
     if is_pbind(cpa) {
-      let __cn = md_consume_count_pre(body, get_pbind_name(cpa), ctx.borrow_param_user, __wcc_bmasks)
+      let __cn = reuse_bind_mode(body, get_pbind_name(cpa), ctx.borrow_param_user, __wcc_bmasks)
       Array::push(bind_consumes, __cn)
       if __cn == 0 {
         has_borrow_bind = true

--- a/lib/@vibe/compiler/perceus/index.vpkg
+++ b/lib/@vibe/compiler/perceus/index.vpkg
@@ -63,6 +63,12 @@ fn pa_is_reuse_alloc(a: PerceusAction) -> Bool
 // plan row's (name, arity) key cannot distinguish sibling arms).
 fn reuse_arm_has_blocker(e: Expr) -> Bool
 
+// ADR-0092 / #2389: one payload bind's admission mode for the reuse fusion
+// (1 pure consume, 0 pure borrow, -1 inadmissible -- a mixed
+// consume-plus-borrow bind could be read after its consume freed the
+// raw-transferred child). Shared with both codegen tiers.
+fn reuse_bind_mode(arm_body: Expr, bn: String, borrow_param_fns: Array[String], bmasks: Array[Int]) -> Int
+
 // --- program-wide name scans (threaded into every function's plan)
 fn compute_borrow_returning_names(stmts: Array[Stmt]) -> Array[String]
 fn compute_scalar_returning_names(stmts: Array[Stmt]) -> Array[String]

--- a/lib/@vibe/compiler/perceus/perceus.vibe
+++ b/lib/@vibe/compiler/perceus/perceus.vibe
@@ -2874,6 +2874,51 @@ export fn reuse_arm_has_blocker(e: Expr) -> Bool {
   }
 }
 
+/// Every occurrence of `name` as an identifier in `e`, lambdas and
+/// shadowed regions INCLUDED -- deliberately an overcount. The admission
+/// below compares it against the consume count, and an overcount can only
+/// DECLINE an arm, never admit one whose reads it missed.
+fn reuse_ident_occurrences(e: Expr, name: String) -> Int {
+  match e {
+    EIdent(n, _) => if n == name {
+      1
+    } else {
+      0
+    },
+    _ => {
+      let kids = expr_children(e)
+      let mut acc = 0
+      let mut i = 0
+      while i < Array::length(kids) {
+        acc = acc + reuse_ident_occurrences(Array::get(kids, i), name)
+        i = i + 1
+      }
+      acc
+    }
+  }
+}
+
+/// The admission mode of one payload bind for the reuse fusion: 1 = pure
+/// consume (consumed exactly once and that consume is its ONLY occurrence),
+/// 0 = pure borrow (never consumed; every read precedes the arm-end
+/// release), -1 = inadmissible. A bind with one consume PLUS borrow reads
+/// is refused (PR #2416 review): the raw-transferred child dies at the
+/// consume, so a read sequenced after it -- later spine let, conditional --
+/// would be use-after-free on the unique path. The normal path never has
+/// this hazard (the container outlives the arm), so declining just takes
+/// the normal path. Exported: the narrow and wide codegen tiers re-run the
+/// same predicate on the arm they fuse.
+export fn reuse_bind_mode(arm_body: Expr, bn: String, borrow_param_fns: Array[String], bmasks: Array[Int]) -> Int {
+  let cc = md_consume_count_pre(arm_body, bn, borrow_param_fns, bmasks)
+  if cc == 0 {
+    0
+  } else if cc == 1 && reuse_ident_occurrences(arm_body, bn) == 1 {
+    1
+  } else {
+    0 - 1
+  }
+}
+
 fn reuse_arm_candidate_arity(sname: String, pat: Pat, arm_body: Expr, borrow_param_fns: Array[String], borrow_param_masks: Array[Int], alias_names: Array[String]) -> Int {
   match pat {
     PCtor(_, pargs) => {
@@ -2903,13 +2948,10 @@ fn reuse_arm_candidate_arity(sname: String, pat: Pat, arm_body: Expr, borrow_par
             // declines -- aliasing can hide an extra owner the consume
             // count does not see; name-keyed, so a same-named alias
             // elsewhere declines conservatively.
-            PBind(bn) => {
-              let __cc = md_consume_count_pre(arm_body, bn, borrow_param_fns, bmasks)
-              if (__cc != 0 && __cc != 1) || name_in(alias_names, bn) {
-                ok = false
-              } else {
-                ()
-              }
+            PBind(bn) => if reuse_bind_mode(arm_body, bn, borrow_param_fns, bmasks) < 0 || name_in(alias_names, bn) {
+              ok = false
+            } else {
+              ()
             },
             PWild => (),
             _ => ok = false

--- a/lib/@vibe/compiler/tests/perceus_reuse_e2e_test.vibe
+++ b/lib/@vibe/compiler/tests/perceus_reuse_e2e_test.vibe
@@ -133,14 +133,31 @@ test "a shared source survives a pure-borrow-bind rebuild untouched" {
   assert_bump_rc_agree(src, "borrow_bind_shared", "8010")
 }
 
-test "a bind both borrowed and consumed still transfers cleanly" {
+test "a bind both borrowed and consumed declines (mixed mode is refused)" {
   // `a` is read by borrow-classified total AND consumed by the recursive
-  // incr2 -- consume count 1 with extra borrow reads. The transfer hands
-  // the child to the consume; the borrow reads happen before it.
+  // incr2 -- consume count 1 with an extra borrow read. Only pure modes
+  // are admitted: a read sequenced AFTER the consume would be
+  // use-after-free on the unique path, and no ordering analysis exists,
+  // so the whole mixed class declines and takes the normal path. Exactly
+  // ONE uniqueness test remains (the Leaf arm's narrow fusion).
   let src = String::concat(tree_prelude(), "let rec incr2: (Node) -> Node = (n) -> {\n  match n {\n    Pair(a, b) => {\n      let w = total(a)\n      let a2 = incr2(a)\n      let b2 = incr2(b)\n      Pair(a2, b2)\n    },\n    Leaf(v) => Leaf(v + 1)\n  }\n}\nfn main() -> Int {\n  let t = build(3)\n  let r = incr2(t)\n  let z = incr2(Leaf(9))\n  total(r) * 100 + total(z)\n}")
   assert_bump_rc_agree(src, "borrow_and_consume", "1610")
   let rc_wasm = compile_wasi_rc(src, "main")
-  inspect(count_token_tests(rc_wasm), content = "2")
+  inspect(count_token_tests(rc_wasm), content = "1")
+}
+
+test "a borrow read AFTER the consume never fuses (use-after-free shape)" {
+  // `swap(a)` consumes `a` (and, being itself a fused same-arity rebuild,
+  // swaps the block IN PLACE when unique); `lv(a)` then reads the leftmost
+  // leaf. If the arm fused, the unique path's raw transfer would let that
+  // read see the freed-and-reused block -- the in-place swap makes the
+  // corruption DETERMINISTIC: lv would answer the right child's 7 instead
+  // of 3. The mixed-mode refusal keeps the arm on the normal path, where
+  // the container's reference holds `a` alive past the consume.
+  let src = "enum Node {\n  Leaf(Int);\n  Pair(Node, Node)\n}\nlet rec lv: (Node) -> Int = (n) -> {\n  match n {\n    Pair(a, _) => lv(a),\n    Leaf(v) => v\n  }\n}\nlet rec total: (Node) -> Int = (n) -> {\n  match n {\n    Pair(a, b) => total(a) + total(b),\n    Leaf(v) => v\n  }\n}\nlet swap: (Node) -> Node = (n) -> {\n  match n {\n    Pair(a, b) => Pair(b, a),\n    Leaf(v) => Leaf(v)\n  }\n}\nlet use_after: (Node) -> Node = (n) -> {\n  match n {\n    Pair(a, b) => {\n      let x = swap(a)\n      let w = lv(a)\n      Pair(x, Leaf(w))\n    },\n    Leaf(v) => Leaf(v)\n  }\n}\nfn main() -> Int {\n  let r = use_after(Pair(Pair(Leaf(3), Leaf(7)), Leaf(1)))\n  let s = swap(Leaf(0))\n  total(r) + total(s)\n}"
+  // r = Pair(swap(Pair(3,7)), Leaf(lv(original a))) = Pair(Pair(7,3), Leaf(3));
+  // total(r) = 13, total(s) = 0 -> 13. A fused arm would read w = 7 -> 17.
+  assert_bump_rc_agree(src, "borrow_after_consume", "13")
 }
 
 test "a sibling arm with a conditional return is never authorized by the eligible arm's plan row" {


### PR DESCRIPTION
Lands the fix for the Codex P1 on #2416 ([thread](https://github.com/mizchi/vibe-lang/pull/2416#discussion_r3889020416)) — #2416 merged with head `8c6d671` moments before this commit was pushed to its branch, so the fix never reached main. Verified as a **real deterministic silent-wrong**, so this should land promptly.

## The bug

A payload bind with one owning consume *plus* borrow reads passed the reuse fusion's `consume == 1` check, but on the unique path the raw-transferred child dies at the consume — a read sequenced after it sees freed memory. With an in-place-swapping consumer the corruption is byte-deterministic: the new use-after-free e2e case answers **17 instead of 13** with the guard removed (`let x = swap(a); let w = lv(a); …` — `lv` reads the swapped block). The narrow tier has carried the same hole since spine lets were admitted (its check never counted borrow reads), so this also fixes a latent pre-#2416 bug.

## The fix

One exported predicate, `reuse_bind_mode`, decides admission for the planner and both codegen tiers:
- **1** — pure consume: the consume is the bind's ONLY identifier occurrence (the occurrence counter deliberately overcounts through lambdas and shadowed regions, which can only decline);
- **0** — pure borrow (wide tier only): every read precedes the arm-end release;
- **−1** — mixed, refused; the arm takes the normal path, where the container's reference outlives the arm.

A statically-present consume that a conditional skips at runtime leaks the transferred child exactly as the normal path leaks its unconsumed bind-time dup — leak parity, not a new class.

## Validation

- Red-tested by mutation: widening mode back to `consume==1` flips the mixed-arm token count (1 → 2) and corrupts the use-after-free case (13 → 17).
- Cherry-picked onto current main (which received unrelated codegen work since #2416) and **fully revalidated on this exact tree**: stage2 == stage3 fixpoint, full unit suite, full compiler gate, both reuse test files (15 tests), `vibe fmt --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0159xd5111g8KFt2CGyNyZvA

---
_Generated by [Claude Code](https://claude.ai/code/session_0159xd5111g8KFt2CGyNyZvA)_