### PR TITLE
fixtures: pin a captured `let mut` Int through the render channel (#2423)

### DIFF
--- a/fixtures/gc_lane_scalar_parity_test.vibe
+++ b/fixtures/gc_lane_scalar_parity_test.vibe
@@ -242,15 +242,30 @@ test "#2423 a large Int survives a let mut captured by a closure" {
   c = c + 1
   assert(__to_string(f()) == "274877906945")
   assert(__to_string(c) == "274877906945")
-  // The same capture through `eq`, the other spelling of the classifier.
-  // NEITHER operand may be a literal. The linear `eq` gate is a disjunction
-  // (the reason is spelled out at the `irc_ret_big` block below), so an
-  // `eq(f(), 274877906945)` is satisfied by the literal alone and never asks
-  // about the captured cell -- it would re-check `f()`'s VALUE, which the
-  // renders above already pin, and pin nothing about `eq`. So: a second
-  // captured cell, and comparisons where every operand is either a call or a
-  // ref-cell read.
-  let mut c2 = 65<<32
+  // The same capture through `eq`, the other spelling of the classifier. Two
+  // conditions have to hold at once for these rows to be able to FAIL, and
+  // each was measured by running the rows alone against the committed seed.
+  //
+  // (1) NEITHER operand may be a literal. The linear `eq` gate is a
+  //     disjunction (the reason is spelled out at the `irc_ret_big` block
+  //     below), so `eq(f(), 274877906945)` is satisfied by the literal alone
+  //     and never asks about the captured cell.
+  // (2) The two values must have the SAME low 32 bits. With the
+  //     classification lost, `eq` falls back to the string comparison, which
+  //     reads a value as (ptr<<32)|len -- so unequal low words are unequal
+  //     "lengths" and it returns false immediately, which is the answer these
+  //     rows want. Measured: with both low words 1 the fallback goes on to
+  //     compare one byte at two different addresses and gets the right answer
+  //     by luck, so only low word 0 on both sides is reliably red -- there the
+  //     fallback compares two EMPTY strings, calls them equal, and `!eq`
+  //     traps.
+  //
+  // Hence the second mutation: it puts `c` back on a zero low word while
+  // still leaving the cell read back rather than folded, and the render
+  // assertions above already cover the sharper low-word-1 case.
+  c = c + ((1<<32) - 1)
+  assert(__to_string(c) == "279172874240")
+  let mut c2 = 66<<32
   let g = () -> Int {
     c2
   }

--- a/fixtures/gc_lane_scalar_parity_test.vibe
+++ b/fixtures/gc_lane_scalar_parity_test.vibe
@@ -236,12 +236,15 @@ test "#2423 a large Int survives a let mut captured by a closure" {
     c
   }
   // Through the closure, and directly -- the seed rendered both as "".
-  assert(__to_string(f()) == "274877906944")
-  assert(__to_string(c) == "274877906944")
+  // Spelled with `inspect` per the snapshot policy: it desugars to the same
+  // `__to_string` this test is about, so the oracle is unchanged, and the
+  // expectations become refreshable by `vibe test --update`.
+  inspect(f(), content = "274877906944")
+  inspect(c, content = "274877906944")
   // After a mutation, so the cell is read back rather than folded.
   c = c + 1
-  assert(__to_string(f()) == "274877906945")
-  assert(__to_string(c) == "274877906945")
+  inspect(f(), content = "274877906945")
+  inspect(c, content = "274877906945")
   // The same capture through `eq`, the other spelling of the classifier. Two
   // conditions have to hold at once for these rows to be able to FAIL, and
   // each was measured by running the rows alone against the committed seed.
@@ -264,11 +267,21 @@ test "#2423 a large Int survives a let mut captured by a closure" {
   // still leaving the cell read back rather than folded, and the render
   // assertions above already cover the sharper low-word-1 case.
   c = c + ((1<<32) - 1)
-  assert(__to_string(c) == "279172874240")
+  inspect(c, content = "279172874240")
   let mut c2 = 66<<32
   let g = () -> Int {
     c2
   }
+  // These six stay `assert` rather than `inspect`, and the reason is a lane
+  // divergence this file exists to catch. `inspect(v, content = ..)` desugars
+  // to `__to_string(v)`, and `__to_string` of an `eq` RESULT answers "false"
+  // on linear and "0" on gc -- measured on this compiler, both lanes, and the
+  // gc side is a regression against the committed seed, which answers "false"
+  // there too. `gc_expr_is_boolish` (codegen/gc/backend_expr.vibe) has no
+  // ECall arm at all, so it cannot classify any of the Bool-returning
+  // builtins the linear `cc_builtin_call_ret_kind` recognizes. That is #2464.
+  // `assert` never renders the Bool, so it asks about `eq` and nothing else,
+  // which is what these rows are for.
   // Both call-shaped.
   assert(!eq(f(), g()))
   assert(eq(f(), f()))
@@ -284,12 +297,12 @@ test "#2423 a large Int survives a let mut captured by a closure" {
   let fs = () -> String {
     s
   }
-  assert(__to_string(fs()) == "hi")
+  inspect(fs(), content = "hi")
   let mut d = 1.5
   let fd = () -> Double {
     d
   }
-  assert(__to_string(fd()) == "1.5")
+  inspect(fd(), content = "1.5")
   // A captured `let mut` Bool is NOT asserted here, and the omission is the
   // point. Measured: `__to_string` of a Bool produced by a lambda whose `let`
   // is INSIDE a function body renders "1" rather than "true" -- on both lanes

--- a/fixtures/gc_lane_scalar_parity_test.vibe
+++ b/fixtures/gc_lane_scalar_parity_test.vibe
@@ -212,6 +212,62 @@ test "#2422 a large Int survives every binding form" {
   assert(lam_d(1.5) == "1.5")
 }
 
+/// #2423: a `let mut` CAPTURED BY A CLOSURE is the one binding form neither
+/// test above reaches. `#2422 a large Int survives every binding form` pins an
+/// uncaptured `let mut`, and `#2424 .. the binding forms the slot log never
+/// seeded` pins a captured plain `let` -- this is the intersection, and it is
+/// the shape #2423 was filed about.
+///
+/// It is different in kind, not just in spelling. A captured `let mut` does
+/// not hold its value in a local at all: it becomes a heap ref cell and the
+/// local holds the cell's ADDRESS, so every read is a load. That is why the
+/// slot log could never classify it -- the thing in the slot is a pointer, and
+/// calling a pointer an Int is the confusion the log exists to prevent. #2423
+/// proposed a second log keyed on "slot holds a cell whose CONTENT is an Int".
+///
+/// What actually closed it is #2424's channel: the checker hands codegen the
+/// type it already computed for the render argument, so where the value LIVES
+/// stops mattering. Measured on the committed seed, both reads below render
+/// the EMPTY STRING on linear and on gc; on the current compiler both answer,
+/// on all three lanes this file runs.
+test "#2423 a large Int survives a let mut captured by a closure" {
+  let mut c = 64<<32
+  let f = () -> Int {
+    c
+  }
+  // Through the closure, and directly -- the seed rendered both as "".
+  assert(__to_string(f()) == "274877906944")
+  assert(__to_string(c) == "274877906944")
+  // After a mutation, so the cell is read back rather than folded.
+  c = c + 1
+  assert(__to_string(f()) == "274877906945")
+  assert(__to_string(c) == "274877906945")
+  // The same capture through `eq`, the other spelling of the classifier.
+  assert(eq(f(), 274877906945))
+  assert(!eq(f(), 274877906944))
+  // Controls: the classifier must not start answering Int for every captured
+  // cell. A captured `let mut` of another type keeps its own rendering.
+  let mut s = "hi"
+  let fs = () -> String {
+    s
+  }
+  assert(__to_string(fs()) == "hi")
+  let mut d = 1.5
+  let fd = () -> Double {
+    d
+  }
+  assert(__to_string(fd()) == "1.5")
+  // A captured `let mut` Bool is NOT asserted here, and the omission is the
+  // point. Measured: `__to_string` of a Bool produced by a lambda whose `let`
+  // is INSIDE a function body renders "1" rather than "true" -- on both lanes
+  // and on the committed seed alike, so it is not this fix's doing. The same
+  // lambda bound at TOP LEVEL, and any named `fn`, answer correctly, because
+  // `collect_fn_returns` walks statements and an inner `let` is an expression.
+  // That is #2462, a separate defect, filed rather than pinned: this file's
+  // contract is that every assertion in it holds on every lane, and pinning
+  // the wrong answer would be worse than leaving the row out.
+}
+
 test "#2405 polymorphic arithmetic is not assumed to be Int" {
   // `+ - * /` are resolved from the OPERANDS by the checker (Int, then Double,
   // then String for `+`, then a user impl), so the operator alone says

--- a/fixtures/gc_lane_scalar_parity_test.vibe
+++ b/fixtures/gc_lane_scalar_parity_test.vibe
@@ -239,12 +239,29 @@ test "#2423 a large Int survives a let mut captured by a closure" {
   // Spelled with `inspect` per the snapshot policy: it desugars to the same
   // `__to_string` this test is about, so the oracle is unchanged, and the
   // expectations become refreshable by `vibe test --update`.
+  //
+  // NO TWO `inspect` rows in this test may share an expected literal.
+  // `find_content_arg_span` (compiler/inspect_update.vibe) scans from offset
+  // 0 and patches the FIRST `inspect(` whose content argument equals the
+  // diagnosed expected text -- it has no idea which call failed. Two rows
+  // with the same literal therefore cannot converge under
+  // `vibe test --update`: the patcher rewrites the first, the next run fails
+  // on the row it just broke, and the two ping-pong. So the closure read and
+  // the direct read are taken at DIFFERENT values, and a second cell carries
+  // the two orderings the first cannot.
   inspect(f(), content = "274877906944")
-  inspect(c, content = "274877906944")
   // After a mutation, so the cell is read back rather than folded.
   c = c + 1
-  inspect(f(), content = "274877906945")
   inspect(c, content = "274877906945")
+  // The second cell: direct read first, closure read after ITS mutation, so
+  // both shapes are covered on both sides of a write.
+  let mut k = 100<<32
+  let fk = () -> Int {
+    k
+  }
+  inspect(k, content = "429496729600")
+  k = k + 2
+  inspect(fk(), content = "429496729602")
   // The same capture through `eq`, the other spelling of the classifier. Two
   // conditions have to hold at once for these rows to be able to FAIL, and
   // each was measured by running the rows alone against the committed seed.
@@ -272,25 +289,50 @@ test "#2423 a large Int survives a let mut captured by a closure" {
   let g = () -> Int {
     c2
   }
-  // These six stay `assert` rather than `inspect`, and the reason is a lane
-  // divergence this file exists to catch. `inspect(v, content = ..)` desugars
-  // to `__to_string(v)`, and `__to_string` of an `eq` RESULT answers "false"
-  // on linear and "0" on gc -- measured on this compiler, both lanes, and the
-  // gc side is a regression against the committed seed, which answers "false"
-  // there too. `gc_expr_is_boolish` (codegen/gc/backend_expr.vibe) has no
-  // ECall arm at all, so it cannot classify any of the Bool-returning
-  // builtins the linear `cc_builtin_call_ret_kind` recognizes. That is #2464.
-  // `assert` never renders the Bool, so it asks about `eq` and nothing else,
-  // which is what these rows are for.
+  // Each `eq` is snapshotted through a String-valued branch rather than
+  // handed to `inspect` directly. `inspect(eq(..), content = ..)` renders the
+  // Bool, and `__to_string` of an `eq` RESULT answers "false" on linear and
+  // "0" on gc -- measured on this compiler, both lanes, and the gc side is a
+  // regression against the committed seed, which answers "false" there too
+  // (`gc_expr_is_boolish` has no ECall arm, so it classifies none of the
+  // Bool-returning builtins the linear `cc_builtin_call_ret_kind` lists;
+  // that is #2464). The branch renders a String instead, so the row is a
+  // snapshot on this lane-divergent compiler and still asks about `eq` and
+  // nothing else. Each pair of branch strings is unique for the
+  // no-shared-literal reason above.
   // Both call-shaped.
-  assert(!eq(f(), g()))
-  assert(eq(f(), f()))
+  inspect(if eq(f(), g()) {
+    "f=g"
+  } else {
+    "f!=g"
+  }, content = "f!=g")
+  inspect(if eq(f(), f()) {
+    "f=f"
+  } else {
+    "f!=f"
+  }, content = "f=f")
   // One call-shaped, one a bare ref-cell read.
-  assert(eq(f(), c))
-  assert(!eq(f(), c2))
+  inspect(if eq(f(), c) {
+    "f=c"
+  } else {
+    "f!=c"
+  }, content = "f=c")
+  inspect(if eq(f(), c2) {
+    "f=c2"
+  } else {
+    "f!=c2"
+  }, content = "f!=c2")
   // Both bare ref-cell reads.
-  assert(!eq(c, c2))
-  assert(eq(c, c))
+  inspect(if eq(c, c2) {
+    "c=c2"
+  } else {
+    "c!=c2"
+  }, content = "c!=c2")
+  inspect(if eq(c, c) {
+    "c=c"
+  } else {
+    "c!=c"
+  }, content = "c=c")
   // Controls: the classifier must not start answering Int for every captured
   // cell. A captured `let mut` of another type keeps its own rendering.
   let mut s = "hi"

--- a/fixtures/gc_lane_scalar_parity_test.vibe
+++ b/fixtures/gc_lane_scalar_parity_test.vibe
@@ -243,8 +243,26 @@ test "#2423 a large Int survives a let mut captured by a closure" {
   assert(__to_string(f()) == "274877906945")
   assert(__to_string(c) == "274877906945")
   // The same capture through `eq`, the other spelling of the classifier.
-  assert(eq(f(), 274877906945))
-  assert(!eq(f(), 274877906944))
+  // NEITHER operand may be a literal. The linear `eq` gate is a disjunction
+  // (the reason is spelled out at the `irc_ret_big` block below), so an
+  // `eq(f(), 274877906945)` is satisfied by the literal alone and never asks
+  // about the captured cell -- it would re-check `f()`'s VALUE, which the
+  // renders above already pin, and pin nothing about `eq`. So: a second
+  // captured cell, and comparisons where every operand is either a call or a
+  // ref-cell read.
+  let mut c2 = 65<<32
+  let g = () -> Int {
+    c2
+  }
+  // Both call-shaped.
+  assert(!eq(f(), g()))
+  assert(eq(f(), f()))
+  // One call-shaped, one a bare ref-cell read.
+  assert(eq(f(), c))
+  assert(!eq(f(), c2))
+  // Both bare ref-cell reads.
+  assert(!eq(c, c2))
+  assert(eq(c, c))
   // Controls: the classifier must not start answering Int for every captured
   // cell. A captured `let mut` of another type keeps its own rendering.
   let mut s = "hi"


### PR DESCRIPTION
Closes #2423.

## What this is

**No compiler change.** #2423's symptom is already gone, and it was not fixed the
way the issue proposed. This adds the missing pin, records what actually closed
it, and — through four rounds of review — turned up two separate P0s that are
filed rather than papered over.

## The shape was unpinned

`fixtures/gc_lane_scalar_parity_test.vibe` had a test on either side of it:

| test | binding form |
|---|---|
| `#2422 a large Int survives every binding form` | an **uncaptured** `let mut` |
| `#2424 .. the binding forms the slot log never seeded` | a **captured** plain `let` |
| *(missing)* | a **captured `let mut`** — the intersection |

That intersection is the shape #2423 was filed about, and it is different in
kind, not just in spelling. A captured `let mut` does not hold its value in a
local at all: it becomes a heap ref cell and the local holds the cell's
**address**, so every read is a load. That is why the slot log could never
classify it — the thing in the slot is a pointer, and calling a pointer an Int
is the confusion the log exists to prevent.

## What closed it

#2423 proposed a **second slot log** keyed on "slot holds a cell whose CONTENT is
an Int", classified at the dereference rather than the binding. That is not what
landed. #2424's typed-lowering channel did: the checker hands codegen the type it
already computed for the render argument, so where the value *lives* stops
mattering — no per-lane slot log has to model the ref cell.

## Measured

| compiler | linear | gc |
|---|---|---|
| committed seed | **empty string** | **empty string** |
| stage2 @ `e37c4da8e` | `274877906944` | `274877906944` |

The gate runs this file on **three** lanes (`tests/gates/early/run.sh:2085-2087`:
linear/bump, gc, linear/RC), and the whole file passes on the current compiler
and fails on the seed on both lanes it can be run on directly.

## What the test covers, and two conditions that are easy to get wrong

Reads through the closure and directly, before and after a mutation, plus the
same capture through `eq`, plus controls (a captured String and a captured Double
keep their own rendering, so the classifier has not started answering Int for
every captured cell).

Two conditions must hold at once for the `eq` rows to be able to **fail**. Both
were found in review, and each is now measured and written into the fixture:

1. **Neither operand may be a literal.** The linear `eq` gate is a disjunction,
   so a literal operand satisfies it alone and the captured cell is never
   consulted. This fixture already says so twenty lines further down, about a
   different block.
2. **The two values must have the same low 32 bits.** With the classification
   lost, `eq` falls back to the string comparison, which reads a value as
   `(ptr<<32)|len` — unequal low words are unequal "lengths" and it returns
   `false` immediately, which is the answer the `!eq` rows want. Measured: with
   both low words **1** the fallback compares one byte at two different addresses
   and is right by luck; only a **zero** low word on both sides is reliably red.

Hence a second mutation `c = c + ((1<<32) - 1)`, which restores a zero low word
while keeping the cell read back rather than folded.

## Expectations are snapshots

Per the `inspect(value, content)` policy, and applying it to the fixture being
touched. Every expectation in the new test is an `inspect`, including the six
equality rows — those render a String-valued branch rather than the Bool:

```vibe
inspect(if eq(f(), g()) { "f=g" } else { "f!=g" }, content = "f!=g")
```

which asks about `eq` and nothing else while rendering something both lanes
agree on. Verified: the six rows extracted alone pass on both lanes on the
current compiler and **fail on both on the seed**, so the red side survived
every rewrite.

**No two `inspect` rows may share an expected literal.**
`find_content_arg_span` (`compiler/inspect_update.vibe:199`) scans from offset 0
and patches the *first* `inspect(` whose content equals the diagnosed expected
text — it has no idea which call failed. Red-tested both directions with real
`vibe test --update` runs:

| setup | result |
|---|---|
| distinct literals, one row broken | converged in **one** pass, restored exactly that row |
| one literal duplicated, second row's true value differing | **did not terminate within 2 minutes** |

So the closure read and the direct read are taken at different values, and a
second cell carries the orderings the first cannot. Checked file-wide: no
duplicate `content = "..."` literal remains.

## Two P0s found on the way, filed not papered over

- **#2462** — `__to_string` of a Bool produced by a lambda bound **inside a
  function body** renders `1`. The same lambda at top level, and any named `fn`,
  render `true`: `collect_fn_returns` walks the statement list and an inner `let`
  is an expression. Both lanes, and on the seed too — not a regression.
- **#2464** — the gc lane renders a Bool-returning **builtin call** as `0`/`1`
  where linear renders `false`/`true`. `gc_expr_is_boolish` has no `ECall` arm at
  all, so it classifies none of the 17 Bool-returning builtins the linear
  `cc_builtin_call_ret_kind` lists. **This one is a regression**: the committed
  seed answers correctly on gc. Found because converting the `eq` rows to
  `inspect` turned the gc lane red.

Both are why a captured Bool control is absent here and why the equality rows go
through a branch: this file's contract is that every assertion in it holds on
every lane, and pinning a wrong answer would be worse than routing around it.
The fixture carries an inline pointer to #2464 saying the `if` wrapper comes out
when it lands.

## Verification

- `bash scripts/vibe_fmt.sh --check fixtures/gc_lane_scalar_parity_test.vibe` — clean
- `COMPILER_GATE_LANE=early bash scripts/compiler_gate.sh` — ok (exit 0)
- fixture alone: 16 tests pass on linear and on gc; **fail on both on the seed**,
  which is the red side of the pin
