### PR TITLE
Builtins in value position (#2433) and Double inside an aggregate (#2431)

### DIFF
--- a/docs/spec/stable-surface.md
+++ b/docs/spec/stable-surface.md
@@ -194,6 +194,12 @@ The stable symbols listed under "Key Builtins" in the
 > anything the frozen entries do not also say; they stay out of the frozen
 > subset by scope decision, not because they are less of a value than the
 > entries above them.
+>
+> The one exception is `FrozenArray::from_array` / `FrozenArray::to_array`,
+> which #1733 gave a real value form by materializing them as a one-argument
+> lambda in both codegen lanes. That exception is a lowering, not a rule:
+> `builtin_ident_has_value_form` in `lib/@vibe/compiler/core/builtin_name.vibe`
+> is the single source of truth, read by the checker and by both lanes.
 
 - **String** (compiler builtin, no import needed): `length`, `concat`,
   `substring`, `contains`, `index_of`, `split`, `trim`, `starts_with`,

--- a/docs/spec/stable-surface.md
+++ b/docs/spec/stable-surface.md
@@ -181,6 +181,20 @@ of each item is [spec/syntax.md](syntax.md) and the
 The stable symbols listed under "Key Builtins" in the
 [cheatsheet](../cheatsheet.md) are frozen:
 
+> **What a frozen builtin promises (#2433).** The freeze covers the
+> **operation** -- its name, its arity and its signature at the call site. It
+> does not promise a first-class function value: `String::length("abc")` is
+> frozen, `let g = String::length` is a checker error on every lane. That is
+> not a narrowing of this list, it is what the compiler has always done --
+> a builtin body lives below `func_offset` and is never in the indirect call
+> table, so taking one as a value emitted a module the runtime refused to load
+> (`invalid signature index`) or trapped with `table index is out of bounds`.
+> #2433 replaced those with a diagnostic that names the call form and the wrap
+> form (`(a, b) -> eq(a, b)`). The carve-outs below therefore no longer say
+> anything the frozen entries do not also say; they stay out of the frozen
+> subset by scope decision, not because they are less of a value than the
+> entries above them.
+
 - **String** (compiler builtin, no import needed): `length`, `concat`,
   `substring`, `contains`, `index_of`, `split`, `trim`, `starts_with`,
   `ends_with`, `join`, `from_char_code`, `char_code_at`, `byte_at`,

--- a/fixtures/tuple_double_eq_test.vibe
+++ b/fixtures/tuple_double_eq_test.vibe
@@ -1,0 +1,133 @@
+// #2431: a `Double` reached through a NAME inside an aggregate was compared by
+// raw bits -- and under RC, the production default, by box IDENTITY.
+//
+// Measured on stage2 before this change, one row per spelling, on all three
+// lanes (linear/RC, linear with VIBE_RC=0, wasm-gc):
+//
+//   let x = (1.5, 1); let y = (1.5, 1); x == y        RC: FALSE   bump/gc: true
+//   let x = (0.0, 1); let y = (-0.0, 1); x == y       FALSE on ALL THREE
+//   let a = Some(0.0); let b = Some(-0.0); a == b     FALSE on ALL THREE
+//
+// The first row is the sharpest: two structurally equal tuples, no signed zero
+// and no NaN in sight, unequal to each other on the lane every user gets by
+// default. Under RC a Double field is a boxed heap value, so the generic `eq`
+// builtin compared two distinct boxes.
+//
+// The LITERAL spellings were already right (`(0.0, c) == (-0.0, c)` answers
+// true on every lane), because `infer_static_eq_type_binop` reads the element
+// types straight off the literal and dispatches to `eq_for_typed`, whose
+// `Double` arm wraps each side in `Double::to_float` and so reaches the
+// unbox-then-`f64.eq` path. Only the name-reached spellings fell through.
+//
+// The fix is the same channel, two steps: the recorded eq SHAPE keeps its
+// tuple element types (it used to record `(,)` for `(0.0, 1)`, since the shape
+// inferencer has no scalar cases), and `Double` joins `Bytes` / `Array` / `Map`
+// as a head the codegen walk gets wrong.
+//
+// KNOWN LIMIT, deliberately fail-closed: an element whose type this pass
+// cannot name from the binding site -- a computed Double reached through a
+// bare name, `let n = f(); let x = (n, 1)` -- stays `__EqUnknown`, keeps the
+// old comparison, and is NOT guessed. Guessing would be worse than the bug: a
+// leaf wrongly called Double routes an Int field through `Double::to_float`.
+// An ANNOTATION supplies what the syntax does not, exactly as it does for
+// `let xs: Array[Int] = []`, and the NaN case below is written that way.
+
+fn mk_pair() -> (Double, Int) {
+  (1.5, 1)
+}
+
+test "#2431: two structurally equal Double tuples are equal" {
+  let x = (1.5, 1)
+  let y = (1.5, 1)
+  assert(x == y)
+  assert(!(x != y))
+}
+
+test "#2431: +0.0 == -0.0 inside a tuple reached through names" {
+  let x = (0.0, 1)
+  let y = (-0.0, 1)
+  assert(x == y)
+}
+
+test "#2431: distinct Doubles in a tuple stay unequal" {
+  let a = (1.5, 1)
+  let b = (2.5, 1)
+  assert(!(a == b))
+  assert(a != b)
+}
+
+test "#2431: the Double may be in any position" {
+  let x = (1, 1.5)
+  let y = (1, 1.5)
+  assert(x == y)
+  let z = (1, 2.5)
+  assert(!(x == z))
+}
+
+test "#2431: two Doubles in one tuple" {
+  let x = (1.5, 2.5)
+  let y = (1.5, 2.5)
+  assert(x == y)
+  let z = (1.5, 3.5)
+  assert(!(x == z))
+}
+
+test "#2431: a tuple reached through a function's declared return type" {
+  let x = mk_pair()
+  let y = mk_pair()
+  assert(x == y)
+}
+
+test "#2431: Option[Double] through names" {
+  let a = Some(0.0)
+  let b = Some(-0.0)
+  assert(a == b)
+  let c = Some(1.5)
+  assert(!(a == c))
+  let d = Some(1.5)
+  assert(c == d)
+}
+
+test "#2431: NaN in a tuple is not equal to itself" {
+  // IEEE 754: `nan == nan` is false. The raw-bit comparison said true, since
+  // the bits are identical. `0.0 / 0.0` is not a literal, so the element type
+  // comes from the annotation -- the documented way to supply what the
+  // binding's syntax does not say.
+  let n = 0.0 / 0.0
+  let x: (Double, Int) = (n, 1)
+  let y: (Double, Int) = (n, 1)
+  assert(!(x == y))
+  assert(x != y)
+}
+
+test "#2431: an Int tuple is untouched" {
+  let x = (7, 1)
+  let y = (7, 1)
+  assert(x == y)
+  let z = (8, 1)
+  assert(!(x == z))
+}
+
+test "#2431: a String tuple is untouched" {
+  let x = ("a", 1)
+  let y = ("a", 1)
+  assert(x == y)
+  let z = ("b", 1)
+  assert(!(x == z))
+}
+
+test "#2431: a nested tuple holding a Double" {
+  let x = ((1.5, 2), 3)
+  let y = ((1.5, 2), 3)
+  assert(x == y)
+  let z = ((2.5, 2), 3)
+  assert(!(x == z))
+}
+
+test "#2431: a bare Double comparison is unchanged" {
+  let a = 0.0
+  let b = -0.0
+  assert(a == b)
+  let c = 1.5
+  assert(!(a == c))
+}

--- a/lib/@vibe/compiler/checker/checker.vibe
+++ b/lib/@vibe/compiler/checker/checker.vibe
@@ -9,7 +9,6 @@ import @vibe/compiler/core {
   TypeEnv,
   TypeExpr,
   apply_type_constructor,
-  builtin_registry,
   canonical_builtin_name,
   collect_tvars,
   compiler_owned_type_arity,
@@ -2238,26 +2237,40 @@ fn railway_ident_lookup_name(name: String) -> String {
   }
 }
 
-/// #2274: a builtin ident is a first-class value iff it has a linear func-table
-/// row. Registry names with only a callsite lowering (`Map::get`) and
-/// fallback-only names (`Map::set`) type-check as `CtFn` today, then ICE in
-/// codegen because there is no function pointer to take. `String::length` is
-/// in the table and stays a value.
-fn builtin_is_first_class_value(name: String) -> Bool {
-  let normalized = canonical_builtin_name(name)
-  let rows = builtin_registry()
-  let mut i = 0
-  let mut found = false
-  while i < Array::length(rows) {
-    let (rname, _, _, in_linear, _) = Array::get(rows, i)
-    if rname == normalized && in_linear {
-      found = true
-      i = Array::length(rows)
-    } else {
-      i = i + 1
-    }
+/// #2433: a builtin ident is a first-class value iff it is NOT a function.
+///
+/// #2274 keyed this on the linear FUNC-TABLE row (`in_linear`), on the reading
+/// that a builtin with a real emitted body has a pointer to take. It does not.
+/// The two tables are different tables: the func table maps a builtin name to
+/// its function INDEX for direct `call`, while the value produced for a
+/// first-class function is an INDIRECT-table slot, and the indirect table is
+/// populated from user functions and lambdas only (`linked_compile.vibe`:
+/// `tei < num_user_funcs` -> `func_offset + tei`, else a lambda). Builtin
+/// bodies sit in the generated-helper index block BELOW `func_offset`, so
+/// `table_slot = fidx - ctx.func_offset` is negative for every one of them,
+/// and they carry no closure-env parameter, so the `closure_type_base + n`
+/// signature would not match even if a slot existed.
+///
+/// Measured on stage2 before this change, all three failure modes with no
+/// source location: `let f = eq` emitted a module the runtime rejected
+/// (`invalid signature index: 11`, the arity-2 closure type nothing else in
+/// the program registered); with a same-arity lambda present so the type
+/// existed, `let f = eq` and `let h = String::length` -- an `in_linear` row,
+/// so #2274 called it a value -- both trapped with `table index is out of
+/// bounds`; `let g = not` reached codegen as an unresolved ident and asked the
+/// user to report a compiler bug.
+///
+/// So the honest predicate is the type, not the registration: a builtin typed
+/// `CtFn` has no value form on any lane. Everything else does and is
+/// unaffected -- a nullary constructor (`None`, and a user enum's `Red`) is
+/// not a `CtFn` and lowers through the `ctor_table` arm of `compile_expr`,
+/// which is why #2274's bare-name exemption existed and why dropping that
+/// exemption is safe now that the test is the type.
+fn builtin_ident_is_value_type(t: Type) -> Bool {
+  match t {
+    CtFn(_, _, _) => false,
+    _ => true
   }
-  found
 }
 
 fn call_only_builtin_param_list(n: Int) -> String {
@@ -7978,15 +7991,17 @@ fn check_expr_capture_impl(expr: Expr, env: TypeEnv, defs: Array[TypeDef], s: Su
         (ti, s1, c1)
       },
       None => match lookup_builtin_in_env(env, railway_ident_lookup_name(name)) {
-        Some(t) => if builtin_is_first_class_value(railway_ident_lookup_name(name)) || !String::contains(name, "::") {
-          // Bare names (`None`) keep the historical lookup: nullary
-          // constructors are values, and rejecting every non-table builtin
-          // silently broke selfhost (`None` is not in the linear func table).
-          // Qualified call-only ops (`Map::get`) are the #2274 hole. Do not
-          // exempt ident_off < 0: the FS compile lane still parses unlocated,
-          // so every user ident is -1. Call sites of those names are typed
-          // by the ECall fallback, which looks up the builtin without this
-          // rejection.
+        Some(t) => if builtin_ident_is_value_type(t) {
+          // A non-function builtin is a value: a nullary constructor (`None`)
+          // lowers through the `ctor_table` arm. This is what #2274's
+          // bare-name exemption was really protecting -- rejecting every
+          // non-table builtin silently broke selfhost on `None`, which is not
+          // in the linear func table. #2433 replaced that exemption with the
+          // type test, so bare `eq` / `not` are rejected here too rather than
+          // reaching codegen. Do not exempt ident_off < 0: the FS compile lane
+          // still parses unlocated, so every user ident is -1. Call sites of
+          // these names are typed by the ECall fallback, which looks up the
+          // builtin without this rejection.
           if ident_off >= 0 {
             tab_identifier_ty(tytab, ident_off, t, capture, lane)
           } else {

--- a/lib/@vibe/compiler/checker/checker.vibe
+++ b/lib/@vibe/compiler/checker/checker.vibe
@@ -9,6 +9,7 @@ import @vibe/compiler/core {
   TypeEnv,
   TypeExpr,
   apply_type_constructor,
+  builtin_ident_has_value_form,
   canonical_builtin_name,
   collect_tvars,
   compiler_owned_type_arity,
@@ -2266,10 +2267,20 @@ fn railway_ident_lookup_name(name: String) -> String {
 /// not a `CtFn` and lowers through the `ctor_table` arm of `compile_expr`,
 /// which is why #2274's bare-name exemption existed and why dropping that
 /// exemption is safe now that the test is the type.
-fn builtin_ident_is_value_type(t: Type) -> Bool {
-  match t {
-    CtFn(_, _, _) => false,
-    _ => true
+/// #1733 is the exception, and it is not a taste call: `compile_expr` and
+/// `backend_expr` materialize the two FrozenArray conversions as a one-argument
+/// LAMBDA (`frozen_array_conversion_closure`), which is an ordinary closure
+/// with an ordinary table slot, so those two really are values.
+/// `builtin_ident_has_value_form` in `core/builtin_name.vibe` is the single
+/// source of truth both lanes read, so this cannot drift from the lowering.
+fn builtin_ident_is_value(name: String, t: Type) -> Bool {
+  if builtin_ident_has_value_form(name) {
+    true
+  } else {
+    match t {
+      CtFn(_, _, _) => false,
+      _ => true
+    }
   }
 }
 
@@ -7991,7 +8002,7 @@ fn check_expr_capture_impl(expr: Expr, env: TypeEnv, defs: Array[TypeDef], s: Su
         (ti, s1, c1)
       },
       None => match lookup_builtin_in_env(env, railway_ident_lookup_name(name)) {
-        Some(t) => if builtin_ident_is_value_type(t) {
+        Some(t) => if builtin_ident_is_value(railway_ident_lookup_name(name), t) {
           // A non-function builtin is a value: a nullary constructor (`None`)
           // lowers through the `ctor_table` arm. This is what #2274's
           // bare-name exemption was really protecting -- rejecting every

--- a/lib/@vibe/compiler/codegen/expr/compile_expr.vibe
+++ b/lib/@vibe/compiler/codegen/expr/compile_expr.vibe
@@ -6,6 +6,7 @@ import @vibe/compiler/core {
   Stmt,
   TypeExpr,
   bsearch_leftmost,
+  builtin_ident_has_value_form,
   bytebuf_length,
   bytebuf_new,
   bytebuf_push,
@@ -239,8 +240,12 @@ import ./compile_match.vibe {
 
 //# Functions
 
+/// #2433: the name list moved to `core/builtin_name.vibe`. The checker rejects
+/// a builtin ident in value position, and it must exempt exactly the names this
+/// lane eta-expands below -- two copies of the list would drift into either a
+/// spurious error or the load-time failure #2433 removed.
 fn is_frozen_array_conversion_name(name: String) -> Bool {
-  name == "FrozenArray::from_array" || name == "FrozenArray::to_array"
+  builtin_ident_has_value_form(name)
 }
 
 /// Builtin indices live before `func_offset`, while ordinary closure table

--- a/lib/@vibe/compiler/codegen/gc/backend_expr.vibe
+++ b/lib/@vibe/compiler/codegen/gc/backend_expr.vibe
@@ -5,6 +5,7 @@ import @vibe/compiler/core {
   Pat,
   Stmt,
   TypeExpr,
+  builtin_ident_has_value_form,
   bytebuf_length,
   bytebuf_new,
   bytebuf_push,
@@ -209,8 +210,12 @@ import ./backend_match.vibe {
 
 //# Functions
 
+/// #2433: the name list moved to `core/builtin_name.vibe`. The checker rejects
+/// a builtin ident in value position, and it must exempt exactly the names this
+/// lane eta-expands below -- two copies of the list would drift into either a
+/// spurious error or the load-time failure #2433 removed.
 fn is_frozen_array_conversion_name(name: String) -> Bool {
-  name == "FrozenArray::from_array" || name == "FrozenArray::to_array"
+  builtin_ident_has_value_form(name)
 }
 
 /// See the linear twin: generated builtins precede `func_offset`, so expose a

--- a/lib/@vibe/compiler/core/builtin_name.vibe
+++ b/lib/@vibe/compiler/core/builtin_name.vibe
@@ -42,6 +42,35 @@ export fn canonical_builtin_name(name: String) -> String {
   }
 }
 
+/// #1733 / #2433: the builtins that have a VALUE form, i.e. that may be bound
+/// to a name and called later rather than only called directly.
+///
+/// The set is small and it is not a matter of taste: a builtin's function index
+/// lives BELOW `func_offset`, while a first-class function value is an index
+/// into the indirect call table, which holds user functions and lambdas only.
+/// `table_slot = fidx - func_offset` is therefore negative for every builtin,
+/// and builtin bodies carry no closure-env parameter, so the closure signature
+/// would not match even if a slot existed. Measured on stage2: `let f = eq`
+/// emitted a module the runtime refused (`invalid signature index`), and
+/// `let h = String::concat` compiled and then trapped with `table index is out
+/// of bounds`.
+///
+/// The two names below are exempt because #1733 gave them a real value form:
+/// `compile_expr` / `backend_expr` materialize them as a one-argument LAMBDA
+/// (`frozen_array_conversion_closure`), which is an ordinary closure with an
+/// ordinary table slot. `fixtures/frozen_array_copies_test.vibe` calls both
+/// through a binding and passes.
+///
+/// This is the single source of truth for that set: the checker rejects a
+/// builtin ident in value position unless this says yes, and both codegen
+/// lanes ask it which names to eta-expand. Adding a name here without the
+/// matching lowering would move a load-time failure into a runtime trap, so
+/// the two must be decided in one place.
+export fn builtin_ident_has_value_form(name: String) -> Bool {
+  let n = canonical_builtin_name(name)
+  n == "FrozenArray::from_array" || n == "FrozenArray::to_array"
+}
+
 //# Builtin deprecation table (ADR-0098 / ADR-0101).
 //#
 //# `#deprecated` is a source declaration marker. Builtins have no declaration

--- a/lib/@vibe/compiler/core/index.vpkg
+++ b/lib/@vibe/compiler/core/index.vpkg
@@ -129,6 +129,7 @@ fn text_mentions_unstable_package(text: String) -> Bool
 
 // --- builtin_name
 fn canonical_builtin_name(name: String) -> String
+fn builtin_ident_has_value_form(name: String) -> Bool
 fn builtin_deprecated_message(name: String) -> Option[String]
 fn append_builtin_deprecated(out: Array[(String, String)]) -> Unit
 

--- a/lib/@vibe/compiler/normalize/desugar_trait_dict.vibe
+++ b/lib/@vibe/compiler/normalize/desugar_trait_dict.vibe
@@ -13865,7 +13865,25 @@ fn infer_eq_shape(e: Expr, struct_sets: Array[(String, Array[String])], var_type
       let mut acc = "("
       let mut i = 0
       while i < Array::length(items) {
-        let sub = infer_eq_shape(Array::get(items, i), struct_sets, var_types, fn_returns)
+        let item = Array::get(items, i)
+        let sub0 = infer_eq_shape(item, struct_sets, var_types, fn_returns)
+        // Strictly ADDITIVE against what the `_` arm used to do, which was
+        // `infer_shape` on the whole tuple, i.e. `infer_shape` per element.
+        // `infer_eq_shape` answers for more elements than that, but for FEWER
+        // in one place: its `EIdent` arm treats a recorded empty as the answer
+        // "not composite" (the #1465 shadowing rule) and stops, where
+        // `infer_shape` goes on to the element's head TYPE NAME. `let x =
+        // Bytes::new(); let a = (x, 0)` is exactly that shape -- recursing
+        // alone recorded `(,Int)` and dropped the `Bytes`, so a tuple of Bytes
+        // compared by pointer and `fixtures/eq_array_option_fields_test.vibe`
+        // regressed. Falling back keeps the head name. It cannot resurrect the
+        // stale composite #1465 guarded: `infer_shape`'s own EIdent arm applies
+        // the same rule and yields a head name, never a container shape.
+        let sub = if String::length(sub0) > 0 {
+          sub0
+        } else {
+          infer_shape(item, struct_sets, var_types, fn_returns)
+        }
         acc = if i == 0 {
           String::concat(acc, sub)
         } else {

--- a/lib/@vibe/compiler/normalize/desugar_trait_dict.vibe
+++ b/lib/@vibe/compiler/normalize/desugar_trait_dict.vibe
@@ -13780,13 +13780,25 @@ fn shape_to_eq_ty(sh: String) -> TypeExpr {
 /// the same remedy (a generated `__map_equals__` helper). The name kept its
 /// two original heads for one release too long and said something false about
 /// the third; it is spelled by intent now.
+///
+/// `Double` joined them in #2431, for the same reason and with a remedy that
+/// was already written: `eq_for_typed`'s `Double` arm wraps each side in the
+/// identity `Double::to_float` so the `==` codegen recognises the operands as
+/// floatish and takes the unbox-then-`f64.eq` path. The walk this trigger
+/// diverts from gets a Double field wrong on EVERY lane -- raw bits separate
+/// `0.0` from `-0.0` and equate two NaNs, neither of which IEEE 754 says, and
+/// under RC a Double field is a BOXED value, so the generic `eq` compares box
+/// identity and two structurally equal tuples come out unequal. Note this
+/// cannot re-route a BARE `Double == Double`: `eq_operand_shape_ty` requires a
+/// COMPOSITE shape, and a scalar binding records none. Only a Double reached
+/// as a tuple element, a constructor field or a container payload changes.
 fn ty_needs_typed_eq(t: TypeExpr) -> Bool {
   ty_needs_typed_eq_expanded(eq_expand_alias_ty(subst_scope_formals_ty(t)))
 }
 
 fn ty_needs_typed_eq_expanded(t: TypeExpr) -> Bool {
   match t {
-    TyName(n) => n == "Bytes",
+    TyName(n) => n == "Bytes" || n == "Double" || n == "Float",
     TyApp(n, args) => if n == "Array" || n == "Map" || builtin_string_map_applied(n, args) || generic_eq_struct_declared(n) {
       true
     } else {
@@ -13828,6 +13840,41 @@ fn ty_needs_typed_eq_expanded(t: TypeExpr) -> Bool {
 /// last.
 fn infer_eq_shape(e: Expr, struct_sets: Array[(String, Array[String])], var_types: Array[(String, String)], fn_returns: Array[(String, String)]) -> String {
   match e {
+    // #2431: a tuple LITERAL keeps its element types here. Without this arm it
+    // fell to the `_` arm, whose `infer_shape` has no scalar cases at all --
+    // every element came back "" and `let x = (0.0, 1)` recorded the shape
+    // `(,)`. That reads back as `(__EqUnknown, __EqUnknown)`, which
+    // `eq_operand_shape_ty` refuses, so the comparison dropped to the codegen
+    // walk and compared each field with the generic `eq` builtin: raw bits on
+    // bump and gc (so `0.0 == -0.0` was false and `nan == nan` true), and box
+    // IDENTITY under RC, where a Double field is a boxed heap value -- there
+    // two structurally equal tuples were unequal to each other. Measured on
+    // the production default lane before this change, `let x = (1.5, 1)` and
+    // `let y = (1.5, 1)` compared FALSE.
+    //
+    // The elements recurse through this same function, so a nested tuple, an
+    // array element, a constructor payload and a scalar literal all resolve
+    // exactly as they do at the top level. An element this classifier cannot
+    // name stays "" and becomes `__EqUnknown`, which keeps the whole shape out
+    // of the typed dispatch -- today's behaviour for that tuple, never a
+    // guessed leaf type. Guessing one would be worse than the bug: a leaf
+    // wrongly called Double routes an Int field through `Double::to_float`.
+    ETuple(items) => if Array::length(items) == 0 {
+      ""
+    } else {
+      let mut acc = "("
+      let mut i = 0
+      while i < Array::length(items) {
+        let sub = infer_eq_shape(Array::get(items, i), struct_sets, var_types, fn_returns)
+        acc = if i == 0 {
+          String::concat(acc, sub)
+        } else {
+          String::concat(acc, String::concat(",", sub))
+        }
+        i = i + 1
+      }
+      String::concat(acc, ")")
+    },
     EIdent(n, _) => {
       match lookup_var_type(var_types, eq_shape_key(n)) {
         Some(s) => s,

--- a/lib/@vibe/compiler/tests/builtin_ident_value_test.vibe
+++ b/lib/@vibe/compiler/tests/builtin_ident_value_test.vibe
@@ -22,6 +22,14 @@
 // the runtime rejected (`invalid signature index`), trapped with `table index
 // is out of bounds`, or reached codegen unresolved and asked the reader to
 // report a compiler bug. The tests below now pin the diagnostic for each.
+//
+// The exception is #1733's two FrozenArray conversions. Those have a REAL value
+// form: both codegen lanes materialize them as a one-argument lambda, which is
+// an ordinary closure with an ordinary table slot, and
+// `fixtures/frozen_array_copies_test.vibe` calls both through a binding and
+// passes. `builtin_ident_has_value_form` (core/builtin_name.vibe) is the single
+// source of truth -- the checker asks it what to admit and both lanes ask it
+// what to eta-expand, so the admission cannot drift from the lowering.
 
 import @vibe/compiler/checker {
   check_program
@@ -147,6 +155,13 @@ test "#2433: the diagnostic gives the wrap form the reader can paste" {
   assert(String::contains(msg, "(a, b) -> eq(a, b)"))
 }
 
+test "#2433: a builtin with no value form names the wrap form, not an ICE" {
+  let msg = first_check_error(value_ident_program("String::concat"))
+  assert(String::contains(msg, "String::concat"))
+  assert(String::contains(msg, "not a value"))
+  assert(!String::contains(msg, "internal compiler error"))
+}
+
 //# Not reported
 
 test "#2274: None as a value is still a constructor" {
@@ -195,5 +210,20 @@ test "#2433: a nullary constructor of a USER enum is still a value" {
 
 test "#2433: a user function is still a first-class value" {
   let src = "fn my_eq(a: Int, b: Int) -> Bool { a == b }\nfn main() -> Unit {\n  let f = my_eq\n  ()\n}\n"
+  inspect(first_check_error(src), content = "")
+}
+
+test "#1733: the two FrozenArray conversions keep their value form" {
+  // Measured on stage2 BEFORE #2433, to make sure the exemption is not
+  // cargo-culted: `let f = String::concat; f("a", "b")` trapped with `table
+  // index is out of bounds`, while the same shape over
+  // `FrozenArray::from_array` / `FrozenArray::to_array` ran and answered.
+  inspect(first_check_error(value_ident_program("FrozenArray::from_array")), content = "")
+  inspect(first_check_error(value_ident_program("FrozenArray::to_array")), content = "")
+  inspect(first_check_error_unlocated(value_ident_program("FrozenArray::from_array")), content = "")
+}
+
+test "#1733: an annotated alias of a FrozenArray conversion still checks" {
+  let src = "fn main() -> Unit {\n  let freeze: (Array[Int]) -> FrozenArray[Int] = FrozenArray::from_array\n  let _ = freeze([1, 2])\n  ()\n}\n"
   inspect(first_check_error(src), content = "")
 }

--- a/lib/@vibe/compiler/tests/builtin_ident_value_test.vibe
+++ b/lib/@vibe/compiler/tests/builtin_ident_value_test.vibe
@@ -7,11 +7,21 @@
 // arm was answering "yes, this name exists" for operations that are not
 // first-class values.
 //
-// Rejection is the close: a call-only builtin ident is a checker error that
-// names the call form and the wrap form. First-class func-table builtins
-// (`String::length`) stay values. `Map::new` stays `unknown name` -- it is
-// a parser-only call desugar, not a registry value -- but it is still a
-// checker error, so the two spellings agree about whether the shape is one.
+// Rejection is the close: a builtin ident used as a value is a checker error
+// that names the call form and the wrap form. `Map::new` stays `unknown name`
+// -- it is a parser-only call desugar, not a registry value -- but it is still
+// a checker error, so the two spellings agree about whether the shape is one.
+//
+// #2433 widened that rejection from qualified call-only names to EVERY builtin
+// typed as a function. #2274 had exempted names with a linear func-table row
+// (`String::length`) and every bare name (`eq`, `not`), on the reading that a
+// func-table row means there is a function pointer to take. Measured, there is
+// not: the indirect table is populated from user functions and lambdas only,
+// builtin bodies sit below `func_offset`, and they carry no closure-env
+// parameter. So those spellings did not "stay values" -- they emitted a module
+// the runtime rejected (`invalid signature index`), trapped with `table index
+// is out of bounds`, or reached codegen unresolved and asked the reader to
+// report a compiler bug. The tests below now pin the diagnostic for each.
 
 import @vibe/compiler/checker {
   check_program
@@ -87,19 +97,61 @@ test "#2274: the diagnostic names the call form, not an ICE" {
   assert(String::contains(msg, "Map::get("))
 }
 
+test "#2433: String::length as a bare value is rejected, not silently emitted" {
+  // #2274 called this one a first-class value because the registry row says
+  // `in_linear`. Measured on stage2 before #2433: the module compiled, then
+  // `h("abc")` trapped with `table index is out of bounds`.
+  let msg = first_check_error(value_ident_program("String::length"))
+  assert(String::contains(msg, "String::length"))
+  assert(String::contains(msg, "not a value"))
+  assert(String::contains(msg, "wrap it"))
+}
+
+test "#2433: Array::length as a bare value is rejected" {
+  let msg = first_check_error(value_ident_program("Array::length"))
+  assert(String::contains(msg, "Array::length"))
+  assert(String::contains(msg, "not a value"))
+}
+
+test "#2433: a BARE builtin name is rejected too -- eq" {
+  // The `!String::contains(name, "::")` exemption sent every bare builtin
+  // straight through. Measured before #2433: `let f = eq` emitted a module
+  // the runtime refused to compile, `invalid signature index: 11`.
+  let msg = first_check_error(value_ident_program("eq"))
+  assert(String::contains(msg, "`eq`"))
+  assert(String::contains(msg, "not a value"))
+  assert(String::contains(msg, "eq(a, b)"))
+}
+
+test "#2433: a bare builtin with no func-table row is rejected -- not" {
+  // This one used to reach codegen as an unresolved ident: "`not` (ident)
+  // reached code generation unresolved ... this is a bug in the compiler and
+  // not in your program -- please report the source that triggers it."
+  let msg = first_check_error(value_ident_program("not"))
+  assert(String::contains(msg, "`not`"))
+  assert(String::contains(msg, "not a value"))
+  assert(!String::contains(msg, "internal compiler error"))
+  assert(!String::contains(msg, "reached code generation"))
+}
+
+test "#2433: the unlocated parse rejects a bare builtin as well" {
+  let msg = first_check_error_unlocated(value_ident_program("eq"))
+  assert(String::contains(msg, "`eq`"))
+  assert(String::contains(msg, "not a value"))
+}
+
+test "#2433: the diagnostic gives the wrap form the reader can paste" {
+  // The wrap form is the edit that fixes it, and it works: measured,
+  // `let f = (a, b) -> eq(a, b)` compiles and answers on every lane.
+  let msg = first_check_error(value_ident_program("eq"))
+  assert(String::contains(msg, "(a, b) -> eq(a, b)"))
+}
+
 //# Not reported
 
 test "#2274: None as a value is still a constructor" {
   inspect(first_check_error(value_ident_program("None")), content = "")
   inspect(first_check_error_unlocated(value_ident_program("None")), content = "")
-}
-
-test "#2274: String::length remains a first-class value" {
-  inspect(first_check_error(value_ident_program("String::length")), content = "")
-}
-
-test "#2274: Array::length remains a first-class value" {
-  inspect(first_check_error(value_ident_program("Array::length")), content = "")
 }
 
 test "#2274: StringBuilder::new() as a call still type-checks" {
@@ -110,5 +162,38 @@ test "#2274: StringBuilder::new() as a call still type-checks" {
 
 test "#2274: Map::get as a call still type-checks" {
   let src = "fn main() -> Unit {\n  let m = Map::new()\n  let _ = Map::get(m, \"k\")\n  ()\n}\n"
+  inspect(first_check_error(src), content = "")
+}
+
+test "#2433: eq as a CALL is untouched" {
+  let src = "fn main() -> Unit {\n  let b = eq(1, 2)\n  ()\n}\n"
+  inspect(first_check_error(src), content = "")
+  inspect(first_check_error_unlocated(src), content = "")
+}
+
+test "#2433: not as a CALL is untouched" {
+  let src = "fn main() -> Unit {\n  let b = not(true)\n  ()\n}\n"
+  inspect(first_check_error(src), content = "")
+}
+
+test "#2433: String::length as a CALL is untouched" {
+  let src = "fn main() -> Unit {\n  let n = String::length(\"abc\")\n  ()\n}\n"
+  inspect(first_check_error(src), content = "")
+}
+
+test "#2433: the wrap form the diagnostic recommends type-checks" {
+  let src = "fn main() -> Unit {\n  let f = (a, b) -> eq(a, b)\n  ()\n}\n"
+  inspect(first_check_error(src), content = "")
+}
+
+test "#2433: a nullary constructor of a USER enum is still a value" {
+  // The type test keeps every non-function builtin, which is what #2274's
+  // bare-name exemption was really protecting.
+  let src = "enum Color { Red; Green }\nfn main() -> Unit {\n  let c = Red\n  ()\n}\n"
+  inspect(first_check_error(src), content = "")
+}
+
+test "#2433: a user function is still a first-class value" {
+  let src = "fn my_eq(a: Int, b: Int) -> Bool { a == b }\nfn main() -> Unit {\n  let f = my_eq\n  ()\n}\n"
   inspect(first_check_error(src), content = "")
 }

--- a/lib/@vibe/compiler/tests/checker_program_result_test.vibe
+++ b/lib/@vibe/compiler/tests/checker_program_result_test.vibe
@@ -208,11 +208,24 @@ test "check_program_with_env remains compatible with its result variant" {
 // are structural only: they deliberately do not add role/provenance to this
 // legacy artifact.
 test "typed occurrences preserve identifier rows across env builtin and qualified ctor branches" {
-  let concat_type = CtFn([CtString, CtString], CtString, None)
-  assert_typed_occurrences(check_expr_occurrences(ESeq(EIdent("x", 10), EIdent("String::concat", 20)), env_bind(EnvEmpty, "x", CtInt), array_empty()), [
-    (10, CtInt),
-    (20, concat_type)
+  assert_typed_occurrences(check_expr_occurrences(EIdent("x", 10), env_bind(EnvEmpty, "x", CtInt), array_empty()), [
+    (10, CtInt)
   ])
+  // #2433: the env-builtin branch now REPORTS in value position instead of
+  // recording an occurrence. This assertion used to read `(20, CtFn([CtString,
+  // CtString], CtString, None))` -- the registry signature is unchanged, but no
+  // program could use it that way: measured on stage2, `let f = String::concat;
+  // f("a", "b")` compiled and then trapped with `table index is out of bounds`,
+  // because a builtin's function index is below `func_offset` and the indirect
+  // table holds user functions and lambdas only. The branch is still exercised
+  // here, by what it does now.
+  let berrors = array_empty()
+  let btytab = array_empty()
+  let _ = check_expr(EIdent("String::concat", 20), EnvEmpty, array_empty(), SubstEmpty, 0, berrors, btytab)
+  assert(Array::length(berrors) == 1)
+  assert(String::contains(Array::get(berrors, 0), "String::concat"))
+  assert(String::contains(Array::get(berrors, 0), "not a value"))
+  assert(Array::length(btytab) == 0)
   let checked = check_program_result([
     SEnum(false, "Choice", array_empty(), [("Pick", array_empty())], array_empty()),
     SLet(false, false, "picked", None, EIdent("Choice::Pick", 30))

--- a/lib/@vibe/compiler/tests/checker_test.vibe
+++ b/lib/@vibe/compiler/tests/checker_test.vibe
@@ -59,8 +59,32 @@ test "ident from env" {
 }
 
 test "ident builtin" {
-  let ty = check(EIdent("String::concat", -1), EnvEmpty)
-  assert(types_equal(ty, CtFn([CtString, CtString], CtString, None)))
+  // #2433: a builtin ident in VALUE position is rejected. It used to type as
+  // `CtFn` and then break in codegen -- measured on stage2, `let f =
+  // String::concat` compiled and trapped with `table index is out of bounds`,
+  // because a builtin's function index is below `func_offset` and the indirect
+  // table holds user functions and lambdas only. The signature is still what
+  // the registry says; it is only unavailable as a value, and the diagnostic
+  // names the call form and the wrap form.
+  let caught = handle {
+    let _ = check(EIdent("String::concat", -1), EnvEmpty)
+    ""
+  } with { Exception::Throw(msg) => msg }
+  assert(String::contains(caught, "String::concat"))
+  assert(String::contains(caught, "not a value"))
+}
+
+test "ident builtin with a value form" {
+  // #1733 gave these two a real value form: both codegen lanes materialize
+  // them as a one-argument lambda, which is an ordinary closure with an
+  // ordinary table slot. `fixtures/frozen_array_copies_test.vibe` calls both
+  // through a binding and passes, so the checker must keep admitting them.
+  let ty = check(EIdent("FrozenArray::from_array", -1), EnvEmpty)
+  let is_fn = match ty {
+    CtFn(_, _, _) => true,
+    _ => false
+  }
+  assert(is_fn)
 }
 
 test "ident unknown" {

--- a/scripts/check_freeze_surface.sh
+++ b/scripts/check_freeze_surface.sh
@@ -13,12 +13,39 @@
 # row to the freeze list would not reach it. Here, adding a row is immediately
 # checked.
 #
-# Existence probe: a bare reference (`let g = String::length`). It resolves iff
-# the name exists AS A VALUE. A real receiver with a real member that is
-# nonetheless not a value (`Map::get`) used to pass this check because the
-# checker printed nothing (#2274) and this script only looked for the
-# substring `unknown name` (#2275). Any diagnostic -- unknown name, "not a
-# value", or the codegen ICE -- means the name does not resolve as a value.
+# Existence probe: a bare reference (`let g = String::length`). What the probe
+# can conclude from it changed in #2433, so read this before editing it.
+#
+# It used to read "resolves iff the name exists AS A VALUE", and treated the
+# "not a value" diagnostic as a missing name -- #2275's rule, whose exemplar
+# was `Map::get`: a real receiver, a real member, and still not a value.
+#
+# #2433 measured that NO builtin is a value on any lane. The indirect table is
+# populated from user functions and lambdas only; builtin bodies sit below
+# `func_offset` and carry no closure-env parameter. `let f = eq` emitted a
+# module the runtime refused (`invalid signature index`) and
+# `let h = String::length` trapped with `table index is out of bounds` -- so
+# the checker now rejects every builtin used as a value, and "not a value" no
+# longer separates `Map::get` from `String::length`. Under the old rule this
+# gate would report the entire frozen surface missing.
+#
+# So the probe measures what it can still measure honestly: does the name
+# EXIST as a builtin operation. Three answers, and each is positive evidence
+# rather than an absence:
+#
+#   - silence          -- the name resolved as a value (a nullary constructor).
+#   - "not a value"    -- the checker looked the name UP, found a builtin row,
+#     naming the symbol      and refused the value position. Emitted only after
+#                            `lookup_builtin_in_env` succeeded, so it proves
+#                            existence. It must quote the probed symbol: a
+#                            diagnostic about some other name says nothing here.
+#   - anything else    -- missing. `unknown name` is the no-such-member case;
+#                            the codegen ICE is the same hole leaking past the
+#                            checker.
+#
+# The fail-open shape #2275 closed is still closed: silence is only accepted
+# for a name that genuinely produced none, and a name that does not exist
+# produces `unknown name`, never silence.
 #
 # Usage: bash scripts/check_freeze_surface.sh
 #   FREEZE_DOC        override the document (default docs/spec/stable-surface.md)
@@ -170,15 +197,28 @@ is_negated() {
 RUNNER="$ROOT_DIR/scripts/run_wasm_vibe_host_runner.sh"
 [ -f "$RUNNER" ] || { echo "check-freeze-surface: missing host runner: $RUNNER" >&2; exit 1; }
 
-# True when the probe output says this name does not resolve as a value.
-# `unknown name` is the missing-member case. `not a value` is the #2274
-# call-only builtin. The codegen ICE is the same hole if it ever leaks past
-# the checker again -- silence is the only passing answer.
-probe_is_missing() {
-  case "$1" in
-    *"unknown name"*|*"not a value"*|*"internal compiler error"*|*"reached code generation"*) return 0 ;;
-    *) return 1 ;;
+# True when the probe output says this name does not exist as a builtin
+# operation. See the header for why "not a value" is EXISTENCE evidence rather
+# than a missing name (#2433), and why it must quote the probed symbol.
+#
+# Order matters: the missing-name answers are tested FIRST, so a diagnostic
+# that happens to contain both cannot be read as present.
+probe_is_missing() { # probe_is_missing <output> <symbol>
+  local out="$1" sym="$2"
+  case "$out" in
+    *"unknown name"*|*"internal compiler error"*|*"reached code generation"*) return 0 ;;
   esac
+  if [ -z "$out" ]; then
+    return 1
+  fi
+  case "$out" in
+    *"not a value"*)
+      case "$out" in
+        *"$sym"*) return 1 ;;
+        *) return 0 ;;
+      esac ;;
+  esac
+  return 0
 }
 
 probe() { # probe <symbol> -> prints the checker's diagnostics
@@ -193,43 +233,64 @@ probe() { # probe <symbol> -> prints the checker's diagnostics
 
 calib_present="$(probe "String::length")"
 calib_absent="$(probe "String::__no_such_builtin__")"
-calib_not_a_value="$(probe "Map::get")"
-case "$calib_present" in
-  *"unknown name"*|*"not a value"*|*"internal compiler error"*|*"reached code generation"*)
-    echo "check-freeze-surface: FAIL: calibration -- String::length did not resolve, so the probe is not measuring what it claims:" >&2
-    echo "  $calib_present" >&2
-    exit 1 ;;
-esac
-if [ -n "$calib_present" ]; then
-  echo "check-freeze-surface: FAIL: calibration -- probing a valid symbol produced output, so a real failure cannot be told apart:" >&2
-  echo "  $calib_present" >&2
+calib_value="$(probe "None")"
+if probe_is_missing "$calib_present" "String::length"; then
+  echo "check-freeze-surface: FAIL: calibration -- String::length was reported missing, so the probe is not measuring what it claims:" >&2
+  echo "  ${calib_present:-<no output>}" >&2
   exit 1
 fi
-if ! probe_is_missing "$calib_absent"; then
+if ! probe_is_missing "$calib_absent" "String::__no_such_builtin__"; then
   echo "check-freeze-surface: FAIL: calibration -- a symbol that cannot exist was not reported missing, so this check cannot detect anything:" >&2
   echo "  ${calib_absent:-<no output>}" >&2
   exit 1
 fi
-# #2275: a real receiver, a real member, and still not a value. The first two
-# calibration points are outside that population -- String::length is a genuine
-# first-class value, String::__no_such_builtin__ has no such member -- so a
-# gate that only knew those two certified Map::get from checker silence.
-if ! probe_is_missing "$calib_not_a_value"; then
-  echo "check-freeze-surface: FAIL: calibration -- Map::get is a real builtin that is not a value, and the probe did not report it missing, so this check cannot tell a resolving name from a call-only operation:" >&2
-  echo "  ${calib_not_a_value:-<no output>}" >&2
+# The silence branch has to keep working on its own: a nullary constructor is
+# the one population that still resolves as a value, and if it stopped being
+# silent the classifier would be running on a single branch without saying so.
+if [ -n "$calib_value" ] || probe_is_missing "$calib_value" "None"; then
+  echo "check-freeze-surface: FAIL: calibration -- None no longer resolves silently as a value, so the probe's silence branch is untested:" >&2
+  echo "  ${calib_value:-<no output>}" >&2
   exit 1
 fi
+# #2433: "not a value" is accepted only when it QUOTES the probed symbol.
+# Re-read the calibration output against a symbol it does NOT name and require
+# a missing verdict -- otherwise any builtin diagnostic would certify any name.
+#
+# Guarded on the branch actually being live. A compiler that predates #2433
+# answers `String::length` with silence, and asserting this there would fail
+# calibration for a reason that has nothing to do with the document -- the
+# shape where a gate gets exempted because it breaks for an unrelated reason
+# (#2252). Silence is already covered by the None calibration above.
+case "$calib_present" in
+  *"not a value"*)
+    if ! probe_is_missing "$calib_present" "String::__freeze_calibration_other__"; then
+      echo "check-freeze-surface: FAIL: calibration -- a diagnostic naming String::length certified an unrelated symbol, so the probe accepts output it did not ask for:" >&2
+      echo "  ${calib_present:-<no output>}" >&2
+      exit 1
+    fi ;;
+esac
 
 checked=0; missing=()
 for sym in "${syms[@]:-}"; do
+  # `"${syms[@]:-}"` yields ONE EMPTY element when the array is empty, and that
+  # element used to be probed like a symbol: `let __g = ` parses badly, the old
+  # classifier saw no "unknown name" in the output and read it as resolving, so
+  # a document with no frozen names reported `1 frozen symbol(s) resolve`. It
+  # also defeated the vacuity guard below, which was measuring that artifact
+  # rather than the document. The stricter #2433 classifier turned the silent
+  # pass into a failure naming a blank symbol, which is how it was found.
+  [ -n "$sym" ] || continue
   is_negated "$sym" && continue
   checked=$((checked + 1))
-  if probe_is_missing "$(probe "$sym")"; then
+  if probe_is_missing "$(probe "$sym")" "$sym"; then
     missing+=("$sym")
   fi
 done
 
-if [ "$checked" -eq 0 ]; then
+# A section holding ONLY explicitly-not-frozen entries is asserting something
+# real (those names are promised NOT to be frozen), so it is not vacuous. The
+# vacuous case is a section from which nothing at all was extracted.
+if [ "$checked" -eq 0 ] && [ "${#negated[@]}" -eq 0 ]; then
   echo "check-freeze-surface: FAIL: extracted 0 symbols from $DOC section 3 -- the check is asserting nothing" >&2
   exit 1
 fi
@@ -282,7 +343,8 @@ fi
 
 index_missing=()
 for sym in "${index_syms[@]}"; do
-  if probe_is_missing "$(probe "$sym")"; then
+  [ -n "$sym" ] || continue
+  if probe_is_missing "$(probe "$sym")" "$sym"; then
     index_missing+=("$sym")
   fi
 done

--- a/scripts/check_freeze_surface_test.sh
+++ b/scripts/check_freeze_surface_test.sh
@@ -68,11 +68,27 @@ expect 0 "a heading plus bare names all resolve"
 doc '- **String**: `length`, `no_such_builtin_here`'
 expect 1 "a frozen name that does not resolve" "no_such_builtin_here"
 
-# 2b. #2275: a real receiver, a real member, and still not a value. Before
-#     the probe observed this population, `Map::get` was certified from
-#     checker silence. The gate must FAIL the name, not report ok.
+# 2b. #2275's case, re-founded by #2433. A real receiver with a NO-SUCH member
+#     must still fail: that is the population `unknown name` covers, and it is
+#     what stops the gate certifying a name from checker output alone.
+doc '- **Map**: `no_such_op`'
+expect 1 "a real receiver with a member that does not exist fails" "Map::no_such_op"
+
+# 2c. #2433: `Map::get` was this case's original exemplar -- a real member
+#     that is not a first-class value. No builtin is one any more (the checker
+#     rejects `let g = String::length` exactly as it rejects `let g = Map::get`),
+#     so "not a value" stopped separating them and now reads as EXISTENCE.
+#     Under the old rule this gate would have reported the whole frozen
+#     surface missing; the case pins the new reading instead.
 doc '- **Map**: `get`'
-expect 1 "a real member that is not a value fails" "Map::get"
+expect 0 "a real call-only operation counts as existing"
+
+# 2d. ...and the frozen surface's own names take the same branch, which is the
+#     half that would have broken. `String::length` is rejected as a value by
+#     the same diagnostic, and must still pass the freeze check.
+doc '- **String**: `length`, `concat`
+- **Array**: `length`, `get`'
+expect 0 "frozen builtin operations pass through the not-a-value branch"
 
 # 3. Already-qualified names are read as-is.
 doc '- **conv**: `Int::to_double`, `Double::to_int`'

--- a/tests/gates/early/run.sh
+++ b/tests/gates/early/run.sh
@@ -2056,6 +2056,20 @@ run_test_block_fixtures_gc "gc-lane scalar parity (gc)" fixtures/gc_lane_scalar_
 run_test_block_fixtures_rc "gc-lane scalar parity (linear, RC)" fixtures/gc_lane_scalar_parity_test.vibe
 echo '[compiler-gate] gc-lane scalar parity ok'
 
+# 15b-4. A Double inside an aggregate reached through a NAME (#2431). Three
+#        lanes for the same reason as 15b-3, and here every lane was wrong in a
+#        DIFFERENT place: `let x = (0.0, 1); let y = (-0.0, 1); x == y` was
+#        false on all three, while `let x = (1.5, 1); let y = (1.5, 1); x == y`
+#        was false ONLY under RC -- a Double field is a boxed value there, so
+#        the generic `eq` compared two distinct boxes and two structurally
+#        equal tuples came out unequal on the production default lane. A
+#        single-lane run sees at most one of those.
+echo '[compiler-gate] 15b-4/15 Double inside an aggregate through a name (#2431)'
+run_test_block_fixtures "aggregate Double equality (linear, bump)" fixtures/tuple_double_eq_test.vibe
+run_test_block_fixtures_gc "aggregate Double equality (gc)" fixtures/tuple_double_eq_test.vibe
+run_test_block_fixtures_rc "aggregate Double equality (linear, RC)" fixtures/tuple_double_eq_test.vibe
+echo '[compiler-gate] aggregate Double equality ok'
+
 # 15c. railway `let*` / `?` generalized to Option (#635): the parser emits a
 #      type-directed sentinel that the pre-check desugar lowers by the operand's
 #      head type — `Option` (Some/None) or `Result` (Ok/Err, the default). The

--- a/tests/gates/early/run.sh
+++ b/tests/gates/early/run.sh
@@ -356,6 +356,23 @@ echo "[compiler-gate] insert_raw bounded probe ok (terminated, rc=$hm_rc)"
 #     blocks down, MUST resolve in both forms. Without them, a probe harness
 #     that silently failed to compile anything would report all-unreachable and
 #     pass.
+#
+#     #2433 changed what "resolves" looks like in the VALUE form, and the
+#     control had to follow. A builtin used as a value is now a checker error
+#     on every lane -- no builtin has a value form, because the indirect table
+#     is populated from user functions and lambdas only -- so `let _x =
+#     simd_skip_ws` reports "`simd_skip_ws` is a builtin operation, not a
+#     value", where it used to report nothing.
+#
+#     The CLASSIFIER above is unaffected: it counts a name unreachable only
+#     when both forms say `unknown name: <n>`, and "not a value" is not that
+#     string, so a reachable-but-call-only name is still classified reachable.
+#     Only the control's expectation ("no diagnostic at all") was wrong. It now
+#     asserts the property the classifier actually uses -- the name is NOT
+#     `unknown name` -- plus, so that a harness which compiled nothing cannot
+#     pass, that the diagnostic it does get is the "not a value" one NAMING
+#     simd_skip_ws. That is strictly stronger than the old empty-output test,
+#     which an empty `.diag` from a dead runner satisfied.
 echo "[compiler-gate] 4g the WASM-intrinsics block is codegen-internal, as it claims (#2343)"
 dcldir="_build/_gate_declarations_reach"
 rm -rf "$dcldir"; mkdir -p "$dcldir"
@@ -441,7 +458,25 @@ for ctl_form in value call; do
   VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
     bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
     "$dcldir/ctl.vibe" "$dcldir/ctl.out" __no_entry__ check >/dev/null 2>&1 || true
-  if [ -s "$dcldir/ctl.out.diag" ]; then
+  if grep -qF "unknown name: simd_skip_ws" "$dcldir/ctl.out.diag" 2>/dev/null; then
+    echo "[compiler-gate] FAIL: the #2343 $ctl_form-form control reported simd_skip_ws unknown -- it is declared in $decl_src and must resolve, so this harness is calling everything unreachable" >&2
+    cat "$dcldir/ctl.out.diag" >&2 2>/dev/null || true
+    rm -rf "$dcldir"
+    exit 1
+  fi
+  if [ "$ctl_form" = "value" ]; then
+    # #2433: the expected answer here is the "not a value" diagnostic, naming
+    # the control. Requiring it (rather than accepting anything that is not
+    # `unknown name`) is what keeps a harness that produced NO output from
+    # passing -- see the header.
+    if ! grep -qF "not a value" "$dcldir/ctl.out.diag" 2>/dev/null \
+       || ! grep -qF "simd_skip_ws" "$dcldir/ctl.out.diag" 2>/dev/null; then
+      echo "[compiler-gate] FAIL: the #2343 value-form control did not produce the expected \"not a value\" diagnostic naming simd_skip_ws -- the probe did not compile, or the diagnostic changed, so this harness is not measuring reachability (#2433)" >&2
+      cat "$dcldir/ctl.out.diag" >&2 2>/dev/null || true
+      rm -rf "$dcldir"
+      exit 1
+    fi
+  elif [ -s "$dcldir/ctl.out.diag" ]; then
     echo "[compiler-gate] FAIL: the #2343 $ctl_form-form control reported a diagnostic -- simd_skip_ws is declared in $decl_src and must resolve, so this harness is calling everything unreachable" >&2
     cat "$dcldir/ctl.out.diag" >&2 2>/dev/null || true
     rm -rf "$dcldir"


### PR DESCRIPTION
Closes #2433. Closes #2431.

Two equality/lowering bugs that share one sentence: **a lane deciding a value's nature from its syntax instead of from what the compiler actually knows.**

---

## #2433 — a builtin used as a first-class value

A builtin bound to a local did not survive codegen. Three failure modes on stage2, none with a source location:

| program | before |
| :--- | :--- |
| `let f = eq` … `f(3, 3)` | invalid wasm: `invalid signature index: 11` |
| `let h = String::length` … `h("abc")` | invalid wasm: `invalid signature index: 10` |
| either of the above, with a same-arity lambda present so the closure type exists | `RuntimeError: table index is out of bounds` |
| `let g = not` … `g(false)` | ``internal compiler error: `not` (ident) reached code generation unresolved`` |
| **control:** `fn my_eq(a: Int, b: Int) -> Bool { … }` … `let f = my_eq` | **ok** |

After:

```
a_test.vibe: line 2:11-13: `eq` is a builtin operation, not a value -- call it
(`eq(a, b)`), or wrap it (`(a, b) -> eq(a, b)`) to pass it as a function
```

The wrap form the diagnostic recommends is measured working on RC, bump and gc.

### Why the old predicate was wrong

#2274 closed the qualified call-only half (`Map::get`) and keyed `builtin_is_first_class_value` on the linear **func-table** row — a builtin with a real emitted body was taken to have a function pointer to take. It does not, and the two tables are different tables:

- the func table maps a builtin name to its function **index**, for a direct `call`;
- the value a first-class function evaluates to is an **indirect-table slot**, and that table is populated from user functions and lambdas only (`linked_compile.vibe`: `tei < num_user_funcs` → `func_offset + tei`, else a lambda).

Builtin bodies sit in the generated-helper index block **below** `func_offset`, so `table_slot = fidx - ctx.func_offset` is negative for every one of them, and they carry no closure-env parameter, so the `closure_type_base + n` signature would not match even if a slot existed.

### The exception, which CI found

`fixtures/frozen_array_copies_test.vibe` binds `FrozenArray::from_array` / `FrozenArray::to_array` to names, calls them, and passes. #1733 gave exactly those two a real value form: both lanes materialize them as a one-argument **lambda** (`frozen_array_conversion_closure`), which is an ordinary closure with an ordinary table slot. Measured, so the exemption is not cargo-culted: `let f = String::concat; f("a", "b")` traps with `table index is out of bounds`, while the same shape over either FrozenArray conversion runs and answers.

`builtin_ident_has_value_form` (`core/builtin_name.vibe`) is now the single source of truth for that set — the checker asks it what to admit, both codegen lanes ask it what to eta-expand, and their two private copies of the name list are gone. A second copy could only drift into a spurious error or back into the load-time failure this PR removes.

Nullary constructors (`None`, a user enum's `Red`) are untouched: they are not `CtFn` and lower through the `ctor_table` arm. That is what #2274's bare-name exemption was really protecting, and dropping it is safe now that the test is the type rather than the spelling.

### Scope note

#2433 asks whether builtins *should* be first-class, and says either answer beats emitting a module that will not load. This PR ships the answer the compiler already gives — **no, except where a lowering exists** — as a diagnostic instead of a broken module. Generalizing #1733's eta-expansion to every builtin is a new capability (and has an effect-row question: a builtin carrying a row, materialized as a value, must not lose it), so it is left as a follow-up rather than decided here.

---

## #2431 — a Double inside an aggregate, reached through a name

Measured before, all three lanes:

| expression | RC (default) | bump | gc |
| :--- | :--- | :--- | :--- |
| `let x = (1.5, 1); let y = (1.5, 1); x == y` | **false** | true | true |
| `let x = (0.0, 1); let y = (-0.0, 1); x == y` | **false** | **false** | **false** |
| `let a = Some(0.0); let b = Some(-0.0); a == b` | **false** | **false** | **false** |
| `(0.0, c) == (-0.0, c)` — literals | true | true | true |

The first row is the sharpest and is wider than the issue reported: two structurally equal tuples, no signed zero and no NaN involved, unequal to each other on the lane every user gets by default. Under RC a Double field is a boxed heap value, so the generic `eq` builtin compared two distinct boxes.

The typed comparator was already correct and already reached for **literal** operands — `eq_for_typed`'s `Double` arm wraps each side in the identity `Double::to_float` so the `==` codegen takes the unbox-then-`f64.eq` path. Name-reached operands missed it in two independent places:

1. **`infer_eq_shape` had no `ETuple` arm**, so a tuple literal fell to the generic `infer_shape`, which has no scalar cases at all: `let x = (0.0, 1)` recorded the shape `(,)`, i.e. `(__EqUnknown, __EqUnknown)`, which the dispatch refuses. It now recurses through itself per element, so `(Double,Int)` is recorded.
2. **`ty_needs_typed_eq`** — the trigger — listed only `Bytes` / `Array` / `Map`. `Double` is a head the codegen walk gets wrong in exactly the same sense, so it joins them: the same shape of fix #2218 applied to `Map`.

**Deliberately fail-closed:** an element this pass cannot name from the binding site stays `__EqUnknown` and keeps the old comparison. Guessing would be worse than the bug — a leaf wrongly called Double routes an `Int` field through `Double::to_float`. An annotation supplies what the syntax does not, exactly as it does for `let xs: Array[Int] = []`. This also cannot re-route a bare `Double == Double`: `eq_operand_shape_ty` requires a composite shape and a scalar binding records none.

---

## Collateral: two gates were founded on the same false premise

- **`check_freeze_surface.sh`** probed existence with `let g = Name` and read `not a value` as a **missing** name (#2275, exemplar `Map::get`). With almost no builtin a value, that rule reports the entire frozen surface missing. The probe now measures whether the name **exists as a builtin operation**: silence (a value), `not a value` **quoting the probed symbol** (emitted only after the builtin lookup succeeds, so it proves existence), or missing. A new calibration re-reads that diagnostic against a symbol it does not name and requires a missing verdict, guarded on the branch being live so a pre-#2433 compiler does not fail calibration for an unrelated reason (#2252).
- The same run surfaced a latent fail-open there: `"${syms[@]:-}"` yields one **empty** element for an empty array, and that element was probed like a symbol and counted toward `checked` — a document with no frozen names reported `1 frozen symbol(s) resolve`, and the vacuity guard was measuring the artifact. Fixed.
- **`tests/gates/early/run.sh` section 4g** (#2343) probes `simd_skip_ws` in the value form expecting no diagnostic. Its classifier was already right (unreachable = `unknown name` in **both** forms, which `not a value` is not); only the control's expectation was wrong. It now requires the `not a value` diagnostic **naming** the control, which is strictly stronger than the old empty-output test that an empty `.diag` from a dead runner satisfied.
- `docs/spec/stable-surface.md` says what a frozen builtin promises: the operation and its call-site signature, not a first-class function value — and names the #1733 exception.

## Verification

- `fixtures/tuple_double_eq_test.vibe` (12 tests): **red on all three lanes before**, green after. Registered in the early gate on linear/bump/gc, next to the #2404/#2405/#2407 parity block and for the same reason — each lane was wrong in a different place here.
- `builtin_ident_value_test.vibe` (25 tests) pins the diagnostic for `eq`, `not`, `String::length`, `Array::length`, `String::concat`; that calls and the recommended wrap form are untouched; that constructors and user functions stay values; and that the two FrozenArray conversions keep their value form. **Red-tested** against the original checker source.
- `checker_test.vibe`'s `ident builtin` asserted `String::concat` types as `CtFn` in value position — a premise no working program backed, since that spelling trapped. It now pins the diagnostic, with a sibling test for a name that does have a value form.
- Early gate lane, serially on a clean tree: **exit 0, 0 FAILs**, 39/39 sections, including `49 intrinsics unreachable in both value and call form, controls resolve` and the new aggregate-Double block.
- `check_freeze_surface.sh`: `25 frozen symbol(s) resolve; 24 explicitly not frozen; 18 builtin(s) indexed`. Its self-test (16 cases) passes against both a pre- and post-#2433 compiler, and its new calibration was **mutation-tested** twice — dropping the symbol match, and pointing the #2343 value control at a name that still is a value.
- `check_gate_portability.sh`, `check_gate_self_tests.sh`, `vibe fmt --check` on every changed `.vibe` and `.vpkg`: ok.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FYMVd6D2o82suTfTwoJPMf