### PR TITLE
Delete the typed-channel binop operand walk; the anchor is the operator offset alone (#2391)

### DIFF
--- a/lib/@vibe/compiler/checker/checker.vibe
+++ b/lib/@vibe/compiler/checker/checker.vibe
@@ -6462,111 +6462,24 @@ fn append_legacy_typed_occurrence(tytab: Array[(Int, Type)], offset: Int, ty: Ty
 /// #2391 slice 2: the CHANNEL anchor for a relational/`+` binop -- the offset
 /// the checker records a String binop under and the FS merge's rewrite pass
 /// recomputes to find it. Exported for exactly that reason: two
-/// implementations of this walk would be a silent-wrong factory.
+/// implementations of this anchor would be a silent-wrong factory.
 ///
-/// The walk prefers anchors that are UNIQUE to this binop -- a
-/// sequence/match/if operand answers -1 in the shallow walk (falling back
-/// to the right operand) instead of descending to its first expression,
-/// because a descended anchor is not unique: in
-/// `(match n + 1 { v => __to_string(v) }) + q` the outer String `+` and the
-/// Int `+` inside the scrutinee would otherwise share n's offset, and the
-/// rewrite corrupted the scrutinee (Codex round 1 on #2429; measured "y"
-/// where content says "4y"). Descent through a call's callee, a dot's base,
-/// or a binop's lhs stays shallow: those chains remain inside the operand.
-///
-/// When BOTH operands are composite (Codex round 2), the shallow walk has
-/// no anchor at all and the binop would silently keep its raw lowering --
-/// measured: `(if c { p } else { q }) + (match ...)` on Strings printed
-/// 2181843386369, the i64.add of the two reprs. So the anchor then falls
-/// back to a DEEP walk -- and the deep walk descends into VALUE positions
-/// only (if THEN-branch, match FIRST-ARM BODY, sequence TAIL, let BODY),
-/// never into control positions (Codex round 3). The node a value-position
-/// walk lands on has the composite operand's own type, so a same-kind binop
-/// that shares the anchor shares the String classification and rewrites
-/// correctly alongside; a control-position walk anchored the outer String
-/// `+` on an Int binop inside the if-CONDITION, where the verdict poison
-/// had to discard the whole anchor and the outer stayed raw (measured
-/// 2199023255553 for "xy"). A residual disagreeing collision still poisons
-/// and degrades to the syntactic classifiers, never a wrong rewrite.
-/// #2435: a binop parsed from source now carries its OPERATOR token's offset
-/// and that IS the anchor -- exact identity, no walk, no collisions, and the
-/// shapes no operand walk could name (literal-valued composite operands,
-/// measured 281320357889 for "xy" on the walk-only form) classify too. The
-/// operand walks below remain only for desugar-SYNTHESIZED binops (own
-/// offset -1), where the verdict poison still guards the residual
-/// collisions.
+/// #2435 made this exact identity: a binop parsed from source carries its
+/// OPERATOR token's offset, every desugar rebuild threads it through, and
+/// that offset IS the anchor -- no walk, no collisions. A binop the
+/// compiler SYNTHESIZES (own offset -1, e.g. the `str_lex_diff(..) < 0`
+/// wrapper the syntactic tracker emits) answers -1: the record site's
+/// `anchor_off >= 0` guard drops it and the rewrite's table lookup misses,
+/// so a synthesized binop is absent from the channel but never wrongly
+/// rewritten. The operand walk that used to fill in -1 anchors (three
+/// Codex rounds of collision guards on #2429) was measured reached ONLY by
+/// synthesized non-String binops, where its answer was -1 or a junk anchor
+/// the verdict poison then had to discard -- so it was deleted rather than
+/// guarded. The poison in string_binop_offsets_from_capture stays: two
+/// checks of the SAME source binop (generic instantiations) can still
+/// classify differently and must degrade, never rewrite.
 export fn typed_lowering_binop_anchor(own_off: Int, left: Expr, right: Expr) -> Int {
-  if own_off >= 0 {
-    own_off
-  } else {
-    typed_lowering_binop_walk_anchor(left, right)
-  }
-}
-
-fn typed_lowering_binop_walk_anchor(left: Expr, right: Expr) -> Int {
-  let loff = typed_lowering_operand_off(left)
-  if loff >= 0 {
-    loff
-  } else {
-    let roff = typed_lowering_operand_off(right)
-    if roff >= 0 {
-      roff
-    } else {
-      let ldeep = typed_lowering_operand_off_deep(left)
-      if ldeep >= 0 {
-        ldeep
-      } else {
-        typed_lowering_operand_off_deep(right)
-      }
-    }
-  }
-}
-
-fn typed_lowering_operand_off_deep(e: Expr) -> Int {
-  match e {
-    EIdent(_, off) => off,
-    ECall(callee, _, off) => if off >= 0 {
-      off
-    } else {
-      typed_lowering_operand_off_deep(callee)
-    },
-    EDot(base, _, off, _) => if off >= 0 {
-      off
-    } else {
-      typed_lowering_operand_off_deep(base)
-    },
-    EBinOp(_, lhs, _, _) => typed_lowering_operand_off_deep(lhs),
-    EIf(_, then_branch, _) => typed_lowering_operand_off_deep(then_branch),
-    EMatch(_, arms) => if Array::length(arms) > 0 {
-      let (_, first_body) = Array::get(arms, 0)
-      typed_lowering_operand_off_deep(first_body)
-    } else {
-      0 - 1
-    },
-    ESeq(_, tail) => typed_lowering_operand_off_deep(tail),
-    ELet(_, _, body, _) => typed_lowering_operand_off_deep(body),
-    ELetMut(_, _, body, _) => typed_lowering_operand_off_deep(body),
-    ELetRec(_, _, body) => typed_lowering_operand_off_deep(body),
-    _ => 0 - 1
-  }
-}
-
-fn typed_lowering_operand_off(e: Expr) -> Int {
-  match e {
-    EIdent(_, off) => off,
-    ECall(callee, _, off) => if off >= 0 {
-      off
-    } else {
-      typed_lowering_operand_off(callee)
-    },
-    EDot(base, _, off, _) => if off >= 0 {
-      off
-    } else {
-      typed_lowering_operand_off(base)
-    },
-    EBinOp(_, lhs, _, _) => typed_lowering_operand_off(lhs),
-    _ => 0 - 1
-  }
+  own_off
 }
 
 /// #2391 slice 2: record a relational/`+` binop's operand types under its

--- a/lib/@vibe/compiler/tests/typed_lowering_binop_anchor_test.vibe
+++ b/lib/@vibe/compiler/tests/typed_lowering_binop_anchor_test.vibe
@@ -1,0 +1,45 @@
+//# Imports
+
+import @vibe/ast {
+  Expr
+}
+
+import @vibe/compiler/checker {
+  typed_lowering_binop_anchor
+}
+
+//# Tests
+
+// #2391: the channel anchor is EXACT identity -- the operator token's own
+// offset (#2435), nothing else. A synthesized binop (own offset -1) answers
+// -1: the record site drops it and the rewrite's lookup misses, so it is
+// absent from the channel but can never be wrongly rewritten. The operand
+// walk that used to fill in -1 anchors from operand offsets was measured
+// reached only by compiler-synthesized non-String binops and was deleted;
+// these tests pin the replacement contract.
+
+test "#2391: a parsed binop's anchor is its operator offset" {
+  let got = typed_lowering_binop_anchor(7, EIdent("a", 3), EIdent("b", 9))
+  inspect(got, content = "7")
+}
+
+test "#2391: a synthesized binop has no anchor, whatever its operands carry" {
+  // Under the deleted operand walk this answered 42 (the left operand's
+  // offset) -- a junk anchor that could collide with a recorded source
+  // binop and had to be guarded by the verdict poison.
+  let got = typed_lowering_binop_anchor(0 - 1, EIdent("a", 42), EInt(0))
+  inspect(got, content = "-1")
+}
+
+test "#2391: the syntactic tracker's str_lex_diff wrapper stays anchorless" {
+  // The shape the tracker emits for a classified String `<`:
+  // `str_lex_diff(a, b) < 0`, every synthesized node at -1. This is the
+  // shape the reachability probe caught in the walk during a selfhost
+  // build.
+  let wrapper = ECall(EIdent("str_lex_diff", 0 - 1), [
+    EIdent("a", 12),
+    EIdent("b", 20)
+  ], 0 - 1)
+  let got = typed_lowering_binop_anchor(0 - 1, wrapper, EInt(0))
+  inspect(got, content = "-1")
+}


### PR DESCRIPTION
## What

Follow-up slice of #2391 on top of #2435/#2436/#2439: the String-binop typed channel's anchor is now **exact identity** — the operator token's own source offset, nothing else. The operand-walk fallback (`typed_lowering_binop_walk_anchor`) and its two helpers (`typed_lowering_operand_off`, `typed_lowering_operand_off_deep`) are deleted: 103 lines, three Codex rounds' worth of collision guards, gone.

## Why this is safe — measured, not argued

Before deleting, reachability was measured: a trap was planted in the walk (an effect-free divide-by-zero — a `throw` is rejected at build because it changes the effect row) and the full stage bootstrap + 1093-file suite were run against the probed compiler.

The walk **is** reached during a selfhost build — but only by compiler-**synthesized** binops (own offset -1), foremost the `str_lex_diff(a, b) < 0` wrapper the syntactic tracker emits. For those its answer was either -1 or a junk operand-derived anchor that the verdict poison then had to discard. With #2435, every source-parsed binop carries its exact operator offset and every desugar rebuild threads it through; the one lane whose source binops are unlocated (the CST lane, `lower.vibe`) has no production consumers (tests/coverage only). So the walk could never contribute a *correct* anchor — only noise the poison had to clean up.

## Behavior

- `typed_lowering_binop_anchor(own_off, l, r)` returns `own_off` (signature kept — it is passed as a function value into the parser package's scan/rewrite).
- A synthesized binop answers -1: the record site's `anchor_off >= 0` guard drops it and the rewrite's table lookup misses — absent from the channel, never wrongly rewritten (design policy: absent but never wrong).
- The extraction poison in `string_binop_offsets_from_capture` **stays**: two checks of the same source binop (generic instantiations) can still classify differently and must degrade to the syntactic classifiers, never rewrite.

## Tests

New `typed_lowering_binop_anchor_test.vibe` pins the contract (Red→Green: the synthesized-binop case answered `42` — the left operand's offset — under the walk, `-1` now; the str_lex_diff wrapper shape from the probe is pinned too).

## Validation

- bundle regen; stage2 == stage3 fixpoint
- `string_binop_typed_channel_fs_lane_test` (13) and `float_call_offset_fs_lane_test` (9) on the new stage2
- cli-core suite; typing-env-reuse oracle
- selfcompile KPI: heap 1,574,603,840 bytes — ~2.8% below the previous 1.62GB baseline (the walk ran on every rel/`+` binop in both the record and scan/rewrite passes)
- 1095/1095 unit-test files; full `compiler_gate.sh` (incl. the 126-case #2391 channel gate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0159xd5111g8KFt2CGyNyZvA

---
_Generated by [Claude Code](https://claude.ai/code/session_0159xd5111g8KFt2CGyNyZvA)_