### PR TITLE
Wire the typed-== channel into the single-source wasi and gc lanes

### DIFF
--- a/lib/@vibe/compiler/checker/checker_stmt.vibe
+++ b/lib/@vibe/compiler/checker/checker_stmt.vibe
@@ -6265,12 +6265,22 @@ export fn typed_lowering_enc_tag(enc: Int) -> Int {
 /// has no Double call results. A caller that cannot tell those apart wires the
 /// channel up green and inert; `check_program_double_call_result_located_observation`
 /// below is the caller-facing form that refuses the first case.
-fn check_program_double_call_result_observation_impl(stmts: Array[Stmt]) -> Option[(CheckedProgram, Array[Int], Int, Int)] with Exception {
+fn check_program_double_call_result_observation_impl(stmts: Array[Stmt]) -> Option[(CheckedProgram, Array[Int], Int, Int, Array[Int], Array[String])] with Exception {
   let capture = reset_double_call_capture()
   let checked = check_program_type_defs_observation_impl(stmts, None, Some(capture)).checked_program
   match double_call_result_offsets_from_capture(checked, capture) {
     None => None,
-    Some((out, primary_calls, located_primary_calls)) => Some((checked, out, primary_calls, located_primary_calls))
+    Some((out, primary_calls, located_primary_calls)) => {
+      // #2441: the typed-`==` rows from the SAME capture the Double
+      // observation already filled -- one check answers both. Unlike the
+      // Double table, these need no located-refusal ambiguity handling OR a
+      // downstream uniqueness filter: an unlocated binop records nothing
+      // (the record site's `anchor_off >= 0` guard), and an offset claimed
+      // by two binops with different types is poisoned at extraction --
+      // with the SAME type, rewriting both is correct.
+      let (eq_offs, eq_keys) = eq_binop_type_keys_from_capture(checked, capture)
+      Some((checked, out, primary_calls, located_primary_calls, eq_offs, eq_keys))
+    }
   }
 }
 
@@ -6348,10 +6358,10 @@ export fn check_program_with_projected_import_env_typed_lowering_located_observa
 /// Check once and retain only source-located primary call results whose
 /// checker-confirmed instantiated type is Double. Offset alone is not enough:
 /// a dot-call receiver and its non-Double result can share the same offset.
-export fn check_program_double_call_result_observation(stmts: Array[Stmt]) -> Option[(CheckedProgram, Array[Int])] with Exception {
+export fn check_program_double_call_result_observation(stmts: Array[Stmt]) -> Option[(CheckedProgram, Array[Int], Array[Int], Array[String])] with Exception {
   match check_program_double_call_result_observation_impl(stmts) {
     None => None,
-    Some((checked, out, _, _)) => Some((checked, out))
+    Some((checked, out, _, _, eq_offs, eq_keys)) => Some((checked, out, eq_offs, eq_keys))
   }
 }
 
@@ -6365,13 +6375,13 @@ export fn check_program_double_call_result_observation(stmts: Array[Stmt]) -> Op
 /// honest "located, and no call result is a Double". A program with no calls at
 /// all is located-vacuously and answers `Some((checked, []))` too; an empty set
 /// classifies nothing either way, so that direction cannot be wrong.
-export fn check_program_double_call_result_located_observation(stmts: Array[Stmt]) -> Option[(CheckedProgram, Array[Int])] with Exception {
+export fn check_program_double_call_result_located_observation(stmts: Array[Stmt]) -> Option[(CheckedProgram, Array[Int], Array[Int], Array[String])] with Exception {
   match check_program_double_call_result_observation_impl(stmts) {
     None => None,
-    Some((checked, out, primary_calls, located_primary_calls)) => if primary_calls > 0 && located_primary_calls == 0 {
+    Some((checked, out, primary_calls, located_primary_calls, eq_offs, eq_keys)) => if primary_calls > 0 && located_primary_calls == 0 {
       None
     } else {
-      Some((checked, out))
+      Some((checked, out, eq_offs, eq_keys))
     }
   }
 }

--- a/lib/@vibe/compiler/checker/index.vpkg
+++ b/lib/@vibe/compiler/checker/index.vpkg
@@ -255,8 +255,8 @@ type CheckedProgram
 type CheckedProgramTypeDefsObservation
 fn check_stmts(raw_stmts: Array[Stmt], i: Int, env: TypeEnv, defs: Array[TypeDef], s: Subst, c: Int, errors: Array[String], tytab: Array[(Int, Type)]) -> (TypeEnv, Subst, Int)
 fn check_program_result(stmts: Array[Stmt]) -> CheckedProgram with Exception
-fn check_program_double_call_result_observation(stmts: Array[Stmt]) -> Option[(CheckedProgram, Array[Int])] with Exception
-fn check_program_double_call_result_located_observation(stmts: Array[Stmt]) -> Option[(CheckedProgram, Array[Int])] with Exception
+fn check_program_double_call_result_observation(stmts: Array[Stmt]) -> Option[(CheckedProgram, Array[Int], Array[Int], Array[String])] with Exception
+fn check_program_double_call_result_located_observation(stmts: Array[Stmt]) -> Option[(CheckedProgram, Array[Int], Array[Int], Array[String])] with Exception
 
 /// #2424: the source offsets of render / `eq` arguments whose
 /// checker-confirmed type is `Int`, for the classifiers that otherwise decide

--- a/lib/@vibe/compiler/entry/source_compile/gc_only/gc_only.vibe
+++ b/lib/@vibe/compiler/entry/source_compile/gc_only/gc_only.vibe
@@ -11,8 +11,8 @@ import @vibe/compiler/checker {
   check_program_double_call_result_observation, checked_int_render_offsets, validate_user_source_stmts
 }
 
-import @vibe/compiler/codegen {
-  desugar_trait_dicts
+import @vibe/compiler/normalize {
+  desugar_trait_dicts_with_typed_eq
 }
 
 import @vibe/compiler/codegen/common_analysis {
@@ -349,7 +349,13 @@ fn compile_stmts_gc_only_impl(stmts: Array[Stmt], entry_name: String, merged_off
   // `lowered_test_ambient_effects` recognizes these two prefixes, so the
   // grant survives the lowering without changing what CODEGEN sees.
   let (effective_entry, generated_test_artifact) = lower_test_blocks_gc(stmts, entry_name)
-  let (checked, gc_float_call_offsets) = match check_program_double_call_result_observation(stmts) {
+  // #2441: the same observation carries the typed-`==` rows. On this lane
+  // they need no rename mapping (the check runs on the POST-merge,
+  // post-rename statements, so the keys already name the merged
+  // declarations) and no uniqueness filter (the extraction poisons an
+  // offset claimed by binops of different types; with the same type,
+  // rewriting both is correct).
+  let (checked, gc_float_call_offsets, gc_eq_offsets, gc_eq_keys) = match check_program_double_call_result_observation(stmts) {
     Some(observation) => observation,
     None => throw("internal compiler error: incomplete GC call-result type observation")
   }
@@ -374,7 +380,7 @@ fn compile_stmts_gc_only_impl(stmts: Array[Stmt], entry_name: String, merged_off
   // rank-1 witness field such as `map[A, B]` as a monomorphic struct field.
   // Constructor-indexed pipeline calls then rejected `Array[Int]` against the
   // generated `Array[A]`, despite the original source checking cleanly.
-  desugar_trait_dicts(stmts)
+  desugar_trait_dicts_with_typed_eq(stmts, gc_eq_offsets, gc_eq_keys)
   // Trait-dict desugaring hoists capture-free effectful lambdas after the
   // pre-erasure snapshot. Add only those generated declarations; ordinary
   // declarations must keep the binder-aware pre-erasure answer.

--- a/lib/@vibe/compiler/entry/source_compile/gc_only/index.vpkg
+++ b/lib/@vibe/compiler/entry/source_compile/gc_only/index.vpkg
@@ -8,6 +8,7 @@ deps = {
   @vibe/compiler/codegen : 0.0.1
   @vibe/compiler/codegen/common_analysis : 0.0.1
   @vibe/compiler/codegen/gc : 0.0.1
+  @vibe/compiler/normalize : 0.0.1
   @vibe/compiler/syntax : 0.0.1
   @vibe/core : 0.2.0
 }

--- a/lib/@vibe/compiler/entry/source_compile/source_compile.vibe
+++ b/lib/@vibe/compiler/entry/source_compile/source_compile.vibe
@@ -47,7 +47,11 @@ export fn compile_source(source: String) -> Bytes with Exception {
 /// answer in codegen exactly as it was.
 fn module_typed_offsets(stmts: Array[Stmt]) -> (Array[Int], Array[Int]) with Exception {
   match check_program_double_call_result_located_observation(stmts) {
-    Some((checked, offsets)) => (offsets, checked_int_render_offsets(checked)),
+    // #2441: the observation also returns the typed-`==` rows, but the
+    // compile_module path this lane feeds has no typed-eq threading yet --
+    // dropping them keeps today's behavior (the syntactic classifiers),
+    // never a wrong comparator.
+    Some((checked, offsets, _, _)) => (offsets, checked_int_render_offsets(checked)),
     None => ([], [])
   }
 }

--- a/lib/@vibe/compiler/entry/source_compile/wasi_only/preprocess_compile.vibe
+++ b/lib/@vibe/compiler/entry/source_compile/wasi_only/preprocess_compile.vibe
@@ -215,10 +215,14 @@ fn maybe_wrap_async_component(bytes: Bytes, wrap_async: Bool) -> Bytes with Exce
 /// is a pure function of the CheckedProgram it already returns, so the two
 /// cost one check between them. `None` is the observation refusing an
 /// unlocated AST, and an empty table classifies nothing.
-fn source_offsets(stmts: Array[Stmt]) -> (Array[Int], Array[Int]) with Exception {
+/// #2441: the typed-`==` rows ride the same observation. One text, one
+/// offset space, no merge and no renames -- the rows apply as-is, and an
+/// unlocated AST yields no rows by construction (the record site's
+/// `anchor_off >= 0` guard).
+fn source_offsets(stmts: Array[Stmt]) -> (Array[Int], Array[Int], Array[Int], Array[String]) with Exception {
   match check_program_double_call_result_located_observation(stmts) {
-    Some((checked, offsets)) => (offsets, checked_int_render_offsets(checked)),
-    None => ([], [])
+    Some((checked, offsets, eq_offs, eq_keys)) => (offsets, checked_int_render_offsets(checked), eq_offs, eq_keys),
+    None => ([], [], [], [])
   }
 }
 
@@ -239,10 +243,10 @@ fn compile_source_wasi_only_impl(source: String, entry_name: String, trusted_gen
   validate_source_if_user(stmts, trusted_generated)
   expand_interp_stmts(stmts)
   // Check before stripping generic type params (see merge_sources.vibe).
-  let (float_call_offsets, int_render_offsets) = source_offsets(stmts)
+  let (float_call_offsets, int_render_offsets, eq_offsets, eq_keys) = source_offsets(stmts)
   let wrap_async = (entry_name == "run") && entry_declares_async_int(stmts, entry_name)
   strip_generic_type_params(stmts)
-  maybe_wrap_async_component(compile_wasi_module_impl_with_typed_offsets(stmts, entry_name, float_call_offsets, int_render_offsets, array_empty(), array_empty()), wrap_async)
+  maybe_wrap_async_component(compile_wasi_module_impl_with_typed_offsets(stmts, entry_name, float_call_offsets, int_render_offsets, eq_offsets, eq_keys), wrap_async)
 }
 
 export fn compile_source_wasi_only(source: String, entry_name: String) -> Bytes with Exception {
@@ -291,10 +295,10 @@ fn compile_source_wasi_only_rc_impl(source: String, entry_name: String, trusted_
   let stmts = parse_program_located(tokens, starts, source)
   validate_source_if_user(stmts, trusted_generated)
   expand_interp_stmts(stmts)
-  let (float_call_offsets, int_render_offsets) = source_offsets(stmts)
+  let (float_call_offsets, int_render_offsets, eq_offsets, eq_keys) = source_offsets(stmts)
   let wrap_async = (entry_name == "run") && entry_declares_async_int(stmts, entry_name)
   strip_generic_type_params(stmts)
-  maybe_wrap_async_component(compile_wasi_module_rc_impl_with_typed_offsets(stmts, entry_name, float_call_offsets, int_render_offsets, array_empty(), array_empty()), wrap_async)
+  maybe_wrap_async_component(compile_wasi_module_rc_impl_with_typed_offsets(stmts, entry_name, float_call_offsets, int_render_offsets, eq_offsets, eq_keys), wrap_async)
 }
 
 export fn compile_source_wasi_only_rc(source: String, entry_name: String) -> Bytes with Exception {


### PR DESCRIPTION
Follow-up to #2443, which noted: "Wiring `source_offsets` and the gc FS lane is a follow-up." This slice carries the typed-`==` rows into the two lanes that were still answering the #2441 class (lambda call-result aggregates under `==`) by identity.

## What changed

- **checker** — `check_program_double_call_result_observation` and its `_located` variant now return the typed-`==` rows alongside the Double call-result offsets, so the one check these lanes already run yields both tables (`checker_stmt.vibe`, signatures in `checker/index.vpkg`). No new check runs.
- **single-source wasi lane** (`wasi_only/preprocess_compile.vibe`) — `source_offsets` returns the eq rows and both compile calls forward them into `compile_wasi_module_{impl,rc_impl}_with_typed_offsets` instead of empties. One text, one offset space, no merge and no renames, so the rows apply as-is; an unlocated AST yields no rows by construction.
- **gc lane** (`gc_only/gc_only.vibe`) — the whole-program observation runs on the post-merge, post-rename stmts, so the nominal keys are automatically correct and need neither the FS lane's rename rebase nor a located-refusal filter; `desugar_trait_dicts_with_typed_eq` consumes the rows directly. Adds the `@vibe/compiler/normalize` dep to the vpkg.
- **compile_module lane** (`source_compile.vibe`) — rows are deliberately dropped with a comment: that path has no typed-eq threading yet, so its behavior is unchanged (syntactic classifiers), never a wrong comparator.

## Red → Green

On current main, the pinned channel fixture fails on the gc backend with the same silent-wrong shape #2441 had on linear:

```
VIBE_TEST_BACKEND=gc bash scripts/vibe_test.sh lib/@vibe/compiler/tests/eq_typed_channel_fs_lane_test.vibe
# actual: false / expected: true  (content-equal arrays identity-compared)
```

With this change, `eq_typed_channel_fs_lane_test.vibe` (9 tests) and `eq_typed_channel_rename_test.vibe` (3 tests) pass on both backends.

## Validation

- bundle regen → `generations.sh build --stage3`: stage2 == stage3 fixpoint
- typed-channel lane tests (13 + 9) with the freshly built stage2
- `test_cli_core.sh`, selfcompile KPI within threshold (heap 1.577 GB), TDRE oracle
- full unit suite + `compiler_gate.sh` running in CI on this PR (same gates)

Refs #2391, #2441.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0159xd5111g8KFt2CGyNyZvA

---
_Generated by [Claude Code](https://claude.ai/code/session_0159xd5111g8KFt2CGyNyZvA)_