### PR TITLE
Let an inline wasm kernel take an Array[Int] (#2348 part 2)

### DIFF
--- a/docs/cheatsheet.md
+++ b/docs/cheatsheet.md
@@ -2220,13 +2220,30 @@ fn simd_add(a: Int, b: Int) -> Int = wasm
 - **Linear backend only** — the wasm-gc backend rejects it with a compile
   error. The declared signature is trusted (extern-let style).
 - **v0.3 slice restrictions**: monomorphic only (no `[T]`), empty effect row,
-  no `where` contracts, params typed literally `Int` or `Bytes`, return type
-  `Int`. A `Bytes` param passes the RAW untagged object pointer (linear heap
-  layout: length at `obj+4`, data pointer at `obj+8`) — the body can
+  no `where` contracts, params typed `Int`, `Bytes` or `Array[Int]`, return
+  type `Int`. A `Bytes` param passes the RAW untagged object pointer (linear
+  heap layout: length at `obj+4`, data pointer at `obj+8`) — the body can
   `i32.load offset=8` the data pointer and feed `v128.load`/`v128.store`
   (the pointer is only valid while the Bytes is alive and un-grown). No
   `call_indirect` / `return_call` / `global.*` / `br_table` / `f32.const` /
   `f64.const`.
+- **`Array[Int]` params** (#2348): `local.get $xs` yields the array's header
+  address — `[capacity@0][length@4][data_ptr@8]`, so the length is
+  `i32.load offset=4` and the element block starts at `i32.load offset=8`.
+  The **same address on both lanes**: an array value is odd under `VIBE_RC=1`
+  (the production default) and even on the bump lane, and the assembler masks
+  the tag off every `local.get` of an array param rather than making the
+  kernel author pick. The mask is why the slot itself is read-only — writing
+  to it would hand RC's epilogue a value it did not allocate — so
+  `local.set $xs` / `local.tee $xs` are located errors; copy into a declared
+  `(local $tmp i64)` instead. What is NOT normalized, and cannot be, is the
+  **element** at `data_ptr + i*8`: it is an `Int` in the lane's own
+  representation, tagged `n<<1` under RC and raw under bump, exactly the trap
+  a scalar `Int` param already has. So `i64x2.add` straight over the slots is
+  correct on both lanes (addition is tag-transparent) while a multiply or a
+  shift is not, and an index arriving as a tagged `Int` scales by 4 under RC
+  where it scales by 8 on bump. The pointer is only valid while the array is
+  alive and un-grown — `Array::push` may reallocate the element block.
 - **Calling another kernel** (#2348): a body may `call` another inline-wasm
   `fn` in the same module — `(call $other (local.get $a) (local.get $b))`.
   Write only the real arguments: the assembler adds the closure-env slot

--- a/docs/cheatsheet.md
+++ b/docs/cheatsheet.md
@@ -2236,7 +2236,11 @@ fn simd_add(a: Int, b: Int) -> Int = wasm
   kernel author pick. The mask is why the slot itself is read-only — writing
   to it would hand RC's epilogue a value it did not allocate — so
   `local.set $xs` / `local.tee $xs` are located errors; copy into a declared
-  `(local $tmp i64)` instead. What is NOT normalized, and cannot be, is the
+  `(local $tmp i64)` instead. Both spellings of the parameter behave the same:
+  the mask is keyed by the resolved wasm index, so `local.get 0` masks exactly
+  as `local.get $xs` does. (The valtype lookup is still keyed by name, so the
+  numeric spelling types as unknown — #2401's gap, which errs toward accepting
+  a body wasm would accept, not toward miscompiling one.) What is NOT normalized, and cannot be, is the
   **element** at `data_ptr + i*8`: it is an `Int` in the lane's own
   representation, tagged `n<<1` under RC and raw under bump, exactly the trap
   a scalar `Int` param already has. So `i64x2.add` straight over the slots is

--- a/fixtures/inline_wasm_test.vibe
+++ b/fixtures/inline_wasm_test.vibe
@@ -127,6 +127,50 @@ fn wasm_calls_forward(a: Int) -> Int = wasm"(call $wasm_declared_later (local.ge
 
 fn wasm_declared_later(a: Int) -> Int = wasm"(i64.sub (i64.const 0) (local.get $a))"
 
+// #2348 part 2: an `Array[Int]` param. `local.get $xs` yields the array's
+// header address -- `[capacity@0][length@4][data_ptr@8]` -- with the RC tag
+// already masked off by the assembler, so ONE spelling reads the same header
+// on the RC and bump lanes.
+//
+// Every kernel here is lane-independent on purpose. The addresses and the
+// loop counter are raw i32; the only value that leaves is a SUM OF SLOTS,
+// and addition is tag-transparent, so the sum of tagged elements is the
+// tagged sum on RC and the raw sum on bump -- correct in both. A kernel that
+// returned the LENGTH would not be: the length is a raw i32 in the header,
+// and turning it into an `Int` needs the `<<1` only the RC lane wants.
+fn wasm_arr_sum(xs: Array[Int]) -> Int = wasm
+"(local $p i32)"
+"(local $e i32)"
+"(local $s i64)"
+"(local.set $p (i32.load offset=8 (i32.wrap_i64 (local.get $xs))))"
+"(local.set $e (i32.add (local.get $p)"
+"                       (i32.mul (i32.load offset=4 (i32.wrap_i64 (local.get $xs)))"
+"                                (i32.const 8))))"
+"(local.set $s (i64.const 0))"
+"(block $done"
+"  (loop $top"
+"    (br_if $done (i32.ge_u (local.get $p) (local.get $e)))"
+"    (local.set $s (i64.add (local.get $s) (i64.load (local.get $p))))"
+"    (local.set $p (i32.add (local.get $p) (i32.const 8)))"
+"    (br $top)))"
+"(local.get $s)"
+
+// The point of the whole exercise: a v128 load straight over the element
+// block, no untag/retag and no copy into a Bytes. Two slots per vector, and
+// `i64x2.add` is tag-transparent exactly like scalar add.
+fn wasm_arr_sum2_simd(xs: Array[Int]) -> Int = wasm
+"(local $p i32)"
+"(local $v v128)"
+"(local.set $p (i32.load offset=8 (i32.wrap_i64 (local.get $xs))))"
+"(local.set $v (v128.load (local.get $p)))"
+"(i64.add (i64x2.extract_lane 0 (local.get $v)) (i64x2.extract_lane 1 (local.get $v)))"
+
+// Subtraction, so an operand-order bug cannot pass: element 1 minus element 0.
+fn wasm_arr_diff01(xs: Array[Int]) -> Int = wasm
+"(local $p i32)"
+"(local.set $p (i32.load offset=8 (i32.wrap_i64 (local.get $xs))))"
+"(i64.sub (i64.load offset=8 (local.get $p)) (i64.load (local.get $p)))"
+
 //# Misc
 
 test "inline wasm: tagged add" {
@@ -211,4 +255,22 @@ test "#2348 inline wasm: a kernel calls another kernel in the same module" {
   assert(wasm_abs_diff(4, 4) == 0)
   assert(wasm_calls_forward(41) == -41)
   assert(wasm_calls_forward(-41) == 41)
+}
+
+test "#2348 part 2: a kernel reads a real Array[Int]" {
+  let xs = [11, 22, 33, 44, 55]
+  assert(wasm_arr_sum(xs) == 165)
+  assert(wasm_arr_sum2_simd(xs) == 33)
+  assert(wasm_arr_diff01(xs) == 11)
+  // The length comes from the header, not from a constant baked into the WAT.
+  assert(wasm_arr_sum([7]) == 7)
+  assert(wasm_arr_sum([1, 2, 3]) == 6)
+  // Negative elements: the slots are two's complement either way, and
+  // i64.load is a full-width load, so nothing here depends on the sign.
+  assert(wasm_arr_sum([0 - 4, 10]) == 6)
+  assert(wasm_arr_diff01([10, 3]) == 0 - 7)
+  // The array survives the call: the kernel borrows the block, it does not
+  // consume it.
+  assert(wasm_arr_sum(xs) == 165)
+  assert(Array::length(xs) == 5)
 }

--- a/fixtures/inline_wasm_test.vibe
+++ b/fixtures/inline_wasm_test.vibe
@@ -165,6 +165,26 @@ fn wasm_arr_sum2_simd(xs: Array[Int]) -> Int = wasm
 "(local.set $v (v128.load (local.get $p)))"
 "(i64.add (i64x2.extract_lane 0 (local.get $v)) (i64x2.extract_lane 1 (local.get $v)))"
 
+// The numeric spelling of the same parameter. `local.get 0` must mask exactly
+// as `local.get $xs` does: keying the mask by name would leave this reading
+// the TAGGED pointer and returning a plausible wrong sum on the RC lane.
+fn wasm_arr_sum_numeric(xs: Array[Int]) -> Int = wasm
+"(local $p i32)"
+"(local $e i32)"
+"(local $s i64)"
+"(local.set $p (i32.load offset=8 (i32.wrap_i64 (local.get 0))))"
+"(local.set $e (i32.add (local.get $p)"
+"                       (i32.mul (i32.load offset=4 (i32.wrap_i64 (local.get 0)))"
+"                                (i32.const 8))))"
+"(local.set $s (i64.const 0))"
+"(block $done"
+"  (loop $top"
+"    (br_if $done (i32.ge_u (local.get $p) (local.get $e)))"
+"    (local.set $s (i64.add (local.get $s) (i64.load (local.get $p))))"
+"    (local.set $p (i32.add (local.get $p) (i32.const 8)))"
+"    (br $top)))"
+"(local.get $s)"
+
 // Subtraction, so an operand-order bug cannot pass: element 1 minus element 0.
 fn wasm_arr_diff01(xs: Array[Int]) -> Int = wasm
 "(local $p i32)"
@@ -260,6 +280,7 @@ test "#2348 inline wasm: a kernel calls another kernel in the same module" {
 test "#2348 part 2: a kernel reads a real Array[Int]" {
   let xs = [11, 22, 33, 44, 55]
   assert(wasm_arr_sum(xs) == 165)
+  assert(wasm_arr_sum_numeric(xs) == 165)
   assert(wasm_arr_sum2_simd(xs) == 33)
   assert(wasm_arr_diff01(xs) == 11)
   // The length comes from the header, not from a constant baked into the WAT.

--- a/lib/@vibe/ast/ast.vibe
+++ b/lib/@vibe/ast/ast.vibe
@@ -346,3 +346,21 @@ export fn impl_method_owner_head(owner: String) -> String {
     String::substring(owner, 0, sep)
   }
 }
+
+/// Is this declared type exactly `Array[Int]`?
+///
+/// #2348 part 2: the one place three passes ask the same question about an
+/// inline-wasm param — the parser's admission check (`parse_fn_wasm_body`),
+/// the codegen splice (`linked_compile.vibe`) and the `vibe check` validation
+/// lane (`check_inline_wasm_fns`). They must agree by construction: a param
+/// the parser admits but codegen does not recognize would reach the body
+/// still tagged, and read its capacity as its length.
+export fn type_expr_is_array_of_int(t: TypeExpr) -> Bool {
+  match t {
+    TyApp(head, args) => head == "Array" && Array::length(args) == 1 && match Array::get(args, 0) {
+      TyName(elem) => elem == "Int",
+      _ => false
+    },
+    _ => false
+  }
+}

--- a/lib/@vibe/ast/ast.vibe
+++ b/lib/@vibe/ast/ast.vibe
@@ -355,8 +355,8 @@ export fn impl_method_owner_head(owner: String) -> String {
 /// lane (`check_inline_wasm_fns`). They must agree by construction: a param
 /// the parser admits but codegen does not recognize would reach the body
 /// still tagged, and read its capacity as its length.
-export fn type_expr_is_array_of_int(t: TypeExpr) -> Bool {
-  match t {
+export fn TypeExpr::is_array_of_int(recv: TypeExpr) -> Bool {
+  match recv {
     TyApp(head, args) => head == "Array" && Array::length(args) == 1 && match Array::get(args, 0) {
       TyName(elem) => elem == "Int",
       _ => false

--- a/lib/@vibe/ast/index.vpkg
+++ b/lib/@vibe/ast/index.vpkg
@@ -55,6 +55,7 @@ fn impl_method_owner_head(owner: String) -> String
 fn type_param_key(name: String, arity: Int) -> String
 fn type_param_name(key: String) -> String
 fn type_param_arity(key: String) -> Int
+fn type_expr_is_array_of_int(t: TypeExpr) -> Bool
 
 /// The declaration kind requested by a kind-qualified import item.
 export enum ImportKind {

--- a/lib/@vibe/ast/index.vpkg
+++ b/lib/@vibe/ast/index.vpkg
@@ -55,7 +55,7 @@ fn impl_method_owner_head(owner: String) -> String
 fn type_param_key(name: String, arity: Int) -> String
 fn type_param_name(key: String) -> String
 fn type_param_arity(key: String) -> Int
-fn type_expr_is_array_of_int(t: TypeExpr) -> Bool
+fn TypeExpr::is_array_of_int(recv: TypeExpr) -> Bool
 
 /// The declaration kind requested by a kind-qualified import item.
 export enum ImportKind {

--- a/lib/@vibe/compiler/codegen/codegen.vibe
+++ b/lib/@vibe/compiler/codegen/codegen.vibe
@@ -30,6 +30,7 @@ import @vibe/compiler/codegen/wasi {
 // same lower-level contract directly.
 export ./common_base {
   compile_inline_wat,
+  compile_inline_wat_array_params,
   compile_inline_wat_calls,
   compile_inline_wat_full,
   desugar_labeled_args,

--- a/lib/@vibe/compiler/codegen/common_base/index.vpkg
+++ b/lib/@vibe/compiler/codegen/common_base/index.vpkg
@@ -238,6 +238,7 @@ fn sized_bytes_new_expr(n_expr: Expr) -> Expr
 fn compile_inline_wat(fn_name: String, wat: String, param_names: Array[String]) -> Bytes with Exception
 fn compile_inline_wat_full(fn_name: String, wat: String, param_names: Array[String], extra_base: Int) -> (Bytes, Int, Int, Int) with Exception
 fn compile_inline_wat_calls(fn_name: String, wat: String, param_names: Array[String], extra_base: Int, callees: Array[(String, Int, Int)]) -> (Bytes, Int, Int, Int) with Exception
+fn compile_inline_wat_array_params(fn_name: String, wat: String, param_names: Array[String], array_param_names: Array[String], extra_base: Int, callees: Array[(String, Int, Int)]) -> (Bytes, Int, Int, Int) with Exception
 fn inline_wat_unclassified_instructions() -> Array[String]
 
 // --- normalize/desugar_trait_dict.vibe (cross-package facade re-export;

--- a/lib/@vibe/compiler/codegen/common_base/inline_wat.vibe
+++ b/lib/@vibe/compiler/codegen/common_base/inline_wat.vibe
@@ -724,31 +724,37 @@ fn iw_name_listed(names: Array[String], want: String) -> Bool {
   found
 }
 
-/// #2348 part 2: is `tok` (`$name`, or a bare index) an `Array[Int]` param?
-/// A bare numeric local index answers false: the mask is a property of the
-/// DECLARED param type, and a numeric slot carries no declared type here.
-/// Spelling an array param numerically therefore reads it tagged -- the same
-/// shape `local.tee 0` already has for its valtype, and the reason the
-/// diagnostic for a numeric local names the `$name` spelling.
-fn iw_local_is_array(locals: Array[(String, Int, Int, Int)], tok: String) -> Bool {
-  if String::length(tok) > 0 && String::char_code_at(tok, 0) == 36 {
-    let want = String::substring(tok, 1, String::length(tok))
-    let n = Array::length(locals)
-    let mut i = 0
-    let mut found = 0
-    while i < n {
-      let (ln, _li, _lt, lk) = Array::get(locals, i)
-      if ln == want {
-        found = lk
-        i = n
-      } else {
-        i = i + 1
-      }
+/// #2348 part 2: is the local at wasm index `idx` an `Array[Int]` param?
+///
+/// Keyed by the RESOLVED INDEX, not by the `$name` token, so the two
+/// spellings of the same parameter cannot answer differently. Keying it by
+/// name looked harmless -- the mask is a property of the declared type, and
+/// `local.get 3` has no declared type to read -- but "not an array" is not
+/// the safe default here: it would leave `local.get 0` handing the body the
+/// TAGGED pointer, so `i32.load offset=4` would read one byte past the
+/// header on the RC lane and return a plausible wrong number, and
+/// `local.set 0` would slip past the read-only check and overwrite the slot
+/// the RC epilogue drops. Both are silent-wrong, which this repository ranks
+/// above every other way of breaking.
+///
+/// This is deliberately NOT the same call as the valtype lookup, which stays
+/// keyed by name and answers "unknown" for a numeric index (#2401). That gap
+/// errs toward ACCEPTING a body wasm would accept; this one erred toward
+/// miscompiling it.
+fn iw_local_at_is_array(locals: Array[(String, Int, Int, Int)], idx: Int) -> Bool {
+  let n = Array::length(locals)
+  let mut i = 0
+  let mut found = 0
+  while i < n {
+    let (_ln, li, _lt, lk) = Array::get(locals, i)
+    if li == idx {
+      found = lk
+      i = n
+    } else {
+      i = i + 1
     }
-    found == 1
-  } else {
-    false
   }
+  found == 1
 }
 
 fn iw_local_idx(fn_name: String, locals: Array[(String, Int, Int, Int)], tok: String, off: Int) -> Int with Exception {
@@ -939,7 +945,7 @@ fn iw_plain_op(buf: Bytes, fn_name: String, kinds: Array[Int], texts: Array[Stri
     }
     let t = iw_want_word(fn_name, kinds, texts, offs, pos + 1, end, name)
     let idx = iw_local_idx(fn_name, locals, t, Array::get(offs, pos + 1))
-    let is_array = iw_local_is_array(locals, t)
+    let is_array = iw_local_at_is_array(locals, idx)
     // #2348 part 2: an `Array[Int]` param is the caller's live object. Writing
     // to its slot would hand the RC epilogue a value it did not allocate, so
     // the two writing forms are refused rather than silently mis-freed.

--- a/lib/@vibe/compiler/codegen/common_base/inline_wat.vibe
+++ b/lib/@vibe/compiler/codegen/common_base/inline_wat.vibe
@@ -86,10 +86,19 @@ fn iw_fresh_strings() -> Array[String] {
   array_empty()
 }
 
-/// #2348: `(name, wasm local index, wasm valtype byte)`. The type is what
-/// lets a folded `call` reject `(call $f (local.get $v))` when `$v` is an
-/// i32 or v128 local -- every inline-wasm parameter slot is an i64.
-fn iw_fresh_locals() -> Array[(String, Int, Int)] {
+/// #2348: `(name, wasm local index, wasm valtype byte, kind)`. The type is
+/// what lets a folded `call` reject `(call $f (local.get $v))` when `$v` is
+/// an i32 or v128 local -- every inline-wasm parameter slot is an i64.
+///
+/// `kind` is 0 for an ordinary local or param and 1 for an `Array[Int]`
+/// param (#2348 part 2). An array param is stored in its slot exactly as the
+/// caller passed it, which is TAGGED on the RC lane and untagged on the bump
+/// lane; `local.get` of one therefore masks the tag off so the body sees the
+/// same `[capacity@0][length@4][data_ptr@8]` header address on both lanes.
+/// The mask lives here rather than in a prologue that rewrites the slot
+/// because the slot is what RC drops at the epilogue -- overwriting it with
+/// an untagged pointer would hand rc_drop something it cannot classify.
+fn iw_fresh_locals() -> Array[(String, Int, Int, Int)] {
   array_empty()
 }
 
@@ -679,14 +688,14 @@ fn iw_mem_lookup(name: String) -> (Int, Int) {
 /// #2348: the wasm valtype byte of `$name`, or 0 when it is not a known local
 /// (a numeric index, or an unknown name -- both refuse to answer rather than
 /// guess).
-fn iw_local_valtype(locals: Array[(String, Int, Int)], tok: String) -> Int {
+fn iw_local_valtype(locals: Array[(String, Int, Int, Int)], tok: String) -> Int {
   if String::length(tok) > 0 && String::char_code_at(tok, 0) == 36 {
     let want = String::substring(tok, 1, String::length(tok))
     let n = Array::length(locals)
     let mut i = 0
     let mut found = 0
     while i < n {
-      let (ln, _li, lt) = Array::get(locals, i)
+      let (ln, _li, lt, _lk) = Array::get(locals, i)
       if ln == want {
         found = lt
         i = n
@@ -700,14 +709,56 @@ fn iw_local_valtype(locals: Array[(String, Int, Int)], tok: String) -> Int {
   }
 }
 
-fn iw_local_idx(fn_name: String, locals: Array[(String, Int, Int)], tok: String, off: Int) -> Int with Exception {
+fn iw_name_listed(names: Array[String], want: String) -> Bool {
+  let n = Array::length(names)
+  let mut i = 0
+  let mut found = false
+  while i < n {
+    if Array::get(names, i) == want {
+      found = true
+      i = n
+    } else {
+      i = i + 1
+    }
+  }
+  found
+}
+
+/// #2348 part 2: is `tok` (`$name`, or a bare index) an `Array[Int]` param?
+/// A bare numeric local index answers false: the mask is a property of the
+/// DECLARED param type, and a numeric slot carries no declared type here.
+/// Spelling an array param numerically therefore reads it tagged -- the same
+/// shape `local.tee 0` already has for its valtype, and the reason the
+/// diagnostic for a numeric local names the `$name` spelling.
+fn iw_local_is_array(locals: Array[(String, Int, Int, Int)], tok: String) -> Bool {
+  if String::length(tok) > 0 && String::char_code_at(tok, 0) == 36 {
+    let want = String::substring(tok, 1, String::length(tok))
+    let n = Array::length(locals)
+    let mut i = 0
+    let mut found = 0
+    while i < n {
+      let (ln, _li, _lt, lk) = Array::get(locals, i)
+      if ln == want {
+        found = lk
+        i = n
+      } else {
+        i = i + 1
+      }
+    }
+    found == 1
+  } else {
+    false
+  }
+}
+
+fn iw_local_idx(fn_name: String, locals: Array[(String, Int, Int, Int)], tok: String, off: Int) -> Int with Exception {
   if String::length(tok) > 0 && String::char_code_at(tok, 0) == '$' {
     let want = String::substring(tok, 1, String::length(tok))
     let n = Array::length(locals)
     let mut i = 0
     let mut found = 0 - 1
     while i < n {
-      let (ln, li, _lt) = Array::get(locals, i)
+      let (ln, li, _lt, _lk) = Array::get(locals, i)
       if ln == want {
         found = li
         i = n
@@ -873,7 +924,7 @@ fn iw_v128_const(buf: Bytes, fn_name: String, kinds: Array[Int], texts: Array[St
 
 /// Emit ONE plain (non-control) instruction word at `pos` plus its immediates
 /// into `buf`. Returns the position after the instruction + immediates.
-fn iw_plain_op(buf: Bytes, fn_name: String, kinds: Array[Int], texts: Array[String], offs: Array[Int], pos: Int, end: Int, locals: Array[(String, Int, Int)], lbl_names: Array[String], lbl_depths: Array[Int], depth: Int) -> Int with Exception {
+fn iw_plain_op(buf: Bytes, fn_name: String, kinds: Array[Int], texts: Array[String], offs: Array[Int], pos: Int, end: Int, locals: Array[(String, Int, Int, Int)], lbl_names: Array[String], lbl_depths: Array[Int], depth: Int) -> Int with Exception {
   let name = Array::get(texts, pos)
   let off = Array::get(offs, pos)
   if name == "block" || name == "loop" || name == "if" || name == "else" || name == "end" || name == "then" {
@@ -888,8 +939,27 @@ fn iw_plain_op(buf: Bytes, fn_name: String, kinds: Array[Int], texts: Array[Stri
     }
     let t = iw_want_word(fn_name, kinds, texts, offs, pos + 1, end, name)
     let idx = iw_local_idx(fn_name, locals, t, Array::get(offs, pos + 1))
+    let is_array = iw_local_is_array(locals, t)
+    // #2348 part 2: an `Array[Int]` param is the caller's live object. Writing
+    // to its slot would hand the RC epilogue a value it did not allocate, so
+    // the two writing forms are refused rather than silently mis-freed.
+    if is_array && name != "local.get" {
+      throw(iw_err(fn_name, "'\{name}' cannot write to '\{t}': an Array[Int] param is read-only inside an inline wasm body (copy it into a declared (local $tmp i64) first)", off))
+    } else {
+      ()
+    }
     bytebuf_push(buf, opc)
     leb128_encode_u32(buf, idx)
+    if is_array {
+      // Mask the RC tag bit off, so the body reads one header address on both
+      // lanes. A bump-lane array pointer is already even, so the mask is a
+      // no-op there rather than a second spelling of this instruction.
+      bytebuf_push(buf, 0x42)
+      leb128_encode_s64(buf, 0 - 2)
+      bytebuf_push(buf, 0x83)
+    } else {
+      ()
+    }
     pos + 2
   } else if name == "br" || name == "br_if" {
     let t = iw_want_word(fn_name, kinds, texts, offs, pos + 1, end, name)
@@ -1159,7 +1229,7 @@ fn iw_simd_result_valtype(name: String) -> Int {
 /// them here, and a result-less `block` / `loop` / `if` is rejected rather
 /// than analyzed. Both reject a program wasm would take; the opposite
 /// direction is what produces the broken module.
-fn iw_operand_valtype(kinds: Array[Int], texts: Array[String], pos: Int, end: Int, locals: Array[(String, Int, Int)]) -> Int {
+fn iw_operand_valtype(kinds: Array[Int], texts: Array[String], pos: Int, end: Int, locals: Array[(String, Int, Int, Int)]) -> Int {
   if pos + 1 >= end || Array::get(kinds, pos + 1) != 3 {
     0
   } else {
@@ -1570,7 +1640,7 @@ fn iw_params2(a: Int, b: Int) -> Array[Int] {
 /// Folded form calls this AFTER walking the operand expressions (the operands
 /// are on the stack by then, which is the whole point); flat form calls it at
 /// the instruction, where the operands are already on the stack too.
-fn iw_stack_effect(st: IwStack, fn_name: String, kinds: Array[Int], texts: Array[String], offs: Array[Int], pos: Int, end: Int, locals: Array[(String, Int, Int)], lbl_names: Array[String], lbl_depths: Array[Int], depth: Int) -> Unit with Exception {
+fn iw_stack_effect(st: IwStack, fn_name: String, kinds: Array[Int], texts: Array[String], offs: Array[Int], pos: Int, end: Int, locals: Array[(String, Int, Int, Int)], lbl_names: Array[String], lbl_depths: Array[Int], depth: Int) -> Unit with Exception {
   let name = Array::get(texts, pos)
   let off = Array::get(offs, pos)
   if name == "local.get" {
@@ -1761,7 +1831,7 @@ export fn inline_wat_unclassified_instructions() -> Array[String] {
 /// the whole reason `call` is folded-only: in the flat spelling the count is
 /// not knowable here, and an unchecked call would surface as a wasm validation
 /// failure at module load instead of a located error.
-fn iw_folded_call(out: Bytes, fn_name: String, kinds: Array[Int], texts: Array[String], offs: Array[Int], pos: Int, end: Int, locals: Array[(String, Int, Int)], lbl_names: Array[String], lbl_depths: Array[Int], depth: Int, callees: Array[(String, Int, Int)], st: IwStack) -> Int with Exception {
+fn iw_folded_call(out: Bytes, fn_name: String, kinds: Array[Int], texts: Array[String], offs: Array[Int], pos: Int, end: Int, locals: Array[(String, Int, Int, Int)], lbl_names: Array[String], lbl_depths: Array[Int], depth: Int, callees: Array[(String, Int, Int)], st: IwStack) -> Int with Exception {
   let head_off = Array::get(offs, pos)
   if pos + 2 >= end || Array::get(kinds, pos + 2) != 3 {
     throw(iw_err(fn_name, "'call' needs a callee name: (call $f ...)", head_off))
@@ -1833,7 +1903,7 @@ fn iw_folded_call(out: Bytes, fn_name: String, kinds: Array[Int], texts: Array[S
 
 /// One sequence item at `pos`: either a folded `(...)` expression or a plain
 /// instruction word. Returns the position after the item.
-fn iw_item(out: Bytes, fn_name: String, kinds: Array[Int], texts: Array[String], offs: Array[Int], pos: Int, end: Int, locals: Array[(String, Int, Int)], lbl_names: Array[String], lbl_depths: Array[Int], depth: Int, callees: Array[(String, Int, Int)], st: IwStack) -> Int with Exception {
+fn iw_item(out: Bytes, fn_name: String, kinds: Array[Int], texts: Array[String], offs: Array[Int], pos: Int, end: Int, locals: Array[(String, Int, Int, Int)], lbl_names: Array[String], lbl_depths: Array[Int], depth: Int, callees: Array[(String, Int, Int)], st: IwStack) -> Int with Exception {
   let k = Array::get(kinds, pos)
   if k == 3 {
     // #2401: flat form -- the operands are already on the stack, so the
@@ -1865,7 +1935,7 @@ fn iw_item(out: Bytes, fn_name: String, kinds: Array[Int], texts: Array[String],
 }
 
 /// A sequence of items up to (not consuming) a closing ')' or the end.
-fn iw_seq(out: Bytes, fn_name: String, kinds: Array[Int], texts: Array[String], offs: Array[Int], pos: Int, end: Int, locals: Array[(String, Int, Int)], lbl_names: Array[String], lbl_depths: Array[Int], depth: Int, callees: Array[(String, Int, Int)], st: IwStack) -> Int with Exception {
+fn iw_seq(out: Bytes, fn_name: String, kinds: Array[Int], texts: Array[String], offs: Array[Int], pos: Int, end: Int, locals: Array[(String, Int, Int, Int)], lbl_names: Array[String], lbl_depths: Array[Int], depth: Int, callees: Array[(String, Int, Int)], st: IwStack) -> Int with Exception {
   let mut p = pos
   let mut done = false
   while !done {
@@ -1882,7 +1952,7 @@ fn iw_seq(out: Bytes, fn_name: String, kinds: Array[Int], texts: Array[String], 
 
 /// Folded `(op <immediates> <operand exprs...>)`: real folded-form semantics —
 /// the operand expressions are emitted FIRST, then the op itself.
-fn iw_folded_op(out: Bytes, fn_name: String, kinds: Array[Int], texts: Array[String], offs: Array[Int], pos: Int, end: Int, locals: Array[(String, Int, Int)], lbl_names: Array[String], lbl_depths: Array[Int], depth: Int, callees: Array[(String, Int, Int)], st: IwStack) -> Int with Exception {
+fn iw_folded_op(out: Bytes, fn_name: String, kinds: Array[Int], texts: Array[String], offs: Array[Int], pos: Int, end: Int, locals: Array[(String, Int, Int, Int)], lbl_names: Array[String], lbl_depths: Array[Int], depth: Int, callees: Array[(String, Int, Int)], st: IwStack) -> Int with Exception {
   let opb = bytebuf_new()
   let after_imm = iw_plain_op(opb, fn_name, kinds, texts, offs, pos + 1, end, locals, lbl_names, lbl_depths, depth)
   let mut p = after_imm
@@ -1907,7 +1977,7 @@ fn iw_folded_op(out: Bytes, fn_name: String, kinds: Array[Int], texts: Array[Str
 }
 
 /// Folded `(block $l? (result T)? ...)` / `(loop $l? (result T)? ...)`.
-fn iw_folded_block(out: Bytes, fn_name: String, kinds: Array[Int], texts: Array[String], offs: Array[Int], pos: Int, end: Int, locals: Array[(String, Int, Int)], lbl_names: Array[String], lbl_depths: Array[Int], depth: Int, callees: Array[(String, Int, Int)], st: IwStack) -> Int with Exception {
+fn iw_folded_block(out: Bytes, fn_name: String, kinds: Array[Int], texts: Array[String], offs: Array[Int], pos: Int, end: Int, locals: Array[(String, Int, Int, Int)], lbl_names: Array[String], lbl_depths: Array[Int], depth: Int, callees: Array[(String, Int, Int)], st: IwStack) -> Int with Exception {
   let head = Array::get(texts, pos + 1)
   bytebuf_push(out, if head == "loop" {
     0x03
@@ -1955,7 +2025,7 @@ fn iw_folded_block(out: Bytes, fn_name: String, kinds: Array[Int], texts: Array[
 
 /// Folded `(if $l? (result T)? <cond exprs...> (then ...) (else ...)?)`.
 /// The condition is emitted first, then 0x04 + blocktype, then the branches.
-fn iw_folded_if(out: Bytes, fn_name: String, kinds: Array[Int], texts: Array[String], offs: Array[Int], pos: Int, end: Int, locals: Array[(String, Int, Int)], lbl_names: Array[String], lbl_depths: Array[Int], depth: Int, callees: Array[(String, Int, Int)], st: IwStack) -> Int with Exception {
+fn iw_folded_if(out: Bytes, fn_name: String, kinds: Array[Int], texts: Array[String], offs: Array[Int], pos: Int, end: Int, locals: Array[(String, Int, Int, Int)], lbl_names: Array[String], lbl_depths: Array[Int], depth: Int, callees: Array[(String, Int, Int)], st: IwStack) -> Int with Exception {
   let lbl_mark = Array::length(lbl_names)
   let mut q = pos + 2
   if q < end && Array::get(kinds, q) == 3 && String::length(Array::get(texts, q)) > 0 && String::char_code_at(Array::get(texts, q), 0) == '$' {
@@ -2039,7 +2109,7 @@ fn iw_folded_if(out: Bytes, fn_name: String, kinds: Array[Int], texts: Array[Str
 /// encodes one run per type, so interleaved declarations would silently
 /// renumber). Each declared local joins `locals` at wasm index
 /// `extra_base + running position`. Returns (body_start, n_i32, n_i64, n_v128).
-fn iw_parse_local_decls(fn_name: String, kinds: Array[Int], texts: Array[String], offs: Array[Int], end: Int, locals: Array[(String, Int, Int)], extra_base: Int) -> (Int, Int, Int, Int) with Exception {
+fn iw_parse_local_decls(fn_name: String, kinds: Array[Int], texts: Array[String], offs: Array[Int], end: Int, locals: Array[(String, Int, Int, Int)], extra_base: Int) -> (Int, Int, Int, Int) with Exception {
   let mut p = 0
   let mut n32 = 0
   let mut n64 = 0
@@ -2079,7 +2149,7 @@ fn iw_parse_local_decls(fn_name: String, kinds: Array[Int], texts: Array[String]
       let want = String::substring(name_tok, 1, String::length(name_tok))
       let mut di = 0
       while di < Array::length(locals) {
-        let (dn, _dx, _dt) = Array::get(locals, di)
+        let (dn, _dx, _dt, _dk) = Array::get(locals, di)
         if dn == want {
           throw(iw_err(fn_name, "duplicate local name '\{name_tok}'", decl_off))
         } else {
@@ -2087,7 +2157,7 @@ fn iw_parse_local_decls(fn_name: String, kinds: Array[Int], texts: Array[String]
         }
         di = di + 1
       }
-      Array::push(locals, (want, extra_base + n32 + n64 + nv, ty))
+      Array::push(locals, (want, extra_base + n32 + n64 + nv, ty, 0))
       if rank == 0 {
         n32 = n32 + 1
       } else if rank == 1 {
@@ -2124,6 +2194,24 @@ export fn compile_inline_wat_full(fn_name: String, wat: String, param_names: Arr
 /// what the two back-compat entries above pass and what the assembler
 /// reported for every `call` before this issue.
 export fn compile_inline_wat_calls(fn_name: String, wat: String, param_names: Array[String], extra_base: Int, callees: Array[(String, Int, Int)]) -> (Bytes, Int, Int, Int) with Exception {
+  compile_inline_wat_array_params(fn_name, wat, param_names, iw_fresh_strings(), extra_base, callees)
+}
+
+/// #2348 part 2 entry: same as `compile_inline_wat_calls`, plus the subset of
+/// `param_names` declared `Array[Int]`. Those params hold the caller's array
+/// value as-is -- tagged on the RC lane, untagged on the bump lane -- so every
+/// `local.get` of one is assembled with the tag masked off and the body reads
+/// the same `[capacity@0][length@4][data_ptr@8]` header on both lanes.
+///
+/// The ELEMENTS at `data_ptr + i*8` are NOT normalized, and cannot be: they
+/// are `Int` values in the lane's own representation, tagged `n<<1` under RC
+/// and raw under bump -- exactly the trap a scalar `Int` param already has.
+/// Addition and subtraction over slots are tag-transparent; multiplication,
+/// division and shifts are not.
+///
+/// An empty list means "no array params", which is what the back-compat
+/// entries above pass.
+export fn compile_inline_wat_array_params(fn_name: String, wat: String, param_names: Array[String], array_param_names: Array[String], extra_base: Int, callees: Array[(String, Int, Int)]) -> (Bytes, Int, Int, Int) with Exception {
   let (kinds, texts, offs) = iw_tokenize(fn_name, wat)
   let out = bytebuf_new()
   let lbl_names = iw_fresh_strings()
@@ -2137,7 +2225,12 @@ export fn compile_inline_wat_calls(fn_name: String, wat: String, param_names: Ar
   let locals = iw_fresh_locals()
   let mut pi = 0
   while pi < Array::length(param_names) {
-    Array::push(locals, (Array::get(param_names, pi), pi, 0x7E))
+    let pname = Array::get(param_names, pi)
+    Array::push(locals, (pname, pi, 0x7E, if iw_name_listed(array_param_names, pname) {
+      1
+    } else {
+      0
+    }))
     pi = pi + 1
   }
   let (body_start, n32, n64, nv) = iw_parse_local_decls(fn_name, kinds, texts, offs, end, locals, extra_base)
@@ -2169,5 +2262,9 @@ export fn compile_inline_wat(fn_name: String, wat: String, param_names: Array[St
 //# Misc
 
 export {
-  compile_inline_wat, compile_inline_wat_calls, compile_inline_wat_full, inline_wat_unclassified_instructions
+  compile_inline_wat,
+  compile_inline_wat_array_params,
+  compile_inline_wat_calls,
+  compile_inline_wat_full,
+  inline_wat_unclassified_instructions
 }

--- a/lib/@vibe/compiler/codegen/index.vpkg
+++ b/lib/@vibe/compiler/codegen/index.vpkg
@@ -70,6 +70,7 @@ fn compile_wasi_module_break(stmts: Array[Stmt], entry_name: String, prov: DbgPr
 fn compile_inline_wat(fn_name: String, wat: String, param_names: Array[String]) -> Bytes with Exception
 fn compile_inline_wat_full(fn_name: String, wat: String, param_names: Array[String], extra_base: Int) -> (Bytes, Int, Int, Int) with Exception
 fn compile_inline_wat_calls(fn_name: String, wat: String, param_names: Array[String], extra_base: Int, callees: Array[(String, Int, Int)]) -> (Bytes, Int, Int, Int) with Exception
+fn compile_inline_wat_array_params(fn_name: String, wat: String, param_names: Array[String], array_param_names: Array[String], extra_base: Int, callees: Array[(String, Int, Int)]) -> (Bytes, Int, Int, Int) with Exception
 fn inline_wat_unclassified_instructions() -> Array[String]
 
 // --- normalize/desugar_trait_dict.vibe (re-exported through

--- a/lib/@vibe/compiler/codegen/wasi/index.vpkg
+++ b/lib/@vibe/compiler/codegen/wasi/index.vpkg
@@ -3,6 +3,7 @@ version = 0.0.1
 description =
   #|@vibe/compiler/codegen/wasi — WASI-lane WASM module compile entry points
 deps = {
+  @vibe/ast : 0.0.1
   @vibe/compiler/codegen/builtin_bodies : 0.0.1
   @vibe/compiler/codegen/common_analysis : 0.0.1
   @vibe/compiler/codegen/common_base : 0.0.1

--- a/lib/@vibe/compiler/codegen/wasi/linked_compile.vibe
+++ b/lib/@vibe/compiler/codegen/wasi/linked_compile.vibe
@@ -27,7 +27,7 @@ import @vibe/compiler/core {
 }
 
 import @vibe/ast {
-  type_expr_is_array_of_int
+  TypeExpr::is_array_of_int
 }
 
 import @vibe/core {
@@ -7927,7 +7927,7 @@ export fn compile_wasi_module_linked_impl_with_float_offsets(stmts: Array[Stmt],
             let (iw_pn, iw_pt) = Array::get(lc_norm_params, iw_pi)
             Array::push(iw_param_names, iw_pn)
             match iw_pt {
-              Some(iw_ptv) => if type_expr_is_array_of_int(iw_ptv) {
+              Some(iw_ptv) => if TypeExpr::is_array_of_int(iw_ptv) {
                 Array::push(iw_array_params, iw_pn)
               } else {
                 ()

--- a/lib/@vibe/compiler/codegen/wasi/linked_compile.vibe
+++ b/lib/@vibe/compiler/codegen/wasi/linked_compile.vibe
@@ -26,6 +26,10 @@ import @vibe/compiler/core {
   verify_lane_builtins
 }
 
+import @vibe/ast {
+  type_expr_is_array_of_int
+}
+
 import @vibe/core {
   array_empty
 }
@@ -169,7 +173,7 @@ import @vibe/compiler/codegen/common_base {
   codegen_body_cache_new,
   codegen_body_cache_record,
   codegen_body_cache_replay,
-  compile_inline_wat_calls,
+  compile_inline_wat_array_params,
   compute_agg_returning,
   ctor_sorted_index,
   desugar_trait_dicts,
@@ -698,7 +702,7 @@ fn gen_heap_grow_check_body() -> Bytes {
 /// scalar-return classification, string-table collection, coverage) sees an
 /// ordinary trivial body and the WAT text never leaks into the data section.
 /// The per-fn codegen loop then splices the assembled instruction bytes
-/// (compile_inline_wat_calls) instead of running compile_expr for these names.
+/// (compile_inline_wat_array_params) instead of running compile_expr for them.
 fn lc_extract_inline_wasm(stmts: Array[Stmt], names: Array[String], wats: Array[String]) -> Unit {
   let mut i = 0
   while i < Array::length(stmts) {
@@ -773,7 +777,7 @@ fn lc_build_iw_callees(iw_names: Array[String], ft_names: Array[String], ft_indi
 /// depth of the flattened module source ("unknown name" on every later
 /// reference, tuple/mut/plain-Int alike), while reads through an
 /// already-in-scope array provably survive (meta_i32 itself is one).
-fn lc_compile_iw_body(body_buf: Bytes, fn_name_dbg: String, iw_wats: Array[String], iw_found: Int, iw_param_names: Array[String], param_count: Int, iw_extra_cell: Array[Int], iw_callees: Array[(String, Int, Int)]) -> Unit with Exception {
+fn lc_compile_iw_body(body_buf: Bytes, fn_name_dbg: String, iw_wats: Array[String], iw_found: Int, iw_param_names: Array[String], iw_array_params: Array[String], param_count: Int, iw_extra_cell: Array[Int], iw_callees: Array[(String, Int, Int)]) -> Unit with Exception {
   Array::set(iw_extra_cell, 0, 0)
   Array::set(iw_extra_cell, 1, 0)
   Array::set(iw_extra_cell, 2, 0)
@@ -783,7 +787,7 @@ fn lc_compile_iw_body(body_buf: Bytes, fn_name_dbg: String, iw_wats: Array[Strin
     // Declared `(local ...)` runs index from param_count (params + the
     // closure-env slot), matching the i32/i64/v128 header runs the meta
     // arrays receive at the code-section assembly.
-    let (iw_bytes, iw_n32, iw_n64, iw_nv) = compile_inline_wat_calls(fn_name_dbg, Array::get(iw_wats, iw_found), iw_param_names, param_count, iw_callees)
+    let (iw_bytes, iw_n32, iw_n64, iw_nv) = compile_inline_wat_array_params(fn_name_dbg, Array::get(iw_wats, iw_found), iw_param_names, iw_array_params, param_count, iw_callees)
     bytebuf_push_buf(body_buf, iw_bytes)
     Array::set(iw_extra_cell, 0, iw_n32)
     Array::set(iw_extra_cell, 1, iw_n64)
@@ -7913,13 +7917,26 @@ export fn compile_wasi_module_linked_impl_with_float_offsets(stmts: Array[Stmt],
             0 - 1
           }
           let iw_param_names = lc_fresh_string_array()
+          // #2348 part 2: the params declared `Array[Int]`, read from the same
+          // declared types the parser admitted -- so the mask the assembler
+          // emits for `local.get $xs` covers exactly the params that carry a
+          // possibly-tagged array value.
+          let iw_array_params = lc_fresh_string_array()
           let mut iw_pi = 0
           while iw_pi < Array::length(lc_norm_params) {
-            let (iw_pn, _) = Array::get(lc_norm_params, iw_pi)
+            let (iw_pn, iw_pt) = Array::get(lc_norm_params, iw_pi)
             Array::push(iw_param_names, iw_pn)
+            match iw_pt {
+              Some(iw_ptv) => if type_expr_is_array_of_int(iw_ptv) {
+                Array::push(iw_array_params, iw_pn)
+              } else {
+                ()
+              },
+              None => ()
+            }
             iw_pi = iw_pi + 1
           }
-          lc_compile_iw_body(body_buf, fn_name_dbg, iw_wats, iw_found, iw_param_names, param_count, iw_extra_cell, iw_callees)
+          lc_compile_iw_body(body_buf, fn_name_dbg, iw_wats, iw_found, iw_param_names, iw_array_params, param_count, iw_extra_cell, iw_callees)
           let final_nl = if iw_found >= 0 {
             param_count
           } else {

--- a/lib/@vibe/compiler/runtime/typecheck_fs.vibe
+++ b/lib/@vibe/compiler/runtime/typecheck_fs.vibe
@@ -15,7 +15,7 @@ import @vibe/core {
 }
 
 import @vibe/ast {
-  TypeExpr, trait_ref_from_key, trait_ref_key, trait_ref_name, type_expr_is_array_of_int, type_param_arity, type_param_name
+  TypeExpr, TypeExpr::is_array_of_int, trait_ref_from_key, trait_ref_key, trait_ref_name, type_param_arity, type_param_name
 }
 
 import @vibe/compiler/checker {
@@ -5585,7 +5585,7 @@ fn collect_inline_wasm_fns(stmts: Array[Stmt]) -> Array[(String, String, Array[S
                     let (pn, pt) = Array::get(iw_params, pi)
                     Array::push(pnames, pn)
                     match pt {
-                      Some(ptv) => if type_expr_is_array_of_int(ptv) {
+                      Some(ptv) => if TypeExpr::is_array_of_int(ptv) {
                         Array::push(parrays, pn)
                       } else {
                         ()

--- a/lib/@vibe/compiler/runtime/typecheck_fs.vibe
+++ b/lib/@vibe/compiler/runtime/typecheck_fs.vibe
@@ -15,7 +15,7 @@ import @vibe/core {
 }
 
 import @vibe/ast {
-  TypeExpr, trait_ref_from_key, trait_ref_key, trait_ref_name, type_param_arity, type_param_name
+  TypeExpr, trait_ref_from_key, trait_ref_key, trait_ref_name, type_expr_is_array_of_int, type_param_arity, type_param_name
 }
 
 import @vibe/compiler/checker {
@@ -77,7 +77,7 @@ import @vibe/compiler/core {
 // #946(4): inline-wasm codegen validation (lane/align/etc. errors) runs as
 // part of `collect_all_diagnostics` too — see check_inline_wasm_fns below.
 import @vibe/compiler/codegen {
-  compile_inline_wat_calls
+  compile_inline_wat_array_params
 }
 
 // #1948: the same Show-interpolation contract `vibe check` runs via
@@ -5563,7 +5563,7 @@ fn dedupe_diagnostics(diags: Array[String]) -> Array[String] {
 /// read-only (no mutation: diagnostics discards `stmts` after this scan, and
 /// running it before codegen would blow away the marker codegen depends on).
 /// Returns (fn_name, wat_text, param_names) triples in declaration order.
-fn collect_inline_wasm_fns(stmts: Array[Stmt]) -> Array[(String, String, Array[String])] {
+fn collect_inline_wasm_fns(stmts: Array[Stmt]) -> Array[(String, String, Array[String], Array[String])] {
   let out = array_empty()
   let mut i = 0
   while i < Array::length(stmts) {
@@ -5575,13 +5575,26 @@ fn collect_inline_wasm_fns(stmts: Array[Stmt]) -> Array[(String, String, Array[S
               match Array::get(iw_args, 0) {
                 EString(iw_wat) => {
                   let pnames = array_empty()
+                  // #2348 part 2: the `Array[Int]` params, so this lane
+                  // assembles the body the way codegen does -- a `local.set`
+                  // on an array param is refused here too, and not first seen
+                  // at build time.
+                  let parrays = array_empty()
                   let mut pi = 0
                   while pi < Array::length(iw_params) {
-                    let (pn, _) = Array::get(iw_params, pi)
+                    let (pn, pt) = Array::get(iw_params, pi)
                     Array::push(pnames, pn)
+                    match pt {
+                      Some(ptv) => if type_expr_is_array_of_int(ptv) {
+                        Array::push(parrays, pn)
+                      } else {
+                        ()
+                      },
+                      None => ()
+                    }
                     pi = pi + 1
                   }
-                  Array::push(out, (iw_name, iw_wat, pnames))
+                  Array::push(out, (iw_name, iw_wat, pnames, parrays))
                 },
                 _ => ()
               }
@@ -5603,19 +5616,19 @@ fn collect_inline_wasm_fns(stmts: Array[Stmt]) -> Array[(String, String, Array[S
 /// #2348: the callee table for the CHECK lane -- one entry per inline-wasm fn
 /// in this module, carrying its position where codegen carries a wasm function
 /// index (see check_inline_wasm_fns for why that is sound here).
-fn check_iw_callee_table(fns: Array[(String, String, Array[String])]) -> Array[(String, Int, Int)] {
+fn check_iw_callee_table(fns: Array[(String, String, Array[String], Array[String])]) -> Array[(String, Int, Int)] {
   let out = array_empty()
   let mut i = 0
   while i < Array::length(fns) {
-    let (fn_name, _wat, pnames) = Array::get(fns, i)
+    let (fn_name, _wat, pnames, _parrays) = Array::get(fns, i)
     Array::push(out, (fn_name, i, Array::length(pnames)))
     i = i + 1
   }
   out
 }
 
-/// #946(4): validate every inline-wasm fn body (compile_inline_wat_calls — the same
-/// assembler codegen uses) and return the FIRST located error, or None when
+/// #946(4): validate every inline-wasm fn body (the same assembler entry
+/// codegen uses) and return the FIRST located error, or None when
 /// every inline-wasm fn assembles cleanly. `compile` surfaced these (e.g. a bad
 /// SIMD lane index) as a located error while `vibe diagnostics` reported clean
 /// — diagnostics only ran the typechecker, never this codegen-adjacent
@@ -5639,9 +5652,9 @@ export fn check_inline_wasm_fns(stmts: Array[Stmt]) -> Option[String] {
     if i >= n {
       done = true
     } else {
-      let (fn_name, wat, pnames) = Array::get(fns, i)
+      let (fn_name, wat, pnames, parrays) = Array::get(fns, i)
       let outcome = handle {
-        let _ = compile_inline_wat_calls(fn_name, wat, pnames, Array::length(pnames) + 1, iw_callees)
+        let _ = compile_inline_wat_array_params(fn_name, wat, pnames, parrays, Array::length(pnames) + 1, iw_callees)
         None
       } with { Exception::Throw(msg) => Some(msg) }
       match outcome {

--- a/lib/@vibe/compiler/tests/inline_wasm_test.vibe
+++ b/lib/@vibe/compiler/tests/inline_wasm_test.vibe
@@ -750,6 +750,25 @@ test "#2348 part 2: an Array[Int] param is read-only inside the body" {
   assert(arr_err("(local.tee $n (i64.const 0))") == "")
 }
 
+test "#2348 part 2: the numeric spelling of an array param behaves identically" {
+  // Keying the mask by `$name` would have let `local.get 0` hand the body the
+  // TAGGED pointer -- a plausible wrong number out of `i32.load offset=4` on
+  // the RC lane, not an error -- and let `local.set 0` overwrite the slot the
+  // RC epilogue drops. Both spellings resolve to the same wasm index, so they
+  // answer the same.
+  let by_name = arr_bytes("(local.get $xs)")
+  let by_index = arr_bytes("(local.get 0)")
+  assert(Bytes::length(by_index) == Bytes::length(by_name))
+  assert(by_index[2] == 0x42)
+  assert(by_index[3] == 0x7E)
+  assert(by_index[4] == 0x83)
+  assert(String::index_of(arr_err("(local.set 0 (i64.const 0)) (local.get $n)"), "an Array[Int] param is read-only") >= 0)
+  assert(String::index_of(arr_err("(local.tee 0 (i64.const 0))"), "an Array[Int] param is read-only") >= 0)
+  // The ordinary Int param at index 1 is still untouched either way.
+  assert(Bytes::length(arr_bytes("(local.get 1)")) == 2)
+  assert(arr_err("(local.tee 1 (i64.const 0))") == "")
+}
+
 test "#2348 part 2: the masked read is still typed as one i64" {
   // The two extra instructions must not disturb the #2401 stack walk: the
   // body still leaves exactly one i64, and an arity error is still reported.

--- a/lib/@vibe/compiler/tests/inline_wasm_test.vibe
+++ b/lib/@vibe/compiler/tests/inline_wasm_test.vibe
@@ -27,11 +27,19 @@ import ../codegen_gc.vibe {
 }
 
 import @vibe/compiler/codegen {
-  compile_inline_wat, compile_inline_wat_calls, compile_inline_wat_full, inline_wat_unclassified_instructions
+  compile_inline_wat,
+  compile_inline_wat_array_params,
+  compile_inline_wat_calls,
+  compile_inline_wat_full,
+  inline_wat_unclassified_instructions
 }
 
 import @vibe/compiler/codegen/common_base {
   codegen_body_cache_new, empty_dbg_prov
+}
+
+import @vibe/compiler/runtime {
+  check_inline_wasm_fns
 }
 
 //# Functions
@@ -88,6 +96,35 @@ fn call_err(wat: String) -> String {
 fn call_bytes(wat: String) -> Bytes with Exception {
   let (out, _n32, _n64, _nv) = compile_inline_wat_calls("probe", wat, ["a", "b"], 3, iw_test_callees())
   out
+}
+
+/// #2348 part 2: assemble with `xs` declared `Array[Int]` and `n` an ordinary
+/// `Int`, the shape a kernel over a real array takes.
+fn arr_bytes(wat: String) -> Bytes with Exception {
+  let (out, _n32, _n64, _nv) = compile_inline_wat_array_params("probe", wat, [
+    "xs",
+    "n"
+  ], ["xs"], 3, iw_test_callees())
+  out
+}
+
+fn arr_err(wat: String) -> String {
+  handle {
+    let _ = arr_bytes(wat)
+    ""
+  } with { Exception::Throw(msg) => msg }
+}
+
+/// The `vibe check` lane's answer for `src` — "" when every inline-wasm fn in
+/// it assembles, otherwise the first located error. Same assembler entry
+/// codegen takes, reached the way `collect_all_diagnostics` reaches it.
+fn check_lane_err(src: String) -> String {
+  handle {
+    match check_inline_wasm_fns(parse_program(lex(src))) {
+      Some(msg) => msg,
+      None => ""
+    }
+  } with { Exception::Throw(msg) => msg }
 }
 
 //# Misc
@@ -663,4 +700,87 @@ test "#2401 inline wasm: the ordinary shapes still assemble" {
   // `result`, where 0 means "pushes nothing" rather than "pushes an unknown",
   // and rejected this valid body for leaving nothing (Codex on #2418).
   assert(wat_err("(local.tee 0 (i64.const 1))") == "")
+}
+
+test "#2348 part 2: local.get of an Array[Int] param masks the RC tag off" {
+  // `local.get 0` then `i64.const -2` then `i64.and` — the body sees the
+  // untagged `[capacity@0][length@4][data_ptr@8]` header address on the RC
+  // lane, and the same address on the bump lane where the pointer is already
+  // even and the mask is a no-op.
+  let masked = arr_bytes("(local.get $xs)")
+  assert(Bytes::length(masked) == 5)
+  assert(masked[0] == 0x20)
+  assert(masked[1] == 0x00)
+  assert(masked[2] == 0x42)
+  // -2 is one signed LEB128 byte.
+  assert(masked[3] == 0x7E)
+  assert(masked[4] == 0x83)
+  let all = arr_bytes("(i64.add (local.get $xs) (i64.const 0))")
+  assert(Bytes::length(all) == 8)
+  assert(all[4] == 0x83)
+  assert(all[7] == 0x7C)
+}
+
+test "#2348 part 2: an ordinary Int param in the same fn is NOT masked" {
+  // The mask follows the declared type, not the position: `n` is the second
+  // param of the same kernel and reads exactly as it always did.
+  let plain = arr_bytes("(local.get $n)")
+  assert(Bytes::length(plain) == 2)
+  assert(plain[0] == 0x20)
+  assert(plain[1] == 0x01)
+  // And a fn with no array params at all assembles byte-identically to the
+  // back-compat entry.
+  let same = compile_inline_wat_array_params("probe", "(local.get $a)", [
+    "a",
+    "b"
+  ], [], 3, iw_test_callees())
+  let (same_bytes, _s32, _s64, _sv) = same
+  assert(Bytes::length(same_bytes) == 2)
+}
+
+test "#2348 part 2: an Array[Int] param is read-only inside the body" {
+  // Writing to the slot would hand the RC epilogue a value it did not
+  // allocate, so both writing forms are refused with the edit that fixes it.
+  let set_err = arr_err("(local.set $xs (i64.const 0)) (local.get $n)")
+  assert(String::index_of(set_err, "an Array[Int] param is read-only") >= 0)
+  assert(String::index_of(set_err, "(local $tmp i64)") >= 0)
+  let tee_err = arr_err("(local.tee $xs (i64.const 0))")
+  assert(String::index_of(tee_err, "an Array[Int] param is read-only") >= 0)
+  // The same instruction on the ordinary Int param stays accepted.
+  assert(arr_err("(local.tee $n (i64.const 0))") == "")
+}
+
+test "#2348 part 2: the masked read is still typed as one i64" {
+  // The two extra instructions must not disturb the #2401 stack walk: the
+  // body still leaves exactly one i64, and an arity error is still reported.
+  assert(arr_err("(local.get $xs)") == "")
+  let two = arr_err("(local.get $xs) (local.get $n)")
+  assert(String::index_of(two, "leaves 2 value(s)") >= 0)
+  // And a masked array pointer is an i64 where an i32 is required.
+  let wrong = arr_err("(i64.extend_i32_s (local.get $xs))")
+  assert(String::index_of(wrong, "expects i32") >= 0)
+}
+
+test "#2348 part 2: an Array[Int] param is admitted, and only Array[Int]" {
+  assert(compiles_linear("fn k(xs: Array[Int]) -> Int = wasm \"(i64.extend_i32_u (i32.load offset=4 (i32.wrap_i64 (local.get $xs))))\"\nfn use_it() -> Int { k([1, 2]) }"))
+  // The element type is part of the contract, not decoration: an element the
+  // body would have to chase a pointer for is not the flat block this admits.
+  let str_elem = parse_err("fn k(xs: Array[String]) -> Int = wasm \"(i64.const 0)\"")
+  assert(String::index_of(str_elem, "must be typed Int, Bytes, or Array[Int]") >= 0)
+  let bare = parse_err("fn k(xs: Array) -> Int = wasm \"(i64.const 0)\"")
+  assert(String::index_of(bare, "must be typed Int, Bytes, or Array[Int]") >= 0)
+}
+
+test "#2348 part 2: vibe check refuses the same bodies the build refuses" {
+  // #1567's contract for this area: the check lane and codegen must not
+  // disagree about a body, so the array-param knowledge reaches both.
+  let ok = "fn k(xs: Array[Int]) -> Int = wasm \"(i64.extend_i32_u (i32.load offset=4 (i32.wrap_i64 (local.get $xs))))\""
+  assert(check_lane_err(ok) == "")
+  let write = "fn k(xs: Array[Int]) -> Int = wasm \"(local.set $xs (i64.const 0)) (i64.const 0)\""
+  assert(String::index_of(check_lane_err(write), "an Array[Int] param is read-only") >= 0)
+  assert(!compiles_linear(String::concat(write, "\nfn use_it() -> Int { k([1, 2]) }")))
+  // The mask is not free typing: reading the header address as an i32 operand
+  // still needs the explicit wrap, and forgetting it is a located error.
+  let unwrapped = "fn k(xs: Array[Int]) -> Int = wasm \"(i64.extend_i32_u (i32.load offset=4 (local.get $xs)))\""
+  assert(String::index_of(check_lane_err(unwrapped), "expects i32") >= 0)
 }

--- a/lib/@vibe/parser/parser_expr.vibe
+++ b/lib/@vibe/parser/parser_expr.vibe
@@ -1,7 +1,7 @@
 //# Imports
 
 import @vibe/ast {
-  Expr, Pat, Stmt, TypeExpr, trait_ref_key, type_expr_is_array_of_int
+  Expr, Pat, Stmt, TypeExpr, TypeExpr::is_array_of_int, trait_ref_key
 }
 
 import ./parser_base.vibe {
@@ -904,7 +904,7 @@ fn parse_fn_wasm_body(tokens: Array[Token], pos: Int, exported: Bool, name: Stri
     // like a scalar Int param -- see docs/cheatsheet.md "Inline wasm".
     let ok = match pt {
       Some(TyName(tn)) => tn == "Int" || tn == "Bytes",
-      Some(other) => type_expr_is_array_of_int(other),
+      Some(other) => TypeExpr::is_array_of_int(other),
       _ => false
     }
     if !ok {

--- a/lib/@vibe/parser/parser_expr.vibe
+++ b/lib/@vibe/parser/parser_expr.vibe
@@ -1,7 +1,7 @@
 //# Imports
 
 import @vibe/ast {
-  Expr, Pat, Stmt, TypeExpr, trait_ref_key
+  Expr, Pat, Stmt, TypeExpr, trait_ref_key, type_expr_is_array_of_int
 }
 
 import ./parser_base.vibe {
@@ -869,8 +869,9 @@ export fn parse_fn_stmt_with_binder_context(tokens: Array[Token], starts: Array[
 /// the mod operator — so user source cannot forge it). Multiple adjacent
 /// string literals are joined with newlines (the lexer has no raw/multiline
 /// strings). v0.3 slice restrictions enforced here: monomorphic, empty
-/// effect row, no where-contracts, and every param + the return type spelled
-/// literally `Int` (raw 62-bit tagged i64 at the boundary, ADR-0055).
+/// effect row, no where-contracts, the return type spelled literally `Int`
+/// (raw 62-bit tagged i64 at the boundary, ADR-0055), and every param typed
+/// `Int`, `Bytes` or `Array[Int]`.
 fn parse_fn_wasm_body(tokens: Array[Token], pos: Int, exported: Bool, name: String, tps: Array[String], tbs: Array[(String, Array[String])], params: Array[(String, Option[TypeExpr])], ret_ty: TypeExpr, eff_opt: Option[String], reqs: Array[Expr], enss: Array[Expr], context: Option[ParserBinderContext]) -> (Stmt, Int) with Exception {
   // pos is at the token AFTER `= wasm`.
   if Array::length(tps) > 0 {
@@ -894,12 +895,20 @@ fn parse_fn_wasm_body(tokens: Array[Token], pos: Int, exported: Bool, name: Stri
     // Bytes params (#805 SIMD follow-up) pass the raw UNTAGGED object
     // pointer — the WAT body reads the length at obj+4 and the data pointer
     // at obj+8 (linear backend heap layout), e.g. to feed v128.load.
+    // Array[Int] params (#2348 part 2) reach the body as the same UNTAGGED
+    // header pointer: an array value is odd on the RC lane and even on the
+    // bump lane, so the assembler masks the tag off every `local.get` of an
+    // array param and the body sees one lane-independent
+    // `[capacity@0][length@4][data_ptr@8]` block either way. What is NOT
+    // lane-independent is the ELEMENT at `data_ptr + i*8`, tagged exactly
+    // like a scalar Int param -- see docs/cheatsheet.md "Inline wasm".
     let ok = match pt {
       Some(TyName(tn)) => tn == "Int" || tn == "Bytes",
+      Some(other) => type_expr_is_array_of_int(other),
       _ => false
     }
     if !ok {
-      throw("inline wasm fn '\{name}': param '\{pn}' must be typed Int or Bytes (raw i64 at the boundary) at #\{pos}")
+      throw("inline wasm fn '\{name}': param '\{pn}' must be typed Int, Bytes, or Array[Int] (raw i64 at the boundary) at #\{pos}")
     } else {
       ()
     }


### PR DESCRIPTION
Closes the second half of #2348. Part 1 (`call` between kernels) landed in #2399.

## The problem

Inline wasm accepted only `Int` and `Bytes` params, so a kernel could not see an array at all. `bench/bench_simd_int_column.vibe` had to rebuild vibe's tagged 8-byte layout inside a `Bytes` by hand just to measure the representation the language already uses.

## Why not the accessor pair I argued for

The issue offered two routes, and [I argued on it](https://github.com/mizchi/vibe-lang/issues/2348#issuecomment-5464530157) that the cheap one — *"allow `Array[Int]` with the same raw-pointer contract `Bytes` has"* — was not safe, because an array value is tagged where a `Bytes` is not and nothing in the signature tells the author which. That objection is answered by **normalizing** rather than by adding accessors: the assembler masks the tag off every `local.get` of an array param, so the body reads one `[capacity@0][length@4][data_ptr@8]` header address and the kernel text is lane-independent. A bump-lane array pointer is already even, so the mask is a no-op there rather than a second spelling.

**The other half of that comment's reasoning was simply wrong, and this PR corrects it.** It reported the bump lane returning garbage for the same recipe. That reading came from a throwaway build that did not mask the tag. The header layout is in fact the *same* on both lanes once the tag is off — `gen_arr_len_body` untags and loads at `+4` under RC, and the bump branch of `gen_arr_new_body` lays out the same three words. Measured with the same kernels compiled both ways, `[11, 22, 33, 44, 55]`:

| | `VIBE_RC=1` (production default) | `VIBE_RC=0` (bump) |
| :--- | ---: | ---: |
| capacity (`i32.load offset=0`) | 8 | 8 |
| length (`i32.load offset=4`) | 5 | 5 |
| element 0 | 11 | 11 |
| element 4 | 55 | 55 |

## What is still lane-dependent, and why that is honest

The **element** at `data_ptr + i*8` is not normalized and cannot be: it is an `Int` in the lane's own representation, tagged `n<<1` under RC and raw under bump — exactly the trap a scalar `Int` param already has, and the one `fixtures/inline_wasm_test.vibe` has always pinned. So addition over slots is tag-transparent while a multiply or a shift is not, and an index arriving as a tagged `Int` scales by 4 under RC where it scales by 8 on bump.

The new fixture kernels are written to be lane-independent *on purpose*: addresses and the loop counter are raw i32, and the only value that leaves is a sum of slots. They return identical answers on both lanes, which is the claim being tested.

## The param slot is read-only

Writing to it would hand RC's epilogue a value it did not allocate, so `local.set $xs` / `local.tee $xs` are located errors naming the edit that fixes them:

```
inline wasm (fn bad_set): 'local.set' cannot write to '$xs': an Array[Int] param
is read-only inside an inline wasm body (copy it into a declared (local $tmp i64)
first) (WAT offset 1)
```

`vibe check` refuses exactly what the build refuses — the check lane passes the same array-param list to the same assembler entry — so a body cannot pass one and fail the other (#1567's contract for this area).

## One predicate, not three

The three passes that must agree about which params are arrays — the parser's admission check, the codegen splice and the check lane — ask `type_expr_is_array_of_int` in `@vibe/ast`. A param the parser admitted but codegen did not recognize would reach the body still tagged and read its capacity as its length; that disagreement is now unrepresentable.

## Verification

- 44 tests in `lib/@vibe/compiler/tests/inline_wasm_test.vibe` (assembler bytes, parser admission, check-lane agreement) and the runtime fixture pass.
- Each new check **red-tested** by mutating the implementation and confirming the intended test is the one that fails: mask removed → the byte test fails; read-only guard removed → the read-only test fails; check lane deprived of the array-param list → the agreement test fails.
- A 2000-iteration stress program returns the same total (`8016000`, the closed-form value) under `VIBE_RC=1`, `VIBE_RC=shadow` (double-free instrumentation) and `VIBE_RC=0`, with the array still live and usable after each kernel call.
- `scripts/vibe_fmt.sh --check` clean on every edited file; `check_fixture_execution.sh` and the review-lint gates pass. The full `compiler_gate.sh` is running locally and I will report it here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FYMVd6D2o82suTfTwoJPMf

---
_Generated by [Claude Code](https://claude.ai/code/session_01FYMVd6D2o82suTfTwoJPMf)_