### PR TITLE
Generalize a `let` by environment-freeness (#2459, #2461), and restore the record pins (#2452)

### DIFF
--- a/fixtures/empty_array_hetero_record_reject.vibe
+++ b/fixtures/empty_array_hetero_record_reject.vibe
@@ -1,0 +1,17 @@
+//# #2452: the #2447 shape one projection away. An empty array in an
+//# ANONYMOUS RECORD field, pushed at two element types -- must be REJECTED at
+//# check time on the import-resolving lane, like its bare siblings beside it.
+//#
+//# This case was dropped from #2450 and could not be restored until #2452:
+//# `r.xs` on a record BINDING never reached the checker's `EDot` arm, because
+//# the desugar rewrites it to `__rec_field(r, slot)` first and the builtin
+//# table typed that call `(CtUnknown, Int) -> CtUnknown`. The restriction side
+//# was already in place -- `ty_has_open_array_elem` descends `CtRecord`
+//# fields -- so the projection was the only thing losing the type.
+
+export fn _start() -> Int {
+  let r = record { xs: [] }
+  let u1 = Array::push(r.xs, 1)
+  let u2 = Array::push(r.xs, "s")
+  0
+}

--- a/lib/@vibe/compiler/checker/checker.vibe
+++ b/lib/@vibe/compiler/checker/checker.vibe
@@ -26,6 +26,7 @@ import @vibe/compiler/core {
   find_typedef,
   fresh_var,
   generalize,
+  generalize_except,
   hkt_apply_ctor,
   instantiate,
   is_alias_constructor,
@@ -3032,26 +3033,25 @@ fn append_row_label(labels: Array[String], label: String) -> Unit {
   }
 }
 
-/// #2455: the type variables reachable from a value, WITHOUT descending
-/// `CtForAll`. A quantified scheme's bound ids belong to another scope's
-/// counter domain -- `instantiate` renames them precisely because they can
-/// collide with locally fresh ids (#743) -- and a scheme's FREE ids carry the
-/// same hazard, since #829 records that those are NOT renamed at all. Reading
-/// either as an environment variable can reject a valid program, so the walk
-/// stops at a scheme. It is the conservative direction: this check only ever
-/// reports fewer binders, never more.
+/// The FREE type variables of a value. A scheme's own bound ids are excluded
+/// -- they belong to another scope's counter domain, and `instantiate` renames
+/// them precisely because they can collide with locally fresh ids (#743) --
+/// but its body IS walked, because what a scheme leaves free is an enclosing
+/// binding's slot showing through.
 ///
-/// Codex P1 on #2458 asked for the body to be walked, excluding the binder
-/// array, and gave a captured
-/// `let g = [U](u: U, k) -> U { Array::push(xs, k)\nu }` as the exploit. The
-/// walk was implemented that way and MEASURED: it does surface the scheme's
-/// free id, and the answer does not change, because the exploit does not run
-/// through a binder at all. Removing the second closure's `[T]` leaves the
-/// program equally accepted, and both spellings put an `Int` and a `String`
-/// into one array at runtime (`1 | s`). What leaks there is `g`'s own scheme,
-/// built from an unannotated parameter that no longer constrains its callers
-/// -- filed separately. Walking the body would therefore add the #829
-/// false-positive risk and close nothing, so it was reverted.
+/// Codex P1 on #2458 asked for exactly this. It was implemented, measured to
+/// change no answer for #2455's binder check, and reverted rather than shipped
+/// on faith. #2459 supplied the input that makes it load-bearing: `let g2 = g`
+/// where `g` captures `let xs = []` reads `g`'s scheme, and the slot that must
+/// not be quantified is precisely the one free variable inside it. Without the
+/// descent `env_reachable_tvars` returns nothing there and the alias
+/// generalizes a captured array -- measured, `1 | s` in one array at runtime.
+///
+/// The #829 hazard the revert cited is real but narrower than it reads: a
+/// scheme's free ids are not renamed by `instantiate`, so an IMPORTED
+/// scheme's free id can collide with a local one. That costs a spurious
+/// exclusion (a binding stays monomorphic) rather than a wrong answer, which
+/// is the safe direction for both callers.
 fn escape_tvars_into(ty: Type, out: Array[Int]) -> Unit {
   match ty {
     CtVar(id) => if !esc_int_has(out, id) {
@@ -3096,6 +3096,20 @@ fn escape_tvars_into(ty: Type, out: Array[Int]) -> Unit {
       let mut i = 0
       while i < Array::length(args) {
         escape_tvars_into(Array::get(args, i), out)
+        i = i + 1
+      }
+    },
+    CtForAll(bound, _, scheme_body) => {
+      let inner = array_empty()
+      escape_tvars_into(scheme_body, inner)
+      let mut i = 0
+      while i < Array::length(inner) {
+        let id = Array::get(inner, i)
+        if esc_int_has(bound, id) || esc_int_has(out, id) {
+          ()
+        } else {
+          Array::push(out, id)
+        }
         i = i + 1
       }
     },
@@ -3159,6 +3173,97 @@ fn esc_name_is_param(name: String, params: Array[(String, Option[TypeExpr])]) ->
     i = i + 1
   }
   found
+}
+
+/// #2459: the type variables an expression can reach THROUGH THE ENVIRONMENT
+/// -- the free names it mentions (including bare callees, per #2455), looked
+/// up in `env` and zonked. A variable can only have entered the expression's
+/// type through a name it mentions, a parameter, or an annotation, so this is
+/// a sound over-approximation of "free in the environment" for the value being
+/// bound, and it costs one walk of the right-hand side instead of a scan of
+/// the whole environment.
+///
+/// `self_name` is the binding being defined. A `let rec` binds a placeholder
+/// for its own recursive uses BEFORE the body is checked and unifies it with
+/// the signature afterwards, so at generalization time the recursive name
+/// carries the very variables being generalized; reading them as
+/// environment-owned would monomorphize every recursive generic function.
+fn env_reachable_tvars(val: Expr, env: TypeEnv, s: Subst, self_name: Option[String]) -> Array[Int] {
+  let out = array_empty()
+  let names = closure_free_names(val, array_empty())
+  for callee in closure_bare_callee_names(val) {
+    if string_array_has(names, callee) {
+      ()
+    } else {
+      Array::push(names, callee)
+    }
+  }
+  let mut i = 0
+  while i < Array::length(names) {
+    let name = Array::get(names, i)
+    let is_self = match self_name {
+      Some(sn) => sn == name,
+      None => false
+    }
+    if is_self {
+      ()
+    } else {
+      match env_lookup(env, name) {
+        // `subst_apply_except` and NOT `subst_apply`: the latter returns a
+        // `CtForAll` untouched (core/types.vibe), so a scheme's free variable
+        // would come back with its pre-unification id and match nothing. The
+        // `except` form substitutes through the body while protecting the
+        // scheme's own bound vars, which is the zonk this needs.
+        Some(raw_ty) => escape_tvars_into(subst_apply_except(s, raw_ty, array_empty()), out),
+        None => ()
+      }
+    }
+    i = i + 1
+  }
+  out
+}
+
+/// #2459 / #2461: the two independent reasons not to generalize a `let`.
+///
+/// (A) The VALUE RESTRICTION: the binding HOLDS a mutable container, so its
+///     element variable must stay a monotype -- `let xs = []` is one array,
+///     and quantifying its element would let two uses disagree about it
+///     (#938, #2447).
+/// (B) The ENVIRONMENT RESTRICTION: a variable that is free in the enclosing
+///     environment belongs to something else and is not this binding's to
+///     quantify (#2459).
+///
+/// (A) is about what the value IS; (B) is about where its variables CAME
+/// FROM. Conflating them is what made both neighbouring bugs: (A) was applied
+/// to a FUNCTION type, where the array is produced per call rather than held,
+/// so `let mk2 = mk` on a perfectly generic `mk[T](v: T) -> Array[T]` was
+/// refused (#2461); and (B) was missing, so `let g2 = g` quantified a captured
+/// slot (#2459). A function value holds a container only when it CAPTURED one,
+/// which is (B)'s question, not (A)'s -- so the `CtFn` case is decided by
+/// environment reachability and every other case by (A) as before.
+export fn let_generalize(val: Expr, vt: Type, env: TypeEnv, s: Subst, self_name: Option[String]) -> Type {
+  let vt_resolved = subst_apply(s, vt)
+  if Array::length(collect_tvars(vt_resolved)) == 0 {
+    // Nothing to quantify; skip the right-hand-side walk entirely. Most
+    // bindings in a real program land here.
+    generalize(s, vt)
+  } else {
+    let env_ids = env_reachable_tvars(val, env, s, self_name)
+    let holds_container = is_array_builder_ty(vt_resolved) || is_region_tagged_ty(vt_resolved) || ty_has_open_array_elem(vt_resolved)
+    let restricted = if !holds_container {
+      false
+    } else {
+      match vt_resolved {
+        CtFn(_, _, _) => esc_ids_intersect(collect_tvars(vt_resolved), env_ids),
+        _ => true
+      }
+    }
+    if restricted {
+      vt
+    } else {
+      generalize_except(s, vt, env_ids)
+    }
+  }
 }
 
 /// #2455: each name this closure CAPTURES from an enclosing scope, paired with
@@ -6996,14 +7101,11 @@ fn check_seq_spine(expr: Expr, env: TypeEnv, defs: Array[TypeDef], s: Subst, c: 
         // `CtNamed("ArrayBuilder", [v])` would re-instantiate a fresh v at
         // every use and pushes could never constrain each other (the exact
         // hole this issue is about). Bind the monotype instead.
-        let vt_resolved = subst_apply(ns, vt)
         // #2447: a still-open Array element var gets the same treatment as
-        // a builder's -- see ty_has_open_array_elem.
-        let gen = if is_array_builder_ty(vt_resolved) || is_region_tagged_ty(vt_resolved) || ty_has_open_array_elem(vt_resolved) {
-          vt
-        } else {
-          generalize(ns, vt)
-        }
+        // a builder's; #2459: a variable free in the ENVIRONMENT is not this
+        // binding's to quantify. See let_generalize for why those are two
+        // rules and not one.
+        let gen = let_generalize(val, vt, cenv, ns, None)
         let aliases_outer = expression_aliases_outer_binding(val, cenv)
         cenv = env_bind(cenv, name, gen)
         cenv = bind_function_dependency_contracts(cenv, name, val)
@@ -7060,12 +7162,7 @@ fn check_seq_spine(expr: Expr, env: TypeEnv, defs: Array[TypeDef], s: Subst, c: 
         // restriction as ELet above -- `let rec get = () -> { xs }` returns
         // the same captured array every call, and this site generalized
         // unconditionally.
-        let rec_resolved = subst_apply(s2, tv)
-        let gen = if is_array_builder_ty(rec_resolved) || is_region_tagged_ty(rec_resolved) || ty_has_open_array_elem(rec_resolved) {
-          tv
-        } else {
-          generalize(s2, tv)
-        }
+        let gen = let_generalize(val, tv, cenv, s2, Some(name))
         cenv = env_bind(cenv, name, gen)
         cenv = bind_function_dependency_contracts(cenv, name, val)
         s1 = s2

--- a/lib/@vibe/compiler/checker/checker.vibe
+++ b/lib/@vibe/compiler/checker/checker.vibe
@@ -3131,6 +3131,33 @@ fn esc_int_has(xs: Array[Int], v: Int) -> Bool {
   found
 }
 
+/// The free variables of a value, each RESOLVED through the substitution.
+///
+/// Collecting from `subst_apply(s, ty)` is not the same thing and is wrong for
+/// a scheme: `subst_apply` and `subst_apply_except` BOTH return a `CtForAll`
+/// untouched (`CtForAll(_, _, _) => ty` in core/types.vibe), so a scheme's free
+/// variable comes back with the id it was written with. Codex P1 on #2460
+/// found what that costs: unify a captured slot `k` with another open slot `j`
+/// -- `link(xs, ys)` for a `fn link[T](a: Array[T], b: Array[T])` -- BEFORE
+/// `let g2 = g`, and the alias's type resolves to `j` while the scan still
+/// reports the stale `k`. `generalize_except` then quantifies `j`, and the
+/// captured array takes an Int and a String again with no diagnostic.
+/// Measured: clean before this, rejected after, with the same program minus
+/// the `link` call rejected either way.
+///
+/// So collect the ids as WRITTEN, then resolve each one. An unbound id
+/// resolves to itself, and for a non-scheme type this is exactly collecting
+/// from the zonked type.
+fn escape_tvars_zonked_into(ty: Type, s: Subst, out: Array[Int]) -> Unit {
+  let raw = array_empty()
+  escape_tvars_into(ty, raw)
+  let mut i = 0
+  while i < Array::length(raw) {
+    escape_tvars_into(subst_apply(s, CtVar(Array::get(raw, i))), out)
+    i = i + 1
+  }
+}
+
 fn esc_ids_intersect(a: Array[Int], b: Array[Int]) -> Bool {
   let mut i = 0
   let mut hit = false
@@ -3209,12 +3236,7 @@ fn env_reachable_tvars(val: Expr, env: TypeEnv, s: Subst, self_name: Option[Stri
       ()
     } else {
       match env_lookup(env, name) {
-        // `subst_apply_except` and NOT `subst_apply`: the latter returns a
-        // `CtForAll` untouched (core/types.vibe), so a scheme's free variable
-        // would come back with its pre-unification id and match nothing. The
-        // `except` form substitutes through the body while protecting the
-        // scheme's own bound vars, which is the zonk this needs.
-        Some(raw_ty) => escape_tvars_into(subst_apply_except(s, raw_ty, array_empty()), out),
+        Some(raw_ty) => escape_tvars_zonked_into(raw_ty, s, out),
         None => ()
       }
     }

--- a/lib/@vibe/compiler/checker/checker.vibe
+++ b/lib/@vibe/compiler/checker/checker.vibe
@@ -3202,6 +3202,100 @@ fn esc_name_is_param(name: String, params: Array[(String, Option[TypeExpr])]) ->
   found
 }
 
+/// #2459: the type NAMES an annotation mentions, minus the ones the annotated
+/// lambda binds itself. A type parameter is bound in the value environment
+/// under its own name (the `EFn` arm does `env_bind(tp_env, tpname, ..)`), so
+/// once the names are in hand the ordinary lookup finds the outer binder's
+/// variable and nothing else is needed.
+fn esc_collect_type_names(te: TypeExpr, skip: Array[String], out: Array[String]) -> Unit {
+  match te {
+    TyName(n) => if string_array_has(skip, n) || string_array_has(out, n) {
+      ()
+    } else {
+      Array::push(out, n)
+    },
+    TyApp(n, args) => {
+      if string_array_has(skip, n) || string_array_has(out, n) {
+        ()
+      } else {
+        Array::push(out, n)
+      }
+      let mut i = 0
+      while i < Array::length(args) {
+        esc_collect_type_names(Array::get(args, i), skip, out)
+        i = i + 1
+      }
+    },
+    TyFn(ps, r, _) => {
+      let mut i = 0
+      while i < Array::length(ps) {
+        esc_collect_type_names(Array::get(ps, i), skip, out)
+        i = i + 1
+      }
+      esc_collect_type_names(r, skip, out)
+    },
+    TyTuple(elems) => {
+      let mut i = 0
+      while i < Array::length(elems) {
+        esc_collect_type_names(Array::get(elems, i), skip, out)
+        i = i + 1
+      }
+    },
+    _ => ()
+  }
+}
+
+/// #2459: every type name written in an ANNOTATION anywhere inside a value.
+///
+/// Codex P1 on #2460. `env_reachable_tvars`'s own doc says a variable enters a
+/// value's type "through a name it mentions, a parameter, or an annotation",
+/// and then only read the names -- so a lambda that mentions an enclosing type
+/// parameter ONLY in its signature looked independent:
+///
+///     fn outer[T](x: T) -> Int {
+///       let f = (v: T) -> Array[T] { [v] }
+///       let a = f(1)
+///       let b = f("s")          // accepted
+///     }
+///
+/// Measured, this is a regression introduced by narrowing the value
+/// restriction for `CtFn`: on `cacbf4d51` the old `ty_has_open_array_elem`
+/// conservatism refused the binding for its `Array` shape and covered this by
+/// accident. Adding `let _ = x` inside the lambda -- a VALUE of type `T` --
+/// made the old scan see it, which is the A/B that isolates the annotation
+/// path.
+///
+/// A lambda's OWN binders are skipped: `[S](v: S) -> Array[S]` owns `S`, and
+/// reading a shadowed outer `S` would monomorphize a genuinely generic lambda.
+fn esc_annotation_type_names(e: Expr, out: Array[String]) -> Unit {
+  match e {
+    EFn(tparams, _, params, ret_ty, _, _) => {
+      let skip = for tpk in tparams {
+        type_param_name(tpk)
+      }
+      let mut i = 0
+      while i < Array::length(params) {
+        match Array::get(params, i) {
+          (_, Some(te)) => esc_collect_type_names(te, skip, out),
+          _ => ()
+        }
+        i = i + 1
+      }
+      match ret_ty {
+        Some(te) => esc_collect_type_names(te, skip, out),
+        None => ()
+      }
+    },
+    _ => ()
+  }
+  let kids = expr_children(e)
+  let mut ci = 0
+  while ci < Array::length(kids) {
+    esc_annotation_type_names(Array::get(kids, ci), out)
+    ci = ci + 1
+  }
+}
+
 /// #2459: the type variables an expression can reach THROUGH THE ENVIRONMENT
 /// -- the free names it mentions (including bare callees, per #2455), looked
 /// up in `env` and zonked. A variable can only have entered the expression's
@@ -3223,6 +3317,17 @@ fn env_reachable_tvars(val: Expr, env: TypeEnv, s: Subst, self_name: Option[Stri
       ()
     } else {
       Array::push(names, callee)
+    }
+  }
+  // A type parameter is bound in this same environment under its own name, so
+  // an annotation that mentions one is read exactly like a value name.
+  let ann_names = array_empty()
+  esc_annotation_type_names(val, ann_names)
+  for tn in ann_names {
+    if string_array_has(names, tn) {
+      ()
+    } else {
+      Array::push(names, tn)
     }
   }
   let mut i = 0

--- a/lib/@vibe/compiler/checker/checker.vibe
+++ b/lib/@vibe/compiler/checker/checker.vibe
@@ -3267,8 +3267,27 @@ fn esc_collect_type_names(te: TypeExpr, skip: Array[String], out: Array[String])
 ///
 /// A lambda's OWN binders are skipped: `[S](v: S) -> Array[S]` owns `S`, and
 /// reading a shadowed outer `S` would monomorphize a genuinely generic lambda.
+///
+/// `EFn` and `ERecord` are the ONLY `Expr` nodes carrying a `TypeExpr`
+/// (lib/@vibe/ast/index.vpkg), so this walk is complete for expressions rather
+/// than complete-for-now. Codex found the `ERecord` half as a P2 on #2460 --
+/// `expr_children` visits an `ERecord`'s field expressions and drops its
+/// type-argument list, so `let make = () -> { Box[T]::{ value: None } }` inside
+/// `fn outer[T]` mentioned `T` nowhere this scan could see. That one predates
+/// this PR (measured clean on `cacbf4d51` too); enumerating the enum rather
+/// than patching the reported site is what makes the pair of them the end of
+/// it.
 fn esc_annotation_type_names(e: Expr, out: Array[String]) -> Unit {
   match e {
+    ERecord(_, _, targs) => {
+      // A record literal's type arguments are written at a site the lambda
+      // does not bind, so there is nothing to skip here.
+      let mut ti = 0
+      while ti < Array::length(targs) {
+        esc_collect_type_names(Array::get(targs, ti), array_empty(), out)
+        ti = ti + 1
+      }
+    },
     EFn(tparams, _, params, ret_ty, _, _) => {
       let skip = for tpk in tparams {
         type_param_name(tpk)

--- a/lib/@vibe/compiler/checker/checker_stmt.vibe
+++ b/lib/@vibe/compiler/checker/checker_stmt.vibe
@@ -81,6 +81,7 @@ import ./checker.vibe {
   formal_application_error,
   is_array_builder_ty,
   is_region_tagged_ty,
+  let_generalize,
   pat_binds_resume,
   preserve_generic_instantiation,
   reject_resume_outside_handler,
@@ -2288,19 +2289,12 @@ fn check_stmts_with_binders(raw_stmts: Array[Stmt], i: Int, env: TypeEnv, defs: 
             (ns_b, preserve_generic_instantiation(resolved_te, subst_apply(ns_b, vt)))
           },
           None => {
-            let vt_resolved = subst_apply(ns0, vt)
-            if is_array_builder_ty(vt_resolved) || is_region_tagged_ty(vt_resolved) || ty_has_open_array_elem(vt_resolved) {
-              // #938 value restriction: keep a builder's element var
-              // un-quantified so pushes constrain each other (see the ELet
-              // arm in checker.vibe). #1081 step 3 Phase B: a region-tagged
-              // endpoint needs the identical treatment (see
-              // is_region_tagged_ty's doc comment in checker.vibe). #2447:
-              // so does a still-open Array element var (see
-              // ty_has_open_array_elem).
-              (ns0, vt)
-            } else {
-              (ns0, generalize(ns0, vt))
-            }
+            // #2459: the SAME decision as the `ELet` / `ELetRec` arms in
+            // checker.vibe, and it is now spelled once. This site carried its
+            // own copy of the predicate, so a top-level `let g2 = g` kept
+            // quantifying a captured slot after both local arms stopped --
+            // three places for one rule is how they drift apart.
+            (ns0, let_generalize(val, vt, env, ns0, None))
           }
         }
         let env1 = bind_function_dependency_contracts(env_bind(env, name, t), name, val)

--- a/lib/@vibe/compiler/checker/index.vpkg
+++ b/lib/@vibe/compiler/checker/index.vpkg
@@ -153,6 +153,8 @@ fn decode_enum_def(ty: Type) -> Option[(Array[String], Array[(String, Array[Type
 fn decode_enum_def_variants(ty: Type) -> Option[Array[(String, Array[Type])]]
 fn is_array_builder_ty(t: Type) -> Bool
 fn is_region_tagged_ty(t: Type) -> Bool
+
+fn let_generalize(val: Expr, vt: Type, env: TypeEnv, s: Subst, self_name: Option[String]) -> Type
 fn ty_has_open_array_elem(t: Type) -> Bool
 fn pat_binds_resume(p: Pat) -> Bool
 fn reject_resume_outside_handler(e: Expr, sh: Bool, errors: Array[String]) -> Unit

--- a/lib/@vibe/compiler/core/index.vpkg
+++ b/lib/@vibe/compiler/core/index.vpkg
@@ -279,6 +279,8 @@ fn impls_overlap_for(env: TypeEnv, trait_name: String, new_target: Type) -> Bool
 fn overlapping_impl_target_for(env: TypeEnv, trait_name: String, new_params: Array[String], new_target: Type) -> Option[Type]
 fn collect_subst_bounds_pairs(s: Subst) -> Array[(Int, Array[String])]
 fn generalize(s: Subst, ty: Type) -> Type
+
+fn generalize_except(s: Subst, ty: Type, exclude: Array[Int]) -> Type
 fn type_implements_trait(env: TypeEnv, s: Subst, ty: Type, trait_name: String) -> Bool
 fn refine_trait_bounds_from_receiver(env: TypeEnv, s: Subst, param: Type, receiver: Type) -> Subst
 fn trait_impl_declared_for_ctor(e: TypeEnv, trait_name: String, resolved: Type) -> Bool

--- a/lib/@vibe/compiler/core/types.vibe
+++ b/lib/@vibe/compiler/core/types.vibe
@@ -4757,6 +4757,45 @@ export fn collect_subst_bounds_pairs(s: Subst) -> Array[(Int, Array[String])] {
   out
 }
 
+/// #2459: `generalize`, minus the variables that are still FREE IN THE
+/// ENVIRONMENT. Quantifying one of those hands every use its own copy of a
+/// slot that has exactly one runtime home -- measured, `let g2 = g` on a
+/// lambda capturing `let xs = []` turned `forall U. (U, ?k) -> U` into
+/// `forall U ?k. (U, ?k) -> U`, and the two calls then put an `Int` and a
+/// `String` into one array.
+///
+/// `exclude` is the caller's answer to "which variables belong to something
+/// else". An empty `exclude` is exactly `generalize`.
+export fn generalize_except(s: Subst, ty: Type, exclude: Array[Int]) -> Type {
+  match ty {
+    CtForAll(vars, bounds, body) => CtForAll(vars, bounds, subst_apply_except(s, body, vars)),
+    _ => {
+      let resolved = subst_apply(s, ty)
+      let tvars = array_empty()
+      for vid in collect_tvars(resolved) {
+        if array_has_int(exclude, vid, 0) {
+          ()
+        } else {
+          Array::push(tvars, vid)
+        }
+      }
+      if Array::length(tvars) == 0 {
+        resolved
+      } else {
+        let bounds_pairs = collect_subst_bounds_pairs(s)
+        let var_bounds = array_empty()
+        for vid in tvars {
+          let bounds = int_bounds_lookup(bounds_pairs, vid, 0)
+          if Array::length(bounds) != 0 {
+            Array::push(var_bounds, (vid, bounds))
+          }
+        }
+        CtForAll(tvars, var_bounds, resolved)
+      }
+    }
+  }
+}
+
 export fn generalize(s: Subst, ty: Type) -> Type {
   match ty {
     CtForAll(vars, bounds, body) => CtForAll(vars, bounds, subst_apply_except(s, body, vars)),

--- a/lib/@vibe/compiler/tests/empty_array_value_restriction_test.vibe
+++ b/lib/@vibe/compiler/tests/empty_array_value_restriction_test.vibe
@@ -45,11 +45,20 @@ test "let mut spelling is rejected the same way" {
   inspect(check_err(src), content = "true")
 }
 
-// A `record { xs: [] }` case is deliberately NOT pinned here: anonymous-record
-// projections are loosely typed independently of empty arrays (#2452 -- even
-// `let s: String = r.n` on an Int field checks clean), so the rejection cannot
-// hold until that is fixed. `ty_has_open_array_elem` already descends CtRecord
-// fields, so the restriction side is in place when it does.
+test "a record field holding an empty array is monomorphic too" {
+  // Restored now that #2452 has landed. The restriction side was always in
+  // place -- `ty_has_open_array_elem` descends `CtRecord` fields -- but the
+  // rejection could not hold, because `r.xs` on a record BINDING never reached
+  // the checker's `EDot` arm: the desugar rewrites it to
+  // `__rec_field(r, slot)`, which the builtin table typed
+  // `(CtUnknown, Int) -> CtUnknown`. The projection was the only thing losing
+  // the type.
+  let src = "fn main() -> Unit { let r = record { xs: [] }\nlet u1 = Array::push(r.xs, 1)\nlet u2 = Array::push(r.xs, \"s\")\n() }"
+  inspect(check_err(src), content = "true")
+  // Homogeneous pushes through the same projection still check.
+  let ok = "fn main() -> Unit { let r = record { xs: [] }\nlet u1 = Array::push(r.xs, 1)\nlet u2 = Array::push(r.xs, 2)\n() }"
+  inspect(check_ok(ok), content = "true")
+}
 
 test "a generic call result with an open element var is monomorphic" {
   // The ELet skip covers any still-open Array element var, not only the

--- a/lib/@vibe/compiler/tests/empty_array_value_restriction_test.vibe
+++ b/lib/@vibe/compiler/tests/empty_array_value_restriction_test.vibe
@@ -100,13 +100,20 @@ test "a generic producer with a composite element is monomorphic" {
   inspect(check_err(src), content = "true")
 }
 
-test "a lambda array factory binds as a monotype" {
-  // The type alone cannot tell a body-fresh `[]` from a captured one, so
-  // the CtFn arm is conservative: this lambda serves ONE element type.
-  // The polymorphic factory keeps a spelling -- the named generic form
-  // below.
+test "a lambda array factory is polymorphic" {
+  // This asserted REJECTION until #2459, and stated its own reason as missing
+  // information: "the type alone cannot tell a body-fresh `[]` from a captured
+  // one, so the CtFn arm is conservative". `let_generalize` now supplies
+  // exactly that -- a captured array is reachable from the environment through
+  // the names the lambda mentions, a body-fresh one is reachable from nothing
+  // -- so the conservatism is no longer needed here.
+  //
+  // The rejection was never a soundness requirement: `() -> { [] }` allocates
+  // a NEW array on every call, so `a` and `b` are two arrays, and pushing an
+  // Int into one and a String into the other is correct. The CAPTURED
+  // spelling, which is unsound, stays rejected by the test above.
   let src = "fn main() -> Unit { let mkf = () -> { [] }\nlet a: Array[Int] = mkf()\nlet b: Array[String] = mkf()\nArray::push(a, 1)\nArray::push(b, \"s\") }"
-  inspect(check_err(src), content = "true")
+  inspect(check_ok(src), content = "true")
 }
 
 test "a recursive closure returning a captured array is monomorphic" {

--- a/lib/@vibe/compiler/tests/let_generalization_env_test.vibe
+++ b/lib/@vibe/compiler/tests/let_generalization_env_test.vibe
@@ -129,3 +129,20 @@ test "2459: an excluded variable is resolved, not taken as written" {
   // the control that shows the `link` call is what the fix is about.
   assert_eq(checks_clean(String::concat(link, String::concat(g, String::concat(calls, "let u0 = link(xs, ys)\n")))), false)
 }
+
+test "2459: the capture is tracked through a chain of aliases" {
+  // `g2 = g` then `g3 = g2`. Each alias re-generalizes, so an exclusion that
+  // only survived one hop would leak at the second -- `g3` would quantify the
+  // captured slot even though `g2` did not.
+  let g = "let xs = []\nlet g = [U](u: U, k) -> U { Array::push(xs, k)\nu }\n"
+  assert_eq(checks_clean(String::concat(g, "let g2 = g\nlet g3 = g2\nlet a = g3(0, 1)\nlet b = g3(0, \"s\")\n")), false)
+}
+
+test "2461: a lambda's alias keeps its polymorphism too" {
+  // `let mk = [T](..)` binds a `CtForAll` DIRECTLY, so the alias takes a
+  // different path from `let m2 = mk` on a named `fn`. Both must stay generic.
+  assert_eq(checks_clean("let idf = [T](v: T) -> T { v }\nlet id2 = idf\nlet a = id2(1)\nlet b = id2(\"s\")\n"), true)
+  assert_eq(checks_clean("let mk = [T](v: T) -> Array[T] { [v] }\nlet m2 = mk\nlet a: Array[Int] = m2(1)\nlet b: Array[String] = m2(\"s\")\n"), true)
+  // And through two hops, where the #2461 direction could equally decay.
+  assert_eq(checks_clean("fn mk[T](v: T) -> Array[T] { [v] }\nlet m2 = mk\nlet m3 = m2\nlet a: Array[Int] = m3(1)\nlet b: Array[String] = m3(\"s\")\n"), true)
+}

--- a/lib/@vibe/compiler/tests/let_generalization_env_test.vibe
+++ b/lib/@vibe/compiler/tests/let_generalization_env_test.vibe
@@ -1,0 +1,111 @@
+//# #2459 / #2461: a `let` generalizes exactly the type variables that are NOT
+//# free in the enclosing environment.
+//#
+//# Two independent rules were being run as one predicate, and the conflation
+//# broke both directions:
+//#
+//#   (A) the VALUE restriction -- a binding that HOLDS a mutable container
+//#       keeps its element variable a monotype (#938, #2447);
+//#   (B) the ENVIRONMENT restriction -- a variable free in the enclosing scope
+//#       belongs to something else and is not this binding's to quantify.
+//#
+//# (A) is about what the value IS, (B) about where its variables CAME FROM.
+//# (B) was missing entirely, so `let g2 = g` quantified a captured array slot
+//# and put an Int and a String in one array (#2459); and (A) was applied to
+//# FUNCTION types, where the array is produced per call rather than held, so
+//# aliasing a perfectly generic `mk[T](v: T) -> Array[T]` was refused (#2461).
+//#
+//# Both were measured on the committed seed: the unsound one is a long-standing
+//# hole, the false rejection is a regression from #2450.
+
+//# Imports
+
+import @vibe/compiler/checker {
+  check_program
+}
+
+import @vibe/compiler/syntax {
+  lex, parse_program
+}
+
+//# Functions
+
+fn checks_clean(source: String) -> Bool {
+  handle {
+    let _ = check_program(parse_program(lex(source)))
+    true
+  } with { Exception::Throw(_) => false }
+}
+
+/// A lambda that CAPTURES `xs` and pushes its second, unannotated argument
+/// into it. Its scheme is correct on its own: `forall U. (U, ?k) -> U`, with
+/// `?k` -- the captured array's element slot -- FREE.
+let capturing_g: String = "let xs = []\nlet g = [U](u: U, k) -> U { Array::push(xs, k)\nu }\n"
+
+test "2459: aliasing a scheme does not quantify its free environment slot" {
+  // Measured before: `forall U. (U, ?k) -> U` became `forall U ?k. (U, ?k) -> U`
+  // at the alias, and the two calls below both passed -- one runtime array
+  // holding `1` and `"s"`.
+  assert_eq(checks_clean(String::concat(capturing_g, "let g2 = g\nlet a = g2(0, 1)\nlet b = g2(0, \"s\")\n")), false)
+}
+
+test "2459: the alias answers the same as the direct use" {
+  // The A/B that isolates it: the alias is the ONLY difference between these,
+  // and before the fix they disagreed.
+  let direct = String::concat(capturing_g, "let a = g(0, 1)\nlet b = g(0, \"s\")\n")
+  let aliased = String::concat(capturing_g, "let g2 = g\nlet a = g2(0, 1)\nlet b = g2(0, \"s\")\n")
+  assert_eq(checks_clean(direct), checks_clean(aliased))
+  assert_eq(checks_clean(direct), false)
+}
+
+test "2459: a wrapper closure over the same capture is rejected too" {
+  // The spelling #2459 was first found with. It reaches the captured slot
+  // through a call rather than a name, which is why the scan reads bare
+  // callees as well as free names.
+  let src = String::concat(capturing_g, "let put = [T](t: T) -> Unit { let _ = g(0, t)\n() }\nput(1)\nput(\"s\")\n")
+  assert_eq(checks_clean(src), false)
+}
+
+test "2459: homogeneous use through the alias still checks" {
+  // The restriction is on QUANTIFYING the slot, not on using it. One element
+  // type through the alias is exactly what the shared slot allows.
+  assert_eq(checks_clean(String::concat(capturing_g, "let g2 = g\nlet a = g2(0, 1)\nlet b = g2(0, 2)\n")), true)
+}
+
+test "2461: aliasing a generic function keeps it polymorphic" {
+  // `mk` builds a FRESH array from its own argument every call, so `m2(1)` and
+  // `m2(\"s\")` return two different arrays and nothing is shared. Rejecting
+  // this was a regression: measured, the committed seed accepts it.
+  let src = "fn mk[T](v: T) -> Array[T] { [v] }\nlet m2 = mk\nlet a: Array[Int] = m2(1)\nlet b: Array[String] = m2(\"s\")\n"
+  assert_eq(checks_clean(src), true)
+  // Without the alias it was always accepted -- the alias was the whole
+  // difference, in the opposite direction from #2459's.
+  assert_eq(checks_clean("fn mk[T](v: T) -> Array[T] { [v] }\nlet a: Array[Int] = mk(1)\nlet b: Array[String] = mk(\"s\")\n"), true)
+}
+
+test "2461: only an Array in the return position was affected" {
+  // The narrowing that identified the predicate: `ty_has_open_array_elem` was
+  // the arm firing, so an alias whose return mentions no Array was never hit.
+  assert_eq(checks_clean("fn idf[T](v: T) -> T { v }\nlet i2 = idf\nlet a = i2(1)\nlet b = i2(\"s\")\n"), true)
+  assert_eq(checks_clean("fn opt[T](v: T) -> Option[T] { Some(v) }\nlet o2 = opt\nlet a = o2(1)\nlet b = o2(\"s\")\n"), true)
+}
+
+test "2459: a recursive binding is not its own environment" {
+  // `let rec` binds a placeholder for its recursive uses BEFORE the body is
+  // checked and unifies it with the signature afterwards, so at generalization
+  // time the recursive name carries the very variables being generalized.
+  // Reading those as environment-owned would monomorphize every recursive
+  // generic function, which is why `let_generalize` takes the name being
+  // defined.
+  assert_eq(checks_clean("fn main() -> Int { let rec go = [T](n: Int, v: T) -> T { if n == 0 { v } else { go(n - 1, v) } }\nlet a = go(2, 1)\nlet b = go(2, \"s\")\n1 }"), true)
+}
+
+test "2459: the rule is spelled once, so a top-level let answers like a local" {
+  // This site had its own copy of the predicate in checker_stmt.vibe, so a
+  // top-level `let g2 = g` kept quantifying the captured slot after both local
+  // arms stopped. Three places for one rule is how they drift.
+  let toplevel = String::concat(capturing_g, "let g2 = g\nlet a = g2(0, 1)\nlet b = g2(0, \"s\")\n")
+  let local = String::concat(capturing_g, "fn main() -> Unit { let g2 = g\nlet a = g2(0, 1)\nlet b = g2(0, \"s\")\n() }")
+  assert_eq(checks_clean(toplevel), checks_clean(local))
+  assert_eq(checks_clean(toplevel), false)
+}

--- a/lib/@vibe/compiler/tests/let_generalization_env_test.vibe
+++ b/lib/@vibe/compiler/tests/let_generalization_env_test.vibe
@@ -177,3 +177,26 @@ test "2459: a lambda's own binder is not read from the environment" {
   assert_eq(checks_clean("fn main() -> Int { let f = [S](v: S) -> Array[S] { [v] }\nlet a: Array[Int] = f(1)\nlet b: Array[String] = f(\"s\")\n1 }\n"), true)
   assert_eq(checks_clean("fn main() -> Int { let f = (v: Int) -> Array[Int] { [v] }\nlet a = f(1)\n1 }\n"), true)
 }
+
+test "2459: a record literal's type arguments are annotations too" {
+  // Codex P2 on #2460. `expr_children` visits an `ERecord`'s field expressions
+  // and drops its type-argument list, so `Box[T]::{ .. }` mentioned `T`
+  // nowhere the scan could see. Unlike the two findings before it, this one
+  // PREDATES the PR -- measured clean on `cacbf4d51` as well -- so it is
+  // residual scope rather than a regression, and the neighbouring annotated
+  // spelling was already improved by this work (clean before, rejected now).
+  //
+  // `EFn` and `ERecord` are the only `Expr` nodes carrying a `TypeExpr`
+  // (lib/@vibe/ast/index.vpkg), so enumerating the enum rather than patching
+  // the reported site is what makes this the end of the class.
+  let boxed = "struct Box[T] { value: Option[T] }\n"
+  let via_targs = String::concat(boxed, "fn outer[T](x: T) -> Int { let make = () -> { Box[T]::{ value: None } }\nlet a: Box[Int] = make()\nlet b: Box[String] = make()\n1 }\n")
+  assert_eq(checks_clean(via_targs), false)
+  let via_ann = String::concat(boxed, "fn outer[T](x: T) -> Int { let make = () -> Box[T] { Box[T]::{ value: None } }\nlet a: Box[Int] = make()\nlet b: Box[String] = make()\n1 }\n")
+  assert_eq(checks_clean(via_ann), false)
+  // One use is monomorphic, not rejected.
+  assert_eq(checks_clean(String::concat(boxed, "fn outer[T](x: T) -> Int { let make = () -> { Box[T]::{ value: None } }\nlet a = make()\n1 }\n")), true)
+  // The lambda's own binder, and a wholly concrete literal, stay generic.
+  assert_eq(checks_clean(String::concat(boxed, "fn main() -> Int { let make = [S]() -> Box[S] { Box[S]::{ value: None } }\nlet a: Box[Int] = make()\nlet b: Box[String] = make()\n1 }\n")), true)
+  assert_eq(checks_clean(String::concat(boxed, "fn main() -> Int { let make = () -> { Box[Int]::{ value: None } }\nlet a = make()\nlet b = make()\n1 }\n")), true)
+}

--- a/lib/@vibe/compiler/tests/let_generalization_env_test.vibe
+++ b/lib/@vibe/compiler/tests/let_generalization_env_test.vibe
@@ -109,3 +109,23 @@ test "2459: the rule is spelled once, so a top-level let answers like a local" {
   assert_eq(checks_clean(toplevel), checks_clean(local))
   assert_eq(checks_clean(toplevel), false)
 }
+
+test "2459: an excluded variable is resolved, not taken as written" {
+  // Codex P1 on #2460. `subst_apply` and `subst_apply_except` BOTH return a
+  // `CtForAll` untouched, so a scheme's free variable comes back with the id
+  // it was written with. Unify the captured slot with another open slot
+  // BEFORE the alias and the alias's type resolves to the second id while the
+  // scan still reports the first, so the exclusion misses and the captured
+  // array takes two element types again.
+  //
+  // Measured before the fix: the `link` call is the whole difference --
+  // without it the alias was already rejected, with it the program was clean.
+  let link = "fn link[T](a: Array[T], b: Array[T]) -> Unit { () }\n"
+  let g = "let xs = []\nlet ys = []\nlet g = [U](u: U, k) -> U { Array::push(xs, k)\nu }\n"
+  let calls = "let g2 = g\nlet a = g2(0, 1)\nlet b = g2(0, \"s\")\n"
+  // The slots are joined BEFORE the alias -- the case that regressed.
+  assert_eq(checks_clean(String::concat(link, String::concat(g, String::concat("let u0 = link(xs, ys)\n", calls)))), false)
+  // Joined AFTER the alias: the exclusion never went stale here, and this is
+  // the control that shows the `link` call is what the fix is about.
+  assert_eq(checks_clean(String::concat(link, String::concat(g, String::concat(calls, "let u0 = link(xs, ys)\n")))), false)
+}

--- a/lib/@vibe/compiler/tests/let_generalization_env_test.vibe
+++ b/lib/@vibe/compiler/tests/let_generalization_env_test.vibe
@@ -146,3 +146,34 @@ test "2461: a lambda's alias keeps its polymorphism too" {
   // And through two hops, where the #2461 direction could equally decay.
   assert_eq(checks_clean("fn mk[T](v: T) -> Array[T] { [v] }\nlet m2 = mk\nlet m3 = m2\nlet a: Array[Int] = m3(1)\nlet b: Array[String] = m3(\"s\")\n"), true)
 }
+
+test "2459: a variable reached only through an ANNOTATION is excluded too" {
+  // Codex P1 on #2460, and a regression this PR introduced: narrowing the
+  // value restriction for `CtFn` removed a cover the old predicate provided by
+  // accident. Measured on `cacbf4d51`, the two-use program below was REJECTED
+  // (the old `ty_has_open_array_elem` refused the binding for its `Array`
+  // shape); after the narrowing it checked clean.
+  //
+  // `env_reachable_tvars`'s own doc said a variable enters through "a name it
+  // mentions, a parameter, or an ANNOTATION", and then read only the names --
+  // so a lambda mentioning the enclosing type parameter solely in its
+  // signature looked independent of it.
+  let ann = "fn outer[T](x: T) -> Int { let f = (v: T) -> Array[T] { [v] }\nlet a = f(1)\nlet b = f(\"s\")\n1 }\n"
+  assert_eq(checks_clean(ann), false)
+  // The A/B that isolates the annotation path: add a VALUE of type `T` inside
+  // the lambda and even the name-only scan saw it.
+  let value_too = "fn outer[T](x: T) -> Int { let f = (v: T) -> Array[T] { let _ = x\n[v] }\nlet a = f(1)\nlet b = f(\"s\")\n1 }\n"
+  assert_eq(checks_clean(value_too), false)
+  // One use is fine -- the binding is monomorphic, not rejected outright.
+  assert_eq(checks_clean("fn outer[T](x: T) -> Int { let f = (v: T) -> Array[T] { [v] }\nlet a = f(x)\n1 }\n"), true)
+}
+
+test "2459: a lambda's own binder is not read from the environment" {
+  // The skip list. Without it, an inner `[S]` that SHADOWS an outer `[S]`
+  // would resolve to the outer binder's variable and monomorphize a genuinely
+  // generic lambda -- the #2461 direction, reintroduced through annotations.
+  assert_eq(checks_clean("fn outer[S](x: S) -> Int { let f = [S](v: S) -> Array[S] { [v] }\nlet a: Array[Int] = f(1)\nlet b: Array[String] = f(\"s\")\n1 }\n"), true)
+  // No enclosing generic at all, and a wholly concrete annotation.
+  assert_eq(checks_clean("fn main() -> Int { let f = [S](v: S) -> Array[S] { [v] }\nlet a: Array[Int] = f(1)\nlet b: Array[String] = f(\"s\")\n1 }\n"), true)
+  assert_eq(checks_clean("fn main() -> Int { let f = (v: Int) -> Array[Int] { [v] }\nlet a = f(1)\n1 }\n"), true)
+}


### PR DESCRIPTION
Six commits, four issues. They are on one branch because it is the only push target available to this session; each is independent and can be read on its own.

| commit | what |
| --- | --- |
| `4c55f3bcb` | #2452 — restore the two pins the issue asked for |
| `2c5d6d8e7` | #2459 + #2461 — one rule for `let` generalization |
| `d1c3b03cc` | Codex P1 — resolve an excluded variable instead of taking it as written |
| `fbf23d2d9` | tests — alias chains and lambda aliases |
| `644f30994` | Codex P1 — exclude variables reached through an ANNOTATION |
| `546675b20` | Codex P2 — a record literal's type arguments are annotations too |

---

# 1. `#2452` — restore the two pins

The issue's body asks for them explicitly, and #2458 landed the fix without them, so the rejection it created was not held by anything:

- **`fixtures/empty_array_hetero_record_reject.vibe`** — no new gate code; the early gate already globs `fixtures/empty_array_hetero_*_reject.vibe`.
- **The record case in `empty_array_value_restriction_test.vibe`**, replacing the comment that explained why it could not be pinned.

Red-verified against `ed1089a9f`. **And the gate was shown to fail** — a passing gate means nothing until it is known to be capable of failing, so the fixture was mutated to a homogeneous push and the gate re-run:

```
gate exit=1
[compiler-gate] FAIL: fixtures/empty_array_hetero_record_reject.vibe compiled; expected a check rejection
```

It names this fixture, so the glob really does pick it up and the assertion really does read its result.

---

# 2. `#2459` + `#2461` — one rule for `let` generalization

Two independent rules were running as one predicate, and the conflation broke both directions:

- **(A) the VALUE restriction** — a binding that HOLDS a mutable container keeps its element variable a monotype (#938, #2447);
- **(B) the ENVIRONMENT restriction** — a variable free in the enclosing scope belongs to something else and is not this binding's to quantify.

(A) is about what the value **is**; (B) is about where its variables **came from**. Only (A) existed, spelled as `ty_has_open_array_elem`, and it was asked to answer both questions.

## #2459 — the unsound direction

```vibe
let xs = []
let g = [U](u: U, k) -> U { Array::push(xs, k)  u }
let g2 = g
let a = g2(0, 1)
let b = g2(0, "s")     // accepted; xs holds an Int and a String
```

Read off the stored types, one program:

```
xs = Array[?t0]
g  = forall ?t1. (?t1, ?t3) -> ?t1        <- correct: ?t3 (k's slot, = xs's element) is FREE
g2 = forall ?t6 ?t3. (?t6, ?t3) -> ?t6    <- ?t3 is now BOUND
```

`g`'s own scheme is right. Reading `g` **instantiates** it to a plain `CtFn`, and generalizing that collected every variable in it, `xs`'s slot included. The alias is the only difference between a rejected program and an accepted one. Present on the committed seed too, so a long-standing hole. The issue's original diagnosis (an unannotated parameter escaping into the scheme) was wrong and is corrected on its thread.

## #2461 — the false-rejection direction

```vibe
fn mk[T](v: T) -> Array[T] { [v] }
let mk2 = mk
let a: Array[Int] = mk2(1)
let b: Array[String] = mk2("s")   // seed: clean.  before this: REJECTED
```

`mk` builds a fresh array from its own argument every call. (A) fired on a FUNCTION type, where the array is produced per call rather than held. A regression from #2450, whose documented escape hatch ("the polymorphic factory keeps a spelling — the named generic form") did not survive being bound to a name.

## The fix

`let_generalize` decides both. (B) excludes the variables reachable from the right-hand side **through the environment**: its free names, its bare callees, and the type names its **annotations** write — each looked up in the environment and resolved through the substitution. (A) keeps deciding every non-function type as before; for a function type it asks (B)'s question, because a function holds a container only when it **captured** one.

**The rule is now spelled once.** A third copy of the predicate lived in `checker_stmt.vibe`'s top-level `SLet`, so a top-level `let g2 = g` kept quantifying the captured slot after both local arms stopped.

## One expectation flips, and it stated its own reason

`a lambda array factory binds as a monotype` asserted rejection because *"the type alone cannot tell a body-fresh `[]` from a captured one, so the CtFn arm is conservative"*. (B) is exactly that information. Verified at runtime rather than argued — `let mkf = () -> { [] }` used at two element types now checks, and gives `a.len=1 a0=1 b.len=1 b0=s`: two distinct arrays. The rejection was conservatism, never soundness. The **captured** spelling beside it stays rejected.

---

# 3. What review found, and what it cost

Three findings on this PR, each reproduced before fixing and pinned by a red-verified test. Two of them were **regressions this PR introduced** — worth naming, because they share a cause:

| finding | verdict |
| --- | --- |
| the exclusion used pre-unification ids (`subst_apply_except` returns a `CtForAll` untouched) | mine; my comment also asserted a zonk that does not happen |
| a variable reached only through an ANNOTATION was not excluded | mine — narrowing (A) for `CtFn` removed a cover the old predicate gave by accident |
| a record literal's type arguments were not scanned | **predates the PR**; measured clean on `cacbf4d51` too |

Both regressions came from narrowing a conservative predicate without first enumerating what that conservatism was covering. On the third finding I took the enumeration route up front: `EFn` and `ERecord` are the ONLY `Expr` nodes carrying a `TypeExpr` (`lib/@vibe/ast/index.vpkg`), so those two are the end of the class rather than the current end of a list, and the doc comment records the reference.

The `CtForAll` descent in `escape_tvars_into` is also back. Codex asked for it on #2458; it was implemented, measured to change no answer there, and reverted rather than shipped on faith. #2459 is the input that makes it load-bearing — the slot that must not be quantified at `let g2 = g` is precisely the one free variable inside `g`'s scheme.

---

# Verification

**14 tests** in `lib/@vibe/compiler/tests/let_generalization_env_test.vibe`, each half red-verified independently: neutralising (B) fails the #2459 tests, restoring (A)'s unconditional `CtFn` arm fails the #2461 tests, dropping the annotation scan or the `ERecord` arm fails their own. #2455's thirteen binder-escape tests pass unchanged; #2450's file passes at 15 with the one flip above.

Every head was self-built and gated locally before pushing:

| measurement | result |
| --- | --- |
| stage2 self-build, each head | stage0 → stage1 → stage2, both validations `0` |
| `compiler_gate.sh` early, each head | exit 0 |
| `compiler_gate.sh` mid / late, on `2c5d6d8` | exit 0 |
| `unit_test_runner.sh`, on `2c5d6d8` | **1103/1103**, exit 0 |
| CI on `2c5d6d8`, `fbf23d2`, `644f3099`, `546675b` | success |
| Codex on `546675b` | completed, no findings |

The self-build carries the weight: this change runs at every `let` in the language, and the compiler's own ~1000 files are nothing but `let`s.

End-to-end on that stage2:

| program | before | after |
| --- | --- | --- |
| `let g2 = g` (#2459) | clean, `1 \| s` at runtime | `argument type mismatch for g2: expected Int, got String` |
| `let mk2 = mk` (#2461) | `argument type mismatch for mk2` | clean |
| `let mkf = () -> { [] }` | rejected | clean, two distinct arrays |

**Cost**, from the perf report on the final head: selfcompile heap **+0.09%**, stage2 size +0.08%, and **±0 on every execution scenario** (fuel, heap, wasm size, linear and gc), output checks 9/9. A rule that runs at every `let` costs that little because the RHS walk is skipped entirely when the binding's type has no variables, which is most bindings.

Refs #2452, #2459, #2461, #2450, #2447, #2455, #829, #938.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FYMVd6D2o82suTfTwoJPMf

---
_Generated by [Claude Code](https://claude.ai/code/session_01FYMVd6D2o82suTfTwoJPMf)_