### PR TITLE
Record #2390's negative results in-code; pin the region-marker recache contract

### DIFF
--- a/lib/@vibe/compiler/core/types.vibe
+++ b/lib/@vibe/compiler/core/types.vibe
@@ -178,6 +178,13 @@ export fn env_bind_with_origin(env: TypeEnv, name: String, ty: Type, origin: Bin
     // by the older cached entry (#1583 -- an import env is cached before a
     // function body is checked, and a parameter named like an import then
     // resolved to the import). Bind shadowing names IN FRONT of the cache.
+    // (#2390 measured the alternative -- always-in-front plus a complete
+    // node whose bsearch miss is authoritative -- and it REGRESSED
+    // env_lookup_binding ~+20%: the hot lookups are HITS on imported
+    // names, and losing head adjacency makes each pay a walk over the
+    // recent binds before any index is consulted. Misses stopped being the
+    // common case when #2385's negative `#active_region` sentinel landed.
+    // The complete-node redesign stays parked behind symbol interning.)
     EnvCached(names_sorted, types_sorted, rest) => if bsearch_leftmost(names_sorted, name) >= 0 {
       EnvBind(name, binding, env)
     } else {
@@ -523,7 +530,25 @@ export fn env_cache(env: TypeEnv) -> TypeEnv {
           }
           done = true
         },
-        EnvCached(_, _, rest) => {
+        EnvCached(inames, ibindings, rest) => {
+          // The arrays can hold entries with NO chain node behind them --
+          // env_cache_binding's single-entry accelerator carries the real
+          // `#active_region` skolem in its array only -- so collect them.
+          // Skipping them (the old behavior) built an index that hid those
+          // entries from every query answered here: the region marker case
+          // seeded the negative CtUnit `#active_region` sentinel OVER a
+          // live region's real skolem, and every region-sensitive check
+          // answered "no active region" -- silently wrong. Same-named
+          // entries keep the node's own leftmost-first (innermost-first)
+          // order; entries mirrored by chain nodes below are collected
+          // twice, which the stable sort + leftmost bsearch resolves to
+          // the same winner.
+          let mut ci = 0
+          while ci < Array::length(inames) {
+            ArrayBuilder::push(names, Array::get(inames, ci))
+            ArrayBuilder::push(types, Array::get(ibindings, ci))
+            ci = ci + 1
+          }
           cur = rest
         }
       }
@@ -1034,7 +1059,7 @@ export fn env_has_reexport_surface_binding(env: TypeEnv, name: String) -> Bool {
       },
       EnvCached(_, _, rest) => {
         // The authoritative chain retains surface-only entries even though
-        // the acceleration arrays intentionally omit them.
+        // single-entry accelerator arrays may omit them.
         cur = rest
       }
     }

--- a/lib/@vibe/compiler/core/types.vibe
+++ b/lib/@vibe/compiler/core/types.vibe
@@ -530,25 +530,18 @@ export fn env_cache(env: TypeEnv) -> TypeEnv {
           }
           done = true
         },
-        EnvCached(inames, ibindings, rest) => {
-          // The arrays can hold entries with NO chain node behind them --
-          // env_cache_binding's single-entry accelerator carries the real
-          // `#active_region` skolem in its array only -- so collect them.
-          // Skipping them (the old behavior) built an index that hid those
-          // entries from every query answered here: the region marker case
-          // seeded the negative CtUnit `#active_region` sentinel OVER a
-          // live region's real skolem, and every region-sensitive check
-          // answered "no active region" -- silently wrong. Same-named
-          // entries keep the node's own leftmost-first (innermost-first)
-          // order; entries mirrored by chain nodes below are collected
-          // twice, which the stable sort + leftmost bsearch resolves to
-          // the same winner.
-          let mut ci = 0
-          while ci < Array::length(inames) {
-            ArrayBuilder::push(names, Array::get(inames, ci))
-            ArrayBuilder::push(types, Array::get(ibindings, ci))
-            ci = ci + 1
-          }
+        EnvCached(_, _, rest) => {
+          // Skip the arrays: they are ACCELERATORS whose entries the
+          // authoritative chain below also carries -- env_cache_binding's
+          // region accelerator included (the checker chain-binds the real
+          // `#active_region` skolem right under it). Collecting them was
+          // tried (#2390 review): it double-indexes every mirrored entry
+          // on each recache, and worse, a node whose REST was refreshed
+          // while its arrays went stale (replace_first_env_binding,
+          // refresh_type_env_prefix) would have its STALE array copy
+          // collected ahead of the refreshed chain entry -- recaching
+          // would silently undo the refresh. The chain is the truth; only
+          // it is read.
           cur = rest
         }
       }
