### PR TITLE
Close #2424's Double projection row, generalize the builtin value form (#2442), and rescope #2437

### DIFF
--- a/docs/cheatsheet.md
+++ b/docs/cheatsheet.md
@@ -1037,6 +1037,11 @@ let nv = {                            // destructure also works in fn/block body
 let m = Map::from_pairs([("key", 42)])
 let e = Map::new()                    // empty map
 let mv = m["key"]
+// `Map::set` is FUNCTIONAL: it returns a new map and leaves the receiver
+// alone. Measured on the RC lane -- `Map::set(m, "b", 2)` as a statement is a
+// silent no-op (`Map::size(m)` stays 1, `Map::has_key(m, "b")` is false), and
+// nothing warns about the discarded result. Bind it.
+let m2 = Map::set(m, "b", 2)
 let sized: (StringMap[Int]) -> Int = (mm) -> { Map::size(mm) }
 
 // Builders (mutable construction)
@@ -1130,7 +1135,9 @@ let w_check = {
 >   binds any field name and works in fn/block bodies too.
 > - **`Map::from_pairs([...])` / `Map::new()` + `Map::*` builtins + `m[k]`
 >   indexing** work standalone (#760/#960): `Map::get` / `has_key` / `set` /
->   `keys` and the `m["k"]` index sugar all lower correctly. The old
+>   `keys` and the `m["k"]` index sugar all lower correctly -- but `set` is
+>   FUNCTIONAL (`let m2 = Map::set(m, k, v)`), so writing it as a statement
+>   updates nothing and nothing warns. The old
 >   `map { ... }` literal was removed in #960 (it now reports a located parse
 >   error naming the replacement API). (`lib/@vibe/core`'s `get`/`get_or`/
 >   `has_key`/`keys`/`values` remain available for a richer Map API, #766.)

--- a/fixtures/builtin_value_form_test.vibe
+++ b/fixtures/builtin_value_form_test.vibe
@@ -1,0 +1,72 @@
+// #2442: a PURE builtin may be bound to a name and called through the binding.
+//
+// #2433 removed a silent load-time failure by REJECTING every builtin in value
+// position, exempting the two FrozenArray conversions #1733 had given a real
+// value form. That left the language answering the same question two ways
+// depending on which name you wrote, and the rule a reader had to learn was a
+// two-element list rather than a property. It is now a property: a builtin has
+// a value form exactly when it is QUALIFIED, the registry knows its arity, and
+// its effect row is empty (`builtin_value_form_arity`, core/builtin_name.vibe).
+//
+// The qualification is a compiler limitation with a measured reason, recorded
+// on that function and pinned in the unit test beside this file: the whole-
+// program lambda-site planner is scope-free, so it cannot tell a use of the
+// builtin `eq` from a use of a local named `eq`, and the walk THROWS on a
+// disagreement. Admitting bare names needs the planner to learn scope.
+//
+// The lowering is an ETA-EXPANSION, not a function pointer to the builtin: a
+// builtin's index is below `func_offset` and its body has no closure-env
+// parameter, so both lanes emit `(a, b) -> name(a, b)` -- an ordinary lambda
+// with an ordinary table slot whose body is the same direct call. Everything
+// below therefore has to answer exactly as the direct call does, which is what
+// each `inspect` pins.
+//
+// Effectful builtins are deliberately still rejected, and the check-time half
+// of that contract (the diagnostic, and the reason it gives) lives in
+// lib/@vibe/compiler/tests/builtin_ident_value_test.vibe -- a rejected program
+// cannot be a runtime fixture.
+
+fn apply_pair(f: (String, String) -> String, a: String, b: String) -> String {
+  f(a, b)
+}
+
+test "#2442 a two-argument pure builtin answers through a binding" {
+  let cat = String::concat
+  inspect(cat("ab", "cd"), "abcd")
+  inspect(String::concat("ab", "cd"), "abcd")
+}
+
+test "#2442 a one-argument pure builtin answers through a binding" {
+  let len = String::length
+  inspect(len("abcde"), "5")
+  inspect(String::length("abcde"), "5")
+}
+
+test "#2442 a generic builtin through a binding" {
+  let alen = Array::length
+  inspect(alen([1, 2, 3]), "3")
+  inspect(Array::length([1, 2, 3]), "3")
+}
+
+test "#2442 a builtin whose result is a value, not a scalar" {
+  let sub = String::substring
+  inspect(sub("abcdef", 1, 4), "bcd")
+  inspect(String::substring("abcdef", 1, 4), "bcd")
+}
+
+test "#2442 a builtin passed directly as an argument" {
+  inspect(apply_pair(String::concat, "x", "y"), "xy")
+}
+
+test "#2442 an annotated binding of a builtin" {
+  let cat: (String, String) -> String = String::concat
+  inspect(cat("p", "q"), "pq")
+}
+
+test "#1733 the two FrozenArray conversions keep answering" {
+  let freeze = FrozenArray::from_array
+  let thaw = FrozenArray::to_array
+  let fz = freeze([1, 2, 3])
+  inspect(FrozenArray::length(fz), "3")
+  inspect(Array::length(thaw(fz)), "3")
+}

--- a/fixtures/builtin_value_form_test.vibe
+++ b/fixtures/builtin_value_form_test.vibe
@@ -5,14 +5,21 @@
 // value form. That left the language answering the same question two ways
 // depending on which name you wrote, and the rule a reader had to learn was a
 // two-element list rather than a property. It is now a property: a builtin has
-// a value form exactly when it is QUALIFIED, the registry knows its arity, and
-// its effect row is empty (`builtin_value_form_arity`, core/builtin_name.vibe).
+// a value form exactly when it is QUALIFIED, its registry signature is
+// CONCRETE, and its effect row is empty (`builtin_value_form_arity`,
+// core/builtin_name.vibe).
 //
-// The qualification is a compiler limitation with a measured reason, recorded
-// on that function and pinned in the unit test beside this file: the whole-
-// program lambda-site planner is scope-free, so it cannot tell a use of the
-// builtin `eq` from a use of a local named `eq`, and the walk THROWS on a
-// disagreement. Admitting bare names needs the planner to learn scope.
+// Both restrictions are compiler limitations with measured reasons, recorded on
+// that function and pinned in the unit test beside this file:
+//
+//   * QUALIFIED, because the whole-program lambda-site planner is scope-free
+//     and cannot tell a use of the builtin `eq` from a use of a local named
+//     `eq`, and the walk THROWS on a disagreement;
+//   * CONCRETE, because the registry writes a polymorphic position as "any
+//     type" with every occurrence independent -- a value form would hand out a
+//     signature that does not relate the argument to the result, and
+//     `let get = Array::get; let s: String = get([1], 0)` checked clean and
+//     printed garbage while the direct call was correctly rejected.
 //
 // The lowering is an ETA-EXPANSION, not a function pointer to the builtin: a
 // builtin's index is below `func_offset` and its body has no closure-env
@@ -42,12 +49,6 @@ test "#2442 a one-argument pure builtin answers through a binding" {
   inspect(String::length("abcde"), "5")
 }
 
-test "#2442 a generic builtin through a binding" {
-  let alen = Array::length
-  inspect(alen([1, 2, 3]), "3")
-  inspect(Array::length([1, 2, 3]), "3")
-}
-
 test "#2442 a builtin whose result is a value, not a scalar" {
   let sub = String::substring
   inspect(sub("abcdef", 1, 4), "bcd")
@@ -61,6 +62,22 @@ test "#2442 a builtin passed directly as an argument" {
 test "#2442 an annotated binding of a builtin" {
   let cat: (String, String) -> String = String::concat
   inspect(cat("p", "q"), "pq")
+}
+
+fn String::last_index_of(a: Int) -> Int {
+  a + 1
+}
+
+test "#2448 a user function that declares a registry name wins" {
+  // `String::last_index_of` is a concrete arity-2 registry row, so it has a
+  // value form -- but this file declares its own arity-1 function with that
+  // name, and the checker resolves the name to the DECLARATION. Codegen has to
+  // agree: measured before the guard, this emitted an arity-2 eta-expansion of
+  // the builtin against the checker's arity-1 type and the runtime refused to
+  // compile the module (`failed to compile: wasm[0]::function[7]`).
+  inspect(String::last_index_of(1), "2")
+  let f = String::last_index_of
+  inspect(f(1), "2")
 }
 
 test "#1733 the two FrozenArray conversions keep answering" {

--- a/fixtures/gc_lane_scalar_parity_test.vibe
+++ b/fixtures/gc_lane_scalar_parity_test.vibe
@@ -722,9 +722,42 @@ test "#2424 a large Int survives a projection out of a tuple or a struct" {
   assert(__to_string(b.label) == "hi")
   assert(__to_string(t.1) == "1")
   assert(__to_string(b.small) == "7")
-  // A Double field is deliberately absent: `__to_string` of a Double-typed
-  // STRUCT field does not render the Double, measured on this same lane both
-  // before and after this change, and it is a separate row (the float
-  // classifier has no projection arm either). Asserting it here would fail for
-  // a reason this change is not about.
+}
+
+/// #2424, the Double half of the same row. The float classifier had no
+/// projection arm either, for the same structural reason: `float_call_offsets`
+/// is keyed by CALL offsets, so a projection had no key in it at all.
+///
+/// Measured before this change, one file per row, on the stage2 that closed the
+/// Int half: `__to_string(b.ratio)` on `DblBox::{ ratio: 1.5 }` printed `256`
+/// on the RC lane and TRAPPED on gc, while the identical Double reached through
+/// a tuple element, a plain `let` or a call result printed `1.5`. It answers now
+/// through tag 4 -- the render/`eq` argument offsets the checker typed `Double`,
+/// keyed by the same `typed_lowering_arg_offset` the Int half uses.
+struct DblBox {
+  ratio: Double;
+  label: String;
+  count: Int
+}
+
+fn dbl_ret_box() -> DblBox {
+  DblBox::{ ratio: 1.5, label: "hi", count: 7 }
+}
+
+test "#2424 a Double survives a projection out of a struct or a tuple" {
+  let b = DblBox::{ ratio: 1.5, label: "hi", count: 7 }
+  assert(__to_string(b.ratio) == "1.5")
+  // Off a CALL result, so the receiver's own offset is a different key.
+  assert(__to_string(dbl_ret_box().ratio) == "1.5")
+  // The tuple spelling, which already answered and must keep answering.
+  let t = (1.5, 2)
+  assert(__to_string(t.0) == "1.5")
+  // Through `eq`, with both operands projections.
+  let c = DblBox::{ ratio: 2.5, label: "hi", count: 7 }
+  assert(!eq(b.ratio, c.ratio))
+  assert(eq(b.ratio, dbl_ret_box().ratio))
+  // The controls: a projection must not be classified `Double` for being one.
+  assert(__to_string(b.label) == "hi")
+  assert(__to_string(b.count) == "7")
+  assert(__to_string(t.1) == "2")
 }

--- a/lib/@vibe/compiler/checker/checker.vibe
+++ b/lib/@vibe/compiler/checker/checker.vibe
@@ -9,7 +9,7 @@ import @vibe/compiler/core {
   TypeEnv,
   TypeExpr,
   apply_type_constructor,
-  builtin_ident_has_value_form,
+  builtin_value_form_arity,
   canonical_builtin_name,
   collect_tvars,
   compiler_owned_type_arity,
@@ -2267,20 +2267,29 @@ fn railway_ident_lookup_name(name: String) -> String {
 /// not a `CtFn` and lowers through the `ctor_table` arm of `compile_expr`,
 /// which is why #2274's bare-name exemption existed and why dropping that
 /// exemption is safe now that the test is the type.
-/// #1733 is the exception, and it is not a taste call: `compile_expr` and
-/// `backend_expr` materialize the two FrozenArray conversions as a one-argument
-/// LAMBDA (`frozen_array_conversion_closure`), which is an ordinary closure
-/// with an ordinary table slot, so those two really are values.
-/// `builtin_ident_has_value_form` in `core/builtin_name.vibe` is the single
-/// source of truth both lanes read, so this cannot drift from the lowering.
+/// #1733 / #2442 is the exception, and it is not a taste call: both lanes
+/// materialize a PURE builtin as an eta-expanded LAMBDA
+/// (`builtin_value_closure`), which is an ordinary closure with an ordinary
+/// table slot, so those really are values.
+/// `builtin_value_form_arity` in `core/builtin_name.vibe` is the single source
+/// of truth both lanes read, so this cannot drift from the lowering.
+///
+/// Two conditions, and each is decided by the side that owns it. The EFFECT
+/// row is read off the type the checker itself inferred, because that is the
+/// authority for effects: an effectful builtin materialized as a value would
+/// carry its row on the binding's function type and would have to be demanded
+/// again at the indirect call, and until that exists `let f = Fs::read_file`
+/// launders authority (ADR-0075/0084/0088). The ARITY must AGREE between the
+/// registry and that same type -- a value form is emitted with the registry's
+/// parameter count, so granting one the checker types differently would move a
+/// check-time error into a runtime signature mismatch.
 fn builtin_ident_is_value(name: String, t: Type) -> Bool {
-  if builtin_ident_has_value_form(name) {
-    true
-  } else {
-    match t {
-      CtFn(_, _, _) => false,
-      _ => true
-    }
+  match t {
+    CtFn(params, _, eff) => match eff {
+      Some(_) => false,
+      None => builtin_value_form_arity(name) == Array::length(params)
+    },
+    _ => true
   }
 }
 
@@ -2317,7 +2326,30 @@ fn call_only_builtin_ident_error(name: String, ty: Type, ident_off: Int) -> Stri
   } else {
     String::concat("(", String::concat(params, String::concat(") -> ", call_form)))
   }
-  String::concat(String::concat("`", name), String::concat("` is a builtin operation, not a value -- call it (`", String::concat(call_form, String::concat("`), or wrap it (`", String::concat(wrap_form, String::concat("`) to pass it as a function", off_marker_len(ident_off, String::length(name))))))))
+  let head = String::concat(String::concat("`", name), "` is a builtin operation, not a value")
+  let why = builtin_value_form_refusal_reason(name, ty)
+  let how = String::concat(" -- call it (`", String::concat(call_form, String::concat("`), or wrap it (`", String::concat(wrap_form, "`) to pass it as a function"))))
+  String::concat(head, String::concat(why, String::concat(how, off_marker_len(ident_off, String::length(name)))))
+}
+
+/// #2442: say WHY this name has no value form, so the reader can tell a
+/// permanent boundary from a gap. Two reasons, and they call for different
+/// things: an effect row means the wrap form is the ANSWER (it puts the call
+/// back at a site where the row is checked against the caller's capability),
+/// while an unknown arity means the compiler has no registry row to expand and
+/// the wrap form is a workaround.
+fn builtin_value_form_refusal_reason(name: String, ty: Type) -> String {
+  match ty {
+    CtFn(_, _, eff) => match eff {
+      Some(row) => String::concat(" (it performs `", String::concat(row, "`, and an effect row is only checked where the call is written)")),
+      None => if String::contains(canonical_builtin_name(name), "::") {
+        " (the compiler has no registry row for it, so it has no arity to expand)"
+      } else {
+        " (an unqualified builtin name has no value form yet: a local of the same name would be indistinguishable to the lambda-site planner)"
+      }
+    },
+    _ => ""
+  }
 }
 
 fn railway_is_return_none(e: Expr) -> Bool {

--- a/lib/@vibe/compiler/checker/checker.vibe
+++ b/lib/@vibe/compiler/checker/checker.vibe
@@ -2333,19 +2333,27 @@ fn call_only_builtin_ident_error(name: String, ty: Type, ident_off: Int) -> Stri
 }
 
 /// #2442: say WHY this name has no value form, so the reader can tell a
-/// permanent boundary from a gap. Two reasons, and they call for different
+/// permanent boundary from a gap. Four reasons, and they call for different
 /// things: an effect row means the wrap form is the ANSWER (it puts the call
 /// back at a site where the row is checked against the caller's capability),
-/// while an unknown arity means the compiler has no registry row to expand and
-/// the wrap form is a workaround.
+/// while the other three mean the wrap form is a workaround for something the
+/// compiler cannot express yet.
 fn builtin_value_form_refusal_reason(name: String, ty: Type) -> String {
+  let canonical = canonical_builtin_name(name)
   match ty {
     CtFn(_, _, eff) => match eff {
       Some(row) => String::concat(" (it performs `", String::concat(row, "`, and an effect row is only checked where the call is written)")),
-      None => if String::contains(canonical_builtin_name(name), "::") {
-        " (the compiler has no registry row for it, so it has no arity to expand)"
-      } else {
+      None => if !String::contains(canonical, "::") {
         " (an unqualified builtin name has no value form yet: a local of the same name would be indistinguishable to the lambda-site planner)"
+      } else if registry_builtin_arity(canonical) >= 0 {
+        // Codex review on #2448. The registry writes a polymorphic position as
+        // `reg_any()`, and each occurrence is independent -- so a value form
+        // would hand out a signature that does not relate the argument to the
+        // result, and `let get = Array::get; let s: String = get([1], 0)`
+        // would check clean. The direct call keeps its refinements.
+        " (its signature has positions the registry leaves open, and a value form cannot say they are the same type)"
+      } else {
+        " (the compiler has no registry row for it, so it has no arity to expand)"
       }
     },
     _ => ""

--- a/lib/@vibe/compiler/checker/checker_facade.vibe
+++ b/lib/@vibe/compiler/checker/checker_facade.vibe
@@ -61,6 +61,7 @@ export ./checker_stmt.vibe {
   check_program_with_projected_import_env_result,
   check_program_with_projected_import_env_typed_lowering_located_observation,
   check_stmts,
+  checked_double_render_offsets,
   checked_int_render_offsets,
   typed_lowering_enc,
   typed_lowering_enc_offset,

--- a/lib/@vibe/compiler/checker/checker_stmt.vibe
+++ b/lib/@vibe/compiler/checker/checker_stmt.vibe
@@ -64,7 +64,8 @@ import @vibe/compiler/core {
   type_constructor_name,
   type_implements_trait,
   type_to_string,
-  typed_lowering_arg_offset
+  typed_lowering_arg_offset,
+  typed_lowering_float_key
 }
 
 import ./checker.vibe {
@@ -6054,13 +6055,25 @@ fn irc_is_render_callee(n: String) -> Bool {
   n == "__to_string" || n == "Int::to_string" || n == "eq"
 }
 
-fn irc_collect_expr(e: Expr, out: Array[Int]) -> Unit {
+/// `want_double` picks the KEY, not just the type filter. The Int channel keys
+/// an argument by `typed_lowering_arg_offset`, which answers for a bare name
+/// too; the Double channel must not, because its table also carries call-result
+/// rows and a call node's offset is its callee identifier's offset -- see
+/// `typed_lowering_float_key` (@vibe/compiler/core) for the whole argument.
+/// Collecting under the key the consumer reads is the point: a candidate filed
+/// under a key nobody looks up is not a wrong answer, it is silence.
+fn irc_collect_expr(e: Expr, out: Array[Int], want_double: Bool) -> Unit {
   match e {
     ECall(callee, args, _) => match callee {
       EIdent(cn, _) => if irc_is_render_callee(cn) {
         let mut ai = 0
         while ai < Array::length(args) {
-          let aoff = typed_lowering_arg_offset(Array::get(args, ai))
+          let arg = Array::get(args, ai)
+          let aoff = if want_double {
+            typed_lowering_float_key(arg)
+          } else {
+            typed_lowering_arg_offset(arg)
+          }
           if aoff >= 0 {
             Array::push(out, aoff)
           } else {
@@ -6078,33 +6091,33 @@ fn irc_collect_expr(e: Expr, out: Array[Int]) -> Unit {
   let kids = expr_children(e)
   let mut i = 0
   while i < Array::length(kids) {
-    irc_collect_expr(Array::get(kids, i), out)
+    irc_collect_expr(Array::get(kids, i), out, want_double)
     i = i + 1
   }
 }
 
-fn irc_collect_stmts(stmts: Array[Stmt], out: Array[Int]) -> Unit {
+fn irc_collect_stmts(stmts: Array[Stmt], out: Array[Int], want_double: Bool) -> Unit {
   let mut i = 0
   while i < Array::length(stmts) {
     match Array::get(stmts, i) {
-      SLet(_, _, _, _, e) => irc_collect_expr(e, out),
-      SLetMut(_, _, e) => irc_collect_expr(e, out),
-      SLetPat(_, e) => irc_collect_expr(e, out),
-      SExpr(e) => irc_collect_expr(e, out),
-      STest(_, e) => irc_collect_expr(e, out),
-      SBench(_, e) => irc_collect_expr(e, out),
+      SLet(_, _, _, _, e) => irc_collect_expr(e, out, want_double),
+      SLetMut(_, _, e) => irc_collect_expr(e, out, want_double),
+      SLetPat(_, e) => irc_collect_expr(e, out, want_double),
+      SExpr(e) => irc_collect_expr(e, out, want_double),
+      STest(_, e) => irc_collect_expr(e, out, want_double),
+      SBench(_, e) => irc_collect_expr(e, out, want_double),
       // `parse_program` lowers `SExample` to `STest` before anything checks
       // the program, so this arm is inert on every compile path today
       // (measured: a render of an `Array::get` result inside an `example`
       // block already answers correctly). It is here so the walk does not
       // depend on that ordering -- `parse_program_preserving` keeps the
       // variant, and an executable block form must not be silently skipped.
-      SExample(_, e) => irc_collect_expr(e, out),
+      SExample(_, e) => irc_collect_expr(e, out, want_double),
       // A render inside a nested module is checked with the rest of the
       // program and its occurrences are in the same table, so skipping the
       // body would leave that code with no classification at all (Codex
-      // review on #2434). `count_call_offsets_stmts` recurses the same way.
-      SModule(_, _, inner) => irc_collect_stmts(inner, out),
+      // review on #2434). `count_typed_lowering_offsets_stmts` recurses the same way.
+      SModule(_, _, inner) => irc_collect_stmts(inner, out, want_double),
       _ => ()
     }
     i = i + 1
@@ -6167,7 +6180,7 @@ fn irc_index_of(sorted: Array[Int], v: Int) -> Int {
 
 /// #2424: the source offsets of expressions that a render (`__to_string` /
 /// `Int::to_string`) or `eq` call takes as an argument AND whose
-/// checker-confirmed type is `Int`.
+/// checker-confirmed type is the one asked for.
 ///
 /// This is the answer codegen cannot compute for itself. Both lanes classify a
 /// render argument syntactically -- `ts_known_int` on linear,
@@ -6180,24 +6193,31 @@ fn irc_index_of(sorted: Array[Int], v: Int) -> Int {
 /// FAIL CLOSED on disagreement. An offset can carry more than one typed
 /// occurrence (a dot-call receiver and its result share one), so an offset is
 /// emitted only when it has at least one occurrence and EVERY occurrence there
-/// resolves to `Int`. A candidate with no occurrence at all -- which is what an
+/// resolves to it. A candidate with no occurrence at all -- which is what an
 /// unlocated `parse_program(lex(source))` AST produces for the whole program --
 /// is simply absent, and an absent offset classifies nothing, leaving the
 /// pre-existing syntactic answer exactly as it was.
-export fn checked_int_render_offsets(checked: CheckedProgram) -> Array[Int] {
+///
+/// #2424: the shared core of the two render/eq ARGUMENT channels. `want_double`
+/// picks which type head an offset must resolve to; everything else -- the
+/// candidate walk, the fail-closed agreement rule, the binary search -- is the
+/// same question asked twice, so it is written once. Reading a candidate set
+/// under one rule and a type under another is how a producer and a consumer
+/// drift into silence.
+fn irc_render_arg_offsets(checked: CheckedProgram, want_double: Bool) -> Array[Int] {
   let raw: Array[Int] = []
-  irc_collect_stmts(checked.checked_stmts, raw)
+  irc_collect_stmts(checked.checked_stmts, raw, want_double)
   let cands = irc_sorted_unique(raw)
   let n = Array::length(cands)
   if n == 0 {
     []
   } else {
     let seen_any: Array[Int] = []
-    let all_int: Array[Int] = []
+    let all_wanted: Array[Int] = []
     let mut k = 0
     while k < n {
       Array::push(seen_any, 0)
-      Array::push(all_int, 1)
+      Array::push(all_wanted, 1)
       k = k + 1
     }
     let mut oi = 0
@@ -6207,10 +6227,15 @@ export fn checked_int_render_offsets(checked: CheckedProgram) -> Array[Int] {
         let idx = irc_index_of(cands, ooff)
         if idx >= 0 {
           Array::set(seen_any, idx, 1)
-          if irc_resolves_to_int(checked.final_subst, oty) {
+          let wanted = if want_double {
+            subst_resolves_to_double(checked.final_subst, oty)
+          } else {
+            irc_resolves_to_int(checked.final_subst, oty)
+          }
+          if wanted {
             ()
           } else {
-            Array::set(all_int, idx, 0)
+            Array::set(all_wanted, idx, 0)
           }
         } else {
           ()
@@ -6223,7 +6248,7 @@ export fn checked_int_render_offsets(checked: CheckedProgram) -> Array[Int] {
     let out: Array[Int] = []
     let mut m = 0
     while m < n {
-      if Array::get(seen_any, m) == 1 && Array::get(all_int, m) == 1 {
+      if Array::get(seen_any, m) == 1 && Array::get(all_wanted, m) == 1 {
         Array::push(out, Array::get(cands, m))
       } else {
         ()
@@ -6234,22 +6259,52 @@ export fn checked_int_render_offsets(checked: CheckedProgram) -> Array[Int] {
   }
 }
 
+/// #2424 tag 3: render/eq argument offsets the checker typed as `Int`.
+export fn checked_int_render_offsets(checked: CheckedProgram) -> Array[Int] {
+  irc_render_arg_offsets(checked, false)
+}
+
+/// #2424 tag 4: the Double half of the same question.
+///
+/// Split out from tag 3 rather than folded into it because the two answers go
+/// to DIFFERENT consumers -- `ts_known_int` / `bc_expr_is_intish` read one and
+/// the four `*_expr_is_floatish` copies read the other -- and an offset that
+/// classified as both would force each consumer to re-derive which half it was
+/// looking at.
+///
+/// The row it closes: a Double-typed STRUCT FIELD through `__to_string`.
+/// `float_call_offsets` (#2158) is keyed by CALL offsets only, so it has no
+/// projection arm, exactly as `ts_known_int` had none before the tag-3 channel;
+/// measured before this change, `DBox::{ ratio: 1.5 }` rendered `b.ratio` as
+/// `256` on the RC lane and trapped on gc, while the same Double reached
+/// through a tuple element or a plain `let` answered `1.5`.
+export fn checked_double_render_offsets(checked: CheckedProgram) -> Array[Int] {
+  irc_render_arg_offsets(checked, true)
+}
+
 /// #2391 slice 2: the typed-lowering channel's value encoding. One table
-/// carries all three per-module channels so the memo/sidecar/rebase carrier
-/// stays a flat Array[Int]: enc = offset * 4 + tag, with tag 0 = Double call
-/// result, 1 = String relational binop anchor, 2 = String `+` binop anchor.
-/// Rebasing a module table by a merge base B therefore adds B * 4. The
-/// decoder lives in file_compile's split; keep the two in lockstep.
+/// carries every per-module channel so the memo/sidecar/rebase carrier stays a
+/// flat Array[Int]: enc = offset * 8 + tag, with tag 0 = Double call result,
+/// 1 = String relational binop anchor, 2 = String `+` binop anchor, 3 = Int
+/// render/`eq` argument, 4 = Double render/`eq` argument. Rebasing a module
+/// table by a merge base B therefore adds B * 8. The decoder lives in
+/// file_compile's split; keep the two in lockstep.
+///
+/// #2424 widened the tag from 2 bits to 3 when tag 4 arrived. Nothing has to be
+/// migrated for that: the persistent artifact key is
+/// `persistent_cache_version_tag()` = "v23|cg-" + `codegen_fingerprint()`, and
+/// the fingerprint hashes every compiler source, so a stale sidecar written
+/// under the old encoding cannot be read back under the new one.
 export fn typed_lowering_enc(offset: Int, tag: Int) -> Int {
-  offset * 4 + tag
+  offset * 8 + tag
 }
 
 export fn typed_lowering_enc_offset(enc: Int) -> Int {
-  enc / 4
+  enc / 8
 }
 
 export fn typed_lowering_enc_tag(enc: Int) -> Int {
-  enc - (enc / 4) * 4
+  enc - (enc / 8) * 8
 }
 
 /// Check once and retain only source-located primary call results whose
@@ -6270,8 +6325,54 @@ fn check_program_double_call_result_observation_impl(stmts: Array[Stmt]) -> Opti
   let checked = check_program_type_defs_observation_impl(stmts, None, Some(capture)).checked_program
   match double_call_result_offsets_from_capture(checked, capture) {
     None => None,
-    Some((out, primary_calls, located_primary_calls)) => Some((checked, out, primary_calls, located_primary_calls))
+    Some((out, primary_calls, located_primary_calls)) => Some((checked, union_double_render_arg_offsets(checked, out), primary_calls, located_primary_calls))
   }
+}
+
+/// #2424: fold the Double render/`eq` ARGUMENT offsets (tag 4 on the modular
+/// channel) into a whole-program Double offset table.
+///
+/// The two sets answer the same consumer question -- "is the value at this
+/// offset a Double?" -- and reach the same array, `CompileCtx.float_call_offsets`
+/// and its gc twin, which the classifiers read with `typed_lowering_arg_offset`.
+/// They are collected separately because their producers are: one comes from
+/// the primary-call-result capture, the other from the render/`eq` argument
+/// walk, and a projection has no call result to capture.
+///
+/// Unioning HERE rather than at each entry lane is deliberate. Every
+/// non-modular consumer of the observation (`compile_source`, the two
+/// `preprocess_compile` entries, the gc entry) goes through this one function,
+/// so none of them can be the caller that forgot -- which is exactly how the
+/// float channel stayed inert on the module lane for three releases (#2437).
+fn union_double_render_arg_offsets(checked: CheckedProgram, call_results: Array[Int]) -> Array[Int] {
+  let out: Array[Int] = []
+  let mut i = 0
+  while i < Array::length(call_results) {
+    Array::push(out, Array::get(call_results, i))
+    i = i + 1
+  }
+  let args = checked_double_render_offsets(checked)
+  let mut j = 0
+  while j < Array::length(args) {
+    let off = Array::get(args, j)
+    let mut seen = false
+    let mut k = 0
+    while k < Array::length(out) {
+      if Array::get(out, k) == off {
+        seen = true
+        k = Array::length(out)
+      } else {
+        k = k + 1
+      }
+    }
+    if seen {
+      ()
+    } else {
+      Array::push(out, off)
+    }
+    j = j + 1
+  }
+  out
 }
 
 /// #2391: the modular form of the #2158 observation, for the per-module check
@@ -6334,6 +6435,17 @@ export fn check_program_with_projected_import_env_typed_lowering_located_observa
       while ii < Array::length(int_renders) {
         Array::push(enc, typed_lowering_enc(Array::get(int_renders, ii), 3))
         ii = ii + 1
+      }
+      // #2424: tag 4 -- the same argument offsets the checker typed as
+      // `Double`. It rides the SAME table for the same reason tag 3 does, and
+      // it is a separate tag rather than more tag-0 rows because tag 0 is keyed
+      // by CALL offsets and this is keyed by `typed_lowering_arg_offset`; the
+      // decoder unions them only once it has read both keys correctly.
+      let double_renders = checked_double_render_offsets(checked)
+      let mut di = 0
+      while di < Array::length(double_renders) {
+        Array::push(enc, typed_lowering_enc(Array::get(double_renders, di), 4))
+        di = di + 1
       }
       // #2441: the typed-`==` rows carry a String payload (the operand
       // TypeExpr's impl_target_key), so they cannot ride the Int-encoded

--- a/lib/@vibe/compiler/checker/index.vpkg
+++ b/lib/@vibe/compiler/checker/index.vpkg
@@ -262,6 +262,7 @@ fn check_program_double_call_result_located_observation(stmts: Array[Stmt]) -> O
 /// checker-confirmed type is `Int`, for the classifiers that otherwise decide
 /// that from the argument's syntax. Fails closed: an offset is emitted only
 /// when every typed occurrence there resolves to `Int`.
+fn checked_double_render_offsets(checked: CheckedProgram) -> Array[Int]
 fn checked_int_render_offsets(checked: CheckedProgram) -> Array[Int]
 fn check_program_type_defs_observation(stmts: Array[Stmt]) -> CheckedProgramTypeDefsObservation with Exception
 fn check_program_typed_occurrence_statement_observation(stmts: Array[Stmt]) -> Option[CheckedTypedOccurrenceStatementObservation] with Exception

--- a/lib/@vibe/compiler/codegen/common_analysis/common_analysis.vibe
+++ b/lib/@vibe/compiler/codegen/common_analysis/common_analysis.vibe
@@ -10,6 +10,7 @@ import @vibe/compiler/core {
   bsearch_leftmost,
   builtin_allocates,
   builtin_registry,
+  builtin_value_form_arity,
   bytebuf_push,
   canonical_builtin_name,
   expr_children,
@@ -557,89 +558,105 @@ export fn collect_strings_stmts(stmts: Array[Stmt]) -> Array[String] {
 /// is really shared would survive as "unique" and classify the wrong call).
 /// Nested `EFn` bodies are descended into as well: a lambda's calls are
 /// compiled by this same program and share its offset space.
-fn count_call_offsets_expr(e: Expr, counts: MutMap[Int, Int]) -> Unit {
+fn count_one_offset(counts: MutMap[Int, Int], off: Int) -> Unit {
+  if off >= 0 {
+    match MutMap::get(counts, off) {
+      Some(n) => MutMap::set(counts, off, n + 1),
+      None => ()
+    }
+  } else {
+    ()
+  }
+}
+
+fn count_typed_lowering_offsets_expr(e: Expr, counts: MutMap[Int, Int]) -> Unit {
+  // #2424: count by `typed_lowering_arg_offset`'s key, not by "is an ECall".
+  // The Double channel now carries PROJECTION rows alongside call-result rows,
+  // and a projection is keyed by its field-name offset -- counting only calls
+  // scored every such row 0 and dropped it, which is the fail-closed direction
+  // and therefore silent: the channel would have been wired up and inert.
+  //
+  // EIdent is deliberately NOT counted. A call's own offset is its callee's
+  // start (`parse_postfix` passes `callee_offset(expr)`), so an ordinary
+  // `f(x)` carries an EIdent and an ECall at ONE offset; counting both would
+  // score 2 and drop every call-result row in the table.
   match e {
-    ECall(_, _, off) => if off >= 0 {
-      match MutMap::get(counts, off) {
-        Some(n) => MutMap::set(counts, off, n + 1),
-        None => ()
-      }
-    } else {
-      ()
-    },
+    ECall(_, _, off) => count_one_offset(counts, off),
+    EDot(_, _, _, field_off) => count_one_offset(counts, field_off),
     _ => ()
   }
   let kids = expr_children(e)
   let mut i = 0
   while i < Array::length(kids) {
-    count_call_offsets_expr(Array::get(kids, i), counts)
+    count_typed_lowering_offsets_expr(Array::get(kids, i), counts)
     i = i + 1
   }
 }
 
-fn count_call_offsets_stmts(stmts: Array[Stmt], counts: MutMap[Int, Int]) -> Unit {
+fn count_typed_lowering_offsets_stmts(stmts: Array[Stmt], counts: MutMap[Int, Int]) -> Unit {
   let mut i = 0
   while i < Array::length(stmts) {
     match Array::get(stmts, i) {
-      SLet(_, _, _, _, expr) => count_call_offsets_expr(expr, counts),
-      SLetMut(_, _, expr) => count_call_offsets_expr(expr, counts),
-      SLetPat(_, expr) => count_call_offsets_expr(expr, counts),
-      SExpr(expr) => count_call_offsets_expr(expr, counts),
-      STest(_, expr) => count_call_offsets_expr(expr, counts),
-      SBench(_, expr) => count_call_offsets_expr(expr, counts),
-      SExample(_, expr) => count_call_offsets_expr(expr, counts),
+      SLet(_, _, _, _, expr) => count_typed_lowering_offsets_expr(expr, counts),
+      SLetMut(_, _, expr) => count_typed_lowering_offsets_expr(expr, counts),
+      SLetPat(_, expr) => count_typed_lowering_offsets_expr(expr, counts),
+      SExpr(expr) => count_typed_lowering_offsets_expr(expr, counts),
+      STest(_, expr) => count_typed_lowering_offsets_expr(expr, counts),
+      SBench(_, expr) => count_typed_lowering_offsets_expr(expr, counts),
+      SExample(_, expr) => count_typed_lowering_offsets_expr(expr, counts),
       SFnDecl(_, _, decl_expr, pre_exprs, post_exprs) => {
-        count_call_offsets_expr(decl_expr, counts)
+        count_typed_lowering_offsets_expr(decl_expr, counts)
         let mut pi = 0
         while pi < Array::length(pre_exprs) {
-          count_call_offsets_expr(Array::get(pre_exprs, pi), counts)
+          count_typed_lowering_offsets_expr(Array::get(pre_exprs, pi), counts)
           pi = pi + 1
         }
         let mut qi = 0
         while qi < Array::length(post_exprs) {
-          count_call_offsets_expr(Array::get(post_exprs, qi), counts)
+          count_typed_lowering_offsets_expr(Array::get(post_exprs, qi), counts)
           qi = qi + 1
         }
       },
-      SModule(_, _, inner) => count_call_offsets_stmts(inner, counts),
+      SModule(_, _, inner) => count_typed_lowering_offsets_stmts(inner, counts),
       _ => ()
     }
     i = i + 1
   }
 }
 
-/// How many `ECall` nodes were counted at `off`; 0 when it was never a
-/// candidate. A named reader rather than an inline match at the use site: the
+/// How many nodes were counted at `off`; 0 when it was never a candidate. A named reader rather than an inline match at the use site: the
 /// answer is a number to compare, not a membership test, and reading it out
 /// here keeps the caller's condition an ordinary numeric comparison.
-fn call_offset_count(counts: MutMap[Int, Int], off: Int) -> Int {
+fn typed_lowering_offset_count(counts: MutMap[Int, Int], off: Int) -> Int {
   match MutMap::get(counts, off) {
     Some(n) => n,
     None => 0
   }
 }
 
-/// #2158: of `candidates`, keep only the offsets that identify EXACTLY ONE
-/// `ECall` node in `stmts`.
+/// #2158 / #2424: of `candidates`, keep only the offsets that identify EXACTLY
+/// ONE typed-lowering node in `stmts` -- one `ECall` (keyed by its own offset)
+/// or one `EDot` (keyed by its field-name offset), which is what
+/// `typed_lowering_arg_offset` reads at the consumer.
 ///
-/// The checker hands codegen a set of source offsets whose call result it
-/// typed as `Double`, and codegen looks an offset up on an `ECall` node. That
-/// is sound only while an offset names one call and one call only, and it is
-/// NOT free: the FS lanes merge many files into a single statement array, and
-/// each file's offsets are relative to its own text -- file A's offset 100 and
-/// file B's offset 100 are the same key. A collision that lands a `Double`
-/// classification on an Int-valued call is silently wrong, which is worse than
-/// the bug the table exists to fix.
+/// The checker hands codegen a set of source offsets whose value it typed as
+/// `Double`, and codegen looks an offset up on a node. That is sound only while
+/// an offset names one node and one node only, and it is NOT free: the FS lanes
+/// merge many files into a single statement array, and each file's offsets are
+/// relative to its own text -- file A's offset 100 and file B's offset 100 are
+/// the same key. A collision that lands a `Double` classification on an
+/// Int-valued node is silently wrong, which is worse than the bug the table
+/// exists to fix.
 ///
 /// So the disjointness is ESTABLISHED here, on exactly the statements codegen
 /// is about to walk, instead of being assumed from how some entry parsed. An
-/// offset survives only when the whole program carries one call node at it; two
+/// offset survives only when the whole program carries one node at it; two
 /// files colliding makes the count 2 and drops it. Fail closed: a dropped
 /// offset classifies nothing and the syntactic answer stands.
 ///
 /// Empty `candidates` returns immediately without walking, so every lane that
 /// supplies no checker offsets pays nothing at all for this.
-export fn unique_call_offsets_in_stmts(stmts: Array[Stmt], candidates: Array[Int]) -> Array[Int] {
+export fn unique_typed_lowering_offsets_in_stmts(stmts: Array[Stmt], candidates: Array[Int]) -> Array[Int] {
   let out: Array[Int] = array_empty()
   if Array::length(candidates) == 0 {
     out
@@ -650,11 +667,11 @@ export fn unique_call_offsets_in_stmts(stmts: Array[Stmt], candidates: Array[Int
       MutMap::set(counts, Array::get(candidates, i), 0)
       i = i + 1
     }
-    count_call_offsets_stmts(stmts, counts)
+    count_typed_lowering_offsets_stmts(stmts, counts)
     let mut j = 0
     while j < Array::length(candidates) {
       let off = Array::get(candidates, j)
-      if call_offset_count(counts, off) == 1 {
+      if typed_lowering_offset_count(counts, off) == 1 {
         Array::push(out, off)
       } else {
         ()
@@ -3984,10 +4001,17 @@ export fn compute_may_return_view_fns(stmts: Array[Stmt]) -> Array[String] {
 /// constants to a table slot nothing installs.
 export fn count_lambda_sites_expr(expr: Expr) -> Int {
   match expr {
-    // #1733: these generated builtins live before func_offset, so their value
-    // form is materialized by both backends as a tiny ordinary lambda with a
-    // valid table slot. Count that synthetic site in the frozen plan.
-    EIdent(name, _) => if name == "FrozenArray::from_array" || name == "FrozenArray::to_array" {
+    // #1733 / #2442: a builtin with a value form lives before func_offset, so
+    // both backends materialize it as a tiny ordinary lambda with a valid table
+    // slot. Count that synthetic site in the frozen plan.
+    //
+    // The predicate is `builtin_value_form_arity`, shared with the checker and
+    // both backends rather than restated as a name list here -- this walk was
+    // the THIRD copy of #1733's two names, and a plan that disagrees with the
+    // walk is not a wrong answer, it is a thrown `lambda plan over-count`.
+    // That the shared predicate admits only QUALIFIED names is what makes this
+    // scope-free walk able to agree with codegen at all; see its doc comment.
+    EIdent(name, _) => if builtin_value_form_arity(name) >= 0 {
       1
     } else {
       0
@@ -4015,7 +4039,7 @@ export fn count_lambda_sites_expr(expr: Expr) -> Int {
     // is materialized as the synthetic lambda above.
     ECall(callee, args, _) => {
       let callee_count = match callee {
-        EIdent(name, _) => if name == "FrozenArray::from_array" || name == "FrozenArray::to_array" {
+        EIdent(name, _) => if builtin_value_form_arity(name) >= 0 {
           0
         } else {
           count_lambda_sites_expr(callee)

--- a/lib/@vibe/compiler/codegen/common_analysis/common_analysis.vibe
+++ b/lib/@vibe/compiler/codegen/common_analysis/common_analysis.vibe
@@ -3999,7 +3999,7 @@ export fn compute_may_return_view_fns(stmts: Array[Stmt]) -> Array[String] {
 /// against the live length at every allocation rather than trusted -- see
 /// CompileCtx.lambda_plan_next. A silent mismatch would key a body's emitted
 /// constants to a table slot nothing installs.
-export fn count_lambda_sites_expr(expr: Expr) -> Int {
+export fn count_lambda_sites_expr(expr: Expr, user_fn_names: Array[String]) -> Int {
   match expr {
     // #1733 / #2442: a builtin with a value form lives before func_offset, so
     // both backends materialize it as a tiny ordinary lambda with a valid table
@@ -4011,7 +4011,14 @@ export fn count_lambda_sites_expr(expr: Expr) -> Int {
     // walk is not a wrong answer, it is a thrown `lambda plan over-count`.
     // That the shared predicate admits only QUALIFIED names is what makes this
     // scope-free walk able to agree with codegen at all; see its doc comment.
-    EIdent(name, _) => if builtin_value_form_arity(name) >= 0 {
+    //
+    // `user_fn_names` is the one piece of scope this walk needs and can have
+    // (Codex review on #2448). A user program may declare `fn Array::get(...)`,
+    // and the checker resolves that name to the DECLARATION -- so codegen must
+    // emit the user function's table slot, not an eta-expansion, and this walk
+    // must not reserve a slot for one. Locals still cannot be seen here, which
+    // is why a bare name has no value form at all.
+    EIdent(name, _) => if builtin_value_form_arity(name) >= 0 && bsearch_leftmost(user_fn_names, name) < 0 {
       1
     } else {
       0
@@ -4024,17 +4031,17 @@ export fn count_lambda_sites_expr(expr: Expr) -> Int {
     EStringInterp(_) => 0,
     EBreak(_) => 0,
     EContinue(_) => 0,
-    EReturn(e) => count_lambda_sites_expr(e),
-    EUnaryOp(_, e) => count_lambda_sites_expr(e),
-    ESpread(e) => count_lambda_sites_expr(e),
-    EDot(obj, _, _, _) => count_lambda_sites_expr(obj),
-    ELabeledArg(_, _, e) => count_lambda_sites_expr(e),
-    ETuple(items) => count_lambda_sites_exprs(items),
-    EArray(items) => count_lambda_sites_exprs(items),
-    ERecord(_, fields, _) => count_lambda_sites_fields(fields),
-    EMap(fields) => count_lambda_sites_fields(fields),
-    EBinOp(_, l, r, _) => count_lambda_sites_expr(l) + count_lambda_sites_expr(r),
-    ESeq(l, r) => count_lambda_sites_expr(l) + count_lambda_sites_expr(r),
+    EReturn(e) => count_lambda_sites_expr(e, user_fn_names),
+    EUnaryOp(_, e) => count_lambda_sites_expr(e, user_fn_names),
+    ESpread(e) => count_lambda_sites_expr(e, user_fn_names),
+    EDot(obj, _, _, _) => count_lambda_sites_expr(obj, user_fn_names),
+    ELabeledArg(_, _, e) => count_lambda_sites_expr(e, user_fn_names),
+    ETuple(items) => count_lambda_sites_exprs(items, user_fn_names),
+    EArray(items) => count_lambda_sites_exprs(items, user_fn_names),
+    ERecord(_, fields, _) => count_lambda_sites_fields(fields, user_fn_names),
+    EMap(fields) => count_lambda_sites_fields(fields, user_fn_names),
+    EBinOp(_, l, r, _) => count_lambda_sites_expr(l, user_fn_names) + count_lambda_sites_expr(r, user_fn_names),
+    ESeq(l, r) => count_lambda_sites_expr(l, user_fn_names) + count_lambda_sites_expr(r, user_fn_names),
     // A direct conversion call stays direct; only a value-position identifier
     // is materialized as the synthetic lambda above.
     ECall(callee, args, _) => {
@@ -4042,60 +4049,60 @@ export fn count_lambda_sites_expr(expr: Expr) -> Int {
         EIdent(name, _) => if builtin_value_form_arity(name) >= 0 {
           0
         } else {
-          count_lambda_sites_expr(callee)
+          count_lambda_sites_expr(callee, user_fn_names)
         },
-        _ => count_lambda_sites_expr(callee)
+        _ => count_lambda_sites_expr(callee, user_fn_names)
       }
-      callee_count + count_lambda_sites_exprs(args)
+      callee_count + count_lambda_sites_exprs(args, user_fn_names)
     },
     EIf(cond, then_e, else_e) =>
-    count_lambda_sites_expr(cond) + count_lambda_sites_expr(then_e) + count_lambda_sites_expr(else_e),
-    ELet(_, val, body, _) => count_lambda_sites_expr(val) + count_lambda_sites_expr(body),
-    ELetRec(_, val, body) => count_lambda_sites_expr(val) + count_lambda_sites_expr(body),
-    ELetMut(_, val, body, _) => count_lambda_sites_expr(val) + count_lambda_sites_expr(body),
-    EAssign(_, val, body) => count_lambda_sites_expr(val) + count_lambda_sites_expr(body),
-    EAssignOp(_, _, val, body) => count_lambda_sites_expr(val) + count_lambda_sites_expr(body),
-    EWhile(cond, body) => count_lambda_sites_expr(cond) + count_lambda_sites_expr(body),
-    EForIn(_, _, iter, body) => count_lambda_sites_expr(iter) + count_lambda_sites_expr(body),
-    ELoop(params, body) => count_lambda_sites_fields(params) + count_lambda_sites_expr(body),
-    EMatch(scr, arms) => count_lambda_sites_expr(scr) + count_lambda_sites_arms(arms),
-    EHandle(body_expr, arms) => count_lambda_sites_expr(body_expr) + count_lambda_sites_arms(arms),
+    count_lambda_sites_expr(cond, user_fn_names) + count_lambda_sites_expr(then_e, user_fn_names) + count_lambda_sites_expr(else_e, user_fn_names),
+    ELet(_, val, body, _) => count_lambda_sites_expr(val, user_fn_names) + count_lambda_sites_expr(body, user_fn_names),
+    ELetRec(_, val, body) => count_lambda_sites_expr(val, user_fn_names) + count_lambda_sites_expr(body, user_fn_names),
+    ELetMut(_, val, body, _) => count_lambda_sites_expr(val, user_fn_names) + count_lambda_sites_expr(body, user_fn_names),
+    EAssign(_, val, body) => count_lambda_sites_expr(val, user_fn_names) + count_lambda_sites_expr(body, user_fn_names),
+    EAssignOp(_, _, val, body) => count_lambda_sites_expr(val, user_fn_names) + count_lambda_sites_expr(body, user_fn_names),
+    EWhile(cond, body) => count_lambda_sites_expr(cond, user_fn_names) + count_lambda_sites_expr(body, user_fn_names),
+    EForIn(_, _, iter, body) => count_lambda_sites_expr(iter, user_fn_names) + count_lambda_sites_expr(body, user_fn_names),
+    ELoop(params, body) => count_lambda_sites_fields(params, user_fn_names) + count_lambda_sites_expr(body, user_fn_names),
+    EMatch(scr, arms) => count_lambda_sites_expr(scr, user_fn_names) + count_lambda_sites_arms(arms, user_fn_names),
+    EHandle(body_expr, arms) => count_lambda_sites_expr(body_expr, user_fn_names) + count_lambda_sites_arms(arms, user_fn_names),
     // The one arm that counts: this node IS a table entry, and its body may
     // hold more.
-    EFn(_, _, _, _, _, body) => 1 + count_lambda_sites_expr(body)
+    EFn(_, _, _, _, _, body) => 1 + count_lambda_sites_expr(body, user_fn_names)
   }
 }
 
-fn count_lambda_sites_exprs(items: Array[Expr]) -> Int {
+fn count_lambda_sites_exprs(items: Array[Expr], user_fn_names: Array[String]) -> Int {
   let n = Array::length(items)
   let mut i = 0
   let mut total = 0
   while i < n {
-    total = total + count_lambda_sites_expr(Array::get(items, i))
+    total = total + count_lambda_sites_expr(Array::get(items, i), user_fn_names)
     i = i + 1
   }
   total
 }
 
-fn count_lambda_sites_fields(fields: Array[(String, Expr)]) -> Int {
+fn count_lambda_sites_fields(fields: Array[(String, Expr)], user_fn_names: Array[String]) -> Int {
   let n = Array::length(fields)
   let mut i = 0
   let mut total = 0
   while i < n {
     let (_, val) = Array::get(fields, i)
-    total = total + count_lambda_sites_expr(val)
+    total = total + count_lambda_sites_expr(val, user_fn_names)
     i = i + 1
   }
   total
 }
 
-fn count_lambda_sites_arms(arms: Array[(Pat, Expr)]) -> Int {
+fn count_lambda_sites_arms(arms: Array[(Pat, Expr)], user_fn_names: Array[String]) -> Int {
   let n = Array::length(arms)
   let mut i = 0
   let mut total = 0
   while i < n {
     let (_, body) = Array::get(arms, i)
-    total = total + count_lambda_sites_expr(body)
+    total = total + count_lambda_sites_expr(body, user_fn_names)
     i = i + 1
   }
   total

--- a/lib/@vibe/compiler/codegen/common_analysis/index.vpkg
+++ b/lib/@vibe/compiler/codegen/common_analysis/index.vpkg
@@ -57,7 +57,7 @@ fn compute_borrow_param_user_fns(stmts: Array[Stmt], exclude: Array[String], out
 fn bmask_max_param() -> Int
 fn bmask_has(mask: Int, i: Int) -> Bool
 fn compute_may_return_view_fns(stmts: Array[Stmt]) -> Array[String]
-fn count_lambda_sites_expr(expr: Expr) -> Int
+fn count_lambda_sites_expr(expr: Expr, user_fn_names: Array[String]) -> Int
 fn packed_lines_to_array_expr(raw_call: Expr, tmp_name: String) -> Expr
 fn region_array_value_copy(value: Expr, tmp: String) -> Expr
 fn region_mutlist_exit_copy(arg: Expr) -> Expr

--- a/lib/@vibe/compiler/codegen/common_analysis/index.vpkg
+++ b/lib/@vibe/compiler/codegen/common_analysis/index.vpkg
@@ -70,4 +70,4 @@ fn compute_float_returning_names(stmts: Array[Stmt]) -> Array[String]
 // exactly one `ECall` node in these statements. Merging files puts several
 // per-file offset spaces in one array, so this is what makes the table's key
 // unambiguous on the program codegen actually walks.
-fn unique_call_offsets_in_stmts(stmts: Array[Stmt], candidates: Array[Int]) -> Array[Int]
+fn unique_typed_lowering_offsets_in_stmts(stmts: Array[Stmt], candidates: Array[Int]) -> Array[Int]

--- a/lib/@vibe/compiler/codegen/common_base/common_base.vibe
+++ b/lib/@vibe/compiler/codegen/common_base/common_base.vibe
@@ -1060,7 +1060,7 @@ export struct CompileCtx {
   //
   // Populated only by an entry that ran a whole-program check over an AST
   // parsed with `parse_program_located`, and then filtered (in
-  // wasi/linked_compile.vibe, via unique_call_offsets_in_stmts) down to the
+  // wasi/linked_compile.vibe, via unique_typed_lowering_offsets_in_stmts) down to the
   // offsets that identify exactly ONE `ECall` node in the program this ctx
   // compiles. That filter is what makes the key unambiguous: the FS lanes
   // merge many files into one statement array and each file's offsets are

--- a/lib/@vibe/compiler/codegen/expr/compile_call.vibe
+++ b/lib/@vibe/compiler/codegen/expr/compile_call.vibe
@@ -23,7 +23,8 @@ import @vibe/compiler/core {
   leb128_encode_s64,
   leb128_encode_u32,
   namespace_exported_name,
-  typed_lowering_arg_offset
+  typed_lowering_arg_offset,
+  typed_lowering_float_key
 }
 
 import @vibe/compiler/codegen/common_analysis {
@@ -553,7 +554,35 @@ export fn cc_fn_returns_float(local_names: Array[String], ctx: CompileCtx, fname
   }
 }
 
+/// #2424: did the CHECKER say this exact node is a `Double`?
+///
+/// The Double twin of the Int render/`eq` term. Same contract, same fail-closed
+/// ends: an extra term in FRONT of the syntactic classifier, never a
+/// replacement, so the table can only add a classification the shape rules
+/// missed. The key is `typed_lowering_float_key` (@vibe/compiler/core), shared
+/// with the producer rather than restated here: a projection answers with its
+/// FIELD-NAME offset, and a bare NAME answers -1, because a call node's offset
+/// is its callee identifier's offset and this array carries call results. Its
+/// doc comment carries the whole argument.
+///
+/// This is what closes the row `float_call_offsets` structurally could not: a
+/// Double-typed STRUCT FIELD. That table is keyed by CALL offsets, so it had no
+/// projection arm at all, and measured before this change `b.ratio` on a
+/// `struct DBox { ratio: Double }` rendered `256` on the RC lane and trapped on
+/// gc, while the same Double through a tuple element or a plain `let` answered
+/// `1.5`. Tag 4 rows arrive in the SAME array (see split_typed_lowering_offsets)
+/// because both answer one question, and they agree on calls: a call node's
+/// `typed_lowering_arg_offset` IS its call offset.
+fn cc_offset_says_float(e: Expr, ctx: CompileCtx) -> Bool {
+  let off = typed_lowering_float_key(e)
+  off >= 0 && array_contains_int(ctx.float_call_offsets, off)
+}
+
 fn cc_expr_is_floatish(e: Expr, local_names: Array[String], ctx: CompileCtx) -> Bool with Exception {
+  cc_offset_says_float(e, ctx) || cc_expr_is_floatish_syntactic(e, local_names, ctx)
+}
+
+fn cc_expr_is_floatish_syntactic(e: Expr, local_names: Array[String], ctx: CompileCtx) -> Bool with Exception {
   // fbox (#797): mirror of expr_is_floatish's EDot tuple-projection case --
   // `t.N` on a tracked tuple-literal binding recurses into the backing
   // ETuple element via the #724 agg log.

--- a/lib/@vibe/compiler/codegen/expr/compile_expr.vibe
+++ b/lib/@vibe/compiler/codegen/expr/compile_expr.vibe
@@ -6,7 +6,7 @@ import @vibe/compiler/core {
   Stmt,
   TypeExpr,
   bsearch_leftmost,
-  builtin_ident_has_value_form,
+  builtin_value_form_arity,
   bytebuf_length,
   bytebuf_new,
   bytebuf_push,
@@ -240,24 +240,26 @@ import ./compile_match.vibe {
 
 //# Functions
 
-/// #2433: the name list moved to `core/builtin_name.vibe`. The checker rejects
-/// a builtin ident in value position, and it must exempt exactly the names this
-/// lane eta-expands below -- two copies of the list would drift into either a
-/// spurious error or the load-time failure #2433 removed.
-fn is_frozen_array_conversion_name(name: String) -> Bool {
-  builtin_ident_has_value_form(name)
-}
-
-/// Builtin indices live before `func_offset`, while ordinary closure table
-/// slots are relative to it. Materialize these two first-class builtins as a
-/// one-argument lambda so their value form uses the same direct runtime body
-/// as a source call instead of encoding a negative table slot (#1733).
-fn frozen_array_conversion_closure(name: String) -> Expr {
-  let param = "__frozen_array_value"
-  let params: Array[(String, Option[TypeExpr])] = [(param, None)]
-  EFn(array_empty(), array_empty(), params, None, None, ECall(EIdent(name, -1), [
-    EIdent(param, -1)
-  ], -1))
+/// #1733 / #2442: builtin indices live before `func_offset`, while ordinary
+/// closure table slots are relative to it. Materialize a first-class builtin as
+/// an eta-expanded lambda so its value form uses the same direct runtime body
+/// as a source call instead of encoding a negative table slot.
+///
+/// The arity is `builtin_value_form_arity` -- the same number the checker used
+/// to grant the value form, so the emitted parameter count cannot disagree with
+/// the type the caller was given. #1733 hardcoded 1 for the two FrozenArray
+/// conversions; nothing else about the shape changed.
+fn builtin_value_closure(name: String, arity: Int) -> Expr {
+  let params: Array[(String, Option[TypeExpr])] = []
+  let args: Array[Expr] = []
+  let mut i = 0
+  while i < arity {
+    let param = String::concat("__builtin_value_arg", Int::to_string(i))
+    Array::push(params, (param, None))
+    Array::push(args, EIdent(param, -1))
+    i = i + 1
+  }
+  EFn(array_empty(), array_empty(), params, None, None, ECall(EIdent(name, -1), args, -1))
 }
 
 /// #672: emit structural equality for two tuples (non-rc layout: element i at
@@ -923,8 +925,23 @@ export fn compile_expr(buf: Bytes, expr: Expr, local_names: Array[String], next_
         emit_local_get(buf, local_idx)
       }
       next_local
-    } else if is_frozen_array_conversion_name(name) {
-      compile_expr(buf, frozen_array_conversion_closure(name), local_names, next_local, ctx, ld)
+    } else if builtin_value_form_arity(name) >= 0 {
+      // #2442: a pure builtin in value position, eta-expanded.
+      //
+      // Placed HERE, above the func table, and that placement is load-bearing:
+      // `ctx.func_table` holds the BUILTIN bodies too, so a builtin name
+      // resolves there and emits `(table_slot<<2)|2` with
+      // `table_slot = fidx - ctx.func_offset` NEGATIVE -- the #2433 failure this
+      // eta-expansion exists to avoid. Measured while writing this: with the
+      // check below the func table instead, `let cat = String::concat` compiled
+      // to zero lambdas and the module was rejected with `lambda plan
+      // over-count: planned through 1, walk stopped at 0`.
+      //
+      // It sits below the LOCALS lookup, and only qualified names have a value
+      // form (see `builtin_value_form_arity`), so nothing this arm can shadow
+      // reaches it -- which is also why the scope-free lambda-site planner can
+      // agree with this walk.
+      compile_expr(buf, builtin_value_closure(name, builtin_value_form_arity(name)), local_names, next_local, ctx, ld)
     } else {
       let mut __ci_idx = -1
       let __ci_len = Array::length(ctx.const_int_names)

--- a/lib/@vibe/compiler/codegen/expr/compile_expr.vibe
+++ b/lib/@vibe/compiler/codegen/expr/compile_expr.vibe
@@ -249,6 +249,16 @@ import ./compile_match.vibe {
 /// to grant the value form, so the emitted parameter count cannot disagree with
 /// the type the caller was given. #1733 hardcoded 1 for the two FrozenArray
 /// conversions; nothing else about the shape changed.
+/// #2448: does a USER function own this name? Builtin bodies are emitted below
+/// `func_offset` and user functions at or above it, so the func table answers
+/// both questions and this reads the half that matters. The plan walk is handed
+/// the same set (`fn_names_list` in linked_compile), because a disagreement
+/// between the two is a thrown `lambda plan over-count`, not a wrong answer.
+fn user_fn_owns_name(ctx: CompileCtx, name: String) -> Bool {
+  let i = func_table_index_of(ctx.func_table, name)
+  i >= 0 && Array::get(ctx.func_table.indices, i) - ctx.func_offset >= 0
+}
+
 fn builtin_value_closure(name: String, arity: Int) -> Expr {
   let params: Array[(String, Option[TypeExpr])] = []
   let args: Array[Expr] = []
@@ -925,7 +935,7 @@ export fn compile_expr(buf: Bytes, expr: Expr, local_names: Array[String], next_
         emit_local_get(buf, local_idx)
       }
       next_local
-    } else if builtin_value_form_arity(name) >= 0 {
+    } else if builtin_value_form_arity(name) >= 0 && !user_fn_owns_name(ctx, name) {
       // #2442: a pure builtin in value position, eta-expanded.
       //
       // Placed HERE, above the func table, and that placement is load-bearing:
@@ -941,6 +951,15 @@ export fn compile_expr(buf: Bytes, expr: Expr, local_names: Array[String], next_
       // form (see `builtin_value_form_arity`), so nothing this arm can shadow
       // reaches it -- which is also why the scope-free lambda-site planner can
       // agree with this walk.
+      //
+      // A USER FUNCTION that declares a registry name is the one thing that
+      // can still own it (Codex review on #2448), and it wins: the checker
+      // resolved the name to the declaration, so this must fall through to the
+      // func-table slot below. Measured before this guard, with
+      // `fn String::concat(a: Int) -> Int` in scope, `let f = String::concat`
+      // emitted an arity-2 eta-expansion against the checker's arity-1 type
+      // and the runtime refused to compile the module. The plan walk is given
+      // the same name set so the two agree.
       compile_expr(buf, builtin_value_closure(name, builtin_value_form_arity(name)), local_names, next_local, ctx, ld)
     } else {
       let mut __ci_idx = -1

--- a/lib/@vibe/compiler/codegen/expr/compile_expr_tail.vibe
+++ b/lib/@vibe/compiler/codegen/expr/compile_expr_tail.vibe
@@ -14,7 +14,8 @@ import @vibe/compiler/core {
   bytebuf_to_bytes,
   is_borrow_ret_builtin,
   leb128_encode_s64,
-  leb128_encode_u32
+  leb128_encode_u32,
+  typed_lowering_float_key
 }
 
 import @vibe/core {
@@ -570,7 +571,35 @@ export fn expr_is_boolish(e: Expr, local_names: Array[String], ctx: CompileCtx) 
 /// ctx.float_local_slots as `let`s compile). This lets `let x = 1.5; x + y`
 /// take the f64 path. Shared by compile_expr (binop/unary instruction choice)
 /// and the `let` handler below (which populates float_local_slots).
+/// #2424: did the CHECKER say this exact node is a `Double`?
+///
+/// The Double twin of the Int render/`eq` term. Same contract, same fail-closed
+/// ends: an extra term in FRONT of the syntactic classifier, never a
+/// replacement, so the table can only add a classification the shape rules
+/// missed. The key is `typed_lowering_float_key` (@vibe/compiler/core), shared
+/// with the producer rather than restated here: a projection answers with its
+/// FIELD-NAME offset, and a bare NAME answers -1, because a call node's offset
+/// is its callee identifier's offset and this array carries call results. Its
+/// doc comment carries the whole argument.
+///
+/// This is what closes the row `float_call_offsets` structurally could not: a
+/// Double-typed STRUCT FIELD. That table is keyed by CALL offsets, so it had no
+/// projection arm at all, and measured before this change `b.ratio` on a
+/// `struct DBox { ratio: Double }` rendered `256` on the RC lane and trapped on
+/// gc, while the same Double through a tuple element or a plain `let` answered
+/// `1.5`. Tag 4 rows arrive in the SAME array (see split_typed_lowering_offsets)
+/// because both answer one question, and they agree on calls: a call node's
+/// `typed_lowering_arg_offset` IS its call offset.
+fn tail_offset_says_float(e: Expr, ctx: CompileCtx) -> Bool {
+  let off = typed_lowering_float_key(e)
+  off >= 0 && array_contains_int(ctx.float_call_offsets, off)
+}
+
 export fn expr_is_floatish(e: Expr, local_names: Array[String], ctx: CompileCtx) -> Bool with Exception {
+  tail_offset_says_float(e, ctx) || expr_is_floatish_syntactic(e, local_names, ctx)
+}
+
+fn expr_is_floatish_syntactic(e: Expr, local_names: Array[String], ctx: CompileCtx) -> Bool with Exception {
   // fbox (#797): `t.N` tuple projection survives to codegen as EDot (expr_tag
   // -1), NOT as __rec_field (that lowering is only produced for tuple
   // DESTRUCTURING and record-pattern desugars). Heap fields store floats as

--- a/lib/@vibe/compiler/codegen/expr/compile_module_expr.vibe
+++ b/lib/@vibe/compiler/codegen/expr/compile_module_expr.vibe
@@ -1,7 +1,7 @@
 //# Imports
 
 import @vibe/compiler/codegen/common_analysis {
-  compute_float_returning_names, unique_call_offsets_in_stmts
+  compute_float_returning_names, unique_typed_lowering_offsets_in_stmts
 }
 
 import @vibe/compiler/core {
@@ -62,7 +62,7 @@ export fn compile_module_expr(stmts: Array[Stmt]) -> Bytes with Exception {
 /// three needs a source map out of `print_program` (or the merge to stop
 /// reprinting), not a second check; tracked on #2437.
 ///
-/// The float table is passed through `unique_call_offsets_in_stmts`, exactly
+/// The float table is passed through `unique_typed_lowering_offsets_in_stmts`, exactly
 /// as the linked lane does, so an offset that names more than one call node in
 /// the statements CODEGEN walks is dropped rather than guessed at.
 export fn compile_module_expr_with_typed_offsets(stmts: Array[Stmt], checker_float_call_offsets: Array[Int], checker_int_render_offsets: Array[Int]) -> Bytes with Exception {
@@ -90,7 +90,7 @@ export fn compile_module_expr_with_typed_offsets(stmts: Array[Stmt], checker_flo
   // #2437: same fail-closed filter the linked lane applies (#2158). An offset
   // that names more than one call node in the statements codegen walks is
   // dropped rather than guessed at; an empty candidate list stays empty.
-  let module_float_call_offsets = unique_call_offsets_in_stmts(stmts, checker_float_call_offsets)
+  let module_float_call_offsets = unique_typed_lowering_offsets_in_stmts(stmts, checker_float_call_offsets)
   let fn_names_list = fresh_string_array()
   let fn_param_counts = fresh_int_array()
   let export_names = fresh_string_array()

--- a/lib/@vibe/compiler/codegen/gc/backend_call.vibe
+++ b/lib/@vibe/compiler/codegen/gc/backend_call.vibe
@@ -16,7 +16,8 @@ import @vibe/compiler/core {
   is_exception_throw_operation,
   leb128_encode_s64,
   leb128_encode_u32,
-  typed_lowering_arg_offset
+  typed_lowering_arg_offset,
+  typed_lowering_float_key
 }
 
 import @vibe/core {
@@ -372,7 +373,35 @@ fn bc_expr_is_intish(e: Expr, local_names: Array[String], ctx: CompileCtxGc) -> 
   }
 }
 
+/// #2424: did the CHECKER say this exact node is a `Double`?
+///
+/// The Double twin of the Int render/`eq` term. Same contract, same fail-closed
+/// ends: an extra term in FRONT of the syntactic classifier, never a
+/// replacement, so the table can only add a classification the shape rules
+/// missed. The key is `typed_lowering_float_key` (@vibe/compiler/core), shared
+/// with the producer rather than restated here: a projection answers with its
+/// FIELD-NAME offset, and a bare NAME answers -1, because a call node's offset
+/// is its callee identifier's offset and this array carries call results. Its
+/// doc comment carries the whole argument.
+///
+/// This is what closes the row `float_call_offsets` structurally could not: a
+/// Double-typed STRUCT FIELD. That table is keyed by CALL offsets, so it had no
+/// projection arm at all, and measured before this change `b.ratio` on a
+/// `struct DBox { ratio: Double }` rendered `256` on the RC lane and trapped on
+/// gc, while the same Double through a tuple element or a plain `let` answered
+/// `1.5`. Tag 4 rows arrive in the SAME array (see split_typed_lowering_offsets)
+/// because both answer one question, and they agree on calls: a call node's
+/// `typed_lowering_arg_offset` IS its call offset.
+fn bc_offset_says_float(e: Expr, ctx: CompileCtxGc) -> Bool {
+  let off = typed_lowering_float_key(e)
+  off >= 0 && array_contains_int(ctx.gc_float_call_offsets, off)
+}
+
 fn bc_expr_is_floatish(e: Expr, local_names: Array[String], ctx: CompileCtxGc) -> Bool {
+  bc_offset_says_float(e, ctx) || bc_expr_is_floatish_syntactic(e, local_names, ctx)
+}
+
+fn bc_expr_is_floatish_syntactic(e: Expr, local_names: Array[String], ctx: CompileCtxGc) -> Bool {
   match e {
     EFloat(_) => true,
     EIdent(fname, _) => {

--- a/lib/@vibe/compiler/codegen/gc/backend_expr.vibe
+++ b/lib/@vibe/compiler/codegen/gc/backend_expr.vibe
@@ -217,6 +217,24 @@ import ./backend_match.vibe {
 /// a tiny ordinary lambda with a valid table slot, eta-expanded to the arity
 /// `builtin_value_form_arity` reports -- the same number the checker used to
 /// grant the value form (#1733 / #2442).
+/// #2448: the gc twin of `user_fn_owns_name`. Same rule, same reason: a user
+/// function that declares a registry name is what the checker resolved the name
+/// to, so the eta-expansion must not pre-empt its table slot.
+fn gc_user_fn_owns_name(ctx: CompileCtxGc, name: String) -> Bool {
+  let names = ctx.func_table.names
+  let mut i = 0
+  let mut found = false
+  while i < Array::length(names) {
+    if Array::get(names, i) == name {
+      found = Array::get(ctx.func_table.indices, i) - ctx.func_offset >= 0
+      i = Array::length(names)
+    } else {
+      i = i + 1
+    }
+  }
+  found
+}
+
 fn builtin_value_closure(name: String, arity: Int) -> Expr {
   let params: Array[(String, Option[TypeExpr])] = []
   let args: Array[Expr] = []
@@ -1282,10 +1300,11 @@ fn compile_expr_gc(buf: Bytes, expr: Expr, local_names: Array[String], next_loca
           emit_local_get(buf, local_idx)
         }
         next_local
-      } else if builtin_value_form_arity(name) >= 0 {
+      } else if builtin_value_form_arity(name) >= 0 && !gc_user_fn_owns_name(ctx, name) {
         // #2442: see the linear twin in codegen/expr/compile_expr.vibe -- the
         // placement above the func table is what keeps a builtin's negative
         // table slot from being emitted, and only qualified names get here.
+        // A user function that declares a registry name still wins (#2448).
         ce(buf, builtin_value_closure(name, builtin_value_form_arity(name)), local_names, next_local, ld)
       } else {
         let ctor_idx = ctor_table_index_of(ctx.gc_ctor_table, name)

--- a/lib/@vibe/compiler/codegen/gc/backend_expr.vibe
+++ b/lib/@vibe/compiler/codegen/gc/backend_expr.vibe
@@ -5,7 +5,7 @@ import @vibe/compiler/core {
   Pat,
   Stmt,
   TypeExpr,
-  builtin_ident_has_value_form,
+  builtin_value_form_arity,
   bytebuf_length,
   bytebuf_new,
   bytebuf_push,
@@ -16,7 +16,8 @@ import @vibe/compiler/core {
   is_exception_throw_handler_name,
   leb128_encode_s64,
   leb128_encode_u32,
-  typed_lowering_arg_offset
+  typed_lowering_arg_offset,
+  typed_lowering_float_key
 }
 
 import @vibe/core {
@@ -211,22 +212,22 @@ import ./backend_match.vibe {
 
 //# Functions
 
-/// #2433: the name list moved to `core/builtin_name.vibe`. The checker rejects
-/// a builtin ident in value position, and it must exempt exactly the names this
-/// lane eta-expands below -- two copies of the list would drift into either a
-/// spurious error or the load-time failure #2433 removed.
-fn is_frozen_array_conversion_name(name: String) -> Bool {
-  builtin_ident_has_value_form(name)
-}
-
-/// See the linear twin: generated builtins precede `func_offset`, so expose a
-/// first-class conversion as a tiny ordinary lambda with a valid table slot.
-fn frozen_array_conversion_closure(name: String) -> Expr {
-  let param = "__frozen_array_value"
-  let params: Array[(String, Option[TypeExpr])] = [(param, None)]
-  EFn(array_empty(), array_empty(), params, None, None, ECall(EIdent(name, -1), [
-    EIdent(param, -1)
-  ], -1))
+/// See the linear twin (`builtin_value_closure` in codegen/expr/compile_expr):
+/// generated builtins precede `func_offset`, so expose a first-class builtin as
+/// a tiny ordinary lambda with a valid table slot, eta-expanded to the arity
+/// `builtin_value_form_arity` reports -- the same number the checker used to
+/// grant the value form (#1733 / #2442).
+fn builtin_value_closure(name: String, arity: Int) -> Expr {
+  let params: Array[(String, Option[TypeExpr])] = []
+  let args: Array[Expr] = []
+  let mut i = 0
+  while i < arity {
+    let param = String::concat("__builtin_value_arg", Int::to_string(i))
+    Array::push(params, (param, None))
+    Array::push(args, EIdent(param, -1))
+    i = i + 1
+  }
+  EFn(array_empty(), array_empty(), params, None, None, ECall(EIdent(name, -1), args, -1))
 }
 
 /// #538 P4.5: shape-based "definitely scalar" test for `==`/`!=` operands,
@@ -257,7 +258,35 @@ fn gc_expr_is_intish(e: Expr) -> Bool {
 /// checking ctx.gc_float_locals -- mirrors gc_expr_is_boolish below, so a
 /// name reused with a non-float binding in a sibling scope is not
 /// misclassified via its old, now-stale slot entry.
+/// #2424: did the CHECKER say this exact node is a `Double`?
+///
+/// The Double twin of the Int render/`eq` term. Same contract, same fail-closed
+/// ends: an extra term in FRONT of the syntactic classifier, never a
+/// replacement, so the table can only add a classification the shape rules
+/// missed. The key is `typed_lowering_float_key` (@vibe/compiler/core), shared
+/// with the producer rather than restated here: a projection answers with its
+/// FIELD-NAME offset, and a bare NAME answers -1, because a call node's offset
+/// is its callee identifier's offset and this array carries call results. Its
+/// doc comment carries the whole argument.
+///
+/// This is what closes the row `float_call_offsets` structurally could not: a
+/// Double-typed STRUCT FIELD. That table is keyed by CALL offsets, so it had no
+/// projection arm at all, and measured before this change `b.ratio` on a
+/// `struct DBox { ratio: Double }` rendered `256` on the RC lane and trapped on
+/// gc, while the same Double through a tuple element or a plain `let` answered
+/// `1.5`. Tag 4 rows arrive in the SAME array (see split_typed_lowering_offsets)
+/// because both answer one question, and they agree on calls: a call node's
+/// `typed_lowering_arg_offset` IS its call offset.
+fn gc_offset_says_float(e: Expr, ctx: CompileCtxGc) -> Bool {
+  let off = typed_lowering_float_key(e)
+  off >= 0 && array_contains_int(ctx.gc_float_call_offsets, off)
+}
+
 fn gc_expr_is_floatish(e: Expr, local_names: Array[String], ctx: CompileCtxGc) -> Bool {
+  gc_offset_says_float(e, ctx) || gc_expr_is_floatish_syntactic(e, local_names, ctx)
+}
+
+fn gc_expr_is_floatish_syntactic(e: Expr, local_names: Array[String], ctx: CompileCtxGc) -> Bool {
   match e {
     EFloat(_) => true,
     EIdent(fname, _) => {
@@ -1253,8 +1282,11 @@ fn compile_expr_gc(buf: Bytes, expr: Expr, local_names: Array[String], next_loca
           emit_local_get(buf, local_idx)
         }
         next_local
-      } else if is_frozen_array_conversion_name(name) {
-        ce(buf, frozen_array_conversion_closure(name), local_names, next_local, ld)
+      } else if builtin_value_form_arity(name) >= 0 {
+        // #2442: see the linear twin in codegen/expr/compile_expr.vibe -- the
+        // placement above the func table is what keeps a builtin's negative
+        // table slot from being emitted, and only qualified names get here.
+        ce(buf, builtin_value_closure(name, builtin_value_form_arity(name)), local_names, next_local, ld)
       } else {
         let ctor_idx = ctor_table_index_of(ctx.gc_ctor_table, name)
         if ctor_idx >= 0 {

--- a/lib/@vibe/compiler/codegen/wasi/linked_compile.vibe
+++ b/lib/@vibe/compiler/codegen/wasi/linked_compile.vibe
@@ -148,7 +148,7 @@ import @vibe/compiler/codegen/common_analysis {
   md_is_borrow_arg0_call,
   scope_tail_proj_root,
   stmts_contain_exceptions,
-  unique_call_offsets_in_stmts,
+  unique_typed_lowering_offsets_in_stmts,
   zero_alloc_check
 }
 
@@ -4669,10 +4669,10 @@ export fn compile_wasi_module_linked_impl_with_typed_offsets(stmts: Array[Stmt],
   // the uniqueness is proven against the program codegen actually compiles
   // rather than against whatever the entry handed the checker. Empty in, empty
   // out, without a walk.
-  let float_call_offsets = unique_call_offsets_in_stmts(stmts, checker_float_call_offsets)
+  let float_call_offsets = unique_typed_lowering_offsets_in_stmts(stmts, checker_float_call_offsets)
   // #2424: the Int render-argument table needs no uniqueness filter of its
   // own. The checker already refuses an offset whose typed occurrences
-  // disagree, and #2429's per-file rebase (`+ base * 4` on the encoded value)
+  // disagree, and #2429's per-file rebase (`+ base * 8` on the encoded value)
   // keeps the merged offset spaces disjoint, so what arrives here is already
   // the fail-closed set.
   let int_render_offsets = checker_int_render_offsets

--- a/lib/@vibe/compiler/codegen/wasi/linked_compile.vibe
+++ b/lib/@vibe/compiler/codegen/wasi/linked_compile.vibe
@@ -7242,6 +7242,27 @@ export fn compile_wasi_module_linked_impl_with_typed_offsets(stmts: Array[Stmt],
   // base is now known before the first body is compiled, so a body no longer
   // depends on its predecessors having been compiled. That is the property
   // step 7's WholeProgramPlan needs.
+  // #2448 (Codex review): the one piece of scope the plan walk needs. A user
+  // program may declare `fn Array::get(...)`, and the checker resolves that
+  // name to the DECLARATION -- so codegen emits the user function's table slot
+  // rather than an eta-expansion of the builtin, and the plan must not reserve
+  // a slot for one.
+  //
+  // Only the FIRST `num_user_funcs` entries: the builtin names are appended to
+  // `fn_names_list` further up (the all-functions table), and `num_user_funcs`
+  // is the length captured before that. Measured on the whole list instead,
+  // EVERY value form planned 0 while the walk emitted 1 -- the guard matched
+  // the builtin's own row, so `let sub = String::substring` failed with
+  // `lambda plan over-count: planned through 0, walk stopped at 1`. The
+  // prefix is the same set codegen tests through the func table, where a user
+  // function is an entry at or above `func_offset`.
+  let user_fn_names_only: Array[String] = []
+  let mut ufn_i = 0
+  while ufn_i < num_user_funcs {
+    Array::push(user_fn_names_only, Array::get(fn_names_list, ufn_i))
+    ufn_i = ufn_i + 1
+  }
+  let user_fn_names_sorted = sorted_names_of(user_fn_names_only)
   let planned_bodies: Array[Expr] = []
   let lambda_bases = lc_fresh_int_array()
   let mut lambda_base_acc = 0
@@ -7273,9 +7294,9 @@ export fn compile_wasi_module_linked_impl_with_typed_offsets(stmts: Array[Stmt],
     // routes it through compile_lambda. Counting it would reserve a dead slot
     // per user function.
     lambda_base_acc = lambda_base_acc + (if is_efn(pb_expr) {
-      count_lambda_sites_expr(get_efn_body(pb_expr))
+      count_lambda_sites_expr(get_efn_body(pb_expr), user_fn_names_sorted)
     } else {
-      count_lambda_sites_expr(pb_expr)
+      count_lambda_sites_expr(pb_expr, user_fn_names_sorted)
     })
     pbi = pbi + 1
   }

--- a/lib/@vibe/compiler/core/builtin_name.vibe
+++ b/lib/@vibe/compiler/core/builtin_name.vibe
@@ -1,3 +1,9 @@
+//# Imports
+
+import ./builtin_registry.vibe {
+  registry_builtin_pure_arity
+}
+
 //# Functions
 
 export fn canonical_builtin_name(name: String) -> String {
@@ -42,33 +48,63 @@ export fn canonical_builtin_name(name: String) -> String {
   }
 }
 
-/// #1733 / #2433: the builtins that have a VALUE form, i.e. that may be bound
-/// to a name and called later rather than only called directly.
+/// #1733 / #2433 / #2442: the arity at which a builtin may be materialized as
+/// a VALUE -- bound to a name and called later rather than only called
+/// directly -- or -1 when it has no value form.
 ///
-/// The set is small and it is not a matter of taste: a builtin's function index
-/// lives BELOW `func_offset`, while a first-class function value is an index
-/// into the indirect call table, which holds user functions and lambdas only.
-/// `table_slot = fidx - func_offset` is therefore negative for every builtin,
-/// and builtin bodies carry no closure-env parameter, so the closure signature
-/// would not match even if a slot existed. Measured on stage2: `let f = eq`
-/// emitted a module the runtime refused (`invalid signature index`), and
-/// `let h = String::concat` compiled and then trapped with `table index is out
-/// of bounds`.
+/// A builtin's function index lives BELOW `func_offset`, while a first-class
+/// function value is an index into the indirect call table, which holds user
+/// functions and lambdas only. `table_slot = fidx - func_offset` is therefore
+/// negative for every builtin, and builtin bodies carry no closure-env
+/// parameter, so the closure signature would not match even if a slot existed.
+/// Measured on stage2 before #2433: `let f = eq` emitted a module the runtime
+/// refused (`invalid signature index`), and `let h = String::concat` compiled
+/// and then trapped with `table index is out of bounds`.
 ///
-/// The two names below are exempt because #1733 gave them a real value form:
-/// `compile_expr` / `backend_expr` materialize them as a one-argument LAMBDA
-/// (`frozen_array_conversion_closure`), which is an ordinary closure with an
-/// ordinary table slot. `fixtures/frozen_array_copies_test.vibe` calls both
-/// through a binding and passes.
+/// The value form is therefore not the builtin itself but an ETA-EXPANSION:
+/// both codegen lanes emit `(a, b) -> name(a, b)`, an ordinary lambda with an
+/// ordinary table slot and an ordinary closure env, whose body is the same
+/// direct call a source call site would have written. #1733 built that for the
+/// two FrozenArray conversions and hardcoded arity 1; this is the same
+/// lowering with the arity read from the registry, so the answer is a PROPERTY
+/// of the name rather than a two-element list a reader has to memorize.
 ///
-/// This is the single source of truth for that set: the checker rejects a
-/// builtin ident in value position unless this says yes, and both codegen
-/// lanes ask it which names to eta-expand. Adding a name here without the
-/// matching lowering would move a load-time failure into a runtime trap, so
-/// the two must be decided in one place.
-export fn builtin_ident_has_value_form(name: String) -> Bool {
+/// `registry_builtin_pure_arity` is the single source of truth: the checker
+/// grants the value form only when it agrees with the arity of the type the
+/// checker itself inferred, and both lanes emit exactly that many parameters.
+/// Two copies of the decision would drift into either a spurious error or the
+/// load-time failure #2433 removed.
+///
+/// An EFFECTFUL builtin is refused by `registry_builtin_pure_arity` -- see
+/// that function. A BARE (unqualified) builtin name is refused here, and that
+/// one is a compiler limitation rather than a language decision:
+///
+/// `count_lambda_sites_expr` (codegen/common_analysis) predicts, for the whole
+/// program, exactly how many lambda table slots the codegen walk will allocate,
+/// and the walk THROWS when the two disagree. It is a purely syntactic walk
+/// with no scope -- its own comment says "binding structure is irrelevant here"
+/// -- so it can only decide the value form from the name. Codegen decides it
+/// after the locals, constructors, constants and the func table have all
+/// failed, which is the order the checker resolves names in. Those two agree
+/// for a name nothing else can bind, and disagree for one that can: with a
+/// bare name admitted, an ordinary `let eq = (a, b) -> ...` would make the
+/// planner reserve a slot for a use codegen resolves to the local, and a
+/// program that compiles today would fail with `lambda plan over-count`.
+/// `lib/@vibe/compiler/tests/builtin_ident_value_test.vibe` measures that count.
+///
+/// A qualified name cannot be bound by `let`, by a parameter, by a pattern or
+/// by a constructor, so the two answers cannot diverge. Admitting the bare
+/// names needs the planner to learn scope (its arms already mirror
+/// `collect_refs_into` in dce.vibe, which threads a bound set) -- that is the
+/// remaining half of #2442, and it is a real change to that walk rather than
+/// another name here.
+export fn builtin_value_form_arity(name: String) -> Int {
   let n = canonical_builtin_name(name)
-  n == "FrozenArray::from_array" || n == "FrozenArray::to_array"
+  if String::contains(n, "::") {
+    registry_builtin_pure_arity(n)
+  } else {
+    0 - 1
+  }
 }
 
 //# Builtin deprecation table (ADR-0098 / ADR-0101).

--- a/lib/@vibe/compiler/core/builtin_name.vibe
+++ b/lib/@vibe/compiler/core/builtin_name.vibe
@@ -1,7 +1,7 @@
 //# Imports
 
 import ./builtin_registry.vibe {
-  registry_builtin_pure_arity
+  registry_builtin_arity, registry_builtin_pure_arity
 }
 
 //# Functions
@@ -98,12 +98,26 @@ export fn canonical_builtin_name(name: String) -> String {
 /// `collect_refs_into` in dce.vibe, which threads a bound set) -- that is the
 /// remaining half of #2442, and it is a real change to that walk rather than
 /// another name here.
+/// #1733's two conversions are an explicit LEGACY exception, and they are the
+/// one place this is a name list rather than a property. Their rows are
+/// polymorphic (`Array[?] -> FrozenArray[?]`), so the unknown test below would
+/// refuse them -- but they have shipped with a value form since #1733 and
+/// `fixtures/frozen_array_copies_test.vibe` binds one through an ANNOTATED
+/// `let`, which is a sound and useful spelling. Refusing them would take that
+/// away. Measured on `aeccc0c97` and on this branch, identically: the
+/// UNANNOTATED `let freeze = FrozenArray::from_array` then
+/// `let fz: FrozenArray[String] = freeze([1, 2])` checks clean and reads the
+/// Ints as Strings. That hole predates this function; it is not widened here,
+/// and closing it means giving the registry a way to say two positions are the
+/// same type.
 export fn builtin_value_form_arity(name: String) -> Int {
   let n = canonical_builtin_name(name)
-  if String::contains(n, "::") {
-    registry_builtin_pure_arity(n)
-  } else {
+  if !String::contains(n, "::") {
     0 - 1
+  } else if n == "FrozenArray::from_array" || n == "FrozenArray::to_array" {
+    registry_builtin_arity(n)
+  } else {
+    registry_builtin_pure_arity(n)
   }
 }
 

--- a/lib/@vibe/compiler/core/builtin_registry.vibe
+++ b/lib/@vibe/compiler/core/builtin_registry.vibe
@@ -517,6 +517,45 @@ export fn registry_builtin_arity(name: String) -> Int {
   found
 }
 
+/// #2442: the parameter count of a checker-visible registry row whose type is
+/// a function with an EMPTY effect row, or -1 for anything else -- a name that
+/// is not a registry row, a row that is not a function, or a row that carries
+/// an effect.
+///
+/// This is the property that replaced `builtin_ident_has_value_form`'s
+/// two-name list (`core/builtin_name.vibe`). The arity is what an eta-expansion
+/// needs, so returning it rather than a Bool keeps the decision and the
+/// lowering reading the same number: a value form is emitted with exactly the
+/// parameter count this reports.
+///
+/// The effect row is the deliberate boundary, not an omission. A direct call to
+/// `Fs::read_file` has its row checked at the call site against the capability
+/// the caller holds; as a VALUE the row would have to be carried by the
+/// binding's function type and demanded again at the indirect call, or
+/// `let f = Fs::read_file` launders authority (ADR-0075/0084/0088). Until that
+/// is built, an effectful builtin keeps the positioned diagnostic.
+export fn registry_builtin_pure_arity(name: String) -> Int {
+  let rows = builtin_registry_typed()
+  let mut i = 0
+  let mut found = 0 - 1
+  while i < Array::length(rows) {
+    let (rname, ty, _, _, visible) = Array::get(rows, i)
+    if rname == name && visible {
+      found = match ty {
+        CtFn(params, _, eff) => match eff {
+          Some(_) => 0 - 1,
+          None => Array::length(params)
+        },
+        _ => 0 - 1
+      }
+      i = Array::length(rows)
+    } else {
+      i = i + 1
+    }
+  }
+  found
+}
+
 /// #1513: the declared type of a checker-visible registry row's parameter `i`,
 /// or None when the name is not a registry row / has no such parameter.
 ///

--- a/lib/@vibe/compiler/core/builtin_registry.vibe
+++ b/lib/@vibe/compiler/core/builtin_registry.vibe
@@ -1,7 +1,7 @@
 //# Imports
 
 import ./types.vibe {
-  Type
+  Type, type_has_unknown
 }
 
 // Standard host-provider and entry-execution policy is a sibling in this
@@ -528,12 +528,26 @@ export fn registry_builtin_arity(name: String) -> Int {
 /// lowering reading the same number: a value form is emitted with exactly the
 /// parameter count this reports.
 ///
-/// The effect row is the deliberate boundary, not an omission. A direct call to
-/// `Fs::read_file` has its row checked at the call site against the capability
-/// the caller holds; as a VALUE the row would have to be carried by the
-/// binding's function type and demanded again at the indirect call, or
-/// `let f = Fs::read_file` launders authority (ADR-0075/0084/0088). Until that
-/// is built, an effectful builtin keeps the positioned diagnostic.
+/// Two boundaries, and neither is an omission.
+///
+/// The EFFECT row: a direct call to `Fs::read_file` has its row checked at the
+/// call site against the capability the caller holds; as a VALUE the row would
+/// have to be carried by the binding's function type and demanded again at the
+/// indirect call, or `let f = Fs::read_file` launders authority
+/// (ADR-0075/0084/0088). Until that is built, an effectful builtin keeps the
+/// positioned diagnostic.
+///
+/// An UNKNOWN anywhere in the signature (Codex review on #2448): the registry
+/// spells a polymorphic row with `reg_any()` = `CtUnknown`, and every
+/// occurrence is independent -- nothing says the element in `Array::get`'s
+/// parameter and its result are the same type. A direct call survives that
+/// through its dedicated refinements; a value exposes the raw row and the
+/// relationship is gone. Measured: `let get = Array::get` then
+/// `let s: String = get([1], 0)` checked CLEAN and printed garbage, while
+/// `Array::get([1], 0)` in the same position was correctly rejected with
+/// `expected String, got Int`. `Array::push` through a binding loses the same
+/// way. So an unknown-bearing row has no sound value form until the registry
+/// can express the relationship, which is a change to the registry, not here.
 export fn registry_builtin_pure_arity(name: String) -> Int {
   let rows = builtin_registry_typed()
   let mut i = 0
@@ -542,13 +556,31 @@ export fn registry_builtin_pure_arity(name: String) -> Int {
     let (rname, ty, _, _, visible) = Array::get(rows, i)
     if rname == name && visible {
       found = match ty {
-        CtFn(params, _, eff) => match eff {
+        CtFn(params, ret, eff) => match eff {
           Some(_) => 0 - 1,
-          None => Array::length(params)
+          None => if types_mention_unknown(params) || type_has_unknown(ret) {
+            0 - 1
+          } else {
+            Array::length(params)
+          }
         },
         _ => 0 - 1
       }
       i = Array::length(rows)
+    } else {
+      i = i + 1
+    }
+  }
+  found
+}
+
+fn types_mention_unknown(ts: Array[Type]) -> Bool {
+  let mut i = 0
+  let mut found = false
+  while i < Array::length(ts) {
+    if type_has_unknown(Array::get(ts, i)) {
+      found = true
+      i = Array::length(ts)
     } else {
       i = i + 1
     }

--- a/lib/@vibe/compiler/core/expr_children.vibe
+++ b/lib/@vibe/compiler/core/expr_children.vibe
@@ -43,6 +43,31 @@ export fn typed_lowering_arg_offset(expr: Expr) -> Int {
   }
 }
 
+/// #2424: the same key, restricted to the shapes the DOUBLE channel may use --
+/// a call result or a dot projection. A bare name answers `-1`.
+///
+/// The restriction is not caution, it is the one collision this encoding has.
+/// The Double channel's array carries two producers: tag 0, the primary CALL
+/// RESULTS whose type is Double, and tag 4, the render/`eq` ARGUMENTS whose
+/// type is Double. A call node's own offset IS its callee identifier's offset
+/// (`parse_postfix` passes `callee_offset(expr)`), so for `f()` returning a
+/// Double the array holds the offset that `EIdent("f")` also answers with.
+/// Reading that array with `typed_lowering_arg_offset` would therefore classify
+/// the function VALUE `f` as a Double wherever a classifier is asked about it,
+/// and lower it through f64 -- silently.
+///
+/// The Int channel does not have this problem and does not use this key: its
+/// producer emits an offset only when EVERY typed occurrence there resolves to
+/// `Int`, so a call offset shared with its callee's `CtFn` occurrence is
+/// dropped on disagreement. Tag 0's producer is the call-result capture
+/// instead, which has no such agreement rule, so the restriction lives here.
+export fn typed_lowering_float_key(expr: Expr) -> Int {
+  match expr {
+    EIdent(_, _) => 0 - 1,
+    _ => typed_lowering_arg_offset(expr)
+  }
+}
+
 export fn expr_children(expr: Expr) -> Array[Expr] {
   let children = array_empty()
   match expr {

--- a/lib/@vibe/compiler/core/index.vpkg
+++ b/lib/@vibe/compiler/core/index.vpkg
@@ -122,6 +122,7 @@ type EnvValueBinding
 // --- expr_children
 fn expr_children(expr: Expr) -> Array[Expr]
 fn typed_lowering_arg_offset(expr: Expr) -> Int
+fn typed_lowering_float_key(expr: Expr) -> Int
 
 // --- unstable_surface
 let unstable_package_name: String
@@ -130,7 +131,7 @@ fn text_mentions_unstable_package(text: String) -> Bool
 
 // --- builtin_name
 fn canonical_builtin_name(name: String) -> String
-fn builtin_ident_has_value_form(name: String) -> Bool
+fn builtin_value_form_arity(name: String) -> Int
 fn builtin_deprecated_message(name: String) -> Option[String]
 fn append_builtin_deprecated(out: Array[(String, String)]) -> Unit
 
@@ -142,6 +143,7 @@ fn borrow_ret_builtin_names() -> Array[String]
 fn builtin_registry() -> Array[(String, Int, Int, Bool, Bool)]
 fn lookup_registry_builtin(name: String) -> Option[Type]
 fn registry_builtin_arity(name: String) -> Int
+fn registry_builtin_pure_arity(name: String) -> Int
 fn registry_builtin_param_type(name: String, i: Int) -> Option[Type]
 fn verify_lane_builtins(lane: String, names: Array[String], param_counts: Array[Int], returns: Array[Int]) -> Unit with Exception
 fn verify_standard_effect_policy_coverage() -> Unit with Exception

--- a/lib/@vibe/compiler/core/index.vpkg
+++ b/lib/@vibe/compiler/core/index.vpkg
@@ -250,6 +250,7 @@ fn resolve_type_constructor_args(params: Array[String], source_args: Array[TypeE
 // call-result observation runs it once per located call result, where the
 // rebuild is pure waste and, on a merged program, quadratic.
 fn subst_resolves_to_double(s: Subst, ty: Type) -> Bool
+fn type_has_unknown(ty: Type) -> Bool
 fn subst_resolves_to_string(s: Subst, ty: Type) -> Bool
 fn trait_defined(env: TypeEnv, name: String) -> Bool
 fn trait_decl_params(env: TypeEnv, name: String) -> Option[Array[String]]

--- a/lib/@vibe/compiler/core/types.vibe
+++ b/lib/@vibe/compiler/core/types.vibe
@@ -2469,6 +2469,74 @@ export fn is_builtin_type_name(name: String) -> Bool {
   }
 }
 
+/// #2442: does this type mention `CtUnknown` anywhere?
+///
+/// The registry spells a polymorphic builtin's type with `reg_any()`, which is
+/// `CtUnknown`, and every occurrence is INDEPENDENT -- the registry has no way
+/// to say that the element in `Array::get`'s parameter and its result are the
+/// same type. Direct calls survive that because they have dedicated
+/// refinements; a first-class VALUE exposes the raw row and loses the
+/// relationship. Measured on this compiler, `let get = Array::get` then
+/// `let s: String = get([1], 0)` checked CLEAN and printed garbage, while the
+/// direct `Array::get([1], 0)` was correctly rejected with `expected String,
+/// got Int`. So a row that mentions an unknown has no sound value form, and
+/// `registry_builtin_pure_arity` refuses it.
+///
+/// Arms are enumerated with no wildcard on purpose: a new `Type` constructor
+/// must fail this match rather than default to "no unknown here", which would
+/// admit a row silently. Same arm list as `type_clone` below.
+export fn type_has_unknown(ty: Type) -> Bool {
+  match ty {
+    CtInt => false,
+    CtDouble => false,
+    CtBool => false,
+    CtString => false,
+    CtChar => false,
+    CtUnit => false,
+    CtBytes => false,
+    CtUnknown => true,
+    CtVar(_) => false,
+    CtConstructor(_, _) => false,
+    CtApplied(head, args) => type_has_unknown(head) || types_have_unknown(args),
+    CtEnum(_) => false,
+    CtStruct(_) => false,
+    CtArray(e) => type_has_unknown(e),
+    CtOption(e) => type_has_unknown(e),
+    CtTuple(es) => types_have_unknown(es),
+    CtFn(ps, ret, _) => types_have_unknown(ps) || type_has_unknown(ret),
+    CtNamed(_, ts) => types_have_unknown(ts),
+    CtForAll(_, _, body) => type_has_unknown(body),
+    CtRecord(fields) => {
+      let mut i = 0
+      let mut found = false
+      while i < Array::length(fields) {
+        let (_, t) = Array::get(fields, i)
+        if type_has_unknown(t) {
+          found = true
+          i = Array::length(fields)
+        } else {
+          i = i + 1
+        }
+      }
+      found
+    }
+  }
+}
+
+fn types_have_unknown(ts: Array[Type]) -> Bool {
+  let mut i = 0
+  let mut found = false
+  while i < Array::length(ts) {
+    if type_has_unknown(Array::get(ts, i)) {
+      found = true
+      i = Array::length(ts)
+    } else {
+      i = i + 1
+    }
+  }
+  found
+}
+
 /// Deep copy of a `Type` tree. Every composite arm allocates a fresh node;
 /// leaves are rebuilt rather than returned by identity. Needed because a
 /// shared child is dropped by Perceus when the result is consumed, and the

--- a/lib/@vibe/compiler/entry/compiler/file_compile/file_compile.vibe
+++ b/lib/@vibe/compiler/entry/compiler/file_compile/file_compile.vibe
@@ -285,11 +285,11 @@ fn append_import_alias_collision_defs_from_sources(merged: Array[Stmt], current_
                       Some(provider_offsets) => {
                         let mut k = 0
                         while k < Array::length(provider_offsets) {
-                          // The table is tag-encoded (offset * 4 + tag, see
+                          // The table is tag-encoded (offset * 8 + tag, see
                           // typed_lowering_enc), so shifting a row by the
-                          // clone's merge-space delta adds (base + delta) * 4
+                          // clone's merge-space delta adds (base + delta) * 8
                           // -- the tag bits stay untouched.
-                          Array::push(clone_float_offsets_out, Array::get(provider_offsets, k) + (provider_base + delta) * 4)
+                          Array::push(clone_float_offsets_out, Array::get(provider_offsets, k) + (provider_base + delta) * 8)
                           k = k + 1
                         }
                       },
@@ -505,8 +505,8 @@ fn build_grouped_merged_stmts_gc(source_groups: Array[(String, Array[(String, St
 /// #2391: shift each file's per-module typed-lowering table (recorded by the
 /// modular check in the file's OWN offset space) by that file's base in a
 /// disjoint-offset merge, and union them into one table. Rows are tag-encoded
-/// (offset * 4 + tag, see typed_lowering_enc in the checker), so the rebase
-/// adds base * 4 and leaves the tag bits untouched. A file the modular check
+/// (offset * 8 + tag, see typed_lowering_enc in the checker), so the rebase
+/// adds base * 8 and leaves the tag bits untouched. A file the modular check
 /// never stepped in this process contributes nothing, which degrades ITS
 /// sites to the syntactic classifiers -- deterministically, because the reuse
 /// arms in runtime/typecheck_fs.vibe re-check a module whose offsets sidecar
@@ -520,7 +520,7 @@ fn union_module_typed_lowering_offsets(flat_paths: Array[String], flat_bases: Ar
         let base = Array::get(flat_bases, i)
         let mut j = 0
         while j < Array::length(offsets) {
-          Array::push(out, Array::get(offsets, j) + base * 4)
+          Array::push(out, Array::get(offsets, j) + base * 8)
           j = j + 1
         }
       },
@@ -639,8 +639,17 @@ fn split_typed_lowering_offsets(enc: Array[Int]) -> (Array[Int], Array[Int], Arr
       // #2424: render (`__to_string` / `Int::to_string`) and `eq` ARGUMENT
       // offsets the checker typed as `Int`.
       Array::push(int_renders, off)
+    } else if tag == 4 {
+      // #2424: the Double half of the same argument set, unioned into the
+      // Double channel. The two tags stay distinct through the encoding
+      // because their KEYS differ -- tag 0 is a call node's own offset, tag 4
+      // is `typed_lowering_arg_offset` (a projection answers with its
+      // field-name offset) -- and they can share one array here because the
+      // consumers read it with `typed_lowering_arg_offset`, which agrees with
+      // the call offset on a call node.
+      Array::push(floats, off)
     } else {
-      // No tag above 3 exists; dropping an unknown row degrades its site to
+      // No tag above 4 exists; dropping an unknown row degrades its site to
       // the syntactic classifiers rather than misclassifying another offset.
       ()
     }
@@ -864,7 +873,7 @@ export fn check_file_fs_mode(entry_path: String) -> Int with Exception + Fs {
 /// per-module capture inside a check that was already running, and the
 /// persistent halves (TypeEnv + offsets sidecar) are required TOGETHER by
 /// every reuse arm, so cache state can never change what a compile emits.
-/// `unique_call_offsets_in_stmts` (codegen/common_analysis) still drops any
+/// `unique_typed_lowering_offsets_in_stmts` (codegen/common_analysis) still drops any
 /// offset that names more than one call node, so a partial answer degrades to
 /// the pre-#2158 syntactic classifier rather than to a wrong one.
 export fn compile_file_fs_mode(entry_path: String, entry_name: String, mode: String) -> Bytes with Exception + Fs {

--- a/lib/@vibe/compiler/entry/source_compile/gc_only/gc_only.vibe
+++ b/lib/@vibe/compiler/entry/source_compile/gc_only/gc_only.vibe
@@ -16,7 +16,7 @@ import @vibe/compiler/codegen {
 }
 
 import @vibe/compiler/codegen/common_analysis {
-  unique_call_offsets_in_stmts
+  unique_typed_lowering_offsets_in_stmts
 }
 
 import @vibe/compiler/codegen/gc {
@@ -385,7 +385,7 @@ fn compile_stmts_gc_only_impl(stmts: Array[Stmt], entry_name: String, merged_off
   // Keep only keys that identify exactly one call in the final statements;
   // a collision then loses a float hint instead of misclassifying an Int call.
   let unique_gc_float_call_offsets = if merged_offset_spaces {
-    unique_call_offsets_in_stmts(stmts, gc_float_call_offsets)
+    unique_typed_lowering_offsets_in_stmts(stmts, gc_float_call_offsets)
   } else {
     // Direct source parsing has one offset space already. Avoid an extra AST
     // walk on the performance-sensitive selfbuild path.

--- a/lib/@vibe/compiler/entry/source_compile/wasi_only/preprocess_compile.vibe
+++ b/lib/@vibe/compiler/entry/source_compile/wasi_only/preprocess_compile.vibe
@@ -200,7 +200,7 @@ fn maybe_wrap_async_component(bytes: Bytes, wrap_async: Bool) -> Bytes with Exce
 ///     lanes re-establish the same property by rebasing each file into a
 ///     disjoint offset range and feeding the per-module answers from the
 ///     modular check -- see `compile_file_fs_mode`'s comment, #2391.)
-///     `unique_call_offsets_in_stmts` re-establishes the property downstream
+///     `unique_typed_lowering_offsets_in_stmts` re-establishes the property downstream
 ///     anyway, on the post-lowering statements codegen actually walks.
 ///   - Fail CLOSED. `check_program_double_call_result_located_observation`
 ///     answers `None` when the AST carried no offsets at all -- the case a

--- a/lib/@vibe/compiler/tests/builtin_ident_value_test.vibe
+++ b/lib/@vibe/compiler/tests/builtin_ident_value_test.vibe
@@ -7,32 +7,56 @@
 // arm was answering "yes, this name exists" for operations that are not
 // first-class values.
 //
-// Rejection is the close: a builtin ident used as a value is a checker error
-// that names the call form and the wrap form. `Map::new` stays `unknown name`
-// -- it is a parser-only call desugar, not a registry value -- but it is still
-// a checker error, so the two spellings agree about whether the shape is one.
+// #2433 turned that into a rejection of EVERY builtin typed as a function.
+// Measured, the exemptions #2274 had kept did not work: a func-table row
+// (`String::length`) or a bare name (`eq`, `not`) emitted a module the runtime
+// rejected (`invalid signature index`), trapped with `table index is out of
+// bounds`, or reached codegen unresolved and asked the reader to report a
+// compiler bug. The indirect table is populated from user functions and
+// lambdas only, builtin bodies sit below `func_offset`, and they carry no
+// closure-env parameter.
 //
-// #2433 widened that rejection from qualified call-only names to EVERY builtin
-// typed as a function. #2274 had exempted names with a linear func-table row
-// (`String::length`) and every bare name (`eq`, `not`), on the reading that a
-// func-table row means there is a function pointer to take. Measured, there is
-// not: the indirect table is populated from user functions and lambdas only,
-// builtin bodies sit below `func_offset`, and they carry no closure-env
-// parameter. So those spellings did not "stay values" -- they emitted a module
-// the runtime rejected (`invalid signature index`), trapped with `table index
-// is out of bounds`, or reached codegen unresolved and asked the reader to
-// report a compiler bug. The tests below now pin the diagnostic for each.
+// #2442 replaced the rejection with support wherever it can be given. The
+// value form is an ETA-EXPANSION -- both lanes emit `(a, b) -> name(a, b)`,
+// an ordinary lambda with an ordinary table slot -- so none of the failure
+// modes above apply to it, and #1733 had already shipped exactly this shape
+// for the two FrozenArray conversions with the arity hardcoded to 1.
 //
-// The exception is #1733's two FrozenArray conversions. Those have a REAL value
-// form: both codegen lanes materialize them as a one-argument lambda, which is
-// an ordinary closure with an ordinary table slot, and
-// `fixtures/frozen_array_copies_test.vibe` calls both through a binding and
-// passes. `builtin_ident_has_value_form` (core/builtin_name.vibe) is the single
-// source of truth -- the checker asks it what to admit and both lanes ask it
-// what to eta-expand, so the admission cannot drift from the lowering.
+// So the rule is now a PROPERTY, not a list: a builtin has a value form when
+// it is QUALIFIED, the registry knows its arity, and its effect row is empty.
+// Three refusals remain, and each says why:
+//
+//   * an EFFECTFUL builtin (`Fs::read_file`) -- as a value its row would have
+//     to be carried by the binding's function type and demanded again at the
+//     indirect call, and until that exists `let f = Fs::read_file` launders
+//     authority (ADR-0075/0084/0088);
+//   * a name with NO registry row (`Map::set`) -- there is no arity to expand;
+//   * a BARE name (`eq`, `not`) -- a compiler limitation, not a decision about
+//     the language, and the one row of #2442 left open. `count_lambda_sites_expr`
+//     predicts for the whole program how many lambda table slots the codegen
+//     walk will allocate, and the walk THROWS when the two disagree. It is
+//     scope-free by construction, so it decides the value form from the name
+//     alone, while codegen decides it only after the locals, constructors,
+//     constants and func table have failed. Those agree for a name nothing
+//     else can bind and disagree for one that can -- the count test below
+//     measures the disagreement on an ordinary `let eq = ...`.
+//
+// `builtin_value_form_arity` (core/builtin_name.vibe) is the single source of
+// truth: the checker asks it what to admit and both lanes ask it what to
+// eta-expand, so the admission cannot drift from the lowering. The RUNTIME
+// half -- that a builtin called through a binding answers exactly as the
+// direct call does, on all three lanes -- is `fixtures/builtin_value_form_test.vibe`.
 
 import @vibe/compiler/checker {
   check_program
+}
+
+import @vibe/compiler/codegen/common_analysis {
+  count_lambda_sites_expr
+}
+
+import @vibe/compiler/core {
+  Expr, builtin_value_form_arity
 }
 
 import @vibe/compiler/syntax {
@@ -60,37 +84,71 @@ fn value_ident_program(name: String) -> String {
   String::concat(String::concat("fn main() -> Unit {\n  let g = ", name), "\n  ()\n}\n")
 }
 
-//# Reported
+//# The property
 
-test "#2274: Map::get as a bare value is a checker error, not a silent pass" {
-  let msg = first_check_error(value_ident_program("Map::get"))
-  assert(String::contains(msg, "Map::get"))
+test "#2442: the value form is decided by arity and effect, not by a name list" {
+  // Pure registry rows report the parameter count the eta-expansion emits.
+  inspect(builtin_value_form_arity("String::length"), "1")
+  inspect(builtin_value_form_arity("String::concat"), "2")
+  inspect(builtin_value_form_arity("Array::length"), "1")
+  inspect(builtin_value_form_arity("Map::get"), "2")
+  // Bare names are pure two-argument rows and are still refused, for the
+  // planner reason above rather than anything about the builtins themselves.
+  inspect(builtin_value_form_arity("eq"), "-1")
+  inspect(builtin_value_form_arity("not"), "-1")
+  // #1733's two are no longer special-cased; they are just arity-1 rows.
+  inspect(builtin_value_form_arity("FrozenArray::from_array"), "1")
+  inspect(builtin_value_form_arity("FrozenArray::to_array"), "1")
+  // An effect row refuses, and so does a name with no row at all.
+  inspect(builtin_value_form_arity("Fs::read_file"), "-1")
+  inspect(builtin_value_form_arity("Env::get"), "-1")
+  inspect(builtin_value_form_arity("Map::set"), "-1")
+  inspect(builtin_value_form_arity("no_such_builtin_at_all"), "-1")
+}
+
+test "#2442: a legacy spelling answers as its canonical name does" {
+  // `canonical_builtin_name` runs first, so the deprecated spelling of an
+  // effectful builtin is refused for the effect, not for being unknown.
+  inspect(builtin_value_form_arity("Fs::ReadFile"), "-1")
+  inspect(builtin_value_form_arity("String::byte_at"), "2")
+  inspect(builtin_value_form_arity("String::char_code_at"), "2")
+}
+
+//# Still rejected -- and the diagnostic says why
+
+test "#2442: an effectful builtin as a bare value is rejected" {
+  let msg = first_check_error(value_ident_program("Fs::read_file"))
+  assert(String::contains(msg, "Fs::read_file"))
   assert(String::contains(msg, "not a value"))
   assert(String::contains(msg, "call it"))
   assert(String::contains(msg, "wrap it"))
 }
 
-test "#2274: unlocated parse still rejects Map::get as a value" {
-  // FS compile uses parse_program(lex(source)), so every ident_off is -1.
-  // The rejection must not be gated on ident_off >= 0.
-  let msg = first_check_error_unlocated(value_ident_program("Map::get"))
-  assert(String::contains(msg, "Map::get"))
-  assert(String::contains(msg, "not a value"))
+test "#2442: the effect refusal names the effect, not just 'no'" {
+  let msg = first_check_error(value_ident_program("Fs::read_file"))
+  assert(String::contains(msg, "performs `Fs`"))
+  assert(String::contains(msg, "only checked where the call is written"))
 }
 
-test "#2274: Map::set as a bare value is the same class of error" {
+test "#2442: Env::get is refused for its effect too" {
+  let msg = first_check_error(value_ident_program("Env::get"))
+  assert(String::contains(msg, "performs `Env`"))
+}
+
+test "#2274: Map::set has no registry row, so it has no arity to expand" {
   let msg = first_check_error(value_ident_program("Map::set"))
   assert(String::contains(msg, "Map::set"))
   assert(String::contains(msg, "not a value"))
+  assert(String::contains(msg, "no registry row"))
 }
 
-test "#2274: Map::delete as a bare value is the same class of error" {
+test "#2274: Map::delete is the same class of refusal" {
   let msg = first_check_error(value_ident_program("Map::delete"))
   assert(String::contains(msg, "Map::delete"))
   assert(String::contains(msg, "not a value"))
 }
 
-test "#2274: Map::new as a bare value is still a checker error" {
+test "#2274: Map::new is still a checker error" {
   // Parser-only call desugar: `Map::new()` becomes EMap, so the ident has
   // no builtin row. The important half is that it does not pass the checker.
   let msg = first_check_error(value_ident_program("Map::new"))
@@ -98,71 +156,111 @@ test "#2274: Map::new as a bare value is still a checker error" {
   assert(String::contains(msg, "Map::new"))
 }
 
-test "#2274: the diagnostic names the call form, not an ICE" {
-  let msg = first_check_error(value_ident_program("Map::get"))
+test "#2274: a refusal names the call form, not an ICE" {
+  let msg = first_check_error(value_ident_program("Map::set"))
   assert(!String::contains(msg, "internal compiler error"))
   assert(!String::contains(msg, "reached code generation"))
-  assert(String::contains(msg, "Map::get("))
+  assert(String::contains(msg, "Map::set("))
 }
 
-test "#2433: String::length as a bare value is rejected, not silently emitted" {
-  // #2274 called this one a first-class value because the registry row says
-  // `in_linear`. Measured on stage2 before #2433: the module compiled, then
-  // `h("abc")` trapped with `table index is out of bounds`.
-  let msg = first_check_error(value_ident_program("String::length"))
-  assert(String::contains(msg, "String::length"))
+test "#2442: the wrap form the diagnostic recommends type-checks" {
+  // The wrap form is the ANSWER for an effectful builtin, not a workaround:
+  // it puts the call back where the row is checked against the capability
+  // the caller holds.
+  let src = "fn read2(p: String) -> String with Fs {\n  let f = (a) -> Fs::read_file(a)\n  f(p)\n}\n"
+  inspect(first_check_error(src), content = "")
+}
+
+test "#2274: the unlocated parse refuses an effectful builtin as well" {
+  // FS compile uses parse_program(lex(source)), so every ident_off is -1.
+  // The rejection must not be gated on ident_off >= 0.
+  let msg = first_check_error_unlocated(value_ident_program("Fs::read_file"))
+  assert(String::contains(msg, "Fs::read_file"))
   assert(String::contains(msg, "not a value"))
-  assert(String::contains(msg, "wrap it"))
 }
 
-test "#2433: Array::length as a bare value is rejected" {
-  let msg = first_check_error(value_ident_program("Array::length"))
-  assert(String::contains(msg, "Array::length"))
-  assert(String::contains(msg, "not a value"))
+//# Now accepted
+
+test "#2442: a pure builtin is a value -- String::length" {
+  // #2274 called this a value because the registry row says `in_linear`, and
+  // #2433 measured that reading wrong and rejected it. It is a value again,
+  // for a different reason: the eta-expansion, not a pointer to the builtin.
+  inspect(first_check_error(value_ident_program("String::length")), content = "")
+  inspect(first_check_error_unlocated(value_ident_program("String::length")), content = "")
 }
 
-test "#2433: a BARE builtin name is rejected too -- eq" {
-  // The `!String::contains(name, "::")` exemption sent every bare builtin
-  // straight through. Measured before #2433: `let f = eq` emitted a module
-  // the runtime refused to compile, `invalid signature index: 11`.
+test "#2442: a pure builtin is a value -- String::concat" {
+  inspect(first_check_error(value_ident_program("String::concat")), content = "")
+}
+
+test "#2442: a bare builtin name is still refused, and says why" {
   let msg = first_check_error(value_ident_program("eq"))
   assert(String::contains(msg, "`eq`"))
   assert(String::contains(msg, "not a value"))
+  assert(String::contains(msg, "unqualified"))
   assert(String::contains(msg, "eq(a, b)"))
+  assert(!String::contains(msg, "internal compiler error"))
 }
 
-test "#2433: a bare builtin with no func-table row is rejected -- not" {
-  // This one used to reach codegen as an unresolved ident: "`not` (ident)
-  // reached code generation unresolved ... this is a bug in the compiler and
-  // not in your program -- please report the source that triggers it."
+test "#2442: `not` is refused the same way" {
   let msg = first_check_error(value_ident_program("not"))
   assert(String::contains(msg, "`not`"))
-  assert(String::contains(msg, "not a value"))
-  assert(!String::contains(msg, "internal compiler error"))
-  assert(!String::contains(msg, "reached code generation"))
+  assert(String::contains(msg, "unqualified"))
 }
 
-test "#2433: the unlocated parse rejects a bare builtin as well" {
-  let msg = first_check_error_unlocated(value_ident_program("eq"))
-  assert(String::contains(msg, "`eq`"))
-  assert(String::contains(msg, "not a value"))
+test "#2442: the planner reserves a slot for exactly the names with a value form" {
+  // `count_lambda_sites_expr` is the whole-program prediction the codegen walk
+  // is checked against, per function body, and the walk THROWS when the two
+  // disagree. It used to carry its own copy of #1733's two names -- the third
+  // copy of that list -- so it now reads the same predicate the checker and
+  // both backends do.
+  inspect(count_lambda_sites_expr(EIdent("String::concat", -1)), "1")
+  inspect(count_lambda_sites_expr(EIdent("FrozenArray::from_array", -1)), "1")
+  // No value form, so no slot: an effectful builtin, a name with no registry
+  // row, an ordinary name, and a bare builtin.
+  inspect(count_lambda_sites_expr(EIdent("Fs::read_file", -1)), "0")
+  inspect(count_lambda_sites_expr(EIdent("Map::set", -1)), "0")
+  inspect(count_lambda_sites_expr(EIdent("some_local", -1)), "0")
+  inspect(count_lambda_sites_expr(EIdent("eq", -1)), "0")
+  // A DIRECT call stays direct: only a value-position identifier becomes the
+  // synthetic lambda, so the callee must not be counted.
+  inspect(count_lambda_sites_expr(ECall(EIdent("String::concat", -1), [
+    EIdent("a", -1),
+    EIdent("b", -1)
+  ], -1)), "0")
 }
 
-test "#2433: the diagnostic gives the wrap form the reader can paste" {
-  // The wrap form is the edit that fixes it, and it works: measured,
-  // `let f = (a, b) -> eq(a, b)` compiles and answers on every lane.
-  let msg = first_check_error(value_ident_program("eq"))
-  assert(String::contains(msg, "(a, b) -> eq(a, b)"))
+test "#2442: a generic pure builtin -- Array::length" {
+  inspect(first_check_error(value_ident_program("Array::length")), content = "")
 }
 
-test "#2433: a builtin with no value form names the wrap form, not an ICE" {
-  let msg = first_check_error(value_ident_program("String::concat"))
-  assert(String::contains(msg, "String::concat"))
-  assert(String::contains(msg, "not a value"))
-  assert(!String::contains(msg, "internal compiler error"))
+test "#2442: the binding is typed as a function, so it can be called" {
+  let src = "fn main() -> Unit {\n  let cat = String::concat\n  let _ = cat(\"a\", \"b\")\n  ()\n}\n"
+  inspect(first_check_error(src), content = "")
 }
 
-//# Not reported
+test "#2442: an annotated binding of a pure builtin agrees with its type" {
+  let src = "fn main() -> Unit {\n  let cat: (String, String) -> String = String::concat\n  let _ = cat(\"a\", \"b\")\n  ()\n}\n"
+  inspect(first_check_error(src), content = "")
+}
+
+test "#2442: a builtin passed directly as an argument checks" {
+  let src = "fn ap(f: (String, String) -> String, a: String, b: String) -> String {\n  f(a, b)\n}\nfn main() -> Unit {\n  let _ = ap(String::concat, \"x\", \"y\")\n  ()\n}\n"
+  inspect(first_check_error(src), content = "")
+}
+
+test "#1733: the two FrozenArray conversions keep their value form" {
+  inspect(first_check_error(value_ident_program("FrozenArray::from_array")), content = "")
+  inspect(first_check_error(value_ident_program("FrozenArray::to_array")), content = "")
+  inspect(first_check_error_unlocated(value_ident_program("FrozenArray::from_array")), content = "")
+}
+
+test "#1733: an annotated alias of a FrozenArray conversion still checks" {
+  let src = "fn main() -> Unit {\n  let freeze: (Array[Int]) -> FrozenArray[Int] = FrozenArray::from_array\n  let _ = freeze([1, 2])\n  ()\n}\n"
+  inspect(first_check_error(src), content = "")
+}
+
+//# Unchanged
 
 test "#2274: None as a value is still a constructor" {
   inspect(first_check_error(value_ident_program("None")), content = "")
@@ -196,11 +294,6 @@ test "#2433: String::length as a CALL is untouched" {
   inspect(first_check_error(src), content = "")
 }
 
-test "#2433: the wrap form the diagnostic recommends type-checks" {
-  let src = "fn main() -> Unit {\n  let f = (a, b) -> eq(a, b)\n  ()\n}\n"
-  inspect(first_check_error(src), content = "")
-}
-
 test "#2433: a nullary constructor of a USER enum is still a value" {
   // The type test keeps every non-function builtin, which is what #2274's
   // bare-name exemption was really protecting.
@@ -210,20 +303,5 @@ test "#2433: a nullary constructor of a USER enum is still a value" {
 
 test "#2433: a user function is still a first-class value" {
   let src = "fn my_eq(a: Int, b: Int) -> Bool { a == b }\nfn main() -> Unit {\n  let f = my_eq\n  ()\n}\n"
-  inspect(first_check_error(src), content = "")
-}
-
-test "#1733: the two FrozenArray conversions keep their value form" {
-  // Measured on stage2 BEFORE #2433, to make sure the exemption is not
-  // cargo-culted: `let f = String::concat; f("a", "b")` trapped with `table
-  // index is out of bounds`, while the same shape over
-  // `FrozenArray::from_array` / `FrozenArray::to_array` ran and answered.
-  inspect(first_check_error(value_ident_program("FrozenArray::from_array")), content = "")
-  inspect(first_check_error(value_ident_program("FrozenArray::to_array")), content = "")
-  inspect(first_check_error_unlocated(value_ident_program("FrozenArray::from_array")), content = "")
-}
-
-test "#1733: an annotated alias of a FrozenArray conversion still checks" {
-  let src = "fn main() -> Unit {\n  let freeze: (Array[Int]) -> FrozenArray[Int] = FrozenArray::from_array\n  let _ = freeze([1, 2])\n  ()\n}\n"
   inspect(first_check_error(src), content = "")
 }

--- a/lib/@vibe/compiler/tests/builtin_ident_value_test.vibe
+++ b/lib/@vibe/compiler/tests/builtin_ident_value_test.vibe
@@ -31,6 +31,16 @@
 //     indirect call, and until that exists `let f = Fs::read_file` launders
 //     authority (ADR-0075/0084/0088);
 //   * a name with NO registry row (`Map::set`) -- there is no arity to expand;
+//   * a POLYMORPHIC row (`Array::get`, `Array::length`) -- the registry spells
+//     an open position as `reg_any()`, and every occurrence is independent, so
+//     a value form hands out a signature that does not relate the argument to
+//     the result. Measured: `let get = Array::get` then
+//     `let s: String = get([1], 0)` checked CLEAN and printed garbage, while
+//     `Array::get([1], 0)` in the same position was correctly rejected. The
+//     two #1733 conversions are the one carve-out -- polymorphic, but shipped
+//     with a value form since then and pinned by an ANNOTATED binding in
+//     `fixtures/frozen_array_copies_test.vibe`, which is sound; their
+//     unannotated hole predates this and is measured on `aeccc0c97` too;
 //   * a BARE name (`eq`, `not`) -- a compiler limitation, not a decision about
 //     the language, and the one row of #2442 left open. `count_lambda_sites_expr`
 //     predicts for the whole program how many lambda table slots the codegen
@@ -90,8 +100,13 @@ test "#2442: the value form is decided by arity and effect, not by a name list" 
   // Pure registry rows report the parameter count the eta-expansion emits.
   inspect(builtin_value_form_arity("String::length"), "1")
   inspect(builtin_value_form_arity("String::concat"), "2")
-  inspect(builtin_value_form_arity("Array::length"), "1")
-  inspect(builtin_value_form_arity("Map::get"), "2")
+  inspect(builtin_value_form_arity("String::substring"), "3")
+  // A POLYMORPHIC row is refused: the registry writes an open position as
+  // `reg_any()` and every occurrence is independent, so a value form cannot
+  // say the element in the parameter and the result are the same type.
+  inspect(builtin_value_form_arity("Array::length"), "-1")
+  inspect(builtin_value_form_arity("Array::get"), "-1")
+  inspect(builtin_value_form_arity("Map::get"), "-1")
   // Bare names are pure two-argument rows and are still refused, for the
   // planner reason above rather than anything about the builtins themselves.
   inspect(builtin_value_form_arity("eq"), "-1")
@@ -208,30 +223,52 @@ test "#2442: `not` is refused the same way" {
   assert(String::contains(msg, "unqualified"))
 }
 
+let no_user_fns: Array[String] = []
+
 test "#2442: the planner reserves a slot for exactly the names with a value form" {
   // `count_lambda_sites_expr` is the whole-program prediction the codegen walk
   // is checked against, per function body, and the walk THROWS when the two
   // disagree. It used to carry its own copy of #1733's two names -- the third
   // copy of that list -- so it now reads the same predicate the checker and
   // both backends do.
-  inspect(count_lambda_sites_expr(EIdent("String::concat", -1)), "1")
-  inspect(count_lambda_sites_expr(EIdent("FrozenArray::from_array", -1)), "1")
+  inspect(count_lambda_sites_expr(EIdent("String::concat", -1), no_user_fns), "1")
+  inspect(count_lambda_sites_expr(EIdent("FrozenArray::from_array", -1), no_user_fns), "1")
   // No value form, so no slot: an effectful builtin, a name with no registry
   // row, an ordinary name, and a bare builtin.
-  inspect(count_lambda_sites_expr(EIdent("Fs::read_file", -1)), "0")
-  inspect(count_lambda_sites_expr(EIdent("Map::set", -1)), "0")
-  inspect(count_lambda_sites_expr(EIdent("some_local", -1)), "0")
-  inspect(count_lambda_sites_expr(EIdent("eq", -1)), "0")
+  inspect(count_lambda_sites_expr(EIdent("Fs::read_file", -1), no_user_fns), "0")
+  inspect(count_lambda_sites_expr(EIdent("Map::set", -1), no_user_fns), "0")
+  inspect(count_lambda_sites_expr(EIdent("some_local", -1), no_user_fns), "0")
+  inspect(count_lambda_sites_expr(EIdent("eq", -1), no_user_fns), "0")
   // A DIRECT call stays direct: only a value-position identifier becomes the
   // synthetic lambda, so the callee must not be counted.
   inspect(count_lambda_sites_expr(ECall(EIdent("String::concat", -1), [
     EIdent("a", -1),
     EIdent("b", -1)
-  ], -1)), "0")
+  ], -1), no_user_fns), "0")
+  // #2448: a USER function that declares the name owns it, so no slot is
+  // reserved -- codegen emits that function's table slot instead. This is the
+  // one piece of scope the walk is given, and the set is the same one codegen
+  // tests through the func table.
+  inspect(count_lambda_sites_expr(EIdent("String::concat", -1), [
+    "String::concat"
+  ]), "0")
 }
 
-test "#2442: a generic pure builtin -- Array::length" {
-  inspect(first_check_error(value_ident_program("Array::length")), content = "")
+test "#2442: a polymorphic builtin is refused, and says why" {
+  // Codex review on #2448. The refusal is the fail-closed direction: measured
+  // before it, `let get = Array::get; let s: String = get([1], 0)` compiled
+  // and printed garbage while `Array::get([1], 0)` in the same position was
+  // rejected with `expected String, got Int`.
+  let msg = first_check_error(value_ident_program("Array::get"))
+  assert(String::contains(msg, "Array::get"))
+  assert(String::contains(msg, "not a value"))
+  assert(String::contains(msg, "positions the registry leaves open"))
+  let msg2 = first_check_error(value_ident_program("Array::length"))
+  assert(String::contains(msg2, "not a value"))
+}
+
+test "#2442: a builtin with a CONCRETE signature is a value -- String::substring" {
+  inspect(first_check_error(value_ident_program("String::substring")), content = "")
 }
 
 test "#2442: the binding is typed as a function, so it can be called" {

--- a/lib/@vibe/compiler/tests/checker_program_result_test.vibe
+++ b/lib/@vibe/compiler/tests/checker_program_result_test.vibe
@@ -211,21 +211,32 @@ test "typed occurrences preserve identifier rows across env builtin and qualifie
   assert_typed_occurrences(check_expr_occurrences(EIdent("x", 10), env_bind(EnvEmpty, "x", CtInt), array_empty()), [
     (10, CtInt)
   ])
-  // #2433: the env-builtin branch now REPORTS in value position instead of
-  // recording an occurrence. This assertion used to read `(20, CtFn([CtString,
-  // CtString], CtString, None))` -- the registry signature is unchanged, but no
-  // program could use it that way: measured on stage2, `let f = String::concat;
-  // f("a", "b")` compiled and then trapped with `table index is out of bounds`,
-  // because a builtin's function index is below `func_offset` and the indirect
-  // table holds user functions and lambdas only. The branch is still exercised
-  // here, by what it does now.
+  // The env-builtin branch has BOTH answers, and which one a name gets is the
+  // subject of #2433 and #2442, so both are asserted here.
+  //
+  // #2433: a builtin with no value form REPORTS instead of recording an
+  // occurrence, because no program could use it as a value -- measured on
+  // stage2, `let f = String::concat; f("a", "b")` compiled and then trapped
+  // with `table index is out of bounds`, since a builtin's function index is
+  // below `func_offset` and the indirect table holds user functions and
+  // lambdas only. An EFFECTFUL builtin is the permanent member of that set.
   let berrors = array_empty()
   let btytab = array_empty()
-  let _ = check_expr(EIdent("String::concat", 20), EnvEmpty, array_empty(), SubstEmpty, 0, berrors, btytab)
+  let _ = check_expr(EIdent("Fs::read_file", 20), EnvEmpty, array_empty(), SubstEmpty, 0, berrors, btytab)
   assert(Array::length(berrors) == 1)
-  assert(String::contains(Array::get(berrors, 0), "String::concat"))
+  assert(String::contains(Array::get(berrors, 0), "Fs::read_file"))
   assert(String::contains(Array::get(berrors, 0), "not a value"))
   assert(Array::length(btytab) == 0)
+  // #2442: a QUALIFIED pure builtin does have a value form -- both lanes
+  // eta-expand it -- so the same branch records the registry signature as an
+  // occurrence. `String::concat` was this case's rejection subject until then.
+  let verrors = array_empty()
+  let vtytab = array_empty()
+  let _ = check_expr(EIdent("String::concat", 22), EnvEmpty, array_empty(), SubstEmpty, 0, verrors, vtytab)
+  assert(Array::length(verrors) == 0)
+  assert_typed_occurrences(vtytab, [
+    (22, CtFn([CtString, CtString], CtString, None))
+  ])
   let checked = check_program_result([
     SEnum(false, "Choice", array_empty(), [("Pick", array_empty())], array_empty()),
     SLet(false, false, "picked", None, EIdent("Choice::Pick", 30))

--- a/lib/@vibe/compiler/tests/checker_test.vibe
+++ b/lib/@vibe/compiler/tests/checker_test.vibe
@@ -58,33 +58,45 @@ test "ident from env" {
   assert(types_equal(check(EIdent("x", -1), env), CtInt))
 }
 
-test "ident builtin" {
-  // #2433: a builtin ident in VALUE position is rejected. It used to type as
-  // `CtFn` and then break in codegen -- measured on stage2, `let f =
-  // String::concat` compiled and trapped with `table index is out of bounds`,
-  // because a builtin's function index is below `func_offset` and the indirect
-  // table holds user functions and lambdas only. The signature is still what
-  // the registry says; it is only unavailable as a value, and the diagnostic
-  // names the call form and the wrap form.
+test "ident builtin without a value form" {
+  // #2433 rejected a builtin ident in VALUE position; #2442 made the rejection
+  // a property instead of a blanket rule, so this case has to be a builtin
+  // that still has none. An EFFECTFUL one is the permanent member of that set:
+  // as a value its row would have to be carried by the binding's function type
+  // and demanded again at the indirect call, and until that exists
+  // `let f = Fs::read_file` launders authority (ADR-0075/0084/0088). The
+  // signature is still what the registry says; it is only unavailable as a
+  // value, and the diagnostic names the call form and the wrap form.
+  //
+  // `String::concat` used to be this case's subject and is now a value, which
+  // is exactly what #2442 changed.
   let caught = handle {
-    let _ = check(EIdent("String::concat", -1), EnvEmpty)
+    let _ = check(EIdent("Fs::read_file", -1), EnvEmpty)
     ""
   } with { Exception::Throw(msg) => msg }
-  assert(String::contains(caught, "String::concat"))
+  assert(String::contains(caught, "Fs::read_file"))
   assert(String::contains(caught, "not a value"))
 }
 
 test "ident builtin with a value form" {
-  // #1733 gave these two a real value form: both codegen lanes materialize
-  // them as a one-argument lambda, which is an ordinary closure with an
-  // ordinary table slot. `fixtures/frozen_array_copies_test.vibe` calls both
-  // through a binding and passes, so the checker must keep admitting them.
+  // #1733 gave the two FrozenArray conversions a real value form and #2442
+  // generalized it: both codegen lanes materialize any QUALIFIED pure builtin
+  // as an eta-expanded lambda, which is an ordinary closure with an ordinary
+  // table slot. `fixtures/frozen_array_copies_test.vibe` and
+  // `fixtures/builtin_value_form_test.vibe` call them through a binding and
+  // pass, so the checker must keep admitting them.
   let ty = check(EIdent("FrozenArray::from_array", -1), EnvEmpty)
   let is_fn = match ty {
     CtFn(_, _, _) => true,
     _ => false
   }
   assert(is_fn)
+  let ty2 = check(EIdent("String::concat", -1), EnvEmpty)
+  let is_fn2 = match ty2 {
+    CtFn(_, _, _) => true,
+    _ => false
+  }
+  assert(is_fn2)
 }
 
 test "ident unknown" {

--- a/tests/gates/early/run.sh
+++ b/tests/gates/early/run.sh
@@ -2056,6 +2056,16 @@ run_test_block_fixtures_gc "gc-lane scalar parity (gc)" fixtures/gc_lane_scalar_
 run_test_block_fixtures_rc "gc-lane scalar parity (linear, RC)" fixtures/gc_lane_scalar_parity_test.vibe
 echo '[compiler-gate] gc-lane scalar parity ok'
 
+# 15b-3b. #2442: a pure builtin bound to a name and called through the binding
+#         must answer exactly as the direct call does. The lowering is an
+#         eta-expanded lambda emitted independently by each backend, so the
+#         three lanes are three separate implementations of the same contract.
+echo '[compiler-gate] 15b-3b/15 builtin value form (#2442)'
+run_test_block_fixtures "builtin value form (linear, bump)" fixtures/builtin_value_form_test.vibe
+run_test_block_fixtures_gc "builtin value form (gc)" fixtures/builtin_value_form_test.vibe
+run_test_block_fixtures_rc "builtin value form (linear, RC)" fixtures/builtin_value_form_test.vibe
+echo '[compiler-gate] builtin value form ok'
+
 # 15b-4. A Double inside an aggregate reached through a NAME (#2431). Three
 #        lanes for the same reason as 15b-3, and here every lane was wrong in a
 #        DIFFERENT place: `let x = (0.0, 1); let y = (-0.0, 1); x == y` was


### PR DESCRIPTION
Three issues, two of them landed here and the third measured and rescoped rather than half-built.

## #2424 — a Double-typed render argument (tag 4)

The last row #2445 left, other than the erased type variable. Measured before this change, on the stage2 that closed the Int half:

| render argument | linear (RC) | wasm-gc |
| :--- | :--- | :--- |
| a Double-typed **struct field** (`b.ratio`) | prints `256` | traps |
| a Double tuple element (`t.0`) | `1.5` | `1.5` |
| a plain `let` Double | `1.5` | `1.5` |
| a Double call result | `1.5` | `1.5` |

The cause is structural, not a missing arm: `float_call_offsets` (#2158) is keyed by CALL offsets only, so a projection has no key in it at all — exactly as `ts_known_int` had none before #2445 gave the Int channel tag 3. So this is the symmetric fix: the render/`eq` ARGUMENT offsets the checker typed `Double`, produced by the same walk and the same fail-closed agreement rule as tag 3 (`irc_render_arg_offsets`, now shared by both).

Tag 4 does not fit in two bits, so `typed_lowering_enc` widens to `offset * 8 + tag` and the per-file rebase to `base * 8`. Nothing has to be migrated: the persistent artifact key embeds `codegen_fingerprint()`, a hash of every compiler source, so a sidecar written under the old encoding cannot be read back under the new one.

Two things this needed that are silent when got wrong, so they are worth naming:

- **`unique_call_offsets_in_stmts` counted `ECall` nodes only**, so a projection row scored 0 and was dropped — the channel would have been wired up and inert. It now counts by the key the consumer reads (`ECall` by its own offset, `EDot` by its field-name offset) and is renamed `unique_typed_lowering_offsets_in_stmts`. `EIdent` is deliberately not counted: a call's offset **is** its callee ident's offset, so counting both would score 2 and drop every call-result row.
- **That same aliasing means the Double table cannot be read with `typed_lowering_arg_offset`.** For `f()` returning a Double the array holds the offset `EIdent("f")` also answers with, so a classifier asked about the function *value* would lower it through f64. `typed_lowering_float_key` is the restricted key — call or projection, `-1` for a bare name — and the producer collects under it, so producer and consumer cannot drift. The Int channel does not need it: its all-occurrences-agree rule already drops such an offset.

Pinned by `fixtures/gc_lane_scalar_parity_test.vibe` on linear/bump, linear/RC and wasm-gc — red on a stage2 built from the parent commit on all three, green after.

## #2442 — any QUALIFIED pure builtin may be used in value position

`builtin_ident_has_value_form`'s two-name list (`FrozenArray::from_array` / `to_array`, #1733) becomes `builtin_value_form_arity`: the arity of a registry row whose effect row is empty, or `-1`. Both backends eta-expand to exactly that arity, so the decision and the lowering read one number.

Two refusals remain, and the diagnostic now says which:

- an **effectful** builtin, decided from the type the checker itself inferred. As a value its row would have to be carried by the binding's function type and demanded again at the indirect call; until that exists `let f = Fs::read_file` launders authority (ADR-0075/0084/0088).
- a **bare** name. This one is a compiler limitation and it is the row left open on the issue. `count_lambda_sites_expr` predicts, per function body, how many lambda table slots the codegen walk will allocate, and the walk *throws* on a disagreement; it is scope-free by construction, so it decides from the name alone, while codegen decides after the locals have failed. A qualified name cannot be bound by `let`, a parameter, a pattern or a constructor, so the two agree — admitting `eq` would make an ordinary `let eq = (a, b) -> ...` reserve a slot for a use codegen resolves to the local, and a program that compiles today would fail with `lambda plan over-count`. Closing it means teaching that walk scope, which its own comment says it deliberately does not have.

That planner was the **third** copy of #1733's two names and now reads the shared predicate.

One measured wrong turn worth recording: I first placed the value-form check *below* the func table, reasoning that it matched the checker's own resolution order (locals, then globals, then builtins) and kept a registry scan off the path of every global reference. `let cat = String::concat` then compiled to zero lambdas and the module was rejected with `lambda plan over-count: planned through 1, walk stopped at 0` — `ctx.func_table` holds the builtin bodies too, so a builtin name resolves there and emits a negative table slot. The check has to sit above it, which is where #1733 put it.

Pinned by `fixtures/builtin_value_form_test.vibe` on all three lanes (red on the parent commit's stage2 with the check-time rejection, green after) and by `lib/@vibe/compiler/tests/builtin_ident_value_test.vibe` for the property, both refusals and the planner's count.

## #2437 — measured, rescoped, no code

My own earlier comment on that issue proposed "a source map out of `print_program`" as the fix that costs nothing. Reading the lane end to end says that is wrong, and in a way that changes what the next PR should do: **the module lane's text is printed twice**, and the first reprint is from an AST that has already been renamed and namespaced, with the parse before it unlocated. A source map would have to survive two printers and those transforms, and there is nothing to map *from*.

The route that does work is the other one, and the machinery already exists: `merged_stmts_and_offsets` returns rebased merged statements plus both tables, at no additional check. But putting the module lane on it changes the in-db artifact key (today content-derived from the reprint, and `compiler_cache_advanced_test.vibe` pins the consequence), rewrites four cache-counter tests that are this lane's only behavioural coverage, and changes the output bytes on purpose. Nothing in CI takes that lane, so none of that is visible from a green gate — which is exactly how the redundant-check regression got into #2445. It is its own PR.

The full analysis, plus a wider row found while measuring (the **inline-source** family parses unlocated and has *all four* channels empty, including two entries on the linked lane), is posted on the issue.

## Also

`Map::set` is functional — it returns a new map. Found while writing #2442's fixture, where I used the statement form and it silently updated nothing; measured identically on this branch, on `aeccc0c97` and on the committed seed. The cheatsheet listed `set` beside `get` / `has_key` / `keys` as builtins that "all lower correctly" and showed `Map::new()` next to the `Map::*` API, which reads as a mutable container. Both places now say it and the example binds the result. Nothing warns about the discarded result of a pure builtin, which is what makes it silent.

Two checker tests used `String::concat` as their rejected case and are retargeted at `Fs::read_file`, with `String::concat` moved to the other side of each — it now asserts the branch's second answer (a `CtFn` type, and a typed occurrence at its offset), which was previously unexercised.

## Verification

- Early compiler gate **39/39**, 0 failures, on stage2 built from this branch.
- Full unit suite on the same stage2 — the two regressions it found are the retargeted checker tests above, fixed in the third commit.
- `check_vibe_fmt.sh`: 1063 files, 0 known debt, 0 new violations.
- `doctest_extract_run.sh docs/cheatsheet.md`: 40 pass, 0 fail.
- `pkf run pre-commit` on each commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FYMVd6D2o82suTfTwoJPMf

---
_Generated by [Claude Code](https://claude.ai/code/session_01FYMVd6D2o82suTfTwoJPMf)_