### PR TITLE
Show-wrapper renders, instrumented-build typed tables, and one producer walk (#2468, #2469)

### DIFF
--- a/fixtures/gc_lane_scalar_parity_test.vibe
+++ b/fixtures/gc_lane_scalar_parity_test.vibe
@@ -230,6 +230,14 @@ test "#2422 a large Int survives every binding form" {
 /// stops mattering. Measured on the committed seed, both reads below render
 /// the EMPTY STRING on linear and on gc; on the current compiler both answer,
 /// on all three lanes this file runs.
+/// #2468: a Show wrapper -- a one-parameter `__to_string` pass-through. The
+/// prelude's `to_string` has exactly this body, and desugar_trait_dict
+/// recognizes the SHAPE, so a call here takes the same type-directed rewrite
+/// `__to_string` does.
+fn show_any[T](x: T) -> String {
+  __to_string(x)
+}
+
 test "#2423 a large Int survives a let mut captured by a closure" {
   let mut c = 64<<32
   let f = () -> Int {
@@ -364,6 +372,25 @@ test "#2423 a large Int survives a let mut captured by a closure" {
   inspect(eq(1, 2), content = "false")
   inspect(eq(2, 2), content = "true")
   inspect(not(eq(1, 2)), content = "true")
+  // #2468: the SAME render, spelled through a Show wrapper. `show_any` below
+  // has the shape desugar_trait_dict matches -- a one-parameter
+  // `__to_string` pass-through -- so it inlines at every call site and these
+  // two lines are ONE lowering with two spellings. Until the producer knew
+  // about the wrapper they disagreed: `__to_string(fb())` -> "true",
+  // `show_any(fb())` -> "1".
+  //
+  // Declared here rather than imported from the prelude on purpose: the
+  // prelude's `to_string` would test the same mechanism, but a locally
+  // declared wrapper also proves the wrapper is recognized by its SHAPE and
+  // not by the name `to_string`.
+  bl = 1 < 2
+  assert(__to_string(fb()) == "true")
+  assert(show_any(fb()) == "true")
+  // The Int and Double controls, so a wrapper row that classified every
+  // argument as Bool would be caught here rather than looking like a fix.
+  assert(show_any(7) == "7")
+  assert(show_any(1.5) == "1.5")
+  assert(show_any("hi") == "hi")
 }
 
 test "#2405 polymorphic arithmetic is not assumed to be Int" {

--- a/lib/@vibe/compiler/checker/checker_facade.vibe
+++ b/lib/@vibe/compiler/checker/checker_facade.vibe
@@ -64,6 +64,7 @@ export ./checker_stmt.vibe {
   check_stmts,
   checked_bool_render_offsets,
   checked_double_render_offsets,
+  checked_int_and_bool_render_offsets,
   checked_int_render_offsets,
   typed_lowering_enc,
   typed_lowering_enc_offset,

--- a/lib/@vibe/compiler/checker/checker_stmt.vibe
+++ b/lib/@vibe/compiler/checker/checker_stmt.vibe
@@ -6052,14 +6052,123 @@ fn irc_resolves_to_scalar(s: Subst, ty: Type, want_bool: Bool) -> Bool {
   result
 }
 
-/// The builtins whose argument codegen must know is an `Int`: the renderer
+/// The builtins whose argument codegen must know the type of: the renderer
 /// (both spellings) and the untyped equality. `\{...}` interpolation is
 /// already `__to_string` HERE -- the parser builds the call
 /// (`parser_expr_primary.vibe`), so a per-module check sees it, which is what
 /// makes this walk usable on the FS lane where interpolation is otherwise
 /// expanded only on the merged program.
-fn irc_is_render_callee(n: String) -> Bool {
-  n == "__to_string" || n == "Int::to_string" || n == "eq"
+///
+/// #2468: `shims` carries the program's generic **Show wrapper**s. The lowering
+/// treats a call to one exactly like `__to_string` (`is_show_shim_call`,
+/// normalize/desugar_trait_dict.vibe), so an argument reaching the renderer
+/// through `to_string(x)` needs the same row as one reaching it directly.
+/// Without them, measured on `lib/@vibe/builtin/builtin_traits_test.vibe`, the
+/// two spellings of one render disagreed:
+///
+///   __to_string(l())  ->  "true"      to_string(l())  ->  "1"
+fn irc_is_render_callee(n: String, shims: Array[String]) -> Bool {
+  n == "__to_string" || n == "Int::to_string" || n == "eq" || irc_names_contain(shims, n)
+}
+
+/// `Array::contains` over `String`. Spelled out rather than imported: the
+/// `str_array_contains` twin is private to `normalize/desugar_trait_dict.vibe`,
+/// and the generic `==` on a `String` element still depends on the lowering
+/// knowing the element type -- which is the very thing this file computes.
+fn irc_names_contain(names: Array[String], n: String) -> Bool {
+  let mut i = 0
+  let mut found = false
+  while i < Array::length(names) {
+    let cur: String = Array::get(names, i)
+    if cur == n {
+      found = true
+    }
+    i = i + 1
+  }
+  found
+}
+
+/// Is `body` exactly `__to_string(<pname>)`? The shim's whole body.
+///
+/// Mirrors `is_bare_to_string_of` (normalize/desugar_trait_dict.vibe) rather
+/// than importing it: the checker runs BEFORE that pass and cannot read the
+/// `dtd_show_shims` it fills, so the producer has to answer the same question
+/// for itself. The two are one edit apart, which is the cost of the phase
+/// order; the shape is small enough to keep them honest.
+fn irc_is_bare_to_string_of(body: Expr, pname: String) -> Bool {
+  match body {
+    ECall(bc, ba, _) => if Array::length(ba) == 1 {
+      match bc {
+        EIdent(cn, _) => if cn == "__to_string" {
+          match Array::get(ba, 0) {
+            EIdent(an, _) => an == pname,
+            _ => false
+          }
+        } else {
+          false
+        },
+        _ => false
+      }
+    } else {
+      false
+    },
+    _ => false
+  }
+}
+
+/// A one-parameter function whose body is just `__to_string` of that parameter.
+fn irc_is_show_shim_value(v: Expr) -> Bool {
+  match v {
+    EFn(_, _, ps, _, _, body) => if Array::length(ps) == 1 {
+      let (pn, _) = Array::get(ps, 0)
+      irc_is_bare_to_string_of(body, pn)
+    } else {
+      false
+    },
+    _ => false
+  }
+}
+
+/// #2468: the program's Show-wrapper names, from its top-level declarations.
+///
+/// Only the TOP level, and both statement spellings. `parse_program` and
+/// `parse_program_located` lower `SFnDecl` to the `SLet` shape before anything
+/// checks the program, so the `SFnDecl` arm is inert on every path that reaches
+/// the checker today -- it is here so the walk does not depend on that
+/// ordering, the same reason `irc_collect_stmts` keeps its `SExample` arm.
+/// `collect_show_shims` (normalize) is the SLet arm alone for the same reason.
+///
+/// A shim declared inside a nested `module` is not collected. That is an
+/// under-approximation, and the fail-closed direction: the call keeps the
+/// syntactic answer it has today rather than getting a wrong one.
+///
+/// The normalize-pass twin also excludes a name shadowed by a local binder.
+/// This one does not, and the omission is safe HERE for a reason that does not
+/// hold there: these rows are TYPE facts, not render facts. An offset is
+/// emitted only when every typed occurrence at it resolves to the wanted type,
+/// so a row filed for an argument of some unrelated call is still a true
+/// statement about that expression's type -- it can be inert, never wrong. The
+/// rewrite pass has no such margin, because it REPLACES the call.
+fn irc_show_shim_names(stmts: Array[Stmt]) -> Array[String] {
+  let out: Array[String] = []
+  let mut i = 0
+  while i < Array::length(stmts) {
+    match Array::get(stmts, i) {
+      SLet(_, _, name, _, value) => if irc_is_show_shim_value(value) {
+        Array::push(out, name)
+      } else {
+        ()
+      },
+      SFnDecl(_, fname, body, _, _) => if irc_is_show_shim_value(body) {
+        Array::push(out, fname)
+      } else {
+        ()
+      },
+      _ => ()
+    }
+    i = i + 1
+  }
+  out
 }
 
 /// `want` is the typed-lowering TAG being collected (3 = Int, 4 = Double,
@@ -6071,10 +6180,10 @@ fn irc_is_render_callee(n: String) -> Bool {
 /// argument. Collecting under the key the consumer reads is the point: a
 /// candidate filed under a key nobody looks up is not a wrong answer, it is
 /// silence.
-fn irc_collect_expr(e: Expr, out: Array[Int], want: Int) -> Unit {
+fn irc_collect_expr(e: Expr, out: Array[Int], want: Int, shims: Array[String]) -> Unit {
   match e {
     ECall(callee, args, _) => match callee {
-      EIdent(cn, _) => if irc_is_render_callee(cn) {
+      EIdent(cn, _) => if irc_is_render_callee(cn, shims) {
         let mut ai = 0
         while ai < Array::length(args) {
           let arg = Array::get(args, ai)
@@ -6100,33 +6209,33 @@ fn irc_collect_expr(e: Expr, out: Array[Int], want: Int) -> Unit {
   let kids = expr_children(e)
   let mut i = 0
   while i < Array::length(kids) {
-    irc_collect_expr(Array::get(kids, i), out, want)
+    irc_collect_expr(Array::get(kids, i), out, want, shims)
     i = i + 1
   }
 }
 
-fn irc_collect_stmts(stmts: Array[Stmt], out: Array[Int], want: Int) -> Unit {
+fn irc_collect_stmts(stmts: Array[Stmt], out: Array[Int], want: Int, shims: Array[String]) -> Unit {
   let mut i = 0
   while i < Array::length(stmts) {
     match Array::get(stmts, i) {
-      SLet(_, _, _, _, e) => irc_collect_expr(e, out, want),
-      SLetMut(_, _, e) => irc_collect_expr(e, out, want),
-      SLetPat(_, e) => irc_collect_expr(e, out, want),
-      SExpr(e) => irc_collect_expr(e, out, want),
-      STest(_, e) => irc_collect_expr(e, out, want),
-      SBench(_, e) => irc_collect_expr(e, out, want),
+      SLet(_, _, _, _, e) => irc_collect_expr(e, out, want, shims),
+      SLetMut(_, _, e) => irc_collect_expr(e, out, want, shims),
+      SLetPat(_, e) => irc_collect_expr(e, out, want, shims),
+      SExpr(e) => irc_collect_expr(e, out, want, shims),
+      STest(_, e) => irc_collect_expr(e, out, want, shims),
+      SBench(_, e) => irc_collect_expr(e, out, want, shims),
       // `parse_program` lowers `SExample` to `STest` before anything checks
       // the program, so this arm is inert on every compile path today
       // (measured: a render of an `Array::get` result inside an `example`
       // block already answers correctly). It is here so the walk does not
       // depend on that ordering -- `parse_program_preserving` keeps the
       // variant, and an executable block form must not be silently skipped.
-      SExample(_, e) => irc_collect_expr(e, out, want),
+      SExample(_, e) => irc_collect_expr(e, out, want, shims),
       // A render inside a nested module is checked with the rest of the
       // program and its occurrences are in the same table, so skipping the
       // body would leave that code with no classification at all (Codex
       // review on #2434). `count_typed_lowering_offsets_stmts` recurses the same way.
-      SModule(_, _, inner) => irc_collect_stmts(inner, out, want),
+      SModule(_, _, inner) => irc_collect_stmts(inner, out, want, shims),
       _ => ()
     }
     i = i + 1
@@ -6211,23 +6320,48 @@ fn irc_index_of(sorted: Array[Int], v: Int) -> Int {
 /// typed-lowering tag (3 = Int, 4 = Double, 5 = Bool) and picks which type head
 /// an offset must resolve to; everything else -- the candidate walk, the
 /// fail-closed agreement rule, the binary search -- is the same question asked
-/// three times, so it is written once. Reading a candidate set under one rule
-/// and a type under another is how a producer and a consumer drift into
-/// silence.
+/// per tag, so it is written once. Reading a candidate set under one rule and a
+/// type under another is how a producer and a consumer drift into silence.
 fn irc_render_arg_offsets(checked: CheckedProgram, want: Int) -> Array[Int] {
+  let (only, _) = irc_render_arg_offsets_pair(checked, want, 0 - 1)
+  only
+}
+
+/// #2462/#2464 perf: tags 3 (Int) and 5 (Bool) answered from ONE walk.
+///
+/// The two share a KEY (`typed_lowering_arg_offset`), so they share a candidate
+/// set exactly -- the same expressions, found by the same walk, looked up in
+/// the same sorted array. Only the type test differs, and that is one line per
+/// occurrence. Running the walk twice re-derived an identical `cands` and
+/// re-scanned `typed_occurrences` to ask a second question about rows it had
+/// already visited.
+///
+/// Measured when tag 5 landed as its own walk: selfcompile heap 1.49 -> 1.50
+/// GiB, +0.86% on the perf report's deterministic section. Tag 4 stays separate
+/// because its key is `typed_lowering_float_key`, a genuinely different
+/// candidate set -- folding it in would mean collecting under one key and
+/// reading under another, which is the silence this file keeps warning about.
+///
+/// `want_b` of -1 asks for `want_a` alone. The two OUTPUT arrays stay separate:
+/// sharing the walk is a cost decision, sharing the answers would put a Bool
+/// offset where `ts_known_int` reads and render `true` as a number.
+fn irc_render_arg_offsets_pair(checked: CheckedProgram, want_a: Int, want_b: Int) -> (Array[Int], Array[Int]) {
   let raw: Array[Int] = []
-  irc_collect_stmts(checked.checked_stmts, raw, want)
+  let shims = irc_show_shim_names(checked.checked_stmts)
+  irc_collect_stmts(checked.checked_stmts, raw, want_a, shims)
   let cands = irc_sorted_unique(raw)
   let n = Array::length(cands)
   if n == 0 {
-    []
+    ([], [])
   } else {
     let seen_any: Array[Int] = []
-    let all_wanted: Array[Int] = []
+    let all_a: Array[Int] = []
+    let all_b: Array[Int] = []
     let mut k = 0
     while k < n {
       Array::push(seen_any, 0)
-      Array::push(all_wanted, 1)
+      Array::push(all_a, 1)
+      Array::push(all_b, 1)
       k = k + 1
     }
     let mut oi = 0
@@ -6237,15 +6371,15 @@ fn irc_render_arg_offsets(checked: CheckedProgram, want: Int) -> Array[Int] {
         let idx = irc_index_of(cands, ooff)
         if idx >= 0 {
           Array::set(seen_any, idx, 1)
-          let wanted = if want == 4 {
-            subst_resolves_to_double(checked.final_subst, oty)
-          } else {
-            irc_resolves_to_scalar(checked.final_subst, oty, want == 5)
-          }
-          if wanted {
+          if irc_occurrence_wants(checked, oty, want_a) {
             ()
           } else {
-            Array::set(all_wanted, idx, 0)
+            Array::set(all_a, idx, 0)
+          }
+          if want_b < 0 || irc_occurrence_wants(checked, oty, want_b) {
+            ()
+          } else {
+            Array::set(all_b, idx, 0)
           }
         } else {
           ()
@@ -6255,18 +6389,44 @@ fn irc_render_arg_offsets(checked: CheckedProgram, want: Int) -> Array[Int] {
       }
       oi = oi + 1
     }
-    let out: Array[Int] = []
+    let out_a: Array[Int] = []
+    let out_b: Array[Int] = []
     let mut m = 0
     while m < n {
-      if Array::get(seen_any, m) == 1 && Array::get(all_wanted, m) == 1 {
-        Array::push(out, Array::get(cands, m))
+      if Array::get(seen_any, m) == 1 {
+        if Array::get(all_a, m) == 1 {
+          Array::push(out_a, Array::get(cands, m))
+        } else {
+          ()
+        }
+        if want_b >= 0 && Array::get(all_b, m) == 1 {
+          Array::push(out_b, Array::get(cands, m))
+        } else {
+          ()
+        }
       } else {
         ()
       }
       m = m + 1
     }
-    out
+    (out_a, out_b)
   }
+}
+
+/// Does this occurrence's type resolve to the head tag `want` asks for?
+fn irc_occurrence_wants(checked: CheckedProgram, oty: Type, want: Int) -> Bool {
+  if want == 4 {
+    subst_resolves_to_double(checked.final_subst, oty)
+  } else {
+    irc_resolves_to_scalar(checked.final_subst, oty, want == 5)
+  }
+}
+
+/// #2424 tag 3 and #2462/#2464 tag 5, from ONE walk. The lanes that want both
+/// -- which is every lane that wants either -- should call this rather than the
+/// two singles, so the shared candidate set is computed once.
+export fn checked_int_and_bool_render_offsets(checked: CheckedProgram) -> (Array[Int], Array[Int]) {
+  irc_render_arg_offsets_pair(checked, 3, 5)
 }
 
 /// #2424 tag 3: render/eq argument offsets the checker typed as `Int`.
@@ -6492,7 +6652,7 @@ fn typed_lowering_located_observation_impl(stmts: Array[Stmt], initial_env: Type
       // than a second one is the whole point of the slice-2 encoding: the
       // memo, the sidecar, the per-file rebase and the reuse arms are already
       // built and already require the sidecar before skipping a check.
-      let int_renders = checked_int_render_offsets(checked)
+      let (int_renders, bool_renders) = checked_int_and_bool_render_offsets(checked)
       let mut ii = 0
       while ii < Array::length(int_renders) {
         Array::push(enc, typed_lowering_enc(Array::get(int_renders, ii), 3))
@@ -6515,7 +6675,6 @@ fn typed_lowering_located_observation_impl(stmts: Array[Stmt], initial_env: Type
       // (`*_expr_is_boolish` rather than `ts_known_int`), and an offset that
       // classified as both would make each one re-derive which half it was
       // looking at.
-      let bool_renders = checked_bool_render_offsets(checked)
       let mut bi = 0
       while bi < Array::length(bool_renders) {
         Array::push(enc, typed_lowering_enc(Array::get(bool_renders, bi), 5))

--- a/lib/@vibe/compiler/checker/index.vpkg
+++ b/lib/@vibe/compiler/checker/index.vpkg
@@ -267,6 +267,7 @@ fn check_program_double_call_result_located_observation(stmts: Array[Stmt]) -> O
 /// when every typed occurrence there resolves to `Int`.
 fn checked_double_render_offsets(checked: CheckedProgram) -> Array[Int]
 fn checked_bool_render_offsets(checked: CheckedProgram) -> Array[Int]
+fn checked_int_and_bool_render_offsets(checked: CheckedProgram) -> (Array[Int], Array[Int])
 fn checked_int_render_offsets(checked: CheckedProgram) -> Array[Int]
 fn check_program_type_defs_observation(stmts: Array[Stmt]) -> CheckedProgramTypeDefsObservation with Exception
 fn check_program_typed_occurrence_statement_observation(stmts: Array[Stmt]) -> Option[CheckedTypedOccurrenceStatementObservation] with Exception

--- a/lib/@vibe/compiler/entry/source_compile/gc_only/gc_only.vibe
+++ b/lib/@vibe/compiler/entry/source_compile/gc_only/gc_only.vibe
@@ -8,7 +8,7 @@ import @vibe/core {
   array_empty
 }
 import @vibe/compiler/checker {
-  check_program_double_call_result_observation, checked_bool_render_offsets, checked_int_render_offsets, validate_user_source_stmts
+  check_program_double_call_result_observation, checked_int_and_bool_render_offsets, validate_user_source_stmts
 }
 
 import @vibe/compiler/normalize {
@@ -401,8 +401,7 @@ fn compile_stmts_gc_only_impl(stmts: Array[Stmt], entry_name: String, merged_off
   // uniqueness filter of its own -- the checker already refuses an offset
   // whose typed occurrences disagree, which is the fail-closed condition a
   // consumer keyed on offset needs.
-  let gc_int_render_offsets = checked_int_render_offsets(checked)
-  let gc_bool_render_offsets = checked_bool_render_offsets(checked)
+  let (gc_int_render_offsets, gc_bool_render_offsets) = checked_int_and_bool_render_offsets(checked)
   compile_wasi_module_gc(stmts, effective_entry, generated_test_artifact, gc_to_string_is_wrapper, direct_abi_generic_names, gc_float_ret_fn_names, unique_gc_float_call_offsets, gc_int_render_offsets, gc_bool_render_offsets)
 }
 

--- a/lib/@vibe/compiler/entry/source_compile/source_compile.vibe
+++ b/lib/@vibe/compiler/entry/source_compile/source_compile.vibe
@@ -4,11 +4,7 @@ import @vibe/compiler/syntax {
   lex, lex_with_offsets, parse_program, parse_program_located
 }
 import @vibe/compiler/checker {
-  check_program,
-  check_program_double_call_result_located_observation,
-  checked_bool_render_offsets,
-  checked_int_render_offsets,
-  validate_user_source_stmts
+  check_program, check_program_double_call_result_located_observation, checked_int_and_bool_render_offsets, validate_user_source_stmts
 }
 
 import @vibe/compiler/codegen {
@@ -42,9 +38,10 @@ export fn compile_source(source: String) -> Bytes with Exception {
 }
 
 /// #2437, #2462/#2464: the Double call-result table and the Int and Bool
-/// render / `eq` tables from ONE check. `checked_int_render_offsets` and
-/// `checked_bool_render_offsets` are pure functions of the CheckedProgram the
-/// observation already returns, so all three cost one check between them.
+/// render / `eq` tables from ONE check, and the Int and Bool halves from ONE
+/// walk (`checked_int_and_bool_render_offsets`) -- they share a candidate set
+/// exactly, so asking separately re-derived it. All of it is a pure function of
+/// the CheckedProgram the observation already returns.
 ///
 /// `None` is the observation refusing an unlocated AST, and empty tables are
 /// the fail-closed answer: they classify nothing, leaving the syntactic answer
@@ -55,7 +52,10 @@ fn module_typed_offsets(stmts: Array[Stmt]) -> (Array[Int], Array[Int], Array[In
     // compile_module path this lane feeds has no typed-eq threading yet --
     // dropping them keeps today's behavior (the syntactic classifiers),
     // never a wrong comparator.
-    Some((checked, offsets, _, _)) => (offsets, checked_int_render_offsets(checked), checked_bool_render_offsets(checked)),
+    Some((checked, offsets, _, _)) => {
+      let (int_renders, bool_renders) = checked_int_and_bool_render_offsets(checked)
+      (offsets, int_renders, bool_renders)
+    },
     None => ([], [], [])
   }
 }

--- a/lib/@vibe/compiler/entry/source_compile/wasi_only/preprocess_compile.vibe
+++ b/lib/@vibe/compiler/entry/source_compile/wasi_only/preprocess_compile.vibe
@@ -1,25 +1,23 @@
 //# Imports
 
 import @vibe/compiler/checker {
-  check_program,
   check_program_double_call_result_located_observation,
-  checked_bool_render_offsets,
-  checked_int_render_offsets,
+  checked_int_and_bool_render_offsets,
   effect_row_contains_label,
   validate_user_source_stmts
 }
 
 import @vibe/compiler/codegen/wasi {
-  compile_wasi_module_coverage_impl,
   compile_wasi_module_impl,
   compile_wasi_module_impl_with_typed_offsets,
   compile_wasi_module_rc_impl,
   compile_wasi_module_rc_impl_with_typed_offsets,
-  compile_wasi_module_rc_shadow_impl
+  compile_wasi_module_rc_shadow_impl_with_typed_offsets,
+  compile_wasi_module_with_sources_coverage_impl_with_typed_offsets
 }
 
 import @vibe/compiler/syntax {
-  lex, lex_with_offsets, parse_program, parse_program_located
+  lex_with_offsets, parse_program_located
 }
 import ./preprocess_interp.vibe {
   expand_interp_stmts
@@ -213,9 +211,10 @@ fn maybe_wrap_async_component(bytes: Bytes, wrap_async: Bool) -> Bytes with Exce
 /// The observation replaces the `check_program` that already ran on this path,
 /// so no second pass over the program is introduced.
 /// #2424, #2462/#2464: every table from the SAME observation.
-/// `checked_int_render_offsets` and `checked_bool_render_offsets`
-/// are pure functions of the CheckedProgram it already returns, so they all
-/// cost one check between them. `None` is the observation refusing an
+/// `checked_int_and_bool_render_offsets` is a pure function of the
+/// CheckedProgram it already returns, so they all cost one check between them
+/// -- and the Int and Bool halves cost ONE walk, not two: they share a
+/// candidate set exactly. `None` is the observation refusing an
 /// unlocated AST, and an empty table classifies nothing.
 /// #2441: the typed-`==` rows ride the same observation. One text, one
 /// offset space, no merge and no renames -- the rows apply as-is, and an
@@ -223,7 +222,10 @@ fn maybe_wrap_async_component(bytes: Bytes, wrap_async: Bool) -> Bytes with Exce
 /// `anchor_off >= 0` guard).
 fn source_offsets(stmts: Array[Stmt]) -> (Array[Int], Array[Int], Array[Int], Array[Int], Array[String]) with Exception {
   match check_program_double_call_result_located_observation(stmts) {
-    Some((checked, offsets, eq_offs, eq_keys)) => (offsets, checked_int_render_offsets(checked), checked_bool_render_offsets(checked), eq_offs, eq_keys),
+    Some((checked, offsets, eq_offs, eq_keys)) => {
+      let (int_renders, bool_renders) = checked_int_and_bool_render_offsets(checked)
+      (offsets, int_renders, bool_renders, eq_offs, eq_keys)
+    },
     None => ([], [], [], [], [])
   }
 }
@@ -264,16 +266,29 @@ export fn compile_generated_source_wasi_only(source: String, entry_name: String)
 /// VIBE_COVERAGE=1 yields an instrumented compiler (per-function hit bitmap +
 /// `vibe_cov` section).
 fn compile_source_wasi_only_coverage_impl(source: String, entry_name: String, trusted_generated: Bool) -> Bytes with Exception {
-  let tokens = lex(source)
-  let stmts = parse_program(tokens)
+  // #2469: located parse + the checker's typed-lowering offsets, same as the
+  // production sibling above. The instrumented build compiles the SAME program
+  // the ordinary one does, so with the plain `lex`/`parse_program` every node
+  // was at offset -1 and the tables came out empty by construction -- a
+  // coverage build rendered a Double, an Int or a Bool by the syntactic
+  // classifier alone while the build it is meant to measure rendered it by
+  // type.
+  //
+  // `compile_wasi_module_coverage_impl(stmts, e)` is by definition
+  // `compile_wasi_module_with_sources_coverage_impl(stmts, e, array_empty())`
+  // (wasi.vibe), and the two `*_with_sources_coverage_*` bodies pass the same
+  // arguments to `compile_wasi_module_linked_impl*`, so going through the
+  // `srcs`-taking typed entry with an empty `srcs` is the same compile.
+  let (tokens, starts, _ends) = lex_with_offsets(source)
+  let stmts = parse_program_located(tokens, starts, source)
   validate_source_if_user(stmts, trusted_generated)
   expand_interp_stmts(stmts)
-  let _ = check_program(stmts)
+  let (float_call_offsets, int_render_offsets, bool_render_offsets, eq_offsets, eq_keys) = source_offsets(stmts)
   strip_generic_type_params(stmts)
   // Coverage consumers require a standalone instrumented core. StdinStream's
   // raw provider ABI is satisfiable only inside the dedicated component, so
   // parse the emitted core imports and fail before returning any artifact.
-  reject_stdin_provider_core(compile_wasi_module_coverage_impl(stmts, entry_name), "VIBE_COVERAGE=1")
+  reject_stdin_provider_core(compile_wasi_module_with_sources_coverage_impl_with_typed_offsets(stmts, entry_name, array_empty(), float_call_offsets, int_render_offsets, bool_render_offsets, eq_offsets, eq_keys), "VIBE_COVERAGE=1")
 }
 
 export fn compile_source_wasi_only_coverage(source: String, entry_name: String) -> Bytes with Exception {
@@ -318,14 +333,19 @@ export fn compile_generated_source_wasi_only_rc(source: String, entry_name: Stri
 /// deterministic trap at the faulting operation. Debug-only (VIBE_RC=shadow):
 /// adds a memory-reservation pad and per-dup/drop checks, so never the default.
 fn compile_source_wasi_only_rc_shadow_impl(source: String, entry_name: String, trusted_generated: Bool) -> Bytes with Exception {
-  let tokens = lex(source)
-  let stmts = parse_program(tokens)
+  // #2469: located parse + typed-lowering offsets, as in the RC sibling above.
+  // A shadow build exists to reproduce an RC bug, so it has to lower the
+  // program the way the RC build does; on the unlocated parse the tables were
+  // empty and the two lanes disagreed on exactly the renders this channel
+  // carries.
+  let (tokens, starts, _ends) = lex_with_offsets(source)
+  let stmts = parse_program_located(tokens, starts, source)
   validate_source_if_user(stmts, trusted_generated)
   expand_interp_stmts(stmts)
-  let _ = check_program(stmts)
+  let (float_call_offsets, int_render_offsets, bool_render_offsets, eq_offsets, eq_keys) = source_offsets(stmts)
   let wrap_async = (entry_name == "run") && entry_declares_async_int(stmts, entry_name)
   strip_generic_type_params(stmts)
-  maybe_wrap_async_component(compile_wasi_module_rc_shadow_impl(stmts, entry_name), wrap_async)
+  maybe_wrap_async_component(compile_wasi_module_rc_shadow_impl_with_typed_offsets(stmts, entry_name, float_call_offsets, int_render_offsets, bool_render_offsets, eq_offsets, eq_keys), wrap_async)
 }
 
 export fn compile_source_wasi_only_rc_shadow(source: String, entry_name: String) -> Bytes with Exception {

--- a/lib/@vibe/compiler/normalize/desugar_trait_dict.vibe
+++ b/lib/@vibe/compiler/normalize/desugar_trait_dict.vibe
@@ -10238,10 +10238,29 @@ fn rewrite_expr(expr: Expr, gens: Array[DictGen], traits: Array[(String, Array[(
             expanded
           } else {
             let missing = interp_missing_show_type(Array::get(args, 0), struct_sets, var_types, fn_returns)
-            if missing == "" {
-              expanded
-            } else {
+            if missing != "" {
               throw(interp_missing_show_msg(missing))
+            } else if is_show_shim_call(callee, args) {
+              // #2468: nothing HERE resolved it, and for a shim call leaving
+              // the call standing is not the same as leaving a `__to_string`
+              // standing. A shim is by definition `fn s(x) { __to_string(x) }`,
+              // so `s(arg)` and `__to_string(arg)` are one lowering -- but only
+              // the second is a render call to CODEGEN, which is where the
+              // typed-lowering channel (#2424/#2462) and the syntactic boolish
+              // classifiers get their turn. Left as `s(arg)` the argument was
+              // never classified and the two spellings of one render disagreed:
+              //
+              //   __to_string(l())  ->  "true"      to_string(l())  ->  "1"
+              //
+              // Rewriting to the direct spelling, at the SAME call offset, is
+              // what makes them one answer again. The callee is unreachable
+              // afterwards only if nothing else calls it; that is DCE's
+              // business, not this pass's.
+              Some(ECall(EIdent("__to_string", -1), Array::slice([
+                rewrite_expr(Array::get(args, 0), gens, traits, struct_sets, dict_binds, var_types, fn_returns)
+              ], 0, 1), off))
+            } else {
+              expanded
             }
           }
         }

--- a/lib/@vibe/compiler/tests/bool_render_channel_test.vibe
+++ b/lib/@vibe/compiler/tests/bool_render_channel_test.vibe
@@ -246,35 +246,41 @@ test "an interpolation-only module keeps its rows" {
 }
 
 test "2468: a Show wrapper's argument gets the same rows as `__to_string`" {
-  // The lowering treats a call to a 1-parameter function whose body is exactly
-  // `__to_string(param)` like `__to_string` itself (`is_show_shim_call`,
-  // normalize/desugar_trait_dict.vibe), so `to_string(x)` and
-  // `__to_string(x)` are the same render. The producer did not know that, and
-  // the two spellings of one render disagreed -- measured on
-  // lib/@vibe/builtin/builtin_traits_test.vibe:
+  // A Show wrapper is a one-parameter function whose body is exactly
+  // `__to_string(param)` -- the prelude's `to_string[T: Show]` has that shape.
+  // `desugar_trait_dict` treats a call to one like `__to_string` itself, so
+  // `to_string(x)` and `__to_string(x)` are ONE lowering, and the two
+  // spellings of one render disagreed:
   //
   //   __to_string(l())  ->  "true"      to_string(l())  ->  "1"
   //
-  // The shim is only reachable through a #2462-shaped producer here, which is
-  // the point: nothing syntactic classifies it, so the row is the whole
-  // mechanism.
-  let shim = "fn to_string(x: Bool) -> String {\n  __to_string(x)\n}\nfn main() -> Unit {\n  let l = () -> Bool { 1 < 2 }\n  let s = to_string(l())\n  ()\n}\n"
+  // The wrapper is GENERIC in every program here, which is what makes the
+  // count readable: `x: T` resolves to nothing, so the shim's own body files
+  // no row and the only row that can appear is the one for the outer call's
+  // argument. The argument is the #2462 shape (a lambda bound by a `let`
+  // INSIDE a function body), so nothing syntactic reaches it either -- the row
+  // is the whole mechanism.
+  let shim = "fn to_string[T](x: T) -> String {\n  __to_string(x)\n}\nfn main() -> Unit {\n  let l = () -> Bool { 1 < 2 }\n  let s = to_string(l())\n  ()\n}\n"
   inspect(bool_rows(shim), content = "1")
-  // Red direction: a 1-parameter function that is NOT a bare `__to_string` of
-  // its parameter is an ordinary call, and its argument files nothing. Same
-  // program otherwise, so the only variable is the body.
-  let not_shim = "fn to_string(x: Bool) -> String {\n  __to_string(x)\n  __to_string(x)\n}\nfn main() -> Unit {\n  let l = () -> Bool { 1 < 2 }\n  let s = to_string(l())\n  ()\n}\n"
+  // Red direction: a one-parameter function that is NOT a bare `__to_string`
+  // of its parameter is an ordinary call, and its argument files nothing.
+  // Same program otherwise, so the only variable is the body.
+  let not_shim = "fn to_string[T](x: T) -> String {\n  let y = x\n  __to_string(y)\n}\nfn main() -> Unit {\n  let l = () -> Bool { 1 < 2 }\n  let s = to_string(l())\n  ()\n}\n"
   inspect(bool_rows(not_shim), content = "0")
-  // And the shim must be recognized by its SHAPE, not by the name
-  // `to_string`: the wrapper the compiler's own sources use is generated with
-  // a mangled name.
-  let other_name = "fn zz(x: Bool) -> String {\n  __to_string(x)\n}\nfn main() -> Unit {\n  let l = () -> Bool { 1 < 2 }\n  let s = zz(l())\n  ()\n}\n"
+  // And the wrapper must be recognized by its SHAPE, not by the name
+  // `to_string`.
+  let other_name = "fn zz[T](x: T) -> String {\n  __to_string(x)\n}\nfn main() -> Unit {\n  let l = () -> Bool { 1 < 2 }\n  let s = zz(l())\n  ()\n}\n"
   inspect(bool_rows(other_name), content = "1")
-  // An Int through the same shim stays an Int row -- the shim widens WHICH
-  // calls are renders, never which type an argument has.
-  let int_shim = "fn to_string(x: Int) -> String {\n  __to_string(x)\n}\nfn main() -> Unit {\n  let n = 7\n  let s = to_string(n)\n  ()\n}\n"
+  // An Int through the same wrapper stays an Int row -- the wrapper widens
+  // WHICH calls are renders, never which type an argument has.
+  let int_shim = "fn to_string[T](x: T) -> String {\n  __to_string(x)\n}\nfn main() -> Unit {\n  let n = 7\n  let s = to_string(n)\n  ()\n}\n"
   inspect(bool_rows(int_shim), content = "0")
   inspect(int_rows(int_shim), content = "1")
+  // A MONOMORPHIC wrapper files its own body's row too, and that is not a
+  // second answer about the same expression: `__to_string(x)` inside the
+  // wrapper is a render of a Bool in its own right.
+  let mono = "fn to_string(x: Bool) -> String {\n  __to_string(x)\n}\nfn main() -> Unit {\n  let l = () -> Bool { 1 < 2 }\n  let s = to_string(l())\n  ()\n}\n"
+  inspect(bool_rows(mono), content = "2")
 }
 
 test "the folded Int+Bool walk answers exactly as the two separate walks" {

--- a/lib/@vibe/compiler/tests/bool_render_channel_test.vibe
+++ b/lib/@vibe/compiler/tests/bool_render_channel_test.vibe
@@ -41,7 +41,11 @@ import @vibe/compiler/syntax {
 }
 
 import @vibe/compiler/checker {
-  check_program_double_call_result_located_observation, check_program_result, checked_bool_render_offsets, checked_int_render_offsets
+  check_program_double_call_result_located_observation,
+  check_program_result,
+  checked_bool_render_offsets,
+  checked_int_and_bool_render_offsets,
+  checked_int_render_offsets
 }
 
 import ./codegen_test_support.vibe {
@@ -239,4 +243,80 @@ test "an interpolation-only module keeps its rows" {
   // like. Synthesized calls inside a located parse are not it.
   inspect(observation_present("fn f() -> Int {\n  1\n}\n\nfn g() -> Int {\n  f()\n}\n"), content = "true")
   inspect(observation_present("fn h(x: Int) -> Int {\n  x + 1\n}\n"), content = "true")
+}
+
+test "2468: a Show wrapper's argument gets the same rows as `__to_string`" {
+  // The lowering treats a call to a 1-parameter function whose body is exactly
+  // `__to_string(param)` like `__to_string` itself (`is_show_shim_call`,
+  // normalize/desugar_trait_dict.vibe), so `to_string(x)` and
+  // `__to_string(x)` are the same render. The producer did not know that, and
+  // the two spellings of one render disagreed -- measured on
+  // lib/@vibe/builtin/builtin_traits_test.vibe:
+  //
+  //   __to_string(l())  ->  "true"      to_string(l())  ->  "1"
+  //
+  // The shim is only reachable through a #2462-shaped producer here, which is
+  // the point: nothing syntactic classifies it, so the row is the whole
+  // mechanism.
+  let shim = "fn to_string(x: Bool) -> String {\n  __to_string(x)\n}\nfn main() -> Unit {\n  let l = () -> Bool { 1 < 2 }\n  let s = to_string(l())\n  ()\n}\n"
+  inspect(bool_rows(shim), content = "1")
+  // Red direction: a 1-parameter function that is NOT a bare `__to_string` of
+  // its parameter is an ordinary call, and its argument files nothing. Same
+  // program otherwise, so the only variable is the body.
+  let not_shim = "fn to_string(x: Bool) -> String {\n  __to_string(x)\n  __to_string(x)\n}\nfn main() -> Unit {\n  let l = () -> Bool { 1 < 2 }\n  let s = to_string(l())\n  ()\n}\n"
+  inspect(bool_rows(not_shim), content = "0")
+  // And the shim must be recognized by its SHAPE, not by the name
+  // `to_string`: the wrapper the compiler's own sources use is generated with
+  // a mangled name.
+  let other_name = "fn zz(x: Bool) -> String {\n  __to_string(x)\n}\nfn main() -> Unit {\n  let l = () -> Bool { 1 < 2 }\n  let s = zz(l())\n  ()\n}\n"
+  inspect(bool_rows(other_name), content = "1")
+  // An Int through the same shim stays an Int row -- the shim widens WHICH
+  // calls are renders, never which type an argument has.
+  let int_shim = "fn to_string(x: Int) -> String {\n  __to_string(x)\n}\nfn main() -> Unit {\n  let n = 7\n  let s = to_string(n)\n  ()\n}\n"
+  inspect(bool_rows(int_shim), content = "0")
+  inspect(int_rows(int_shim), content = "1")
+}
+
+test "the folded Int+Bool walk answers exactly as the two separate walks" {
+  // Perf: tags 3 and 5 share a key (`typed_lowering_arg_offset`), so they scan
+  // the same candidate set and one walk can fill both arrays. Tag 4 keeps its
+  // own walk -- `typed_lowering_float_key` is a genuinely different key.
+  //
+  // The fold is an optimization, so what it has to prove is that it changed
+  // nothing. Each program below is one where the two tags disagree, so a fold
+  // that crossed the arrays would be caught by count alone.
+  let progs = [
+    "fn main() -> Unit { let a = 1\nlet b = 2\nlet s = __to_string(eq(a, b))\n() }",
+    "fn main() -> Unit { let l = () -> Bool { 1 < 2 }\nlet s = __to_string(l())\n() }",
+    "fn main() -> Unit { let n = 7\nlet s = __to_string(n)\n() }",
+    "fn main() -> Unit { let b = 1 < 2\n() }"
+  ]
+  let mut i = 0
+  let mut agree = true
+  while i < Array::length(progs) {
+    let src: String = Array::get(progs, i)
+    let (pi, pb) = handle {
+      let (toks, starts, _) = lex_with_offsets(src)
+      let checked = check_program_result(parse_program_located(toks, starts, src))
+      let (a, b) = checked_int_and_bool_render_offsets(checked)
+      (Array::length(a), Array::length(b))
+    } with { Exception::Throw(_) => (0 - 1, 0 - 1) }
+    if pi != int_rows(src) {
+      agree = false
+    }
+    if pb != bool_rows(src) {
+      agree = false
+    }
+    i = i + 1
+  }
+  inspect(agree, content = "true")
+  // The counts the loop compares against, spelled out -- so a fold that
+  // returned two EMPTY arrays could not pass by agreeing with a
+  // simultaneously-broken single-tag path.
+  inspect(int_rows(Array::get(progs, 0)), content = "2")
+  inspect(bool_rows(Array::get(progs, 0)), content = "1")
+  inspect(int_rows(Array::get(progs, 1)), content = "0")
+  inspect(bool_rows(Array::get(progs, 1)), content = "1")
+  inspect(int_rows(Array::get(progs, 2)), content = "1")
+  inspect(bool_rows(Array::get(progs, 2)), content = "0")
 }

--- a/tests/gates/early/run.sh
+++ b/tests/gates/early/run.sh
@@ -1630,6 +1630,57 @@ fi
 rm -rf "$cdir"
 echo "[compiler-gate] coverage instrumentation regression ok"
 
+# 13b. #2469: an INSTRUMENTED build must lower a render the way the production
+#      build does. The coverage entry parsed with plain `lex`/`parse_program`,
+#      which leaves every node at offset -1, so the checker's offset-keyed
+#      typed-lowering tables came out empty BY CONSTRUCTION and only the
+#      syntactic classifiers answered. The program below is the #2462 shape --
+#      a lambda bound by a `let` INSIDE a function body, which
+#      `collect_fn_returns` (a STATEMENT walk) cannot see -- so nothing
+#      syntactic classifies it and the table is the whole mechanism.
+#
+#      Encoded as an Int rather than compared as text so the failure names the
+#      wrong value: "true" -> 4*1000 + 't'(116) = 4116, "1" -> 1*1000 +
+#      '1'(49) = 1049. Red-tested by reverting the entry to the unlocated
+#      parse: 1049.
+echo "[compiler-gate] 13b/13 instrumented build typed-lowering tables (#2469)"
+tldir="_build/_gate_typed_instrumented"
+rm -rf "$tldir"; mkdir -p "$tldir"
+cat > "$tldir/bool_render.vibe" <<'EOF'
+export let _start: () -> Int = () -> {
+  let l = () -> Bool { 1 < 2 }
+  let s = __to_string(l())
+  String::length(s) * 1000 + String::char_code_at(s, 0)
+}
+EOF
+VIBE_COVERAGE=1 VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
+  bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
+  "$tldir/bool_render.vibe" "$tldir/cov.wasm" _start >/dev/null 2>&1 || true
+if [ ! -s "$tldir/cov.wasm" ]; then
+  echo "[compiler-gate] FAIL: coverage build of the #2469 probe produced no wasm" >&2
+  cat "$tldir/cov.wasm.diag" 2>/dev/null >&2 || true
+  exit 1
+fi
+tl_cov_out="$(VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh \
+  --invoke _start "$tldir/cov.wasm" 2>/dev/null | tr -dc '0-9')"
+if [ "$tl_cov_out" != "4116" ]; then
+  echo "[compiler-gate] FAIL: VIBE_COVERAGE=1 rendered a Bool as '$tl_cov_out' (want 4116 = \"true\"; 1049 = \"1\" means the coverage entry is back on the unlocated parse and its typed-lowering tables are empty -- #2469)" >&2
+  exit 1
+fi
+# The control: the SAME program through the ordinary entry. Both must agree --
+# that agreement, not the constant, is what #2469 is about.
+VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
+  bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
+  "$tldir/bool_render.vibe" "$tldir/plain.wasm" _start >/dev/null 2>&1 || true
+tl_plain_out="$(VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh \
+  --invoke _start "$tldir/plain.wasm" 2>/dev/null | tr -dc '0-9')"
+if [ "$tl_plain_out" != "$tl_cov_out" ]; then
+  echo "[compiler-gate] FAIL: the coverage build ($tl_cov_out) and the ordinary build ($tl_plain_out) rendered the same Bool differently (#2469)" >&2
+  exit 1
+fi
+rm -rf "$tldir"
+echo "[compiler-gate] instrumented build typed-lowering tables ok (#2469)"
+
 # 14. method-bearing-trait dictionary passing regression (#641 PR-3): a
 #     `[T: Trait]` generic calling `T::method(x)` must dispatch to the concrete
 #     impl via a synthesized witness dictionary (desugar_trait_dict.vibe). Covers

--- a/tests/gates/early/run.sh
+++ b/tests/gates/early/run.sh
@@ -1634,7 +1634,18 @@ echo "[compiler-gate] coverage instrumentation regression ok"
 #      build does. The coverage entry parsed with plain `lex`/`parse_program`,
 #      which leaves every node at offset -1, so the checker's offset-keyed
 #      typed-lowering tables came out empty BY CONSTRUCTION and only the
-#      syntactic classifiers answered. The program below is the #2462 shape --
+#      syntactic classifiers answered.
+#
+#      NO `VIBE_FS_COMPILE=1` here, and that is the whole reason this step can
+#      fail: the entries #2469 fixes are the DIRECT-SOURCE ones
+#      (`compile_source_wasi_only_coverage_impl` /
+#      `_rc_shadow_impl`, reached from cli_adapter's non-FS_COMPILE branch).
+#      With FS_COMPILE set, the compile takes the module lane instead and this
+#      probe answers 4116 on a compiler that has none of the fix -- measured
+#      against origin/main, which is how the first cut of this step passed
+#      while proving nothing.
+#
+#      The program below is the #2462 shape --
 #      a lambda bound by a `let` INSIDE a function body, which
 #      `collect_fn_returns` (a STATEMENT walk) cannot see -- so nothing
 #      syntactic classifies it and the table is the whole mechanism.
@@ -1653,7 +1664,7 @@ export let _start: () -> Int = () -> {
   String::length(s) * 1000 + String::char_code_at(s, 0)
 }
 EOF
-VIBE_COVERAGE=1 VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
+VIBE_COVERAGE=1 VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_IMPORT_ABI=raw \
   bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
   "$tldir/bool_render.vibe" "$tldir/cov.wasm" _start >/dev/null 2>&1 || true
 if [ ! -s "$tldir/cov.wasm" ]; then
@@ -1669,7 +1680,7 @@ if [ "$tl_cov_out" != "4116" ]; then
 fi
 # The control: the SAME program through the ordinary entry. Both must agree --
 # that agreement, not the constant, is what #2469 is about.
-VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
+VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_IMPORT_ABI=raw \
   bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
   "$tldir/bool_render.vibe" "$tldir/plain.wasm" _start >/dev/null 2>&1 || true
 tl_plain_out="$(VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh \

--- a/tests/gates/mid/run.sh
+++ b/tests/gates/mid/run.sh
@@ -458,7 +458,16 @@ echo "[compiler-gate] RC shadow-liveness regression guard ok (25297489)"
 #        thing being debugged. The shadow entry parsed with plain
 #        `lex`/`parse_program`, leaving every node at offset -1, so the
 #        checker's offset-keyed typed-lowering tables were empty by
-#        construction. The probe is the #2462 shape (a lambda bound by a `let`
+#        construction.
+#
+#        NO `VIBE_FS_COMPILE=1`, and that is the whole reason this step can
+#        fail: the entry #2469 fixes is the DIRECT-SOURCE
+#        `compile_source_wasi_only_rc_shadow_impl`, reached from
+#        cli_adapter's non-FS_COMPILE branch. With FS_COMPILE set the compile
+#        takes the module lane and this probe answers 4116 on a compiler that
+#        has none of the fix -- measured against origin/main.
+#
+#        The probe is the #2462 shape (a lambda bound by a `let`
 #        INSIDE a function body), which no syntactic rule reaches -- the table
 #        is the whole mechanism. "true" -> 4*1000 + 't'(116) = 4116;
 #        "1" -> 1*1000 + '1'(49) = 1049 is the pre-fix answer.
@@ -472,7 +481,7 @@ export let _start: () -> Int = () -> {
   String::length(s) * 1000 + String::char_code_at(s, 0)
 }
 EOF
-VIBE_RC=shadow VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
+VIBE_RC=shadow VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_IMPORT_ABI=raw \
   bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
   "$tlsdir/bool_render.vibe" "$tlsdir/shadow.wasm" _start >/dev/null 2>&1 || true
 if [ ! -s "$tlsdir/shadow.wasm" ]; then

--- a/tests/gates/mid/run.sh
+++ b/tests/gates/mid/run.sh
@@ -452,6 +452,43 @@ fi
 rm -rf "$shdir"
 echo "[compiler-gate] RC shadow-liveness regression guard ok (25297489)"
 
+# 40f1b. #2469: the shadow build must lower a render the way the RC build does.
+#        A shadow build exists to REPRODUCE an RC bug, so a program that
+#        lowers differently under it is a debugging tool that changes the
+#        thing being debugged. The shadow entry parsed with plain
+#        `lex`/`parse_program`, leaving every node at offset -1, so the
+#        checker's offset-keyed typed-lowering tables were empty by
+#        construction. The probe is the #2462 shape (a lambda bound by a `let`
+#        INSIDE a function body), which no syntactic rule reaches -- the table
+#        is the whole mechanism. "true" -> 4*1000 + 't'(116) = 4116;
+#        "1" -> 1*1000 + '1'(49) = 1049 is the pre-fix answer.
+echo "[compiler-gate] 40f1b/40 shadow build typed-lowering tables (#2469)"
+tlsdir="_build/_gate_typed_shadow"
+rm -rf "$tlsdir"; mkdir -p "$tlsdir"
+cat > "$tlsdir/bool_render.vibe" <<'EOF'
+export let _start: () -> Int = () -> {
+  let l = () -> Bool { 1 < 2 }
+  let s = __to_string(l())
+  String::length(s) * 1000 + String::char_code_at(s, 0)
+}
+EOF
+VIBE_RC=shadow VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
+  bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
+  "$tlsdir/bool_render.vibe" "$tlsdir/shadow.wasm" _start >/dev/null 2>&1 || true
+if [ ! -s "$tlsdir/shadow.wasm" ]; then
+  echo "[compiler-gate] FAIL: VIBE_RC=shadow build of the #2469 probe produced no wasm" >&2
+  cat "$tlsdir/shadow.wasm.diag" 2>/dev/null >&2 || true
+  exit 1
+fi
+tls_out="$(VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh \
+  --invoke _start "$tlsdir/shadow.wasm" 2>/dev/null | tr -dc '0-9')"
+if [ "$tls_out" != "4116" ]; then
+  echo "[compiler-gate] FAIL: VIBE_RC=shadow rendered a Bool as '$tls_out' (want 4116 = \"true\"; 1049 = \"1\" means the shadow entry is back on the unlocated parse and its typed-lowering tables are empty -- #2469)" >&2
+  exit 1
+fi
+rm -rf "$tlsdir"
+echo "[compiler-gate] shadow build typed-lowering tables ok (#2469)"
+
 # 40f2. Shadow-RC checked-artifact smoke (#1986).
 #      40f covers the #715 shape corpus. That is not enough: the first cut of
 #      #1964 (`460e8421c`) double-freed inside railway_rw when the compiled

--- a/tests/gates/registry.tsv
+++ b/tests/gates/registry.tsv
@@ -41,6 +41,7 @@ x-parser-binder-context-spine	bootstrap	parser binder-context spine
 11/11	early	11/11 forward-reference regression
 12/12	early	12/12 string-interpolation conversion regression
 13/13	early	13/13 coverage instrumentation regression
+13b/13	early	13b/13 instrumented build typed-lowering tables (#2469)
 14/14	early	14/14 method-bearing-trait dict-passing regression
 14b/14	early	14b/14 rank-1 trait-method generics regression (#684)
 14c/14	early	14c/14 UFCS-on-bounded-tparam dict dispatch (#931)
@@ -93,6 +94,7 @@ x-two-exported-async-functions-still-refuse-to-gue	mid	two exported Async functi
 40c2/40	mid	40c2/40 RC user-shadowed builtin name (#1746)
 40d/40	mid	40d/40 RC reclamation leak guard (tuple+cell+closure+enum+loop-consume+builder-return)
 40f/40	mid	40f/40 RC shadow-liveness regression guard (#715 shapes)
+40f1b/40	mid	40f1b/40 shadow build typed-lowering tables (#2469)
 40f2/40	mid	40f2/40 RC shadow checked-artifact smoke (#1986)
 40g/40	mid	40g/40 #cfg conditional compilation
 40h/40	mid	40h/40 wasm-gc backend smoke


### PR DESCRIPTION
The three open items after #2466: two P0s where one render answered two ways, and the perf drift that PR's third walk introduced.

## #2468 — `to_string(x)` and `__to_string(x)` are one lowering, and they disagreed

Measured on `lib/@vibe/builtin/builtin_traits_test.vibe`:

```
__to_string(l())  ->  "true"      to_string(l())  ->  "1"
```

`l` is the #2462 shape — a lambda bound by a `let` **inside** a function body, which `collect_fn_returns` (a statement walk) cannot see — so nothing syntactic classifies it and the typed-lowering channel is the whole mechanism.

It took **three** pieces, and each of the first two looked complete on its own:

- **Producer** (`checker_stmt.vibe`): `irc_is_render_callee` now also accepts the program's Show-wrapper names, found by the same shape test the normalize pass uses. The checker runs before that pass and cannot read the `dtd_show_shims` it fills, so the question is answered again here.
- **Consumer** (`desugar_trait_dict.vibe`): with the rows filed, `show_any(l())` **still rendered "1"** — measured, which is how this was caught. `desugar_trait_dict` handles a wrapper call on the same path as `__to_string` — a `T::to_string`, then a Bool it can see through `fn_returns`/`var_types`, then a structural shape — and when all three miss it left the call standing. For a `__to_string` call that is right: codegen gets a render call and its classifiers get their turn. For a **wrapper** call it is not: codegen sees an ordinary call to a user function, classifies nothing, and inside the wrapper the parameter is a type variable, so the ADR-0058 heuristic renders a Bool as "1". A wrapper is by definition `fn s(x) { __to_string(x) }`, so emitting the direct spelling at the same call offset is what makes the two one answer again.
- **Imported wrappers** (Codex P1 on this PR, thread [r3921038374](https://github.com/mizchi/vibe-lang/pull/2470#discussion_r3921038374)). The shape scan only saw the module's own statements, so the prelude's `to_string` — the way anyone actually writes it — was never recognized, and the FS lane still rendered `"1"`. The local-wrapper tests could not catch it, and the parity fixture declares its wrapper locally, so the normal path was the one case nothing covered. Every imported local name now joins the candidate set with no shape test. That is an over-approximation, and it is safe because a row is a **type** fact, not a render fact: it says "the expression at this offset resolved to Bool", which the agreement rule verified, and codegen reads the table only while lowering a render argument (`bool_offset_says_bool` inside `cc_expr_is_boolish`, and its two twins). A row filed for an ordinary imported call is inert — nothing looks it up — and a true statement about an expression's type cannot become a wrong classification. The precise alternative needs per-module wrapper metadata that survives a cache hit skipping the dependency's check; that is #2472, with its measured price recorded below.

Verified end to end on a stage2 from this branch:

| spelling | `origin/main` | this branch |
|---|---|---|
| `__to_string(l())` | `"true"` | `"true"` |
| local wrapper `show_any(l())` | `"1"` | `"true"` |
| imported `to_string(l())` (FS lane) | `"1"` | `"true"` |

The normalize twin's shadowing exclusion is deliberately **omitted** from the producer, for the same type-fact reason as the imported over-approximation. The rewrite pass has no such margin, because it REPLACES the call.

## #2469 — the instrumented builds had empty typed tables by construction

`compile_source_wasi_only_coverage_impl` and `compile_source_wasi_only_rc_shadow_impl` parsed with plain `lex`/`parse_program`, which leaves every node's offset at -1. The tables are keyed by offset, so on those two entries they came out empty and only the syntactic classifiers answered — while the production entries two functions above each already routed the located parse.

Both instrumented builds compile the **same program** the build they are meant to measure compiles. A coverage build that renders a Bool as "1" where the ordinary build renders "true" measures a different program; a shadow build that does it changes the thing being debugged.

`compile_wasi_module_rc_shadow_impl_with_typed_offsets` already existed. For coverage only the `srcs`-taking variant does, and going through it with an empty `srcs` is the same compile — checked, not assumed: `compile_wasi_module_coverage_impl(stmts, e)` is *defined* as `compile_wasi_module_with_sources_coverage_impl(stmts, e, array_empty())`, and the two `*_with_sources_coverage_*` bodies pass the same arguments to `compile_wasi_module_linked_impl*`.

Measured, one render, direct-source lane:

| compiler | plain | coverage | shadow |
|---|---:|---:|---:|
| `origin/main` | 4116 `"true"` | **1049 `"1"`** | **1049 `"1"`** |
| this branch | 4116 | 4116 | 4116 |

**The first cut of the gate steps could not fail.** They carried `VIBE_FS_COMPILE=1`, copied from the neighbouring coverage and shadow steps, which routed the compile through the module lane instead of the direct-source entries this fixes — so both passed against an `origin/main` artifact. Removed; both lanes now fail against that artifact, naming the wrong value.

## Perf — the Int and Bool producer walks folded into one

#2466 landed tag 5 as its own walk and cost +0.86% selfcompile heap. Tags 3 and 5 share a key (`typed_lowering_arg_offset`), so they scan an identical candidate set and only the type test differs; running them separately re-derived the candidates and re-scanned `typed_occurrences` to ask a second question about rows already visited.

Tag 4 keeps its own walk — `typed_lowering_float_key` is a genuinely different candidate set, and folding it in would mean collecting under one key and reading under another. The two **output** arrays stay separate: sharing the walk is a cost decision, sharing the answers would put a Bool offset where `ts_known_int` reads.

Measured per `.claude/skills/compiler-perf-profiling`: `VIBE_BUILD_CACHE_DIR=$(mktemp -d)` per run, cold-vs-cold and warm-vs-warm, N=3 on `codegen_lexer_test.vibe`. `heap_ptr` is byte-deterministic and was identical across every run of each configuration:

| | selfcompile heap_ptr | Δ vs main |
|---|---:|---:|
| `origin/main` | 1,614,358,984 | — |
| fold only | 1,602,688,560 | −0.72% |
| fold + imported wrappers (shipped) | 1,607,232,240 | **−0.44%** |

The imported-wrapper candidate widening costs +0.28% against the middle row (same source tree, so that delta is the clean one); the fold more than pays for it. Wall time moved the same direction but is machine-dependent; the heap number is the one to read.

## Tests

**Producer rows** (`bool_render_channel_test.vibe`) — the wrapper's argument gets the same rows as `__to_string`; a one-parameter function whose body is not a bare `__to_string` of its parameter files nothing (the red direction); the wrapper is recognized by SHAPE, not by the name `to_string`; an Int through the same wrapper stays an Int row. The counts are written around a **generic** wrapper on purpose — `x: T` resolves to nothing, so the wrapper's own body files no row and the only row that can appear is the outer call's. The monomorphic case is its own assertion (2 rows), because the wrapper body's `__to_string(x)` is a render of a Bool in its own right.

**The imported wrapper** (`builtin_traits_test.vibe`) — next to the wrapper it imports, with Int and Double controls so a row claiming every imported call's argument is a Bool would be caught rather than look like a fix. The existing `to_string(true)` there could never have caught this: every classifier already answers a Bool literal.

**The fold** gets its own test, because an optimization has to prove it changed nothing. Each program it compares is one where the two tags disagree, so a fold that crossed the arrays would be caught by count alone — and the expected counts are spelled out, so a fold returning two empty arrays could not pass by agreeing with a simultaneously-broken single-tag path.

**Gate steps** for #2469 in the early (coverage) and mid (shadow) lanes, plus their `tests/gates/registry.tsv` rows. The probe is the #2462 shape, and the render is encoded as an Int so a failure names the wrong value: `"true"` → 4116, `"1"` → 1049. The coverage step also compares against the ordinary entry on the same program, because the *agreement*, not the constant, is what this fixes.

**Behavioural pin** (`gc_lane_scalar_parity_test.vibe`, all three lanes): the same render through a locally declared wrapper and through `__to_string`, plus Int, Double and String controls.

## Verification run

- Gate lanes `early`, `mid`, `late` — green on a stage2 from this branch. The `late` lane caught the two new sections missing from `tests/gates/registry.tsv` (fail-closed by design); registered.
- Unit suite: **1105/1105**.
- Both #2469 gate steps red-tested against an `origin/main` stage2, as above.

Closes #2468. Closes #2469. Follow-up: #2472.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FYMVd6D2o82suTfTwoJPMf