### PR TITLE
Feed the FS lanes' float-call-offset channel from the modular check (#2391)

### DIFF
--- a/fixtures/float_call_offset_source_lane.vibe
+++ b/fixtures/float_call_offset_source_lane.vibe
@@ -17,15 +17,16 @@
 //   let lam = (v: Double) -> Double { .. }; lam(..) -> 864
 //
 // THIS FILE MUST BE COMPILED THROUGH THE SINGLE-SOURCE LANE
-// (`compile_source_wasi_only`), which is the linear entry that supplies the
-// offsets -- it is the one that already runs a whole-program `check_program`,
-// so the observation costs no extra pass. `scripts/vibe_test.sh` and
-// `scripts/unit_test_runner.sh` both set VIBE_FS_COMPILE=1 and would take the
-// FS merge lane instead, where this channel is NOT wired (see
-// `compile_file_fs_mode`'s comment for the measurement that says why). That is
-// why the file is named without a `_test` suffix -- the `*_test.vibe` glob
-// would route it to the wrong lane -- and why it is run by an explicit block
-// in tests/gates/late/run.sh instead.
+// (`compile_source_wasi_only`), which is the linear entry whose offsets come
+// out of its whole-program `check_program`. `scripts/vibe_test.sh` and
+// `scripts/unit_test_runner.sh` both set VIBE_FS_COMPILE=1 and take the FS
+// merge lane instead -- since #2391 that lane carries the channel too (via
+// the modular check; its pin is
+// lib/@vibe/compiler/tests/float_call_offset_fs_lane_test.vibe), but this
+// file exists to pin the SINGLE-SOURCE supply specifically. That is why it is
+// named without a `_test` suffix -- the `*_test.vibe` glob would route it to
+// the other lane -- and why it is run by an explicit block in
+// tests/gates/late/run.sh instead.
 //
 // The gc lane's copy of the same shapes lives in
 // fixtures/float_return_to_string_gc_test.vibe.

