### PR TITLE
Compare Doubles as Doubles on the gc and bump lanes (#2426)

### DIFF
--- a/fixtures/gc_lane_scalar_parity_test.vibe
+++ b/fixtures/gc_lane_scalar_parity_test.vibe
@@ -290,3 +290,111 @@ test "#2407 eq answers on two distinct large Ints" {
   assert(eq(64<<32, 65<<32) == ((64<<32) == (65<<32)))
   assert(eq(3, 3) == (3 == 3))
 }
+
+/// #2426: `Double` equality reached no float comparison on the gc lane.
+/// `emit_gc_eq_value` routes on `gc_expr_is_intish` and otherwise falls
+/// through to the `eq` builtin, and neither consults `gc_expr_is_floatish` --
+/// which the neighbouring `<` `>` `<=` `>=` lowering has consulted all along,
+/// with a comment naming `-0.0` as one of the values a raw bit compare
+/// misranks.
+///
+/// That left two silent wrong answers, and this pair of helpers covers the
+/// second one, where the operand arrives through a parameter rather than as a
+/// literal:
+///
+///   * The `eq` builtin's fallback reads each operand as a `(ptr << 32) | len`
+///     fat pointer. `-0.0` has bit 63 set, so its implied pointer is far out
+///     of bounds, the "both operands look like strings" guard answers no, and
+///     the result is "not equal" -- while IEEE 754 says `+0.0 == -0.0` is
+///     true. The linear lane agrees with IEEE; only gc disagreed.
+///   * `gc_expr_is_intish` answers true for `+ - * /` from the OPERATOR alone,
+///     so two float arithmetic operands took a raw `i64.eq` over their f64
+///     bits instead. `1.5 + 2.5 == 4.0` was right only because equal Doubles
+///     have equal bit patterns -- an accident, not a routing.
+fn dbl_eq(a: Double, b: Double) -> Bool {
+  a == b
+}
+
+fn dbl_ne(a: Double, b: Double) -> Bool {
+  a != b
+}
+
+/// A division the compiler cannot fold, so `dz(0.0, 0.0)` really is a NaN
+/// produced at run time.
+fn dz(a: Double, b: Double) -> Double {
+  a / b
+}
+
+test "#2426 Double equality follows IEEE 754, not the bit pattern" {
+  // The pair whose bit patterns differ ONLY in the sign bit -- which is what a
+  // raw i64 compare distinguishes and an f64 compare does not.
+  assert(0.0 == -0.0)
+  assert(-0.0 == 0.0)
+  assert(!(0.0 != -0.0))
+  // Through names, either side, and both sides at once: the operand shapes
+  // that reach the classifier as a bare ident rather than a literal.
+  let a = 0.0
+  let b = -0.0
+  assert(a == -0.0)
+  assert(0.0 == b)
+  assert(a == b)
+  assert(!(a != b))
+  // Through an annotated parameter, the binding form the slot log seeds
+  // separately from a `let`.
+  assert(dbl_eq(0.0, -0.0))
+  assert(!dbl_ne(0.0, -0.0))
+  // `-0.0` arising from ARITHMETIC rather than from the literal, which is how
+  // it turns up in real code (an underflowing negative product), and the
+  // branch on it that used to be taken wrongly.
+  let z = 0.0 * -1.0
+  assert(z == 0.0)
+  if z == 0.0 {
+    assert(true)
+  } else {
+    assert(false)
+  }
+  // Ordinary Double equality, which was already right and must stay right --
+  // including the arithmetic operands that `gc_expr_is_intish` claimed.
+  assert(1.5 == 1.5)
+  assert(!(1.5 == 2.5))
+  assert(-1.5 == -1.5)
+  assert(!(-1.5 == 1.5))
+  assert(1.5 + 2.5 == 4.0)
+  assert(!(1.5 + 2.5 == 4.5))
+  assert(2.5 * 2.0 == 5.0)
+  assert(1.5 != 2.5)
+  assert(dbl_eq(1.5, 1.5))
+  assert(!dbl_eq(1.5, 2.5))
+  // A `while` condition is a third call site into the same routing, next to
+  // the plain expression and the `if` above.
+  let mut n = 3.0
+  let mut steps = 0
+  while n != 0.0 {
+    n = n - 1.0
+    steps = steps + 1
+  }
+  assert(steps == 3)
+  // NaN is the other value IEEE 754 separates from a bit compare, and in the
+  // opposite direction: two NaNs have IDENTICAL bits and are still not equal.
+  // Measured on main's gc stage2, both inversions were live -- `nan == nan`
+  // answered true and `nan != nan` answered false -- while linear answered
+  // both the IEEE way. `!=` gets this from the callers' `eqz` over the same
+  // `f64.eq`, so it needs no arm of its own.
+  let nan = dz(0.0, 0.0)
+  assert(!(nan == nan))
+  assert(nan != nan)
+  assert(!(nan == 1.5))
+  assert(nan != 1.5)
+  assert(!dbl_eq(nan, nan))
+  assert(dbl_ne(nan, nan))
+  // The Int and String sides of the same routing are untouched: a float guard
+  // that also swallowed these would trade one silent wrong answer for another.
+  assert(0 == 0)
+  assert(!(0 == 1))
+  assert((64<<32) == (64<<32))
+  assert(!((64<<32) == (65<<32)))
+  assert("ab" == "ab")
+  assert(!("ab" == "ac"))
+  assert(true == true)
+  assert(!(true == false))
+}

--- a/lib/@vibe/compiler/codegen/expr/compile_expr.vibe
+++ b/lib/@vibe/compiler/codegen/expr/compile_expr.vibe
@@ -1062,20 +1062,29 @@ export fn compile_expr(buf: Bytes, expr: Expr, local_names: Array[String], next_
         emit_end(buf)
         nl2
       }
-    } else if op == "==" && !(ctx.enable_rc && (expr_is_floatish(lhs, local_names, ctx) || expr_is_floatish(rhs, local_names, ctx))) {
-      // #704: float `==`/`!=` under RC must NOT go through emit_eq_value — under
-      // RC a float is a BOXED heap value, so the generic eq compares box
-      // pointers (always unequal for two distinct boxes), making `0.0 == 0.0`
-      // false. Divert floatish RC `==`/`!=` to the float branch below, which
-      // unboxes and compares values with f64_eq/f64_ne. (Non-RC keeps the raw
-      // i64-bits compare here, so the default path is byte-identical.)
+    } else if op == "==" && !(expr_is_floatish(lhs, local_names, ctx) || expr_is_floatish(rhs, local_names, ctx)) {
+      // #704: float `==`/`!=` must NOT go through emit_eq_value. Under RC a
+      // float is a BOXED heap value, so the generic eq compares box pointers
+      // (always unequal for two distinct boxes), making `0.0 == 0.0` false.
+      // Divert a floatish `==`/`!=` to the float branch below, which unboxes
+      // when RC is on and compares values with f64_eq/f64_ne.
+      //
+      // #2426: this used to divert only `ctx.enable_rc`, on the ground that
+      // leaving non-RC on the raw i64-bits compare kept that path
+      // byte-identical. Byte-identity was preserving two wrong answers, and
+      // they are the same two the gc lane had: raw bits separate `0.0` from
+      // `-0.0`, which IEEE 754 does not, and they equate two NaNs, which IEEE
+      // 754 also does not. Measured on `VIBE_RC=0` before this change:
+      // `0.0 == -0.0` false, `nan == nan` true. The float branch below has
+      // been non-RC-aware since #704 (every unbox is already guarded), so the
+      // diversion is all that was missing.
       let nle = emit_eq_value(buf, lhs, rhs, local_names, next_local, ctx, ld, compile_expr)
       if ctx.enable_rc {
         emit_i64_const(buf, 1)
         emit_i64_shl(buf)
       }
       nle
-    } else if op == "!=" && !(ctx.enable_rc && (expr_is_floatish(lhs, local_names, ctx) || expr_is_floatish(rhs, local_names, ctx))) {
+    } else if op == "!=" && !(expr_is_floatish(lhs, local_names, ctx) || expr_is_floatish(rhs, local_names, ctx)) {
       let nle = emit_eq_value(buf, lhs, rhs, local_names, next_local, ctx, ld, compile_expr)
       emit_i64_eqz(buf)
       emit_i64_extend_i32_s(buf)
@@ -1263,11 +1272,11 @@ export fn compile_expr(buf: Bytes, expr: Expr, local_names: Array[String], next_
       if cop == "==" || cop == "!=" || cop == "<" || cop == ">" || cop == "<=" || cop == ">=" {
         let clhs = get_ebinop_lhs(cond)
         let crhs = get_ebinop_rhs(cond)
-        if cop == "==" && !(ctx.enable_rc && (expr_is_floatish(clhs, local_names, ctx) || expr_is_floatish(crhs, local_names, ctx))) {
+        if cop == "==" && !(expr_is_floatish(clhs, local_names, ctx) || expr_is_floatish(crhs, local_names, ctx)) {
           let cnl2 = emit_eq_value(buf, clhs, crhs, local_names, next_local, ctx, ld, compile_expr)
           emit_i32_wrap_i64(buf)
           cnl2
-        } else if cop == "!=" && !(ctx.enable_rc && (expr_is_floatish(clhs, local_names, ctx) || expr_is_floatish(crhs, local_names, ctx))) {
+        } else if cop == "!=" && !(expr_is_floatish(clhs, local_names, ctx) || expr_is_floatish(crhs, local_names, ctx)) {
           let cnl2 = emit_eq_value(buf, clhs, crhs, local_names, next_local, ctx, ld, compile_expr)
           emit_i32_wrap_i64(buf)
           emit_i32_eqz(buf)
@@ -1349,12 +1358,12 @@ export fn compile_expr(buf: Bytes, expr: Expr, local_names: Array[String], next_
           if iop == "==" || iop == "!=" || iop == "<" || iop == ">" || iop == "<=" || iop == ">=" {
             let ilhs = get_ebinop_lhs(uoperand)
             let irhs = get_ebinop_rhs(uoperand)
-            if iop == "==" && !(ctx.enable_rc && (expr_is_floatish(ilhs, local_names, ctx) || expr_is_floatish(irhs, local_names, ctx))) {
+            if iop == "==" && !(expr_is_floatish(ilhs, local_names, ctx) || expr_is_floatish(irhs, local_names, ctx)) {
               let inl2 = emit_eq_value(buf, ilhs, irhs, local_names, next_local, ctx, ld, compile_expr)
               emit_i32_wrap_i64(buf)
               emit_i32_eqz(buf)
               inl2
-            } else if iop == "!=" && !(ctx.enable_rc && (expr_is_floatish(ilhs, local_names, ctx) || expr_is_floatish(irhs, local_names, ctx))) {
+            } else if iop == "!=" && !(expr_is_floatish(ilhs, local_names, ctx) || expr_is_floatish(irhs, local_names, ctx)) {
               let inl2 = emit_eq_value(buf, ilhs, irhs, local_names, next_local, ctx, ld, compile_expr)
               emit_i32_wrap_i64(buf)
               emit_i32_eqz(buf)

--- a/lib/@vibe/compiler/codegen/gc/backend_expr.vibe
+++ b/lib/@vibe/compiler/codegen/gc/backend_expr.vibe
@@ -486,9 +486,16 @@ fn emit_gc_ctor_struct_eq(buf: Bytes, lhs: Expr, rhs: Expr, fc: Int, local_names
 }
 
 /// The equality value for `lhs == rhs` (raw i64 0/1 on the stack): tuple / ctor
-/// literals get structural comparison, provably-scalar operands a raw i64.eq,
-/// everything else the generic `eq` builtin (bit-equal fast path + string
-/// content fall-back). Mirrors the linear lane's emit_eq_value routing.
+/// literals get structural comparison, floatish operands an `f64.eq` (#2426 --
+/// raw bits separate `0.0` from `-0.0`, IEEE 754 does not), provably-scalar
+/// operands a raw i64.eq, everything else the generic `eq` builtin (bit-equal
+/// fast path + string content fall-back). Mirrors the linear lane's
+/// emit_eq_value routing, including which operands it declines to take.
+///
+/// `!=` is the callers' `eqz` over this value, so it needs no arm of its own
+/// and stays IEEE-correct through the same one: `f64.eq(NaN, NaN)` is 0, and
+/// its negation is the `true` that `NaN != NaN` owes. The raw i64 compare
+/// answered `true` for `NaN == NaN`, since the bits are identical.
 fn emit_gc_eq_value(buf: Bytes, lhs: Expr, rhs: Expr, local_names: Array[String], next_local: Int, ctx: CompileCtxGc, ld: Int, cefn: (Bytes, Expr, Array[String], Int, CompileCtxGc, Int) -> Int with Exception) -> Int with Exception {
   let lhs_is_tuple = match lhs {
     ETuple(_) => true,
@@ -549,6 +556,32 @@ fn emit_gc_eq_value(buf: Bytes, lhs: Expr, rhs: Expr, local_names: Array[String]
       rfc
     }
     emit_gc_ctor_struct_eq(buf, lhs, rhs, cfc, local_names, next_local, ctx, ld, cefn)
+  } else if gc_expr_is_floatish(lhs, local_names, ctx) || gc_expr_is_floatish(rhs, local_names, ctx) {
+    // #2426: Double equality, which reached no float comparison at all before.
+    // Both arms below answer on the RAW BITS -- `gc_expr_is_intish` claims
+    // `+ - * /` from the operator alone and emits `i64.eq`, and the `eq`
+    // builtin's fall-back reads each operand as a `(ptr << 32) | len` fat
+    // pointer -- and `0.0` and `-0.0` differ in exactly the sign bit. So
+    // `i64.eq` said "not equal", and the builtin agreed for a different
+    // reason: bit 63 makes `-0.0`'s implied pointer far out of bounds, its
+    // "both operands look like strings" guard answers no, and the fall-back
+    // returns 0. IEEE 754 says `+0.0 == -0.0` is true, and the linear lane
+    // says so too (`compile_expr`'s `==` arm diverts a floatish operand away
+    // from `emit_eq_value` for the same reason, one lane over).
+    //
+    // The `<` `>` `<=` `>=` lowering in compile_expr_gc has routed through
+    // f64 since #538, and its comment already names -0.0 as a value raw bits
+    // misrank; equality was simply never given the same arm. Placed AFTER the
+    // structural arms so a tuple or constructor holding Doubles keeps its
+    // field-wise comparison, and before the scalar ones so a float never
+    // reaches a bit compare.
+    let nlf1 = cefn(buf, lhs, local_names, next_local, ctx, ld)
+    emit_f64_reinterpret_i64(buf)
+    let nlf2 = cefn(buf, rhs, local_names, nlf1, ctx, ld)
+    emit_f64_reinterpret_i64(buf)
+    emit_f64_eq(buf)
+    emit_i64_extend_i32_s(buf)
+    nlf2
   } else if gc_expr_is_intish(lhs) || gc_expr_is_intish(rhs) {
     let nl1 = cefn(buf, lhs, local_names, next_local, ctx, ld)
     let nl2 = cefn(buf, rhs, local_names, nl1, ctx, ld)

--- a/tests/gates/early/run.sh
+++ b/tests/gates/early/run.sh
@@ -1823,6 +1823,36 @@ run_test_block_fixtures_gc() {
   done
 }
 
+# #2426: the same fixtures on the BUMP lane (VIBE_RC=0), the third codegen
+# configuration. `0.0 == -0.0` was false and `nan == nan` true there for the
+# same reason as on gc -- equality compared raw f64 bits -- and neither of the
+# two lanes above could see it: RC diverted floats to f64 comparisons and bump
+# did not. Measured before the fix, this fixture failed here and passed on
+# linear, which is exactly the shape a two-lane gate is blind to.
+run_test_block_fixtures_bump() {
+  local label="$1"; shift
+  local fx fxout
+  [ "$#" -gt 0 ] || { echo "[compiler-gate] FAIL: $label matched no fixtures" >&2; exit 1; }
+  for fx in "$@"; do
+    [ -f "$fx" ] || { echo "[compiler-gate] FAIL: $label: no such fixture '$fx'" >&2; exit 1; }
+    fxout="_build/_gate_tbfbump_$(basename "${fx%.vibe}").wasm"
+    rm -f "$fxout" "$fxout.diag"
+    VIBE_RC=0 VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
+      bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
+      "$fx" "$fxout" __no_entry__ >/dev/null 2>&1 || true
+    if [ ! -s "$fxout" ]; then
+      echo "[compiler-gate] FAIL: $fx did not compile on the bump lane ($label)" >&2
+      cat "$fxout.diag" 2>/dev/null >&2; exit 1
+    fi
+    if ! VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh \
+        --invoke _start "$fxout" >/dev/null 2>&1; then
+      echo "[compiler-gate] FAIL: $fx has a failing test on the bump lane (assert trapped) ($label)" >&2
+      exit 1
+    fi
+    rm -f "$fxout" "$fxout.diag" "$fxout.funcmap"
+  done
+}
+
 # 15b. extended derive(...) regression (#638 / #694): enum `derive(Ord/Show)`,
 #      struct + enum `derive(Default)`, `derive(Eq)`, and `derive(Hash)`
 #      including transparent Map keys — `map_key_to_string = [K: Hash](key) ->
@@ -1986,6 +2016,7 @@ echo '[compiler-gate] bit-not ~ ok'
 echo '[compiler-gate] 15b-3/15 gc-lane scalar parity (#2404/#2405/#2407)'
 run_test_block_fixtures "gc-lane scalar parity (linear)" fixtures/gc_lane_scalar_parity_test.vibe
 run_test_block_fixtures_gc "gc-lane scalar parity (gc)" fixtures/gc_lane_scalar_parity_test.vibe
+run_test_block_fixtures_bump "gc-lane scalar parity (bump)" fixtures/gc_lane_scalar_parity_test.vibe
 echo '[compiler-gate] gc-lane scalar parity ok'
 
 # 15c. railway `let*` / `?` generalized to Option (#635): the parser emits a

--- a/tests/gates/early/run.sh
+++ b/tests/gates/early/run.sh
@@ -1823,30 +1823,32 @@ run_test_block_fixtures_gc() {
   done
 }
 
-# #2426: the same fixtures on the BUMP lane (VIBE_RC=0), the third codegen
-# configuration. `0.0 == -0.0` was false and `nan == nan` true there for the
-# same reason as on gc -- equality compared raw f64 bits -- and neither of the
-# two lanes above could see it: RC diverted floats to f64 comparisons and bump
-# did not. Measured before the fix, this fixture failed here and passed on
-# linear, which is exactly the shape a two-lane gate is blind to.
-run_test_block_fixtures_bump() {
+# #2426: the same fixtures on the RC lane, which this gate never reached.
+# `tests/gates/lib.sh` pins `VIBE_RC=0` for every lane, so the plain
+# `run_test_block_fixtures` above compiles on the BUMP allocator despite its
+# "linear" label -- and RC, the production default, was not exercised here at
+# all. Adding a second bump invocation would have run the identical
+# configuration twice (Codex review on #2430 caught exactly that). Selecting RC
+# inline in the command, per the #2248 rule that a selector is never routed
+# through a variable.
+run_test_block_fixtures_rc() {
   local label="$1"; shift
   local fx fxout
   [ "$#" -gt 0 ] || { echo "[compiler-gate] FAIL: $label matched no fixtures" >&2; exit 1; }
   for fx in "$@"; do
     [ -f "$fx" ] || { echo "[compiler-gate] FAIL: $label: no such fixture '$fx'" >&2; exit 1; }
-    fxout="_build/_gate_tbfbump_$(basename "${fx%.vibe}").wasm"
+    fxout="_build/_gate_tbfrc_$(basename "${fx%.vibe}").wasm"
     rm -f "$fxout" "$fxout.diag"
-    VIBE_RC=0 VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
+    VIBE_RC=1 VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
       bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
       "$fx" "$fxout" __no_entry__ >/dev/null 2>&1 || true
     if [ ! -s "$fxout" ]; then
-      echo "[compiler-gate] FAIL: $fx did not compile on the bump lane ($label)" >&2
+      echo "[compiler-gate] FAIL: $fx did not compile on the RC lane ($label)" >&2
       cat "$fxout.diag" 2>/dev/null >&2; exit 1
     fi
     if ! VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh \
         --invoke _start "$fxout" >/dev/null 2>&1; then
-      echo "[compiler-gate] FAIL: $fx has a failing test on the bump lane (assert trapped) ($label)" >&2
+      echo "[compiler-gate] FAIL: $fx has a failing test on the RC lane (assert trapped) ($label)" >&2
       exit 1
     fi
     rm -f "$fxout" "$fxout.diag" "$fxout.funcmap"
@@ -2014,9 +2016,9 @@ echo '[compiler-gate] bit-not ~ ok'
 #        rendered as the empty string, and `eq` on two distinct large Ints
 #        trapped. A single-lane run cannot see any of them.
 echo '[compiler-gate] 15b-3/15 gc-lane scalar parity (#2404/#2405/#2407)'
-run_test_block_fixtures "gc-lane scalar parity (linear)" fixtures/gc_lane_scalar_parity_test.vibe
+run_test_block_fixtures "gc-lane scalar parity (linear, bump)" fixtures/gc_lane_scalar_parity_test.vibe
 run_test_block_fixtures_gc "gc-lane scalar parity (gc)" fixtures/gc_lane_scalar_parity_test.vibe
-run_test_block_fixtures_bump "gc-lane scalar parity (bump)" fixtures/gc_lane_scalar_parity_test.vibe
+run_test_block_fixtures_rc "gc-lane scalar parity (linear, RC)" fixtures/gc_lane_scalar_parity_test.vibe
 echo '[compiler-gate] gc-lane scalar parity ok'
 
 # 15c. railway `let*` / `?` generalized to Option (#635): the parser emits a


### PR DESCRIPTION
Closes #2426.

`0.0 == -0.0` answered **false** on the wasm-gc lane and **true** on linear. IEEE 754 says it is true. Measuring the fix turned up a second lane and a second value: on the **bump** lane (`VIBE_RC=0`) `0.0 == -0.0` was also false, and on both gc and bump `nan == nan` answered **true** — the same defect in the other direction, since two NaNs have identical bits and are still not equal.

## The routing, found rather than assumed

The issue's own "where to look" section named `gc_expr_is_intish` as the likely mechanism and said so was **not confirmed** — correctly, because `gc_expr_is_intish(EFloat)` answers false. Reading the routing out:

* **gc.** `emit_gc_eq_value` decides between three arms, and none of them consults `gc_expr_is_floatish`. Two Double literals fall past the structural arms, past the intish arm, into the generic **`eq` builtin** — whose fall-back reads each operand as a `(ptr << 32) | len` fat pointer (`gen_eq_body` → `emit_looks_like_string`). `-0.0` has bit 63 set, so its implied pointer is `2147483648` and `ptr + len <= memory_size` fails; the "both operands look like strings" guard answers no and the builtin returns 0.
  The intish arm is the *other* half of the same defect: it answers true for `+ - * /` from the **operator alone**, so two float arithmetic operands took a raw `i64.eq` instead. `1.5 + 2.5 == 4.0` was right only because equal Doubles have equal bit patterns — an accident, not a routing.
* **bump.** `compile_expr`'s `==`/`!=` arms diverted a floatish operand away from `emit_eq_value` only under `ctx.enable_rc`. #704 needed that diversion for RC's *boxed* floats and deliberately left non-RC on the raw i64-bits compare "so the default path is byte-identical". Byte-identity was preserving two wrong answers.

## The fix

Both lanes get the arm the neighbouring `<` `>` `<=` `>=` lowering has had since #538 — whose comment already names `-0.0` as a value raw bits misrank.

* gc: an `f64.eq` arm in `emit_gc_eq_value`, placed **after** the structural arms so a tuple or constructor holding Doubles keeps its field-wise comparison, and before the scalar ones so a float never reaches a bit compare.
* linear: `ctx.enable_rc &&` dropped from six guards. The float branch they divert into has been non-RC-aware since #704 — every unbox is already guarded — so the diversion was all that was missing.

`!=` is the callers' `eqz` over the same value on both lanes, so it needs no arm of its own and comes out IEEE-correct with it (`f64.eq(NaN, NaN)` is 0; its negation is the `true` that `NaN != NaN` owes).

## Measured

One file per claim, three lanes, against a stage2 built from `978ccefc4` and one built from this tree. Neither run reports an error either way, which is what makes this a P0.

| claim | before: RC / bump / gc | after: all three |
| :--- | :--- | :--- |
| `0.0 == -0.0` | true / **false** / **false** | true |
| `nan == nan` | false / **true** / **true** | false |
| `nan != nan` | true / **false** / **false** | true |
| `(0.0, 1) == (-0.0, 1)` | true / **false** / **false** | true — the structural comparator lowers each field through the ordinary expression path, so the new arm applies per element |

`bash scripts/compiler_gate.sh` passes end to end, **stage2 == stage3 fixpoint included** — the compiler still compiles itself byte-identically with this change.

## What pins it

`fixtures/gc_lane_scalar_parity_test.vibe` grows a `#2426` test: both literals, either side through a name, both sides through names, an annotated parameter, `-0.0` arising from *arithmetic* rather than a literal (`0.0 * -1.0`, which is how it turns up in real code) and the branch on it, the `if` and `while` condition fast paths — two more call sites into the same routing — NaN both ways, and Int / String / Bool controls so a float guard that also swallowed those would be caught here.

`tests/gates/early/run.sh` gains an **RC** invocation of that fixture. This started as a bump line and was wrong: `tests/gates/lib.sh` pins `VIBE_RC=0` for every lane, so the existing line labelled "linear" already *is* bump and a second bump line asserted nothing new — while RC, the production default, was not exercised by this gate at all (Codex review, `258b82c6c`). Proved rather than assumed: the same fixture through the gate's own invocation gives 22,905 B under `VIBE_RC=0` and 30,424 B under `VIBE_RC=1`, different hashes, both green; and with one `assert(1 == 2)` appended the RC invocation fails. The existing bump line is the red-capable one for this bug — measured before the fix, the fixture fails on bump and passes on RC, because RC's `==` already diverted floats. So the gate now covers RC, bump and gc: three genuinely distinct configurations.

## What this does not touch

Two things, both pre-existing on `main` and unchanged in every measured cell by this PR:

* **The builtin `eq` spelling.** `eq(0.0, -0.0)` is false on bump, `eq(nan, nan)` is true on bump and gc, and — worse than the review described — `eq(0.0, 1.5)` is **true on gc**, for two ordinary distinct Doubles: the content fall-back reads a Double's low 32 bits as a length, and a round value's mantissa tail is zero, so two different Doubles decode as two zero-length strings and compare equal. Fix written and verified; going in as an explicit follow-up PR at the author's direction rather than widening this one.
* **A `Double` nested in a tuple reached through names.** `let x = (0.0, 1); let y = (-0.0, 1); x == y` is wrong on RC too, and cannot be reached by a comparator: `agg_info_of_ident` records a shape, never field types. Filed as #2431 — it is #2424's missing type channel applied to aggregate fields.

The bit-pattern heuristic itself is still there, and #2424 is the issue for it: `__to_string` decides Int-vs-String the same way, from the bits, because no type reaches the lowering. This change does not narrow that; it routes one operator away from it where the shape classifier already knew the answer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FYMVd6D2o82suTfTwoJPMf