### PR TITLE
Compare Doubles as Doubles in the places #2430 missed: `eq`, a join, and a join's own binder (#2426 follow-up)

### DIFF
--- a/fixtures/gc_lane_scalar_parity_test.vibe
+++ b/fixtures/gc_lane_scalar_parity_test.vibe
@@ -518,6 +518,35 @@ test "#2426 a Double keeps its type through a join" {
   }
   assert(ba == bb)
   assert(eq(ba, bb))
+  // A join arm that ends in its OWN binder. The body is a bare `EIdent`, so a
+  // plain body recursion answers "not a Double" -- the name has no slot at
+  // classification time. Answered without an environment: the `let`
+  // immediately above the identifier binds that exact name, so no inner scope
+  // intervenes and no outer binding of the name is reachable (Codex review on
+  // #2432).
+  let la = if jcond(1) {
+    let lx = 0.0
+    lx
+  } else {
+    let lx = 1.0
+    lx
+  }
+  let lb2 = if jcond(1) {
+    let ly = (-0.0)
+    ly
+  } else {
+    let ly = 1.0
+    ly
+  }
+  assert(la == lb2)
+  assert(eq(la, lb2))
+  assert(!(la == 1.5))
+  // NOT asserted, deliberately, and measured: ONE HOP FURTHER
+  // (`let x = 0.0; let z = x; z` in each arm) still compares by raw bits on
+  // all three lanes. That shape cannot be answered from syntax alone -- it
+  // needs the binding's TYPE -- and carrying an environment through the
+  // descent instead is the design CLAUDE.md records going silently wrong (an
+  // outer `let v = 1` read for an inner `v` of another type). #2424.
   // NaN through a join, the other direction: identical bits, not equal.
   let na = if jcond(1) {
     dz(0.0, 0.0)

--- a/fixtures/gc_lane_scalar_parity_test.vibe
+++ b/fixtures/gc_lane_scalar_parity_test.vibe
@@ -398,3 +398,62 @@ test "#2426 Double equality follows IEEE 754, not the bit pattern" {
   assert(true == true)
   assert(!(true == false))
 }
+
+/// #2426 follow-up (Codex review on #2430): the BUILTIN `eq` is the other
+/// spelling of `==`, and it was routed on raw bits after `==` stopped being.
+/// Two operands, one concept -- the repository's rule is that these may not
+/// answer differently.
+fn eq_dbl(a: Double, b: Double) -> Bool {
+  eq(a, b)
+}
+
+test "#2426 the eq builtin answers on Doubles, not on their bits" {
+  // The sharpest case, and it is NOT signed zero: on the gc lane `eq` fell
+  // through to the content fall-back, which reads each operand as
+  // `(ptr << 32) | len`. A Double's low 32 bits are its mantissa TAIL, which
+  // is zero for every round value -- so `0.0` and `1.5` both decoded as
+  // zero-length strings and `String::equals` called them EQUAL. Measured on
+  // 978ccefc4, gc: `eq(0.0, 1.5)` answered true, for two ordinary distinct
+  // Doubles, with no diagnostic.
+  assert(!eq(0.0, 1.5))
+  assert(!eq(2.0, 4.0))
+  assert(!eq(1.0, 8.0))
+  // Signed zero, where the linear lane's arm was RC-only: its own comment
+  // gave the reason as "non-RC matches the existing `==` behavior", and `==`
+  // had just stopped behaving that way.
+  assert(eq(0.0, -0.0))
+  assert(eq(-0.0, 0.0))
+  // NaN, the opposite direction: identical bits, and still not equal.
+  let nan2 = dz(0.0, 0.0)
+  assert(!eq(nan2, nan2))
+  assert(!eq(nan2, 1.5))
+  // Ordinary equal Doubles, which must keep answering true.
+  assert(eq(1.5, 1.5))
+  let da = 1.5
+  let db = 1.5
+  assert(eq(da, db))
+  let dz1 = 0.0
+  let dz2 = -0.0
+  assert(eq(dz1, dz2))
+  assert(!eq(dz1, 1.5))
+  // Through annotated parameters, the binding form each lane seeds
+  // separately from a `let`.
+  assert(eq_dbl(0.0, -0.0))
+  assert(!eq_dbl(0.0, 1.5))
+  assert(eq_dbl(1.5, 1.5))
+  // The two spellings must agree, which is the property this test exists for.
+  assert(eq(0.0, -0.0) == (0.0 == -0.0))
+  assert(eq(0.0, 1.5) == (0.0 == 1.5))
+  assert(eq(2.0, 4.0) == (2.0 == 4.0))
+  assert(eq(1.5, 1.5) == (1.5 == 1.5))
+  assert(eq(nan2, nan2) == (nan2 == nan2))
+  assert(eq(da, db) == (da == db))
+  // And the Int and String sides of `eq` keep their own routing: a float arm
+  // that swallowed them would trade one silent wrong answer for another.
+  assert(eq(3, 3) == (3 == 3))
+  assert(eq(64<<32, 65<<32) == ((64<<32) == (65<<32)))
+  assert(eq("ab", "ab"))
+  assert(!eq("ab", "ac"))
+  assert(eq(true, true))
+  assert(!eq(true, false))
+}

--- a/fixtures/gc_lane_scalar_parity_test.vibe
+++ b/fixtures/gc_lane_scalar_parity_test.vibe
@@ -457,3 +457,121 @@ test "#2426 the eq builtin answers on Doubles, not on their bits" {
   assert(eq(true, true))
   assert(!eq(true, false))
 }
+
+/// #2426 follow-up (Codex review on #2430): a Double that arrives through a
+/// JOIN -- an `if`, a `match`, a block -- was invisible to every float
+/// classifier, so the binding was never logged and `==` fell back to a raw
+/// bit compare. Measured before the fix, on ALL THREE lanes including RC:
+/// the `if`, `match` and block forms each answered `0.0 == -0.0` false and
+/// `nan == nan` true, while the same values written as literals answered
+/// correctly. The linear lane's `expr_is_boolish` has classified joins since
+/// #825; the float twin never got the arms.
+///
+/// `jcond` keeps the condition out of reach of constant folding, so the join
+/// is a real one at run time.
+fn jcond(n: Int) -> Bool {
+  n > 0
+}
+
+fn jpick(n: Int) -> Int {
+  n
+}
+
+test "#2426 a Double keeps its type through a join" {
+  // if
+  let ia = if jcond(1) {
+    0.0
+  } else {
+    1.0
+  }
+  let ib = if jcond(1) {
+    -0.0
+  } else {
+    1.0
+  }
+  assert(ia == ib)
+  assert(eq(ia, ib))
+  assert(!(ia == 1.5))
+  // match
+  let ma = match jpick(1) {
+    1 => 0.0,
+    _ => 1.0
+  }
+  let mb = match jpick(1) {
+    1 => -0.0,
+    _ => 1.0
+  }
+  assert(ma == mb)
+  assert(eq(ma, mb))
+  // A block, which reaches the classifier as a `let` wrapper rather than as a
+  // sequence. `(-0.0)` is parenthesized on purpose: a `-` at the START of a
+  // line continues the previous line's expression, so the bare form here
+  // parses as `jcond(1) - 0.0` and the checker rejects it -- measured, and
+  // exactly what `binop_mismatch_msg`'s Unit-left-operand hint describes.
+  let ba = {
+    let _bu = jcond(1)
+    0.0
+  }
+  let bb = {
+    let _bu2 = jcond(1)
+    (-0.0)
+  }
+  assert(ba == bb)
+  assert(eq(ba, bb))
+  // NaN through a join, the other direction: identical bits, not equal.
+  let na = if jcond(1) {
+    dz(0.0, 0.0)
+  } else {
+    1.0
+  }
+  assert(!(na == na))
+  assert(na != na)
+  assert(!eq(na, na))
+  // Ordinary Doubles through a join still compare as Doubles.
+  let pa = if jcond(1) {
+    1.5
+  } else {
+    2.5
+  }
+  let pb = if jcond(1) {
+    1.5
+  } else {
+    9.5
+  }
+  assert(pa == pb)
+  assert(!(pa == 2.5))
+  // A join whose branches are NOT Doubles must keep its own routing: AND
+  // semantics means one non-float way out leaves the whole join unfloatish,
+  // and a float arm that swallowed these would trade one silent wrong answer
+  // for another.
+  let sa = if jcond(1) {
+    64<<32
+  } else {
+    1
+  }
+  assert(sa == 64<<32)
+  assert(!(sa == 65<<32))
+  let sb = if jcond(1) {
+    "hi"
+  } else {
+    "there"
+  }
+  assert(sb == "hi")
+  assert(!(sb == "there"))
+  let sc = if jcond(1) {
+    true
+  } else {
+    false
+  }
+  assert(sc == true)
+  assert(!(sc == false))
+  // NOT asserted here, deliberately: `__to_string` of a join. Measured on
+  // this compiler, `let sa = if c { 64<<32 } else { 1 }` renders as the
+  // EMPTY STRING on all three lanes, and a Bool join renders as `1` on gc,
+  // because the Int and Bool classifiers have the same missing join arms this
+  // test adds to the float one. Those are #2424's subject -- one classifier
+  // enumerating binding forms -- and closing them means routing on the
+  // checked type, not adding a fourth arm here. Pinning the wrong answer
+  // would be worse than leaving the row out: this file's contract is that
+  // every assertion in it holds on every lane.
+}

--- a/lib/@vibe/compiler/codegen/expr/compile_call.vibe
+++ b/lib/@vibe/compiler/codegen/expr/compile_call.vibe
@@ -1740,28 +1740,43 @@ fn compile_call_core(buf: Bytes, callee: Expr, args: Array[Expr], local_names: A
         nl_c
       }
     }
