### PR TITLE
Two checker unsoundness fixes: type anonymous-record projections (#2452), reject a binder that quantifies a captured slot (#2455)

### DIFF
--- a/docs/cheatsheet.md
+++ b/docs/cheatsheet.md
@@ -2438,6 +2438,52 @@ Pinned by `fixtures/builtin_value_form_test.vibe` (the runtime answers, all
 three lanes) and `lib/@vibe/compiler/tests/builtin_ident_value_test.vibe` (the
 admission rule and every diagnostic quoted above).
 
+### A generic binder may not quantify a slot the lambda CAPTURED
+
+An explicit binder (`[T]`) makes a lambda generic per call. That is only sound
+when the thing the binder describes is created per call too. A binder that ends
+up naming a slot of an ENCLOSING binding is rejected at its declaration:
+
+```vibe skip
+fn main() -> Unit {
+  let xs = []
+
+  // -- rejected
+  let get = [T]() -> Array[T] { xs }
+  // move `xs` inside the lambda, or drop the `[T]` binder: the captured `xs`
+  // fixes `T`, so every call would use one value at a different type
+
+  // -- accepted: a fresh array per call, so `T` really does vary
+  let mk = [T]() -> Array[T] { [] }
+  let a: Array[Int] = mk()
+  let b: Array[String] = mk()
+}
+```
+
+Checking `-> Array[T]` unifies `xs`'s element slot with the binder, so without
+the check `fill(get(), 1)` and `fill_s(get(), "s")` both pass and ONE runtime
+array holds an Int and a String (#2455). It is the same silent-wrong class as
+the empty-array value restriction (#2447: `let xs = []` used at two element
+types), one quantifier away — the restriction cannot see it, because after
+unification the captured slot and the bound variable are literally one
+variable.
+
+The two edits in the message are the whole fix, and which one is right depends
+on what you meant: **move the value inside** if each call should get its own,
+**drop the binder** if they should share one (the lambda is then monomorphic,
+and its element type is decided by the first use).
+
+Only an OPEN slot is an escape. These all stay clean, measured:
+
+| captured | why it is fine |
+|---|---|
+| `let n = 1`, `let xs: Array[Int] = []` | no open variable to fix |
+| `let xs = [1]` with `[T](v: T) -> Int` | the binder does not touch `xs`'s slot |
+| a generic `fn mk[T]()` | a scheme, instantiated fresh at the call |
+| the lambda's own recursive name | unified with its signature only after the body is checked |
+
+Pinned by `lib/@vibe/compiler/tests/generic_binder_escape_test.vibe`.
+
 ### A `handle` that type-checks can still fail to compile
 
 Eligibility is not part of the type system, so this failure is invisible to

--- a/docs/cheatsheet.md
+++ b/docs/cheatsheet.md
@@ -2450,8 +2450,9 @@ fn main() -> Unit {
 
   // -- rejected
   let get = [T]() -> Array[T] { xs }
-  // move `xs` inside the lambda, or drop the `[T]` binder: the captured `xs`
-  // fixes `T`, so every call would use one value at a different type
+  // move `xs` inside the lambda, or drop `[T]` and every `T` in its
+  // signature: the captured `xs` fixes `T`, so every call would use one
+  // value at a different type
 
   // -- accepted: a fresh array per call, so `T` really does vary
   let mk = [T]() -> Array[T] { [] }
@@ -2472,6 +2473,19 @@ The two edits in the message are the whole fix, and which one is right depends
 on what you meant: **move the value inside** if each call should get its own,
 **drop the binder** if they should share one (the lambda is then monomorphic,
 and its element type is decided by the first use).
+
+Drop the binder's `T`s along with the binder. `[T]` and the `T` in
+`-> Array[T]` are one declaration and one use, so removing only the first
+leaves `unknown type `T`` behind:
+
+```vibe skip
+// -- still an error: the binder is gone, its use is not
+let get = () -> Array[T] { xs }
+
+// -- accepted
+let get = () -> { xs }
+let a: Array[Int] = get()
+```
 
 Only an OPEN slot is an escape. These all stay clean, measured:
 

--- a/lib/@vibe/compiler/checker/checker.vibe
+++ b/lib/@vibe/compiler/checker/checker.vibe
@@ -11751,6 +11751,15 @@ fn check_expr_capture_impl(expr: Expr, env: TypeEnv, defs: Array[TypeDef], s: Su
       // is provenance, so it is read from the environment here rather than
       // from the type. Rank-1: the binder is rejected at its own declaration,
       // so no call site has to carry the provenance.
+      //
+      // Both edits in the message are spelled so that following them
+      // literally works. Codex P2 on #2458: an earlier wording said "drop the
+      // `[T]` binder", and doing exactly that to the demonstrated case leaves
+      // `T` in the return annotation, so the next answer is
+      // `unknown type `T`` -- a fix that does not fix, which is the one thing
+      // a diagnostic may not be. Measured, all three: dropping only `[T]`
+      // fails that way, dropping it WITH the signature `T`s checks clean, and
+      // moving the value inside checks clean.
       let escaping = if tplen == 0 {
         array_empty()
       } else {
@@ -11768,7 +11777,7 @@ fn check_expr_capture_impl(expr: Expr, env: TypeEnv, defs: Array[TypeDef], s: Su
           let (ecname, ecids) = Array::get(escaping, eci)
           if !ereported && esc_ids_intersect(binder_ids, ecids) {
             ereported = true
-            Array::push(errors, String::concat(String::concat(String::concat(String::concat(String::concat(String::concat("move `", ecname), "` inside the lambda, or drop the `["), etpname), "]` binder: the captured `"), ecname), String::concat(String::concat(String::concat("` fixes `", etpname), "`, so every call would use one value at a different type"), off_marker(railway_expr_off(body)))))
+            Array::push(errors, String::concat(String::concat(String::concat(String::concat(String::concat(String::concat(String::concat("move `", ecname), "` inside the lambda, or drop `["), etpname), "]` and every `"), etpname), "` in its signature: the captured `"), String::concat(String::concat(String::concat(String::concat(ecname, "` fixes `"), etpname), "`, so every call would use one value at a different type"), off_marker(railway_expr_off(body)))))
           } else {
             ()
           }

--- a/lib/@vibe/compiler/checker/checker.vibe
+++ b/lib/@vibe/compiler/checker/checker.vibe
@@ -8642,14 +8642,26 @@ fn check_expr_capture_impl(expr: Expr, env: TypeEnv, defs: Array[TypeDef], s: Su
           // PATTERNS over receivers this pass cannot resolve, and the fix is
           // to stop losing a type that IS known, not to start rejecting types
           // that are not.
+          //
+          // The index KEEPS its `Int` constraint. Refining the result is the
+          // only thing this arm adds; taking the call over from the builtin
+          // table would otherwise drop the one thing the old signature did
+          // check. Source can write `__rec_field(r, "bad")` directly -- the
+          // name is not reserved from expressions -- and codegen requires an
+          // `EInt` index, so dropping the constraint made `vibe check` answer
+          // "clean" for a program that then throws. Found by Codex on #2458;
+          // measured on `ed1089a9f`, a `String` and a `Bool` index were both
+          // rejected before and both clean after, which is why the red test
+          // for this is a direct call rather than a desugared one.
           let (obj_ty, s1, c1) = check_expr_capture(Array::get(args, 0), env, defs, s, c, errors, tytab, capture, lane)
-          let (_, s2, c2) = check_expr_capture(Array::get(args, 1), env, defs, s1, c1, errors, tytab, capture, lane)
-          let result = match subst_apply(s2, obj_ty) {
+          let (idx_ty, s2, c2) = check_expr_capture(Array::get(args, 1), env, defs, s1, c1, errors, tytab, capture, lane)
+          let s2b = check_assignable(CtInt, subst_apply(s2, idx_ty), s2, errors, "__rec_field index must be Int", call_off)
+          let result = match subst_apply(s2b, obj_ty) {
             CtRecord(rfields) => match Array::get(args, 1) {
-              // The index is always a literal here (both producers emit
-              // `EInt`). Anything else, or out of range, stays tolerant --
-              // the desugar cannot emit it, so an error would be unreachable
-              // and this is not the place to invent a new rejection.
+              // Both producers emit a literal `EInt`. A non-literal index is
+              // left tolerant rather than rejected: it cannot be resolved to a
+              // field here, and the `Int` constraint above already covers the
+              // type. An out-of-range literal keeps the pre-#2452 answer too.
               EInt(slot) => if slot >= 0 && slot < Array::length(rfields) {
                 let (_, fty) = Array::get(rfields, slot)
                 fty
@@ -8660,7 +8672,7 @@ fn check_expr_capture_impl(expr: Expr, env: TypeEnv, defs: Array[TypeDef], s: Su
             },
             _ => CtUnknown
           }
-          (tab_call_ty(tytab, call_off, result, capture, lane), s2, c2)
+          (tab_call_ty(tytab, call_off, result, capture, lane), s2b, c2)
         } else if name == "__slice" && Array::length(args) == 3 {
           // #1682: the old fallback signature was
           // `(CtUnknown, Int, Int) -> CtUnknown`, so both the receiver and

--- a/lib/@vibe/compiler/checker/checker.vibe
+++ b/lib/@vibe/compiler/checker/checker.vibe
@@ -8616,6 +8616,51 @@ fn check_expr_capture_impl(expr: Expr, env: TypeEnv, defs: Array[TypeDef], s: Su
             _ => CtUnknown
           }
           (tab_call_ty(tytab, call_off, result, capture, lane), s2, c2)
+        } else if name == "__rec_field" && Array::length(args) == 2 {
+          // #2452: `r.field` on an anonymous-record BINDING never reaches the
+          // `EDot` arm below -- the desugar rewrites it to
+          // `__rec_field(r, slot)` first (`anon_dot_rewrite`,
+          // normalize/desugar_trait_dict.vibe), and the builtin table types
+          // that call `(CtUnknown, Int) -> CtUnknown`. Its own comment called
+          // that "lenient ... only needs to resolve, not constrain", which was
+          // true while it served only the record-PATTERN desugar; #1839 routed
+          // EVERY dot access on an anonymous record through it and the
+          // leniency became a silent-wrong hole.
+          //
+          // Measured before this, all clean: `let r = record { n: 1 }` then
+          // `let s: String = r.n`, `String::length(r.n)`, `if r.n { .. }`,
+          // `r.n(1)`, and `let r = record { xs: [1] }` then
+          // `Array::push(r.xs, "s")`. An INLINE `(record { n: 1 }).n` was
+          // strict the whole time -- with no binding there is no sentinel, so
+          // it keeps its `EDot` and reaches the record arm there. Two
+          // spellings of one read disagreed, and the loose one is the one
+          // people write.
+          //
+          // Resolve the slot against the receiver's own field list, the same
+          // way the `EDot` `CtTuple` arm resolves `.N`. A non-record receiver
+          // keeps the tolerant answer: this call is also emitted for record
+          // PATTERNS over receivers this pass cannot resolve, and the fix is
+          // to stop losing a type that IS known, not to start rejecting types
+          // that are not.
+          let (obj_ty, s1, c1) = check_expr_capture(Array::get(args, 0), env, defs, s, c, errors, tytab, capture, lane)
+          let (_, s2, c2) = check_expr_capture(Array::get(args, 1), env, defs, s1, c1, errors, tytab, capture, lane)
+          let result = match subst_apply(s2, obj_ty) {
+            CtRecord(rfields) => match Array::get(args, 1) {
+              // The index is always a literal here (both producers emit
+              // `EInt`). Anything else, or out of range, stays tolerant --
+              // the desugar cannot emit it, so an error would be unreachable
+              // and this is not the place to invent a new rejection.
+              EInt(slot) => if slot >= 0 && slot < Array::length(rfields) {
+                let (_, fty) = Array::get(rfields, slot)
+                fty
+              } else {
+                CtUnknown
+              },
+              _ => CtUnknown
+            },
+            _ => CtUnknown
+          }
+          (tab_call_ty(tytab, call_off, result, capture, lane), s2, c2)
         } else if name == "__slice" && Array::length(args) == 3 {
           // #1682: the old fallback signature was
           // `(CtUnknown, Int, Int) -> CtUnknown`, so both the receiver and

--- a/lib/@vibe/compiler/checker/checker.vibe
+++ b/lib/@vibe/compiler/checker/checker.vibe
@@ -3032,6 +3032,127 @@ fn append_row_label(labels: Array[String], label: String) -> Unit {
   }
 }
 
+/// #2455: the type variables reachable from a value, WITHOUT descending
+/// `CtForAll`. A quantified scheme's bound ids belong to another scope's
+/// counter domain -- `instantiate` renames them precisely because they can
+/// collide with locally fresh ids (#743) -- so reading them as environment
+/// variables would reject valid programs. Everything a scheme leaves free is
+/// unreachable through this walk too, which is the conservative direction:
+/// the escape check below only ever reports fewer binders, never more.
+fn escape_tvars_into(ty: Type, out: Array[Int]) -> Unit {
+  match ty {
+    CtVar(id) => if !esc_int_has(out, id) {
+      Array::push(out, id)
+    } else {
+      ()
+    },
+    CtFn(ps, r, _) => {
+      let mut i = 0
+      while i < Array::length(ps) {
+        escape_tvars_into(Array::get(ps, i), out)
+        i = i + 1
+      }
+      escape_tvars_into(r, out)
+    },
+    CtArray(elem) => escape_tvars_into(elem, out),
+    CtOption(elem) => escape_tvars_into(elem, out),
+    CtTuple(elems) => {
+      let mut i = 0
+      while i < Array::length(elems) {
+        escape_tvars_into(Array::get(elems, i), out)
+        i = i + 1
+      }
+    },
+    CtRecord(rfields) => {
+      let mut i = 0
+      while i < Array::length(rfields) {
+        let (_, rft) = Array::get(rfields, i)
+        escape_tvars_into(rft, out)
+        i = i + 1
+      }
+    },
+    CtNamed(_, args) => {
+      let mut i = 0
+      while i < Array::length(args) {
+        escape_tvars_into(Array::get(args, i), out)
+        i = i + 1
+      }
+    },
+    CtApplied(head, args) => {
+      escape_tvars_into(head, out)
+      let mut i = 0
+      while i < Array::length(args) {
+        escape_tvars_into(Array::get(args, i), out)
+        i = i + 1
+      }
+    },
+    _ => ()
+  }
+}
+
+fn esc_int_has(xs: Array[Int], v: Int) -> Bool {
+  let mut i = 0
+  let mut found = false
+  while i < Array::length(xs) && !found {
+    if Array::get(xs, i) == v {
+      found = true
+    } else {
+      ()
+    }
+    i = i + 1
+  }
+  found
+}
+
+fn esc_ids_intersect(a: Array[Int], b: Array[Int]) -> Bool {
+  let mut i = 0
+  let mut hit = false
+  while i < Array::length(a) && !hit {
+    if esc_int_has(b, Array::get(a, i)) {
+      hit = true
+    } else {
+      ()
+    }
+    i = i + 1
+  }
+  hit
+}
+
+/// #2455: each name this closure CAPTURES from an enclosing scope, paired with
+/// the still-open type variables of the value bound to it.
+///
+/// A RECURSIVE binding does not need excluding here, measured both spellings
+/// (`let rec f = [T](..)` and a top-level `fn f[T](..)`) and both uses (a call
+/// and a bare value reference): an unannotated recursive name is bound to a
+/// placeholder variable that is unified with the signature only AFTER the body
+/// is checked, so while this runs it shares no id with the binders; an
+/// annotated one is a `CtForAll`, which the walk above does not descend. The
+/// controls are pinned in tests/generic_binder_escape_test.vibe -- a sentinel
+/// excluding the name being defined was written first and deleted, because no
+/// input could be found that made it change an answer.
+fn captured_escape_tvars(body: Expr, params: Array[(String, Option[TypeExpr])], env: TypeEnv, s: Subst) -> Array[(String, Array[Int])] {
+  let out = array_empty()
+  let names = closure_free_names(body, params)
+  let mut i = 0
+  while i < Array::length(names) {
+    let name = Array::get(names, i)
+    match env_lookup(env, name) {
+      Some(raw_ty) => {
+        let ids = array_empty()
+        escape_tvars_into(subst_apply(s, raw_ty), ids)
+        if Array::length(ids) == 0 {
+          ()
+        } else {
+          Array::push(out, (name, ids))
+        }
+      },
+      None => ()
+    }
+    i = i + 1
+  }
+  out
+}
+
 /// Add closure-capture provenance to the checked row. The labels beginning
 /// with `#` are not effects and cannot be written by source; core/types keeps
 /// them through ordinary substitution while excluding them from effect-set
@@ -11556,6 +11677,46 @@ fn check_expr_capture_impl(expr: Expr, env: TypeEnv, defs: Array[TypeDef], s: Su
           }
           enum_dependency_effect
         }
+      }
+      // #2455: a declared binder that has unified with a type variable
+      // reachable from a CAPTURED binding is not generic -- it IS the
+      // enclosing binding's own slot. `[T]() -> Array[T] { xs }` makes `T` the
+      // element variable of the enclosing `let xs = []`, and the `CtForAll`
+      // below then lets every call instantiate that ONE runtime array at a
+      // different type: #2447's silent-wrong class, one quantifier away.
+      //
+      // #2450's value restriction cannot reach this. `ty_has_open_array_elem`
+      // does not descend `CtForAll`, and a refined walk that descends while
+      // excluding the bound vars still misses it, because after unification
+      // the captured slot and the bound var ARE one id. The distinguishing
+      // fact -- "this variable originated in an enclosing binding's type" --
+      // is provenance, so it is read from the environment here rather than
+      // from the type. Rank-1: the binder is rejected at its own declaration,
+      // so no call site has to carry the provenance.
+      let escaping = if tplen == 0 {
+        array_empty()
+      } else {
+        captured_escape_tvars(body, params, env, s3)
+      }
+      let mut esi = 0
+      while esi < tplen {
+        let evid = Array::get(tparam_ids, esi)
+        let binder_ids = array_empty()
+        escape_tvars_into(subst_apply(s3, CtVar(evid)), binder_ids)
+        let etpname = type_param_name(Array::get(tparams, esi))
+        let mut eci = 0
+        let mut ereported = false
+        while eci < Array::length(escaping) {
+          let (ecname, ecids) = Array::get(escaping, eci)
+          if !ereported && esc_ids_intersect(binder_ids, ecids) {
+            ereported = true
+            Array::push(errors, String::concat(String::concat(String::concat(String::concat(String::concat(String::concat("move `", ecname), "` inside the lambda, or drop the `["), etpname), "]` binder: the captured `"), ecname), String::concat(String::concat(String::concat("` fixes `", etpname), "`, so every call would use one value at a different type"), off_marker(railway_expr_off(body)))))
+          } else {
+            ()
+          }
+          eci = eci + 1
+        }
+        esi = esi + 1
       }
       let keep_ids = array_empty()
       let mut ki0 = 0

--- a/lib/@vibe/compiler/checker/checker.vibe
+++ b/lib/@vibe/compiler/checker/checker.vibe
@@ -3035,10 +3035,23 @@ fn append_row_label(labels: Array[String], label: String) -> Unit {
 /// #2455: the type variables reachable from a value, WITHOUT descending
 /// `CtForAll`. A quantified scheme's bound ids belong to another scope's
 /// counter domain -- `instantiate` renames them precisely because they can
-/// collide with locally fresh ids (#743) -- so reading them as environment
-/// variables would reject valid programs. Everything a scheme leaves free is
-/// unreachable through this walk too, which is the conservative direction:
-/// the escape check below only ever reports fewer binders, never more.
+/// collide with locally fresh ids (#743) -- and a scheme's FREE ids carry the
+/// same hazard, since #829 records that those are NOT renamed at all. Reading
+/// either as an environment variable can reject a valid program, so the walk
+/// stops at a scheme. It is the conservative direction: this check only ever
+/// reports fewer binders, never more.
+///
+/// Codex P1 on #2458 asked for the body to be walked, excluding the binder
+/// array, and gave a captured
+/// `let g = [U](u: U, k) -> U { Array::push(xs, k)\nu }` as the exploit. The
+/// walk was implemented that way and MEASURED: it does surface the scheme's
+/// free id, and the answer does not change, because the exploit does not run
+/// through a binder at all. Removing the second closure's `[T]` leaves the
+/// program equally accepted, and both spellings put an `Int` and a `String`
+/// into one array at runtime (`1 | s`). What leaks there is `g`'s own scheme,
+/// built from an unannotated parameter that no longer constrains its callers
+/// -- filed separately. Walking the body would therefore add the #829
+/// false-positive risk and close nothing, so it was reverted.
 fn escape_tvars_into(ty: Type, out: Array[Int]) -> Unit {
   match ty {
     CtVar(id) => if !esc_int_has(out, id) {
@@ -3118,6 +3131,36 @@ fn esc_ids_intersect(a: Array[Int], b: Array[Int]) -> Bool {
   hit
 }
 
+/// #2455: a closure's own parameter, under either optional-argument spelling
+/// (`x~` / `x?`), is not a capture. `closure_free_names` strips these itself;
+/// the bare-callee scan beside it does not, so the same normalization is
+/// applied here.
+fn esc_name_is_param(name: String, params: Array[(String, Option[TypeExpr])]) -> Bool {
+  let mut i = 0
+  let mut found = false
+  while i < Array::length(params) && !found {
+    let (raw_name, _) = Array::get(params, i)
+    let nlen = String::length(raw_name)
+    let pname = if nlen > 0 {
+      let last = String::char_code_at(raw_name, nlen - 1)
+      if last == '~' || last == '?' {
+        raw_name[0: nlen - 1]
+      } else {
+        raw_name
+      }
+    } else {
+      raw_name
+    }
+    if pname == name {
+      found = true
+    } else {
+      ()
+    }
+    i = i + 1
+  }
+  found
+}
+
 /// #2455: each name this closure CAPTURES from an enclosing scope, paired with
 /// the still-open type variables of the value bound to it.
 ///
@@ -3133,6 +3176,21 @@ fn esc_ids_intersect(a: Array[Int], b: Array[Int]) -> Bool {
 fn captured_escape_tvars(body: Expr, params: Array[(String, Option[TypeExpr])], env: TypeEnv, s: Subst) -> Array[(String, Array[Int])] {
   let out = array_empty()
   let names = closure_free_names(body, params)
+  // A DIRECTLY CALLED capture is a capture. `closure_free_names` skips the
+  // callee of an `ECall(EIdent(..))`, so `put(v)` recorded nothing while
+  // `let p = put\np(v)` recorded `put` -- the binder laundered the escape
+  // exactly when the value was spelled as a call. Codex P1 on #2458;
+  // measured, all three of `[T](v: T) -> Array[T] { put(v) }` (clean),
+  // the same closure without the binder (rejected), and the value spelling
+  // with the binder (rejected). `closure_capture_row` reads the same two
+  // sources for the same reason.
+  for callee in closure_bare_callee_names(body) {
+    if esc_name_is_param(callee, params) || string_array_has(names, callee) {
+      ()
+    } else {
+      Array::push(names, callee)
+    }
+  }
   let mut i = 0
   while i < Array::length(names) {
     let name = Array::get(names, i)

--- a/lib/@vibe/compiler/tests/anon_record_dot_access_test.vibe
+++ b/lib/@vibe/compiler/tests/anon_record_dot_access_test.vibe
@@ -118,3 +118,67 @@ test "839: nonexistent field on an anon record is still rejected" {
   assert_eq(compiles_via_check_program(src, "main"), false)
   assert_eq(compiles_via_desugar_trait_dicts(src, "main"), false)
 }
+
+//# #2452: the projection is TYPED, not merely resolved.
+//
+// `r.field` on an anonymous-record binding is rewritten to
+// `__rec_field(r, slot)` before the check runs (`anon_dot_rewrite`,
+// normalize/desugar_trait_dict.vibe), and the builtin table typed that call
+// `(CtUnknown, Int) -> CtUnknown` -- deliberately, while it served only the
+// record-PATTERN desugar, where nothing knows the field type. #1839 routed
+// every dot access on an anonymous record through it and the leniency became
+// a hole: the read resolved to the right SLOT and carried no type at all.
+//
+// Measured before the fix, every one of these checked CLEAN. The inline
+// spelling `(record { n: 1 }).n` was strict the whole time -- with no binding
+// there is no sentinel, so it keeps its `EDot` and reaches the checker's
+// record arm -- so the two spellings of one read disagreed, and the loose one
+// is the one people write.
+
+fn checks_clean(src: String) -> Bool {
+  handle {
+    let _ = check_program(parse_program(lex(src)))
+    true
+  } with { Exception::Throw(_) => false }
+}
+
+test "2452: a scalar field read at the wrong type is rejected" {
+  assert_eq(checks_clean("fn g() -> Int {\n  let r = record { n: 1 }\n  let s: String = r.n\n  1\n}\n"), false)
+  // The same read at its own type still checks.
+  assert_eq(checks_clean("fn g() -> Int {\n  let r = record { n: 1 }\n  let s: Int = r.n\n  1\n}\n"), true)
+}
+
+test "2452: each field keeps its own type" {
+  assert_eq(checks_clean("fn g() -> Int {\n  let r = record { n: 1, m: \"x\" }\n  let a: Int = r.n\n  let b: String = r.m\n  1\n}\n"), true)
+  // Swapping the two annotations must fail -- a slot-only answer would pass.
+  assert_eq(checks_clean("fn g() -> Int {\n  let r = record { n: 1, m: \"x\" }\n  let a: String = r.n\n  1\n}\n"), false)
+}
+
+test "2452: an array field is pushed at its own element type" {
+  assert_eq(checks_clean("fn g() -> Int {\n  let r = record { xs: [1] }\n  let u = Array::push(r.xs, \"s\")\n  1\n}\n"), false)
+  assert_eq(checks_clean("fn g() -> Int {\n  let r = record { xs: [1] }\n  let u = Array::push(r.xs, 2)\n  1\n}\n"), true)
+}
+
+test "2452: the #2447 shape one projection away" {
+  // An EMPTY array in a record: the value restriction gives it a real element
+  // slot, and the projection now carries that slot instead of losing it, so
+  // the second push at another type is rejected.
+  assert_eq(checks_clean("fn g() -> Int {\n  let r = record { xs: [] }\n  let u1 = Array::push(r.xs, 1)\n  let u2 = Array::push(r.xs, \"s\")\n  1\n}\n"), false)
+}
+
+test "2452: the projection constrains its use position, not just a binding" {
+  // A binding annotation is only one consumer. Before the fix these were
+  // clean too, which is why the fix is in the projection rather than in the
+  // `let`.
+  assert_eq(checks_clean("fn g() -> Int {\n  let r = record { n: 1 }\n  let z = String::length(r.n)\n  1\n}\n"), false)
+  assert_eq(checks_clean("fn g() -> Int {\n  let r = record { n: 1 }\n  if r.n {\n    1\n  } else {\n    2\n  }\n}\n"), false)
+}
+
+test "2452: a record PATTERN binding still checks" {
+  // `__rec_field` is also emitted for record patterns, where the receiver may
+  // be one this pass cannot resolve. Those keep the tolerant answer -- the fix
+  // stops losing a type that IS known, it does not start rejecting types that
+  // are not.
+  assert_eq(checks_clean("fn g() -> Int {\n  let record { n: a } = record { n: 1 }\n  a\n}\n"), true)
+}
+

--- a/lib/@vibe/compiler/tests/anon_record_dot_access_test.vibe
+++ b/lib/@vibe/compiler/tests/anon_record_dot_access_test.vibe
@@ -182,3 +182,18 @@ test "2452: a record PATTERN binding still checks" {
   assert_eq(checks_clean("fn g() -> Int {\n  let record { n: a } = record { n: 1 }\n  a\n}\n"), true)
 }
 
+test "2452: the index keeps its Int constraint" {
+  // Codex on #2458: refining the RESULT is the only thing the new arm adds,
+  // and taking the call over from the builtin table must not drop the one
+  // thing the old `(CtUnknown, Int) -> CtUnknown` signature did check.
+  // `__rec_field` is not reserved from expressions, so source can write it
+  // directly, and codegen requires an `EInt` index -- a non-Int one that
+  // checks clean is a program `vibe check` calls compilable and then throws
+  // on. Measured on `ed1089a9f`: both of these were rejected before #2452 and
+  // clean after it, which is why the red test is a direct call.
+  assert_eq(checks_clean("fn g() -> Int {\n  let r = record { n: 1 }\n  let x = __rec_field(r, \"bad\")\n  1\n}\n"), false)
+  assert_eq(checks_clean("fn g() -> Int {\n  let r = record { n: 1 }\n  let x = __rec_field(r, true)\n  1\n}\n"), false)
+  // An Int index still resolves the field, at its own type and no other.
+  assert_eq(checks_clean("fn g() -> Int {\n  let r = record { n: 1 }\n  let x: Int = __rec_field(r, 0)\n  1\n}\n"), true)
+  assert_eq(checks_clean("fn g() -> Int {\n  let r = record { n: 1 }\n  let x: String = __rec_field(r, 0)\n  1\n}\n"), false)
+}

--- a/lib/@vibe/compiler/tests/generic_binder_escape_test.vibe
+++ b/lib/@vibe/compiler/tests/generic_binder_escape_test.vibe
@@ -119,3 +119,30 @@ test "2455: the escape is found however the capture is spelled" {
   // capture is still fixed by every call.
   assert_eq(checks_clean("fn main() -> Int { let xs = []\nlet put = [T](v: T) -> Unit { Array::push(xs, v) }\n1 }"), false)
 }
+
+test "2455: a DIRECTLY CALLED capture is a capture" {
+  // Codex P1 on #2458. `closure_free_names` skips the callee of an
+  // `ECall(EIdent(..))`, so the binder laundered the escape exactly when the
+  // captured value was spelled as a call rather than named. Three-way
+  // measurement, one program, before the fix:
+  //
+  //   [T](v: T) -> Array[T] { put(v) }        CLEAN      <- laundered
+  //   (v) -> { put(v) }                       rejected   <- no binder
+  //   [T](v: T) -> Array[T] { let p = put; p(v) }  rejected  <- named value
+  //
+  // `put` is monomorphic here because `(v) -> { Array::push(xs, v); xs }`
+  // returns an open Array, which is #2450's CtFn arm of the value
+  // restriction -- that is what makes the two calls share one slot.
+  let put = "let put = (v) -> { Array::push(xs, v)\nxs }\n"
+  let called = String::concat(fill_prelude, String::concat("fn main() -> Unit { let xs = []\n", String::concat(put, "let w = [T](v: T) -> Array[T] { put(v) }\nfill(w(1), 1)\nfill_s(w(\"s\"), \"s\") }")))
+  assert_eq(checks_clean(called), false)
+  // The same capture named as a value -- caught before the fix too, and the
+  // control that proves the two spellings now agree.
+  let named = String::concat(fill_prelude, String::concat("fn main() -> Unit { let xs = []\n", String::concat(put, "let w = [T](v: T) -> Array[T] { let p = put\np(v) }\nfill(w(1), 1)\nfill_s(w(\"s\"), \"s\") }")))
+  assert_eq(checks_clean(named), false)
+  // A top-level function called from the body is NOT a capture: its type is
+  // ground, so the callee scan adds a name that contributes no variable.
+  assert_eq(checks_clean("fn idn(v: Int) -> Int { v }\nfn main() -> Int { let w = [T](v: T) -> T { let _ = idn(1)\nv }\nw(1) }"), true)
+  // Nor is the closure's own parameter, called as a function.
+  assert_eq(checks_clean("fn main() -> Int { let w = [T](v: T, f: (T) -> T) -> T { f(v) }\nw(1, (x) -> x) }"), true)
+}

--- a/lib/@vibe/compiler/tests/generic_binder_escape_test.vibe
+++ b/lib/@vibe/compiler/tests/generic_binder_escape_test.vibe
@@ -1,0 +1,105 @@
+//# #2455: an explicit generic binder may not quantify a slot that belongs to a
+//# CAPTURED binding. `[T]() -> Array[T] { xs }` unifies `T` with the element
+//# variable of the enclosing `let xs = []`, and the scheme the checker then
+//# builds lets every call instantiate that ONE runtime array at a different
+//# type -- the #2447 silent-wrong class, one quantifier away.
+//#
+//# #2450's value restriction cannot reach it: `ty_has_open_array_elem` does not
+//# descend `CtForAll`, and descending while excluding the bound vars still
+//# misses it, because after unification the captured slot and the bound var are
+//# one id. The fact that separates them lives in the ENVIRONMENT, not in the
+//# type, so the check reads it from there.
+
+//# Imports
+
+import @vibe/compiler/checker {
+  check_program
+}
+
+import @vibe/compiler/syntax {
+  lex, parse_program
+}
+
+//# Functions
+
+fn checks_clean(source: String) -> Bool {
+  handle {
+    let _ = check_program(parse_program(lex(source)))
+    true
+  } with { Exception::Throw(_) => false }
+}
+
+fn first_error(source: String) -> String {
+  handle {
+    let _ = check_program(parse_program(lex(source)))
+    "CLEAN"
+  } with { Exception::Throw(message) => message }
+}
+
+let fill_prelude: String = "fn fill(xs: Array[Int], v: Int) -> Unit { Array::push(xs, v) }\nfn fill_s(xs: Array[String], v: String) -> Unit { Array::push(xs, v) }\n"
+
+test "2455: a binder quantifying a captured array slot is rejected" {
+  let src = String::concat(fill_prelude, "fn main() -> Unit { let xs = []\nlet get = [T]() -> Array[T] { xs }\nfill(get(), 1)\nfill_s(get(), \"s\") }")
+  assert_eq(checks_clean(src), false)
+}
+
+test "2455: the diagnostic names the capture, the binder and the edit" {
+  // Diagnostics lead with the edit that fixes it, not with an internal term.
+  let src = String::concat(fill_prelude, "fn main() -> Unit { let xs = []\nlet get = [T]() -> Array[T] { xs }\nfill(get(), 1) }")
+  inspect(first_error(src), content = "move `xs` inside the lambda, or drop the `[T]` binder: the captured `xs` fixes `T`, so every call would use one value at a different type")
+}
+
+test "2455: the rejection does not need the two conflicting calls" {
+  // The binder is rejected at its own declaration (rank-1), so no call site
+  // has to carry the provenance -- and a single-call program, which is not
+  // yet wrong, is still reported as the unsound generalization it is.
+  assert_eq(checks_clean("fn main() -> Int { let xs = []\nlet get = [T]() -> Array[T] { xs }\n1 }"), false)
+}
+
+test "2455: an array created inside the lambda stays polymorphic" {
+  // The whole point of the environment lookup: a body-local `[]` is a fresh
+  // array per call, so quantifying its element variable is sound.
+  let src = "fn main() -> Int { let mk = [T]() -> Array[T] { [] }\nlet a: Array[Int] = mk()\nlet b: Array[String] = mk()\n1 }"
+  assert_eq(checks_clean(src), true)
+}
+
+test "2455: an ordinary generic lambda is untouched" {
+  assert_eq(checks_clean("fn main() -> Int { let idf = [T](v: T) -> T { v }\nlet a = idf(1)\nlet b = idf(\"s\")\n1 }"), true)
+}
+
+test "2455: capturing a concrete binding is not an escape" {
+  // `n` has no open variable, so it fixes nothing.
+  assert_eq(checks_clean("fn main() -> Int { let n = 1\nlet f = [T](v: T) -> T { let _ = n\nv }\nf(1) }"), true)
+  // Nor does an annotated array, whose element slot is already closed.
+  assert_eq(checks_clean("fn main() -> Int { let xs: Array[Int] = []\nlet g = [T](v: T) -> T { let n = Array::length(xs)\nv }\n1 }"), true)
+}
+
+test "2455: capturing an open array is fine while the binder is unrelated" {
+  // `T` does not touch `xs`'s element slot here, so there is nothing to fix.
+  assert_eq(checks_clean("fn main() -> Int { let xs = [1]\nlet g = [T](v: T) -> Int { Array::length(xs) }\ng(1) }"), true)
+}
+
+test "2455: capturing a generic function is not an escape" {
+  // A captured SCHEME contributes no free variable: `mk` is instantiated
+  // fresh at the call, so the lambda really is generic in `T`.
+  let src = "fn mk[T]() -> Array[T] { [] }\nfn main() -> Int { let g = [T]() -> Array[T] { mk() }\nlet a: Array[Int] = g()\nlet b: Array[String] = g()\n1 }"
+  assert_eq(checks_clean(src), true)
+}
+
+test "2455: a recursive generic binding is not read as its own capture" {
+  // Measured both spellings and both uses. An unannotated recursive name is
+  // bound to a placeholder that is unified with the signature only AFTER the
+  // body is checked, so it shares no id with the binders while this runs; an
+  // annotated one is a `CtForAll`, which the walk does not descend. A sentinel
+  // excluding the name being defined was written first and deleted: no input
+  // could be found that made it change an answer.
+  assert_eq(checks_clean("fn main() -> Int { let rec go = [T](n: Int, v: T) -> T { if n == 0 { v } else { go(n - 1, v) } }\ngo(2, 1) }"), true)
+  assert_eq(checks_clean("fn go[T](n: Int, v: T) -> T { if n == 0 { v } else { go(n - 1, v) } }\nfn main() -> Int { go(2, 1) }"), true)
+  assert_eq(checks_clean("fn main() -> Int { let rec f = [T](v: T) -> T { let g = f\nv }\nf(1) }"), true)
+  assert_eq(checks_clean("fn go[T](v: T) -> T { let g = go\nv }\nfn main() -> Int { go(1) }"), true)
+}
+
+test "2455: a generic lambda passed to a higher-order function still checks" {
+  let src = "fn ap[A, B](f: (A) -> B, x: A) -> B { f(x) }\nfn main() -> Int { ap([T](v: T) -> T { v }, 1) }"
+  assert_eq(checks_clean(src), true)
+}

--- a/lib/@vibe/compiler/tests/generic_binder_escape_test.vibe
+++ b/lib/@vibe/compiler/tests/generic_binder_escape_test.vibe
@@ -46,7 +46,24 @@ test "2455: a binder quantifying a captured array slot is rejected" {
 test "2455: the diagnostic names the capture, the binder and the edit" {
   // Diagnostics lead with the edit that fixes it, not with an internal term.
   let src = String::concat(fill_prelude, "fn main() -> Unit { let xs = []\nlet get = [T]() -> Array[T] { xs }\nfill(get(), 1) }")
-  inspect(first_error(src), content = "move `xs` inside the lambda, or drop the `[T]` binder: the captured `xs` fixes `T`, so every call would use one value at a different type")
+  inspect(first_error(src), content = "move `xs` inside the lambda, or drop `[T]` and every `T` in its signature: the captured `xs` fixes `T`, so every call would use one value at a different type")
+}
+
+test "2455: both edits the diagnostic offers actually work" {
+  // Codex P2 on #2458: the wording said "drop the `[T]` binder", and doing
+  // exactly that leaves `T` in the return annotation -- so the advertised fix
+  // answered `unknown type `T`` instead of fixing anything. A diagnostic that
+  // names an edit has to name one that works, so the message now says to drop
+  // the signature's `T`s with it.
+  //
+  // Dropping ONLY the binder is still an error, and this pins WHY the wording
+  // has to mention the signature.
+  assert_eq(checks_clean("fn main() -> Int { let xs = []\nlet get = () -> Array[T] { xs }\n1 }"), false)
+  // Edit 1, as the message now spells it: the binder and its `T`s go together.
+  // The lambda is monomorphic, and the array it serves is the captured one.
+  assert_eq(checks_clean("fn main() -> Int { let xs = []\nlet get = () -> { xs }\nlet a: Array[Int] = get()\n1 }"), true)
+  // Edit 2: move the value inside, and the binder is sound to keep.
+  assert_eq(checks_clean("fn main() -> Int { let get = [T]() -> Array[T] { [] }\nlet a: Array[Int] = get()\nlet b: Array[String] = get()\n1 }"), true)
 }
 
 test "2455: the rejection does not need the two conflicting calls" {

--- a/lib/@vibe/compiler/tests/generic_binder_escape_test.vibe
+++ b/lib/@vibe/compiler/tests/generic_binder_escape_test.vibe
@@ -103,3 +103,19 @@ test "2455: a generic lambda passed to a higher-order function still checks" {
   let src = "fn ap[A, B](f: (A) -> B, x: A) -> B { f(x) }\nfn main() -> Int { ap([T](v: T) -> T { v }, 1) }"
   assert_eq(checks_clean(src), true)
 }
+
+test "2455: the escape is found however the capture is spelled" {
+  // The issue describes one shape (a bare captured name in RETURN position).
+  // The check is on the binder, not on that shape, so these are caught too --
+  // each measured, and each the same unsoundness.
+  //
+  // A `let mut` binding:
+  assert_eq(checks_clean("fn main() -> Int { let mut xs = []\nlet get = [T]() -> Array[T] { xs }\n1 }"), false)
+  // Reached through a nested closure rather than named directly:
+  assert_eq(checks_clean("fn main() -> Int { let xs = []\nlet get = [T]() -> Array[T] { let inner = () -> { xs }\ninner() }\n1 }"), false)
+  // Projected out of a captured tuple:
+  assert_eq(checks_clean("fn main() -> Int { let p = ([], 1)\nlet get = [T]() -> Array[T] { p.0 }\n1 }"), false)
+  // The binder in PARAMETER position only -- nothing is returned, and the
+  // capture is still fixed by every call.
+  assert_eq(checks_clean("fn main() -> Int { let xs = []\nlet put = [T](v: T) -> Unit { Array::push(xs, v) }\n1 }"), false)
+}


### PR DESCRIPTION
Two P0 silent-wrong defects in the checker. They arrived on one branch rather than two because the branch is the only push target available to this session, and holding a verified P0 fix unpushed on an ephemeral container is the worse risk. They are independent commits and can be read separately; only the second touches generalization.

---

# 1. `#2452` — an anonymous-record projection was resolved but not typed

`let r = record { n: 1 }` then `let s: String = r.n` checked CLEAN, as did `String::length(r.n)`, `if r.n { .. }`, `r.n(1)`, and `let r = record { xs: [1] }` then `Array::push(r.xs, "s")`.

## What it actually is

#2452 reads this as the dot projection not constraining against the record literal's field types. That is the symptom; the mechanism is one layer earlier.

`r.field` on an anonymous-record **binding** never reaches the checker's `EDot` arm at all — the desugar rewrites it to `__rec_field(r, slot)` first (`anon_dot_rewrite`, `normalize/desugar_trait_dict.vibe`) — and the builtin table types that call `(CtUnknown, Int) -> CtUnknown`, with its own comment saying why:

```vibe
// Lenient (field type unknown); only needs to resolve, not constrain.
```

That was true while `__rec_field` served only the record-**pattern** desugar, where nothing knows the field type. #1839 routed EVERY dot access on an anonymous record through it, and the leniency became a silent-wrong hole.

The bisection that pinned it — three spellings of one read, measured on `ed1089a9f`:

| spelling | before |
| --- | --- |
| `(record { n: 1 }).n` (inline) | **strict** — no binding, no sentinel, so it keeps its `EDot` |
| `r.n`, field exists | **tolerant** — rewritten to `__rec_field` |
| `r.zzz`, field does not exist | **strict** — the slot lookup fails, so the `EDot` survives |

So the two spellings of one read disagreed, and the loose one is the one people write. The unknown-field diagnostic kept working throughout, which is exactly why this looked like a typed projection from the outside.

## The fix

A type-directed `__rec_field` arm in the checker, modelled on the `__index` arm a few lines above it — that one had the identical defect ("typed polymorphically by the builtin table, losing the result type"; `let s: String = a[0]` over an `Array[Int]` slipped through) and the identical remedy.

The slot resolves against the receiver's own `CtRecord` field list. A receiver this pass cannot resolve keeps the tolerant answer, so record **patterns** over an unresolvable receiver are unaffected: the point is to stop losing a type that IS known, not to start rejecting types that are not.

Measured after, on the same programs:

```
let s: String = r.n      binding type mismatch: expected String, got Int
Array::push(r.xs, "s")   Array::push value type mismatch: expected Int, got String
String::length(r.n)      argument type mismatch: receiver type Int
if r.n { .. }            if condition must be Bool, got Int
```

The index keeps its `Int` constraint (`2c6ebee94`, Codex P2): taking the call over from the builtin table had dropped the one thing the old signature did check. `__rec_field` is not reserved from expressions, so that reaches source, and codegen requires an `EInt` index — `vibe check` calling a program compilable and then throwing on it is the CLI contract's worst failure mode.

## Tests

Ten tests in `lib/@vibe/compiler/tests/anon_record_dot_access_test.vibe` (13 in the file), each red-verified: the scalar read at the wrong type and at its own; per-field types with the annotations swapped (a slot-only answer would pass); an array field's element type both directions; the #2447 empty-array shape one projection away; two NON-binding use positions, which is why the fix is in the projection rather than in the `let`; the record-pattern case that must stay clean; and the index's `Int` constraint.

---

# 2. `#2455` — an explicit binder could quantify a captured slot

```vibe
let xs = []
let get = [T]() -> Array[T] { xs }
fill(get(), 1)
fill_s(get(), "s")     // accepted
```

Checking the return annotation unifies `xs`'s element slot with the lambda's own binder `T`, and the explicit-binder `EFn` wraps that same slot in `CtForAll`. Every call then instantiates `T` fresh, so ONE runtime array is used as both `Array[Int]` and `Array[String]` — #2447's silent-wrong class, one quantifier away.

## Why #2450's value restriction cannot reach it

`ty_has_open_array_elem` does not descend `CtForAll`, and a refined walk that descends while excluding the bound vars still misses it: after unification the captured slot and the bound var are **one id**. What separates them — "this variable originated in an enclosing binding's type" — is provenance, and provenance is not in the type. So the check reads it from the environment instead.

## The fix

Rank-1 escape check at the explicit-binder `EFn`. For each declared binder, zonk it and intersect its variables with those reachable from the values the body CAPTURES. A hit is reported at the binder's own declaration, so no call site has to carry the provenance, and a single-call program — not yet wrong, but already unsoundly generalized — is reported too.

The capture scan reads both the body's free names and its **bare callees** (`1f1324e20`, Codex P1): `closure_free_names` skips the callee of an `ECall(EIdent(..))`, so the binder laundered the escape exactly when the captured value was spelled as a call. Three-way measurement, one program, before that fix:

| body | result |
| --- | --- |
| `[T](v: T) -> Array[T] { put(v) }` | **CLEAN** |
| `(v) -> { put(v) }` — no binder | rejected |
| `[T](v: T) -> Array[T] { let p = put; p(v) }` — named | rejected |

The walk deliberately does not descend `CtForAll`; the measurement behind that decision is in the code comment and in the #2459 thread below.

The diagnostic leads with an edit, and both edits it names are ones that work (`a598b7563`, Codex P2 — "drop the `[T]` binder" alone answers `unknown type \`T\``):

```
move `xs` inside the lambda, or drop `[T]` and every `T` in its signature:
the captured `xs` fixes `T`, so every call would use one value at a different type
```

## Beyond the shape the issue names

The check is on the binder, not on "a bare captured name in return position", so four more spellings are caught, each measured: a `let mut` binding, a capture reached through a nested closure, one projected out of a captured tuple, and a binder that appears only in PARAMETER position.

## Two pieces of machinery that were written and then deleted

- **A self-binding sentinel.** Recursion looked like an obvious false positive, so an exclusion for the name being defined was implemented first. It never changed an answer — measured across `let rec f = [T](..)` and `fn f[T](..)`, with the recursive name used both as a call and as a bare value. An unannotated recursive name is unified with its signature only AFTER the body is checked; an annotated one is a `CtForAll` the walk does not descend.
- **A `CtForAll` descent** (Codex P1). The code observation was right and the exploit is real, but implementing it changed no answer, and deleting the binder from the same program leaves it equally accepted — so the leak is not the escape check's to close. Filed as **#2459** with runtime evidence: both spellings put an `Int` and a `String` into one array. Keeping the walk would have added the #829 free-id collision hazard for no benefit today.

Untestable machinery is worse than none, so both were removed and the measurements are recorded where they were.

## Tests

Thirteen tests in `lib/@vibe/compiler/tests/generic_binder_escape_test.vibe`, red-verified. Controls that must stay clean: a body-local `[]`, an ordinary generic lambda, a captured concrete or annotated binding, a capture whose slot the binder does not touch, a captured generic function, a called top-level function, a called parameter, a generic lambda passed to a higher-order function, and recursion in both spellings with both uses.

A `docs/cheatsheet.md` pitfall entry records the rule, which of the two edits to pick, and why the binder's `T`s go with it.

---

# Verification

Re-run in full on the final head, since three review rounds landed after the first measurement and two of them changed checker behaviour:

| measurement | result |
| --- | --- |
| stage2 self-build | stage0 → stage1 → stage2, both validations `0` |
| `compiler_gate.sh` early lane | exit 0 |
| `unit_test_runner.sh` | **1102/1102**, exit 0 |
| CI on `a598b7563` | **28/28** success |
| Codex on `a598b75` | completed, no findings |

The self-build is the sharpest measurement: the compiler's own source is ~1000 files of exactly the code these changes tighten, and it compiles itself under both without a single new diagnostic.

End-to-end for #2455, with a control, on the issue's exact program:

```
$ VIBE_CLI_WASM=_build/n2455b/stage2.wasm vibe check e2455.vibe
error: e2455.vibe: line 7:5: move `xs` inside the lambda, or drop `[T]` and every `T` in its signature: the captured `xs` fixes `T`, so every call would use one value at a different type
exit=1

$ VIBE_CLI_WASM=bootstrap/seed/compiler.wasm vibe check e2455.vibe
exit=0
```

The seed says clean on the program the issue reports as silent-wrong; the fix reports it with a position.

Refs #2452, #2455, #2459, #2447, #2450, #1839, #743, #829.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FYMVd6D2o82suTfTwoJPMf

---
_Generated by [Claude Code](https://claude.ai/code/session_01FYMVd6D2o82suTfTwoJPMf)_