### PR TITLE
Give the inline-source merge an offset space (#2449), and the registry real type variables (#2451)

### DIFF
--- a/docs/cheatsheet.md
+++ b/docs/cheatsheet.md
@@ -2416,14 +2416,14 @@ let bad: String = g([1], 0)          // expected String, got Int
 ```
 
 A builtin has a value form exactly when it is **qualified**, the registry knows
-its **arity**, its signature has no **opaque handle** position, and its **effect
-row is empty**. The three refusals each say why, and they are not the same kind
+its **arity**, every position in its signature is either concrete or a real
+type variable, and its **effect row is empty**. The three refusals each say why, and they are not the same kind
 of thing:
 
 | refused | why | what to write instead |
 |---|---|---|
 | `Fs::read_file`, `Env::get` | an effect row is only checked where the call is written, so a value form would launder authority | `(p) -> Fs::read_file(p)` — the wrap form is the answer, not a workaround |
-| `Map::get`, `ArrayBuilder::push` | an internal handle has no checker type, so the value form could not say what it takes or returns | call it directly |
+| `Map::get`, `FixedArray::get` | a position is still an unconstrained unknown — an internal handle, or an element type nothing relates to the result | call it directly |
 | `eq`, `not` (bare names) | the whole-program lambda-site planner is scope-free and cannot tell the builtin from a local of the same name | `(a, b) -> eq(a, b)`, or qualify it |
 
 Being polymorphic is **not** a refusal: `Array::get` is `(Array[T], Int) -> T`

--- a/docs/cheatsheet.md
+++ b/docs/cheatsheet.md
@@ -2397,6 +2397,47 @@ defining it — a bodyless declaration on the export surface, the shape
 `String::utf8_length` uses — so `import @vibe/builtin { String::split }`
 resolves without anything shadowing the builtin.
 
+### A builtin can be a value, and the rule is one property
+
+`String::concat` / `Array::get` / `FrozenArray::from_array` can be bound to a
+name and called through it. The lowering is an eta-expansion (`(a, b) -> f(a, b)`),
+so the binding is an ordinary closure and answers exactly as the direct call does.
+
+```vibe skip
+// -- accepted
+let get = Array::get
+let n: Int = get([1, 2], 0)          // 1
+let cat = String::concat
+let s = cat("ab", "cd")              // "abcd"
+
+// -- rejected, with the SAME message the direct call gives
+let g = Array::get
+let bad: String = g([1], 0)          // expected String, got Int
+```
+
+A builtin has a value form exactly when it is **qualified**, the registry knows
+its **arity**, its signature has no **opaque handle** position, and its **effect
+row is empty**. The three refusals each say why, and they are not the same kind
+of thing:
+
+| refused | why | what to write instead |
+|---|---|---|
+| `Fs::read_file`, `Env::get` | an effect row is only checked where the call is written, so a value form would launder authority | `(p) -> Fs::read_file(p)` — the wrap form is the answer, not a workaround |
+| `Map::get`, `ArrayBuilder::push` | an internal handle has no checker type, so the value form could not say what it takes or returns | call it directly |
+| `eq`, `not` (bare names) | the whole-program lambda-site planner is scope-free and cannot tell the builtin from a local of the same name | `(a, b) -> eq(a, b)`, or qualify it |
+
+Being polymorphic is **not** a refusal: `Array::get` is `(Array[T], Int) -> T`
+in the registry and each use instantiates its own `T` (#2451). Before that it
+was refused as a class, and #1733's two `FrozenArray` conversions were carved
+out of the refusal by name — with the hole that made the carve-out visible:
+`let freeze = FrozenArray::from_array` then
+`let fz: FrozenArray[String] = freeze([1, 2])` checked clean and read the Ints
+as Strings. That is now rejected.
+
+Pinned by `fixtures/builtin_value_form_test.vibe` (the runtime answers, all
+three lanes) and `lib/@vibe/compiler/tests/builtin_ident_value_test.vibe` (the
+admission rule and every diagnostic quoted above).
+
 ### A `handle` that type-checks can still fail to compile
 
 Eligibility is not part of the type system, so this failure is invisible to

--- a/fixtures/builtin_value_form_test.vibe
+++ b/fixtures/builtin_value_form_test.vibe
@@ -15,8 +15,9 @@
 //   * QUALIFIED, because the whole-program lambda-site planner is scope-free
 //     and cannot tell a use of the builtin `eq` from a use of a local named
 //     `eq`, and the walk THROWS on a disagreement;
-//   * a row with an OPAQUE HANDLE position (`Map::get`'s map), because
-//     `reg_opaque` has no checker type at all, so nothing could relate what
+//   * a row with a position still spelled as an unconstrained unknown -- an
+//     internal handle (`Map::get`'s map) or a relationship nobody has written
+//     as a variable yet (`FixedArray::*`) -- because nothing could relate what
 //     the value form takes to what it returns.
 //
 // #2451 removed the third restriction, which used to read "CONCRETE". A row

--- a/fixtures/builtin_value_form_test.vibe
+++ b/fixtures/builtin_value_form_test.vibe
@@ -15,11 +15,16 @@
 //   * QUALIFIED, because the whole-program lambda-site planner is scope-free
 //     and cannot tell a use of the builtin `eq` from a use of a local named
 //     `eq`, and the walk THROWS on a disagreement;
-//   * CONCRETE, because the registry writes a polymorphic position as "any
-//     type" with every occurrence independent -- a value form would hand out a
-//     signature that does not relate the argument to the result, and
-//     `let get = Array::get; let s: String = get([1], 0)` checked clean and
-//     printed garbage while the direct call was correctly rejected.
+//   * a row with an OPAQUE HANDLE position (`Map::get`'s map), because
+//     `reg_opaque` has no checker type at all, so nothing could relate what
+//     the value form takes to what it returns.
+//
+// #2451 removed the third restriction, which used to read "CONCRETE". A row
+// whose openness is a real type VARIABLE (`reg_var`: `Array::get` is
+// `(Array[T], Int) -> T`) relates its positions, and the checker instantiates
+// the row per occurrence, so those builtins have value forms too. Measured
+// before that: `let get = Array::get; let s: String = get([1], 0)` checked
+// clean and printed garbage while the direct call was correctly rejected.
 //
 // The lowering is an ETA-EXPANSION, not a function pointer to the builtin: a
 // builtin's index is below `func_offset` and its body has no closure-env
@@ -86,4 +91,33 @@ test "#1733 the two FrozenArray conversions keep answering" {
   let fz = freeze([1, 2, 3])
   inspect(FrozenArray::length(fz), "3")
   inspect(Array::length(thaw(fz)), "3")
+}
+
+test "#2451 a polymorphic builtin answers through a binding" {
+  // The eta-expansion is the same shape as a concrete builtin's, so the point
+  // here is that the runtime answer is the direct call's. The check-time half
+  // -- that a WRONG element type through the binding is now rejected with the
+  // direct call's own message -- is in the unit test beside this file, since a
+  // rejected program cannot be a runtime fixture.
+  let get = Array::get
+  let len = Array::length
+  let push = Array::push
+  let xs: Array[Int] = [10, 20, 30]
+  inspect(get(xs, 1), "20")
+  inspect(Array::get(xs, 1), "20")
+  inspect(len(xs), "3")
+  let _ = push(xs, 40)
+  inspect(len(xs), "4")
+  inspect(get(xs, 3), "40")
+}
+
+test "#2451 a polymorphic builtin value form over Strings" {
+  // The SAME binding shape at a different element type. Each occurrence
+  // instantiates the row's variable on its own, so this cannot be answering by
+  // accident of the Int case above.
+  let get = Array::get
+  let ss: Array[String] = ["a", "b"]
+  inspect(get(ss, 0), "a")
+  let slice = Array::slice
+  inspect(Array::length(slice(ss, 0, 1)), "1")
 }

--- a/lib/@vibe/compiler/checker/checker.vibe
+++ b/lib/@vibe/compiler/checker/checker.vibe
@@ -38,6 +38,7 @@ import @vibe/compiler/core {
   refine_trait_bounds_from_receiver,
   registry_builtin_arity,
   registry_builtin_param_type,
+  registry_builtin_scheme,
   resolve_builtin,
   resolve_type_alias_params,
   resolve_type_constructor_args,
@@ -2293,6 +2294,35 @@ fn builtin_ident_is_value(name: String, t: Type) -> Bool {
   }
 }
 
+/// #2451: the TYPE a builtin value form binds -- the registry row instantiated
+/// with fresh variables for this occurrence, when the row has any.
+///
+/// `lookup_builtin` answers with the ERASED row (every open position back to
+/// `CtUnknown`), which is right for every other consumer and useless here: it
+/// says nothing about which positions are the same type, so a value form typed
+/// from it accepts anything. Measured before this: `let get = Array::get` then
+/// `let s: String = get([1], 0)` checked CLEAN and printed garbage, while the
+/// direct `Array::get([1], 0)` was correctly rejected with
+/// `expected String, got Int`.
+///
+/// Instantiating HERE and not generalizing the binding is deliberate: the
+/// binding is monomorphic, which is what an unannotated `let` gets for a user
+/// function too. It is enough for soundness -- the argument fixes the variable
+/// and the annotation is then checked against it -- and it keeps the value
+/// form from being MORE polymorphic than anything else a `let` can hold.
+///
+/// A row with no variables (`String::concat`) instantiates to itself, so this
+/// is a no-op for every concrete builtin.
+fn builtin_ident_value_type(name: String, erased: Type, c: Int) -> (Type, Int) {
+  match registry_builtin_scheme(canonical_builtin_name(name)) {
+    Some(scheme) => {
+      let (ty, c1, _bounds) = instantiate(scheme, c)
+      (ty, c1)
+    },
+    None => (erased, c)
+  }
+}
+
 fn call_only_builtin_param_list(n: Int) -> String {
   if n <= 0 {
     ""
@@ -2346,12 +2376,15 @@ fn builtin_value_form_refusal_reason(name: String, ty: Type) -> String {
       None => if !String::contains(canonical, "::") {
         " (an unqualified builtin name has no value form yet: a local of the same name would be indistinguishable to the lambda-site planner)"
       } else if registry_builtin_arity(canonical) >= 0 {
-        // Codex review on #2448. The registry writes a polymorphic position as
-        // `reg_any()`, and each occurrence is independent -- so a value form
-        // would hand out a signature that does not relate the argument to the
-        // result, and `let get = Array::get; let s: String = get([1], 0)`
-        // would check clean. The direct call keeps its refinements.
-        " (its signature has positions the registry leaves open, and a value form cannot say they are the same type)"
+        // #2451: a row whose openness is a real type VARIABLE says which
+        // positions are the same type (`reg_var`) and now HAS a value form, so
+        // what is left here is openness the registry cannot close: an
+        // `reg_opaque` handle (`Map::get`'s map, a builder object) has no
+        // checker type at all to relate anything to. Giving one a value form
+        // would hand out a signature that relates nothing, which is what
+        // `let get = Array::get; let s: String = get([1], 0)` used to check
+        // clean on before those rows gained variables.
+        " (its signature has a position with no checker type -- an internal handle -- so a value form could not say what it takes or returns)"
       } else {
         " (the compiler has no registry row for it, so it has no arity to expand)"
       }
@@ -7985,12 +8018,15 @@ fn check_expr_capture_impl(expr: Expr, env: TypeEnv, defs: Array[TypeDef], s: Su
           // still parses unlocated, so every user ident is -1. Call sites of
           // these names are typed by the ECall fallback, which looks up the
           // builtin without this rejection.
+          // #2451: bind the row's own variables, freshened for this
+          // occurrence, rather than the erased row's independent unknowns.
+          let (value_ty, value_c) = builtin_ident_value_type(railway_ident_lookup_name(name), t, c)
           if ident_off >= 0 {
-            tab_identifier_ty(tytab, ident_off, t, capture, lane)
+            tab_identifier_ty(tytab, ident_off, value_ty, capture, lane)
           } else {
             ()
           }
-          (t, s, c)
+          (value_ty, s, value_c)
         } else {
           Array::push(errors, call_only_builtin_ident_error(name, t, ident_off))
           (CtUnknown, s, c)

--- a/lib/@vibe/compiler/checker/checker.vibe
+++ b/lib/@vibe/compiler/checker/checker.vibe
@@ -2377,14 +2377,20 @@ fn builtin_value_form_refusal_reason(name: String, ty: Type) -> String {
         " (an unqualified builtin name has no value form yet: a local of the same name would be indistinguishable to the lambda-site planner)"
       } else if registry_builtin_arity(canonical) >= 0 {
         // #2451: a row whose openness is a real type VARIABLE says which
-        // positions are the same type (`reg_var`) and now HAS a value form, so
-        // what is left here is openness the registry cannot close: an
-        // `reg_opaque` handle (`Map::get`'s map, a builder object) has no
-        // checker type at all to relate anything to. Giving one a value form
-        // would hand out a signature that relates nothing, which is what
-        // `let get = Array::get; let s: String = get([1], 0)` used to check
-        // clean on before those rows gained variables.
-        " (its signature has a position with no checker type -- an internal handle -- so a value form could not say what it takes or returns)"
+        // positions are the same type and now HAS a value form, so what is
+        // left here is a position still spelled as an unconstrained unknown.
+        //
+        // The message must NOT say which KIND of unknown it is (Codex review
+        // on #2453). The registry distinguishes an internal handle
+        // (`reg_opaque`, `Map::get`'s map) from a merely-unwritten
+        // relationship (`reg_any`, the `FixedArray::*` rows) in its SOURCE
+        // only -- both produce `CtUnknown`, which is exactly what that file's
+        // own comment says is "documentation the type system cannot express".
+        // An earlier spelling here claimed "an internal handle" for every such
+        // row, which reported `FixedArray::get` as something it is not. A
+        // diagnostic that names a cause the compiler cannot actually observe
+        // is worse than one that names the class.
+        " (its signature has a position the compiler leaves open -- an internal handle, or an element type it does not yet relate to the result -- so a value form could not say what it takes or returns)"
       } else {
         " (the compiler has no registry row for it, so it has no arity to expand)"
       }

--- a/lib/@vibe/compiler/checker/checker_facade.vibe
+++ b/lib/@vibe/compiler/checker/checker_facade.vibe
@@ -55,6 +55,7 @@ export ./checker_stmt.vibe {
   check_program_with_env_result,
   check_program_with_env_statement_root_type_observation,
   check_program_with_env_type_defs_observation,
+  check_program_with_env_typed_lowering_located_observation,
   check_program_with_env_typed_occurrence_expression_path_observation,
   check_program_with_env_typed_occurrence_role_lane_observation,
   check_program_with_env_typed_occurrence_statement_observation,

--- a/lib/@vibe/compiler/checker/checker_stmt.vibe
+++ b/lib/@vibe/compiler/checker/checker_stmt.vibe
@@ -6407,8 +6407,22 @@ fn union_double_render_arg_offsets(checked: CheckedProgram, call_results: Array[
 /// program is identical to what check_program_result /
 /// check_program_with_projected_import_env_result produce today.
 export fn check_program_with_projected_import_env_typed_lowering_located_observation(stmts: Array[Stmt], initial_env: TypeEnv) -> (CheckedProgram, Option[Array[Int]], Array[Int], Array[String]) with Exception {
+  typed_lowering_located_observation_impl(stmts, initial_env, true)
+}
+
+/// #2449: the same observation for the lane whose import statements are NOT
+/// pre-projected -- the in-memory module walk in `runtime/ensure_fingerprint`,
+/// which reaches the checker through `check_program_with_env` and so must keep
+/// `imports_already_projected = false`. Everything after the check is shared
+/// with the projected entry above; only that flag differs, because a lane that
+/// changed it would be checking a different program in order to observe one.
+export fn check_program_with_env_typed_lowering_located_observation(stmts: Array[Stmt], initial_env: TypeEnv) -> (CheckedProgram, Option[Array[Int]], Array[Int], Array[String]) with Exception {
+  typed_lowering_located_observation_impl(stmts, initial_env, false)
+}
+
+fn typed_lowering_located_observation_impl(stmts: Array[Stmt], initial_env: TypeEnv, imports_already_projected: Bool) -> (CheckedProgram, Option[Array[Int]], Array[Int], Array[String]) with Exception {
   let capture = reset_double_call_capture()
-  let checked = check_program_with_env_type_defs_observation_impl(stmts, initial_env, None, Some(capture), true).checked_program
+  let checked = check_program_with_env_type_defs_observation_impl(stmts, initial_env, None, Some(capture), imports_already_projected).checked_program
   match double_call_result_offsets_from_capture(checked, capture) {
     None => (checked, None, array_empty(), array_empty()),
     Some((out, primary_calls, located_primary_calls)) => if primary_calls > 0 && located_primary_calls == 0 {

--- a/lib/@vibe/compiler/checker/index.vpkg
+++ b/lib/@vibe/compiler/checker/index.vpkg
@@ -277,6 +277,7 @@ fn validate_user_source_stmts(stmts: Array[Stmt]) -> Unit with Exception
 fn check_program_type_table(stmts: Array[Stmt]) -> (Array[(Int, Type)], Subst) with Exception
 fn check_program_with_env_result(stmts: Array[Stmt], initial_env: TypeEnv) -> CheckedProgram with Exception
 fn check_program_with_projected_import_env_result(stmts: Array[Stmt], initial_env: TypeEnv) -> CheckedProgram with Exception
+fn check_program_with_env_typed_lowering_located_observation(stmts: Array[Stmt], initial_env: TypeEnv) -> (CheckedProgram, Option[Array[Int]], Array[Int], Array[String]) with Exception
 fn check_program_with_projected_import_env_typed_lowering_located_observation(stmts: Array[Stmt], initial_env: TypeEnv) -> (CheckedProgram, Option[Array[Int]], Array[Int], Array[String]) with Exception
 fn typed_lowering_enc(offset: Int, tag: Int) -> Int
 fn typed_lowering_enc_offset(enc: Int) -> Int

--- a/lib/@vibe/compiler/core/builtin_name.vibe
+++ b/lib/@vibe/compiler/core/builtin_name.vibe
@@ -1,7 +1,7 @@
 //# Imports
 
 import ./builtin_registry.vibe {
-  registry_builtin_arity, registry_builtin_pure_arity
+  registry_builtin_pure_arity
 }
 
 //# Functions
@@ -98,24 +98,24 @@ export fn canonical_builtin_name(name: String) -> String {
 /// `collect_refs_into` in dce.vibe, which threads a bound set) -- that is the
 /// remaining half of #2442, and it is a real change to that walk rather than
 /// another name here.
-/// #1733's two conversions are an explicit LEGACY exception, and they are the
-/// one place this is a name list rather than a property. Their rows are
-/// polymorphic (`Array[?] -> FrozenArray[?]`), so the unknown test below would
-/// refuse them -- but they have shipped with a value form since #1733 and
-/// `fixtures/frozen_array_copies_test.vibe` binds one through an ANNOTATED
-/// `let`, which is a sound and useful spelling. Refusing them would take that
-/// away. Measured on `aeccc0c97` and on this branch, identically: the
+/// #2451: there is no name list left here. #1733's `FrozenArray::from_array` /
+/// `FrozenArray::to_array` used to be carved out by name, because their rows
+/// were polymorphic (`Array[?] -> FrozenArray[?]`) and the unknown test below
+/// refused every polymorphic row -- but they had shipped with a value form
+/// since #1733, so refusing them would have taken away a spelling users had.
+/// The carve-out was honest about the cost: with the row saying nothing about
+/// the relationship between the argument's element and the result's, the
 /// UNANNOTATED `let freeze = FrozenArray::from_array` then
-/// `let fz: FrozenArray[String] = freeze([1, 2])` checks clean and reads the
-/// Ints as Strings. That hole predates this function; it is not widened here,
-/// and closing it means giving the registry a way to say two positions are the
-/// same type.
+/// `let fz: FrozenArray[String] = freeze([1, 2])` checked CLEAN and read the
+/// Ints as Strings.
+///
+/// Those rows now say it (`reg_var`, core/builtin_registry.vibe), so they
+/// mention no unknown and reach the same property every other row does. The
+/// annotated spelling still compiles; the unannotated one is now rejected.
 export fn builtin_value_form_arity(name: String) -> Int {
   let n = canonical_builtin_name(name)
   if !String::contains(n, "::") {
     0 - 1
-  } else if n == "FrozenArray::from_array" || n == "FrozenArray::to_array" {
-    registry_builtin_arity(n)
   } else {
     registry_builtin_pure_arity(n)
   }

--- a/lib/@vibe/compiler/core/builtin_registry.vibe
+++ b/lib/@vibe/compiler/core/builtin_registry.vibe
@@ -1,7 +1,7 @@
 //# Imports
 
 import ./types.vibe {
-  Type, type_has_unknown
+  Type, collect_type_var_ids, type_erase_vars, type_has_unknown
 }
 
 // Standard host-provider and entry-execution policy is a sibling in this
@@ -53,9 +53,14 @@ import @vibe/core {
 // constructor, so a reader can tell a deliberately-unchecked position from a
 // placeholder someone forgot to fill in:
 //
-//   - reg_any()     — deliberately POLYMORPHIC: any value type is legal at this
-//                     position and the checker's head-kind compare tolerates it
-//                     (`eq` / `assert_eq`, container element types).
+//   - reg_any()     — deliberately UNRELATED: any value type is legal at this
+//                     position and nothing ties it to any other position, so
+//                     the checker's head-kind compare tolerates it (`eq` /
+//                     `assert_eq`, `__to_string`).
+//   - reg_var(n)    — a real type VARIABLE scoped to the row: two positions
+//                     written `reg_var(0)` are the SAME type (`Array::get` is
+//                     `(Array[T], Int) -> T`). This is the one a first-class
+//                     value form can be typed from; see `reg_var` below.
 //   - reg_opaque(k) — an internal HANDLE with no checker-type representation
 //                     (builder objects, Map). `k` names the handle kind for the
 //                     reader; the value is ignored.
@@ -65,11 +70,39 @@ import @vibe/core {
 //                     row nobody had thought about from a row deliberately
 //                     left open.
 //
-// All three produce the same runtime value (CtUnknown) — this is documentation
-// the type system cannot express, enforced by review + the golden positive
-// corpus (builtin_registry_golden_test.vibe), not by the checker.
+// `reg_any()` and `reg_opaque(k)` produce the same runtime value (CtUnknown) —
+// that distinction is documentation the type system cannot express, enforced
+// by review + the golden positive corpus (builtin_registry_golden_test.vibe),
+// not by the checker. `reg_var(n)` is different in kind: it is a real `CtVar`,
+// and the checker reads it.
 fn reg_any() -> Type {
   CtUnknown
+}
+
+/// #2451: an open position that is a real type VARIABLE, scoped to its row.
+/// Two positions written `reg_var(0)` are the SAME type; `reg_any()` twice is
+/// two independent unknowns.
+///
+/// This is what a first-class value form needs and `reg_any()` cannot give it.
+/// Measured before this existed: `let get = Array::get` then
+/// `let s: String = get([1], 0)` checked CLEAN and printed garbage, while the
+/// direct `Array::get([1], 0)` in the same position was correctly rejected
+/// with `expected String, got Int`. The relationship was simply not in the
+/// row, so the value form had nothing to lose it from.
+///
+/// Ids are row-local and start at 0. `registry_builtin_scheme` closes a row
+/// that mentions them into a `CtForAll`, and `instantiate` freshens the ids
+/// per use site -- including past the importing module's own counter (#743),
+/// which is why a row may use 0 and 1 without colliding with inference.
+///
+/// Every OTHER consumer of a registry row reads the erased view
+/// (`builtin_registry_typed`, where `type_erase_vars` turns each variable back
+/// into `CtUnknown`), so adding variables to a row cannot change what the
+/// direct-call fast path, the effect walk, the contract checker or the codegen
+/// lookups see. That separation is deliberate: unifying a raw `CtVar(0)` from
+/// a row against a module's own inference would bind ITS variable 0.
+fn reg_var(id: Int) -> Type {
+  CtVar(id)
 }
 
 fn reg_opaque(kind: String) -> Type {
@@ -313,12 +346,12 @@ let registry_typed_rows: Array[(String, Type, Bool, Bool, Bool)] = [
   ("String::length", CtFn(reg_p1(CtString), CtInt, None), true, true, true),
   ("String::equals", CtFn(reg_p2(CtString, CtString), CtBool, None), true, true, true),
   ("String::concat", CtFn(reg_p2(CtString, CtString), CtString, None), true, true, true),
-  ("array_new", CtFn(reg_p0(), CtArray(reg_any()), None), true, true, true),
-  ("Array::length", CtFn(reg_p1(CtArray(reg_any())), CtInt, None), true, true, true),
-  ("Array::get", CtFn(reg_p2(CtArray(reg_any()), CtInt), reg_any(), None), true, true, true),
-  ("Array::push", CtFn(reg_p2(CtArray(reg_any()), reg_any()), CtUnit, None), true, true, true),
-  ("Array::push_all", CtFn(reg_p2(CtArray(reg_any()), CtArray(reg_any())), CtUnit, None), true, true, true),
-  ("Array::set", CtFn(reg_p3(CtArray(reg_any()), CtInt, reg_any()), CtUnit, None), true, true, true),
+  ("array_new", CtFn(reg_p0(), CtArray(reg_var(0)), None), true, true, true),
+  ("Array::length", CtFn(reg_p1(CtArray(reg_var(0))), CtInt, None), true, true, true),
+  ("Array::get", CtFn(reg_p2(CtArray(reg_var(0)), CtInt), reg_var(0), None), true, true, true),
+  ("Array::push", CtFn(reg_p2(CtArray(reg_var(0)), reg_var(0)), CtUnit, None), true, true, true),
+  ("Array::push_all", CtFn(reg_p2(CtArray(reg_var(0)), CtArray(reg_var(0))), CtUnit, None), true, true, true),
+  ("Array::set", CtFn(reg_p3(CtArray(reg_var(0)), CtInt, reg_var(0)), CtUnit, None), true, true, true),
   ("Double::to_int", CtFn(reg_p1(CtDouble), CtInt, None), true, true, true),
   ("Int::to_double", CtFn(reg_p1(CtInt), CtDouble, None), true, true, true),
   // #2344: scalar bit primitives. Both lanes -- these are ordinary wasm
@@ -330,7 +363,7 @@ let registry_typed_rows: Array[(String, Type, Bool, Bool, Bool)] = [
   ("String::char_code_at", CtFn(reg_p2(CtString, CtInt), CtInt, None), true, true, true),
   ("String::from_char_code", CtFn(reg_p1(CtInt), CtString, None), true, true, true),
   ("String::substring", CtFn(reg_p3(CtString, CtInt, CtInt), CtString, None), true, true, true),
-  ("Array::truncate", CtFn(reg_p2(CtArray(reg_any()), CtInt), CtUnit, None), true, true, true),
+  ("Array::truncate", CtFn(reg_p2(CtArray(reg_var(0)), CtInt), CtUnit, None), true, true, true),
   ("String::join", CtFn(reg_p2(CtArray(CtString), CtString), CtString, None), true, true, true),
   // #1513: POLYMORPHIC — `eq` is the structural equality builtin and is applied
   // to enums / structs / strings, not just Int. The `CtInt` placeholder here was
@@ -358,17 +391,22 @@ let registry_typed_rows: Array[(String, Type, Bool, Bool, Bool)] = [
   // just above: from_array/to_array are pure identity casts, get/length
   // alias Array::get/Array::length's own bodies -- see
   // gc/backend_body.vibe and wasi/linked_compile.vibe). checker.vibe's
-  // FrozenArray::* ECall branches refine these reg_any()-shaped rows with
-  // the real per-call-site element type; these rows exist so both codegen
-  // lanes' func-table registration (which is DRIVEN by this registry, #415
-  // B-1) has a row to loop over and so a bare reference to the name (not a
-  // direct call) still resolves to a sane function type.
-  ("FrozenArray::from_array", CtFn(reg_p1(CtArray(reg_any())), CtNamed("FrozenArray", reg_p1(reg_any())), None), true, true, true),
-  ("FrozenArray::get", CtFn(reg_p2(CtNamed("FrozenArray", reg_p1(reg_any())), CtInt), reg_any(), None), true, true, true),
-  ("FrozenArray::length", CtFn(reg_p1(CtNamed("FrozenArray", reg_p1(reg_any()))), CtInt, None), true, true, true),
-  ("FrozenArray::to_array", CtFn(reg_p1(CtNamed("FrozenArray", reg_p1(reg_any()))), CtArray(reg_any()), None), true, true, true),
-  ("Array::slice", CtFn(reg_p3(CtArray(reg_any()), CtInt, CtInt), CtArray(reg_any()), None), true, true, true),
-  ("Array::concat", CtFn(reg_p2(CtArray(reg_any()), CtArray(reg_any())), CtArray(reg_any()), None), true, true, true),
+  // FrozenArray::* ECall branches still refine the DIRECT call with the real
+  // per-call-site element type -- they are tolerant where these rows are not
+  // (measured: `FrozenArray::length` on an `Array[Int]` checks clean), so they
+  // are not redundant yet. #2451 gave the rows real variables for the VALUE
+  // form, which had no refinement to fall back on: before that,
+  // `let freeze = FrozenArray::from_array` then
+  // `let fz: FrozenArray[String] = freeze([1, 2])` checked clean and read the
+  // Ints as Strings. These rows also exist so both codegen lanes' func-table
+  // registration (which is DRIVEN by this registry, #415 B-1) has a row to
+  // loop over.
+  ("FrozenArray::from_array", CtFn(reg_p1(CtArray(reg_var(0))), CtNamed("FrozenArray", reg_p1(reg_var(0))), None), true, true, true),
+  ("FrozenArray::get", CtFn(reg_p2(CtNamed("FrozenArray", reg_p1(reg_var(0))), CtInt), reg_var(0), None), true, true, true),
+  ("FrozenArray::length", CtFn(reg_p1(CtNamed("FrozenArray", reg_p1(reg_var(0)))), CtInt, None), true, true, true),
+  ("FrozenArray::to_array", CtFn(reg_p1(CtNamed("FrozenArray", reg_p1(reg_var(0)))), CtArray(reg_var(0)), None), true, true, true),
+  ("Array::slice", CtFn(reg_p3(CtArray(reg_var(0)), CtInt, CtInt), CtArray(reg_var(0)), None), true, true, true),
+  ("Array::concat", CtFn(reg_p2(CtArray(reg_var(0)), CtArray(reg_var(0))), CtArray(reg_var(0)), None), true, true, true),
   ("Bytes::new", CtFn(reg_p0(), CtBytes, None), true, true, true),
   ("Bytes::from_array", CtFn(reg_p1(CtArray(CtInt)), CtBytes, None), true, true, true),
   ("Bytes::to_array", CtFn(reg_p1(CtBytes), CtArray(CtInt), None), true, true, true),
@@ -448,8 +486,72 @@ let registry_typed_rows: Array[(String, Type, Bool, Bool, Bool)] = [
   ("map_has", CtFn(reg_p2(reg_opaque("Map"), CtString), CtBool, None), false, true, true)
 ]
 
+/// #2451: the memo for the ERASED view below. Filled on first use rather than
+/// at module init so it cannot depend on module-level `let` ordering.
+let registry_typed_rows_erased: Array[(String, Type, Bool, Bool, Bool)] = []
+
+/// The rows as every consumer but the value form sees them: each `reg_var`
+/// erased back to `CtUnknown`, so a row that gained real variables reads
+/// EXACTLY as it did before (`type_erase_vars`, core/types.vibe, explains why
+/// the separation is load-bearing). Rows with no variables are shared, not
+/// copied.
 export fn builtin_registry_typed() -> Array[(String, Type, Bool, Bool, Bool)] {
-  registry_typed_rows
+  if Array::length(registry_typed_rows_erased) == 0 {
+    let mut i = 0
+    while i < Array::length(registry_typed_rows) {
+      let (name, ty, in_linear, in_gc, visible) = Array::get(registry_typed_rows, i)
+      let vars: Array[Int] = []
+      collect_type_var_ids(ty, vars)
+      let erased = if Array::length(vars) == 0 {
+        ty
+      } else {
+        type_erase_vars(ty)
+      }
+      Array::push(registry_typed_rows_erased, (name, erased, in_linear, in_gc, visible))
+      i = i + 1
+    }
+  } else {
+    ()
+  }
+  registry_typed_rows_erased
+}
+
+/// #2451: the row CLOSED into a scheme -- `CtForAll(row variables, [], row)`
+/// when it uses `reg_var`, the row itself otherwise, and `None` when the name
+/// is not a checker-visible row.
+///
+/// This is the only reader of the un-erased rows, and the value-form path in
+/// the checker is its only caller: it instantiates the scheme so each use site
+/// gets its own copy of the row's variables. That is what makes
+/// `let get = Array::get` then `let s: String = get([1], 0)` fail with the
+/// same message the direct call gives, instead of checking clean and printing
+/// garbage.
+export fn registry_builtin_scheme(name: String) -> Option[Type] {
+  let mut i = 0
+  let mut found: Option[Type] = None
+  while i < Array::length(registry_typed_rows) {
+    let (rname, ty, _, _, visible) = Array::get(registry_typed_rows, i)
+    if rname == name && visible {
+      let vars: Array[Int] = []
+      collect_type_var_ids(ty, vars)
+      found = if Array::length(vars) == 0 {
+        Some(ty)
+      } else {
+        Some(CtForAll(vars, empty_registry_var_bounds(), ty))
+      }
+      i = Array::length(registry_typed_rows)
+    } else {
+      i = i + 1
+    }
+  }
+  found
+}
+
+/// A registry row's variables carry no trait bounds: the rows describe wasm
+/// builtins, whose lowering is one instruction sequence for every element
+/// type. A bound here would be a claim the codegen cannot honor.
+fn empty_registry_var_bounds() -> Array[(Int, Array[String])] {
+  array_empty()
 }
 
 /// Derived 5-tuple view for the two codegen lanes -- SAME shape as the B-0/B-1
@@ -549,7 +651,10 @@ export fn registry_builtin_arity(name: String) -> Int {
 /// way. So an unknown-bearing row has no sound value form until the registry
 /// can express the relationship, which is a change to the registry, not here.
 export fn registry_builtin_pure_arity(name: String) -> Int {
-  let rows = builtin_registry_typed()
+  // #2451: the UN-erased rows. A row spelled with `reg_var` mentions no
+  // unknown, so it passes the test below and gains a value form; the erased
+  // view would put `CtUnknown` back and refuse every one of them.
+  let rows = registry_typed_rows
   let mut i = 0
   let mut found = 0 - 1
   while i < Array::length(rows) {

--- a/lib/@vibe/compiler/core/index.vpkg
+++ b/lib/@vibe/compiler/core/index.vpkg
@@ -144,6 +144,7 @@ fn builtin_registry() -> Array[(String, Int, Int, Bool, Bool)]
 fn lookup_registry_builtin(name: String) -> Option[Type]
 fn registry_builtin_arity(name: String) -> Int
 fn registry_builtin_pure_arity(name: String) -> Int
+fn registry_builtin_scheme(name: String) -> Option[Type]
 fn registry_builtin_param_type(name: String, i: Int) -> Option[Type]
 fn verify_lane_builtins(lane: String, names: Array[String], param_counts: Array[Int], returns: Array[Int]) -> Unit with Exception
 fn verify_standard_effect_policy_coverage() -> Unit with Exception
@@ -250,6 +251,8 @@ fn resolve_type_constructor_args(params: Array[String], source_args: Array[TypeE
 // call-result observation runs it once per located call result, where the
 // rebuild is pure waste and, on a merged program, quadratic.
 fn subst_resolves_to_double(s: Subst, ty: Type) -> Bool
+fn collect_type_var_ids(ty: Type, out: Array[Int]) -> Unit
+fn type_erase_vars(ty: Type) -> Type
 fn type_has_unknown(ty: Type) -> Bool
 fn subst_resolves_to_string(s: Subst, ty: Type) -> Bool
 fn trait_defined(env: TypeEnv, name: String) -> Bool

--- a/lib/@vibe/compiler/core/types.vibe
+++ b/lib/@vibe/compiler/core/types.vibe
@@ -2523,6 +2523,127 @@ export fn type_has_unknown(ty: Type) -> Bool {
   }
 }
 
+/// #2451: the type with every `CtVar` replaced by `CtUnknown`.
+///
+/// The builtin registry writes an open position as `reg_var(n)` when the row
+/// really means "this position and that position are the SAME type"
+/// (`Array::get`'s element and result), and `reg_any()` when it means "any
+/// value type is legal here and nothing relates it to anything else". Only the
+/// value-form path reads the variables; every other consumer of a registry row
+/// -- the direct-call fast path, the effect walk, the contract checker, the
+/// codegen lookups -- reads the ERASED view, which is byte-for-byte the row
+/// those consumers saw before variables existed. That is what keeps a change
+/// to the registry's expressiveness from being a change to what the compiler
+/// accepts.
+///
+/// Arms are enumerated with no wildcard for the same reason `type_has_unknown`
+/// above does it: a new `Type` constructor must fail this match rather than
+/// pass a variable through unerased.
+export fn type_erase_vars(ty: Type) -> Type {
+  match ty {
+    CtInt => ty,
+    CtDouble => ty,
+    CtBool => ty,
+    CtString => ty,
+    CtChar => ty,
+    CtUnit => ty,
+    CtBytes => ty,
+    CtUnknown => ty,
+    CtVar(_) => CtUnknown,
+    CtConstructor(_, _) => ty,
+    CtApplied(head, args) => CtApplied(type_erase_vars(head), types_erase_vars(args)),
+    CtEnum(_) => ty,
+    CtStruct(_) => ty,
+    CtArray(e) => CtArray(type_erase_vars(e)),
+    CtOption(e) => CtOption(type_erase_vars(e)),
+    CtTuple(es) => CtTuple(types_erase_vars(es)),
+    CtFn(ps, ret, eff) => CtFn(types_erase_vars(ps), type_erase_vars(ret), eff),
+    CtNamed(n, ts) => CtNamed(n, types_erase_vars(ts)),
+    // A scheme's variables are BOUND by its own binder, not open positions, so
+    // erasing them would destroy the scheme rather than hide a relationship.
+    // Registry rows are never schemes -- `registry_builtin_scheme` is what
+    // BUILDS one, from a row this has already left alone.
+    CtForAll(_, _, _) => ty,
+    CtRecord(fields) => CtRecord(for field in fields {
+      let (fname, ft) = field
+      (fname, type_erase_vars(ft))
+    })
+  }
+}
+
+fn types_erase_vars(ts: Array[Type]) -> Array[Type] {
+  for t in ts {
+    type_erase_vars(t)
+  }
+}
+
+/// #2451: every distinct `CtVar` id mentioned by a type, in first-occurrence
+/// order. Used to close a registry row into a `CtForAll` scheme, so each use
+/// site instantiates its own copy of the row's variables.
+export fn collect_type_var_ids(ty: Type, out: Array[Int]) -> Unit {
+  match ty {
+    CtInt => (),
+    CtDouble => (),
+    CtBool => (),
+    CtString => (),
+    CtChar => (),
+    CtUnit => (),
+    CtBytes => (),
+    CtUnknown => (),
+    CtVar(id) => if int_array_contains(out, id) {
+      ()
+    } else {
+      Array::push(out, id)
+    },
+    CtConstructor(_, _) => (),
+    CtApplied(head, args) => {
+      collect_type_var_ids(head, out)
+      collect_types_var_ids(args, out)
+    },
+    CtEnum(_) => (),
+    CtStruct(_) => (),
+    CtArray(e) => collect_type_var_ids(e, out),
+    CtOption(e) => collect_type_var_ids(e, out),
+    CtTuple(es) => collect_types_var_ids(es, out),
+    CtFn(ps, ret, _) => {
+      collect_types_var_ids(ps, out)
+      collect_type_var_ids(ret, out)
+    },
+    CtNamed(_, ts) => collect_types_var_ids(ts, out),
+    CtForAll(_, _, body) => collect_type_var_ids(body, out),
+    CtRecord(fields) => {
+      let mut i = 0
+      while i < Array::length(fields) {
+        let (_, ft) = Array::get(fields, i)
+        collect_type_var_ids(ft, out)
+        i = i + 1
+      }
+    }
+  }
+}
+
+fn collect_types_var_ids(ts: Array[Type], out: Array[Int]) -> Unit {
+  let mut i = 0
+  while i < Array::length(ts) {
+    collect_type_var_ids(Array::get(ts, i), out)
+    i = i + 1
+  }
+}
+
+fn int_array_contains(xs: Array[Int], v: Int) -> Bool {
+  let mut i = 0
+  let mut found = false
+  while i < Array::length(xs) {
+    if Array::get(xs, i) == v {
+      found = true
+      i = Array::length(xs)
+    } else {
+      i = i + 1
+    }
+  }
+  found
+}
+
 fn types_have_unknown(ts: Array[Type]) -> Bool {
   let mut i = 0
   let mut found = false

--- a/lib/@vibe/compiler/entry/compiler/file_compile/file_compile.vibe
+++ b/lib/@vibe/compiler/entry/compiler/file_compile/file_compile.vibe
@@ -18,14 +18,9 @@ import @vibe/core {
   array_empty
 }
 
-import @vibe/ast {
-  impl_target_from_key, impl_target_key
-}
-
 import @vibe/compiler/core {
   ExportRenamePlan,
   Stmt,
-  TypeExpr,
   append_builtin_iterator_plan_operation_markers,
   append_import_alias_rewritten_non_import_stmts_with_renames,
   append_non_import_stmts_without_alias_rewrite,
@@ -39,9 +34,7 @@ import @vibe/compiler/core {
   export_plan_renames_for,
   import_value_rename_locals,
   merged_source_boundary_names,
-  namespace_private_name,
   namespace_private_value_stmts,
-  namespace_rename_original,
   namespace_rename_originals_reset,
   resolution_env_seed,
   resolve_import_path,
@@ -88,7 +81,7 @@ import @vibe/compiler/loader {
 }
 
 import @vibe/compiler/checker {
-  file_entry_cacheable, file_tests_cacheable, typed_lowering_binop_anchor, typed_lowering_enc_offset, typed_lowering_enc_tag
+  file_entry_cacheable, file_tests_cacheable, typed_lowering_binop_anchor
 }
 
 import @vibe/compiler/runtime {
@@ -102,9 +95,11 @@ import @vibe/compiler/runtime {
   db_store_artifact,
   db_typecheck,
   db_typecheck_fs,
-  module_typed_eq_rows_for_path,
   module_typed_lowering_offsets_for_path,
-  parse_program_with_path
+  parse_program_with_path,
+  split_typed_lowering_offsets,
+  union_module_typed_eq_rows,
+  union_module_typed_lowering_with_clones
 }
 
 import @vibe/compiler/cache {
@@ -500,162 +495,6 @@ fn build_grouped_merged_stmts(source_groups: Array[(String, Array[(String, Strin
 
 fn build_grouped_merged_stmts_gc(source_groups: Array[(String, Array[(String, String)])]) -> Array[Stmt] with Exception {
   build_grouped_merged_stmts_impl(source_groups, true, array_empty(), array_empty(), array_empty())
-}
-
-/// #2391: shift each file's per-module typed-lowering table (recorded by the
-/// modular check in the file's OWN offset space) by that file's base in a
-/// disjoint-offset merge, and union them into one table. Rows are tag-encoded
-/// (offset * 8 + tag, see typed_lowering_enc in the checker), so the rebase
-/// adds base * 8 and leaves the tag bits untouched. A file the modular check
-/// never stepped in this process contributes nothing, which degrades ITS
-/// sites to the syntactic classifiers -- deterministically, because the reuse
-/// arms in runtime/typecheck_fs.vibe re-check a module whose offsets sidecar
-/// is missing rather than reusing half a cache entry.
-fn union_module_typed_lowering_offsets(flat_paths: Array[String], flat_bases: Array[Int]) -> Array[Int] {
-  let out: Array[Int] = []
-  let mut i = 0
-  while i < Array::length(flat_paths) {
-    match module_typed_lowering_offsets_for_path(Array::get(flat_paths, i)) {
-      Some(offsets) => {
-        let base = Array::get(flat_bases, i)
-        let mut j = 0
-        while j < Array::length(offsets) {
-          Array::push(out, Array::get(offsets, j) + base * 8)
-          j = j + 1
-        }
-      },
-      None => ()
-    }
-    i = i + 1
-  }
-  out
-}
-
-/// The per-file union plus the alias-collision clones' duplicated entries
-/// (already in merge space and encoded, see the clone emission above).
-fn union_module_typed_lowering_with_clones(flat_paths: Array[String], flat_bases: Array[Int], clone_float_offsets: Array[Int]) -> Array[Int] {
-  let out = union_module_typed_lowering_offsets(flat_paths, flat_bases)
-  let mut ci = 0
-  while ci < Array::length(clone_float_offsets) {
-    Array::push(out, Array::get(clone_float_offsets, ci))
-    ci = ci + 1
-  }
-  out
-}
-
-/// #2441 (Codex round 1 on #2443): a module-PRIVATE nominal type in an eq
-/// row must follow the merge's private-type rename, or the row still names
-/// the source spelling while the merged declarations name the mangled one.
-/// Measured before this mapping: a dependency's private `Point` row, with
-/// the ENTRY declaring a different `Point`, dispatched the entry's
-/// `Point::equals` on the dependency's values -- `true` for content-unequal
-/// pairs. The mapping consults the SAME rename record the merge populated
-/// (#2205): a name is rewritten to `namespace_private_name(path, name)`
-/// exactly when that mangled spelling is recorded as a rename of this name,
-/// so an exported (unrenamed) type, a builtin head, and the entry file's
-/// own types all pass through unchanged.
-fn eq_key_rename_name(path: String, name: String) -> String {
-  let candidate = namespace_private_name(path, name)
-  if namespace_rename_original(candidate) == name {
-    candidate
-  } else {
-    name
-  }
-}
-
-fn eq_key_rename_ty(path: String, te: TypeExpr) -> TypeExpr {
-  match te {
-    TyName(n) => TyName(eq_key_rename_name(path, n)),
-    TyApp(n, args) => TyApp(eq_key_rename_name(path, n), for a in args {
-      eq_key_rename_ty(path, a)
-    }),
-    TyTuple(items) => TyTuple(for a in items {
-      eq_key_rename_ty(path, a)
-    }),
-    _ => te
-  }
-}
-
-/// #2441: the typed-`==` union -- the same per-file walk as
-/// union_module_typed_lowering_offsets, but the rows are (offset, TypeExpr
-/// key) pairs, so the rebase adds the plain byte base (no tag bits to
-/// preserve) and each key's nominal names are rebased through the merge's
-/// rename record (eq_key_rename_ty above). A key that does not parse is
-/// dropped rather than passed through -- fail closed. Alias-collision clone
-/// statements contribute no eq rows -- a cloned definition's `==` sites
-/// simply degrade to the syntactic classifiers, which is today's behavior
-/// for every site, never a wrong comparator.
-fn union_module_typed_eq_rows(flat_paths: Array[String], flat_bases: Array[Int]) -> (Array[Int], Array[String]) {
-  let out_offs: Array[Int] = []
-  let out_keys: Array[String] = []
-  let mut i = 0
-  while i < Array::length(flat_paths) {
-    match module_typed_eq_rows_for_path(Array::get(flat_paths, i)) {
-      Some((eq_offs, eq_keys)) => {
-        let path = Array::get(flat_paths, i)
-        let base = Array::get(flat_bases, i)
-        let mut j = 0
-        while j < Array::length(eq_offs) {
-          match impl_target_from_key(Array::get(eq_keys, j)) {
-            Some(te) => {
-              Array::push(out_offs, Array::get(eq_offs, j) + base)
-              Array::push(out_keys, impl_target_key(eq_key_rename_ty(path, te)))
-            },
-            None => ()
-          }
-          j = j + 1
-        }
-      },
-      None => ()
-    }
-    i = i + 1
-  }
-  (out_offs, out_keys)
-}
-
-/// #2391 slice 2: decode one merged typed-lowering table into its three
-/// channels -- Double call-result offsets (tag 0) for
-/// `CompileCtx.float_call_offsets`, String relational anchors (tag 1) and
-/// String `+` anchors (tag 2) for the rewrite pass. The encoding is the
-/// checker's typed_lowering_enc; the enc/dec pair lives on the checker
-/// boundary so the two sides cannot drift.
-fn split_typed_lowering_offsets(enc: Array[Int]) -> (Array[Int], Array[Int], Array[Int], Array[Int]) {
-  let floats: Array[Int] = []
-  let rels: Array[Int] = []
-  let pluses: Array[Int] = []
-  let int_renders: Array[Int] = []
-  let mut i = 0
-  while i < Array::length(enc) {
-    let value = Array::get(enc, i)
-    let tag = typed_lowering_enc_tag(value)
-    let off = typed_lowering_enc_offset(value)
-    if tag == 0 {
-      Array::push(floats, off)
-    } else if tag == 1 {
-      Array::push(rels, off)
-    } else if tag == 2 {
-      Array::push(pluses, off)
-    } else if tag == 3 {
-      // #2424: render (`__to_string` / `Int::to_string`) and `eq` ARGUMENT
-      // offsets the checker typed as `Int`.
-      Array::push(int_renders, off)
-    } else if tag == 4 {
-      // #2424: the Double half of the same argument set, unioned into the
-      // Double channel. The two tags stay distinct through the encoding
-      // because their KEYS differ -- tag 0 is a call node's own offset, tag 4
-      // is `typed_lowering_arg_offset` (a projection answers with its
-      // field-name offset) -- and they can share one array here because the
-      // consumers read it with `typed_lowering_arg_offset`, which agrees with
-      // the call offset on a call node.
-      Array::push(floats, off)
-    } else {
-      // No tag above 4 exists; dropping an unknown row degrades its site to
-      // the syntactic classifiers rather than misclassifying another offset.
-      ()
-    }
-    i = i + 1
-  }
-  (floats, rels, pluses, int_renders)
 }
 
 /// #2391: the merge every offsets-consuming linear FS lane shares -- each file

--- a/lib/@vibe/compiler/entry/compiler/fs_compile/fs_compile.vibe
+++ b/lib/@vibe/compiler/entry/compiler/fs_compile/fs_compile.vibe
@@ -586,12 +586,20 @@ export fn compile_with_modules_cached(db: TypeDb, main_source: String, main_path
   }
 }
 
+/// #2449 (Codex review on #2453): the artifact kind is `wasi-typed`, not
+/// `wasi`. The `wasi` kind is what an entry that compiles WITHOUT the
+/// typed-lowering tables writes, and this one now emits different bytes for the
+/// same sources -- the fingerprint is derived from the sources alone, so
+/// sharing the kind means the second of two entries called on one `TypeDb`
+/// silently gets the first's lowering. Measured before the split, unchecked
+/// then checked on a shared db: the checked call returned the UNCHECKED bytes,
+/// which differed from what it produces on a fresh db.
 export fn compile_with_modules_wasi_cached(db: TypeDb, main_source: String, main_path: String, sources: Array[(String, String)], entry_name: String) -> (Bytes, TypeDb) with Exception {
   let next_db = prepare_modules_cached(db, main_path, main_source, sources)
   let ordered_sources = collect_inline_sources_ordered(main_path, main_source, sources)
   let merge_fingerprint = build_merge_fingerprint_inline(ordered_sources)
   let artifact_fingerprint = artifact_fingerprint_from_source(String::concat(merge_fingerprint, String::concat("|", entry_name)))
-  match db_load_artifact(next_db, main_path, "wasi", entry_name, artifact_fingerprint) {
+  match db_load_artifact(next_db, main_path, "wasi-typed", entry_name, artifact_fingerprint) {
     Some(bytes) => (bytes, next_db),
     None => {
       // #2449: `next_db` is `prepare_modules_cached`'s, so every module of this
@@ -601,7 +609,7 @@ export fn compile_with_modules_wasi_cached(db: TypeDb, main_source: String, main
       let (merged_stmts, float_offsets, int_offsets, eq_offsets, eq_keys) = merged_stmts_and_offsets_inline(ordered_sources)
       let pruned_stmts = prune_entry_stmts(merged_stmts, entry_name)
       let bytes = compile_wasi_module_impl_with_typed_offsets(pruned_stmts, entry_name, float_offsets, int_offsets, eq_offsets, eq_keys)
-      (bytes, db_store_artifact(next_db, main_path, "wasi", entry_name, artifact_fingerprint, bytes))
+      (bytes, db_store_artifact(next_db, main_path, "wasi-typed", entry_name, artifact_fingerprint, bytes))
     }
   }
 }
@@ -611,7 +619,7 @@ export fn compile_with_closure_sources_wasi_cached(db: TypeDb, main_source: Stri
   let next_db = prepare_modules_cached(db, main_path, main_source, ordered_sources)
   let merge_fingerprint = build_merge_fingerprint_inline(ordered_sources)
   let artifact_fingerprint = artifact_fingerprint_from_source(String::concat(merge_fingerprint, String::concat("|", entry_name)))
-  match db_load_artifact(next_db, main_path, "wasi", entry_name, artifact_fingerprint) {
+  match db_load_artifact(next_db, main_path, "wasi-typed", entry_name, artifact_fingerprint) {
     Some(bytes) => (bytes, next_db),
     None => {
       // #2449: `next_db` is `prepare_modules_cached`'s, so every module of this
@@ -621,7 +629,7 @@ export fn compile_with_closure_sources_wasi_cached(db: TypeDb, main_source: Stri
       let (merged_stmts, float_offsets, int_offsets, eq_offsets, eq_keys) = merged_stmts_and_offsets_inline(ordered_sources)
       let pruned_stmts = prune_entry_stmts(merged_stmts, entry_name)
       let bytes = compile_wasi_module_impl_with_typed_offsets(pruned_stmts, entry_name, float_offsets, int_offsets, eq_offsets, eq_keys)
-      (bytes, db_store_artifact(next_db, main_path, "wasi", entry_name, artifact_fingerprint, bytes))
+      (bytes, db_store_artifact(next_db, main_path, "wasi-typed", entry_name, artifact_fingerprint, bytes))
     }
   }
 }
@@ -630,10 +638,13 @@ export fn compile_with_closure_sources_wasi_mode_cached(db: TypeDb, main_source:
   let ordered_sources = collect_inline_sources_ordered(main_path, main_source, sources)
   let next_db = prepare_modules_cached(db, main_path, main_source, ordered_sources)
   let merge_fingerprint = build_merge_fingerprint_inline(ordered_sources)
+  // #2449 (Codex review on #2453): `-typed` for the same reason the two
+  // entries above carry it -- this entry now compiles WITH the typed-lowering
+  // tables, so it must not share a cache key with one that does not.
   let artifact_kind = if mode == "mvp" {
-    "wasi-mvp"
+    "wasi-mvp-typed"
   } else if mode == "no-dce" {
-    "wasi"
+    "wasi-typed"
   } else {
     throw(String::concat("unsupported compile mode: ", mode))
   }

--- a/lib/@vibe/compiler/entry/compiler/fs_compile/fs_compile.vibe
+++ b/lib/@vibe/compiler/entry/compiler/fs_compile/fs_compile.vibe
@@ -1,7 +1,7 @@
 //# Imports
 
 import @vibe/compiler/syntax {
-  lex, parse_program
+  lex, parse_program, rewrite_string_binops_stmts, shift_stmt_offsets, shift_stmts_offsets
 }
 
 import @vibe/core {
@@ -13,11 +13,15 @@ import @vibe/compiler/codegen {
 }
 
 import @vibe/compiler/codegen/wasi {
-  compile_wasi_module_impl, compile_wasi_module_no_dce_impl, compile_wasi_module_rc_impl
+  compile_wasi_module_impl,
+  compile_wasi_module_impl_with_typed_offsets,
+  compile_wasi_module_no_dce_impl,
+  compile_wasi_module_no_dce_impl_with_typed_offsets,
+  compile_wasi_module_rc_impl
 }
 
 import @vibe/compiler/checker {
-  check_program
+  check_program, typed_lowering_binop_anchor
 }
 
 import @vibe/compiler/core {
@@ -58,7 +62,12 @@ import @vibe/compiler/runtime {
   db_store_artifact,
   db_typecheck,
   db_typecheck_count,
-  db_typecheck_fs
+  db_typecheck_fs,
+  module_typed_lowering_offsets_for_path,
+  parse_program_with_path,
+  split_typed_lowering_offsets,
+  union_module_typed_eq_rows,
+  union_module_typed_lowering_with_clones
 }
 
 import @vibe/compiler/cache {
@@ -212,7 +221,19 @@ fn string_array_contains_local(items: Array[String], target: String) -> Bool {
 /// #716: collision-def fallback (see merge_sources.vibe). `excluded_locals`
 /// are the locals the export-rename plan already rewrites; the inline copy gets
 /// the target file's export renames applied first.
-fn append_inline_import_alias_collision_defs(merged: Array[Stmt], current_path: String, stmts: Array[Stmt], sources: Array[(String, String)], plan: ExportRenamePlan, excluded_locals: Array[String]) -> Unit with Exception {
+/// #716: collision-def fallback. `excluded_locals` are the locals the
+/// export-rename plan already rewrites.
+///
+/// #2449: the provider body comes from the merge's own authoritative parsed
+/// copy (already rebased into the provider file's offset range), not from a
+/// second `parse_program(lex(source))` of the same text. A clone is a real
+/// second copy of provider CODE, so it gets an offset range of its own past
+/// every file's -- and, with it, a second copy of the provider's
+/// typed-lowering rows, or a Double-returning call inside the clone's body
+/// would fall back to the syntactic classifier and print raw bits. Entries for
+/// provider statements the clone does not contain match no node and stay
+/// inert.
+fn append_inline_import_alias_collision_defs(merged: Array[Stmt], current_path: String, stmts: Array[Stmt], file_paths: Array[String], located_file_stmts: Array[Array[Stmt]], plan: ExportRenamePlan, excluded_locals: Array[String], flat_paths: Array[String], flat_bases: Array[Int], clone_offset_delta: Array[Int], clone_offset_span: Int, clone_float_offsets_out: Array[Int]) -> Unit with Exception {
   let refs = collect_import_alias_collision_refs(stmts)
   let emitted = array_empty()
   let base_dir = dir_of_path(current_path)
@@ -221,14 +242,33 @@ fn append_inline_import_alias_collision_defs(merged: Array[Stmt], current_path: 
     let (raw_path, original, local) = Array::get(refs, i)
     if !string_array_contains_local(emitted, local) && !string_array_contains_local(excluded_locals, local) {
       let resolved = resolve_import_path(base_dir, raw_path)
-      let source = source_lookup_or_throw(sources, resolved)
-      let source_stmts = namespace_private_value_stmts(resolved, apply_export_renames_stmts(parse_program(lex(source)), export_plan_renames_for(plan, resolved)))
+      let provider_index = index_of_path_or_throw(file_paths, resolved)
+      let source_stmts = namespace_private_value_stmts(resolved, apply_export_renames_stmts(Array::get(located_file_stmts, provider_index), export_plan_renames_for(plan, resolved)))
       let mut j = 0
       let mut done = false
       while j < Array::length(source_stmts) && !done {
         match rewrite_imported_value_stmt_to_local(Array::get(source_stmts, j), original, local) {
           Some(local_stmt) => {
-            Array::push(merged, local_stmt)
+            let delta = Array::get(clone_offset_delta, 0)
+            Array::set(clone_offset_delta, 0, delta + clone_offset_span)
+            match lookup_inline_flat_base(flat_paths, flat_bases, resolved) {
+              Some(provider_base) => match module_typed_lowering_offsets_for_path(resolved) {
+                Some(provider_offsets) => {
+                  let mut k = 0
+                  while k < Array::length(provider_offsets) {
+                    // The table is tag-encoded (offset * 8 + tag, see
+                    // typed_lowering_enc), so shifting a row by the clone's
+                    // merge-space delta adds (base + delta) * 8 -- the tag
+                    // bits stay untouched.
+                    Array::push(clone_float_offsets_out, Array::get(provider_offsets, k) + (provider_base + delta) * 8)
+                    k = k + 1
+                  }
+                },
+                None => ()
+              },
+              None => ()
+            }
+            Array::push(merged, shift_stmt_offsets(local_stmt, delta))
             Array::push(emitted, local)
             done = true
           },
@@ -239,6 +279,46 @@ fn append_inline_import_alias_collision_defs(merged: Array[Stmt], current_path: 
     }
     i = i + 1
   }
+}
+
+/// The index of `path` in the merge's flat file list. A collision ref names an
+/// import this merge already resolved, so a miss is an internal inconsistency,
+/// not a user error -- it throws rather than skipping the clone silently,
+/// which is what `source_lookup_or_throw` did for the same reason.
+fn index_of_path_or_throw(file_paths: Array[String], path: String) -> Int with Exception {
+  let n = Array::length(file_paths)
+  let mut i = 0
+  let mut found = 0 - 1
+  while i < n {
+    if Array::get(file_paths, i) == path {
+      found = i
+      i = n
+    } else {
+      i = i + 1
+    }
+  }
+  if found < 0 {
+    throw(String::concat("inline merge: no source for import target ", path))
+  } else {
+    ()
+  }
+  found
+}
+
+/// The disjoint-merge offset base recorded for `path`.
+fn lookup_inline_flat_base(flat_paths: Array[String], flat_bases: Array[Int], path: String) -> Option[Int] {
+  let n = Array::length(flat_paths)
+  let mut i = 0
+  let mut found: Option[Int] = None
+  while i < n {
+    if Array::get(flat_paths, i) == path {
+      found = Some(Array::get(flat_bases, i))
+      i = n
+    } else {
+      i = i + 1
+    }
+  }
+  found
 }
 
 export fn prepare_modules_cached(db: TypeDb, main_path: String, main_source: String, sources: Array[(String, String)]) -> TypeDb with Exception {
@@ -316,7 +396,32 @@ fn build_merge_fingerprint_inline(sources: Array[(String, String)]) -> String {
   acc
 }
 
+/// The merge WITHOUT the offset tables: statement counts, and the entries that
+/// deliberately skip the per-module check. Both merges are the same program --
+/// this one just discards the bases, so nothing downstream can read rows that
+/// were not proven for these sources (see merged_stmts_and_offsets_inline).
 fn build_merged_stmts_inline(sources: Array[(String, String)]) -> Array[Stmt] with Exception {
+  build_merged_stmts_inline_impl(sources, array_empty(), array_empty(), array_empty())
+}
+
+/// #2449: the inline-source merge, with each file rebased into its own
+/// disjoint offset range and its base reported -- the same shape
+/// `build_grouped_merged_stmts_impl` (entry/compiler/file_compile) has had
+/// since #2391, one layer down.
+///
+/// Before this the merge parsed with `parse_program(lex(source))`, so every
+/// node offset was -1 and there was no offset space at all: every entry built
+/// on this merge compiled with each typed-lowering channel EMPTY, the linked
+/// lane included. An empty table classifies nothing, so what those entries got
+/// was the pre-#2158 syntactic answer -- a large `Int` rendering as the empty
+/// string, a `Double` reached through a projection not rendering as a Double,
+/// `a < b` on Strings comparing pointers wherever the desugar tracker cannot
+/// see the shape syntactically.
+///
+/// The parse is now `parse_program_with_path`, which is BOTH located and the
+/// same memoized parse the per-module check already performed, so this reads
+/// one merge's worth of parsing rather than adding a second one.
+fn build_merged_stmts_inline_impl(sources: Array[(String, String)], flat_paths_out: Array[String], flat_bases_out: Array[Int], clone_float_offsets_out: Array[Int]) -> Array[Stmt] with Exception {
   // #2205: the rename table describes ONE merged program.
   namespace_rename_originals_reset()
   let merged = empty_stmt_array()
@@ -329,9 +434,30 @@ fn build_merged_stmts_inline(sources: Array[(String, String)]) -> Array[Stmt] wi
   while pi < source_count {
     let (path, source) = Array::get(sources, pi)
     Array::push(file_paths, path)
-    Array::push(file_stmts, parse_program(lex(source)))
+    Array::push(file_stmts, parse_program_with_path(path, source))
     pi = pi + 1
   }
+  // Every parser offset is relative to one file. The typed-lowering tables are
+  // keyed by those offsets, so merging files without rebasing would let one
+  // file's Double call classify another file's Int call. Shift before the
+  // namespace/import rewrites; they preserve locations.
+  let located_file_stmts = array_empty()
+  let mut offset_base = 0
+  let mut li = 0
+  while li < source_count {
+    Array::push(located_file_stmts, shift_stmts_offsets(Array::get(file_stmts, li), offset_base))
+    Array::push(flat_paths_out, Array::get(file_paths, li))
+    Array::push(flat_bases_out, offset_base)
+    let (_, source) = Array::get(sources, li)
+    // A source of N bytes occupies [base, base + N). The extra byte keeps
+    // even an offset exactly at EOF disjoint from the following file.
+    offset_base = offset_base + String::length(source) + 1
+    li = li + 1
+  }
+  // Alias-collision clones are second copies of provider code, so they get
+  // offset ranges of their own past every file's range.
+  let clone_offset_span = offset_base
+  let clone_offset_delta = [offset_base]
   let plan_entry = if source_count > 0 {
     Array::get(file_paths, source_count - 1)
   } else {
@@ -341,7 +467,7 @@ fn build_merged_stmts_inline(sources: Array[(String, String)]) -> Array[Stmt] wi
   let mut si = 0
   while si < source_count {
     let path = Array::get(file_paths, si)
-    let stmts = Array::get(file_stmts, si)
+    let stmts = Array::get(located_file_stmts, si)
     let is_entry_source = si == source_count - 1
     let import_renames = collect_import_value_renames(plan, path, stmts)
     let (boundary_locals, boundary_surface_only) = merged_source_boundary_names(stmts)
@@ -364,11 +490,30 @@ fn build_merged_stmts_inline(sources: Array[(String, String)]) -> Array[Stmt] wi
       namespace_private_value_stmts(path, export_renamed)
     }
     let skipped_locals = collect_import_alias_collision_locals(stmts)
-    append_inline_import_alias_collision_defs(merged, path, stmts, sources, plan, import_value_rename_locals(import_renames))
+    append_inline_import_alias_collision_defs(merged, path, stmts, file_paths, located_file_stmts, plan, import_value_rename_locals(import_renames), flat_paths_out, flat_bases_out, clone_offset_delta, clone_offset_span, clone_float_offsets_out)
     append_import_alias_rewritten_non_import_stmts_with_renames(merged, namespaced_stmts, skipped_locals, import_renames)
     si = si + 1
   }
   merged
+}
+
+/// #2449: the inline merge plus the typed-lowering tables the per-module check
+/// recorded, rebased into the merge's offset space -- the inline-source
+/// sibling of `merged_stmts_and_offsets` (entry/compiler/file_compile).
+///
+/// Only entries that actually ran `prepare_modules_cached` may use this. The
+/// memo is process-global and keyed by PATH, so an entry that deliberately
+/// skips the check (the `*_unchecked_*` family) must keep the empty tables:
+/// reading rows an earlier compile of a DIFFERENT source at the same path left
+/// behind is exactly the silently-wrong shape these tables exist to remove.
+fn merged_stmts_and_offsets_inline(sources: Array[(String, String)]) -> (Array[Stmt], Array[Int], Array[Int], Array[Int], Array[String]) with Exception {
+  let flat_paths: Array[String] = []
+  let flat_bases: Array[Int] = []
+  let clone_float_offsets: Array[Int] = []
+  let merged = build_merged_stmts_inline_impl(sources, flat_paths, flat_bases, clone_float_offsets)
+  let (floats, rels, pluses, int_renders) = split_typed_lowering_offsets(union_module_typed_lowering_with_clones(flat_paths, flat_bases, clone_float_offsets))
+  let (eq_offs, eq_keys) = union_module_typed_eq_rows(flat_paths, flat_bases)
+  (rewrite_string_binops_stmts(merged, rels, pluses, typed_lowering_binop_anchor), floats, int_renders, eq_offs, eq_keys)
 }
 
 fn prune_entry_stmts(stmts: Array[Stmt], entry_name: String) -> Array[Stmt] {
@@ -428,6 +573,12 @@ export fn compile_with_modules_cached(db: TypeDb, main_source: String, main_path
   match db_load_artifact(codegen_db, main_path, "module", "", artifact_fingerprint) {
     Some(bytes) => (bytes, codegen_db),
     None => {
+      // #2437: this entry does NOT go through the statement merge -- it
+      // reprints the program to `module_source` and reparses that text, so the
+      // per-module offsets have no space to be rebased into and the tables stay
+      // empty here. Routing this lane onto `merged_stmts_and_offsets_inline` is
+      // #2437's remaining work; it changes cache identity and output bytes, so
+      // it is not folded in here.
       let stmts = parse_program(lex(module_source))
       let bytes = compile_module(stmts)
       (bytes, db_store_artifact(codegen_db, main_path, "module", "", artifact_fingerprint, bytes))
@@ -443,9 +594,13 @@ export fn compile_with_modules_wasi_cached(db: TypeDb, main_source: String, main
   match db_load_artifact(next_db, main_path, "wasi", entry_name, artifact_fingerprint) {
     Some(bytes) => (bytes, next_db),
     None => {
-      let merged_stmts = build_merged_stmts_inline(ordered_sources)
+      // #2449: `next_db` is `prepare_modules_cached`'s, so every module of this
+      // program has been checked in this process and published its
+      // typed-lowering rows. The merge rebases them into one offset space and
+      // hands them to codegen -- the tables the linked lane exists to consume.
+      let (merged_stmts, float_offsets, int_offsets, eq_offsets, eq_keys) = merged_stmts_and_offsets_inline(ordered_sources)
       let pruned_stmts = prune_entry_stmts(merged_stmts, entry_name)
-      let bytes = compile_wasi_module(pruned_stmts, entry_name)
+      let bytes = compile_wasi_module_impl_with_typed_offsets(pruned_stmts, entry_name, float_offsets, int_offsets, eq_offsets, eq_keys)
       (bytes, db_store_artifact(next_db, main_path, "wasi", entry_name, artifact_fingerprint, bytes))
     }
   }
@@ -459,9 +614,13 @@ export fn compile_with_closure_sources_wasi_cached(db: TypeDb, main_source: Stri
   match db_load_artifact(next_db, main_path, "wasi", entry_name, artifact_fingerprint) {
     Some(bytes) => (bytes, next_db),
     None => {
-      let merged_stmts = build_merged_stmts_inline(ordered_sources)
+      // #2449: `next_db` is `prepare_modules_cached`'s, so every module of this
+      // program has been checked in this process and published its
+      // typed-lowering rows. The merge rebases them into one offset space and
+      // hands them to codegen -- the tables the linked lane exists to consume.
+      let (merged_stmts, float_offsets, int_offsets, eq_offsets, eq_keys) = merged_stmts_and_offsets_inline(ordered_sources)
       let pruned_stmts = prune_entry_stmts(merged_stmts, entry_name)
-      let bytes = compile_wasi_module(pruned_stmts, entry_name)
+      let bytes = compile_wasi_module_impl_with_typed_offsets(pruned_stmts, entry_name, float_offsets, int_offsets, eq_offsets, eq_keys)
       (bytes, db_store_artifact(next_db, main_path, "wasi", entry_name, artifact_fingerprint, bytes))
     }
   }
@@ -482,12 +641,13 @@ export fn compile_with_closure_sources_wasi_mode_cached(db: TypeDb, main_source:
   match db_load_artifact(next_db, main_path, artifact_kind, entry_name, artifact_fingerprint) {
     Some(bytes) => (bytes, next_db),
     None => {
-      let merged_stmts = build_merged_stmts_inline(ordered_sources)
+      // #2449: checked entry -- see compile_with_modules_wasi_cached above.
+      let (merged_stmts, float_offsets, int_offsets, eq_offsets, eq_keys) = merged_stmts_and_offsets_inline(ordered_sources)
       let bytes = if mode == "mvp" {
         let pruned_stmts = prune_entry_stmts(merged_stmts, entry_name)
-        compile_wasi_module_impl(pruned_stmts, entry_name)
+        compile_wasi_module_impl_with_typed_offsets(pruned_stmts, entry_name, float_offsets, int_offsets, eq_offsets, eq_keys)
       } else {
-        compile_wasi_module_no_dce_impl(merged_stmts, entry_name)
+        compile_wasi_module_no_dce_impl_with_typed_offsets(merged_stmts, entry_name, float_offsets, int_offsets, eq_offsets, eq_keys)
       }
       (bytes, db_store_artifact(next_db, main_path, artifact_kind, entry_name, artifact_fingerprint, bytes))
     }

--- a/lib/@vibe/compiler/runtime/index.vpkg
+++ b/lib/@vibe/compiler/runtime/index.vpkg
@@ -136,6 +136,7 @@ fn db_typecheck_fs(db: TypeDb, path: String) -> TypeDb with Exception + Fs
 fn module_typed_lowering_offsets_for_path(path: String) -> Option[Array[Int]]
 fn module_typed_eq_rows_for_path(path: String) -> Option[(Array[Int], Array[String])]
 fn publish_module_typed_lowering_offsets(path: String, fingerprint: String, offsets: Option[Array[Int]], eq_offs: Array[Int], eq_keys: Array[String]) -> Unit
+fn rebind_module_typed_lowering_offsets(path: String, fingerprint: String) -> Bool
 
 // #2449: the per-file rebase and the tag decoder for the typed-lowering
 // tables, shared by BOTH merges (the grouped file merge and the

--- a/lib/@vibe/compiler/runtime/index.vpkg
+++ b/lib/@vibe/compiler/runtime/index.vpkg
@@ -135,6 +135,15 @@ fn db_typecheck(db: TypeDb, path: String) -> TypeDb with Exception
 fn db_typecheck_fs(db: TypeDb, path: String) -> TypeDb with Exception + Fs
 fn module_typed_lowering_offsets_for_path(path: String) -> Option[Array[Int]]
 fn module_typed_eq_rows_for_path(path: String) -> Option[(Array[Int], Array[String])]
+fn publish_module_typed_lowering_offsets(path: String, fingerprint: String, offsets: Option[Array[Int]], eq_offs: Array[Int], eq_keys: Array[String]) -> Unit
+
+// #2449: the per-file rebase and the tag decoder for the typed-lowering
+// tables, shared by BOTH merges (the grouped file merge and the
+// inline-source merge) so a tag cannot be understood by only one of them.
+fn union_module_typed_lowering_offsets(flat_paths: Array[String], flat_bases: Array[Int]) -> Array[Int]
+fn union_module_typed_lowering_with_clones(flat_paths: Array[String], flat_bases: Array[Int], clone_float_offsets: Array[Int]) -> Array[Int]
+fn union_module_typed_eq_rows(flat_paths: Array[String], flat_bases: Array[Int]) -> (Array[Int], Array[String])
+fn split_typed_lowering_offsets(enc: Array[Int]) -> (Array[Int], Array[Int], Array[Int], Array[Int])
 fn db_program_source(db: TypeDb, path: String) -> (String, String, TypeDb) with Exception
 fn db_merged_source(db: TypeDb, _entry_path: String, sources: Array[(String, String)]) -> (String, String, TypeDb) with Exception
 fn db_grouped_merged_source(db: TypeDb, groups: Array[(String, Array[(String, String)])]) -> (String, String, TypeDb) with Exception

--- a/lib/@vibe/compiler/runtime/runtime.vibe
+++ b/lib/@vibe/compiler/runtime/runtime.vibe
@@ -41,7 +41,7 @@ import @vibe/core {
 }
 
 import @vibe/compiler/checker {
-  check_program_with_env, typing_semantics_seed
+  check_program_with_env_typed_lowering_located_observation, typing_semantics_seed
 }
 
 import @vibe/compiler/runtime/eval_loader {
@@ -55,9 +55,11 @@ import ./typecheck_fs.vibe {
   load_persistent_dep_list,
   load_persistent_leaf_fingerprint,
   load_persistent_type_env,
+  parse_program_with_path,
   persistent_dep_list_text,
   persistent_leaf_fingerprint_text,
-  persistent_type_env_cache_text
+  persistent_type_env_cache_text,
+  publish_module_typed_lowering_offsets
 }
 
 import @vibe/compiler/syntax {
@@ -103,7 +105,14 @@ export ./escape_spans.vibe {
 }
 
 export ./typecheck_fs.vibe {
-  collect_all_diagnostics, module_plan_manifest_fs, module_typed_eq_rows_for_path, module_typed_lowering_offsets_for_path
+  collect_all_diagnostics,
+  module_plan_manifest_fs,
+  module_typed_eq_rows_for_path,
+  module_typed_lowering_offsets_for_path,
+  split_typed_lowering_offsets,
+  union_module_typed_eq_rows,
+  union_module_typed_lowering_offsets,
+  union_module_typed_lowering_with_clones
 }
 
 // Note: `eval_loader/` has its own `index.vibe` and is already its own
@@ -139,12 +148,6 @@ fn unwrap_db(db: TypeDb) -> TypeDbState {
 
 fn wrap_db(state: TypeDbState) -> TypeDb {
   TypeDb(state)
-}
-
-fn parse_program_with_path(path: String, source: String) -> Array[Stmt] with Exception {
-  handle {
-    parse_program(lex(source))
-  } with { Exception::Throw(msg) => throw(String::concat(String::concat(path, ": "), msg)) }
 }
 
 fn add_dep(acc: Array[String], raw_path: String, base_dir: String) -> Array[String] {
@@ -482,6 +485,27 @@ fn resolve_deps_for_source_fs(rdb: RippleDb, dep_source_cache: Array[(String, St
   }
 }
 
+/// #2449: the in-memory module walk's check, with the typed-lowering tables
+/// published per module the way the FS lane publishes them
+/// (`check_module_impl` in typecheck_fs.vibe).
+///
+/// Before this the walk called `check_program_with_env`, which reports only a
+/// TypeEnv, so every module of the "sources passed in memory" family recorded
+/// NO table -- and the inline merge downstream therefore compiled with each
+/// typed-lowering channel empty, on the linked lane included. The observation
+/// entry runs the same check with the same `imports_already_projected = false`
+/// this lane has always used; the only addition is the capture.
+///
+/// A module whose parse carried no offsets publishes the empty table, which
+/// classifies nothing and leaves the syntactic classifiers in charge -- the
+/// same degradation `module_typed_lowering_offsets_for_path` answering `None`
+/// produces, and never a wrong classification.
+fn check_module_publishing_typed_lowering_offsets(path: String, fingerprint: String, stmts: Array[Stmt], import_env: TypeEnv) -> TypeEnv with Exception {
+  let (checked, offsets, eq_offs, eq_keys) = check_program_with_env_typed_lowering_located_observation(stmts, import_env)
+  publish_module_typed_lowering_offsets(path, fingerprint, offsets, eq_offs, eq_keys)
+  checked.final_env
+}
+
 fn ensure_fingerprint(rdb: RippleDb, env_cache: Array[(String, TypeEnv)], dep_source_cache: Array[(String, String)], parse_count: Int, path: String, stack: Array[String]) -> (String, RippleDb, Array[(String, TypeEnv)], Array[(String, String)], Int) with Exception {
   if contains_str(stack, path) {
     throw(String::concat("type_db: import cycle detected at ", path))
@@ -527,7 +551,7 @@ fn ensure_fingerprint(rdb: RippleDb, env_cache: Array[(String, TypeEnv)], dep_so
             let stmts = parse_program_with_path(path, source)
             let final_parse_count = parse_count_after_deps + 1
             let (import_env, reexport_declarations) = build_import_envs(stmts, dir_of_path(path), env_cache_after_deps)
-            let full_checked_env = check_program_with_env(stmts, import_env)
+            let full_checked_env = check_module_publishing_typed_lowering_offsets(path, fingerprint, stmts, import_env)
             let checked_env = checked_module_public_env_with_reexport_declarations(stmts, full_checked_env, reexport_declarations)
             let next_env_cache = upsert_env_cache(env_cache_after_deps, path, checked_env)
             let next_db = ripple_record_eval(db_after_deps, path, fingerprint, deps)
@@ -537,7 +561,7 @@ fn ensure_fingerprint(rdb: RippleDb, env_cache: Array[(String, TypeEnv)], dep_so
             let stmts = parse_program_with_path(path, source)
             let final_parse_count = parse_count_after_deps + 1
             let (import_env, reexport_declarations) = build_import_envs(stmts, dir_of_path(path), env_cache_after_deps)
-            let full_checked_env = check_program_with_env(stmts, import_env)
+            let full_checked_env = check_module_publishing_typed_lowering_offsets(path, fingerprint, stmts, import_env)
             let checked_env = checked_module_public_env_with_reexport_declarations(stmts, full_checked_env, reexport_declarations)
             let next_env_cache = upsert_env_cache(env_cache_after_deps, path, checked_env)
             let next_db = ripple_record_eval(db_after_deps, path, fingerprint, deps)

--- a/lib/@vibe/compiler/runtime/runtime.vibe
+++ b/lib/@vibe/compiler/runtime/runtime.vibe
@@ -59,7 +59,8 @@ import ./typecheck_fs.vibe {
   persistent_dep_list_text,
   persistent_leaf_fingerprint_text,
   persistent_type_env_cache_text,
-  publish_module_typed_lowering_offsets
+  publish_module_typed_lowering_offsets,
+  rebind_module_typed_lowering_offsets
 }
 
 import @vibe/compiler/syntax {
@@ -109,6 +110,7 @@ export ./typecheck_fs.vibe {
   module_plan_manifest_fs,
   module_typed_eq_rows_for_path,
   module_typed_lowering_offsets_for_path,
+  rebind_module_typed_lowering_offsets,
   split_typed_lowering_offsets,
   union_module_typed_eq_rows,
   union_module_typed_lowering_offsets,
@@ -545,7 +547,15 @@ fn ensure_fingerprint(rdb: RippleDb, env_cache: Array[(String, TypeEnv)], dep_so
         let fingerprint = build_fingerprint(source, dep_fps)
         match ripple_get_fingerprint(db_after_deps, path) {
           Some(cached_fp) =>
-          if cached_fp == fingerprint {
+          // #2449 (Codex review on #2453): a cache hit skips the check, and a
+          // skip publishes no typed-lowering rows -- so the hit must also
+          // REBIND this module's rows from the memo, and must fall through to
+          // a real check when it cannot. Without the second half the merge
+          // downstream reads whatever another compile in this process left at
+          // this path: measured, rows went 1 -> 0 across a warm-db re-prepare.
+          // Same fail-closed rule the FS lane's reuse arms follow
+          // (`ensure_module_typed_lowering_offsets`).
+          if cached_fp == fingerprint && rebind_module_typed_lowering_offsets(path, fingerprint) {
             (fingerprint, db_after_deps, env_cache_after_deps, dep_source_cache_after_deps, parse_count_after_deps)
           } else {
             let stmts = parse_program_with_path(path, source)

--- a/lib/@vibe/compiler/runtime/typecheck_fs.vibe
+++ b/lib/@vibe/compiler/runtime/typecheck_fs.vibe
@@ -710,6 +710,36 @@ export fn split_typed_lowering_offsets(enc: Array[Int]) -> (Array[Int], Array[In
   (floats, rels, pluses, int_renders)
 }
 
+/// #2449 (Codex review on #2453): rebind `path`'s typed-lowering rows from the
+/// memo BY FINGERPRINT, and report whether it could.
+///
+/// The in-memory module walk (`ensure_fingerprint`, runtime.vibe) skips the
+/// check when the `TypeDb` already holds this module's fingerprint, and a skip
+/// publishes nothing -- so the merge downstream reads whatever
+/// `module_typed_lowering_offsets_for_path` happens to hold for that path,
+/// which another compile in the same process may have overwritten. Measured
+/// before this: rows for a path went 1 -> 0 across a warm-db re-prepare.
+///
+/// `false` means the rows are not available for this fingerprint, and the
+/// caller must fall through to a real check rather than proceed -- the same
+/// fail-closed rule `ensure_module_typed_lowering_offsets` gives the FS lane.
+/// This is the memo-only sibling of that function: the in-memory walk carries
+/// no `Fs` effect, so there is no sidecar to fall back on.
+///
+/// Binding the hit to THIS path (not just proving the fingerprint) is the
+/// #2425 rule: `build_fingerprint` excludes the module's own path, so two
+/// byte-identical modules share a fingerprint and the consumer looks up by
+/// path.
+export fn rebind_module_typed_lowering_offsets(path: String, fingerprint: String) -> Bool {
+  match module_typed_lowering_memo_get_by_fp(fingerprint) {
+    Some((offsets, eq_offs, eq_keys)) => {
+      module_typed_lowering_memo_put(path, fingerprint, offsets, eq_offs, eq_keys)
+      true
+    },
+    None => false
+  }
+}
+
 /// True when `path`'s offsets for `fingerprint` are available (memo, else the
 /// persistent sidecar, loaded into the memo). Every reuse arm that would skip
 /// this module's check calls this alongside `valid_persistent_type_env`; a

--- a/lib/@vibe/compiler/runtime/typecheck_fs.vibe
+++ b/lib/@vibe/compiler/runtime/typecheck_fs.vibe
@@ -16,7 +16,15 @@ import @vibe/core {
 }
 
 import @vibe/ast {
-  TypeExpr, TypeExpr::is_array_of_int, trait_ref_from_key, trait_ref_key, trait_ref_name, type_param_arity, type_param_name
+  TypeExpr,
+  TypeExpr::is_array_of_int,
+  impl_target_from_key,
+  impl_target_key,
+  trait_ref_from_key,
+  trait_ref_key,
+  trait_ref_name,
+  type_param_arity,
+  type_param_name
 }
 
 import @vibe/compiler/checker {
@@ -30,6 +38,8 @@ import @vibe/compiler/checker {
   detect_unused_imports,
   import_item_kind_errors,
   report_unknown_type_names_deferred_validation,
+  typed_lowering_enc_offset,
+  typed_lowering_enc_tag,
   typing_semantics_seed,
   validate_derives
 }
@@ -64,6 +74,8 @@ import @vibe/compiler/core {
   is_builtin_iterator_serialized_boundary_path,
   is_contract_ext,
   lookup_registry_builtin,
+  namespace_private_name,
+  namespace_rename_original,
   normalize_path,
   resolution_env_seed,
   resolve_builtin,
@@ -243,6 +255,22 @@ fn module_typed_lowering_memo_put(path: String, fingerprint: String, offsets: Ar
   } else {
     ()
   }
+}
+
+/// #2449: the in-memory module walk's publication point. `ensure_fingerprint`
+/// (runtime.vibe) checks each module of the "sources passed in memory" family
+/// with the same observation the FS lane uses, and this is where its table
+/// reaches the memo the merge consumers read by path.
+///
+/// It is a thin wrapper rather than an exported `module_typed_lowering_memo_put`
+/// so the `None` case -- the parse carried no offsets, which the located-channel
+/// refusal reports -- is normalized HERE, in the file that owns the memo, to the
+/// empty table that classifies nothing.
+export fn publish_module_typed_lowering_offsets(path: String, fingerprint: String, offsets: Option[Array[Int]], eq_offs: Array[Int], eq_keys: Array[String]) -> Unit {
+  module_typed_lowering_memo_put(path, fingerprint, match offsets {
+    Some(table) => table,
+    None => array_empty()
+  }, eq_offs, eq_keys)
 }
 
 fn module_typed_lowering_memo_get_by_fp(fingerprint: String) -> Option[(Array[Int], Array[Int], Array[String])] {
@@ -515,6 +543,171 @@ fn parse_module_typed_lowering_offsets_text(text: String) -> Option[(Array[Int],
       None
     }
   }
+}
+
+/// #2391: shift each file's per-module typed-lowering table (recorded by the
+/// modular check in the file's OWN offset space) by that file's base in a
+/// disjoint-offset merge, and union them into one table. Rows are tag-encoded
+/// (offset * 8 + tag, see typed_lowering_enc in the checker), so the rebase
+/// adds base * 8 and leaves the tag bits untouched. A file the modular check
+/// never stepped in this process contributes nothing, which degrades ITS
+/// sites to the syntactic classifiers -- deterministically, because the reuse
+/// arms in typecheck_fs.vibe re-check a module whose offsets sidecar is
+/// missing rather than reusing half a cache entry.
+///
+/// #2449: this lives beside the memo it reads rather than in one merge's
+/// file, because BOTH merges need it -- the grouped file merge
+/// (entry/compiler/file_compile) and the inline-source merge
+/// (entry/compiler/fs_compile). A second copy of the decoder below is the
+/// shape that goes wrong quietly: a tag added on one side classifies nothing
+/// on the other, and an empty channel looks exactly like "nothing to
+/// classify".
+export fn union_module_typed_lowering_offsets(flat_paths: Array[String], flat_bases: Array[Int]) -> Array[Int] {
+  let out: Array[Int] = []
+  let mut i = 0
+  while i < Array::length(flat_paths) {
+    match module_typed_lowering_offsets_for_path(Array::get(flat_paths, i)) {
+      Some(offsets) => {
+        let base = Array::get(flat_bases, i)
+        let mut j = 0
+        while j < Array::length(offsets) {
+          Array::push(out, Array::get(offsets, j) + base * 8)
+          j = j + 1
+        }
+      },
+      None => ()
+    }
+    i = i + 1
+  }
+  out
+}
+
+/// The per-file union plus the alias-collision clones' duplicated entries
+/// (already in merge space and encoded, see the clone emission in each merge).
+export fn union_module_typed_lowering_with_clones(flat_paths: Array[String], flat_bases: Array[Int], clone_float_offsets: Array[Int]) -> Array[Int] {
+  let out = union_module_typed_lowering_offsets(flat_paths, flat_bases)
+  let mut ci = 0
+  while ci < Array::length(clone_float_offsets) {
+    Array::push(out, Array::get(clone_float_offsets, ci))
+    ci = ci + 1
+  }
+  out
+}
+
+/// #2441 (Codex round 1 on #2443): a module-PRIVATE nominal type in an eq
+/// row must follow the merge's private-type rename, or the row still names
+/// the source spelling while the merged declarations name the mangled one.
+/// Measured before this mapping: a dependency's private `Point` row, with
+/// the ENTRY declaring a different `Point`, dispatched the entry's
+/// `Point::equals` on the dependency's values -- `true` for content-unequal
+/// pairs. The mapping consults the SAME rename record the merge populated
+/// (#2205): a name is rewritten to `namespace_private_name(path, name)`
+/// exactly when that mangled spelling is recorded as a rename of this name,
+/// so an exported (unrenamed) type, a builtin head, and the entry file's
+/// own types all pass through unchanged.
+fn eq_key_rename_name(path: String, name: String) -> String {
+  let candidate = namespace_private_name(path, name)
+  if namespace_rename_original(candidate) == name {
+    candidate
+  } else {
+    name
+  }
+}
+
+fn eq_key_rename_ty(path: String, te: TypeExpr) -> TypeExpr {
+  match te {
+    TyName(n) => TyName(eq_key_rename_name(path, n)),
+    TyApp(n, args) => TyApp(eq_key_rename_name(path, n), for a in args {
+      eq_key_rename_ty(path, a)
+    }),
+    TyTuple(items) => TyTuple(for a in items {
+      eq_key_rename_ty(path, a)
+    }),
+    _ => te
+  }
+}
+
+/// #2441: the typed-`==` union -- the same per-file walk as
+/// union_module_typed_lowering_offsets, but the rows are (offset, TypeExpr
+/// key) pairs, so the rebase adds the plain byte base (no tag bits to
+/// preserve) and each key's nominal names are rebased through the merge's
+/// rename record (eq_key_rename_ty above). A key that does not parse is
+/// dropped rather than passed through -- fail closed. Alias-collision clone
+/// statements contribute no eq rows -- a cloned definition's `==` sites
+/// simply degrade to the syntactic classifiers, which is today's behavior
+/// for every site, never a wrong comparator.
+export fn union_module_typed_eq_rows(flat_paths: Array[String], flat_bases: Array[Int]) -> (Array[Int], Array[String]) {
+  let out_offs: Array[Int] = []
+  let out_keys: Array[String] = []
+  let mut i = 0
+  while i < Array::length(flat_paths) {
+    match module_typed_eq_rows_for_path(Array::get(flat_paths, i)) {
+      Some((eq_offs, eq_keys)) => {
+        let path = Array::get(flat_paths, i)
+        let base = Array::get(flat_bases, i)
+        let mut j = 0
+        while j < Array::length(eq_offs) {
+          match impl_target_from_key(Array::get(eq_keys, j)) {
+            Some(te) => {
+              Array::push(out_offs, Array::get(eq_offs, j) + base)
+              Array::push(out_keys, impl_target_key(eq_key_rename_ty(path, te)))
+            },
+            None => ()
+          }
+          j = j + 1
+        }
+      },
+      None => ()
+    }
+    i = i + 1
+  }
+  (out_offs, out_keys)
+}
+
+/// #2391 slice 2: decode one merged typed-lowering table into its channels --
+/// Double call-result offsets (tag 0) for `CompileCtx.float_call_offsets`,
+/// String relational anchors (tag 1) and String `+` anchors (tag 2) for the
+/// rewrite pass, and the render/`eq` argument offsets the checker typed as
+/// `Int` (tag 3) or `Double` (tag 4). The encoding is the checker's
+/// typed_lowering_enc; the enc/dec pair lives on the checker boundary so the
+/// two sides cannot drift.
+export fn split_typed_lowering_offsets(enc: Array[Int]) -> (Array[Int], Array[Int], Array[Int], Array[Int]) {
+  let floats: Array[Int] = []
+  let rels: Array[Int] = []
+  let pluses: Array[Int] = []
+  let int_renders: Array[Int] = []
+  let mut i = 0
+  while i < Array::length(enc) {
+    let value = Array::get(enc, i)
+    let tag = typed_lowering_enc_tag(value)
+    let off = typed_lowering_enc_offset(value)
+    if tag == 0 {
+      Array::push(floats, off)
+    } else if tag == 1 {
+      Array::push(rels, off)
+    } else if tag == 2 {
+      Array::push(pluses, off)
+    } else if tag == 3 {
+      // #2424: render (`__to_string` / `Int::to_string`) and `eq` ARGUMENT
+      // offsets the checker typed as `Int`.
+      Array::push(int_renders, off)
+    } else if tag == 4 {
+      // #2424: the Double half of the same argument set, unioned into the
+      // Double channel. The two tags stay distinct through the encoding
+      // because their KEYS differ -- tag 0 is a call node's own offset, tag 4
+      // is `typed_lowering_arg_offset` (a projection answers with its
+      // field-name offset) -- and they can share one array here because the
+      // consumers read it with `typed_lowering_arg_offset`, which agrees with
+      // the call offset on a call node.
+      Array::push(floats, off)
+    } else {
+      // No tag above 4 exists; dropping an unknown row degrades its site to
+      // the syntactic classifiers rather than misclassifying another offset.
+      ()
+    }
+    i = i + 1
+  }
+  (floats, rels, pluses, int_renders)
 }
 
 /// True when `path`'s offsets for `fingerprint` are available (memo, else the

--- a/lib/@vibe/compiler/tests/builtin_ident_value_test.vibe
+++ b/lib/@vibe/compiler/tests/builtin_ident_value_test.vibe
@@ -31,9 +31,12 @@
 //     indirect call, and until that exists `let f = Fs::read_file` launders
 //     authority (ADR-0075/0084/0088);
 //   * a name with NO registry row (`Map::set`) -- there is no arity to expand;
-//   * a row with an OPAQUE HANDLE position (`Map::get`'s map, a builder
-//     object) -- `reg_opaque` has no checker type at all, so a value form
-//     would hand out a signature that relates nothing;
+//   * a row with a position still spelled as an unconstrained unknown -- an
+//     internal handle (`Map::get`'s map) or a relationship nobody has written
+//     as a variable yet (the `FixedArray::*` rows) -- so a value form would
+//     hand out a signature that relates nothing. The refusal deliberately does
+//     not claim WHICH of the two it is: the registry draws that distinction in
+//     its source only, and both spellings produce `CtUnknown`;
 //
 // #2451 removed a fourth refusal and the last name list with it. A row whose
 // openness is a real type VARIABLE (`reg_var`: `Array::get` is
@@ -264,15 +267,30 @@ test "#2442: the planner reserves a slot for exactly the names with a value form
   ]), "0")
 }
 
-test "#2451: a row with an opaque handle position is refused, and says why" {
+test "#2451: a row with an unconstrained position is refused, and says why" {
   // What is left of #2448's blanket polymorphic refusal. `Map::get`'s receiver
-  // is `reg_opaque("Map")` -- an internal handle with no checker type -- so
-  // there is no variable that could relate it to anything, and the value form
-  // would hand out a signature that says nothing.
+  // is an internal handle and `FixedArray::get`'s element is a relationship
+  // nobody has written as a variable; both reach this arm.
   let msg = first_check_error(value_ident_program("Map::get"))
   assert(String::contains(msg, "Map::get"))
   assert(String::contains(msg, "not a value"))
-  assert(String::contains(msg, "no checker type"))
+  assert(String::contains(msg, "a position the compiler leaves open"))
+}
+
+test "#2453: the refusal does not claim a cause the compiler cannot observe" {
+  // Codex review on #2453. An earlier spelling said "an internal handle" for
+  // every unconstrained row, which reported `FixedArray::get` -- whose
+  // positions are ordinary unknowns, not a handle -- as something it is not.
+  // The registry draws that distinction in its SOURCE only; both spellings
+  // produce `CtUnknown`, so no message keyed off the row can tell them apart.
+  let fixed = first_check_error(value_ident_program("FixedArray::get"))
+  assert(String::contains(fixed, "FixedArray::get"))
+  assert(String::contains(fixed, "not a value"))
+  assert(!String::contains(fixed, "an internal handle -- so"))
+  assert(String::contains(fixed, "a position the compiler leaves open"))
+  // Both classes get the same sentence, because the compiler sees one thing.
+  let opaque = first_check_error(value_ident_program("Map::get"))
+  assert(String::contains(opaque, "a position the compiler leaves open"))
 }
 
 test "#2451: a polymorphic builtin's value form answers as its direct call does" {

--- a/lib/@vibe/compiler/tests/builtin_ident_value_test.vibe
+++ b/lib/@vibe/compiler/tests/builtin_ident_value_test.vibe
@@ -31,16 +31,21 @@
 //     indirect call, and until that exists `let f = Fs::read_file` launders
 //     authority (ADR-0075/0084/0088);
 //   * a name with NO registry row (`Map::set`) -- there is no arity to expand;
-//   * a POLYMORPHIC row (`Array::get`, `Array::length`) -- the registry spells
-//     an open position as `reg_any()`, and every occurrence is independent, so
-//     a value form hands out a signature that does not relate the argument to
-//     the result. Measured: `let get = Array::get` then
-//     `let s: String = get([1], 0)` checked CLEAN and printed garbage, while
-//     `Array::get([1], 0)` in the same position was correctly rejected. The
-//     two #1733 conversions are the one carve-out -- polymorphic, but shipped
-//     with a value form since then and pinned by an ANNOTATED binding in
-//     `fixtures/frozen_array_copies_test.vibe`, which is sound; their
-//     unannotated hole predates this and is measured on `aeccc0c97` too;
+//   * a row with an OPAQUE HANDLE position (`Map::get`'s map, a builder
+//     object) -- `reg_opaque` has no checker type at all, so a value form
+//     would hand out a signature that relates nothing;
+//
+// #2451 removed a fourth refusal and the last name list with it. A row whose
+// openness is a real type VARIABLE (`reg_var`: `Array::get` is
+// `(Array[T], Int) -> T`) says which positions are the same type, so the
+// checker instantiates the row per occurrence and the value form is sound.
+// Measured before that, and the reason the whole class was refused:
+// `let get = Array::get` then `let s: String = get([1], 0)` checked CLEAN and
+// printed garbage, while `Array::get([1], 0)` in the same position was
+// rejected with `expected String, got Int`. Both now give that same message.
+// #1733's two FrozenArray conversions were the carve-out kept through that
+// refusal (polymorphic, but shipped with a value form since #1733); they are
+// ordinary rows again, and their unannotated hole is closed with the rest.
 //   * a BARE name (`eq`, `not`) -- a compiler limitation, not a decision about
 //     the language, and the one row of #2442 left open. `count_lambda_sites_expr`
 //     predicts for the whole program how many lambda table slots the codegen
@@ -101,17 +106,22 @@ test "#2442: the value form is decided by arity and effect, not by a name list" 
   inspect(builtin_value_form_arity("String::length"), "1")
   inspect(builtin_value_form_arity("String::concat"), "2")
   inspect(builtin_value_form_arity("String::substring"), "3")
-  // A POLYMORPHIC row is refused: the registry writes an open position as
-  // `reg_any()` and every occurrence is independent, so a value form cannot
-  // say the element in the parameter and the result are the same type.
-  inspect(builtin_value_form_arity("Array::length"), "-1")
-  inspect(builtin_value_form_arity("Array::get"), "-1")
+  // #2451: a row spelled with `reg_var` relates its positions, so it reports
+  // its arity like any other.
+  inspect(builtin_value_form_arity("Array::length"), "1")
+  inspect(builtin_value_form_arity("Array::get"), "2")
+  inspect(builtin_value_form_arity("Array::push"), "2")
+  inspect(builtin_value_form_arity("Array::slice"), "3")
+  // A row with an OPAQUE handle position is still refused: `reg_opaque` has no
+  // checker type, so there is nothing for a variable to relate.
   inspect(builtin_value_form_arity("Map::get"), "-1")
+  inspect(builtin_value_form_arity("ArrayBuilder::push"), "-1")
   // Bare names are pure two-argument rows and are still refused, for the
   // planner reason above rather than anything about the builtins themselves.
   inspect(builtin_value_form_arity("eq"), "-1")
   inspect(builtin_value_form_arity("not"), "-1")
-  // #1733's two are no longer special-cased; they are just arity-1 rows.
+  // #1733's two are no longer special-cased anywhere: #2442 removed the name
+  // list in the codegen planner and #2451 removed the last one here.
   inspect(builtin_value_form_arity("FrozenArray::from_array"), "1")
   inspect(builtin_value_form_arity("FrozenArray::to_array"), "1")
   // An effect row refuses, and so does a name with no row at all.
@@ -254,17 +264,41 @@ test "#2442: the planner reserves a slot for exactly the names with a value form
   ]), "0")
 }
 
-test "#2442: a polymorphic builtin is refused, and says why" {
-  // Codex review on #2448. The refusal is the fail-closed direction: measured
-  // before it, `let get = Array::get; let s: String = get([1], 0)` compiled
-  // and printed garbage while `Array::get([1], 0)` in the same position was
-  // rejected with `expected String, got Int`.
-  let msg = first_check_error(value_ident_program("Array::get"))
-  assert(String::contains(msg, "Array::get"))
+test "#2451: a row with an opaque handle position is refused, and says why" {
+  // What is left of #2448's blanket polymorphic refusal. `Map::get`'s receiver
+  // is `reg_opaque("Map")` -- an internal handle with no checker type -- so
+  // there is no variable that could relate it to anything, and the value form
+  // would hand out a signature that says nothing.
+  let msg = first_check_error(value_ident_program("Map::get"))
+  assert(String::contains(msg, "Map::get"))
   assert(String::contains(msg, "not a value"))
-  assert(String::contains(msg, "positions the registry leaves open"))
-  let msg2 = first_check_error(value_ident_program("Array::length"))
-  assert(String::contains(msg2, "not a value"))
+  assert(String::contains(msg, "no checker type"))
+}
+
+test "#2451: a polymorphic builtin's value form answers as its direct call does" {
+  // The measurement this issue exists for. Both spellings must give the SAME
+  // message; before the registry could relate two positions, the left column
+  // checked clean and printed garbage.
+  let through_value = first_check_error("let get = Array::get\nlet s: String = get([1], 0)\n")
+  let direct = first_check_error("let s2: String = Array::get([1], 0)\n")
+  assert(String::contains(through_value, "expected String, got Int"))
+  assert(String::contains(direct, "expected String, got Int"))
+  // The other direction, and the other row: an element the array cannot hold.
+  let pushed = first_check_error("let p = Array::push\nlet xs: Array[Int] = []\nlet u = p(xs, \"nope\")\n")
+  assert(String::contains(pushed, "expected Int, got String"))
+  // A correct use still checks.
+  inspect(first_check_error("let g = Array::get\nlet n: Int = g([1], 0)\n"), content = "")
+  inspect(first_check_error("let len = Array::length\nlet n2: Int = len([1, 2])\n"), content = "")
+}
+
+test "#2451: the unannotated FrozenArray binding is rejected, the annotated one is not" {
+  // #1733's hole, and the last silently-wrong value form in the language: the
+  // row said `Array[?] -> FrozenArray[?]`, so this read Ints as Strings with a
+  // clean check.
+  let unannotated = first_check_error("let freeze = FrozenArray::from_array\nlet fz: FrozenArray[String] = freeze([1, 2])\n")
+  assert(String::contains(unannotated, "expected FrozenArray[String], got FrozenArray[Int]"))
+  // The spelling `fixtures/frozen_array_copies_test.vibe` uses is unaffected.
+  inspect(first_check_error("let freeze2: (Array[String]) -> FrozenArray[String] = FrozenArray::from_array\nlet fz2 = freeze2([\"a\"])\n"), content = "")
 }
 
 test "#2442: a builtin with a CONCRETE signature is a value -- String::substring" {

--- a/lib/@vibe/compiler/tests/inline_lane_typed_offsets_test.vibe
+++ b/lib/@vibe/compiler/tests/inline_lane_typed_offsets_test.vibe
@@ -29,7 +29,11 @@
 //# Imports
 
 import @vibe/compiler/entry/compiler/fs_compile {
-  compile_with_closure_sources_wasi_cached, compile_with_closure_sources_wasi_unchecked_cached
+  compile_with_closure_sources_wasi_cached, compile_with_closure_sources_wasi_unchecked_cached, prepare_modules_cached
+}
+
+import @vibe/compiler/runtime {
+  module_typed_lowering_offsets_for_path, publish_module_typed_lowering_offsets
 }
 
 import @vibe/core {
@@ -37,7 +41,7 @@ import @vibe/core {
 }
 
 import ../type_db.vibe {
-  db_new
+  TypeDb, db_new
 }
 
 //# Functions
@@ -59,12 +63,12 @@ let inline_projection_source: String = "fn main() -> Unit with Stdout {\n  let t
 let inline_plain_source: String = "fn main() -> Unit with Stdout {\n  let a = 7\n  let b = 4\n  let _ = a - b\n  println(\"x\")\n}\n"
 
 fn compile_checked(source: String) -> Bytes with Exception {
-  let (bytes, _) = compile_with_closure_sources_wasi_cached(db_new(), source, "main.vibe", no_extra_sources(), "main")
+  let (bytes, _) = compile_checked_with(db_new(), source)
   bytes
 }
 
 fn compile_unchecked(source: String) -> Bytes with Exception {
-  let (bytes, _) = compile_with_closure_sources_wasi_unchecked_cached(db_new(), source, "main.vibe", no_extra_sources(), "main")
+  let (bytes, _) = compile_unchecked_with(db_new(), source)
   bytes
 }
 
@@ -78,4 +82,54 @@ test "#2449 a program with nothing to classify compiles byte-identically" {
   let with_tables = compile_checked(inline_plain_source)
   let without_tables = compile_unchecked(inline_plain_source)
   assert(with_tables == without_tables)
+}
+
+//# Codex review on #2453 -- the two ways this channel could be filled and then
+// silently bypassed. Each was measured on the fix's own branch before the fix.
+
+test "#2449 the checked entry's bytes do not depend on a shared TypeDb" {
+  // The artifact fingerprint is derived from the SOURCES alone, so an artifact
+  // kind shared with an entry that emits different bytes hands the second
+  // caller the first one's lowering. Before the `wasi-typed` split, measured
+  // on one db with the unchecked entry first: the checked call returned the
+  // UNCHECKED bytes, and they differed from what it produces on a fresh db --
+  // the caller asked for the typed lowering and silently got the other one.
+  let (unchecked, shared_db) = compile_unchecked_with(db_new(), inline_projection_source)
+  let (checked_after, _) = compile_checked_with(shared_db, inline_projection_source)
+  let (checked_alone, _) = compile_checked_with(db_new(), inline_projection_source)
+  assert(!(unchecked == checked_after))
+  assert(checked_after == checked_alone)
+}
+
+test "#2449 a warm TypeDb still leaves this module's rows bound" {
+  // `ensure_fingerprint` skips the check when the db already holds the
+  // module's fingerprint, and a skip publishes nothing. Measured before the
+  // rebind: with another compile in the same process having overwritten this
+  // path's memo row, the rows went 1 -> 0 across a warm re-prepare, and the
+  // merge downstream then read an empty (or another source's) table.
+  let warm_path = "warm_rebind_probe.vibe"
+  let db1 = prepare_modules_cached(db_new(), warm_path, inline_projection_source, no_extra_sources())
+  assert(row_count(warm_path) > 0)
+  // Stand in for that other compile: rebind the path to an unrelated
+  // fingerprint with no rows.
+  let emptied: Array[Int] = []
+  let no_keys: Array[String] = []
+  publish_module_typed_lowering_offsets(warm_path, "#2453-unrelated-fingerprint", Some(emptied), emptied, no_keys)
+  let _ = prepare_modules_cached(db1, warm_path, inline_projection_source, no_extra_sources())
+  assert(row_count(warm_path) > 0)
+}
+
+fn row_count(path: String) -> Int {
+  match module_typed_lowering_offsets_for_path(path) {
+    Some(rows) => Array::length(rows),
+    None => 0 - 1
+  }
+}
+
+fn compile_checked_with(db: TypeDb, source: String) -> (Bytes, TypeDb) with Exception {
+  compile_with_closure_sources_wasi_cached(db, source, "main.vibe", no_extra_sources(), "main")
+}
+
+fn compile_unchecked_with(db: TypeDb, source: String) -> (Bytes, TypeDb) with Exception {
+  compile_with_closure_sources_wasi_unchecked_cached(db, source, "main.vibe", no_extra_sources(), "main")
 }

--- a/lib/@vibe/compiler/tests/inline_lane_typed_offsets_test.vibe
+++ b/lib/@vibe/compiler/tests/inline_lane_typed_offsets_test.vibe
@@ -1,0 +1,81 @@
+//# #2449: the inline-source merge (`build_merged_stmts_inline`) and its
+// typed-lowering tables.
+//
+// The merge parsed with `parse_program(lex(source))` -- unlocated, every node
+// offset -1 -- and computed no per-file bases, so there was no offset space to
+// rebase a per-module table into. Every entry built on it therefore compiled
+// with each typed-lowering channel EMPTY, including two on the LINKED lane,
+// which is the lane those tables exist to feed.
+//
+// Two halves are pinned here, the same pair `module_lane_typed_offsets_test`
+// uses for #2437's lane, and for the same reasons:
+//
+//   1. The tables now REACH codegen and change what it emits. The CHECKED
+//      entry (`compile_with_closure_sources_wasi_cached`, which runs
+//      `prepare_modules_cached` and so has per-module rows to rebase) and the
+//      UNCHECKED one (`compile_with_closure_sources_wasi_unchecked_cached`,
+//      which deliberately runs no check and therefore keeps empty tables) must
+//      produce DIFFERENT bytes for a program whose render argument no
+//      syntactic arm classifies. Both reach the SAME codegen entry, so the
+//      tables are the only difference between them.
+//   2. It is inert where it should be. For a program with nothing to classify,
+//      the two must be byte-identical -- a channel that moved unrelated output
+//      would be a regression, not a fix.
+//
+// That the classification is CORRECT is pinned behaviourally by
+// fixtures/gc_lane_scalar_parity_test.vibe, which runs the same
+// `CompileCtx.int_render_offsets` / `float_call_offsets` consumers.
+
+//# Imports
+
+import @vibe/compiler/entry/compiler/fs_compile {
+  compile_with_closure_sources_wasi_cached, compile_with_closure_sources_wasi_unchecked_cached
+}
+
+import @vibe/core {
+  array_empty
+}
+
+import ../type_db.vibe {
+  db_new
+}
+
+//# Functions
+
+fn no_extra_sources() -> Array[(String, String)] {
+  array_empty()
+}
+
+/// A projection is the sharpest argument to use here: the render's argument is
+/// an `EDot`, which no syntactic arm classifies, so without the table
+/// `__to_string` falls through to its runtime string-pointer heuristic -- which
+/// for `64 << 32` (a zero low word, an in-bounds high word) answers with the
+/// EMPTY STRING. With the table it takes the integer path, and the emitted code
+/// differs.
+let inline_projection_source: String = "fn main() -> Unit with Stdout {\n  let t = (64 << 32, 1)\n  println(__to_string(t.0))\n}\n"
+
+/// No render, no `eq`, no Double call result: nothing for either table to
+/// carry, so the located parse and the per-file rebase must not move a byte.
+let inline_plain_source: String = "fn main() -> Unit with Stdout {\n  let a = 7\n  let b = 4\n  let _ = a - b\n  println(\"x\")\n}\n"
+
+fn compile_checked(source: String) -> Bytes with Exception {
+  let (bytes, _) = compile_with_closure_sources_wasi_cached(db_new(), source, "main.vibe", no_extra_sources(), "main")
+  bytes
+}
+
+fn compile_unchecked(source: String) -> Bytes with Exception {
+  let (bytes, _) = compile_with_closure_sources_wasi_unchecked_cached(db_new(), source, "main.vibe", no_extra_sources(), "main")
+  bytes
+}
+
+test "#2449 the inline merge's typed-lowering tables reach codegen" {
+  let with_tables = compile_checked(inline_projection_source)
+  let without_tables = compile_unchecked(inline_projection_source)
+  assert(!(with_tables == without_tables))
+}
+
+test "#2449 a program with nothing to classify compiles byte-identically" {
+  let with_tables = compile_checked(inline_plain_source)
+  let without_tables = compile_unchecked(inline_plain_source)
+  assert(with_tables == without_tables)
+}


### PR DESCRIPTION
Two independent defects, both about a channel that was quietly inert.

## #2449 — the inline-source merge compiled with every typed-lowering channel empty

`build_merged_stmts_inline` merged every "sources passed in memory" program from an **unlocated** parse (every node offset `-1`) and computed no per-file bases, so there was no offset space for a per-module typed-lowering table to be rebased into. Every entry built on it compiled with each channel empty — including two on the **linked** lane, which is the lane those tables exist to feed.

The producer was missing too, and that half is why the merge had nothing to rebase. `runtime.vibe` defined its own private `parse_program_with_path` as `parse_program(lex(source))`, **shadowing** the located, memoized one next to it in the same package. So the in-memory module walk (`ensure_fingerprint`, reached by `prepare_modules_cached`) checked an unlocated AST, and `check_program_with_env` reported only a `TypeEnv` anyway.

Three changes, and the middle one is the root cause:

- `ensure_fingerprint` checks through a new `check_program_with_env_typed_lowering_located_observation` — the same observation the FS lane uses, with the same `imports_already_projected = false` this lane has always had — and publishes the module's rows.
- the shadowing `parse_program_with_path` is deleted; `runtime.vibe` imports the located, memoized sibling. That also removes a second parse of the same text: the merge and the check now share one.
- the merge rebases each file into a disjoint offset range and reports its base, as `build_grouped_merged_stmts_impl` has since #2391, and the collision-def clones reuse the merge's own parsed copies instead of reparsing the provider.

The per-file rebase and the tag decoder move next to the memo they read, so both merges share **one** decoder. A second copy is the shape that fails quietly: a tag understood by one side and not the other leaves an empty channel, and an empty channel is indistinguishable from "nothing to classify".

Only entries that run `prepare_modules_cached` consume the tables, and they now write a **distinct artifact kind** (`wasi-typed` / `wasi-mvp-typed`) so a cache entry cannot cross between an entry that compiles with the tables and one that compiles without them. The warm-`TypeDb` path rebinds the rows by fingerprint and falls through to a real check when it cannot. Both of those came from review; see below.

Measured, checked entry vs the unchecked one on the same source (RC lane, two files so the rebase is exercised):

| render | checked | unchecked |
| --- | --- | --- |
| `Double` field, dependency file | `2.25` | `4612248968380809216` |
| `Int` `64 << 32`, entry file | `274877906944` | *(empty string)* |

`compile_with_modules_cached` is **not** fixed here: it does not go through the statement merge at all — it reprints the program to `module_source` and reparses that text — so its tables stay empty until #2437's statement-merge work lands. There is a comment at that call site saying so.

## #2451 — a polymorphic builtin had no sound value form

The registry spelled every open position `reg_any()` = `CtUnknown`, and each occurrence is independent, so the `Array::get` row did not say that the array's element and the result are the same type. Direct calls survive that through dedicated refinements; a first-class **value** exposes the raw row.

```
let get = Array::get
let s: String = get([1], 0)          // CLEAN, prints garbage
let s2: String = Array::get([1], 0)  // expected String, got Int
```

#2448 handled it by refusing every unknown-bearing row, which left #1733's two `FrozenArray` conversions carved out **by name** — and the carve-out carried the hole: `let freeze = FrozenArray::from_array` then `let fz: FrozenArray[String] = freeze([1, 2])` checked clean and read the Ints as Strings. That was the last silently-wrong value form in the language.

`reg_var(n)` is the missing spelling: two positions written `reg_var(0)` are the same type, and thirteen `Array::*` / `FrozenArray::*` rows use it. `registry_builtin_scheme` closes such a row into a `CtForAll`, and the checker's value-form arm instantiates it per occurrence.

Every **other** consumer reads an erased view — `builtin_registry_typed()` returns the rows with each variable turned back into `CtUnknown`, memoized on first use. That is the design, not caution: unifying a raw `CtVar(0)` out of a row against a module's own inference would bind *its* variable 0, and returning the scheme from `lookup_registry_builtin` instead would wrap rows in a `CtForAll` that the effect walk, the contract checker and the codegen lookups all pattern-match past — losing an effect row with no diagnostic.

Measured after:

```
let get = Array::get; let s: String = get([1], 0)
  -> expected String, got Int                      (the direct call's own message)
let freeze = FrozenArray::from_array
let fz: FrozenArray[String] = freeze([1, 2])
  -> expected FrozenArray[String], got FrozenArray[Int]
let p = Array::push; p(xs_of_Int, "nope")
  -> expected Int, got String
let freeze2: (Array[String]) -> FrozenArray[String] = FrozenArray::from_array
  -> clean                                         (the fixture's spelling)
```

`builtin_value_form_arity` has no name list left in it. What still has no value form is an effect row, a bare name, and a row with a position still spelled as an unconstrained unknown. The refusal for the third names the class rather than a cause — see the third review item below for why it cannot do better.

### One "done when" item deliberately not met

#2451 also asked for a direct-call refinement arm to be deleted in favour of the row's scheme, as evidence the relationship really lives in the row. Measured, that is **not** behaviour-neutral: those arms are deliberately tolerant — `FrozenArray::length` applied to an `Array[Int]` checks clean today, as does `Array::get` on a `FrozenArray[Int]` — while the scheme unifies and would reject both. Filed as #2454.

## Review findings, all measured before fixing

| finding | measured before | fix |
| --- | --- | --- |
| P1 checked and unchecked inline entries shared an artifact key | on one `TypeDb`, the checked call returned the **unchecked** bytes | the three entries whose bytes this PR changed write `wasi-typed` / `wasi-mvp-typed`; the unchanged entry keeps `wasi`, so every existing key keeps its old meaning |
| P1 a warm `TypeDb` cache hit published no rows | rows went **1 → 0** across a warm re-prepare | the hit rebinds by fingerprint and **falls through to a real check when it cannot** — the FS lane's own fail-closed rule |
| P2 the refusal claimed "an internal handle" for rows that have none | `FixedArray::get` was told it contained a handle | the message could never have been right: `reg_any()` and `reg_opaque(k)` both produce `CtUnknown`, so nothing keyed off the row can tell them apart. It now names the class and gives the edit for each case |

The `FixedArray::*` rows were left unmigrated on purpose. They declare `in_linear=false`, yet a direct `FixedArray::get` call measurably compiles and answers on the **linear** lane and fails on **gc** — the row's own lane metadata is the opposite of what the lanes do, and `verify_lane_builtins` (#415) is driven by those same flags. Added to #2454.

## Verification

- `inline_lane_typed_offsets_test.vibe` (new, 4 tests): the channel reaches codegen, is inert where it should be, and both review findings — each verified to fail without its fix, separately, since the runner reports only the first failing test in a file.
- `builtin_ident_value_test.vibe`: 34 tests, rewritten for the new contract, including that the refusal does not claim a cause the compiler cannot observe.
- `fixtures/builtin_value_form_test.vibe`: two new runtime tests exercising a polymorphic builtin's value form at two element types, run on all three lanes by the early gate.
- Early gate **39/39 exit 0** and unit suite **1100/1100 exit 0** against a stage2 built from this tree; cheatsheet doctest 40 pass / 0 fail; `check_cheatsheet_signatures.sh`; `vibe fmt --check`; `pkf run pre-commit` on every commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FYMVd6D2o82suTfTwoJPMf