--- a/lib/@vibe/compiler/cache/index.vpkg
+++ b/lib/@vibe/compiler/cache/index.vpkg
@@ -98,6 +98,7 @@ fn store_persistent_artifact(kind: String, entry_name: String, fingerprint: Stri
 fn load_persistent_artifact(kind: String, entry_name: String, fingerprint: String) -> Option[Bytes] with Exception + Fs
 fn persistent_dep_list_cache_path(path: String, source_fingerprint: String) -> String
 fn persistent_type_env_cache_path(fingerprint: String) -> String
+fn persistent_module_float_call_offsets_cache_path(fingerprint: String) -> String
 fn persistent_typing_dependency_env_reuse_sidecar_path(typing_input_key: String) -> String
 fn persistent_typing_dependency_env_reuse_eligibility_path(fingerprint: String) -> String
 fn persistent_source_list_cache_path(entry_path: String) -> String

--- a/lib/@vibe/compiler/cache/persistent_cache.vibe
+++ b/lib/@vibe/compiler/cache/persistent_cache.vibe
@@ -163,6 +163,16 @@ export fn persistent_type_env_cache_path(fingerprint: String) -> String {
   cache_persistent_type_env_cache_path(persistent_cache_version_tag(), fingerprint)
 }
 
+/// #2391: the per-module Double call-result offsets the FS lanes feed codegen
+/// (`CompileCtx.float_call_offsets`, #2158). Keyed by the SAME module
+/// fingerprint as the TypeEnv entry, because it is a second output of the same
+/// module check -- and the reuse arms in runtime/typecheck_fs.vibe require
+/// BOTH files before skipping a check, so a compile's output can never depend
+/// on which halves of the cache happen to exist.
+export fn persistent_module_float_call_offsets_cache_path(fingerprint: String) -> String {
+  cache_stable_text_cache_path(persistent_cache_version_tag(), "selfhost_module_float_call_offsets_v1", fingerprint)
+}
+
 /// TDRE9 typing-input aliases are deliberately separate from the TypeEnv-v9
 /// artifact namespace and all earlier TDRE namespaces. The referenced TypeEnv
 /// remains in its conservative fingerprint-addressed cache entry.

--- a/lib/@vibe/compiler/checker/checker.vibe
+++ b/lib/@vibe/compiler/checker/checker.vibe
@@ -6129,6 +6129,14 @@ fn resolve_tparams_in(ty: Type, env: TypeEnv) -> Type {
 // legacy `(offset, Type)` table as its only output.
 export struct TypedOccurrenceRoleLaneCapture {
   entries: Array[(String, String)];
+  // #2391/#2425 KPI: with provenance_enabled = false, append_legacy records
+  // into THIS flag array instead of `entries` -- one Int (1 = a primary
+  // call result, 0 = anything else) per typed occurrence, so an
+  // entries-only capture allocates no per-occurrence tuple block at all.
+  // The wasm32 CLI-core build sits within a few MB of the 4GB linear-memory
+  // ceiling (tests/gates/bootstrap/stage2_oracles.sh), so the per-module
+  // capture has to stay allocation-free beyond this one flat array.
+  entries_flags: Array[Int];
   provenance_entries: Array[(Array[Int], Array[Int], String, String, Type)];
   mut statement_path: Array[Int];
   frame_paths: Array[Array[Int]];
@@ -6395,14 +6403,19 @@ fn append_legacy_typed_occurrence(tytab: Array[(Int, Type)], offset: Int, ty: Ty
   Array::push(tytab, (offset, ty))
   match capture {
     Some(capture_entries) => {
-      Array::push(capture_entries.entries, (role, lane))
       if !capture_entries.provenance_enabled {
-        // #2391: entries-only mode -- no provenance row, no completeness
-        // bookkeeping (see the field's note on the struct).
-        ()
+        // #2391: entries-only mode -- one flag, no tuple, no provenance row,
+        // no completeness bookkeeping (see the field's note on the struct).
+        Array::push(capture_entries.entries_flags, if role == "CallResult" && lane == "Primary" {
+          1
+        } else {
+          0
+        })
       } else if lane == "SyntheticRewrite" || lane == "AuxiliaryResumeValueRecheck" || capture_entries.frame_depth == 0 {
+        Array::push(capture_entries.entries, (role, lane))
         capture_entries.complete = false
       } else {
+        Array::push(capture_entries.entries, (role, lane))
         let expression_path = Array::get(capture_entries.frame_paths, capture_entries.frame_depth - 1)
         Array::push(capture_entries.provenance_entries, (Array::slice(capture_entries.statement_path, 0, Array::length(capture_entries.statement_path)), Array::slice(expression_path, 0, Array::length(expression_path)), role, lane, ty))
       }

--- a/lib/@vibe/compiler/checker/checker.vibe
+++ b/lib/@vibe/compiler/checker/checker.vibe
@@ -6137,15 +6137,39 @@ export struct TypedOccurrenceRoleLaneCapture {
   frame_direct_recorded: Array[Bool];
   direct_entries: Array[(Array[Int], Array[Int], Type)];
   direct_enabled: Bool;
+  // #2391/#2425: false = record ONLY the (role, lane) entries and skip the
+  // whole frame/provenance machinery. Every capture function below funnels
+  // through provenance_capture, so a disabled capture never allocates a
+  // per-expression path array or a per-occurrence provenance row -- that
+  // allocation, run once per module across a compiler-sized closure, grew
+  // the selfcompile bump high-water past the CI KPI heap gate (+11.5%).
+  // The Double call-result observation only needs entries aligned with
+  // typed_occurrences; `complete` is meaningless when this is false.
+  provenance_enabled: Bool;
   mut frame_depth: Int;
   mut complete: Bool
+}
+
+/// The single guard for the frame/provenance half of a capture: a capture
+/// constructed with provenance_enabled = false behaves as None for every
+/// function below, while append_legacy_typed_occurrence still records its
+/// (role, lane) entries.
+fn provenance_capture(capture: Option[TypedOccurrenceRoleLaneCapture]) -> Option[TypedOccurrenceRoleLaneCapture] {
+  match capture {
+    Some(c) => if c.provenance_enabled {
+      capture
+    } else {
+      None
+    },
+    None => None
+  }
 }
 
 /// Start one retained statement's expression root. This mutable state exists
 /// only for explicit provenance observations; the production checker passes
 /// None and performs no path allocation.
 export fn typed_occurrence_capture_begin_statement(capture: Option[TypedOccurrenceRoleLaneCapture], statement_path: Array[Int]) -> Unit {
-  match capture {
+  match provenance_capture(capture) {
     Some(c) => {
       c.statement_path = Array::slice(statement_path, 0, Array::length(statement_path))
       c.frame_depth = 0
@@ -6157,7 +6181,7 @@ export fn typed_occurrence_capture_begin_statement(capture: Option[TypedOccurren
 /// End a retained statement. Clearing the logical stack prevents a later
 /// statement from ever inheriting an expression coordinate.
 export fn typed_occurrence_capture_end_statement(capture: Option[TypedOccurrenceRoleLaneCapture]) -> Unit {
-  match capture {
+  match provenance_capture(capture) {
     Some(c) => {
       // Every statement root must have exited before the statement boundary.
       // Do not let a checker traversal-order divergence leak into the next
@@ -6174,7 +6198,7 @@ export fn typed_occurrence_capture_end_statement(capture: Option[TypedOccurrence
 }
 
 fn typed_occurrence_capture_enter_expression(capture: Option[TypedOccurrenceRoleLaneCapture], expr: Expr) -> Unit {
-  match capture {
+  match provenance_capture(capture) {
     Some(c) => {
       let path = if c.frame_depth == 0 {
         // The statement coordinate is captured independently at append time;
@@ -6207,7 +6231,7 @@ fn typed_occurrence_capture_enter_expression(capture: Option[TypedOccurrenceRole
 }
 
 fn typed_occurrence_capture_exit_expression(capture: Option[TypedOccurrenceRoleLaneCapture]) -> Unit {
-  match capture {
+  match provenance_capture(capture) {
     Some(c) => {
       if c.frame_depth > 0 {
         let index = c.frame_depth - 1
@@ -6229,7 +6253,7 @@ fn typed_occurrence_capture_exit_expression(capture: Option[TypedOccurrenceRoleL
 /// recurse into (for example a recognized call callee). The next actual
 /// recursive child then still receives its `expr_children` index.
 fn typed_occurrence_capture_skip_children(capture: Option[TypedOccurrenceRoleLaneCapture], count: Int) -> Unit {
-  match capture {
+  match provenance_capture(capture) {
     Some(c) => {
       if c.frame_depth > 0 {
         let parent_index = c.frame_depth - 1
@@ -6252,7 +6276,7 @@ fn typed_occurrence_capture_skip_children(capture: Option[TypedOccurrenceRoleLan
 /// rather than through `check_expr_capture`. This is needed for the right
 /// spine of sequence/let expressions and for specialized call traversal.
 fn typed_occurrence_capture_enter_virtual_child(capture: Option[TypedOccurrenceRoleLaneCapture], expected_child: Int, expected_children: Int) -> Unit {
-  match capture {
+  match provenance_capture(capture) {
     Some(c) => {
       if c.frame_depth > 0 {
         let parent_index = c.frame_depth - 1
@@ -6289,7 +6313,7 @@ fn typed_occurrence_capture_enter_virtual_child(capture: Option[TypedOccurrenceR
 /// Restore a virtual traversal stack to its entry depth. Any imbalance is
 /// incomplete rather than a fabricated provenance path.
 fn typed_occurrence_capture_restore_frame_depth(capture: Option[TypedOccurrenceRoleLaneCapture], expected_depth: Int) -> Unit {
-  match capture {
+  match provenance_capture(capture) {
     Some(c) => {
       if c.frame_depth < expected_depth {
         c.complete = false
@@ -6316,7 +6340,7 @@ fn typed_occurrence_capture_restore_frame_depth(capture: Option[TypedOccurrenceR
 }
 
 fn typed_occurrence_capture_record_direct_return(capture: Option[TypedOccurrenceRoleLaneCapture], ty: Type, lane: String) -> Unit {
-  match capture {
+  match provenance_capture(capture) {
     Some(c) => if c.direct_enabled {
       if c.frame_depth <= 0 || lane != "Primary" {
         c.complete = false
@@ -6338,7 +6362,7 @@ fn typed_occurrence_capture_record_direct_return(capture: Option[TypedOccurrence
 }
 
 fn typed_occurrence_capture_record_virtual_spine_returns(capture: Option[TypedOccurrenceRoleLaneCapture], start_depth: Int, ty: Type, lane: String) -> Unit {
-  match capture {
+  match provenance_capture(capture) {
     Some(c) => if c.direct_enabled {
       let mut index = start_depth
       while index < c.frame_depth {
@@ -6359,7 +6383,7 @@ fn typed_occurrence_capture_record_virtual_spine_returns(capture: Option[TypedOc
 }
 
 fn typed_occurrence_capture_frame_depth(capture: Option[TypedOccurrenceRoleLaneCapture]) -> Int {
-  match capture {
+  match provenance_capture(capture) {
     Some(c) => c.frame_depth,
     None => -1
   }
@@ -6372,7 +6396,11 @@ fn append_legacy_typed_occurrence(tytab: Array[(Int, Type)], offset: Int, ty: Ty
   match capture {
     Some(capture_entries) => {
       Array::push(capture_entries.entries, (role, lane))
-      if lane == "SyntheticRewrite" || lane == "AuxiliaryResumeValueRecheck" || capture_entries.frame_depth == 0 {
+      if !capture_entries.provenance_enabled {
+        // #2391: entries-only mode -- no provenance row, no completeness
+        // bookkeeping (see the field's note on the struct).
+        ()
+      } else if lane == "SyntheticRewrite" || lane == "AuxiliaryResumeValueRecheck" || capture_entries.frame_depth == 0 {
         capture_entries.complete = false
       } else {
         let expression_path = Array::get(capture_entries.frame_paths, capture_entries.frame_depth - 1)

--- a/lib/@vibe/compiler/checker/checker_facade.vibe
+++ b/lib/@vibe/compiler/checker/checker_facade.vibe
@@ -58,6 +58,7 @@ export ./checker_stmt.vibe {
   check_program_with_env_typed_occurrence_expression_path_observation,
   check_program_with_env_typed_occurrence_role_lane_observation,
   check_program_with_env_typed_occurrence_statement_observation,
+  check_program_with_projected_import_env_double_call_result_located_observation,
   check_program_with_projected_import_env_result,
   check_stmts,
   validate_user_source_stmts

--- a/lib/@vibe/compiler/checker/checker_stmt.vibe
+++ b/lib/@vibe/compiler/checker/checker_stmt.vibe
@@ -5493,6 +5493,7 @@ fn direct_expression_return_observation_from_capture(checked: CheckedProgram, ca
 fn direct_expression_return_capture() -> TypedOccurrenceRoleLaneCapture {
   TypedOccurrenceRoleLaneCapture::{
     entries: array_empty(),
+    entries_flags: array_empty(),
     provenance_entries: array_empty(),
     statement_path: array_empty(),
     frame_paths: array_empty(),
@@ -5536,6 +5537,7 @@ export fn check_program_statement_root_type_observation(stmts: Array[Stmt]) -> O
 export fn check_program_typed_occurrence_role_lane_observation(stmts: Array[Stmt]) -> Option[CheckedTypedOccurrenceRoleLaneObservation] with Exception {
   let entries = TypedOccurrenceRoleLaneCapture::{
     entries: array_empty(),
+    entries_flags: array_empty(),
     provenance_entries: array_empty(),
     statement_path: array_empty(),
     frame_paths: array_empty(),
@@ -5557,6 +5559,7 @@ export fn check_program_typed_occurrence_role_lane_observation(stmts: Array[Stmt
 export fn check_program_typed_occurrence_expression_path_observation(stmts: Array[Stmt]) -> Option[CheckedTypedOccurrenceExpressionPathObservation] with Exception {
   let entries = TypedOccurrenceRoleLaneCapture::{
     entries: array_empty(),
+    entries_flags: array_empty(),
     provenance_entries: array_empty(),
     statement_path: array_empty(),
     frame_paths: array_empty(),
@@ -5592,9 +5595,35 @@ export fn check_program_result(stmts: Array[Stmt]) -> CheckedProgram with Except
   check_program_type_defs_observation_impl(stmts, None, None).checked_program
 }
 
+/// ONE process-wide entries-only capture for the Double observations, reset
+/// before every use. A fresh capture per module made the bump high-water grow
+/// with the SUM of every module's typed occurrences; truncating and reusing
+/// the same backing arrays bounds it by the LARGEST module instead, which is
+/// what keeps the wasm32 CLI-core build (already within a few MB of the 4GB
+/// linear-memory ceiling) standing. The wave loop runs module checks
+/// serially, and every consumer copies its answer out before the next reset.
+let shared_double_call_capture: TypedOccurrenceRoleLaneCapture = double_call_result_role_lane_capture()
+
+fn reset_double_call_capture() -> TypedOccurrenceRoleLaneCapture {
+  let capture = shared_double_call_capture
+  Array::truncate(capture.entries, 0)
+  Array::truncate(capture.entries_flags, 0)
+  Array::truncate(capture.provenance_entries, 0)
+  Array::truncate(capture.statement_path, 0)
+  Array::truncate(capture.frame_paths, 0)
+  Array::truncate(capture.frame_next_children, 0)
+  Array::truncate(capture.frame_expected_children, 0)
+  Array::truncate(capture.frame_direct_recorded, 0)
+  Array::truncate(capture.direct_entries, 0)
+  capture.frame_depth = 0
+  capture.complete = true
+  capture
+}
+
 fn double_call_result_role_lane_capture() -> TypedOccurrenceRoleLaneCapture {
   TypedOccurrenceRoleLaneCapture::{
     entries: array_empty(),
+    entries_flags: array_empty(),
     provenance_entries: array_empty(),
     statement_path: array_empty(),
     frame_paths: array_empty(),
@@ -5618,9 +5647,11 @@ fn double_call_result_role_lane_capture() -> TypedOccurrenceRoleLaneCapture {
 /// primary call results whose checker-confirmed instantiated type is Double,
 /// plus the two counts that say whether the AST was located at all. `None`
 /// means the capture did not line up with the typed occurrences and nothing
-/// can be classified.
+/// can be classified. Reads the entries-only FLAG array (one Int per
+/// occurrence; see the struct's entries_flags note), not the role/lane
+/// tuples -- the Double captures run with provenance_enabled = false.
 fn double_call_result_offsets_from_capture(checked: CheckedProgram, capture: TypedOccurrenceRoleLaneCapture) -> Option[(Array[Int], Int, Int)] {
-  if Array::length(capture.entries) != Array::length(checked.typed_occurrences) {
+  if Array::length(capture.entries_flags) != Array::length(checked.typed_occurrences) {
     None
   } else {
     let out: Array[Int] = []
@@ -5629,17 +5660,17 @@ fn double_call_result_offsets_from_capture(checked: CheckedProgram, capture: Typ
     let mut i = 0
     while i < Array::length(checked.typed_occurrences) {
       let (off, raw_ty) = Array::get(checked.typed_occurrences, i)
-      let (role, lane) = Array::get(capture.entries, i)
-      // The role/lane test comes FIRST, and the type query is the cheap head
-      // form. Both are about cost, and the cost is not incidental: this loop
-      // used to resolve EVERY typed occurrence through `subst_apply`, which
-      // rebuilds the whole substituted type, and then throw all but the head
-      // away. On a single file that is invisible; on a merged program it is
-      // quadratic, because `subst_lookup` walks a substitution that grows with
-      // the program. Measured on `lib/@vibe/compiler/tests/compiler_fs_test.vibe`
-      // (import closure: the whole compiler), compiling it went 6.1s -> 77.5s
-      // with the old shape and back to a small delta with this one.
-      if role == "CallResult" && lane == "Primary" {
+      // The primary-call-result test comes FIRST, and the type query is the
+      // cheap head form. Both are about cost, and the cost is not
+      // incidental: this loop used to resolve EVERY typed occurrence through
+      // `subst_apply`, which rebuilds the whole substituted type, and then
+      // throw all but the head away. On a single file that is invisible; on
+      // a merged program it is quadratic, because `subst_lookup` walks a
+      // substitution that grows with the program. Measured on
+      // `lib/@vibe/compiler/tests/compiler_fs_test.vibe` (import closure:
+      // the whole compiler), compiling it went 6.1s -> 77.5s with the old
+      // shape and back to a small delta with this one.
+      if Array::get(capture.entries_flags, i) == 1 {
         primary_calls = primary_calls + 1
         if off >= 0 {
           located_primary_calls = located_primary_calls + 1
@@ -5686,7 +5717,7 @@ fn double_call_result_offsets_from_capture(checked: CheckedProgram, capture: Typ
 /// channel up green and inert; `check_program_double_call_result_located_observation`
 /// below is the caller-facing form that refuses the first case.
 fn check_program_double_call_result_observation_impl(stmts: Array[Stmt]) -> Option[(CheckedProgram, Array[Int], Int, Int)] with Exception {
-  let capture = double_call_result_role_lane_capture()
+  let capture = reset_double_call_capture()
   let checked = check_program_type_defs_observation_impl(stmts, None, Some(capture)).checked_program
   match double_call_result_offsets_from_capture(checked, capture) {
     None => None,
@@ -5711,7 +5742,7 @@ fn check_program_double_call_result_observation_impl(stmts: Array[Stmt]) -> Opti
 /// program is identical to what check_program_result /
 /// check_program_with_projected_import_env_result produce today.
 export fn check_program_with_projected_import_env_double_call_result_located_observation(stmts: Array[Stmt], initial_env: TypeEnv) -> (CheckedProgram, Option[Array[Int]]) with Exception {
-  let capture = double_call_result_role_lane_capture()
+  let capture = reset_double_call_capture()
   let checked = check_program_with_env_type_defs_observation_impl(stmts, initial_env, None, Some(capture), true).checked_program
   match double_call_result_offsets_from_capture(checked, capture) {
     None => (checked, None),
@@ -5901,6 +5932,7 @@ export fn check_program_with_env_statement_root_type_observation(stmts: Array[St
 export fn check_program_with_env_typed_occurrence_role_lane_observation(stmts: Array[Stmt], initial_env: TypeEnv) -> Option[CheckedTypedOccurrenceRoleLaneObservation] with Exception {
   let entries = TypedOccurrenceRoleLaneCapture::{
     entries: array_empty(),
+    entries_flags: array_empty(),
     provenance_entries: array_empty(),
     statement_path: array_empty(),
     frame_paths: array_empty(),
@@ -5920,6 +5952,7 @@ export fn check_program_with_env_typed_occurrence_role_lane_observation(stmts: A
 export fn check_program_with_env_typed_occurrence_expression_path_observation(stmts: Array[Stmt], initial_env: TypeEnv) -> Option[CheckedTypedOccurrenceExpressionPathObservation] with Exception {
   let entries = TypedOccurrenceRoleLaneCapture::{
     entries: array_empty(),
+    entries_flags: array_empty(),
     provenance_entries: array_empty(),
     statement_path: array_empty(),
     frame_paths: array_empty(),

--- a/lib/@vibe/compiler/checker/checker_stmt.vibe
+++ b/lib/@vibe/compiler/checker/checker_stmt.vibe
@@ -5589,21 +5589,8 @@ export fn check_program_result(stmts: Array[Stmt]) -> CheckedProgram with Except
   check_program_type_defs_observation_impl(stmts, None, None).checked_program
 }
 
-/// Check once and retain only source-located primary call results whose
-/// checker-confirmed instantiated type is Double, plus the two counts that say
-/// whether the AST was located at all: how many primary call results the
-/// program has, and how many of those carry a source offset.
-///
-/// The counts exist because an EMPTY offset array is ambiguous. `check_program`
-/// records an occurrence for every primary call result either way, but
-/// `tab_call_ty` (checker.vibe) only files one under an offset when that offset
-/// is `>= 0` -- so an AST built by `parse_program(lex(source))` produces an
-/// empty table BY CONSTRUCTION, indistinguishable from a program that simply
-/// has no Double call results. A caller that cannot tell those apart wires the
-/// channel up green and inert; `check_program_double_call_result_located_observation`
-/// below is the caller-facing form that refuses the first case.
-fn check_program_double_call_result_observation_impl(stmts: Array[Stmt]) -> Option[(CheckedProgram, Array[Int], Int, Int)] with Exception {
-  let capture = TypedOccurrenceRoleLaneCapture::{
+fn double_call_result_role_lane_capture() -> TypedOccurrenceRoleLaneCapture {
+  TypedOccurrenceRoleLaneCapture::{
     entries: array_empty(),
     provenance_entries: array_empty(),
     statement_path: array_empty(),
@@ -5616,7 +5603,14 @@ fn check_program_double_call_result_observation_impl(stmts: Array[Stmt]) -> Opti
     frame_depth: 0,
     complete: true
   }
-  let checked = check_program_type_defs_observation_impl(stmts, None, Some(capture)).checked_program
+}
+
+/// Shared extraction half of the #2158 observation: retain only source-located
+/// primary call results whose checker-confirmed instantiated type is Double,
+/// plus the two counts that say whether the AST was located at all. `None`
+/// means the capture did not line up with the typed occurrences and nothing
+/// can be classified.
+fn double_call_result_offsets_from_capture(checked: CheckedProgram, capture: TypedOccurrenceRoleLaneCapture) -> Option[(Array[Int], Int, Int)] {
   if Array::length(capture.entries) != Array::length(checked.typed_occurrences) {
     None
   } else {
@@ -5665,7 +5659,58 @@ fn check_program_double_call_result_observation_impl(stmts: Array[Stmt]) -> Opti
       }
       i = i + 1
     }
-    Some((checked, out, primary_calls, located_primary_calls))
+    Some((out, primary_calls, located_primary_calls))
+  }
+}
+
+/// Check once and retain only source-located primary call results whose
+/// checker-confirmed instantiated type is Double, plus the two counts that say
+/// whether the AST was located at all: how many primary call results the
+/// program has, and how many of those carry a source offset.
+///
+/// The counts exist because an EMPTY offset array is ambiguous. `check_program`
+/// records an occurrence for every primary call result either way, but
+/// `tab_call_ty` (checker.vibe) only files one under an offset when that offset
+/// is `>= 0` -- so an AST built by `parse_program(lex(source))` produces an
+/// empty table BY CONSTRUCTION, indistinguishable from a program that simply
+/// has no Double call results. A caller that cannot tell those apart wires the
+/// channel up green and inert; `check_program_double_call_result_located_observation`
+/// below is the caller-facing form that refuses the first case.
+fn check_program_double_call_result_observation_impl(stmts: Array[Stmt]) -> Option[(CheckedProgram, Array[Int], Int, Int)] with Exception {
+  let capture = double_call_result_role_lane_capture()
+  let checked = check_program_type_defs_observation_impl(stmts, None, Some(capture)).checked_program
+  match double_call_result_offsets_from_capture(checked, capture) {
+    None => None,
+    Some((out, primary_calls, located_primary_calls)) => Some((checked, out, primary_calls, located_primary_calls))
+  }
+}
+
+/// #2391: the modular form of the #2158 observation, for the per-module check
+/// the FS lanes already run (check_module). One checker invocation answers
+/// both questions: the CheckedProgram every consumer of the module check needs,
+/// and this module's source-located Double call-result offsets, in the module's
+/// OWN offset space (the FS merge rebases them per file before codegen).
+///
+/// The offsets are `None` exactly when the located form below would refuse the
+/// channel: the program has primary call results and not one is located (an
+/// unlocated `parse_program(lex(source))` AST), or the capture did not line up.
+/// `Some([])` stays the honest "located, and no call result is a Double".
+///
+/// `initial_env` follows check_module's two production entries: `EnvEmpty`
+/// delegates to the plain whole-program check, anything else takes the
+/// projected-import-env path (`imports_already_projected`), so the checked
+/// program is identical to what check_program_result /
+/// check_program_with_projected_import_env_result produce today.
+export fn check_program_with_projected_import_env_double_call_result_located_observation(stmts: Array[Stmt], initial_env: TypeEnv) -> (CheckedProgram, Option[Array[Int]]) with Exception {
+  let capture = double_call_result_role_lane_capture()
+  let checked = check_program_with_env_type_defs_observation_impl(stmts, initial_env, None, Some(capture), true).checked_program
+  match double_call_result_offsets_from_capture(checked, capture) {
+    None => (checked, None),
+    Some((out, primary_calls, located_primary_calls)) => if primary_calls > 0 && located_primary_calls == 0 {
+      (checked, None)
+    } else {
+      (checked, Some(out))
+    }
   }
 }
 

--- a/lib/@vibe/compiler/checker/checker_stmt.vibe
+++ b/lib/@vibe/compiler/checker/checker_stmt.vibe
@@ -5501,6 +5501,7 @@ fn direct_expression_return_capture() -> TypedOccurrenceRoleLaneCapture {
     frame_direct_recorded: array_empty(),
     direct_entries: array_empty(),
     direct_enabled: true,
+    provenance_enabled: true,
     frame_depth: 0,
     complete: true
   }
@@ -5543,6 +5544,7 @@ export fn check_program_typed_occurrence_role_lane_observation(stmts: Array[Stmt
     frame_direct_recorded: array_empty(),
     direct_entries: array_empty(),
     direct_enabled: false,
+    provenance_enabled: true,
     frame_depth: 0,
     complete: true
   }
@@ -5563,6 +5565,7 @@ export fn check_program_typed_occurrence_expression_path_observation(stmts: Arra
     frame_direct_recorded: array_empty(),
     direct_entries: array_empty(),
     direct_enabled: false,
+    provenance_enabled: true,
     frame_depth: 0,
     complete: true
   }
@@ -5600,6 +5603,12 @@ fn double_call_result_role_lane_capture() -> TypedOccurrenceRoleLaneCapture {
     frame_direct_recorded: array_empty(),
     direct_entries: array_empty(),
     direct_enabled: false,
+    // Entries-only: the Double observation reads (role, lane) aligned with
+    // typed_occurrences and nothing else, so the per-expression path and
+    // per-occurrence provenance allocation stays off. Run once per module
+    // across a compiler-sized closure, that allocation tripped the CI
+    // selfcompile KPI heap gate (see the struct field's note).
+    provenance_enabled: false,
     frame_depth: 0,
     complete: true
   }
@@ -5900,6 +5909,7 @@ export fn check_program_with_env_typed_occurrence_role_lane_observation(stmts: A
     frame_direct_recorded: array_empty(),
     direct_entries: array_empty(),
     direct_enabled: false,
+    provenance_enabled: true,
     frame_depth: 0,
     complete: true
   }
@@ -5918,6 +5928,7 @@ export fn check_program_with_env_typed_occurrence_expression_path_observation(st
     frame_direct_recorded: array_empty(),
     direct_entries: array_empty(),
     direct_enabled: false,
+    provenance_enabled: true,
     frame_depth: 0,
     complete: true
   }

--- a/lib/@vibe/compiler/checker/index.vpkg
+++ b/lib/@vibe/compiler/checker/index.vpkg
@@ -270,6 +270,7 @@ fn validate_user_source_stmts(stmts: Array[Stmt]) -> Unit with Exception
 fn check_program_type_table(stmts: Array[Stmt]) -> (Array[(Int, Type)], Subst) with Exception
 fn check_program_with_env_result(stmts: Array[Stmt], initial_env: TypeEnv) -> CheckedProgram with Exception
 fn check_program_with_projected_import_env_result(stmts: Array[Stmt], initial_env: TypeEnv) -> CheckedProgram with Exception
+fn check_program_with_projected_import_env_double_call_result_located_observation(stmts: Array[Stmt], initial_env: TypeEnv) -> (CheckedProgram, Option[Array[Int]]) with Exception
 fn import_item_kind_errors(items: Array[ImportItem], initial_env: TypeEnv, builtin_authority: Bool) -> Array[String]
 fn check_program_with_env_type_defs_observation(stmts: Array[Stmt], initial_env: TypeEnv) -> CheckedProgramTypeDefsObservation with Exception
 fn check_program_with_env_typed_occurrence_statement_observation(stmts: Array[Stmt], initial_env: TypeEnv) -> Option[CheckedTypedOccurrenceStatementObservation] with Exception

--- a/lib/@vibe/compiler/codegen/wasi/index.vpkg
+++ b/lib/@vibe/compiler/codegen/wasi/index.vpkg
@@ -52,6 +52,9 @@ fn compile_wasi_module_break_impl(stmts: Array[Stmt], entry_name: String, prov: 
 fn compile_wasi_module_with_sources_impl(stmts: Array[Stmt], entry_name: String, srcs: Array[(String, String)]) -> Bytes with Exception
 fn compile_wasi_module_with_sources_impl_with_float_offsets(stmts: Array[Stmt], entry_name: String, srcs: Array[(String, String)], checker_float_call_offsets: Array[Int]) -> Bytes with Exception
 fn compile_wasi_module_with_sources_coverage_impl(stmts: Array[Stmt], entry_name: String, srcs: Array[(String, String)]) -> Bytes with Exception
+fn compile_wasi_module_with_sources_coverage_impl_with_float_offsets(stmts: Array[Stmt], entry_name: String, srcs: Array[(String, String)], checker_float_call_offsets: Array[Int]) -> Bytes with Exception
+fn compile_wasi_module_with_sources_trace_impl_with_float_offsets(stmts: Array[Stmt], entry_name: String, srcs: Array[(String, String)], checker_float_call_offsets: Array[Int]) -> Bytes with Exception
+fn compile_wasi_module_with_sources_break_impl_with_float_offsets(stmts: Array[Stmt], entry_name: String, srcs: Array[(String, String)], prov: DbgProv, checker_float_call_offsets: Array[Int]) -> Bytes with Exception
 fn compile_wasi_module_with_sources_trace_impl(stmts: Array[Stmt], entry_name: String, srcs: Array[(String, String)]) -> Bytes with Exception
 fn compile_wasi_module_with_sources_break_impl(stmts: Array[Stmt], entry_name: String, srcs: Array[(String, String)], prov: DbgProv) -> Bytes with Exception
 fn compile_wasi_module_linked_impl(stmts: Array[Stmt], entry_name: String, srcs: Array[(String, String)], linked_imports: Array[(String, String, Int, Int)], library_mode: Bool, enable_rc: Bool, coverage: Bool, debug_trace: Bool, debug_break: Bool, rc_shadow: Bool, enable_late_dce: Bool, prov: DbgProv, body_cache_in: CodegenBodyCache, body_cache_out: CodegenBodyCache, slice_lo: Int, slice_hi: Int) -> Bytes with Exception
@@ -64,3 +67,4 @@ fn compile_wasi_module_rc_cached_impl(stmts_in: Array[Stmt], entry_name: String,
 fn compile_wasi_module_rc_cached_impl_with_float_offsets(stmts_in: Array[Stmt], entry_name: String, body_cache_in: CodegenBodyCache, body_cache_out: CodegenBodyCache, checker_float_call_offsets: Array[Int]) -> Bytes with Exception
 fn compile_wasi_module_rc_impl_with_float_offsets(stmts_in: Array[Stmt], entry_name: String, checker_float_call_offsets: Array[Int]) -> Bytes with Exception
 fn compile_wasi_module_rc_shadow_impl(stmts_in: Array[Stmt], entry_name: String) -> Bytes with Exception
+fn compile_wasi_module_rc_shadow_impl_with_float_offsets(stmts_in: Array[Stmt], entry_name: String, checker_float_call_offsets: Array[Int]) -> Bytes with Exception

--- a/lib/@vibe/compiler/codegen/wasi/index.vpkg
+++ b/lib/@vibe/compiler/codegen/wasi/index.vpkg
@@ -61,5 +61,6 @@ fn compile_wasi_module_replayed_impl(stmts: Array[Stmt], entry_name: String) -> 
 fn compile_wasi_module_sliced_impl(stmts: Array[Stmt], entry_name: String) -> Bytes with Exception
 fn compile_wasi_module_rc_impl(stmts_in: Array[Stmt], entry_name: String) -> Bytes with Exception
 fn compile_wasi_module_rc_cached_impl(stmts_in: Array[Stmt], entry_name: String, body_cache_in: CodegenBodyCache, body_cache_out: CodegenBodyCache) -> Bytes with Exception
+fn compile_wasi_module_rc_cached_impl_with_float_offsets(stmts_in: Array[Stmt], entry_name: String, body_cache_in: CodegenBodyCache, body_cache_out: CodegenBodyCache, checker_float_call_offsets: Array[Int]) -> Bytes with Exception
 fn compile_wasi_module_rc_impl_with_float_offsets(stmts_in: Array[Stmt], entry_name: String, checker_float_call_offsets: Array[Int]) -> Bytes with Exception
 fn compile_wasi_module_rc_shadow_impl(stmts_in: Array[Stmt], entry_name: String) -> Bytes with Exception

--- a/lib/@vibe/compiler/codegen/wasi/linked_compile.vibe
+++ b/lib/@vibe/compiler/codegen/wasi/linked_compile.vibe
@@ -9882,6 +9882,14 @@ export fn compile_wasi_module_rc_cached_impl(stmts_in: Array[Stmt], entry_name: 
   compile_wasi_module_linked_impl(stmts, entry_name, array_empty(), array_empty(), false, true, false, false, false, false, true, empty_dbg_prov(), body_cache_in, body_cache_out, 0, 0 - 1)
 }
 
+/// #2391: `compile_wasi_module_rc_cached_impl` plus the checker's Double
+/// call-result offsets (#2158), so the body-cached FS lane compiles the same
+/// program the ordinary rc lane does and their outputs stay byte-comparable.
+export fn compile_wasi_module_rc_cached_impl_with_float_offsets(stmts_in: Array[Stmt], entry_name: String, body_cache_in: CodegenBodyCache, body_cache_out: CodegenBodyCache, checker_float_call_offsets: Array[Int]) -> Bytes with Exception {
+  let stmts = elaborate_heap_params(stmts_in)
+  compile_wasi_module_linked_impl_with_float_offsets(stmts, entry_name, array_empty(), array_empty(), false, true, false, false, false, false, true, empty_dbg_prov(), body_cache_in, body_cache_out, 0, 0 - 1, checker_float_call_offsets)
+}
+
 /// Preserve the post-lowering AST for the explicit `no-dce` compile mode.
 export fn compile_wasi_module_no_dce_impl(stmts: Array[Stmt], entry_name: String) -> Bytes with Exception {
   compile_wasi_module_linked_impl(stmts, entry_name, array_empty(), array_empty(), false, false, false, false, false, false, false, empty_dbg_prov(), codegen_body_cache_new(), codegen_body_cache_new(), 0, 0 - 1)

--- a/lib/@vibe/compiler/codegen/wasi/linked_compile.vibe
+++ b/lib/@vibe/compiler/codegen/wasi/linked_compile.vibe
@@ -9908,6 +9908,14 @@ export fn compile_wasi_module_rc_shadow_impl(stmts_in: Array[Stmt], entry_name: 
   compile_wasi_module_linked_impl(stmts, entry_name, array_empty(), array_empty(), false, true, false, false, false, true, true, empty_dbg_prov(), codegen_body_cache_new(), codegen_body_cache_new(), 0, 0 - 1)
 }
 
+/// #2391 (#2425 review round 4): shadow-instrumented RC with the checker's
+/// Double call-result offsets, so VIBE_RC=shadow compiles the same program
+/// the production rc lane does.
+export fn compile_wasi_module_rc_shadow_impl_with_float_offsets(stmts_in: Array[Stmt], entry_name: String, checker_float_call_offsets: Array[Int]) -> Bytes with Exception {
+  let stmts = elaborate_heap_params(stmts_in)
+  compile_wasi_module_linked_impl_with_float_offsets(stmts, entry_name, array_empty(), array_empty(), false, true, false, false, false, true, true, empty_dbg_prov(), codegen_body_cache_new(), codegen_body_cache_new(), 0, 0 - 1, checker_float_call_offsets)
+}
+
 /// #1259 step 7: compile the module twice -- once compiling every body and
 /// harvesting it, once replaying every harvested body -- and return the
 /// REPLAYED module, throwing if the two disagree.
@@ -10039,4 +10047,21 @@ export fn compile_wasi_module_with_sources_trace_impl(stmts: Array[Stmt], entry_
 /// compile_wasi_module_with_sources_impl but with debug_break enabled.
 export fn compile_wasi_module_with_sources_break_impl(stmts: Array[Stmt], entry_name: String, srcs: Array[(String, String)], prov: DbgProv) -> Bytes with Exception {
   compile_wasi_module_linked_impl(stmts, entry_name, srcs, array_empty(), false, true, false, false, true, false, true, prov, codegen_body_cache_new(), codegen_body_cache_new(), 0, 0 - 1)
+}
+
+/// #2391 (#2425 review round 4): the instrumented builds compile the same
+/// program the production lanes do, so they take the same checker Double
+/// call-result offsets -- otherwise a coverage/trace/shadow/break build of a
+/// program whose Doubles need the channel silently renders raw f64 bits
+/// where the ordinary build renders numbers.
+export fn compile_wasi_module_with_sources_coverage_impl_with_float_offsets(stmts: Array[Stmt], entry_name: String, srcs: Array[(String, String)], checker_float_call_offsets: Array[Int]) -> Bytes with Exception {
+  compile_wasi_module_linked_impl_with_float_offsets(stmts, entry_name, srcs, array_empty(), false, true, true, false, false, false, true, empty_dbg_prov(), codegen_body_cache_new(), codegen_body_cache_new(), 0, 0 - 1, checker_float_call_offsets)
+}
+
+export fn compile_wasi_module_with_sources_trace_impl_with_float_offsets(stmts: Array[Stmt], entry_name: String, srcs: Array[(String, String)], checker_float_call_offsets: Array[Int]) -> Bytes with Exception {
+  compile_wasi_module_linked_impl_with_float_offsets(stmts, entry_name, srcs, array_empty(), false, true, false, true, false, false, true, empty_dbg_prov(), codegen_body_cache_new(), codegen_body_cache_new(), 0, 0 - 1, checker_float_call_offsets)
+}
+
+export fn compile_wasi_module_with_sources_break_impl_with_float_offsets(stmts: Array[Stmt], entry_name: String, srcs: Array[(String, String)], prov: DbgProv, checker_float_call_offsets: Array[Int]) -> Bytes with Exception {
+  compile_wasi_module_linked_impl_with_float_offsets(stmts, entry_name, srcs, array_empty(), false, true, false, false, true, false, true, prov, codegen_body_cache_new(), codegen_body_cache_new(), 0, 0 - 1, checker_float_call_offsets)
 }

--- a/lib/@vibe/compiler/entry/compiler/file_compile/file_compile.vibe
+++ b/lib/@vibe/compiler/entry/compiler/file_compile/file_compile.vibe
@@ -49,8 +49,6 @@ import @vibe/compiler/codegen {
   compile_wasi_module,
   compile_wasi_module_break,
   compile_wasi_module_coverage,
-  compile_wasi_module_rc,
-  compile_wasi_module_rc_body_cached,
   compile_wasi_module_rc_shadow,
   compile_wasi_module_trace
 }
@@ -68,7 +66,11 @@ import @vibe/compiler/codegen/common_base {
 }
 
 import @vibe/compiler/codegen/wasi {
-  compile_wasi_module_impl, compile_wasi_module_no_dce_impl, effect_lowering_prelude
+  compile_wasi_module_impl_with_float_offsets,
+  compile_wasi_module_no_dce_impl_with_float_offsets,
+  compile_wasi_module_rc_cached_impl_with_float_offsets,
+  compile_wasi_module_rc_impl_with_float_offsets,
+  effect_lowering_prelude
 }
 
 import @vibe/compiler/entry/source_compile/gc_only {
@@ -94,6 +96,7 @@ import @vibe/compiler/runtime {
   db_store_artifact,
   db_typecheck,
   db_typecheck_fs,
+  module_float_call_offsets_for_path,
   parse_program_with_path
 }
 
@@ -369,7 +372,7 @@ fn build_merged_stmts_from_sources(entry_path: String, sources: Array[(String, S
   merged
 }
 
-fn build_grouped_merged_stmts_impl(source_groups: Array[(String, Array[(String, String)])], disjoint_offset_spaces: Bool) -> Array[Stmt] with Exception {
+fn build_grouped_merged_stmts_impl(source_groups: Array[(String, Array[(String, String)])], disjoint_offset_spaces: Bool, flat_paths_out: Array[String], flat_bases_out: Array[Int]) -> Array[Stmt] with Exception {
   // #2205: the rename table describes ONE merged program.
   namespace_rename_originals_reset()
   let merged = array_empty()
@@ -388,6 +391,11 @@ fn build_grouped_merged_stmts_impl(source_groups: Array[(String, Array[(String, 
     let mut source_idx = 0
     while source_idx < Array::length(flat_sources) {
       Array::push(out, shift_stmts_offsets(Array::get(file_stmts, source_idx), offset_base))
+      // #2391: report each flat file's offset base so a caller can shift
+      // per-module offset tables (module_float_call_offsets_for_path, keyed
+      // in each file's OWN offset space) into this merge's space.
+      Array::push(flat_paths_out, Array::get(file_paths, source_idx))
+      Array::push(flat_bases_out, offset_base)
       let (_, source) = Array::get(flat_sources, source_idx)
       // A source of N bytes occupies [base, base + N). The extra byte keeps
       // even an offset exactly at EOF disjoint from the following file.
@@ -436,11 +444,50 @@ fn build_grouped_merged_stmts_impl(source_groups: Array[(String, Array[(String, 
 }
 
 fn build_grouped_merged_stmts(source_groups: Array[(String, Array[(String, String)])]) -> Array[Stmt] with Exception {
-  build_grouped_merged_stmts_impl(source_groups, false)
+  build_grouped_merged_stmts_impl(source_groups, false, array_empty(), array_empty())
 }
 
 fn build_grouped_merged_stmts_gc(source_groups: Array[(String, Array[(String, String)])]) -> Array[Stmt] with Exception {
-  build_grouped_merged_stmts_impl(source_groups, true)
+  build_grouped_merged_stmts_impl(source_groups, true, array_empty(), array_empty())
+}
+
+/// #2391: shift each file's per-module Double call-result offsets (recorded by
+/// the modular check in the file's OWN offset space) by that file's base in a
+/// disjoint-offset merge, and union them into one table for
+/// `CompileCtx.float_call_offsets`. A file the modular check never stepped in
+/// this process contributes nothing, which degrades ITS calls to the
+/// pre-#2158 syntactic classifier -- deterministically, because the reuse
+/// arms in runtime/typecheck_fs.vibe re-check a module whose offsets sidecar
+/// is missing rather than reusing half a cache entry.
+fn union_module_float_offsets(flat_paths: Array[String], flat_bases: Array[Int]) -> Array[Int] {
+  let out: Array[Int] = []
+  let mut i = 0
+  while i < Array::length(flat_paths) {
+    match module_float_call_offsets_for_path(Array::get(flat_paths, i)) {
+      Some(offsets) => {
+        let base = Array::get(flat_bases, i)
+        let mut j = 0
+        while j < Array::length(offsets) {
+          Array::push(out, base + Array::get(offsets, j))
+          j = j + 1
+        }
+      },
+      None => ()
+    }
+    i = i + 1
+  }
+  out
+}
+
+/// #2391: the merge every offsets-consuming linear FS lane shares -- each file
+/// rebased into a disjoint offset range (same rebase as the gc lane, #2226) so
+/// the per-module offset tables union without collisions. Returns the merged
+/// program plus the unioned float-call-offset table for codegen.
+fn merged_stmts_and_float_offsets(source_groups: Array[(String, Array[(String, String)])]) -> (Array[Stmt], Array[Int]) with Exception {
+  let flat_paths: Array[String] = []
+  let flat_bases: Array[Int] = []
+  let merged = build_grouped_merged_stmts_impl(source_groups, true, flat_paths, flat_bases)
+  (merged, union_module_float_offsets(flat_paths, flat_bases))
 }
 
 /// Interior-line breakpoints (span-arc step5): the basename of a file path (text
@@ -589,52 +636,40 @@ export fn check_file_fs_mode(entry_path: String) -> Int with Exception + Fs {
   check_file_fs_mode_from_source_groups(entry_path, source_groups)
 }
 
-/// #2158 (NOT wired here, and the measurement that says why).
+/// #2158/#2391: this lane's codegen is untyped, so a `Double` that arrives
+/// through a call renders as its raw f64 bits without help.
+/// `CompileCtx.float_call_offsets` is the channel that fixes it -- the
+/// checker's per-call-site type, keyed by source offset -- and here it is fed
+/// by the MODULAR check this lane already runs
+/// (`prepare_file_fs_from_source_groups_persistent_cached`): check_module
+/// retains each module's Double call-result offsets in that module's own
+/// offset space, and `merged_stmts_and_float_offsets` rebases every file into
+/// a disjoint offset range (the same rebase the gc lane uses, #2226) and
+/// unions the tables. No whole-program re-check is involved.
 ///
-/// This lane's codegen is untyped, so a `Double` that arrives through a call
-/// renders as its raw f64 bits. `CompileCtx.float_call_offsets` is the channel
-/// that fixes it -- the checker's per-call-site type, keyed by source offset --
-/// and it is live on the single-source lane
-/// (`compile_source_wasi_only`, entry/source_compile/wasi_only/preprocess_compile.vibe)
-/// and on the gc lane. It is NOT live here, and the reason is cost, not design.
-///
-/// Those two lanes already run a whole-program `check_program`, so the offsets
-/// come out of a check that was happening anyway. This lane does not: it
-/// type-checks per MODULE via `prepare_file_fs_from_source_groups_persistent_cached`,
-/// against a persistent cache, and then merges statements. Getting the
-/// observation here means adding a whole-program re-check of the merged
-/// program. Measured, same file, one compiler, warm caches:
-///
-/// | entry file                            | closure         | before | with re-check |
-/// |---------------------------------------|-----------------|-------:|--------------:|
-/// | lib/@vibe/core/sha1_test.vibe          | a few files     | 0.31s  |         0.32s |
-/// | lib/@vibe/compiler/tests/parser_test   | the parser      | 1.01s  |         2.98s |
-/// | lib/@vibe/compiler/tests/compiler_fs   | the compiler    | 6.12s  |        77.55s |
-///
-/// 12.7x on a compiler-sized closure, and superlinear in program size. The cost
-/// is the INFERENCE, not the observation bookkeeping: rewriting the
-/// observation's per-occurrence `subst_apply` into the head query
-/// `subst_resolves_to_double` (types.vibe) changed 77.55s to 77.55s.
-///
-/// So the remaining work is not "wire it up" -- that was tried and measured --
-/// it is to make the answer available without a second whole-program pass. The
-/// shape that fits this lane: have the MODULAR check carry the observation per
-/// module (it already infers every module, and its result is cached), and give
-/// each file a base-shifted offset space so the per-module answers can be
-/// unioned without colliding. `unique_call_offsets_in_stmts`
-/// (codegen/common_analysis) already drops any offset that names more than one
-/// call node, so a partial or colliding answer degrades to today's behavior
-/// rather than to a wrong one.
+/// That shape is a MEASURED choice, twice. Adding a whole-program re-check of
+/// the merged program instead cost 6.12s -> 77.55s at #2158 time; re-measured
+/// on 2026-08-30 (this repo, codegen_lexer_test's full-compiler closure,
+/// interleaved runs) it still cost ~5.6x warm (5.8s -> 32.6s) and ~3.8x cold,
+/// needed a 128MB host stack (the recursive whole-program checker exhausts
+/// the default stack on a compiler-sized merged program), and mutated the
+/// merged AST enough to change the emitted wasm. The modular carry costs a
+/// per-module capture inside a check that was already running, and the
+/// persistent halves (TypeEnv + offsets sidecar) are required TOGETHER by
+/// every reuse arm, so cache state can never change what a compile emits.
+/// `unique_call_offsets_in_stmts` (codegen/common_analysis) still drops any
+/// offset that names more than one call node, so a partial answer degrades to
+/// the pre-#2158 syntactic classifier rather than to a wrong one.
 export fn compile_file_fs_mode(entry_path: String, entry_name: String, mode: String) -> Bytes with Exception + Fs {
   let source_groups = collect_source_groups_fs(entry_path)
   let next_db = prepare_file_fs_from_source_groups_persistent_cached(db_new(), entry_path, source_groups)
   let _ = next_db
-  let merged_stmts = build_grouped_merged_stmts(source_groups)
+  let (merged_stmts, float_offsets) = merged_stmts_and_float_offsets(source_groups)
   if mode == "mvp" {
     let pruned_stmts = dce_stmts(merged_stmts, [entry_name])
-    compile_wasi_module_impl(pruned_stmts, entry_name)
+    compile_wasi_module_impl_with_float_offsets(pruned_stmts, entry_name, float_offsets)
   } else if mode == "no-dce" {
-    compile_wasi_module_no_dce_impl(merged_stmts, entry_name)
+    compile_wasi_module_no_dce_impl_with_float_offsets(merged_stmts, entry_name, float_offsets)
   } else {
     throw(String::concat("unsupported compile mode: ", mode))
   }
@@ -662,21 +697,23 @@ export fn compile_file_fs_mode_rc(entry_path: String, entry_name: String) -> Byt
   let source_groups = collect_source_groups_fs(entry_path)
   let next_db = prepare_file_fs_from_source_groups_persistent_cached(db_new(), entry_path, source_groups)
   let _ = next_db
-  let merged_stmts = build_grouped_merged_stmts(source_groups)
-  // #2158: this is the lane `vibe test` and `vibe run` actually take -- the
-  // adapter routes anything but an explicit `VIBE_RC=0` here, since `VIBE_RC`
-  // unset is `"" != "0"`. It is also the lane that cannot afford the
-  // checker's offsets today; see compile_file_fs_mode above for the numbers.
-  compile_wasi_module_rc(merged_stmts, entry_name)
+  // #2158/#2391: this is the lane `vibe test` and `vibe run` actually take --
+  // the adapter routes anything but an explicit `VIBE_RC=0` here, since
+  // `VIBE_RC` unset is `"" != "0"`. The checker's Double call-result offsets
+  // ride the modular check; see compile_file_fs_mode above for the design and
+  // the measurements.
+  let (merged_stmts, float_offsets) = merged_stmts_and_float_offsets(source_groups)
+  compile_wasi_module_rc_impl_with_float_offsets(merged_stmts, entry_name, float_offsets)
 }
 
-/// #2388 step 3: like build_grouped_merged_stmts, but ALSO reports, per flat
-/// source file, its path, its content fingerprint, and how many merged
-/// top-level statements it contributed -- measured by length delta around
-/// each append, the same technique build_grouped_merged_stmts_prov uses, so
-/// the counts stay aligned however many statements a file contributes.
-/// `merged` is identical to the normal path's.
-fn build_grouped_merged_stmts_counted(source_groups: Array[(String, Array[(String, String)])]) -> (Array[Stmt], Array[String], Array[String], Array[Int]) with Exception {
+/// #2388 step 3: like the rc lane's merge, but ALSO reports, per flat source
+/// file, its path, its content fingerprint, how many merged top-level
+/// statements it contributed -- measured by length delta around each append,
+/// the same technique build_grouped_merged_stmts_prov uses, so the counts
+/// stay aligned however many statements a file contributes -- and (#2391) its
+/// disjoint offset base for the float-offset union. `merged` is identical to
+/// the ordinary rc lane's (merged_stmts_and_float_offsets).
+fn build_grouped_merged_stmts_counted(source_groups: Array[(String, Array[(String, String)])]) -> (Array[Stmt], Array[String], Array[String], Array[Int], Array[Int]) with Exception {
   namespace_rename_originals_reset()
   let merged = array_empty()
   let out_paths = array_empty()
@@ -684,13 +721,29 @@ fn build_grouped_merged_stmts_counted(source_groups: Array[(String, Array[(Strin
   let out_counts = array_empty()
   let flat_sources = flatten_source_groups_local(source_groups)
   let (file_paths, file_stmts) = parse_sources_for_merge(flat_sources)
+  // #2391: mirror build_grouped_merged_stmts_impl's disjoint-offset rebase,
+  // so the body-cached lane's `merged` stays byte-identical to the ordinary
+  // rc lane's (codegen_body_cache_persist_test compares the two), and record
+  // each file's base for the float-offset union.
+  let located_file_stmts = array_empty()
+  let out_bases: Array[Int] = []
+  let mut offset_base = 0
+  let mut source_idx = 0
+  while source_idx < Array::length(flat_sources) {
+    Array::push(located_file_stmts, shift_stmts_offsets(Array::get(file_stmts, source_idx), offset_base))
+    Array::push(out_bases, offset_base)
+    let (_, rebased_source) = Array::get(flat_sources, source_idx)
+    offset_base = offset_base + String::length(rebased_source) + 1
+    source_idx = source_idx + 1
+  }
   let plan_entry = if Array::length(file_paths) > 0 {
     Array::get(file_paths, Array::length(file_paths) - 1)
   } else {
     ""
   }
   let plan = build_export_rename_plan(file_paths, file_stmts, plan_entry)
-  let fallback_clone_offset_delta = [0]
+  let fallback_clone_offset_delta = [offset_base]
+  let fallback_clone_offset_span = offset_base
   let mut flat_idx = 0
   let mut gi = 0
   while gi < Array::length(source_groups) {
@@ -702,14 +755,14 @@ fn build_grouped_merged_stmts_counted(source_groups: Array[(String, Array[(Strin
       Array::push(out_paths, path)
       Array::push(out_fps, compact_string_fingerprint(source))
       let before = Array::length(merged)
-      append_merged_stmts_for_file(merged, path, Array::get(file_stmts, flat_idx), flat_idx == Array::length(file_paths) - 1, plan, flat_sources, file_stmts, fallback_clone_offset_delta, 0)
+      append_merged_stmts_for_file(merged, path, Array::get(located_file_stmts, flat_idx), flat_idx == Array::length(file_paths) - 1, plan, flat_sources, located_file_stmts, fallback_clone_offset_delta, fallback_clone_offset_span)
       Array::push(out_counts, Array::length(merged) - before)
       flat_idx = flat_idx + 1
       si = si + 1
     }
     gi = gi + 1
   }
-  (merged, out_paths, out_fps, out_counts)
+  (merged, out_paths, out_fps, out_counts, out_bases)
 }
 
 //# #2388 step 3: codegen body-cache artifact (wrapper codec)
@@ -954,7 +1007,8 @@ export fn compile_file_fs_mode_rc_body_cached(entry_path: String, entry_name: St
   let source_groups = collect_source_groups_fs(entry_path)
   let next_db = prepare_file_fs_from_source_groups_persistent_cached(db_new(), entry_path, source_groups)
   let _ = next_db
-  let (merged_stmts, file_paths, file_fps, file_counts) = build_grouped_merged_stmts_counted(source_groups)
+  let (merged_stmts, file_paths, file_fps, file_counts, file_bases) = build_grouped_merged_stmts_counted(source_groups)
+  let float_offsets = union_module_float_offsets(file_paths, file_bases)
   // The key is independent of source CONTENT (the point is to hit after an
   // edit) but scoped to the entry PATH: two roots that share a conventional
   // entry name (`run`, `main`) must not share one artifact slot, or their
@@ -966,7 +1020,7 @@ export fn compile_file_fs_mode_rc_body_cached(entry_path: String, entry_name: St
   }
   if cache_mode == "verify" {
     let fresh_out = codegen_body_cache_new()
-    let fresh = compile_wasi_module_rc_body_cached(merged_stmts, entry_name, codegen_body_cache_new(), fresh_out)
+    let fresh = compile_wasi_module_rc_cached_impl_with_float_offsets(merged_stmts, entry_name, codegen_body_cache_new(), fresh_out, float_offsets)
     if Array::length(cache_in.fn_indices) > 0 && body_cache_guards_equal(cache_in, fresh_out) {
       // Guard drift (an edit flipped a whole-program fact the guards pin)
       // is an EXPECTED cache miss, checked above against the fresh
@@ -978,7 +1032,7 @@ export fn compile_file_fs_mode_rc_body_cached(entry_path: String, entry_name: St
       // replay/sliced gates prove that recompile is byte-identical to the
       // first, so any difference here is attributable to the persisted
       // bodies being replayed.
-      let replayed = compile_wasi_module_rc_body_cached(merged_stmts, entry_name, cache_in, codegen_body_cache_new())
+      let replayed = compile_wasi_module_rc_cached_impl_with_float_offsets(merged_stmts, entry_name, cache_in, codegen_body_cache_new(), float_offsets)
       let fresh_n = Bytes::length(fresh)
       let rn = Bytes::length(replayed)
       if fresh_n != rn {
@@ -1007,7 +1061,7 @@ export fn compile_file_fs_mode_rc_body_cached(entry_path: String, entry_name: St
     fresh
   } else {
     let cache_out = codegen_body_cache_new()
-    let bytes = compile_wasi_module_rc_body_cached(merged_stmts, entry_name, cache_in, cache_out)
+    let bytes = compile_wasi_module_rc_cached_impl_with_float_offsets(merged_stmts, entry_name, cache_in, cache_out, float_offsets)
     // Replayed entries are not re-recorded, so the refreshed artifact is
     // the new harvest plus the entries it replayed -- but ONLY when the
     // cache was actually consumed (its guards match the new harvest's).
@@ -1056,9 +1110,9 @@ export fn compile_file_fs_mode_rc_heap_marked(entry_path: String, entry_name: St
   let next_db = prepare_file_fs_from_source_groups_persistent_cached(db_new(), entry_path, source_groups)
   let _ = next_db
   fs_heap_mark("prepared_db")
-  let merged_stmts = build_grouped_merged_stmts(source_groups)
+  let (merged_stmts, float_offsets) = merged_stmts_and_float_offsets(source_groups)
   fs_heap_mark("merged_stmts")
-  let bytes = compile_wasi_module_rc(merged_stmts, entry_name)
+  let bytes = compile_wasi_module_rc_impl_with_float_offsets(merged_stmts, entry_name, float_offsets)
   fs_heap_mark("codegen_rc")
   bytes
 }
@@ -1075,9 +1129,9 @@ export fn compile_file_fs_mode_bump_heap_marked(entry_path: String, entry_name: 
   let next_db = prepare_file_fs_from_source_groups_persistent_cached(db_new(), entry_path, source_groups)
   let _ = next_db
   fs_heap_mark("prepared_db")
-  let merged_stmts = build_grouped_merged_stmts(source_groups)
+  let (merged_stmts, float_offsets) = merged_stmts_and_float_offsets(source_groups)
   fs_heap_mark("merged_stmts")
-  let bytes = compile_wasi_module_no_dce_impl(merged_stmts, entry_name)
+  let bytes = compile_wasi_module_no_dce_impl_with_float_offsets(merged_stmts, entry_name, float_offsets)
   fs_heap_mark("codegen_bump")
   bytes
 }
@@ -1105,7 +1159,7 @@ export fn compile_file_fs_mode_testmeta(entry_path: String, entry_name: String, 
   let source_groups = collect_source_groups_fs(entry_path)
   let next_db = prepare_file_fs_from_source_groups_persistent_cached(db_new(), entry_path, source_groups)
   let _ = next_db
-  let merged_stmts = build_grouped_merged_stmts(source_groups)
+  let (merged_stmts, float_offsets) = merged_stmts_and_float_offsets(source_groups)
   // Compute the cacheability verdict BEFORE codegen (it only needs the stmts)
   // but write it only AFTER codegen succeeds, so a failed compile leaves no
   // stale sidecar.
@@ -1116,9 +1170,9 @@ export fn compile_file_fs_mode_testmeta(entry_path: String, entry_name: String, 
   }
   let bytes = if mode == "mvp" {
     let pruned_stmts = dce_stmts(merged_stmts, [entry_name])
-    compile_wasi_module_impl(pruned_stmts, entry_name)
+    compile_wasi_module_impl_with_float_offsets(pruned_stmts, entry_name, float_offsets)
   } else if mode == "no-dce" {
-    compile_wasi_module_no_dce_impl(merged_stmts, entry_name)
+    compile_wasi_module_no_dce_impl_with_float_offsets(merged_stmts, entry_name, float_offsets)
   } else {
     throw(String::concat("unsupported compile mode: ", mode))
   }
@@ -1210,14 +1264,14 @@ export fn compile_file_fs_mode_profiled(entry_path: String, entry_name: String, 
   let _ = build_source_groups_fingerprint(source_groups)
   let bundle_us = elapsed_us_since(bundle_start)
   let parse_start = profiler_now_us()
-  let merged_stmts = build_grouped_merged_stmts(source_groups)
+  let (merged_stmts, float_offsets) = merged_stmts_and_float_offsets(source_groups)
   let parse_us = elapsed_us_since(parse_start)
   let compile_start = profiler_now_us()
   let bytes = if mode == "mvp" {
     let pruned_stmts = dce_stmts(merged_stmts, [entry_name])
-    compile_wasi_module_impl(pruned_stmts, entry_name)
+    compile_wasi_module_impl_with_float_offsets(pruned_stmts, entry_name, float_offsets)
   } else if mode == "no-dce" {
-    compile_wasi_module_no_dce_impl(merged_stmts, entry_name)
+    compile_wasi_module_no_dce_impl_with_float_offsets(merged_stmts, entry_name, float_offsets)
   } else {
     throw(String::concat("unsupported compile mode: ", mode))
   }
@@ -1257,14 +1311,14 @@ fn compile_file_fs_mode_cached_slow_profiled(db: TypeDb, entry_path: String, ent
         Some(bytes) => (bytes, next_db, load_us, type_us, bundle_us, 0, 0),
         None => {
           let parse_start = profiler_now_us()
-          let merged_stmts = build_grouped_merged_stmts(source_groups)
+          let (merged_stmts, float_offsets) = merged_stmts_and_float_offsets(source_groups)
           let parse_us = elapsed_us_since(parse_start)
           let compile_start = profiler_now_us()
           let bytes = if mode == "mvp" {
             let pruned_stmts = dce_stmts(merged_stmts, [entry_name])
-            compile_wasi_module_impl(pruned_stmts, entry_name)
+            compile_wasi_module_impl_with_float_offsets(pruned_stmts, entry_name, float_offsets)
           } else {
-            compile_wasi_module_no_dce_impl(merged_stmts, entry_name)
+            compile_wasi_module_no_dce_impl_with_float_offsets(merged_stmts, entry_name, float_offsets)
           }
           store_persistent_artifact(persistent_artifact_kind, entry_name, persistent_artifact_fingerprint, bytes)
           let compile_us = elapsed_us_since(compile_start)
@@ -1298,12 +1352,12 @@ fn compile_file_fs_mode_cached_slow_observed(db: TypeDb, entry_path: String, ent
       match db_load_artifact(next_db, entry_path, artifact_kind, entry_name, artifact_fingerprint) {
         Some(bytes) => (bytes, next_db, source_groups_fingerprint, persistent_artifact_fingerprint, "miss"),
         None => {
-          let merged_stmts = build_grouped_merged_stmts(source_groups)
+          let (merged_stmts, float_offsets) = merged_stmts_and_float_offsets(source_groups)
           let bytes = if mode == "mvp" {
             let pruned_stmts = dce_stmts(merged_stmts, [entry_name])
-            compile_wasi_module_impl(pruned_stmts, entry_name)
+            compile_wasi_module_impl_with_float_offsets(pruned_stmts, entry_name, float_offsets)
           } else {
-            compile_wasi_module_no_dce_impl(merged_stmts, entry_name)
+            compile_wasi_module_no_dce_impl_with_float_offsets(merged_stmts, entry_name, float_offsets)
           }
           store_persistent_artifact(persistent_artifact_kind, entry_name, persistent_artifact_fingerprint, bytes)
           (bytes, db_store_artifact(next_db, entry_path, artifact_kind, entry_name, artifact_fingerprint, bytes), source_groups_fingerprint, persistent_artifact_fingerprint, "miss")

--- a/lib/@vibe/compiler/entry/compiler/file_compile/file_compile.vibe
+++ b/lib/@vibe/compiler/entry/compiler/file_compile/file_compile.vibe
@@ -45,12 +45,7 @@ import @vibe/compiler/core {
 }
 
 import @vibe/compiler/codegen {
-  compile_module,
-  compile_wasi_module,
-  compile_wasi_module_break,
-  compile_wasi_module_coverage,
-  compile_wasi_module_rc_shadow,
-  compile_wasi_module_trace
+  compile_module, compile_wasi_module
 }
 
 import @vibe/compiler/codegen/common_base {
@@ -70,6 +65,10 @@ import @vibe/compiler/codegen/wasi {
   compile_wasi_module_no_dce_impl_with_float_offsets,
   compile_wasi_module_rc_cached_impl_with_float_offsets,
   compile_wasi_module_rc_impl_with_float_offsets,
+  compile_wasi_module_rc_shadow_impl_with_float_offsets,
+  compile_wasi_module_with_sources_break_impl_with_float_offsets,
+  compile_wasi_module_with_sources_coverage_impl_with_float_offsets,
+  compile_wasi_module_with_sources_trace_impl_with_float_offsets,
   effect_lowering_prelude
 }
 
@@ -523,18 +522,23 @@ fn union_module_float_offsets(flat_paths: Array[String], flat_bases: Array[Int])
 /// rebased into a disjoint offset range (same rebase as the gc lane, #2226) so
 /// the per-module offset tables union without collisions. Returns the merged
 /// program plus the unioned float-call-offset table for codegen.
+/// The per-file union plus the alias-collision clones' duplicated entries.
+fn union_module_float_offsets_with_clones(flat_paths: Array[String], flat_bases: Array[Int], clone_float_offsets: Array[Int]) -> Array[Int] {
+  let out = union_module_float_offsets(flat_paths, flat_bases)
+  let mut ci = 0
+  while ci < Array::length(clone_float_offsets) {
+    Array::push(out, Array::get(clone_float_offsets, ci))
+    ci = ci + 1
+  }
+  out
+}
+
 fn merged_stmts_and_float_offsets(source_groups: Array[(String, Array[(String, String)])]) -> (Array[Stmt], Array[Int]) with Exception {
   let flat_paths: Array[String] = []
   let flat_bases: Array[Int] = []
   let clone_float_offsets: Array[Int] = []
   let merged = build_grouped_merged_stmts_impl(source_groups, true, flat_paths, flat_bases, clone_float_offsets)
-  let unioned = union_module_float_offsets(flat_paths, flat_bases)
-  let mut ci = 0
-  while ci < Array::length(clone_float_offsets) {
-    Array::push(unioned, Array::get(clone_float_offsets, ci))
-    ci = ci + 1
-  }
-  (merged, unioned)
+  (merged, union_module_float_offsets_with_clones(flat_paths, flat_bases, clone_float_offsets))
 }
 
 /// Interior-line breakpoints (span-arc step5): the basename of a file path (text
@@ -581,9 +585,17 @@ fn file_newline_offsets(src: String) -> Array[Int] {
 ///   stmt_file_id[s]                        — file id of merged top-level stmt s
 /// Provenance is captured by measuring the merged-array length delta around each
 /// source's append, so it stays aligned no matter how many statements a source
-/// contributes; the append calls themselves mirror build_merged_stmts_from_sources
-/// exactly, so `merged` is identical to the normal path.
-fn build_grouped_merged_stmts_prov(source_groups: Array[(String, Array[(String, String)])]) -> (Array[Stmt], Array[String], Array[Array[Int]], Array[Int]) with Exception {
+/// contributes; the append calls themselves mirror the ordinary offsets merge
+/// exactly, so `merged` is identical to the normal (rc/bump) path.
+///
+/// #2391: the merge is disjoint-rebased like the ordinary path, and each
+/// file's NEWLINE table is shifted by the same base. `offset_to_line` only
+/// compares newline offsets against statement offsets, so shifting both
+/// sides by one base leaves every computed line number unchanged -- the
+/// break lane keeps its per-file line mapping with no codegen change, and
+/// the float-offset union (via the caller-passed sinks, same contract as
+/// build_grouped_merged_stmts_impl) speaks the same offset space.
+fn build_grouped_merged_stmts_prov(source_groups: Array[(String, Array[(String, String)])], flat_paths_out: Array[String], flat_bases_out: Array[Int], clone_float_offsets_out: Array[Int]) -> (Array[Stmt], Array[String], Array[Array[Int]], Array[Int]) with Exception {
   // #2205: the rename table describes ONE merged program.
   namespace_rename_originals_reset()
   let merged = array_empty()
@@ -594,13 +606,33 @@ fn build_grouped_merged_stmts_prov(source_groups: Array[(String, Array[(String, 
   // stays identical to the normal (non-break) merge.
   let flat_sources = flatten_source_groups_local(source_groups)
   let (file_paths, file_stmts) = parse_sources_for_merge(flat_sources)
+  let located_file_stmts = array_empty()
+  let mut offset_base = 0
+  let mut source_idx = 0
+  while source_idx < Array::length(flat_sources) {
+    Array::push(located_file_stmts, shift_stmts_offsets(Array::get(file_stmts, source_idx), offset_base))
+    let (flat_path, flat_source) = Array::get(flat_sources, source_idx)
+    Array::push(flat_paths_out, flat_path)
+    Array::push(flat_bases_out, offset_base)
+    Array::push(files, path_basename(flat_path))
+    let nls = file_newline_offsets(flat_source)
+    let mut nli = 0
+    while nli < Array::length(nls) {
+      Array::set(nls, nli, Array::get(nls, nli) + offset_base)
+      nli = nli + 1
+    }
+    Array::push(file_nls, nls)
+    offset_base = offset_base + String::length(flat_source) + 1
+    source_idx = source_idx + 1
+  }
   let plan_entry = if Array::length(file_paths) > 0 {
     Array::get(file_paths, Array::length(file_paths) - 1)
   } else {
     ""
   }
   let plan = build_export_rename_plan(file_paths, file_stmts, plan_entry)
-  let fallback_clone_offset_delta = [0]
+  let fallback_clone_offset_delta = [offset_base]
+  let fallback_clone_offset_span = offset_base
   let mut flat_idx = 0
   let mut gi = 0
   while gi < Array::length(source_groups) {
@@ -608,14 +640,12 @@ fn build_grouped_merged_stmts_prov(source_groups: Array[(String, Array[(String, 
     let source_count = Array::length(sources)
     let mut si = 0
     while si < source_count {
-      let (path, source) = Array::get(sources, si)
-      let file_id = Array::length(files)
-      Array::push(files, path_basename(path))
-      Array::push(file_nls, file_newline_offsets(source))
+      let (path, _) = Array::get(sources, si)
+      let file_id = flat_idx
       let before = Array::length(merged)
       // #740: last-of-WHOLE-merge, not last-of-group (see the note in
       // build_grouped_merged_stmts).
-      append_merged_stmts_for_file(merged, path, Array::get(file_stmts, flat_idx), flat_idx == Array::length(file_paths) - 1, plan, flat_sources, file_stmts, fallback_clone_offset_delta, 0, array_empty(), array_empty(), array_empty())
+      append_merged_stmts_for_file(merged, path, Array::get(located_file_stmts, flat_idx), flat_idx == Array::length(file_paths) - 1, plan, flat_sources, located_file_stmts, fallback_clone_offset_delta, fallback_clone_offset_span, flat_paths_out, flat_bases_out, clone_float_offsets_out)
       let after = Array::length(merged)
       let mut k = before
       while k < after {
@@ -1059,12 +1089,7 @@ export fn compile_file_fs_mode_rc_body_cached(entry_path: String, entry_name: St
   let next_db = prepare_file_fs_from_source_groups_persistent_cached(db_new(), entry_path, source_groups)
   let _ = next_db
   let (merged_stmts, file_paths, file_fps, file_counts, file_bases, clone_float_offsets) = build_grouped_merged_stmts_counted(source_groups)
-  let float_offsets = union_module_float_offsets(file_paths, file_bases)
-  let mut ci = 0
-  while ci < Array::length(clone_float_offsets) {
-    Array::push(float_offsets, Array::get(clone_float_offsets, ci))
-    ci = ci + 1
-  }
+  let float_offsets = union_module_float_offsets_with_clones(file_paths, file_bases, clone_float_offsets)
   // The key is independent of source CONTENT (the point is to hit after an
   // edit) but scoped to the entry PATH: two roots that share a conventional
   // entry name (`run`, `main`) must not share one artifact slot, or their
@@ -1200,8 +1225,8 @@ export fn compile_file_fs_mode_rc_shadow(entry_path: String, entry_name: String)
   let source_groups = collect_source_groups_fs(entry_path)
   let next_db = prepare_file_fs_from_source_groups_persistent_cached(db_new(), entry_path, source_groups)
   let _ = next_db
-  let merged_stmts = build_grouped_merged_stmts(source_groups)
-  compile_wasi_module_rc_shadow(merged_stmts, entry_name)
+  let (merged_stmts, float_offsets) = merged_stmts_and_float_offsets(source_groups)
+  compile_wasi_module_rc_shadow_impl_with_float_offsets(merged_stmts, entry_name, float_offsets)
 }
 
 /// #634 (ADR-0026): same as compile_file_fs_mode, but ALSO writes the pure-test
@@ -1268,8 +1293,8 @@ export fn compile_file_fs_mode_coverage(entry_path: String, entry_name: String) 
   let source_groups = collect_source_groups_fs(entry_path)
   let next_db = prepare_file_fs_from_source_groups_persistent_cached(db_new(), entry_path, source_groups)
   let _ = next_db
-  let merged_stmts = build_grouped_merged_stmts(source_groups)
-  compile_wasi_module_coverage(merged_stmts, entry_name)
+  let (merged_stmts, float_offsets) = merged_stmts_and_float_offsets(source_groups)
+  compile_wasi_module_with_sources_coverage_impl_with_float_offsets(merged_stmts, entry_name, array_empty(), float_offsets)
 }
 
 /// Trace (debugger / DAP P1 groundwork): FS-mode compile with function-call
@@ -1281,8 +1306,8 @@ export fn compile_file_fs_mode_trace(entry_path: String, entry_name: String) -> 
   let source_groups = collect_source_groups_fs(entry_path)
   let next_db = prepare_file_fs_from_source_groups_persistent_cached(db_new(), entry_path, source_groups)
   let _ = next_db
-  let merged_stmts = build_grouped_merged_stmts(source_groups)
-  compile_wasi_module_trace(merged_stmts, entry_name)
+  let (merged_stmts, float_offsets) = merged_stmts_and_float_offsets(source_groups)
+  compile_wasi_module_with_sources_trace_impl_with_float_offsets(merged_stmts, entry_name, array_empty(), float_offsets)
 }
 
 /// Break (debugger / DAP P1): FS-mode compile with `vibe::dbg_break` host-hook
@@ -1299,12 +1324,16 @@ export fn compile_file_fs_mode_break(entry_path: String, entry_name: String) -> 
   // statement boundary, mapping each statement's char offset to a line in its OWN
   // source file (multi-file: offsets from different files collide). `merged` is
   // identical to the non-break merge.
-  let (merged_stmts, dbg_files, dbg_file_nls, dbg_stmt_file_id) = build_grouped_merged_stmts_prov(source_groups)
-  compile_wasi_module_break(merged_stmts, entry_name, DbgProv::{
+  let flat_paths: Array[String] = []
+  let flat_bases: Array[Int] = []
+  let clone_float_offsets: Array[Int] = []
+  let (merged_stmts, dbg_files, dbg_file_nls, dbg_stmt_file_id) = build_grouped_merged_stmts_prov(source_groups, flat_paths, flat_bases, clone_float_offsets)
+  let float_offsets = union_module_float_offsets_with_clones(flat_paths, flat_bases, clone_float_offsets)
+  compile_wasi_module_with_sources_break_impl_with_float_offsets(merged_stmts, entry_name, array_empty(), DbgProv::{
     files: dbg_files,
     file_nls: dbg_file_nls,
     stmt_file_id: dbg_stmt_file_id
-  })
+  }, float_offsets)
 }
 
 export fn compile_file_fs_mode_profiled(entry_path: String, entry_name: String, mode: String) -> (Bytes, Int, Int, Int, Int, Int, Int) with Exception + Fs + Profiler {

--- a/lib/@vibe/compiler/entry/compiler/file_compile/file_compile.vibe
+++ b/lib/@vibe/compiler/entry/compiler/file_compile/file_compile.vibe
@@ -235,7 +235,7 @@ fn parse_program_for_path(path: String, source: String) -> Array[Stmt] with Exce
 /// #716: collision-def fallback (see merge_sources.vibe). `excluded_locals`
 /// are the locals the export-rename plan already rewrites; the inline copy gets
 /// the target file's export renames applied first.
-fn append_import_alias_collision_defs_from_sources(merged: Array[Stmt], current_path: String, stmts: Array[Stmt], sources: Array[(String, String)], source_stmts: Array[Array[Stmt]], plan: ExportRenamePlan, fallback_clone_offset_delta: Array[Int], fallback_clone_offset_span: Int, excluded_locals: Array[String]) -> Unit with Exception {
+fn append_import_alias_collision_defs_from_sources(merged: Array[Stmt], current_path: String, stmts: Array[Stmt], sources: Array[(String, String)], source_stmts: Array[Array[Stmt]], plan: ExportRenamePlan, fallback_clone_offset_delta: Array[Int], fallback_clone_offset_span: Int, excluded_locals: Array[String], flat_paths: Array[String], flat_bases: Array[Int], clone_float_offsets_out: Array[Int]) -> Unit with Exception {
   let refs = collect_import_alias_collision_refs(stmts)
   let emitted = array_empty()
   let base_dir = dir_of_path(current_path)
@@ -263,6 +263,29 @@ fn append_import_alias_collision_defs_from_sources(merged: Array[Stmt], current_
                   // both the original and the clone's Double observations.
                   let delta = Array::get(fallback_clone_offset_delta, 0)
                   Array::set(fallback_clone_offset_delta, 0, delta + fallback_clone_offset_span)
+                  // #2391 (#2425 review): the clone is a second copy of
+                  // provider CODE in a fresh offset range, so it needs a
+                  // second copy of the provider's Double call-result offsets
+                  // too, or a Double-returning call inside the clone's body
+                  // falls back to the syntactic classifier and prints raw
+                  // bits. The clone's node offsets are the provider's
+                  // MERGE-SPACE offsets (its file base plus its module-space
+                  // offset -- source_stmts is the rebased table) plus this
+                  // clone's delta; entries for provider statements the clone
+                  // does not contain match no call node and stay inert.
+                  match lookup_flat_base(flat_paths, flat_bases, resolved) {
+                    Some(provider_base) => match module_float_call_offsets_for_path(resolved) {
+                      Some(provider_offsets) => {
+                        let mut k = 0
+                        while k < Array::length(provider_offsets) {
+                          Array::push(clone_float_offsets_out, provider_base + Array::get(provider_offsets, k) + delta)
+                          k = k + 1
+                        }
+                      },
+                      None => ()
+                    },
+                    None => ()
+                  }
                   shift_stmt_offsets(local_stmt, delta)
                 } else {
                   local_stmt
@@ -281,6 +304,23 @@ fn append_import_alias_collision_defs_from_sources(merged: Array[Stmt], current_
     }
     i = i + 1
   }
+}
+
+/// The disjoint-merge offset base recorded for `path`, or None when the merge
+/// runs without disjoint offset spaces (the callers then pass empty tables).
+fn lookup_flat_base(flat_paths: Array[String], flat_bases: Array[Int], path: String) -> Option[Int] {
+  let n = Array::length(flat_paths)
+  let mut i = 0
+  let mut found: Option[Int] = None
+  while i < n {
+    if Array::get(flat_paths, i) == path {
+      found = Some(Array::get(flat_bases, i))
+      i = n
+    } else {
+      i = i + 1
+    }
+  }
+  found
 }
 
 /// #716: parse every source once and build the export-rename plan for the whole
@@ -304,7 +344,7 @@ fn parse_sources_for_merge(sources: Array[(String, String)]) -> (Array[String], 
 /// statements, `is_entry_source` mirrors the pre-#716 per-group entry rule
 /// (entry keeps its private names), and `plan`/`sources` drive the export-name
 /// rewriting and the collision-def fallback.
-fn append_merged_stmts_for_file(merged: Array[Stmt], path: String, stmts: Array[Stmt], is_entry_source: Bool, plan: ExportRenamePlan, sources: Array[(String, String)], source_stmts: Array[Array[Stmt]], fallback_clone_offset_delta: Array[Int], fallback_clone_offset_span: Int) -> Unit with Exception {
+fn append_merged_stmts_for_file(merged: Array[Stmt], path: String, stmts: Array[Stmt], is_entry_source: Bool, plan: ExportRenamePlan, sources: Array[(String, String)], source_stmts: Array[Array[Stmt]], fallback_clone_offset_delta: Array[Int], fallback_clone_offset_span: Int, flat_paths: Array[String], flat_bases: Array[Int], clone_float_offsets_out: Array[Int]) -> Unit with Exception {
   // Preserve the proof that an optimized trait namespace came from the
   // standard module. Desugaring consumes this source-local marker before
   // codegen; it is not part of the runtime program.
@@ -334,7 +374,7 @@ fn append_merged_stmts_for_file(merged: Array[Stmt], path: String, stmts: Array[
   }
   if stmts_have_import_deep(stmts) {
     let skipped_locals = collect_import_alias_collision_locals(stmts)
-    append_import_alias_collision_defs_from_sources(merged, path, stmts, sources, source_stmts, plan, fallback_clone_offset_delta, fallback_clone_offset_span, import_value_rename_locals(import_renames))
+    append_import_alias_collision_defs_from_sources(merged, path, stmts, sources, source_stmts, plan, fallback_clone_offset_delta, fallback_clone_offset_span, import_value_rename_locals(import_renames), flat_paths, flat_bases, clone_float_offsets_out)
     append_import_alias_rewritten_non_import_stmts_with_renames(merged, namespaced_stmts, skipped_locals, import_renames)
   } else {
     append_non_import_stmts_without_alias_rewrite(merged, namespaced_stmts)
@@ -366,13 +406,13 @@ fn build_merged_stmts_from_sources(entry_path: String, sources: Array[(String, S
     } else {
       path == entry_path
     }
-    append_merged_stmts_for_file(merged, path, Array::get(file_stmts, si), is_entry_source, plan, sources, file_stmts, fallback_clone_offset_delta, 0)
+    append_merged_stmts_for_file(merged, path, Array::get(file_stmts, si), is_entry_source, plan, sources, file_stmts, fallback_clone_offset_delta, 0, array_empty(), array_empty(), array_empty())
     si = si + 1
   }
   merged
 }
 
-fn build_grouped_merged_stmts_impl(source_groups: Array[(String, Array[(String, String)])], disjoint_offset_spaces: Bool, flat_paths_out: Array[String], flat_bases_out: Array[Int]) -> Array[Stmt] with Exception {
+fn build_grouped_merged_stmts_impl(source_groups: Array[(String, Array[(String, String)])], disjoint_offset_spaces: Bool, flat_paths_out: Array[String], flat_bases_out: Array[Int], clone_float_offsets_out: Array[Int]) -> Array[Stmt] with Exception {
   // #2205: the rename table describes ONE merged program.
   namespace_rename_originals_reset()
   let merged = array_empty()
@@ -434,7 +474,7 @@ fn build_grouped_merged_stmts_impl(source_groups: Array[(String, Array[(String, 
       // call-result table is keyed by those offsets, so merging files without
       // rebasing lets one file's Double call classify another file's Int call.
       // Shift before the namespace/import rewrites; they preserve locations.
-      append_merged_stmts_for_file(merged, path, stmts, flat_idx == flat_total - 1, plan, flat_sources, located_file_stmts, fallback_clone_offset_delta, fallback_clone_offset_span)
+      append_merged_stmts_for_file(merged, path, stmts, flat_idx == flat_total - 1, plan, flat_sources, located_file_stmts, fallback_clone_offset_delta, fallback_clone_offset_span, flat_paths_out, flat_bases_out, clone_float_offsets_out)
       flat_idx = flat_idx + 1
       si = si + 1
     }
@@ -444,11 +484,11 @@ fn build_grouped_merged_stmts_impl(source_groups: Array[(String, Array[(String, 
 }
 
 fn build_grouped_merged_stmts(source_groups: Array[(String, Array[(String, String)])]) -> Array[Stmt] with Exception {
-  build_grouped_merged_stmts_impl(source_groups, false, array_empty(), array_empty())
+  build_grouped_merged_stmts_impl(source_groups, false, array_empty(), array_empty(), array_empty())
 }
 
 fn build_grouped_merged_stmts_gc(source_groups: Array[(String, Array[(String, String)])]) -> Array[Stmt] with Exception {
-  build_grouped_merged_stmts_impl(source_groups, true, array_empty(), array_empty())
+  build_grouped_merged_stmts_impl(source_groups, true, array_empty(), array_empty(), array_empty())
 }
 
 /// #2391: shift each file's per-module Double call-result offsets (recorded by
@@ -486,8 +526,15 @@ fn union_module_float_offsets(flat_paths: Array[String], flat_bases: Array[Int])
 fn merged_stmts_and_float_offsets(source_groups: Array[(String, Array[(String, String)])]) -> (Array[Stmt], Array[Int]) with Exception {
   let flat_paths: Array[String] = []
   let flat_bases: Array[Int] = []
-  let merged = build_grouped_merged_stmts_impl(source_groups, true, flat_paths, flat_bases)
-  (merged, union_module_float_offsets(flat_paths, flat_bases))
+  let clone_float_offsets: Array[Int] = []
+  let merged = build_grouped_merged_stmts_impl(source_groups, true, flat_paths, flat_bases, clone_float_offsets)
+  let unioned = union_module_float_offsets(flat_paths, flat_bases)
+  let mut ci = 0
+  while ci < Array::length(clone_float_offsets) {
+    Array::push(unioned, Array::get(clone_float_offsets, ci))
+    ci = ci + 1
+  }
+  (merged, unioned)
 }
 
 /// Interior-line breakpoints (span-arc step5): the basename of a file path (text
@@ -568,7 +615,7 @@ fn build_grouped_merged_stmts_prov(source_groups: Array[(String, Array[(String, 
       let before = Array::length(merged)
       // #740: last-of-WHOLE-merge, not last-of-group (see the note in
       // build_grouped_merged_stmts).
-      append_merged_stmts_for_file(merged, path, Array::get(file_stmts, flat_idx), flat_idx == Array::length(file_paths) - 1, plan, flat_sources, file_stmts, fallback_clone_offset_delta, 0)
+      append_merged_stmts_for_file(merged, path, Array::get(file_stmts, flat_idx), flat_idx == Array::length(file_paths) - 1, plan, flat_sources, file_stmts, fallback_clone_offset_delta, 0, array_empty(), array_empty(), array_empty())
       let after = Array::length(merged)
       let mut k = before
       while k < after {
@@ -713,27 +760,33 @@ export fn compile_file_fs_mode_rc(entry_path: String, entry_name: String) -> Byt
 /// stay aligned however many statements a file contributes -- and (#2391) its
 /// disjoint offset base for the float-offset union. `merged` is identical to
 /// the ordinary rc lane's (merged_stmts_and_float_offsets).
-fn build_grouped_merged_stmts_counted(source_groups: Array[(String, Array[(String, String)])]) -> (Array[Stmt], Array[String], Array[String], Array[Int], Array[Int]) with Exception {
+fn build_grouped_merged_stmts_counted(source_groups: Array[(String, Array[(String, String)])]) -> (Array[Stmt], Array[String], Array[String], Array[Int], Array[Int], Array[Int]) with Exception {
   namespace_rename_originals_reset()
   let merged = array_empty()
   let out_paths = array_empty()
   let out_fps = array_empty()
   let out_counts = array_empty()
+  let clone_float_offsets_out: Array[Int] = []
   let flat_sources = flatten_source_groups_local(source_groups)
   let (file_paths, file_stmts) = parse_sources_for_merge(flat_sources)
   // #2391: mirror build_grouped_merged_stmts_impl's disjoint-offset rebase,
   // so the body-cached lane's `merged` stays byte-identical to the ordinary
   // rc lane's (codegen_body_cache_persist_test compares the two), and record
-  // each file's base for the float-offset union.
+  // each file's base for the float-offset union. The paths/fps rows are
+  // filled HERE, not in the append loop below, so the table is complete
+  // before the first append -- an alias-collision clone may reference a
+  // provider LATER in the flat order than the importing file.
   let located_file_stmts = array_empty()
   let out_bases: Array[Int] = []
   let mut offset_base = 0
   let mut source_idx = 0
   while source_idx < Array::length(flat_sources) {
     Array::push(located_file_stmts, shift_stmts_offsets(Array::get(file_stmts, source_idx), offset_base))
+    let (flat_path, flat_source) = Array::get(flat_sources, source_idx)
+    Array::push(out_paths, flat_path)
+    Array::push(out_fps, compact_string_fingerprint(flat_source))
     Array::push(out_bases, offset_base)
-    let (_, rebased_source) = Array::get(flat_sources, source_idx)
-    offset_base = offset_base + String::length(rebased_source) + 1
+    offset_base = offset_base + String::length(flat_source) + 1
     source_idx = source_idx + 1
   }
   let plan_entry = if Array::length(file_paths) > 0 {
@@ -751,18 +804,16 @@ fn build_grouped_merged_stmts_counted(source_groups: Array[(String, Array[(Strin
     let source_count = Array::length(sources)
     let mut si = 0
     while si < source_count {
-      let (path, source) = Array::get(sources, si)
-      Array::push(out_paths, path)
-      Array::push(out_fps, compact_string_fingerprint(source))
+      let (path, _) = Array::get(sources, si)
       let before = Array::length(merged)
-      append_merged_stmts_for_file(merged, path, Array::get(located_file_stmts, flat_idx), flat_idx == Array::length(file_paths) - 1, plan, flat_sources, located_file_stmts, fallback_clone_offset_delta, fallback_clone_offset_span)
+      append_merged_stmts_for_file(merged, path, Array::get(located_file_stmts, flat_idx), flat_idx == Array::length(file_paths) - 1, plan, flat_sources, located_file_stmts, fallback_clone_offset_delta, fallback_clone_offset_span, out_paths, out_bases, clone_float_offsets_out)
       Array::push(out_counts, Array::length(merged) - before)
       flat_idx = flat_idx + 1
       si = si + 1
     }
     gi = gi + 1
   }
-  (merged, out_paths, out_fps, out_counts, out_bases)
+  (merged, out_paths, out_fps, out_counts, out_bases, clone_float_offsets_out)
 }
 
 //# #2388 step 3: codegen body-cache artifact (wrapper codec)
@@ -1007,8 +1058,13 @@ export fn compile_file_fs_mode_rc_body_cached(entry_path: String, entry_name: St
   let source_groups = collect_source_groups_fs(entry_path)
   let next_db = prepare_file_fs_from_source_groups_persistent_cached(db_new(), entry_path, source_groups)
   let _ = next_db
-  let (merged_stmts, file_paths, file_fps, file_counts, file_bases) = build_grouped_merged_stmts_counted(source_groups)
+  let (merged_stmts, file_paths, file_fps, file_counts, file_bases, clone_float_offsets) = build_grouped_merged_stmts_counted(source_groups)
   let float_offsets = union_module_float_offsets(file_paths, file_bases)
+  let mut ci = 0
+  while ci < Array::length(clone_float_offsets) {
+    Array::push(float_offsets, Array::get(clone_float_offsets, ci))
+    ci = ci + 1
+  }
   // The key is independent of source CONTENT (the point is to hit after an
   // edit) but scoped to the entry PATH: two roots that share a conventional
   // entry name (`run`, `main`) must not share one artifact slot, or their

--- a/lib/@vibe/compiler/entry/source_compile/wasi_only/preprocess_compile.vibe
+++ b/lib/@vibe/compiler/entry/source_compile/wasi_only/preprocess_compile.vibe
@@ -189,9 +189,9 @@ fn maybe_wrap_async_component(bytes: Bytes, wrap_async: Bool) -> Bytes with Exce
 ///
 ///   - ONE offset space. This lane lexes and parses one text, so an offset
 ///     names one position and there is nothing to collide with. (The FS merge
-///     lanes concatenate many files' statements and each file's offsets are
-///     relative to its own text -- see `compile_file_fs_mode`'s comment for why
-///     this channel is not wired there yet, and what it costs.)
+///     lanes re-establish the same property by rebasing each file into a
+///     disjoint offset range and feeding the per-module answers from the
+///     modular check -- see `compile_file_fs_mode`'s comment, #2391.)
 ///     `unique_call_offsets_in_stmts` re-establishes the property downstream
 ///     anyway, on the post-lowering statements codegen actually walks.
 ///   - Fail CLOSED. `check_program_double_call_result_located_observation`

--- a/lib/@vibe/compiler/runtime/index.vpkg
+++ b/lib/@vibe/compiler/runtime/index.vpkg
@@ -133,6 +133,7 @@ fn db_module_source_count(db: TypeDb) -> Int
 fn db_codegen_count(db: TypeDb) -> Int
 fn db_typecheck(db: TypeDb, path: String) -> TypeDb with Exception
 fn db_typecheck_fs(db: TypeDb, path: String) -> TypeDb with Exception + Fs
+fn module_float_call_offsets_for_path(path: String) -> Option[Array[Int]]
 fn db_program_source(db: TypeDb, path: String) -> (String, String, TypeDb) with Exception
 fn db_merged_source(db: TypeDb, _entry_path: String, sources: Array[(String, String)]) -> (String, String, TypeDb) with Exception
 fn db_grouped_merged_source(db: TypeDb, groups: Array[(String, Array[(String, String)])]) -> (String, String, TypeDb) with Exception

--- a/lib/@vibe/compiler/runtime/runtime.vibe
+++ b/lib/@vibe/compiler/runtime/runtime.vibe
@@ -103,7 +103,7 @@ export ./escape_spans.vibe {
 }
 
 export ./typecheck_fs.vibe {
-  collect_all_diagnostics, module_plan_manifest_fs
+  collect_all_diagnostics, module_float_call_offsets_for_path, module_plan_manifest_fs
 }
 
 // Note: `eval_loader/` has its own `index.vibe` and is already its own

--- a/lib/@vibe/compiler/runtime/typecheck_fs.vibe
+++ b/lib/@vibe/compiler/runtime/typecheck_fs.vibe
@@ -268,9 +268,29 @@ export fn module_float_call_offsets_for_path(path: String) -> Option[Array[Int]]
   found
 }
 
+/// Order-sensitive checksum over the offset rows, kept non-negative so it
+/// round-trips through the digit-only row parser below. The mask constant is
+/// spelled by arithmetic because the committed seed still enforces the old
+/// 2^61-1 literal bound (see CLAUDE.md's Int notes).
+fn module_float_offsets_checksum(offsets: Array[Int]) -> Int {
+  let mask = (1<<60) - 1
+  let n = Array::length(offsets)
+  let mut h = 17
+  let mut i = 0
+  while i < n {
+    h = ((h * 131) + Array::get(offsets, i) + 1)&mask
+    i = i + 1
+  }
+  h
+}
+
 fn module_float_offsets_text(offsets: Array[Int]) -> String {
   let parts = array_empty()
-  Array::push(parts, "module_float_call_offsets\tv1")
+  // v2 (#2425 review round 3): the header DECLARES the row count and an
+  // order-sensitive checksum, so a torn write (header plus only some rows)
+  // or a digit-level corruption decodes as a miss instead of silently
+  // changing which call sites the compile classifies.
+  Array::push(parts, String::concat("module_float_call_offsets\tv2\t", String::concat(__to_string(Array::length(offsets)), String::concat("\t", __to_string(module_float_offsets_checksum(offsets))))))
   let n = Array::length(offsets)
   let mut i = 0
   while i < n {
@@ -280,46 +300,75 @@ fn module_float_offsets_text(offsets: Array[Int]) -> String {
   String::concat(String::join(parts, "\n"), "\n")
 }
 
-/// Tolerant decode: any deviation from the exact v1 shape is `None` (an
-/// ordinary cold-cache miss that re-checks the module), never a throw and
-/// never a partial answer.
-fn parse_module_float_offsets_text(text: String) -> Option[Array[Int]] {
-  let lines = String::split(normalize_persistent_cache_text(text), "\n")
-  if Array::length(lines) == 0 || Array::get(lines, 0) != "module_float_call_offsets\tv1" {
+/// Digit-only row decode; any other character poisons the whole parse.
+fn module_float_offsets_parse_nat(line: String) -> Option[Int] {
+  let len = String::length(line)
+  if len == 0 {
     None
   } else {
-    let out: Array[Int] = []
+    let mut value = 0
     let mut ok = true
-    let mut i = 1
-    while i < Array::length(lines) {
-      let line = Array::get(lines, i)
-      if String::length(line) == 0 {
-        ()
+    let mut j = 0
+    while j < len && ok {
+      let c = String::char_code_at(line, j)
+      if c >= 48 && c <= 57 {
+        value = value * 10 + (c - 48)
       } else {
-        let mut value = 0
-        let mut j = 0
-        let len = String::length(line)
-        while j < len && ok {
-          let c = String::char_code_at(line, j)
-          if c >= 48 && c <= 57 {
-            value = value * 10 + (c - 48)
-          } else {
-            ok = false
-          }
-          j = j + 1
-        }
-        if ok {
-          Array::push(out, value)
-        } else {
-          ()
-        }
+        ok = false
       }
-      i = i + 1
+      j = j + 1
     }
     if ok {
-      Some(out)
+      Some(value)
     } else {
       None
+    }
+  }
+}
+
+/// Strict v2 decode: the header's declared count and checksum must both match
+/// the rows actually present, or the answer is `None` -- an ordinary
+/// cold-cache miss that re-checks the module. A truncated file fails the
+/// count, a corrupted row fails the checksum (or the digit parse), and a v1
+/// or foreign header fails outright; none of them can change what a compile
+/// emits.
+fn parse_module_float_offsets_text(text: String) -> Option[Array[Int]] {
+  let lines = String::split(normalize_persistent_cache_text(text), "\n")
+  if Array::length(lines) == 0 {
+    None
+  } else {
+    let header = String::split(Array::get(lines, 0), "\t")
+    if Array::length(header) != 4 || Array::get(header, 0) != "module_float_call_offsets" || Array::get(header, 1) != "v2" {
+      None
+    } else {
+      match module_float_offsets_parse_nat(Array::get(header, 2)) {
+        None => None,
+        Some(declared_count) => match module_float_offsets_parse_nat(Array::get(header, 3)) {
+          None => None,
+          Some(declared_checksum) => {
+            let out: Array[Int] = []
+            let mut ok = true
+            let mut i = 1
+            while i < Array::length(lines) && ok {
+              let line = Array::get(lines, i)
+              if String::length(line) == 0 {
+                ()
+              } else {
+                match module_float_offsets_parse_nat(line) {
+                  Some(value) => Array::push(out, value),
+                  None => ok = false
+                }
+              }
+              i = i + 1
+            }
+            if ok && Array::length(out) == declared_count && module_float_offsets_checksum(out) == declared_checksum {
+              Some(out)
+            } else {
+              None
+            }
+          }
+        }
+      }
     }
   }
 }

--- a/lib/@vibe/compiler/runtime/typecheck_fs.vibe
+++ b/lib/@vibe/compiler/runtime/typecheck_fs.vibe
@@ -178,11 +178,19 @@ fn valid_persistent_leaf_fingerprint(path: String, source: String) -> Option[Str
 // gc lanes already carry the channel; compile_file_fs_mode's #2158 note has
 // the measurement for why a whole-program re-check was not the way).
 //
-// The memo is process-wide and keyed by path (latest fingerprint wins), like
-// the parse memo below; the persistent sidecar is keyed by the SAME module
-// fingerprint as the TypeEnv cache entry, because both are outputs of the
-// same check. Every reuse arm that skips a module check requires the sidecar
-// too (ensure_module_float_offsets), so which halves of the cache happen to
+// The memo is scoped to ONE typecheck walk: ensure_fingerprint_fs_impl
+// resets it up front, every module the walk accepts (checked, reused, or
+// TDRE9-transported) binds its own path row before the walk returns, and the
+// FS merge unions the rows right after. That lifecycle is what makes the two
+// consumer-side hazards structural non-events rather than policies: a row
+// can never be STALE (nothing from an earlier compile of a since-edited file
+// survives the reset), and nothing EVICTS a row the active compile still
+// needs (the memo is bounded by the closure's module count, so a daemon's
+// memory is bounded per compile without an eviction cap). The persistent
+// sidecar is keyed by the SAME module fingerprint as the TypeEnv cache
+// entry, because both are outputs of the same check. Every reuse arm that
+// skips a module check requires the sidecar too
+// (ensure_module_float_offsets), so which halves of the cache happen to
 // exist can never change a compile's OUTPUT -- a missing sidecar re-checks
 // the module once and writes it (self-healing: no semantics-seed bump, old
 // caches migrate on first touch). The #906 worker transport does not publish
@@ -194,6 +202,12 @@ let module_float_offsets_memo_paths: Array[String] = []
 let module_float_offsets_memo_fps: Array[String] = []
 
 let module_float_offsets_memo_offsets: Array[Array[Int]] = []
+
+fn module_float_offsets_memo_reset() -> Unit {
+  Array::truncate(module_float_offsets_memo_paths, 0)
+  Array::truncate(module_float_offsets_memo_fps, 0)
+  Array::truncate(module_float_offsets_memo_offsets, 0)
+}
 
 fn module_float_offsets_memo_put(path: String, fingerprint: String, offsets: Array[Int]) -> Unit {
   let n = Array::length(module_float_offsets_memo_paths)
@@ -210,15 +224,6 @@ fn module_float_offsets_memo_put(path: String, fingerprint: String, offsets: Arr
     }
   }
   if !found {
-    // Same bound and reset discipline as the parse memo: process-wide, so a
-    // long-lived daemon must not grow it monotonically.
-    if Array::length(module_float_offsets_memo_paths) >= 2048 {
-      Array::truncate(module_float_offsets_memo_paths, 0)
-      Array::truncate(module_float_offsets_memo_fps, 0)
-      Array::truncate(module_float_offsets_memo_offsets, 0)
-    } else {
-      ()
-    }
     Array::push(module_float_offsets_memo_paths, path)
     Array::push(module_float_offsets_memo_fps, fingerprint)
     Array::push(module_float_offsets_memo_offsets, offsets)
@@ -326,7 +331,17 @@ fn parse_module_float_offsets_text(text: String) -> Option[Array[Int]] {
 /// republishes both cache halves.
 fn ensure_module_float_offsets(path: String, fingerprint: String) -> Bool with Exception + Fs {
   match module_float_offsets_memo_get_by_fp(fingerprint) {
-    Some(_) => true,
+    // Bind the hit to THIS path too (Codex P1 on #2425): build_fingerprint
+    // excludes the module's own path, so two byte-identical modules share a
+    // fingerprint, and the consumer lookup is by path -- a hit that only
+    // proved the fingerprint would leave the second module with no row (its
+    // Double calls degrading to the syntactic classifier). Same fingerprint
+    // means same source and dependency fingerprints, so the offsets are the
+    // same table.
+    Some(offsets) => {
+      module_float_offsets_memo_put(path, fingerprint, offsets)
+      true
+    },
     None => {
       let sidecar = persistent_module_float_call_offsets_cache_path(fingerprint)
       if !(Fs::exists(sidecar)) {
@@ -5604,6 +5619,13 @@ fn scheduler_trace_project(buf: StringBuilder, order: Array[String], ranks: Arra
 /// differently from run to run, and scripts/dep_order_oracle.sh asserts the
 /// compiled output is byte-identical across seeds regardless.
 export fn ensure_fingerprint_fs_impl(rdb: RippleDb, env_cache: Array[(String, TypeEnv)], dep_source_cache: Array[(String, String)], parse_count: Int, path: String) -> (String, RippleDb, Array[(String, TypeEnv)], Array[(String, String)], Int) with Exception + Fs {
+  // #2391: the float-offsets memo lives for exactly one walk -- every module
+  // this walk accepts re-binds its row (from the check, the sidecar, or the
+  // TDRE9 target), and the FS merge consumes the rows right after the walk
+  // returns. Resetting here is what rules out a row surviving from an
+  // earlier compile of a since-edited file, without any eviction policy that
+  // could drop a row the ACTIVE compile still needs.
+  module_float_offsets_memo_reset()
   let (plan_leaf_fps, plan_edges, planned_parse_count, plan_diags) = plan_import_graph_fs(rdb, dep_source_cache, parse_count, path)
   // #1239 step 4(A): an import cycle is rejected HERE -- before a single
   // module is checked, committed, or written to the persistent cache --

--- a/lib/@vibe/compiler/runtime/typecheck_fs.vibe
+++ b/lib/@vibe/compiler/runtime/typecheck_fs.vibe
@@ -268,35 +268,25 @@ export fn module_float_call_offsets_for_path(path: String) -> Option[Array[Int]]
   found
 }
 
-/// Order-sensitive checksum over the offset rows, kept non-negative so it
-/// round-trips through the digit-only row parser below. The mask constant is
-/// spelled by arithmetic because the committed seed still enforces the old
-/// 2^61-1 literal bound (see CLAUDE.md's Int notes).
-fn module_float_offsets_checksum(offsets: Array[Int]) -> Int {
-  let mask = (1<<60) - 1
-  let n = Array::length(offsets)
-  let mut h = 17
-  let mut i = 0
-  while i < n {
-    h = ((h * 131) + Array::get(offsets, i) + 1)&mask
-    i = i + 1
-  }
-  h
-}
-
 fn module_float_offsets_text(offsets: Array[Int]) -> String {
   let parts = array_empty()
-  // v2 (#2425 review round 3): the header DECLARES the row count and an
-  // order-sensitive checksum, so a torn write (header plus only some rows)
-  // or a digit-level corruption decodes as a miss instead of silently
-  // changing which call sites the compile classifies.
-  Array::push(parts, String::concat("module_float_call_offsets\tv2\t", String::concat(__to_string(Array::length(offsets)), String::concat("\t", __to_string(module_float_offsets_checksum(offsets))))))
+  // v3 (#2425 review round 3): a torn write survives as a PREFIX of the
+  // intended file, so the envelope closes with an explicit end marker the
+  // strict decoder requires -- truncation loses the marker and decodes as a
+  // miss, and a corrupted row already fails the digit parse. The earlier v2
+  // shape declared a count and checksum instead; rendering those Int call
+  // results through __to_string trips a latent bundle-lane float-offset
+  // misclassification in the compiler's own build (probed to the call-site
+  // offset, not the values -- see the issue linked from PR #2425), so the
+  // envelope deliberately adds no new integer-rendering call sites.
+  Array::push(parts, "module_float_call_offsets\tv3")
   let n = Array::length(offsets)
   let mut i = 0
   while i < n {
     Array::push(parts, __to_string(Array::get(offsets, i)))
     i = i + 1
   }
+  Array::push(parts, "module_float_call_offsets\tend")
   String::concat(String::join(parts, "\n"), "\n")
 }
 
@@ -326,49 +316,41 @@ fn module_float_offsets_parse_nat(line: String) -> Option[Int] {
   }
 }
 
-/// Strict v2 decode: the header's declared count and checksum must both match
-/// the rows actually present, or the answer is `None` -- an ordinary
-/// cold-cache miss that re-checks the module. A truncated file fails the
-/// count, a corrupted row fails the checksum (or the digit parse), and a v1
-/// or foreign header fails outright; none of them can change what a compile
-/// emits.
+/// Strict v3 decode: the header line, digit-only rows, and the closing end
+/// marker must all be present, or the answer is `None` -- an ordinary
+/// cold-cache miss that re-checks the module. A truncated file loses the end
+/// marker, a corrupted row fails the digit parse, and a v1/v2 or foreign
+/// header fails outright; none of them can change what a compile emits.
 fn parse_module_float_offsets_text(text: String) -> Option[Array[Int]] {
   let lines = String::split(normalize_persistent_cache_text(text), "\n")
-  if Array::length(lines) == 0 {
+  if Array::length(lines) == 0 || Array::get(lines, 0) != "module_float_call_offsets\tv3" {
     None
   } else {
-    let header = String::split(Array::get(lines, 0), "\t")
-    if Array::length(header) != 4 || Array::get(header, 0) != "module_float_call_offsets" || Array::get(header, 1) != "v2" {
-      None
-    } else {
-      match module_float_offsets_parse_nat(Array::get(header, 2)) {
-        None => None,
-        Some(declared_count) => match module_float_offsets_parse_nat(Array::get(header, 3)) {
-          None => None,
-          Some(declared_checksum) => {
-            let out: Array[Int] = []
-            let mut ok = true
-            let mut i = 1
-            while i < Array::length(lines) && ok {
-              let line = Array::get(lines, i)
-              if String::length(line) == 0 {
-                ()
-              } else {
-                match module_float_offsets_parse_nat(line) {
-                  Some(value) => Array::push(out, value),
-                  None => ok = false
-                }
-              }
-              i = i + 1
-            }
-            if ok && Array::length(out) == declared_count && module_float_offsets_checksum(out) == declared_checksum {
-              Some(out)
-            } else {
-              None
-            }
-          }
+    let out: Array[Int] = []
+    let mut ok = true
+    let mut saw_end = false
+    let mut i = 1
+    while i < Array::length(lines) && ok {
+      let line = Array::get(lines, i)
+      if String::length(line) == 0 {
+        ()
+      } else if saw_end {
+        // Content after the end marker is not a prefix of any valid write.
+        ok = false
+      } else if line == "module_float_call_offsets\tend" {
+        saw_end = true
+      } else {
+        match module_float_offsets_parse_nat(line) {
+          Some(value) => Array::push(out, value),
+          None => ok = false
         }
       }
+      i = i + 1
+    }
+    if ok && saw_end {
+      Some(out)
+    } else {
+      None
     }
   }
 }

--- a/lib/@vibe/compiler/runtime/typecheck_fs.vibe
+++ b/lib/@vibe/compiler/runtime/typecheck_fs.vibe
@@ -270,17 +270,19 @@ export fn module_float_call_offsets_for_path(path: String) -> Option[Array[Int]]
 
 fn module_float_offsets_text(offsets: Array[Int]) -> String {
   let parts = array_empty()
-  // v4 (#2425 review rounds 3+5): a torn write survives as a PREFIX of the
-  // intended file, so the envelope closes with an explicit end marker the
-  // strict decoder requires -- truncation loses the marker and decodes as a
-  // miss -- and every row is duplicated so a digit-level corruption breaks
-  // the duplicate equality instead of being accepted. The earlier v2
+  // v5 (#2425 review rounds 3+5+6): a torn write survives as a PREFIX of
+  // the intended file, so the envelope closes with an explicit end marker
+  // the strict decoder requires -- truncation loses the marker and decodes
+  // as a miss -- every row is duplicated so a digit-level corruption breaks
+  // the duplicate equality, and a unary count line binds the row-set size
+  // so deleting or inserting a whole row fails too. The earlier v2
   // shape declared a count and checksum instead; rendering those Int call
   // results through __to_string trips a latent bundle-lane float-offset
   // misclassification in the compiler's own build (probed to the call-site
   // offset, not the values -- see the issue linked from PR #2425), so the
   // envelope deliberately adds no new integer-rendering call sites.
-  Array::push(parts, "module_float_call_offsets\tv4")
+  Array::push(parts, "module_float_call_offsets\tv5")
+  let count_marks = array_empty()
   let n = Array::length(offsets)
   let mut i = 0
   while i < n {
@@ -291,8 +293,16 @@ fn module_float_offsets_text(offsets: Array[Int]) -> String {
     // header note on why a rendered checksum is off the table).
     let row_text = __to_string(Array::get(offsets, i))
     Array::push(parts, String::concat(row_text, String::concat("\t", row_text)))
+    Array::push(count_marks, "#")
     i = i + 1
   }
+  // The count line binds the ROW SET's size in UNARY (#2425 round 6): one
+  // '#' per row, so deleting or inserting a whole duplicated row breaks the
+  // count without rendering any integer through __to_string (the #2427
+  // constraint). Reordering rows is semantically inert -- the table is a
+  // SET of offsets -- so size plus per-row duplicate equality plus the end
+  // marker covers every corruption that could change what a compile emits.
+  Array::push(parts, String::concat("module_float_call_offsets\tcount\t", String::join(count_marks, "")))
   Array::push(parts, "module_float_call_offsets\tend")
   String::concat(String::join(parts, "\n"), "\n")
 }
@@ -323,21 +333,23 @@ fn module_float_offsets_parse_nat(line: String) -> Option[Int] {
   }
 }
 
-/// Strict v4 decode: the header line, duplicated digit-only rows, and the
-/// closing end marker must all be present, or the answer is `None` -- an
-/// ordinary cold-cache miss that re-checks the module. A truncated file
-/// loses the end marker, a corrupted row fails the digit parse or the
-/// duplicate equality (a random digit change cannot hit both copies
-/// identically), and a v1/v2/v3 or foreign header fails outright; none of
-/// them can change what a compile emits.
+/// Strict v5 decode: the header line, duplicated digit-only rows, exactly
+/// one unary count line whose length equals the row count, and the closing
+/// end marker must all be present, or the answer is `None` -- an ordinary
+/// cold-cache miss that re-checks the module. A truncated file loses the
+/// end marker, a corrupted row fails the digit parse or the duplicate
+/// equality (a random digit change cannot hit both copies identically), a
+/// deleted or inserted row fails the count, and a v1..v4 or foreign header
+/// fails outright; none of them can change what a compile emits.
 fn parse_module_float_offsets_text(text: String) -> Option[Array[Int]] {
   let lines = String::split(normalize_persistent_cache_text(text), "\n")
-  if Array::length(lines) == 0 || Array::get(lines, 0) != "module_float_call_offsets\tv4" {
+  if Array::length(lines) == 0 || Array::get(lines, 0) != "module_float_call_offsets\tv5" {
     None
   } else {
     let out: Array[Int] = []
     let mut ok = true
     let mut saw_end = false
+    let mut declared_count = 0 - 1
     let mut i = 1
     while i < Array::length(lines) && ok {
       let line = Array::get(lines, i)
@@ -348,6 +360,28 @@ fn parse_module_float_offsets_text(text: String) -> Option[Array[Int]] {
         ok = false
       } else if line == "module_float_call_offsets\tend" {
         saw_end = true
+      } else if String::starts_with(line, "module_float_call_offsets\tcount\t") {
+        if declared_count >= 0 {
+          // A second count line is not a prefix of any valid write.
+          ok = false
+        } else {
+          let unary_start = String::length("module_float_call_offsets\tcount\t")
+          let line_len = String::length(line)
+          let mut mark = unary_start
+          let mut marks_ok = true
+          while mark < line_len && marks_ok {
+            if String::char_code_at(line, mark) == 35 {
+              mark = mark + 1
+            } else {
+              marks_ok = false
+            }
+          }
+          if marks_ok {
+            declared_count = line_len - unary_start
+          } else {
+            ok = false
+          }
+        }
       } else {
         let cells = String::split(line, "\t")
         if Array::length(cells) != 2 || Array::get(cells, 0) != Array::get(cells, 1) {
@@ -361,7 +395,7 @@ fn parse_module_float_offsets_text(text: String) -> Option[Array[Int]] {
       }
       i = i + 1
     }
-    if ok && saw_end {
+    if ok && saw_end && declared_count == Array::length(out) {
       Some(out)
     } else {
       None

--- a/lib/@vibe/compiler/runtime/typecheck_fs.vibe
+++ b/lib/@vibe/compiler/runtime/typecheck_fs.vibe
@@ -5,6 +5,7 @@ import @vibe/compiler/cache {
   normalize_persistent_cache_text,
   persistent_dep_list_cache_path,
   persistent_leaf_fingerprint_cache_path,
+  persistent_module_float_call_offsets_cache_path,
   persistent_type_env_cache_path,
   persistent_typing_dependency_env_reuse_eligibility_path,
   persistent_typing_dependency_env_reuse_sidecar_path
@@ -21,10 +22,9 @@ import @vibe/ast {
 import @vibe/compiler/checker {
   CheckedProgram,
   check_program,
-  check_program_result,
   check_program_type_table,
   check_program_with_env_result,
-  check_program_with_projected_import_env_result,
+  check_program_with_projected_import_env_double_call_result_located_observation,
   detect_redundant_namespace_imports,
   detect_unbound_nonunit_returns,
   detect_unused_imports,
@@ -164,6 +164,183 @@ fn valid_persistent_leaf_fingerprint(path: String, source: String) -> Option[Str
       None => None
     },
     None => None
+  }
+}
+
+//# #2391: per-module Double call-result offsets (the #2158 channel, modular)
+//
+// check_module retains, per checked module, the source-located primary call
+// results whose checker-confirmed instantiated type is Double -- in the
+// module's OWN offset space. The FS compile lanes rebase each file into a
+// disjoint offset range and union these tables to feed
+// `CompileCtx.float_call_offsets`, so a Double that arrives through a call
+// renders correctly on the import-resolving lanes too (the single-source and
+// gc lanes already carry the channel; compile_file_fs_mode's #2158 note has
+// the measurement for why a whole-program re-check was not the way).
+//
+// The memo is process-wide and keyed by path (latest fingerprint wins), like
+// the parse memo below; the persistent sidecar is keyed by the SAME module
+// fingerprint as the TypeEnv cache entry, because both are outputs of the
+// same check. Every reuse arm that skips a module check requires the sidecar
+// too (ensure_module_float_offsets), so which halves of the cache happen to
+// exist can never change a compile's OUTPUT -- a missing sidecar re-checks
+// the module once and writes it (self-healing: no semantics-seed bump, old
+// caches migrate on first touch). The #906 worker transport does not publish
+// the sidecar yet, so a worker-checked module is re-checked by the next
+// in-driver compile rather than silently losing its offsets.
+
+let module_float_offsets_memo_paths: Array[String] = []
+
+let module_float_offsets_memo_fps: Array[String] = []
+
+let module_float_offsets_memo_offsets: Array[Array[Int]] = []
+
+fn module_float_offsets_memo_put(path: String, fingerprint: String, offsets: Array[Int]) -> Unit {
+  let n = Array::length(module_float_offsets_memo_paths)
+  let mut i = 0
+  let mut found = false
+  while i < n {
+    if Array::get(module_float_offsets_memo_paths, i) == path {
+      Array::set(module_float_offsets_memo_fps, i, fingerprint)
+      Array::set(module_float_offsets_memo_offsets, i, offsets)
+      found = true
+      i = n
+    } else {
+      i = i + 1
+    }
+  }
+  if !found {
+    // Same bound and reset discipline as the parse memo: process-wide, so a
+    // long-lived daemon must not grow it monotonically.
+    if Array::length(module_float_offsets_memo_paths) >= 2048 {
+      Array::truncate(module_float_offsets_memo_paths, 0)
+      Array::truncate(module_float_offsets_memo_fps, 0)
+      Array::truncate(module_float_offsets_memo_offsets, 0)
+    } else {
+      ()
+    }
+    Array::push(module_float_offsets_memo_paths, path)
+    Array::push(module_float_offsets_memo_fps, fingerprint)
+    Array::push(module_float_offsets_memo_offsets, offsets)
+  } else {
+    ()
+  }
+}
+
+fn module_float_offsets_memo_get_by_fp(fingerprint: String) -> Option[Array[Int]] {
+  let n = Array::length(module_float_offsets_memo_fps)
+  let mut i = 0
+  let mut found: Option[Array[Int]] = None
+  while i < n {
+    if Array::get(module_float_offsets_memo_fps, i) == fingerprint {
+      found = Some(Array::get(module_float_offsets_memo_offsets, i))
+      i = n
+    } else {
+      i = i + 1
+    }
+  }
+  found
+}
+
+/// The consumer query: this module's Double call-result offsets, in its own
+/// offset space, as recorded by the most recent check (or sidecar load) of
+/// `path` in this process. `None` means the module was never stepped here --
+/// the FS lanes treat that file as contributing no offsets, which degrades
+/// that file's calls to the pre-#2158 syntactic classifier rather than to a
+/// wrong answer.
+export fn module_float_call_offsets_for_path(path: String) -> Option[Array[Int]] {
+  let n = Array::length(module_float_offsets_memo_paths)
+  let mut i = 0
+  let mut found: Option[Array[Int]] = None
+  while i < n {
+    if Array::get(module_float_offsets_memo_paths, i) == path {
+      found = Some(Array::get(module_float_offsets_memo_offsets, i))
+      i = n
+    } else {
+      i = i + 1
+    }
+  }
+  found
+}
+
+fn module_float_offsets_text(offsets: Array[Int]) -> String {
+  let parts = array_empty()
+  Array::push(parts, "module_float_call_offsets\tv1")
+  let n = Array::length(offsets)
+  let mut i = 0
+  while i < n {
+    Array::push(parts, __to_string(Array::get(offsets, i)))
+    i = i + 1
+  }
+  String::concat(String::join(parts, "\n"), "\n")
+}
+
+/// Tolerant decode: any deviation from the exact v1 shape is `None` (an
+/// ordinary cold-cache miss that re-checks the module), never a throw and
+/// never a partial answer.
+fn parse_module_float_offsets_text(text: String) -> Option[Array[Int]] {
+  let lines = String::split(normalize_persistent_cache_text(text), "\n")
+  if Array::length(lines) == 0 || Array::get(lines, 0) != "module_float_call_offsets\tv1" {
+    None
+  } else {
+    let out: Array[Int] = []
+    let mut ok = true
+    let mut i = 1
+    while i < Array::length(lines) {
+      let line = Array::get(lines, i)
+      if String::length(line) == 0 {
+        ()
+      } else {
+        let mut value = 0
+        let mut j = 0
+        let len = String::length(line)
+        while j < len && ok {
+          let c = String::char_code_at(line, j)
+          if c >= 48 && c <= 57 {
+            value = value * 10 + (c - 48)
+          } else {
+            ok = false
+          }
+          j = j + 1
+        }
+        if ok {
+          Array::push(out, value)
+        } else {
+          ()
+        }
+      }
+      i = i + 1
+    }
+    if ok {
+      Some(out)
+    } else {
+      None
+    }
+  }
+}
+
+/// True when `path`'s offsets for `fingerprint` are available (memo, else the
+/// persistent sidecar, loaded into the memo). Every reuse arm that would skip
+/// this module's check calls this alongside `valid_persistent_type_env`; a
+/// `false` makes the arm fall through to a real check, which recomputes AND
+/// republishes both cache halves.
+fn ensure_module_float_offsets(path: String, fingerprint: String) -> Bool with Exception + Fs {
+  match module_float_offsets_memo_get_by_fp(fingerprint) {
+    Some(_) => true,
+    None => {
+      let sidecar = persistent_module_float_call_offsets_cache_path(fingerprint)
+      if !(Fs::exists(sidecar)) {
+        false
+      } else {
+        match parse_module_float_offsets_text(Fs::read_file(sidecar)) {
+          Some(offsets) => {
+            module_float_offsets_memo_put(path, fingerprint, offsets)
+            true
+          },
+          None => false
+        }
+      }
+    }
   }
 }
 
@@ -4336,10 +4513,19 @@ fn check_module_impl(job: ModuleJob, observe_typing_artifact: Bool) -> ModuleOut
       // invocation. No caller-supplied CheckedProgram or diagnostic assertion
       // participates in the #1550 observation.
       incremental_typecheck_telemetry_add(6, 1)
-      let checked_program = match import_env {
-        EnvEmpty => check_program_result(stmts),
-        _ => check_program_with_projected_import_env_result(stmts, import_env)
-      }
+      // #2391: one checker invocation, two outputs -- the CheckedProgram this
+      // function always produced (EnvEmpty delegates to the plain check, so
+      // both former arms are preserved), plus this module's Double
+      // call-result offsets for the FS lanes' float_call_offsets channel.
+      let (checked_program, located_offsets) = check_program_with_projected_import_env_double_call_result_located_observation(stmts, import_env)
+      // `None` (the parse carried no offsets) cannot happen on this lane --
+      // parse_program_with_path_impl lexes with offsets -- but if it did, an
+      // empty table classifies nothing and leaves the syntactic classifier
+      // in charge, deterministically.
+      module_float_offsets_memo_put(job.path, fingerprint, match located_offsets {
+        Some(offsets) => offsets,
+        None => array_empty()
+      })
       let full_checked_env = checked_program.final_env
       // #1533: what leaves this function is the module's PUBLISHED
       // environment -- restricted to its export surface -- because every
@@ -4408,6 +4594,15 @@ fn commit_module_outcome(rdb: RippleDb, env_cache: Array[(String, TypeEnv)], dep
       // the exact same text as the conservative target; serializing it a second
       // time materially inflates fresh selfcompile heap without adding evidence.
       let target_text = store_persistent_type_env(fingerprint, checked_env)
+      // #2391: publish the second output of the same check next to the env.
+      // check_module recorded it in the process memo under this fingerprint;
+      // an outcome that arrived WITHOUT a memo entry (the #906 worker
+      // transport checks in another process) publishes no sidecar, and the
+      // reuse arms then re-check that module in-driver next time.
+      match module_float_offsets_memo_get_by_fp(fingerprint) {
+        Some(offsets) => Fs::write_file(persistent_module_float_call_offsets_cache_path(fingerprint), module_float_offsets_text(offsets)),
+        None => ()
+      }
       // Publish in commit order: canonical target first, bound witness second,
       // alias last. Diagnosed/thrown checks never enter this Checked arm. Keep
       // the extra canonical target text and input serialization wholly inside
@@ -4666,7 +4861,17 @@ fn parse_publish_manifest_rows(text: String) -> Array[(String, String)] with Exc
 /// cross-check) that identical fingerprint itself, the same way a worker
 /// would -- one canonical computation, not a value trusted from the caller.
 fn finish_typecheck_fs_impl(rdb: RippleDb, env_cache: Array[(String, TypeEnv)], dep_source_cache: Array[(String, String)], parse_count: Int, path: String, source: String, deps: Array[String], dep_fps: Array[(String, String)], fingerprint: String) -> (String, RippleDb, Array[(String, TypeEnv)], Array[(String, String)], Int) with Exception + Fs {
-  match valid_persistent_type_env(fingerprint) {
+  // #2391: reuse requires the float-offsets sidecar alongside the TypeEnv
+  // entry, or the arm below runs the real check (which republishes both).
+  let reusable_cached_env = match valid_persistent_type_env(fingerprint) {
+    Some(cached_env) => if ensure_module_float_offsets(path, fingerprint) {
+      Some(cached_env)
+    } else {
+      None
+    },
+    None => None
+  }
+  match reusable_cached_env {
     Some(cached_env) => {
       if incremental_interface_trace_enabled() {
         incremental_trace_observe_checked_env(path, source, cached_env)
@@ -4687,7 +4892,22 @@ fn finish_typecheck_fs_impl(rdb: RippleDb, env_cache: Array[(String, TypeEnv)], 
         if typing_dependency_env_reuse_is_eligible(dep_fps) {
           let input_key = typing_dependency_transport_input_key(path, source, typing_semantics_seed(), projected_dep_envs)
           match load_typing_dependency_env_reuse_target(input_key) {
-            Some((target_fingerprint, target_text, target_env)) => Some((input_key, target_fingerprint, target_text, target_env)),
+            // #2391: the transported env must bring the module's float
+            // offsets along, or the reuse would publish a conservative env
+            // entry with no sidecar and every later compile would decline
+            // the half-entry. The offsets live under the TARGET fingerprint
+            // -- the original check that published this eligibility also
+            // committed them there -- and the input key binds this module's
+            // VERBATIM source plus each dependency's exact env text, so a
+            // hit implies the offsets are identical for this compile; the
+            // acceptance arm below republishes them under the new
+            // conservative fingerprint. Missing offsets decline the reuse,
+            // and the one real check republishes both halves.
+            Some((target_fingerprint, target_text, target_env)) => if ensure_module_float_offsets(path, target_fingerprint) {
+              Some((input_key, target_fingerprint, target_text, target_env))
+            } else {
+              None
+            },
             None => None
           }
         } else {
@@ -4697,11 +4917,22 @@ fn finish_typecheck_fs_impl(rdb: RippleDb, env_cache: Array[(String, TypeEnv)], 
         None
       }
       match reused_env {
-        Some((input_key, _target_fingerprint, target_text, target_env)) => {
+        Some((input_key, target_fingerprint, target_text, target_env)) => {
           // Preserve the ordinary conservative fingerprint path for every later
           // consumer. Commit this target first, then its exact bound witness, and
           // only then the alias, so torn publication always fails closed.
           Fs::write_file(persistent_type_env_cache_path(fingerprint), target_text)
+          // #2391: republish the target's float offsets under the new
+          // conservative fingerprint, so the entry the line above created
+          // has both halves and the plain reuse arms accept it. The gate
+          // above hydrated the memo from the target fingerprint.
+          match module_float_offsets_memo_get_by_fp(target_fingerprint) {
+            Some(reused_offsets) => {
+              module_float_offsets_memo_put(path, fingerprint, reused_offsets)
+              Fs::write_file(persistent_module_float_call_offsets_cache_path(fingerprint), module_float_offsets_text(reused_offsets))
+            },
+            None => ()
+          }
           publish_typing_dependency_env_reuse_eligibility(input_key, fingerprint, target_text)
           write_typing_dependency_env_reuse_sidecar(input_key, fingerprint, target_text)
           let next_env_cache = upsert_env_cache(coordinated_env_cache, path, target_env)
@@ -4812,8 +5043,10 @@ fn plan_import_graph_fs(rdb: RippleDb, dep_source_cache: Array[(String, String)]
       Some(source) => {
         let reusable = if dep_source_cache_is_current(dep_source_cache, path, source) {
           match ripple_get_fingerprint(rdb, path) {
+            // #2391: reuse needs BOTH cache halves -- the TypeEnv and the
+            // module's float-offsets sidecar -- or the walk must re-check.
             Some(fingerprint) => match valid_persistent_type_env(fingerprint) {
-              Some(_) => true,
+              Some(_) => ensure_module_float_offsets(path, fingerprint),
               None => false
             },
             None => false
@@ -4906,8 +5139,9 @@ fn plan_deps_of(plan_edges: Array[(String, Array[String])], path: String) -> Opt
 fn commit_leaf_fingerprint_fs(rdb: RippleDb, env_cache: Array[(String, TypeEnv)], dep_source_cache: Array[(String, String)], parse_count: Int, path: String, source: String, leaf_fingerprint: String) -> (String, RippleDb, Array[(String, TypeEnv)], Array[(String, String)], Int) with Exception + Fs {
   // The plan read this cache earlier, but recheck at the accepting edge: a
   // stale/malformed leaf pointer must cold-check rather than become authority.
+  // #2391: the float-offsets sidecar is part of that acceptance too.
   match valid_persistent_type_env(leaf_fingerprint) {
-    Some(cached_env) => {
+    Some(cached_env) => if ensure_module_float_offsets(path, leaf_fingerprint) {
       if incremental_interface_trace_enabled() {
         incremental_trace_observe_checked_env(path, source, cached_env)
       } else {
@@ -4918,6 +5152,8 @@ fn commit_leaf_fingerprint_fs(rdb: RippleDb, env_cache: Array[(String, TypeEnv)]
       let next_db = ripple_record_eval(rdb, path, leaf_fingerprint, empty_stack())
       incremental_typecheck_telemetry_add(7, 1)
       (leaf_fingerprint, next_db, env_cache, next_dep_source_cache, parse_count)
+    } else {
+      finish_typecheck_fs_impl(rdb, env_cache, dep_source_cache, parse_count, path, source, empty_stack(), empty_dep_fps(), build_fingerprint(source, empty_dep_fps(), typing_semantics_seed()))
     },
     None => finish_typecheck_fs_impl(rdb, env_cache, dep_source_cache, parse_count, path, source, empty_stack(), empty_dep_fps(), build_fingerprint(source, empty_dep_fps(), typing_semantics_seed()))
   }
@@ -4947,9 +5183,12 @@ fn commit_with_deps_fs(fps: Array[(String, String)], rdb: RippleDb, env_cache: A
     Some(cached_fp) =>
     if cached_fp == fingerprint {
       match valid_persistent_type_env(fingerprint) {
-        Some(_) => {
+        // #2391: both cache halves, or re-check (which republishes both).
+        Some(_) => if ensure_module_float_offsets(path, fingerprint) {
           incremental_typecheck_telemetry_add(7, 1)
           (fingerprint, rdb, env_cache, dep_source_cache, parse_count)
+        } else {
+          finish_typecheck_fs_impl(rdb, env_cache, dep_source_cache, parse_count, path, source, deps, dep_fps, fingerprint)
         },
         None => finish_typecheck_fs_impl(rdb, env_cache, dep_source_cache, parse_count, path, source, deps, dep_fps, fingerprint)
       }
@@ -4987,8 +5226,13 @@ fn step_module_fs(plan_leaf_fps: Array[(String, String)], plan_edges: Array[(Str
     Some(source) => {
       let reusable = if dep_source_cache_is_current(dep_source_cache, path, source) {
         match ripple_get_fingerprint(rdb_loaded, path) {
+          // #2391: both cache halves, or no reuse (see ensure_module_float_offsets).
           Some(fingerprint) => match valid_persistent_type_env(fingerprint) {
-            Some(_) => Some(fingerprint),
+            Some(_) => if ensure_module_float_offsets(path, fingerprint) {
+              Some(fingerprint)
+            } else {
+              None
+            },
             None => None
           },
           None => None

--- a/lib/@vibe/compiler/runtime/typecheck_fs.vibe
+++ b/lib/@vibe/compiler/runtime/typecheck_fs.vibe
@@ -270,20 +270,27 @@ export fn module_float_call_offsets_for_path(path: String) -> Option[Array[Int]]
 
 fn module_float_offsets_text(offsets: Array[Int]) -> String {
   let parts = array_empty()
-  // v3 (#2425 review round 3): a torn write survives as a PREFIX of the
+  // v4 (#2425 review rounds 3+5): a torn write survives as a PREFIX of the
   // intended file, so the envelope closes with an explicit end marker the
   // strict decoder requires -- truncation loses the marker and decodes as a
-  // miss, and a corrupted row already fails the digit parse. The earlier v2
+  // miss -- and every row is duplicated so a digit-level corruption breaks
+  // the duplicate equality instead of being accepted. The earlier v2
   // shape declared a count and checksum instead; rendering those Int call
   // results through __to_string trips a latent bundle-lane float-offset
   // misclassification in the compiler's own build (probed to the call-site
   // offset, not the values -- see the issue linked from PR #2425), so the
   // envelope deliberately adds no new integer-rendering call sites.
-  Array::push(parts, "module_float_call_offsets\tv3")
+  Array::push(parts, "module_float_call_offsets\tv4")
   let n = Array::length(offsets)
   let mut i = 0
   while i < n {
-    Array::push(parts, __to_string(Array::get(offsets, i)))
+    // Each row carries the SAME rendered value twice (#2425 round 5): a
+    // digit-level corruption inside an otherwise-intact file breaks the
+    // duplicate equality and decodes as a miss, without introducing any new
+    // integer-rendering call site (one __to_string, reused -- see the
+    // header note on why a rendered checksum is off the table).
+    let row_text = __to_string(Array::get(offsets, i))
+    Array::push(parts, String::concat(row_text, String::concat("\t", row_text)))
     i = i + 1
   }
   Array::push(parts, "module_float_call_offsets\tend")
@@ -316,14 +323,16 @@ fn module_float_offsets_parse_nat(line: String) -> Option[Int] {
   }
 }
 
-/// Strict v3 decode: the header line, digit-only rows, and the closing end
-/// marker must all be present, or the answer is `None` -- an ordinary
-/// cold-cache miss that re-checks the module. A truncated file loses the end
-/// marker, a corrupted row fails the digit parse, and a v1/v2 or foreign
-/// header fails outright; none of them can change what a compile emits.
+/// Strict v4 decode: the header line, duplicated digit-only rows, and the
+/// closing end marker must all be present, or the answer is `None` -- an
+/// ordinary cold-cache miss that re-checks the module. A truncated file
+/// loses the end marker, a corrupted row fails the digit parse or the
+/// duplicate equality (a random digit change cannot hit both copies
+/// identically), and a v1/v2/v3 or foreign header fails outright; none of
+/// them can change what a compile emits.
 fn parse_module_float_offsets_text(text: String) -> Option[Array[Int]] {
   let lines = String::split(normalize_persistent_cache_text(text), "\n")
-  if Array::length(lines) == 0 || Array::get(lines, 0) != "module_float_call_offsets\tv3" {
+  if Array::length(lines) == 0 || Array::get(lines, 0) != "module_float_call_offsets\tv4" {
     None
   } else {
     let out: Array[Int] = []
@@ -340,9 +349,14 @@ fn parse_module_float_offsets_text(text: String) -> Option[Array[Int]] {
       } else if line == "module_float_call_offsets\tend" {
         saw_end = true
       } else {
-        match module_float_offsets_parse_nat(line) {
-          Some(value) => Array::push(out, value),
-          None => ok = false
+        let cells = String::split(line, "\t")
+        if Array::length(cells) != 2 || Array::get(cells, 0) != Array::get(cells, 1) {
+          ok = false
+        } else {
+          match module_float_offsets_parse_nat(Array::get(cells, 0)) {
+            Some(value) => Array::push(out, value),
+            None => ok = false
+          }
         }
       }
       i = i + 1

--- a/lib/@vibe/compiler/tests/float_call_offset_fs_coll_a.vibe
+++ b/lib/@vibe/compiler/tests/float_call_offset_fs_coll_a.vibe
@@ -1,0 +1,15 @@
+//# Functions
+
+// #2391 (#2425 review round 2): imported by
+// float_call_offset_fs_lane_test.vibe both directly and through the
+// re-export facade float_call_offset_fs_coll_facade.vibe -- a
+// collision-shaped import pair (same original name, two import paths).
+// See the test's comment for what this does and does not reach: the
+// export-rename plan covers this shape before the #716 clone fallback
+// would fire, so the test pins the reachable collision path.
+export fn fs_coll_describe() -> String {
+  let f = () -> {
+    2.5
+  }
+  __to_string(f())
+}

--- a/lib/@vibe/compiler/tests/float_call_offset_fs_coll_facade.vibe
+++ b/lib/@vibe/compiler/tests/float_call_offset_fs_coll_facade.vibe
@@ -1,0 +1,11 @@
+//# Imports
+
+// #2391 (#2425 review round 2): re-export facade over
+// float_call_offset_fs_coll_a.vibe. Importing `fs_coll_describe` from BOTH
+// this facade and the implementation file gives the same original name two
+// import paths -- a collision-shaped pair. See the lane test's comment:
+// the export-rename plan covers this shape before the #716 clone fallback
+// would fire.
+export ./float_call_offset_fs_coll_a.vibe {
+  fs_coll_describe
+}

--- a/lib/@vibe/compiler/tests/float_call_offset_fs_dep.vibe
+++ b/lib/@vibe/compiler/tests/float_call_offset_fs_dep.vibe
@@ -1,0 +1,10 @@
+//# Functions
+
+// #2391: dependency half of float_call_offset_fs_lane_test.vibe. The literal
+// `-> Double` annotation is deliberate -- what the test pins is the CALL SITE
+// in the importing file, where the name `fs_dep_half` resolves through the
+// import environment rather than a local declaration the syntactic
+// classifier could scan.
+export fn fs_dep_half(a: Double) -> Double {
+  a / 2.0
+}

--- a/lib/@vibe/compiler/tests/float_call_offset_fs_lane_test.vibe
+++ b/lib/@vibe/compiler/tests/float_call_offset_fs_lane_test.vibe
@@ -4,6 +4,14 @@ import ./float_call_offset_fs_dep.vibe {
   fs_dep_half
 }
 
+import ./float_call_offset_fs_twin_a.vibe {
+  fs_twin_describe as twin_a_describe
+}
+
+import ./float_call_offset_fs_twin_b.vibe {
+  fs_twin_describe as twin_b_describe
+}
+
 //# Functions
 
 // #2391: the checker's per-call-site Double answer reaching the LINEAR
@@ -77,6 +85,17 @@ test "#2391 fs-lane offsets: a call to an IMPORTED Double function" {
   inspect(__to_string(fs_dep_half(5.0)), "2.5")
   let h = fs_dep_half
   inspect(__to_string(h(5.0)), "2.5")
+}
+
+test "#2391 fs-lane offsets: two byte-identical modules both keep their offsets" {
+  // Codex P1 on #2425: the twin files are byte-identical, so they share a
+  // module fingerprint (build_fingerprint excludes the path). The walk
+  // checks one and reuses the other off the just-written cache entry; a
+  // fingerprint-keyed memo hit that did not also bind the second PATH left
+  // that module with no offsets row, and its internal Double printed raw
+  // bits. Both twins must answer, whichever the walk happened to check.
+  inspect(twin_a_describe(), "2.5")
+  inspect(twin_b_describe(), "2.5")
 }
 
 test "#2391 fs-lane offsets: an Int-returning call is NOT reclassified" {

--- a/lib/@vibe/compiler/tests/float_call_offset_fs_lane_test.vibe
+++ b/lib/@vibe/compiler/tests/float_call_offset_fs_lane_test.vibe
@@ -1,0 +1,87 @@
+//# Imports
+
+import ./float_call_offset_fs_dep.vibe {
+  fs_dep_half
+}
+
+//# Functions
+
+// #2391: the checker's per-call-site Double answer reaching the LINEAR
+// backend on the IMPORT-RESOLVING FS lane -- the lane `vibe test` and
+// `vibe run` take by default (compile_file_fs_mode_rc).
+//
+// This is the FS-lane sibling of fixtures/float_call_offset_source_lane.vibe
+// (#2158), which pinned the same shapes on the single-source lane. Here the
+// offsets ride the MODULAR check (check_module records each module's Double
+// call-result offsets in its own offset space; the merge rebases every file
+// into a disjoint range and unions the tables), so this file runs through the
+// ordinary `vibe test` glob on purpose: the unit runner compiles it with
+// VIBE_FS_COMPILE=1, which is exactly the lane under test.
+//
+// Measured on the stage2 before the wiring (2026-08-30), each non-control
+// shape below printed the f64 bits as a plausible integer (e.g. the inferred
+// lambda's 2.5 printed as 584 and Array::get's 1.5 as 306 in the probe that
+// motivated this file).
+
+fn fs_dbl(x: Double) -> Double {
+  x * 2.0
+}
+
+fn fs_id[T](v: T) -> T {
+  v
+}
+
+fn fs_arr() -> Array[Double] {
+  [2.5, 3.5]
+}
+
+fn fs_int_pair() -> (Int, Int) {
+  (3, 4)
+}
+
+//# Tests
+
+test "#2391 fs-lane offsets: an inferred lambda's result" {
+  let f = () -> {
+    2.5
+  }
+  inspect(__to_string(f()), "2.5")
+}
+
+test "#2391 fs-lane offsets: a generic instantiated at Double" {
+  inspect(__to_string(fs_id(2.5)), "2.5")
+  inspect(__to_string(fs_id(1)), "1")
+}
+
+test "#2391 fs-lane offsets: a call through a local alias" {
+  let g = fs_dbl
+  inspect(__to_string(g(1.25)), "2.5")
+}
+
+test "#2391 fs-lane offsets: an annotated lambda binding" {
+  let lam = (v: Double) -> Double {
+    v * 2.5
+  }
+  inspect(__to_string(lam(1.0)), "2.5")
+}
+
+test "#2391 fs-lane offsets: Array::get on an Array[Double]" {
+  inspect(__to_string(Array::get(fs_arr(), 0)), "2.5")
+}
+
+test "#2391 fs-lane offsets: a call to an IMPORTED Double function" {
+  // The shape only the FS lane has: the callee's declaration lives in another
+  // module, so its type reaches this call site through the import environment
+  // the modular check projected -- there is nothing in THIS file for a
+  // declaration scan to read through the lambda-shaped alias below.
+  inspect(__to_string(fs_dep_half(5.0)), "2.5")
+  let h = fs_dep_half
+  inspect(__to_string(h(5.0)), "2.5")
+}
+
+test "#2391 fs-lane offsets: an Int-returning call is NOT reclassified" {
+  // The other direction: the checker records these as Int, so their offsets
+  // never enter the table, and a tagged integer is never read as an f64.
+  inspect(__to_string(fs_int_pair().0 + fs_int_pair().1), "7")
+  inspect(__to_string(fs_int_pair().0), "3")
+}

--- a/lib/@vibe/compiler/tests/float_call_offset_fs_lane_test.vibe
+++ b/lib/@vibe/compiler/tests/float_call_offset_fs_lane_test.vibe
@@ -4,6 +4,14 @@ import ./float_call_offset_fs_dep.vibe {
   fs_dep_half
 }
 
+import ./float_call_offset_fs_coll_a.vibe {
+  fs_coll_describe as coll_a_describe
+}
+
+import ./float_call_offset_fs_coll_facade.vibe {
+  fs_coll_describe as coll_facade_describe
+}
+
 import ./float_call_offset_fs_twin_a.vibe {
   fs_twin_describe as twin_a_describe
 }
@@ -96,6 +104,25 @@ test "#2391 fs-lane offsets: two byte-identical modules both keep their offsets"
   // bits. Both twins must answer, whichever the walk happened to check.
   inspect(twin_a_describe(), "2.5")
   inspect(twin_b_describe(), "2.5")
+}
+
+test "#2391 fs-lane offsets: collision-shaped imports keep their offsets" {
+  // Codex round 2 on #2425 flagged the #716 alias-collision fallback
+  // (append_import_alias_collision_defs_from_sources): a fallback CLONE is
+  // provider code shifted into a fresh offset range, so the union now
+  // duplicates the provider's Double call-result offsets with the clone's
+  // delta. An END-TO-END red for that arm was not reproducible: both
+  // collision shapes constructed for it -- the same original name exported
+  // by two providers, and (here) the same original imported directly and
+  // through a re-export facade -- are covered by the export-rename plan
+  // before the fallback would fire, and the executed copies answer from the
+  // ordinary per-file union. This test pins those reachable collision
+  // shapes; the clone-table duplication itself is inert-or-correct by
+  // construction (a clone is a byte-for-byte provider copy at a disjoint
+  // delta, so a duplicated offset lands on the corresponding cloned call
+  // node or on nothing).
+  inspect(coll_a_describe(), "2.5")
+  inspect(coll_facade_describe(), "2.5")
 }
 
 test "#2391 fs-lane offsets: an Int-returning call is NOT reclassified" {

--- a/lib/@vibe/compiler/tests/float_call_offset_fs_twin_a.vibe
+++ b/lib/@vibe/compiler/tests/float_call_offset_fs_twin_a.vibe
@@ -1,0 +1,16 @@
+//# Functions
+
+// #2391 (Codex P1 on #2425): this file and float_call_offset_fs_twin_b.vibe
+// are BYTE-IDENTICAL on purpose. build_fingerprint excludes the module's own
+// path, so the two share a module fingerprint; the second one the walk
+// reaches reuses the first's just-written cache entry, and the offsets memo
+// must bind a row for BOTH paths or the second module's internal Double
+// call results degrade to the syntactic classifier and print raw bits.
+// Editing one of the twins without the other only weakens the test (the
+// fingerprints diverge and the shared-fingerprint arm stops being covered).
+export fn fs_twin_describe() -> String {
+  let f = () -> {
+    2.5
+  }
+  __to_string(f())
+}

--- a/lib/@vibe/compiler/tests/float_call_offset_fs_twin_b.vibe
+++ b/lib/@vibe/compiler/tests/float_call_offset_fs_twin_b.vibe
@@ -1,0 +1,16 @@
+//# Functions
+
+// #2391 (Codex P1 on #2425): this file and float_call_offset_fs_twin_b.vibe
+// are BYTE-IDENTICAL on purpose. build_fingerprint excludes the module's own
+// path, so the two share a module fingerprint; the second one the walk
+// reaches reuses the first's just-written cache entry, and the offsets memo
+// must bind a row for BOTH paths or the second module's internal Double
+// call results degrade to the syntactic classifier and print raw bits.
+// Editing one of the twins without the other only weakens the test (the
+// fingerprints diverge and the shared-fingerprint arm stops being covered).
+export fn fs_twin_describe() -> String {
+  let f = () -> {
+    2.5
+  }
+  __to_string(f())
+}

--- a/tests/gates/late/run.sh
+++ b/tests/gates/late/run.sh
@@ -9231,5 +9231,44 @@ if ! cmp -s "$ffsdir/cold.wasm" "$ffsdir/torn.wasm"; then
   echo "[compiler-gate] FAIL: a torn float-offsets sidecar changed the emitted bytes (#2391)" >&2
   exit 1
 fi
+# Digit-level corruption inside an INTACT sidecar must also decode as a miss
+# (#2425 review round 5): the torn compile above re-warmed the cache, so flip
+# one digit of the first offset row's first copy in every sidecar (same
+# length -- the end marker survives) and compile again. The v4 duplicated-row
+# equality rejects the row, the module re-checks, and the bytes stay
+# identical; the v3 decoder accepted this and the emitted bytes CHANGED
+# (red-proven on the PR).
+flipped_rows=0
+while IFS= read -r sc_file; do
+  awk -F'\t' 'BEGIN { OFS = "\t"; done = 0 }
+    done == 0 && NF == 2 && $1 ~ /^[0-9]+$/ {
+      first = substr($1, 1, 1)
+      $1 = (first != "9" ? "9" : "1") substr($1, 2)
+      done = 1
+    }
+    { print }' "$sc_file" > "$sc_file.flip" && mv "$sc_file.flip" "$sc_file"
+  file_mismatches=$(awk -F'\t' 'NF == 2 && $1 ~ /^[0-9]+$/ && $2 ~ /^[0-9]+$/ && $1 != $2 { n += 1 } END { print n + 0 }' "$sc_file")
+  flipped_rows=$((flipped_rows + file_mismatches))
+done < <(grep -rl "^module_float_call_offsets" "$ffsdir/cache" 2>/dev/null)
+# The mutation must actually HIT (gate discipline: a red test that matched
+# nothing proves nothing) -- the lane test's own modules carry offset rows,
+# so at least one sidecar must now hold a mismatched duplicate pair.
+if [ "$flipped_rows" = "0" ]; then
+  echo "[compiler-gate] FAIL: digit-flip mutation matched no sidecar row (#2391) -- the probe went stale" >&2
+  exit 1
+fi
+VIBE_BUILD_CACHE_DIR="$ffsdir/cache" VIBE_FS_COMPILE=1 VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_IMPORT_ABI=raw \
+  bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
+  lib/@vibe/compiler/tests/float_call_offset_fs_lane_test.vibe "$ffsdir/flipped.wasm" __no_entry__ \
+  >/dev/null 2>&1 || true
+if [ ! -s "$ffsdir/flipped.wasm" ]; then
+  echo "[compiler-gate] FAIL: FS-lane float call-offset test did not compile over digit-flipped sidecars (#2391)" >&2
+  cat "$ffsdir/flipped.wasm.diag" 2>/dev/null >&2 || true
+  exit 1
+fi
+if ! cmp -s "$ffsdir/cold.wasm" "$ffsdir/flipped.wasm"; then
+  echo "[compiler-gate] FAIL: a digit-corrupted float-offsets sidecar changed the emitted bytes (#2391)" >&2
+  exit 1
+fi
 rm -rf "$ffsdir"
 echo "[compiler-gate] FS-lane Double call-result offsets + cache-state byte identity ok (#2391)"

--- a/tests/gates/late/run.sh
+++ b/tests/gates/late/run.sh
@@ -9204,10 +9204,10 @@ if ! VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh \
 fi
 # Torn/corrupted sidecars must decode as MISSES, not as partial answers
 # (#2425 review round 3): truncate every offsets sidecar in the warm cache to
-# its header line plus at most one row, then compile again. The v2 envelope's
-# declared count/checksum rejects the truncation, the affected modules
-# re-check, and the output stays byte-identical; a decoder that accepted the
-# torn file would drop classifications and change the bytes.
+# its header line plus at most one row, then compile again. The v3 envelope's
+# required end marker rejects the truncation, the affected modules re-check,
+# and the output stays byte-identical; a decoder that accepted the torn file
+# would drop classifications and change the bytes.
 found_sidecar=0
 while IFS= read -r sc_file; do
   found_sidecar=1

--- a/tests/gates/late/run.sh
+++ b/tests/gates/late/run.sh
@@ -5909,11 +5909,12 @@ echo "[compiler-gate] generic transparent alias + opaque control ok (#1700)"
 #
 #      Compiled through the SINGLE-SOURCE lane on purpose -- no
 #      VIBE_FS_COMPILE, so `compile_source_wasi_only` runs, which is the linear
-#      entry that supplies the offsets. `scripts/vibe_test.sh` and
-#      `scripts/unit_test_runner.sh` both set VIBE_FS_COMPILE=1 and would take
-#      the FS merge lane, where the channel is not wired; running the fixture
-#      there would assert the wrong thing (and fail). The fixture is named
-#      without a `_test` suffix so the unit runner's glob does not pick it up.
+#      entry whose offsets come out of its whole-program check. The FS merge
+#      lane carries the channel too since #2391 (fed by the modular check;
+#      pinned by block 125 below and by the unit suite's
+#      float_call_offset_fs_lane_test.vibe); this fixture pins the
+#      single-source supply specifically, and is named without a `_test`
+#      suffix so the unit runner's glob does not route it to the other lane.
 echo "[compiler-gate] 105/105 checker Double call-result offsets on the linear source lane (#2158)"
 fcodir="_build/_gate_float_call_offsets"
 rm -rf "$fcodir"; mkdir -p "$fcodir"
@@ -9164,3 +9165,42 @@ for probe in clean local; do
 done
 rm -rf "$utdir"
 echo "[compiler-gate] unknown contract field/payload types are refused by both lanes at the declaration; builtin and local provenance stay clean ok (#2317)"
+
+# 125. #2391: FS-lane Double call-result offsets ride the MODULAR check
+#      (compile_file_fs_mode_rc -- the lane `vibe test` / `vibe run` take by
+#      default), and persistent-cache state must not change the emitted bytes.
+#
+#      Cold compile (empty cache: every module is checked in-process, offsets
+#      come from the memo) vs warm compile (typing cache + offsets sidecars
+#      hit: offsets come from the persistent sidecars) must emit byte-identical
+#      wasm -- the reuse arms in runtime/typecheck_fs.vibe require BOTH cache
+#      halves, so a half-populated cache re-checks instead of silently
+#      degrading. Running the warm artifact proves the rendered Doubles (the
+#      test file's inspect snapshots, including a call to an IMPORTED Double
+#      function -- the shape only this lane has).
+echo "[compiler-gate] 125/125 FS-lane Double call-result offsets ride the modular check (#2391)"
+ffsdir="_build/_gate_float_call_offsets_fs"
+rm -rf "$ffsdir"; mkdir -p "$ffsdir/cache"
+for pass in cold warm; do
+  VIBE_BUILD_CACHE_DIR="$ffsdir/cache" VIBE_FS_COMPILE=1 VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_IMPORT_ABI=raw \
+    bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
+    lib/@vibe/compiler/tests/float_call_offset_fs_lane_test.vibe "$ffsdir/$pass.wasm" __no_entry__ \
+    >/dev/null 2>&1 || true
+  if [ ! -s "$ffsdir/$pass.wasm" ]; then
+    echo "[compiler-gate] FAIL: FS-lane float call-offset test did not compile ($pass, #2391)" >&2
+    cat "$ffsdir/$pass.wasm.diag" 2>/dev/null >&2 || true
+    exit 1
+  fi
+done
+if ! cmp -s "$ffsdir/cold.wasm" "$ffsdir/warm.wasm"; then
+  echo "[compiler-gate] FAIL: FS-lane output depends on persistent-cache state (#2391)" >&2
+  exit 1
+fi
+if ! VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh \
+  --invoke _start "$ffsdir/warm.wasm" >"$ffsdir/run.log" 2>&1; then
+  echo "[compiler-gate] FAIL: a Double reaching __to_string through a call renders as raw bits on the FS lane (#2391)" >&2
+  cat "$ffsdir/run.log" >&2 || true
+  exit 1
+fi
+rm -rf "$ffsdir"
+echo "[compiler-gate] FS-lane Double call-result offsets + cache-state byte identity ok (#2391)"

--- a/tests/gates/late/run.sh
+++ b/tests/gates/late/run.sh
@@ -9204,7 +9204,7 @@ if ! VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh \
 fi
 # Torn/corrupted sidecars must decode as MISSES, not as partial answers
 # (#2425 review round 3): truncate every offsets sidecar in the warm cache to
-# its header line plus at most one row, then compile again. The v4 envelope's
+# its header line plus at most one row, then compile again. The v5 envelope's
 # required end marker rejects the truncation, the affected modules re-check,
 # and the output stays byte-identical; a decoder that accepted the torn file
 # would drop classifications and change the bytes. (Digit-level corruption is
@@ -9234,7 +9234,7 @@ fi
 # Digit-level corruption inside an INTACT sidecar must also decode as a miss
 # (#2425 review round 5): the torn compile above re-warmed the cache, so flip
 # one digit of the first offset row's first copy in every sidecar (same
-# length -- the end marker survives) and compile again. The v4 duplicated-row
+# length -- the end marker survives) and compile again. The v5 duplicated-row
 # equality rejects the row, the module re-checks, and the bytes stay
 # identical; the v3 decoder accepted this and the emitted bytes CHANGED
 # (red-proven on the PR).
@@ -9268,6 +9268,39 @@ if [ ! -s "$ffsdir/flipped.wasm" ]; then
 fi
 if ! cmp -s "$ffsdir/cold.wasm" "$ffsdir/flipped.wasm"; then
   echo "[compiler-gate] FAIL: a digit-corrupted float-offsets sidecar changed the emitted bytes (#2391)" >&2
+  exit 1
+fi
+# Whole-row deletion inside an intact sidecar must also decode as a miss
+# (#2425 review round 6): the flipped compile re-warmed the cache, so delete
+# the first duplicated row from every sidecar (header, remaining pairs,
+# count line, and end marker all survive) and compile again. The v5 unary
+# count line no longer matches the row set, the module re-checks, and the
+# bytes stay identical.
+deleted_rows=0
+while IFS= read -r sc_file; do
+  before_rows=$(awk -F'\t' 'NF == 2 && $1 ~ /^[0-9]+$/ && $1 == $2 { n += 1 } END { print n + 0 }' "$sc_file")
+  awk -F'\t' 'BEGIN { done = 0 }
+    done == 0 && NF == 2 && $1 ~ /^[0-9]+$/ && $1 == $2 { done = 1; next }
+    { print }' "$sc_file" > "$sc_file.del" && mv "$sc_file.del" "$sc_file"
+  if [ "$before_rows" -gt 0 ]; then
+    deleted_rows=$((deleted_rows + 1))
+  fi
+done < <(grep -rl "^module_float_call_offsets" "$ffsdir/cache" 2>/dev/null)
+if [ "$deleted_rows" = "0" ]; then
+  echo "[compiler-gate] FAIL: row-deletion mutation matched no sidecar row (#2391) -- the probe went stale" >&2
+  exit 1
+fi
+VIBE_BUILD_CACHE_DIR="$ffsdir/cache" VIBE_FS_COMPILE=1 VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_IMPORT_ABI=raw \
+  bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
+  lib/@vibe/compiler/tests/float_call_offset_fs_lane_test.vibe "$ffsdir/rowdel.wasm" __no_entry__ \
+  >/dev/null 2>&1 || true
+if [ ! -s "$ffsdir/rowdel.wasm" ]; then
+  echo "[compiler-gate] FAIL: FS-lane float call-offset test did not compile over row-deleted sidecars (#2391)" >&2
+  cat "$ffsdir/rowdel.wasm.diag" 2>/dev/null >&2 || true
+  exit 1
+fi
+if ! cmp -s "$ffsdir/cold.wasm" "$ffsdir/rowdel.wasm"; then
+  echo "[compiler-gate] FAIL: a row-deleted float-offsets sidecar changed the emitted bytes (#2391)" >&2
   exit 1
 fi
 rm -rf "$ffsdir"

--- a/tests/gates/late/run.sh
+++ b/tests/gates/late/run.sh
@@ -9204,10 +9204,11 @@ if ! VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh \
 fi
 # Torn/corrupted sidecars must decode as MISSES, not as partial answers
 # (#2425 review round 3): truncate every offsets sidecar in the warm cache to
-# its header line plus at most one row, then compile again. The v3 envelope's
+# its header line plus at most one row, then compile again. The v4 envelope's
 # required end marker rejects the truncation, the affected modules re-check,
 # and the output stays byte-identical; a decoder that accepted the torn file
-# would drop classifications and change the bytes.
+# would drop classifications and change the bytes. (Digit-level corruption is
+# rejected by the duplicated-row equality -- rounds 3+5 on the PR.)
 found_sidecar=0
 while IFS= read -r sc_file; do
   found_sidecar=1

--- a/tests/gates/late/run.sh
+++ b/tests/gates/late/run.sh
@@ -9202,5 +9202,33 @@ if ! VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh \
   cat "$ffsdir/run.log" >&2 || true
   exit 1
 fi
+# Torn/corrupted sidecars must decode as MISSES, not as partial answers
+# (#2425 review round 3): truncate every offsets sidecar in the warm cache to
+# its header line plus at most one row, then compile again. The v2 envelope's
+# declared count/checksum rejects the truncation, the affected modules
+# re-check, and the output stays byte-identical; a decoder that accepted the
+# torn file would drop classifications and change the bytes.
+found_sidecar=0
+while IFS= read -r sc_file; do
+  found_sidecar=1
+  head -2 "$sc_file" > "$sc_file.torn" && mv "$sc_file.torn" "$sc_file"
+done < <(grep -rl "^module_float_call_offsets" "$ffsdir/cache" 2>/dev/null)
+if [ "$found_sidecar" != "1" ]; then
+  echo "[compiler-gate] FAIL: no float-offsets sidecars found to corrupt (#2391) -- the probe went stale" >&2
+  exit 1
+fi
+VIBE_BUILD_CACHE_DIR="$ffsdir/cache" VIBE_FS_COMPILE=1 VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_IMPORT_ABI=raw \
+  bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
+  lib/@vibe/compiler/tests/float_call_offset_fs_lane_test.vibe "$ffsdir/torn.wasm" __no_entry__ \
+  >/dev/null 2>&1 || true
+if [ ! -s "$ffsdir/torn.wasm" ]; then
+  echo "[compiler-gate] FAIL: FS-lane float call-offset test did not compile over torn sidecars (#2391)" >&2
+  cat "$ffsdir/torn.wasm.diag" 2>/dev/null >&2 || true
+  exit 1
+fi
+if ! cmp -s "$ffsdir/cold.wasm" "$ffsdir/torn.wasm"; then
+  echo "[compiler-gate] FAIL: a torn float-offsets sidecar changed the emitted bytes (#2391)" >&2
+  exit 1
+fi
 rm -rf "$ffsdir"
 echo "[compiler-gate] FS-lane Double call-result offsets + cache-state byte identity ok (#2391)"

--- a/tests/gates/registry.tsv
+++ b/tests/gates/registry.tsv
@@ -243,3 +243,4 @@ x-adr-0090-1937-exception-unwind-region-restore	late	ADR-0090 #1937 exception-un
 122/122	late	122/122 a duplicated contract declaration is refused by both lanes, and named (#2317)
 123/123	late	123/123 a located contract diagnostic names the contract at its declaration (#2317)
 124/124	late	124/124 contract unknown type heads are refused by the full and buffer lanes (#2317)
+125/125	late	125/125 FS-lane Double call-result offsets ride the modular check (#2391)


### PR DESCRIPTION
First slice of #2391 (typed lowering lane): the #2158 Double channel (`CompileCtx.float_call_offsets`) was live on the single-source and gc lanes but **not** on the import-resolving FS lanes — the ones `vibe test` / `vibe run` take by default. A `Double` arriving through an inferred lambda, a generic at `Double`, an alias call, `Array::get` on `Array[Double]`, or an **imported** function silently printed its raw f64 bits there. Measured probe on main, FS lane:

```
lambda call   = 584    (should be 2.5)
array get     = 306    (should be 1.5)
```

## Premise re-measurement first (what the issue asked for)

The recorded 6.12s → 77.55s for a whole-program re-check has two contradictory comments in-tree (the checker's says the head-query fix brought it back to "a small delta"; `compile_file_fs_mode`'s says 77.55 → 77.55). Re-measured on current main, full-compiler closure, interleaved runs: the whole-program re-check still costs **~5.6x warm (5.8s → 32.6s), ~3.8x cold**, needs a **128MB host stack** (the recursive checker exhausts the default stack on a compiler-sized merged program), and **mutates the merged AST** enough to change the emitted wasm. That route stays dead; both comments now record the re-measurement.

## The wiring (the shape `compile_file_fs_mode`'s comment predicted)

- `check_module` retains each module's source-located Double call-result offsets **from the check it already runs** — one checker invocation, two outputs (`check_program_with_projected_import_env_double_call_result_located_observation`, sharing the #2158 extraction loop).
- The offsets persist in a sidecar keyed by the **same module fingerprint** as the TypeEnv entry. Every reuse arm (plan, step, dep-fold, leaf, finish, and the experimental TDRE9 transport) requires **both halves** before skipping a check, so cache state can never change what a compile emits; a missing sidecar re-checks that one module and republishes both (self-healing — no semantics-seed bump, old caches migrate on first touch). TDRE9 reuse carries the target fingerprint's offsets over (its input key binds the verbatim source + exact dep env texts, so a hit implies identical offsets); the previously-failing reuse oracle passes.
- The linear FS merges rebase each file into a disjoint offset range (the gc lane's #2226 rebase) and union the per-module tables; the offsets ride into the rc, bump, body-cached, heap-marked, testmeta, profiled, and artifact-cached lanes. `unique_call_offsets_in_stmts` still drops any ambiguous offset, so a partial answer degrades to the pre-#2158 classifier, never to a wrong one.

## Validation

- stage2 == stage3 fixpoint; full unit suite **1091/1091** (every test file now compiles through the rebased merge); `scripts/compiler_gate.sh` green end-to-end including the TDRE9 reuse oracle.
- New pin: `lib/@vibe/compiler/tests/float_call_offset_fs_lane_test.vibe` (7 tests, runs through the ordinary `vibe test` glob = the lane under test, including the imported-Double shape only this lane has). **Red-proven**: against the unwired baseline stage2 it fails with `actual: 256 / expected: 2.5`.
- New late gate 125: compiles the test cold (empty cache) and warm (typing cache + sidecars hot) and requires **byte-identical** wasm plus the rendered Doubles — pinning the "cache state cannot change output" invariant.
- Probe after: `lambda call = 2.5`, `array get = 1.5`, imported call `2.5`; cold and warm compiles byte-identical.

## Cost (interleaved, full-compiler closure, N=3)

| phase | before | after | delta |
|---|---:|---:|---|
| cold compile | 9.71s | 10.24s | +5.4% (per-module capture + sidecar writes, first compile into an empty cache only) |
| warm compile | 5.84s | 5.89s | +0.8% (noise level — the common loop) |

Output wasm for the compiler closure itself is byte-identical before/after (it has no classified Double call results), so this is pure channel-wiring, no codegen drift.

Next #2391 slices can ride the same per-module carrier (structural-eq shapes, `String <`) — this PR establishes the pattern: per-module observation at modular-check cost instead of a whole-program re-check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0159xd5111g8KFt2CGyNyZvA

---
_Generated by [Claude Code](https://claude.ai/code/session_0159xd5111g8KFt2CGyNyZvA)_