### PR TITLE
The normalized checked-function codec retains the binop operator offset (#2435)

### DIFF
--- a/lib/@vibe/compiler/checker/artifacts/checked_implementation_body_artifact.vibe
+++ b/lib/@vibe/compiler/checker/artifacts/checked_implementation_body_artifact.vibe
@@ -1221,9 +1221,11 @@ fn normalized_expr_bytes(expr: Expr, depth: Int) -> Option[String] {
       },
       None => None
     },
-    EBinOp(op, left, right, _) => match (normalized_expr_bytes(left, depth + 1), normalized_expr_bytes(right, depth + 1)) {
+    EBinOp(op, left, right, boff) => match (normalized_expr_bytes(left, depth + 1), normalized_expr_bytes(right, depth + 1)) {
       (Some(l), Some(r)) => {
-        let out = StringBuilder::new(); StringBuilder::push(out, "o"); body_push_piece(out, op); body_push_piece(out, l); body_push_piece(out, r); Some(StringBuilder::freeze(out))
+        // #2435: the operator offset is typed-channel identity, retained
+        // exactly as ECall / EDot retain theirs above.
+        let out = StringBuilder::new(); StringBuilder::push(out, "o"); body_push_piece(out, op); body_push_piece(out, __to_string(boff)); body_push_piece(out, l); body_push_piece(out, r); Some(StringBuilder::freeze(out))
       },
       _ => None
     },
@@ -1532,8 +1534,11 @@ fn normalized_expr_valid(text: String, depth: Int) -> Bool {
     else if tag == 111 {
       match body_piece(text, 1) {
         Some((op, p1)) => match body_piece(text, p1) {
-          Some((left, p2)) => match body_piece(text, p2) {
-            Some((right, end)) => String::length(op) > 0 && normalized_expr_valid(left, depth + 1) && normalized_expr_valid(right, depth + 1) && end == String::length(text),
+          Some((boff, p2)) => match body_piece(text, p2) {
+            Some((left, p3)) => match body_piece(text, p3) {
+              Some((right, end)) => String::length(op) > 0 && normalized_decimal_piece_valid(boff) && normalized_expr_valid(left, depth + 1) && normalized_expr_valid(right, depth + 1) && end == String::length(text),
+              None => false
+            },
             None => false
           },
           None => false

--- a/lib/@vibe/compiler/tests/checked_implementation_body_artifact_test.vibe
+++ b/lib/@vibe/compiler/tests/checked_implementation_body_artifact_test.vibe
@@ -245,6 +245,20 @@ test "#1958: mutable and control expression constructors round-trip" {
   }
 }
 
+test "#2435: binop snapshots discriminate on the operator offset" {
+  // The typed String-binop channel keys on the operator's own offset, so
+  // the normalized codec must retain it exactly as it retains the offsets
+  // of ECall / EDot / EIdent -- two bodies differing only in a binop's
+  // position are distinct located IR and must not collapse to one artifact.
+  let at_5 = normalized_checked_expression_snapshot_for_test(EBinOp("+", EInt(1), EInt(2), 5))
+  let at_9 = normalized_checked_expression_snapshot_for_test(EBinOp("+", EInt(1), EInt(2), 9))
+  let at_5_again = normalized_checked_expression_snapshot_for_test(EBinOp("+", EInt(1), EInt(2), 5))
+  assert(at_5 != None)
+  assert(at_9 != None)
+  assert(at_5 == at_5_again)
+  assert(at_5 != at_9)
+}
+
 test "#1958: record checked type codec is structured" {
   assert(normalized_checked_type_snapshot_for_test(CtRecord([
     ("name", CtString),


### PR DESCRIPTION
Follow-up to #2436 (merged), closing the one Codex thread it left open ([r3896320767](https://github.com/mizchi/vibe-lang/pull/2436#discussion_r3896320767)).

## What

The normalized checked-function codec's `EBinOp` arm discarded `boff` while its `ECall` / `EDot` siblings serialize their offsets — and #2435 makes the binop offset compilation-relevant identity the same way #2434 made theirs (the typed String-binop channel keys on it). Two bodies differing only in a binop operator's position must not collapse to one normalized artifact.

- The encoder writes the offset piece into the `"o"` record.
- The structural validator (`normalized_expr_valid`, the strict decoder's fail-closed gate) requires it, so old-format bytes fail decode and recompute rather than being misread.

## Validation

- Verified red first: snapshots of `EBinOp("+", 1, 2, 5)` and `EBinOp("+", 1, 2, 9)` were byte-identical pre-fix; the new discrimination test pins that they now differ (and that equal inputs still snapshot equal).
- The encoder-only change correctly broke the existing let-call-binop round-trip test, which exposed the decode-side validator; with both halves updated, all 31 artifact tests pass.
- Full chain on this tree: bundle regen → stage2 == stage3 fixpoint, lane tests 13/13 + 9/9, `test_cli_core.sh` ok, selfcompile KPI 1.588GB (under cap), typing-env-reuse oracle ok, `unit_test_runner.sh` 1093/1093.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0159xd5111g8KFt2CGyNyZvA

---
_Generated by [Claude Code](https://claude.ai/code/session_0159xd5111g8KFt2CGyNyZvA)_