### PR TITLE
Point the Zed extension at a revision that has `~` (#2409)

### DIFF
--- a/integrations/zed-vibe/README.md
+++ b/integrations/zed-vibe/README.md
@@ -20,18 +20,25 @@ The grammar is fetched from the `integrations/treesitter-vibe` directory in this
 
 ## Update grammar
 
-After updating `treesitter-vibe`, update the `rev` in `extension.toml`:
+Zed builds the grammar itself from the revision named here, so `grammars/vibe.wasm`
+in this directory is a build artifact Zed never reads — **the `rev` is what Zed
+users actually get.** After a grammar change reaches `main`, point it at a commit
+that contains that change:
 
 ```bash
-# Push changes first
-git push origin main
-
-# Update rev to the latest commit
-git rev-parse HEAD
-# Edit extension.toml [grammars.vibe] rev = "<new-sha>"
+git fetch origin main
+git rev-parse origin/main
+# Edit extension.toml [grammars.vibe] rev = "<that sha>"
 ```
 
 Then reinstall the dev extension in Zed.
+
+This bump can only happen **after** the grammar change is merged, since the SHA
+does not exist before then — which is why it is a separate follow-up and why no
+CI gate enforces it. A gate would have to fail on every PR that touches the
+grammar, for a condition that PR cannot satisfy, and a gate nobody can satisfy is
+a gate that gets disabled. #2409 is the record of what that costs: `~` parsed in
+the corpus suite and stayed a syntax error in Zed, and nothing noticed.
 
 ## Structure
 

--- a/integrations/zed-vibe/extension.toml
+++ b/integrations/zed-vibe/extension.toml
@@ -8,5 +8,5 @@ repository = "https://github.com/mizchi/vibe-lang"
 
 [grammars.vibe]
 repository = "https://github.com/mizchi/vibe-lang"
-rev = "b398e5effa1f3e1e1399eb24fc7e6e2e5f3cdc7d"
+rev = "d710185a72adfa62cbad5645a1be3f7f6d32ff7a"
 path = "integrations/treesitter-vibe"


### PR DESCRIPTION
Closes #2409 — this is its last step, and the one #2422 could not take.

## What was still stale

`integrations/zed-vibe/extension.toml` named `rev = "b398e5eff..."`, which predates the prefix-`~` grammar. Zed **compiles the grammar itself** from that revision, so `integrations/zed-vibe/grammars/vibe.wasm` is a build artifact Zed never reads — the `rev` is what Zed users actually get. `~x` stayed a syntax error for them regardless of what the committed wasm contained.

Bumped to `d710185a72adfa62cbad5645a1be3f7f6d32ff7a`, the merge commit of #2422.

## Verified rather than assumed

That the target revision really carries the change:

| check at `d710185a7` | result |
| :--- | :--- |
| `grammar.js` occurrences of `"~"` | 3 |
| `src/parser.c` | `#define LANGUAGE_VERSION 15` |
| `test/corpus/expressions.txt` | holds the `bit-not prefix operator` case |

And that nothing else pointed at the old SHA: `git grep b398e5eff` over tracked files returns exactly the one line this PR changes.

## Why this is a separate PR

The SHA is #2422's own merge commit, so it did not exist while that PR was open. A merged PR cannot carry new work, so this branch was restarted from `main`.

## Why there is no gate for it

Deliberate, and the README now says so. A pre-merge check would have to fail on every PR that touches the grammar, for a condition that PR *cannot satisfy* — the SHA does not exist yet. A gate nobody can satisfy is a gate that gets disabled, which is the failure mode the rest of #2409 was about.

What was actually missing was not a check but a fact nobody had written down: **the `rev`, not the committed wasm, is what Zed consumes.** The README says that now, next to the procedure, with #2409 cited as the record of what its absence cost — `~` parsed in the corpus suite and stayed a syntax error in Zed, and nothing noticed.

The two gates #2422 added (`check_treesitter_artifacts.sh`, `check_treesitter_wasm_corpus.sh`) both pass on this branch; they cover the three generated artifacts, which this change does not touch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FYMVd6D2o82suTfTwoJPMf

---
_Generated by [Claude Code](https://claude.ai/code/session_01FYMVd6D2o82suTfTwoJPMf)_