@@ -1059,7 +1052,7 @@ export fn env_has_reexport_surface_binding(env: TypeEnv, name: String) -> Bool {
       },
       EnvCached(_, _, rest) => {
         // The authoritative chain retains surface-only entries even though
-        // single-entry accelerator arrays may omit them.
+        // the acceleration arrays intentionally omit them.
         cur = rest
       }
     }

--- a/lib/@vibe/compiler/tests/types_test.vibe
+++ b/lib/@vibe/compiler/tests/types_test.vibe
@@ -230,13 +230,17 @@ test "env_bind keeps cached env lookup path" {
   }
 }
 
-test "an inner single-entry cache survives an outer env_cache (#2390)" {
-  // env_cache_binding's accelerator holds its entry in the ARRAYS ONLY --
-  // the real `#active_region` skolem rides one. The outer env_cache walk
-  // must collect inner cache arrays: skipping them would seed the outer
-  // index with the negative CtUnit marker and hide the real skolem from
-  // every region-sensitive check -- silently wrong.
-  let inner = env_cache_binding(env_bind(EnvEmpty, "v", CtInt), "#active_region", CtNamed("#region_r", array_empty()))
+test "a region accelerator recaches through env_cache (real entry shape)" {
+  // The checker's region entry chain-binds the real `#active_region`
+  // skolem and puts env_cache_binding's accelerator OVER it -- the arrays
+  // are a mirror, never the only copy. That is what lets env_cache skip
+  // inner cache arrays (the chain is the truth; a stale array must never
+  // out-shadow a refreshed chain entry -- #2390 review). Pin the contract:
+  // an outer env_cache over the real shape keeps answering the real
+  // skolem, not the negative CtUnit marker it seeds for cache-less envs.
+  let region_ty = CtNamed("#region_r", array_empty())
+  let chain = env_bind(env_bind(EnvEmpty, "v", CtInt), "#active_region", region_ty)
+  let inner = env_cache_binding(chain, "#active_region", region_ty)
   let outer = env_cache(inner)
   match env_lookup(outer, "#active_region") {
     Some(t) => match t {
@@ -245,7 +249,6 @@ test "an inner single-entry cache survives an outer env_cache (#2390)" {
     },
     None => assert(false)
   }
-  // ...and chain entries below the inner accelerator still answer.
   match env_lookup(outer, "v") {
     Some(t) => assert(types_equal(t, CtInt)),
     None => assert(false)

--- a/lib/@vibe/compiler/tests/types_test.vibe
+++ b/lib/@vibe/compiler/tests/types_test.vibe
@@ -220,14 +220,14 @@ test "env_bind keeps cached env lookup path" {
     EnvCached(_, _, _) => assert(true),
     _ => assert(false)
   }
-  match env_lookup(env, "x") {
-    Some(t) => assert(types_equal(t, CtString)),
-    None => assert(false)
-  }
-  match env_lookup(env, "base") {
-    Some(t) => assert(types_equal(t, CtInt)),
-    None => assert(false)
-  }
+  inspect(match env_lookup(env, "x") {
+    Some(t) => type_to_string(t),
+    None => "absent"
+  }, "String")
+  inspect(match env_lookup(env, "base") {
+    Some(t) => type_to_string(t),
+    None => "absent"
+  }, "Int")
 }
 
 test "a region accelerator recaches through env_cache (real entry shape)" {

--- a/lib/@vibe/compiler/tests/types_test.vibe
+++ b/lib/@vibe/compiler/tests/types_test.vibe
@@ -242,17 +242,14 @@ test "a region accelerator recaches through env_cache (real entry shape)" {
   let chain = env_bind(env_bind(EnvEmpty, "v", CtInt), "#active_region", region_ty)
   let inner = env_cache_binding(chain, "#active_region", region_ty)
   let outer = env_cache(inner)
-  match env_lookup(outer, "#active_region") {
-    Some(t) => match t {
-      CtNamed(n, _) => assert(n == "#region_r"),
-      _ => assert(false)
-    },
-    None => assert(false)
-  }
-  match env_lookup(outer, "v") {
-    Some(t) => assert(types_equal(t, CtInt)),
-    None => assert(false)
-  }
+  inspect(match env_lookup(outer, "#active_region") {
+    Some(t) => type_to_string(t),
+    None => "absent"
+  }, "#region_r")
+  inspect(match env_lookup(outer, "v") {
+    Some(t) => type_to_string(t),
+    None => "absent"
+  }, "Int")
 }
 
 test "env_bind shadowing a cached name wins env_lookup (#1583)" {

--- a/lib/@vibe/compiler/tests/types_test.vibe
+++ b/lib/@vibe/compiler/tests/types_test.vibe
@@ -210,6 +210,10 @@ test "env_cache handles empty env" {
 }
 
 test "env_bind keeps cached env lookup path" {
+  // Non-shadowing binds tuck BEHIND a head cache so hot lookups of cached
+  // (imported) names keep hitting the index first. #2390 measured the
+  // always-in-front alternative and it regressed ~+20% on
+  // env_lookup_binding; head adjacency is a deliberate property.
   let base = env_cache(env_bind(EnvEmpty, "base", CtInt))
   let env = env_bind(base, "x", CtString)
   match env {
@@ -218,6 +222,32 @@ test "env_bind keeps cached env lookup path" {
   }
   match env_lookup(env, "x") {
     Some(t) => assert(types_equal(t, CtString)),
+    None => assert(false)
+  }
+  match env_lookup(env, "base") {
+    Some(t) => assert(types_equal(t, CtInt)),
+    None => assert(false)
+  }
+}
+
+test "an inner single-entry cache survives an outer env_cache (#2390)" {
+  // env_cache_binding's accelerator holds its entry in the ARRAYS ONLY --
+  // the real `#active_region` skolem rides one. The outer env_cache walk
+  // must collect inner cache arrays: skipping them would seed the outer
+  // index with the negative CtUnit marker and hide the real skolem from
+  // every region-sensitive check -- silently wrong.
+  let inner = env_cache_binding(env_bind(EnvEmpty, "v", CtInt), "#active_region", CtNamed("#region_r", array_empty()))
+  let outer = env_cache(inner)
+  match env_lookup(outer, "#active_region") {
+    Some(t) => match t {
+      CtNamed(n, _) => assert(n == "#region_r"),
+      _ => assert(false)
+    },
+    None => assert(false)
+  }
+  // ...and chain entries below the inner accelerator still answer.
+  match env_lookup(outer, "v") {
+    Some(t) => assert(types_equal(t, CtInt)),
     None => assert(false)
   }
 }


### PR DESCRIPTION
Working #2390 ended in two withdrawals, both measured/verified, now recorded where the next person would retry them. Net diff vs main: comments + one test (no behavior change).

## What this PR contains

1. **A note at the tuck-behind site** (`env_bind_with_origin`): the issue's complete-node redesign (always-in-front binds + authoritative bsearch miss) was implemented in full, validated (stage2==stage3 fixpoint, full suite), and profiled at `env_lookup_binding` **525/584ms → 655/646ms (~+20% regression)** in interleaved paired runs — the hot lookups are HITS on imported names, and losing head adjacency costs more than miss-stopping saves (misses stopped being common when #2385 landed; the env band is 3.9% today, down from the issue's ~6%). Parked behind symbol interning, as the issue predicted. Details on #2390.

2. **A note at the `env_cache` walk's cache-skip arm**, from this PR's own review (thank you): my first version collected inner cache arrays, claiming a latent region-marker hiding — re-reading the checker's region entry showed the real `#active_region` skolem is chain-bound UNDER the accelerator, so the arrays are pure mirrors and the claimed bug exists in no production shape. Worse, collecting would let a STALE array copy (a node whose `rest` was refreshed by `replace_first_env_binding` / `refresh_type_env_prefix`) win the leftmost bsearch over the refreshed chain entry, and it double-indexes every mirrored entry per recache. Withdrawn; both hazards recorded at the site.

3. **A pinned test of the real region-entry shape**: an outer `env_cache` over the chain-bound skolem plus its accelerator keeps answering the real skolem, not the negative CtUnit marker.

## Validation

- Pinned env tests green: `types_test.vibe`, `persistent_env_codec_test.vibe`, `cache_underlying_env_override_test.vibe` (57 tests); `vibe fmt --check` clean; `vibe check` clean.
- The intermediate states were each validated through stage2==stage3 fixpoint + full suite + full gate before being measured out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0159xd5111g8KFt2CGyNyZvA