-    else if fname == "eq" && Array::length(args) == 2 && local_idx_hint < 0 && ctx.enable_rc && (cc_expr_is_floatish(Array::get(args, 0), local_names, ctx) || cc_expr_is_floatish(Array::get(args, 1), local_names, ctx)) && func_table_user_index_of(ctx.func_table, fname, ctx.num_user_funcs) < 0 {
+    else if fname == "eq" && Array::length(args) == 2 && local_idx_hint < 0 && (cc_expr_is_floatish(Array::get(args, 0), local_names, ctx) || cc_expr_is_floatish(Array::get(args, 1), local_names, ctx)) && func_table_user_index_of(ctx.func_table, fname, ctx.num_user_funcs) < 0 {
       // #745: under RC floats are BOXED — the scalar i64.eq below would
       // compare box pointers, so `eq(0.0125, 0.0125)` returned false. Take
-      // the same unbox + f64.eq path the `==` binop uses. Non-RC floats are
-      // raw f64 bits in an i64, where bitwise i64.eq matches the existing
-      // `==` behavior, so this branch is RC-only.
+      // the same unbox + f64.eq path the `==` binop uses.
+      //
+      // #2426: this arm was RC-only, and its reason was explicitly "non-RC
+      // floats are raw f64 bits, where bitwise i64.eq matches the existing
+      // `==` behavior". That justification is gone: `==` now takes a real
+      // f64 comparison on every lane, so keeping `eq` on raw bits under
+      // non-RC would make the two spellings of ONE concept disagree --
+      // measured on `VIBE_RC=0` before this change, `eq(0.0, -0.0)` was
+      // false while `0.0 == -0.0` was true, and `eq(nan, nan)` was true
+      // while `nan == nan` was false. The unbox and the Bool tag below are
+      // the only RC-specific steps, so both are guarded instead.
       //
       // #2309: `local_idx_hint < 0` for the same reason as the scalar arm
       // below -- and this arm had NO guard at all, so it was the sharper of
       // the two: `let eq = (a: Double, b: Double) -> Double { a + b }` then
       // `eq(1.5, 2.5)` printed `0` under RC, which is the production lane.
       let mut nl = ce(buf, Array::get(args, 0), local_names, next_local, ctx, ld)
-      emit_unbox_float(buf)
+      if ctx.enable_rc {
+        emit_unbox_float(buf)
+      }
       emit_f64_reinterpret_i64(buf)
       nl = ce(buf, Array::get(args, 1), local_names, nl, ctx, ld)
-      emit_unbox_float(buf)
+      if ctx.enable_rc {
+        emit_unbox_float(buf)
+      }
       emit_f64_reinterpret_i64(buf)
       emit_f64_eq(buf)
       emit_i64_extend_i32_s(buf)
-      // Tag the Bool like the scalar branch below (ADR-0055).
-      emit_i64_const(buf, 1)
-      emit_i64_shl(buf)
+      // Tag the Bool like the scalar branch below (ADR-0055). Untagged lanes
+      // hold a Bool as a raw 0/1, so the shift is RC-only.
+      if ctx.enable_rc {
+        emit_i64_const(buf, 1)
+        emit_i64_shl(buf)
+      }
       nl
     }
     else if fname == "eq" && Array::length(args) == 2 && local_idx_hint < 0 && (!prefer_bound_call || cc_arg_is_scalarish(Array::get(args, 0), local_names, ctx) || cc_arg_is_scalarish(Array::get(args, 1), local_names, ctx)) && func_table_user_index_of(ctx.func_table, fname, ctx.num_user_funcs) < 0 {

--- a/lib/@vibe/compiler/codegen/expr/compile_call.vibe
+++ b/lib/@vibe/compiler/codegen/expr/compile_call.vibe
@@ -620,6 +620,46 @@ fn cc_expr_is_floatish(e: Expr, local_names: Array[String], ctx: CompileCtx) -> 
     } else {
       false
     }
+  } else if tag == 7 || tag == 9 || tag == 10 || tag == 11 || tag == 14 || tag == 16 {
+    // #2426 follow-up (Codex review on #2430): a Double that arrives through a
+    // JOIN was invisible here, so `let a = if c { 0.0 } else { 1.0 }` left the
+    // slot unclassified and `a == b` fell back to a raw bit compare -- on
+    // every lane, RC included. Measured before this change: the `if`, `match`
+    // and block forms all answered `0.0 == -0.0` false and `nan == nan` true.
+    //
+    // The arms are the ones `cc_expr_is_boolish`, in this same file, has had since #825
+    // -- if / match / the three let wrappers the normalize pass introduces /
+    // sequence -- with the same AND semantics, which is the fail-closed
+    // direction: a join is a Double only when EVERY way out of it is.
+    if tag == 7 {
+      cc_expr_is_floatish(get_eif_then(e), local_names, ctx) && cc_expr_is_floatish(get_eif_else(e), local_names, ctx)
+    } else if tag == 9 {
+      cc_expr_is_floatish(get_elet_body(e), local_names, ctx)
+    } else if tag == 10 {
+      cc_expr_is_floatish(get_eletrec_body(e), local_names, ctx)
+    } else if tag == 11 {
+      cc_expr_is_floatish(get_eletmut_body(e), local_names, ctx)
+    } else if tag == 14 {
+      cc_expr_is_floatish(get_eseq_second(e), local_names, ctx)
+    } else {
+      let jarms = get_match_arms(e)
+      let jn = Array::length(jarms)
+      if jn == 0 {
+        false
+      } else {
+        let mut jall = true
+        let mut ji = 0
+        while ji < jn {
+          if !cc_expr_is_floatish(get_arm_body(Array::get(jarms, ji)), local_names, ctx) {
+            jall = false
+          } else {
+            ()
+          }
+          ji = ji + 1
+        }
+        jall
+      }
+    }
   } else if tag == 8 {
     let callee = get_ecall_callee(e)
     if array_contains_int(ctx.float_call_offsets, get_ecall_off(e)) {

--- a/lib/@vibe/compiler/codegen/expr/compile_call.vibe
+++ b/lib/@vibe/compiler/codegen/expr/compile_call.vibe
@@ -634,11 +634,38 @@ fn cc_expr_is_floatish(e: Expr, local_names: Array[String], ctx: CompileCtx) -> 
     if tag == 7 {
       cc_expr_is_floatish(get_eif_then(e), local_names, ctx) && cc_expr_is_floatish(get_eif_else(e), local_names, ctx)
     } else if tag == 9 {
-      cc_expr_is_floatish(get_elet_body(e), local_names, ctx)
+      // A join arm that ends in its OWN binder -- `if c { let x = 0.0; x }` --
+      // is the shape a bare body recursion misses, because the body is
+      // `EIdent(x)` and `x` has no slot at classification time (Codex review
+      // on #2432). It is answerable WITHOUT an environment: the body is a
+      // single identifier and the `let` immediately above it binds that exact
+      // name, so no inner scope can intervene and no outer binding of the same
+      // name is reachable. Anything further -- `let x = 0.0; let z = x; z` --
+      // is NOT answerable this way and stays open, measured: it still compares
+      // by raw bits on all three lanes. Closing it needs the binding's TYPE,
+      // which is #2424's channel; the alternative, an environment carried
+      // through the descent, is the design CLAUDE.md records going silently
+      // wrong (an outer `let v = 1` read for an inner `v` of another type).
+      let jb9 = get_elet_body(e)
+      if expr_tag(jb9) == 4 && get_eident_name(jb9) == get_elet_name(e) {
+        cc_expr_is_floatish(get_elet_val(e), local_names, ctx)
+      } else {
+        cc_expr_is_floatish(jb9, local_names, ctx)
+      }
     } else if tag == 10 {
-      cc_expr_is_floatish(get_eletrec_body(e), local_names, ctx)
+      let jb10 = get_eletrec_body(e)
+      if expr_tag(jb10) == 4 && get_eident_name(jb10) == get_eletrec_name(e) {
+        cc_expr_is_floatish(get_eletrec_val(e), local_names, ctx)
+      } else {
+        cc_expr_is_floatish(jb10, local_names, ctx)
+      }
     } else if tag == 11 {
-      cc_expr_is_floatish(get_eletmut_body(e), local_names, ctx)
+      let jb11 = get_eletmut_body(e)
+      if expr_tag(jb11) == 4 && get_eident_name(jb11) == get_eletmut_name(e) {
+        cc_expr_is_floatish(get_eletmut_val(e), local_names, ctx)
+      } else {
+        cc_expr_is_floatish(jb11, local_names, ctx)
+      }
     } else if tag == 14 {
       cc_expr_is_floatish(get_eseq_second(e), local_names, ctx)
     } else {

--- a/lib/@vibe/compiler/codegen/expr/compile_expr_tail.vibe
+++ b/lib/@vibe/compiler/codegen/expr/compile_expr_tail.vibe
@@ -672,11 +672,38 @@ export fn expr_is_floatish(e: Expr, local_names: Array[String], ctx: CompileCtx)
     if tag == 7 {
       expr_is_floatish(get_eif_then(e), local_names, ctx) && expr_is_floatish(get_eif_else(e), local_names, ctx)
     } else if tag == 9 {
-      expr_is_floatish(get_elet_body(e), local_names, ctx)
+      // A join arm that ends in its OWN binder -- `if c { let x = 0.0; x }` --
+      // is the shape a bare body recursion misses, because the body is
+      // `EIdent(x)` and `x` has no slot at classification time (Codex review
+      // on #2432). It is answerable WITHOUT an environment: the body is a
+      // single identifier and the `let` immediately above it binds that exact
+      // name, so no inner scope can intervene and no outer binding of the same
+      // name is reachable. Anything further -- `let x = 0.0; let z = x; z` --
+      // is NOT answerable this way and stays open, measured: it still compares
+      // by raw bits on all three lanes. Closing it needs the binding's TYPE,
+      // which is #2424's channel; the alternative, an environment carried
+      // through the descent, is the design CLAUDE.md records going silently
+      // wrong (an outer `let v = 1` read for an inner `v` of another type).
+      let jb9 = get_elet_body(e)
+      if expr_tag(jb9) == 4 && get_eident_name(jb9) == get_elet_name(e) {
+        expr_is_floatish(get_elet_val(e), local_names, ctx)
+      } else {
+        expr_is_floatish(jb9, local_names, ctx)
+      }
     } else if tag == 10 {
-      expr_is_floatish(get_eletrec_body(e), local_names, ctx)
+      let jb10 = get_eletrec_body(e)
+      if expr_tag(jb10) == 4 && get_eident_name(jb10) == get_eletrec_name(e) {
+        expr_is_floatish(get_eletrec_val(e), local_names, ctx)
+      } else {
+        expr_is_floatish(jb10, local_names, ctx)
+      }
     } else if tag == 11 {
-      expr_is_floatish(get_eletmut_body(e), local_names, ctx)
+      let jb11 = get_eletmut_body(e)
+      if expr_tag(jb11) == 4 && get_eident_name(jb11) == get_eletmut_name(e) {
+        expr_is_floatish(get_eletmut_val(e), local_names, ctx)
+      } else {
+        expr_is_floatish(jb11, local_names, ctx)
+      }
     } else if tag == 14 {
       expr_is_floatish(get_eseq_second(e), local_names, ctx)
     } else {

--- a/lib/@vibe/compiler/codegen/expr/compile_expr_tail.vibe
+++ b/lib/@vibe/compiler/codegen/expr/compile_expr_tail.vibe
@@ -658,6 +658,46 @@ export fn expr_is_floatish(e: Expr, local_names: Array[String], ctx: CompileCtx)
     } else {
       false
     }
+  } else if tag == 7 || tag == 9 || tag == 10 || tag == 11 || tag == 14 || tag == 16 {
+    // #2426 follow-up (Codex review on #2430): a Double that arrives through a
+    // JOIN was invisible here, so `let a = if c { 0.0 } else { 1.0 }` left the
+    // slot unclassified and `a == b` fell back to a raw bit compare -- on
+    // every lane, RC included. Measured before this change: the `if`, `match`
+    // and block forms all answered `0.0 == -0.0` false and `nan == nan` true.
+    //
+    // The arms are the ones `expr_is_boolish`, in this same file, has had since #825
+    // -- if / match / the three let wrappers the normalize pass introduces /
+    // sequence -- with the same AND semantics, which is the fail-closed
+    // direction: a join is a Double only when EVERY way out of it is.
+    if tag == 7 {
+      expr_is_floatish(get_eif_then(e), local_names, ctx) && expr_is_floatish(get_eif_else(e), local_names, ctx)
+    } else if tag == 9 {
+      expr_is_floatish(get_elet_body(e), local_names, ctx)
+    } else if tag == 10 {
+      expr_is_floatish(get_eletrec_body(e), local_names, ctx)
+    } else if tag == 11 {
+      expr_is_floatish(get_eletmut_body(e), local_names, ctx)
+    } else if tag == 14 {
+      expr_is_floatish(get_eseq_second(e), local_names, ctx)
+    } else {
+      let jarms = get_match_arms(e)
+      let jn = Array::length(jarms)
+      if jn == 0 {
+        false
+      } else {
+        let mut jall = true
+        let mut ji = 0
+        while ji < jn {
+          if !expr_is_floatish(get_arm_body(Array::get(jarms, ji)), local_names, ctx) {
+            jall = false
+          } else {
+            ()
+          }
+          ji = ji + 1
+        }
+        jall
+      }
+    }
   } else if tag == 8 {
     let callee = get_ecall_callee(e)
     if array_contains_int(ctx.float_call_offsets, get_ecall_off(e)) {

--- a/lib/@vibe/compiler/codegen/gc/backend_call.vibe
+++ b/lib/@vibe/compiler/codegen/gc/backend_call.vibe
@@ -382,9 +382,39 @@ fn bc_expr_is_floatish(e: Expr, local_names: Array[String], ctx: CompileCtxGc) -
     // than one lowering, and their gap is #2424's subject rather than this
     // one's.
     EIf(_, jt, jf) => bc_expr_is_floatish(jt, local_names, ctx) && bc_expr_is_floatish(jf, local_names, ctx),
-    ELet(_, _, jlb, _) => bc_expr_is_floatish(jlb, local_names, ctx),
-    ELetRec(_, _, jrb) => bc_expr_is_floatish(jrb, local_names, ctx),
-    ELetMut(_, _, jmb, _) => bc_expr_is_floatish(jmb, local_names, ctx),
+    // A join arm that ends in its OWN binder -- `if c { let x = 0.0; x }` --
+    // is the shape a bare body recursion misses: the body is `EIdent(x)` and
+    // `x` has no slot at classification time (Codex review on #2432).
+    // Answerable WITHOUT an environment, because the body is a single
+    // identifier and the `let` immediately above binds that exact name, so no
+    // inner scope intervenes and no outer binding of the name is reachable.
+    // One hop further -- `let x = 0.0; let z = x; z` -- is not, and stays
+    // open (measured: still a raw bit compare on all three lanes). That one
+    // needs the binding's TYPE, i.e. #2424's channel.
+    ELet(jlbn, jlbv, jlb, _) => match jlb {
+      EIdent(jlbn2, _) => if jlbn == jlbn2 {
+        bc_expr_is_floatish(jlbv, local_names, ctx)
+      } else {
+        bc_expr_is_floatish(jlb, local_names, ctx)
+      },
+      _ => bc_expr_is_floatish(jlb, local_names, ctx)
+    },
+    ELetRec(jrbn, jrbv, jrb) => match jrb {
+      EIdent(jrbn2, _) => if jrbn == jrbn2 {
+        bc_expr_is_floatish(jrbv, local_names, ctx)
+      } else {
+        bc_expr_is_floatish(jrb, local_names, ctx)
+      },
+      _ => bc_expr_is_floatish(jrb, local_names, ctx)
+    },
+    ELetMut(jmbn, jmbv, jmb, _) => match jmb {
+      EIdent(jmbn2, _) => if jmbn == jmbn2 {
+        bc_expr_is_floatish(jmbv, local_names, ctx)
+      } else {
+        bc_expr_is_floatish(jmb, local_names, ctx)
+      },
+      _ => bc_expr_is_floatish(jmb, local_names, ctx)
+    },
     ESeq(_, jsb) => bc_expr_is_floatish(jsb, local_names, ctx),
     EMatch(_, jarms) => {
       let jn = Array::length(jarms)

--- a/lib/@vibe/compiler/codegen/gc/backend_call.vibe
+++ b/lib/@vibe/compiler/codegen/gc/backend_call.vibe
@@ -2289,7 +2289,26 @@ fn compile_call_gc(buf: Bytes, callee: Expr, args: Array[Expr], local_names: Arr
         // in compile_call.vibe); it was never ported here. One operand is
         // enough: `==` already routes that way (`emit_gc_eq_value`), and a
         // scalar can only be equal to another scalar's bit pattern.
-        if bc_expr_is_intish(Array::get(args, 0), local_names, ctx) || bc_expr_is_intish(Array::get(args, 1), local_names, ctx) {
+        if bc_expr_is_floatish(Array::get(args, 0), local_names, ctx) || bc_expr_is_floatish(Array::get(args, 1), local_names, ctx) {
+          // #2426: a provably Double operand takes a real f64 comparison,
+          // like `==` does (emit_gc_eq_value) and like the linear lane's own
+          // `eq` arm has since #745. Without it BOTH remaining arms answer on
+          // raw bits, and the content fall-back below is the sharper of the
+          // two: it reads each operand as `(ptr << 32) | len`, and a Double's
+          // low 32 bits are its mantissa tail, which is ZERO for every
+          // round value. Two zero-length "strings" compare EQUAL, so
+          // `eq(0.0, 1.5)` answered **true** -- measured on 978ccefc4, gc
+          // lane, for two ordinary distinct Doubles with no diagnostic. The
+          // `i64.eq` arm below is wrong for Doubles in the other direction:
+          // `-0.0` and `nan` (identical bits, and IEEE 754 says not equal).
+          let mut fnl = ce(buf, Array::get(args, 0), local_names, next_local, ld)
+          emit_f64_reinterpret_i64(buf)
+          fnl = ce(buf, Array::get(args, 1), local_names, fnl, ld)
+          emit_f64_reinterpret_i64(buf)
+          emit_f64_eq(buf)
+          emit_i64_extend_i32_s(buf)
+          fnl
+        } else if bc_expr_is_intish(Array::get(args, 0), local_names, ctx) || bc_expr_is_intish(Array::get(args, 1), local_names, ctx) {
           let mut snl = ce(buf, Array::get(args, 0), local_names, next_local, ld)
           snl = ce(buf, Array::get(args, 1), local_names, snl, ld)
           emit_i64_eq(buf)

--- a/lib/@vibe/compiler/codegen/gc/backend_call.vibe
+++ b/lib/@vibe/compiler/codegen/gc/backend_call.vibe
@@ -367,6 +367,44 @@ fn bc_expr_is_floatish(e: Expr, local_names: Array[String], ctx: CompileCtxGc) -
       EIdent(cn, _) => array_contains_int(ctx.gc_float_call_offsets, call_off) || cn == "Int::to_double" || cn == "Double::from_i64_bits" || cn == "Float::to_double" || cn == "Double::to_float" || cn == "Int::to_float" || gc_fn_returns_float(local_names, ctx, cn),
       _ => false
     },
+    // #2426 follow-up (Codex review on #2430): a Double arriving through a
+    // JOIN. Without these arms `let a = if c { 0.0 } else { 1.0 }` left the
+    // slot unlogged, and `a == b` then took a raw bit compare -- measured
+    // before this change, the `if`, `match` and block forms each answered
+    // `0.0 == -0.0` false and `nan == nan` true, on this lane and on both
+    // linear ones. AND semantics (every way out of the join must be a
+    // Double) is the fail-closed direction, and it matches how the linear
+    // lane's `expr_is_boolish` has treated joins since #825.
+    //
+    // Only the FLOAT classifier gets them here. The gc boolish and intish
+    // predicates have the same gap and are deliberately left alone: they
+    // route `__to_string` and `==`, where widening the answer changes more
+    // than one lowering, and their gap is #2424's subject rather than this
+    // one's.
+    EIf(_, jt, jf) => bc_expr_is_floatish(jt, local_names, ctx) && bc_expr_is_floatish(jf, local_names, ctx),
+    ELet(_, _, jlb, _) => bc_expr_is_floatish(jlb, local_names, ctx),
+    ELetRec(_, _, jrb) => bc_expr_is_floatish(jrb, local_names, ctx),
+    ELetMut(_, _, jmb, _) => bc_expr_is_floatish(jmb, local_names, ctx),
+    ESeq(_, jsb) => bc_expr_is_floatish(jsb, local_names, ctx),
+    EMatch(_, jarms) => {
+      let jn = Array::length(jarms)
+      if jn == 0 {
+        false
+      } else {
+        let mut jall = true
+        let mut ji = 0
+        while ji < jn {
+          let (_, jbody) = Array::get(jarms, ji)
+          if !bc_expr_is_floatish(jbody, local_names, ctx) {
+            jall = false
+          } else {
+            ()
+          }
+          ji = ji + 1
+        }
+        jall
+      }
+    },
     _ => false
   }
 }

--- a/lib/@vibe/compiler/codegen/gc/backend_expr.vibe
+++ b/lib/@vibe/compiler/codegen/gc/backend_expr.vibe
@@ -264,6 +264,44 @@ fn gc_expr_is_floatish(e: Expr, local_names: Array[String], ctx: CompileCtxGc) -
       EIdent(cn, _) => array_contains_int(ctx.gc_float_call_offsets, call_off) || cn == "Int::to_double" || cn == "Double::from_i64_bits" || cn == "Float::to_double" || cn == "Double::to_float" || cn == "Int::to_float" || gc_fn_returns_float(local_names, ctx, cn),
       _ => false
     },
+    // #2426 follow-up (Codex review on #2430): a Double arriving through a
+    // JOIN. Without these arms `let a = if c { 0.0 } else { 1.0 }` left the
+    // slot unlogged, and `a == b` then took a raw bit compare -- measured
+    // before this change, the `if`, `match` and block forms each answered
+    // `0.0 == -0.0` false and `nan == nan` true, on this lane and on both
+    // linear ones. AND semantics (every way out of the join must be a
+    // Double) is the fail-closed direction, and it matches how the linear
+    // lane's `expr_is_boolish` has treated joins since #825.
+    //
+    // Only the FLOAT classifier gets them here. The gc boolish and intish
+    // predicates have the same gap and are deliberately left alone: they
+    // route `__to_string` and `==`, where widening the answer changes more
+    // than one lowering, and their gap is #2424's subject rather than this
+    // one's.
+    EIf(_, jt, jf) => gc_expr_is_floatish(jt, local_names, ctx) && gc_expr_is_floatish(jf, local_names, ctx),
+    ELet(_, _, jlb, _) => gc_expr_is_floatish(jlb, local_names, ctx),
+    ELetRec(_, _, jrb) => gc_expr_is_floatish(jrb, local_names, ctx),
+    ELetMut(_, _, jmb, _) => gc_expr_is_floatish(jmb, local_names, ctx),
+    ESeq(_, jsb) => gc_expr_is_floatish(jsb, local_names, ctx),
+    EMatch(_, jarms) => {
+      let jn = Array::length(jarms)
+      if jn == 0 {
+        false
+      } else {
+        let mut jall = true
+        let mut ji = 0
+        while ji < jn {
+          let (_, jbody) = Array::get(jarms, ji)
+          if !gc_expr_is_floatish(jbody, local_names, ctx) {
+            jall = false
+          } else {
+            ()
+          }
+          ji = ji + 1
+        }
+        jall
+      }
+    },
     _ => false
   }
 }

--- a/lib/@vibe/compiler/codegen/gc/backend_expr.vibe
+++ b/lib/@vibe/compiler/codegen/gc/backend_expr.vibe
@@ -279,9 +279,39 @@ fn gc_expr_is_floatish(e: Expr, local_names: Array[String], ctx: CompileCtxGc) -
     // than one lowering, and their gap is #2424's subject rather than this
     // one's.
     EIf(_, jt, jf) => gc_expr_is_floatish(jt, local_names, ctx) && gc_expr_is_floatish(jf, local_names, ctx),
-    ELet(_, _, jlb, _) => gc_expr_is_floatish(jlb, local_names, ctx),
-    ELetRec(_, _, jrb) => gc_expr_is_floatish(jrb, local_names, ctx),
-    ELetMut(_, _, jmb, _) => gc_expr_is_floatish(jmb, local_names, ctx),
+    // A join arm that ends in its OWN binder -- `if c { let x = 0.0; x }` --
+    // is the shape a bare body recursion misses: the body is `EIdent(x)` and
+    // `x` has no slot at classification time (Codex review on #2432).
+    // Answerable WITHOUT an environment, because the body is a single
+    // identifier and the `let` immediately above binds that exact name, so no
+    // inner scope intervenes and no outer binding of the name is reachable.
+    // One hop further -- `let x = 0.0; let z = x; z` -- is not, and stays
+    // open (measured: still a raw bit compare on all three lanes). That one
+    // needs the binding's TYPE, i.e. #2424's channel.
+    ELet(jlbn, jlbv, jlb, _) => match jlb {
+      EIdent(jlbn2, _) => if jlbn == jlbn2 {
+        gc_expr_is_floatish(jlbv, local_names, ctx)
+      } else {
+        gc_expr_is_floatish(jlb, local_names, ctx)
+      },
+      _ => gc_expr_is_floatish(jlb, local_names, ctx)
+    },
+    ELetRec(jrbn, jrbv, jrb) => match jrb {
+      EIdent(jrbn2, _) => if jrbn == jrbn2 {
+        gc_expr_is_floatish(jrbv, local_names, ctx)
+      } else {
+        gc_expr_is_floatish(jrb, local_names, ctx)
+      },
+      _ => gc_expr_is_floatish(jrb, local_names, ctx)
+    },
+    ELetMut(jmbn, jmbv, jmb, _) => match jmb {
+      EIdent(jmbn2, _) => if jmbn == jmbn2 {
+        gc_expr_is_floatish(jmbv, local_names, ctx)
+      } else {
+        gc_expr_is_floatish(jmb, local_names, ctx)
+      },
+      _ => gc_expr_is_floatish(jmb, local_names, ctx)
+    },
     ESeq(_, jsb) => gc_expr_is_floatish(jsb, local_names, ctx),
     EMatch(_, jarms) => {
       let jn = Array::length(jarms)


### PR DESCRIPTION
Follow-up to #2430, which closed #2426 for the `==` operator on literal and named operands. Codex's review found places the fix did not reach; measuring each one widened it. Three rounds, all here.

Every "before" cell below is **unchanged by #2430** — these are pre-existing wrong answers, not regressions from it.

---

## 1. The builtin `eq` was left on raw bits

`eq` is the other spelling of `==`. Measured on `978ccefc4`, one file per claim:

| claim | RC | bump | gc |
| :--- | :--- | :--- | :--- |
| `eq(0.0, -0.0)` | true ✓ | **false** ✗ | true ✓ |
| `eq(nan, nan)` | false ✓ | **true** ✗ | **true** ✗ |
| **`eq(0.0, 1.5)`** | false ✓ | false ✓ | **true** ✗ |

**The last row is the one to look at, and it is not about signed zero.** On gc, `eq` fell through to the content fall-back, which reads each operand as a `(ptr << 32) | len` fat pointer. A Double's low 32 bits are its **mantissa tail**, which is zero for every round value — so `0.0` and `1.5` both decode as zero-length strings, and `String::equals` calls two zero-length strings equal. Two ordinary distinct Doubles, answered `true`, with no diagnostic.

That also explains the cells that looked fine: `eq(0.0, -0.0)` was right on gc for the same wrong reason (also length 0), and `eq(2.0, 4.0)` escaped only because both implied pointers land out of bounds. So `main` already had the two spellings disagreeing before #2430: `0.0 == 1.5` is correctly false on gc while `eq(0.0, 1.5)` is true.

**Fix** — each change is the arm `==` already has:

* `compile_call.vibe` — drop `ctx.enable_rc &&` from the `eq` float arm. Its own comment gave the guard's reason as *"non-RC floats are raw f64 bits, where bitwise `i64.eq` matches the existing `==` behavior"*, and #2430 removed exactly that. The unbox and the ADR-0055 Bool tag are the only RC-specific steps, so both are guarded individually instead.
* `backend_call.vibe` — a `bc_expr_is_floatish` arm before the `bc_expr_is_intish` one, so a Double reaches neither bit path.

---

## 2. A Double arriving through a JOIN was never classified

`expr_is_floatish` had no `EIf` arm, so `let a = if c { 0.0 } else { 1.0 }` left the slot unlogged and `a == b` still took a raw bit compare. Measuring widened it twice — `match` and a block are wrong the same way, and unlike the literal case **all three are wrong on RC too**:

| shape | `0.0 == -0.0` | `nan == nan` |
| :--- | :--- | :--- |
| `if` join | false — RC, bump, gc | true — RC, bump, gc |
| `match` join | false — RC, bump, gc | true — RC, bump, gc |
| block join | false — RC, bump, gc | true — RC, bump, gc |
| the same values as literals | true | false |

**Fix**: the arms `expr_is_boolish` — the twin sitting in the same two files — has had since #825: if (both branches), match (every arm), the three `let` wrappers the normalize pass introduces, and sequence. **AND** semantics, the fail-closed direction: a join is a Double only when every way out of it is. Applied to **all four** copies of the classifier — #2158 records that fixing one copy and not the others is precisely how this predicate breaks.

---

## 3. A join arm that ends in its own binder

`let a = if c { let x = 0.0; x } else { let x = 1.0; x }` — the body is `EIdent(x)` and `x` has no slot at classification time, so round 2's body recursion answered "not a Double". Measured on that build: false for `0.0`/`-0.0`, NaN equal to itself, all three lanes.

**Fix**: that exact shape needs no environment. The body is a single identifier and the `let` immediately above it binds that same name, so no inner scope can intervene and no outer binding of the name is reachable. The arm compares the two names and reads the initializer when they match, for `ELet` / `ELetRec` / `ELetMut`, in all four classifiers.

**What it deliberately does not do** is carry a binding environment through the descent. One hop further — `let x = 0.0; let z = x; z` — therefore stays wrong, measured, and the fixture says so in a comment instead of asserting it. CLAUDE.md records what happened the last time a codegen scan recovered types from an environment: *"six review findings came from that one decision, the first of them silently wrong"*. Type-aware is the right answer, and it is #2424.

---

## What pins it

`fixtures/gc_lane_scalar_parity_test.vibe` gains two tests: one pinning the two spellings **together** (`eq(x, y) == (x == y)` for signed zero, distinct round values, NaN, equal Doubles) plus the operand shapes each lane classifies separately; one covering if / match / block joins and a join arm ending in its own binder, for both `==` and `eq`, with NaN and with Int / String / Bool joins as controls the float arms must not swallow.

It deliberately does **not** assert `__to_string` of a join, or the one-hop-further binder shape. Pinning a wrong answer would be worse than leaving the row out: this file's contract is that every assertion in it holds on every lane.

Measured: red on main's compiler (`de902cfbf`) on all three lanes, red on each intermediate build for the part that build did not yet fix, and green on RC, bump and gc with all three changes. `bash scripts/compiler_gate.sh` passes end to end, stage2 == stage3 fixpoint included.

One gotcha worth the comment it got in the fixture: a `-` at the **start of a line** continues the previous line's expression, so `(-0.0)` inside a block needs its parentheses — the bare form parses as `jcond(1) - 0.0` and the checker rejects it. Measured; exactly what the Unit-left-operand hint in `binop_mismatch_msg` describes.

## Left open, deliberately

The review rounds stopped converging — each fix drew a new one reshaped around the same classifier, and round 4's finding turned out to be a different bug class entirely. Rather than a fifth arm, what is still flagged:

| still open | where |
| :--- | :--- |
| `let x = 0.0; let z = x; z` in a join arm — one hop past what syntax can answer | #2424 |
| `__to_string` of an Int or Bool join | #2424 |
| a `Double` field of a tuple reached through names | #2431 |
| a builtin as a first-class value — emits a module that will not load, on `main` too, for `Int` as much as `Double` | #2433 |

Every one is the same sentence: codegen deciding a value's type from its syntax because the checker's answer never reaches it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FYMVd6D2o82suTfTwoJPMf