### PR TITLE
Compare Int payloads exactly through literal shapes and bare Option/Result bindings (#2457)

### DIFF
--- a/fixtures/structural_eq_owned_scalar_array_literal_trap.vibe
+++ b/fixtures/structural_eq_owned_scalar_array_literal_trap.vibe
@@ -1,0 +1,19 @@
+//# Codex round 4 on #2471 (#2457): a program may declare a struct whose
+//# spelling is a scalar's. A literal-derived `==` shape then cannot say which
+//# `Int` it means -- the checker's row and the syntactic inference both spell a
+//# literal's builtin `Int` exactly like the struct -- and dispatching through
+//# the declared comparator read two Int words as struct pointers (measured on
+//# the FS lane at 44dd270: this program answered `1`, i.e. `true`). It must
+//# TRAP instead: never a guessed answer.
+
+struct Int {
+  value: String
+} derive (Eq)
+
+export fn _start() -> Int {
+  if [1] == [2] {
+    1
+  } else {
+    0
+  }
+}

--- a/fixtures/structural_eq_owned_scalar_bare_option_trap.vibe
+++ b/fixtures/structural_eq_owned_scalar_bare_option_trap.vibe
@@ -1,0 +1,25 @@
+//# Codex round 4 on #2471 (#2457): a program may declare a struct whose
+//# spelling is a scalar's. A literal-derived `==` shape then cannot say which
+//# `Int` it means -- the checker's row and the syntactic inference both spell a
+//# literal's builtin `Int` exactly like the struct -- and dispatching through
+//# the declared comparator read two Int words as struct pointers (measured on
+//# the FS lane at 44dd270: this program answered `1`, i.e. `true`). It must
+//# TRAP instead: never a guessed answer.
+
+struct Int {
+  value: String
+} derive (Eq)
+
+fn mk(v: Int) -> Option[Int] {
+  Some(v)
+}
+
+export fn _start() -> Int {
+  let a = Some(1)
+  let b = Some(2)
+  if a == b {
+    1
+  } else {
+    0
+  }
+}

--- a/fixtures/structural_eq_owned_scalar_literal_push_trap.vibe
+++ b/fixtures/structural_eq_owned_scalar_literal_push_trap.vibe
@@ -1,0 +1,25 @@
+//# Codex round 4 on #2471 (#2457), the untyped-empty side: the #2157 push
+//# scan names a pushed Int literal `Int`, and with `struct Int` declared that
+//# spelling is the struct's, so the comparison dispatched the words to
+//# `Int::equals` and answered `1` (`true`) on main. The array rung now fails
+//# closed on a shape that mentions a source-owned scalar spelling. (A struct
+//# literal push, `Array::push(xs, Int::{ value: "x" })`, spells the same
+//# `Int` and traps here too until #2475 gives the shape channel a way to tell
+//# the two apart; a push by NAME still answers through the checker's row --
+//# `structural_eq_untyped_empty_owned_int_typed.vibe`.)
+
+struct Int {
+  value: String
+} derive (Eq)
+
+export fn _start() -> Int {
+  let left = []
+  Array::push(left, 1)
+  let right = []
+  Array::push(right, 2)
+  if left == right {
+    1
+  } else {
+    0
+  }
+}

--- a/fixtures/structural_eq_owned_scalar_some_literal_trap.vibe
+++ b/fixtures/structural_eq_owned_scalar_some_literal_trap.vibe
@@ -1,0 +1,19 @@
+//# Codex round 4 on #2471 (#2457): a program may declare a struct whose
+//# spelling is a scalar's. A literal-derived `==` shape then cannot say which
+//# `Int` it means -- the checker's row and the syntactic inference both spell a
+//# literal's builtin `Int` exactly like the struct -- and dispatching through
+//# the declared comparator read two Int words as struct pointers (measured on
+//# the FS lane at 44dd270: this program answered `1`, i.e. `true`). It must
+//# TRAP instead: never a guessed answer.
+
+struct Int {
+  value: String
+} derive (Eq)
+
+export fn _start() -> Int {
+  if Some(1) == Some(2) {
+    1
+  } else {
+    0
+  }
+}

--- a/fixtures/structural_eq_owned_scalar_tuple_literal_trap.vibe
+++ b/fixtures/structural_eq_owned_scalar_tuple_literal_trap.vibe
@@ -1,0 +1,19 @@
+//# Codex round 4 on #2471 (#2457): a program may declare a struct whose
+//# spelling is a scalar's. A literal-derived `==` shape then cannot say which
+//# `Int` it means -- the checker's row and the syntactic inference both spell a
+//# literal's builtin `Int` exactly like the struct -- and dispatching through
+//# the declared comparator read two Int words as struct pointers (measured on
+//# the FS lane at 44dd270: this program answered `1`, i.e. `true`). It must
+//# TRAP instead: never a guessed answer.
+
+struct Int {
+  value: String
+} derive (Eq)
+
+export fn _start() -> Int {
+  if (1, "a") == (2, "a") {
+    1
+  } else {
+    0
+  }
+}

--- a/lib/@vibe/compiler/codegen/expr/compile_expr.vibe
+++ b/lib/@vibe/compiler/codegen/expr/compile_expr.vibe
@@ -526,7 +526,16 @@ fn ctor_shape_field_exprs(shape: Expr, ct: CtorTable) -> Array[Expr] with Except
 /// is not statically an aggregate (scalar, or an opaque call-result / bound
 /// name we cannot see the literal shape of) keeps the old generic-`eq` leaf
 /// comparison — same residual as before, just one level shallower.
-fn emit_eq_shape_slots(buf: Bytes, shape: Expr, asl: Int, bsl: Int, local_names: Array[String], nl0: Int, ctx: CompileCtx, ld: Int, ce: (Bytes, Expr, Array[String], Int, CompileCtx, Int) -> Int with Exception) -> Int with Exception {
+/// `live` (#2457, Codex round 1 on #2471): whether `shape` is the operand
+/// literal written AT this compare site. A shape recorded at an earlier
+/// `let` (CompileCtx.agg_local_exprs) carries identifiers from THAT scope;
+/// resolving one against `local_names` here would read whatever binding
+/// currently owns the name -- `let t = (s, 1); let s = 64 << 32; t == u`
+/// would classify the String field from the Int slot and compare two
+/// string words with `i64.eq`. So a saved shape classifies only a leaf
+/// that names nothing (a literal, an operator tree over literals); a live
+/// shape may consult the scope, which is the scope its names were written in.
+fn emit_eq_shape_slots(buf: Bytes, shape: Expr, live: Bool, asl: Int, bsl: Int, local_names: Array[String], nl0: Int, ctx: CompileCtx, ld: Int, ce: (Bytes, Expr, Array[String], Int, CompileCtx, Int) -> Int with Exception) -> Int with Exception {
   let (eq_fidx, _, _) = resolve_func(ctx.func_table, "eq")
   if is_etuple(shape) {
     let elems = get_etuple_elems(shape)
@@ -575,9 +584,9 @@ fn emit_eq_shape_slots(buf: Bytes, shape: Expr, asl: Int, bsl: Int, local_names:
         emit_i32_wrap_i64(buf)
         emit_i64_load(buf, 3, field_off + i * 8)
         emit_local_set(buf, nb)
-        nl = emit_eq_shape_slots(buf, el_shape, na, nb, local_names, nl + 2, ctx, ld, ce)
+        nl = emit_eq_shape_slots(buf, el_shape, live && !is_eident(el), na, nb, local_names, nl + 2, ctx, ld, ce)
         emit_i64_and(buf)
-      } else if expr_is_intish(el, local_names, ctx) {
+      } else if eq_leaf_is_intish(el, live, local_names, ctx) {
         // #2457: a leaf whose literal payload EXPRESSION is provably an
         // Int / Bool word (`64 << 32`, a `let`-bound int slot) compares with a
         // plain `i64.eq`. The generic `eq` builtin's string fall-back reads a
@@ -650,9 +659,9 @@ fn emit_eq_shape_slots(buf: Bytes, shape: Expr, asl: Int, bsl: Int, local_names:
         emit_i32_wrap_i64(buf)
         emit_i64_load(buf, 3, 8 + i * 8)
         emit_local_set(buf, nb)
-        nl = emit_eq_shape_slots(buf, el_shape, na, nb, local_names, nl + 2, ctx, ld, ce)
+        nl = emit_eq_shape_slots(buf, el_shape, live && !is_eident(el), na, nb, local_names, nl + 2, ctx, ld, ce)
         emit_i64_and(buf)
-      } else if expr_is_intish(el, local_names, ctx) {
+      } else if eq_leaf_is_intish(el, live, local_names, ctx) {
         // #2457: a leaf whose literal payload EXPRESSION is provably an
         // Int / Bool word (`64 << 32`, a `let`-bound int slot) compares with a
         // plain `i64.eq`. The generic `eq` builtin's string fall-back reads a
@@ -707,7 +716,7 @@ fn emit_eq_shape_slots(buf: Bytes, shape: Expr, asl: Int, bsl: Int, local_names:
 /// callers fall back to the old flat comparators when only a shallow kind+n
 /// is known (no literal in scope — e.g. a round-2 declared-return-type or
 /// dynamic-argc tracked binding), which is unchanged from before this change.
-fn emit_eq_shape_top(buf: Bytes, shape: Expr, lhs: Expr, rhs: Expr, local_names: Array[String], next_local: Int, ctx: CompileCtx, ld: Int, ce: (Bytes, Expr, Array[String], Int, CompileCtx, Int) -> Int with Exception) -> Int with Exception {
+fn emit_eq_shape_top(buf: Bytes, shape: Expr, live: Bool, lhs: Expr, rhs: Expr, local_names: Array[String], next_local: Int, ctx: CompileCtx, ld: Int, ce: (Bytes, Expr, Array[String], Int, CompileCtx, Int) -> Int with Exception) -> Int with Exception {
   let aptr = next_local
   Array::push(local_names, "__seqa")
   let bptr = next_local + 1
@@ -716,7 +725,31 @@ fn emit_eq_shape_top(buf: Bytes, shape: Expr, lhs: Expr, rhs: Expr, local_names:
   emit_local_set(buf, aptr)
   let nl2 = ce(buf, rhs, local_names, nl1, ctx, ld)
   emit_local_set(buf, bptr)
-  emit_eq_shape_slots(buf, shape, aptr, bptr, local_names, nl2, ctx, ld, ce)
+  emit_eq_shape_slots(buf, shape, live, aptr, bptr, local_names, nl2, ctx, ld, ce)
+}
+
+/// #2457: may this leaf of a shape compare with a plain `i64.eq`? See
+/// emit_eq_shape_slots's `live`: a saved shape's leaf must name nothing.
+fn eq_leaf_is_intish(el: Expr, live: Bool, local_names: Array[String], ctx: CompileCtx) -> Bool with Exception {
+  if live || expr_names_nothing(el) {
+    expr_is_intish(el, local_names, ctx)
+  } else {
+    false
+  }
+}
+
+/// A literal, or an operator tree over literals: no identifier, no call, no
+/// projection -- nothing whose meaning depends on a scope.
+fn expr_names_nothing(e: Expr) -> Bool {
+  match e {
+    EInt(_) => true,
+    EBool(_) => true,
+    EString(_) => true,
+    EFloat(_) => true,
+    EBinOp(_, l, r, _) => expr_names_nothing(l) && expr_names_nothing(r),
+    EUnaryOp(_, inner) => expr_names_nothing(inner),
+    _ => false
+  }
 }
 
 /// #672: emit the equality test for `lhs == rhs`, leaving a raw i64 0/1 on the
@@ -740,7 +773,7 @@ fn emit_eq_value(buf: Bytes, lhs: Expr, rhs: Expr, local_names: Array[String], n
     } else {
       rhs
     }
-    emit_eq_shape_top(buf, lit, lhs, rhs, local_names, next_local, ctx, ld, ce)
+    emit_eq_shape_top(buf, lit, true, lhs, rhs, local_names, next_local, ctx, ld, ce)
   } else if lhs_agg / 64 == 1 || rhs_agg / 64 == 1 {
     // Tracked tuple binding on at least one side; the checker guarantees the
     // other side is the same tuple type, so its arity matches. #672: when the
@@ -755,7 +788,7 @@ fn emit_eq_value(buf: Bytes, lhs: Expr, rhs: Expr, local_names: Array[String], n
       agg_expr_of_ident(ctx.agg_local_slots, ctx.agg_local_exprs, rhs, local_names)
     }
     if is_etuple(tshape) {
-      emit_eq_shape_top(buf, tshape, lhs, rhs, local_names, next_local, ctx, ld, ce)
+      emit_eq_shape_top(buf, tshape, false, lhs, rhs, local_names, next_local, ctx, ld, ce)
     } else {
       let tn = if lhs_agg / 64 == 1 {
         lhs_agg % 64
@@ -772,7 +805,7 @@ fn emit_eq_value(buf: Bytes, lhs: Expr, rhs: Expr, local_names: Array[String], n
     } else {
       rhs
     }
-    emit_eq_shape_top(buf, clit, lhs, rhs, local_names, next_local, ctx, ld, ce)
+    emit_eq_shape_top(buf, clit, true, lhs, rhs, local_names, next_local, ctx, ld, ce)
   } else if lhs_agg / 64 == 2 || rhs_agg / 64 == 2 {
     // Tracked ctor/record binding: values carry [tag@0][argc@4][fields@8+],
     // so the tag-comparing structural walk applies. #672: recurse through the
@@ -789,7 +822,7 @@ fn emit_eq_value(buf: Bytes, lhs: Expr, rhs: Expr, local_names: Array[String], n
       agg_expr_of_ident(ctx.agg_local_slots, ctx.agg_local_exprs, rhs, local_names)
     }
     if is_agg_shape(cshape, ctx.ctor_table) {
-      emit_eq_shape_top(buf, cshape, lhs, rhs, local_names, next_local, ctx, ld, ce)
+      emit_eq_shape_top(buf, cshape, false, lhs, rhs, local_names, next_local, ctx, ld, ce)
     } else {
       let lfc = if lhs_agg / 64 == 2 {
         lhs_agg % 64

--- a/lib/@vibe/compiler/codegen/expr/compile_expr.vibe
+++ b/lib/@vibe/compiler/codegen/expr/compile_expr.vibe
@@ -577,6 +577,24 @@ fn emit_eq_shape_slots(buf: Bytes, shape: Expr, asl: Int, bsl: Int, local_names:
         emit_local_set(buf, nb)
         nl = emit_eq_shape_slots(buf, el_shape, na, nb, local_names, nl + 2, ctx, ld, ce)
         emit_i64_and(buf)
+      } else if expr_is_intish(el, local_names, ctx) {
+        // #2457: a leaf whose literal payload EXPRESSION is provably an
+        // Int / Bool word (`64 << 32`, a `let`-bound int slot) compares with a
+        // plain `i64.eq`. The generic `eq` builtin's string fall-back reads a
+        // word with a zero low half as a zero-length string when the high
+        // half is a plausible pointer, so `Some(64 << 32) == Some(65 << 32)`
+        // and `(big, 1) == (other, 1)` answered `true`. Same test the
+        // top-level `==` arm applies (expr_is_intish); a leaf it cannot
+        // classify keeps the generic compare below.
+        emit_local_get(buf, ap)
+        emit_i32_wrap_i64(buf)
+        emit_i64_load(buf, 3, field_off + i * 8)
+        emit_local_get(buf, bp)
+        emit_i32_wrap_i64(buf)
+        emit_i64_load(buf, 3, field_off + i * 8)
+        emit_i64_eq(buf)
+        emit_i64_extend_i32_s(buf)
+        emit_i64_and(buf)
       } else {
         emit_local_get(buf, ap)
         emit_i32_wrap_i64(buf)
@@ -633,6 +651,24 @@ fn emit_eq_shape_slots(buf: Bytes, shape: Expr, asl: Int, bsl: Int, local_names:
         emit_i64_load(buf, 3, 8 + i * 8)
         emit_local_set(buf, nb)
         nl = emit_eq_shape_slots(buf, el_shape, na, nb, local_names, nl + 2, ctx, ld, ce)
+        emit_i64_and(buf)
+      } else if expr_is_intish(el, local_names, ctx) {
+        // #2457: a leaf whose literal payload EXPRESSION is provably an
+        // Int / Bool word (`64 << 32`, a `let`-bound int slot) compares with a
+        // plain `i64.eq`. The generic `eq` builtin's string fall-back reads a
+        // word with a zero low half as a zero-length string when the high
+        // half is a plausible pointer, so `Some(64 << 32) == Some(65 << 32)`
+        // and `(big, 1) == (other, 1)` answered `true`. Same test the
+        // top-level `==` arm applies (expr_is_intish); a leaf it cannot
+        // classify keeps the generic compare below.
+        emit_local_get(buf, ap)
+        emit_i32_wrap_i64(buf)
+        emit_i64_load(buf, 3, 8 + i * 8)
+        emit_local_get(buf, bp)
+        emit_i32_wrap_i64(buf)
+        emit_i64_load(buf, 3, 8 + i * 8)
+        emit_i64_eq(buf)
+        emit_i64_extend_i32_s(buf)
         emit_i64_and(buf)
       } else {
         emit_local_get(buf, ap)

--- a/lib/@vibe/compiler/codegen/gc/backend_expr.vibe
+++ b/lib/@vibe/compiler/codegen/gc/backend_expr.vibe
@@ -546,7 +546,13 @@ fn gc_is_ctor_expr(e: Expr, ctx: CompileCtxGc) -> Bool {
 /// Structural equality for two tuples (gc layout: raw even ptr, element i at
 /// ptr+i*8, no header). Ported from the linear emit_tuple_struct_eq; leaves a
 /// raw i64 0/1. `cefn` is compile_expr_gc, threaded to avoid a forward ref.
-fn emit_gc_tuple_struct_eq(buf: Bytes, lhs: Expr, rhs: Expr, num: Int, local_names: Array[String], next_local: Int, ctx: CompileCtxGc, ld: Int, cefn: (Bytes, Expr, Array[String], Int, CompileCtxGc, Int) -> Int with Exception) -> Int with Exception {
+/// `field_exprs` (#2457): the literal operand's element expressions when a
+/// literal is in scope (empty otherwise). An element that is provably an Int
+/// / Bool word by SHAPE (`gc_expr_is_intish`) compares with a plain `i64.eq`
+/// instead of the generic `eq`, whose string fall-back equated
+/// `(64 << 32, 1)` and `(65 << 32, 1)`; a leaf the shape test cannot classify
+/// keeps the generic compare.
+fn emit_gc_tuple_struct_eq(buf: Bytes, lhs: Expr, rhs: Expr, num: Int, field_exprs: Array[Expr], local_names: Array[String], next_local: Int, ctx: CompileCtxGc, ld: Int, cefn: (Bytes, Expr, Array[String], Int, CompileCtxGc, Int) -> Int with Exception) -> Int with Exception {
   let aptr = next_local
   Array::push(local_names, "[gc-temp]__gceqa")
   let bptr = next_local + 1
@@ -565,7 +571,12 @@ fn emit_gc_tuple_struct_eq(buf: Bytes, lhs: Expr, rhs: Expr, num: Int, local_nam
     emit_local_get(buf, bptr)
     emit_i32_wrap_i64(buf)
     emit_i64_load(buf, 3, i * 8)
-    emit_call(buf, eq_fidx)
+    if i < Array::length(field_exprs) && gc_expr_is_intish(Array::get(field_exprs, i)) {
+      emit_i64_eq(buf)
+      emit_i64_extend_i32_s(buf)
+    } else {
+      emit_call(buf, eq_fidx)
+    }
     emit_i64_and(buf)
     i = i + 1
   }
@@ -577,7 +588,9 @@ fn emit_gc_tuple_struct_eq(buf: Bytes, lhs: Expr, rhs: Expr, num: Int, local_nam
 /// by content there). The generic `eq` builtin compares ctor POINTERS — fresh
 /// allocations are never bit-equal, which made the gc-compiled checker's
 /// `Some(av) == rb` effect-row comparison (unify_effects) always false.
-fn emit_gc_ctor_struct_eq(buf: Bytes, lhs: Expr, rhs: Expr, fc: Int, local_names: Array[String], next_local: Int, ctx: CompileCtxGc, ld: Int, cefn: (Bytes, Expr, Array[String], Int, CompileCtxGc, Int) -> Int with Exception) -> Int with Exception {
+/// `field_exprs` (#2457): as for emit_gc_tuple_struct_eq -- the ctor literal's
+/// argument expressions when one is in scope, empty otherwise.
+fn emit_gc_ctor_struct_eq(buf: Bytes, lhs: Expr, rhs: Expr, fc: Int, field_exprs: Array[Expr], local_names: Array[String], next_local: Int, ctx: CompileCtxGc, ld: Int, cefn: (Bytes, Expr, Array[String], Int, CompileCtxGc, Int) -> Int with Exception) -> Int with Exception {
   let aptr = next_local
   Array::push(local_names, "[gc-temp]__gcceqa")
   let bptr = next_local + 1
@@ -665,7 +678,12 @@ fn emit_gc_ctor_struct_eq(buf: Bytes, lhs: Expr, rhs: Expr, fc: Int, local_names
       emit_local_get(buf, bptr)
       emit_i32_wrap_i64(buf)
       emit_i64_load(buf, 3, 8 + i * 8)
-      emit_call(buf, eq_fidx)
+      if i < Array::length(field_exprs) && gc_expr_is_intish(Array::get(field_exprs, i)) {
+        emit_i64_eq(buf)
+        emit_i64_extend_i32_s(buf)
+      } else {
+        emit_call(buf, eq_fidx)
+      }
       emit_i64_and(buf)
       i = i + 1
     }
@@ -708,25 +726,33 @@ fn emit_gc_eq_value(buf: Bytes, lhs: Expr, rhs: Expr, local_names: Array[String]
         _ => 0
       }
     }
-    emit_gc_tuple_struct_eq(buf, lhs, rhs, num, local_names, next_local, ctx, ld, cefn)
+    let elems = match lhs {
+      ETuple(les) => les,
+      _ => match rhs {
+        ETuple(res) => res,
+        _ => array_empty()
+      }
+    }
+    emit_gc_tuple_struct_eq(buf, lhs, rhs, num, elems, local_names, next_local, ctx, ld, cefn)
   } else if lhs_agg / 64 == 1 || rhs_agg / 64 == 1 {
     let tn = if lhs_agg / 64 == 1 {
       lhs_agg % 64
     } else {
       rhs_agg % 64
     }
-    emit_gc_tuple_struct_eq(buf, lhs, rhs, tn, local_names, next_local, ctx, ld, cefn)
+    emit_gc_tuple_struct_eq(buf, lhs, rhs, tn, array_empty(), local_names, next_local, ctx, ld, cefn)
   } else if gc_is_ctor_expr(lhs, ctx) || gc_is_ctor_expr(rhs, ctx) {
     let clit = if gc_is_ctor_expr(lhs, ctx) {
       lhs
     } else {
       rhs
     }
-    let cfc = match clit {
-      ECall(_, cargs, _) => Array::length(cargs),
-      _ => 0
+    let cargs_lit = match clit {
+      ECall(_, cargs, _) => cargs,
+      _ => array_empty()
     }
-    emit_gc_ctor_struct_eq(buf, lhs, rhs, cfc, local_names, next_local, ctx, ld, cefn)
+    let cfc = Array::length(cargs_lit)
+    emit_gc_ctor_struct_eq(buf, lhs, rhs, cfc, cargs_lit, local_names, next_local, ctx, ld, cefn)
   } else if lhs_agg / 64 == 2 || rhs_agg / 64 == 2 {
     // Tag comparison short-circuits unequal variants before any field read,
     // so walking the larger tracked field count is safe (see the linear
@@ -746,7 +772,7 @@ fn emit_gc_eq_value(buf: Bytes, lhs: Expr, rhs: Expr, local_names: Array[String]
     } else {
       rfc
     }
-    emit_gc_ctor_struct_eq(buf, lhs, rhs, cfc, local_names, next_local, ctx, ld, cefn)
+    emit_gc_ctor_struct_eq(buf, lhs, rhs, cfc, array_empty(), local_names, next_local, ctx, ld, cefn)
   } else if gc_expr_is_floatish(lhs, local_names, ctx) || gc_expr_is_floatish(rhs, local_names, ctx) {
     // #2426: Double equality, which reached no float comparison at all before.
     // Both arms below answer on the RAW BITS -- `gc_expr_is_intish` claims

--- a/lib/@vibe/compiler/normalize/desugar_trait_dict.vibe
+++ b/lib/@vibe/compiler/normalize/desugar_trait_dict.vibe
@@ -10838,7 +10838,19 @@ fn rewrite_expr(expr: Expr, gens: Array[DictGen], traits: Array[(String, Array[(
               // shapes (never user struct/enum names), and unknown positions
               // carry the `__EqUnknown` marker which `eq_for_typed` compares
               // with raw `==` (status quo for that position).
-              let sty = infer_static_eq_type_binop(l, r)
+              // #2457: the checker's row for this site, when the allow-list
+              // admits it, is the COMPLETE operand type and wins over the
+              // literal-syntax shape. `Some(64 << 32) == Some(65 << 32)` used
+              // to infer `Option[__EqUnknown]` (a shift is not a literal this
+              // inference named), and the unknown payload position compared
+              // with the raw `==` -- the generic `eq`, whose string fall-back
+              // equated the two words. With the row, `Option[Int]` compares
+              // the payload exactly; a lane with no rows keeps the syntactic
+              // shape, whose leaf inference now names such an expression too.
+              let sty = match dtd_typed_eq_admitted_ty(boff) {
+                Some(te) => Some(te),
+                None => infer_static_eq_type_binop(l, r)
+              }
               let dty = match sty {
                 Some(t) => if static_eq_dispatchable(t) {
                   Some(t)
@@ -10849,7 +10861,7 @@ fn rewrite_expr(expr: Expr, gens: Array[DictGen], traits: Array[(String, Array[(
               }
               match dty {
                 Some(dt) => {
-                  let call = eq_for_typed(dt, rl, rr, empty_str_array())
+                  let call = eq_for_typed(dt, rl, rr, dtd_eq_known_types)
                   if op == "==" {
                     call
                   } else {
@@ -10898,14 +10910,29 @@ fn rewrite_expr(expr: Expr, gens: Array[DictGen], traits: Array[(String, Array[(
                         // compare with `==` — correct for scalar payloads (the common
                         // case); an aggregate-payload bare-Option variable is a #695
                         // residual (route it through a struct field for full recursion).
-                        let eqm = opt_eq_match(rl, rr)
+                        // #2457: the structural match compares each payload
+                        // with a raw `==`, which codegen cannot classify (a
+                        // match binder), so an `Int` payload went through the
+                        // generic `eq` and `mk(64 << 32) == mk(65 << 32)`
+                        // answered `true`. When the checker's row for this
+                        // site names an admitted type (`Option[Int]`), the
+                        // typed comparator compares that payload exactly;
+                        // with no row, or a type the allow-list refuses, the
+                        // match stays as it was.
+                        let eqm = match dtd_typed_eq_admitted_ty(boff) {
+                          Some(te) => eq_for_typed(te, rl, rr, dtd_eq_known_types),
+                          None => opt_eq_match(rl, rr)
+                        }
                         if op == "==" {
                           eqm
                         } else {
                           ECall(EIdent("not", -1), [eqm], -1)
                         }
                       } else if t == "Result" {
-                        let eqm = result_eq_match(rl, rr)
+                        let eqm = match dtd_typed_eq_admitted_ty(boff) {
+                          Some(te) => eq_for_typed(te, rl, rr, dtd_eq_known_types),
+                          None => result_eq_match(rl, rr)
+                        }
                         if op == "==" {
                           eqm
                         } else {
@@ -14804,6 +14831,41 @@ fn infer_static_eq_type(e: Expr) -> Option[TypeExpr] {
     EString(_) => Some(TyName("String")),
     EFloat(_) => Some(TyName("Double")),
     EUnit => Some(TyUnit),
+    // #2457: an operator expression whose result is an Int / Bool word by
+    // construction. A shift or bitwise operator admits only Int operands; a
+    // comparison or logical operator yields Bool; `~` is Int (#2344) and `!`
+    // is Bool. Arithmetic is named Int only when BOTH operands are named Int
+    // here -- `1.5 + x` must not become an Int leaf (a Double compares
+    // through `Double::to_float`, never a word compare). Anything else stays
+    // unnamed, exactly as before: an unknown leaf keeps the raw compare, a
+    // guessed one would be the worse bug.
+    EBinOp(bop, bl, br, _) => if bop == "<<" || bop == ">>" || bop == "&" || bop == "|" || bop == "^" || bop == "%" {
+      Some(TyName("Int"))
+    } else if bop == "<" || bop == ">" || bop == "<=" || bop == ">=" || bop == "==" || bop == "!=" || bop == "&&" || bop == "||" {
+      Some(TyName("Bool"))
+    } else if bop == "+" || bop == "-" || bop == "*" || bop == "/" {
+      let both_int = match infer_static_eq_type(bl) {
+        Some(TyName(ln)) => ln == "Int" && (match infer_static_eq_type(br) {
+          Some(TyName(rn)) => rn == "Int",
+          _ => false
+        }),
+        _ => false
+      }
+      if both_int {
+        Some(TyName("Int"))
+      } else {
+        None
+      }
+    } else {
+      None
+    },
+    EUnaryOp(uop, _) => if uop == "~" {
+      Some(TyName("Int"))
+    } else if uop == "!" {
+      Some(TyName("Bool"))
+    } else {
+      None
+    },
     ERecord(name, fields, targs) => if generic_eq_struct_declared(name) && Array::length(targs) > 0 {
       Some(TyApp(name, targs))
     } else if generic_eq_struct_declared(name) {

--- a/lib/@vibe/compiler/normalize/desugar_trait_dict.vibe
+++ b/lib/@vibe/compiler/normalize/desugar_trait_dict.vibe
@@ -10815,7 +10815,10 @@ fn rewrite_expr(expr: Expr, gens: Array[DictGen], traits: Array[(String, Array[(
           }
         } else {
           match arr_elem {
-            Some(elem) => {
+            Some(elem) => if ty_mentions_owned_scalar(elem) {
+              // Codex round 4 on #2471: see ty_mentions_owned_scalar.
+              eq_fail_closed(op)
+            } else {
               // #1526: record before emitting -- this is one of the two sites
               // that can reference a `__arr_equals__<key>` helper, and the
               // recorded set is what generates them (see arr_eq_needed_record).
@@ -10834,10 +10837,11 @@ fn rewrite_expr(expr: Expr, gens: Array[DictGen], traits: Array[(String, Array[(
               // elements), route through the fully-recursive `eq_for_typed` so
               // aggregate payloads (`Some([1,2])`, `Ok([1,2])`, `Some(Some(1))`,
               // `([1,2], 0)`) compare structurally instead of by word identity.
-              // `known_types` is empty: this inference only ever yields builtin
-              // shapes (never user struct/enum names), and unknown positions
-              // carry the `?EqUnknown` marker which `eq_for_typed` compares
-              // with raw `==` (status quo for that position).
+              // This inference yields builtin shapes and generic struct
+              // literals; unknown positions carry the `?EqUnknown` marker,
+              // which `eq_for_typed` compares with raw `==` (status quo for
+              // that position). A scalar spelling the source also declares is
+              // ambiguous here and fails closed (ty_mentions_owned_scalar).
               // #2457: the checker's row for this site, when the allow-list
               // admits it, is the COMPLETE operand type and wins over the
               // literal-syntax shape. `Some(64 << 32) == Some(65 << 32)` used
@@ -10860,7 +10864,10 @@ fn rewrite_expr(expr: Expr, gens: Array[DictGen], traits: Array[(String, Array[(
                 None => None
               }
               match dty {
-                Some(dt) => {
+                Some(dt) => if ty_mentions_owned_scalar(dt) {
+                  // Codex round 4 on #2471: see ty_mentions_owned_scalar.
+                  eq_fail_closed(op)
+                } else {
                   let call = eq_for_typed(dt, rl, rr, dtd_eq_known_types)
                   if op == "==" {
                     call
@@ -10919,8 +10926,15 @@ fn rewrite_expr(expr: Expr, gens: Array[DictGen], traits: Array[(String, Array[(
                         // typed comparator compares that payload exactly;
                         // with no row, or a type the allow-list refuses, the
                         // match stays as it was.
+                        // Codex round 4 on #2471: a row spelling a scalar the
+                        // source also declares is ambiguous (see
+                        // ty_mentions_owned_scalar) and fails closed.
                         let eqm = match dtd_typed_eq_admitted_ty(boff) {
-                          Some(te) => eq_for_typed(te, rl, rr, dtd_eq_known_types),
+                          Some(te) => if ty_mentions_owned_scalar(te) {
+                            eq_fail_closed("==")
+                          } else {
+                            eq_for_typed(te, rl, rr, dtd_eq_known_types)
+                          },
                           None => opt_eq_match(rl, rr)
                         }
                         if op == "==" {
@@ -10930,7 +10944,11 @@ fn rewrite_expr(expr: Expr, gens: Array[DictGen], traits: Array[(String, Array[(
                         }
                       } else if t == "Result" {
                         let eqm = match dtd_typed_eq_admitted_ty(boff) {
-                          Some(te) => eq_for_typed(te, rl, rr, dtd_eq_known_types),
+                          Some(te) => if ty_mentions_owned_scalar(te) {
+                            eq_fail_closed("==")
+                          } else {
+                            eq_for_typed(te, rl, rr, dtd_eq_known_types)
+                          },
                           None => result_eq_match(rl, rr)
                         }
                         if op == "==" {
@@ -11688,6 +11706,62 @@ fn gen_show_fn(tname: String, fields: Array[(String, TypeExpr)], known_types: Ar
 /// through its generated `T::equals`.
 fn is_scalar_type_name(n: String) -> Bool {
   n == "Int" || n == "Double" || n == "Float" || n == "Bool" || n == "String" || n == "Char" || n == "Unit" || n == "Bytes"
+}
+
+/// Codex round 4 on #2471: a program may declare a struct whose spelling is a
+/// scalar's (`struct Int { value: String }`, #2456 round 17). A shape that
+/// reaches the static-shape rung or the array-literal rung then cannot say
+/// which `Int` it means -- the checker's row spells a literal's builtin `Int`
+/// and the declared struct the same way, and the syntactic inference names a
+/// literal `Int` too. Dispatching such a position through the declared
+/// comparator read two Int words as struct pointers (measured on the FS
+/// lane: `Some(1) == Some(2)` and `(1, "a") == (2, "a")` answered `true`,
+/// `[1] == [2]` answered `true` on main as well); the builtin arm would
+/// misjudge a struct payload the same way. Those rungs fail closed instead.
+/// A program that owns no scalar spelling never sees this test succeed.
+fn ty_mentions_owned_scalar(t: TypeExpr) -> Bool {
+  match t {
+    TyName(n) => is_scalar_type_name(n) && str_array_contains(dtd_eq_type_owners, n),
+    TyApp(h, args) => if is_scalar_type_name(h) && str_array_contains(dtd_eq_type_owners, h) {
+      true
+    } else {
+      let mut hit = false
+      let mut i = 0
+      while i < Array::length(args) {
+        if ty_mentions_owned_scalar(Array::get(args, i)) {
+          hit = true
+        } else {
+          ()
+        }
+        i = i + 1
+      }
+      hit
+    },
+    TyTuple(ts) => {
+      let mut hit = false
+      let mut i = 0
+      while i < Array::length(ts) {
+        if ty_mentions_owned_scalar(Array::get(ts, i)) {
+          hit = true
+        } else {
+          ()
+        }
+        i = i + 1
+      }
+      hit
+    },
+    _ => false
+  }
+}
+
+/// The fail-closed `==` result: trap, never a guessed answer.
+fn eq_fail_closed(op: String) -> Expr {
+  let trapped = ESeq(ECall(EIdent("assert_true", -1), [EBool(false)], -1), EBool(false))
+  if op == "==" {
+    trapped
+  } else {
+    ECall(EIdent("not", -1), [trapped], -1)
+  }
 }
 
 /// A stable, fn-name-safe key for a TypeExpr, used to name the monomorphic array

--- a/lib/@vibe/compiler/normalize/desugar_trait_dict.vibe
+++ b/lib/@vibe/compiler/normalize/desugar_trait_dict.vibe
@@ -256,22 +256,6 @@ fn empty_expr_array() -> Array[Expr] {
   array_empty()
 }
 
-/// `xs` minus every occurrence of `x`; a fresh array, `xs` untouched.
-fn str_array_without(xs: Array[String], x: String) -> Array[String] {
-  let out = empty_str_array()
-  let mut i = 0
-  while i < Array::length(xs) {
-    let s = Array::get(xs, i)
-    if s != x {
-      Array::push(out, s)
-    } else {
-      ()
-    }
-    i = i + 1
-  }
-  out
-}
-
 fn empty_str_array() -> Array[String] {
   array_empty()
 }
@@ -6239,7 +6223,7 @@ fn pushed_empty_elem_shape(name: String, body: Expr, struct_sets: Array[(String,
 /// A declared name is admitted because `desugar_derives` generates a `::equals`
 /// for EVERY declared struct/enum, not only `derive(Eq)` ones -- which is the
 /// same fact `dtd_eq_known_types` records for the shape dispatch below.
-/// `Option` / `Result` shapes are left out: their `__EqUnknown` positions would
+/// `Option` / `Result` shapes are left out: their `?EqUnknown` positions would
 /// re-introduce exactly that raw `==`.
 fn adoptable_pushed_elem_shape(sh: String) -> Bool {
   if shape_is_composite(sh) {
@@ -10852,37 +10836,20 @@ fn rewrite_expr(expr: Expr, gens: Array[DictGen], traits: Array[(String, Array[(
               // `([1,2], 0)`) compare structurally instead of by word identity.
               // `known_types` is empty: this inference only ever yields builtin
               // shapes (never user struct/enum names), and unknown positions
-              // carry the `__EqUnknown` marker which `eq_for_typed` compares
+              // carry the `?EqUnknown` marker which `eq_for_typed` compares
               // with raw `==` (status quo for that position).
               // #2457: the checker's row for this site, when the allow-list
               // admits it, is the COMPLETE operand type and wins over the
               // literal-syntax shape. `Some(64 << 32) == Some(65 << 32)` used
-              // to infer `Option[__EqUnknown]` (a shift is not a literal this
+              // to infer `Option[?EqUnknown]` (a shift is not a literal this
               // inference named), and the unknown payload position compared
               // with the raw `==` -- the generic `eq`, whose string fall-back
               // equated the two words. With the row, `Option[Int]` compares
               // the payload exactly; a lane with no rows keeps the syntactic
               // shape, whose leaf inference now names such an expression too.
-              // Codex round 2 on #2471: the syntactic shape carries the
-              // `__EqUnknown` marker in every position the literal inference
-              // cannot name, and a program may legally declare
-              // `struct __EqUnknown`; with that name among the declared ones
-              // such a position dispatched to `__EqUnknown::equals` over
-              // whatever word sits there (measured: the FS lane called it on
-              // two Int words, the flat lane failed to compile). The shape's
-              // name set therefore omits the marker, and only the marker --
-              // every other declared name still reaches its comparator, as
-              // before #2457. A ROW never contains the marker, so it keeps
-              // the full set. The copy is made only when there is something
-              // to remove: a copy per site cost 5.2 MB of selfcompile heap
-              // (measured, 1,615,494,632 -> 1,620,653,296 bytes).
-              let (sty, shape_known) = match dtd_typed_eq_admitted_ty(boff) {
-                Some(te) => (Some(te), dtd_eq_known_types),
-                None => (infer_static_eq_type_binop(l, r), if str_array_contains(dtd_eq_known_types, "__EqUnknown") {
-                  str_array_without(dtd_eq_known_types, "__EqUnknown")
-                } else {
-                  dtd_eq_known_types
-                })
+              let sty = match dtd_typed_eq_admitted_ty(boff) {
+                Some(te) => Some(te),
+                None => infer_static_eq_type_binop(l, r)
               }
               let dty = match sty {
                 Some(t) => if static_eq_dispatchable(t) {
@@ -10894,7 +10861,7 @@ fn rewrite_expr(expr: Expr, gens: Array[DictGen], traits: Array[(String, Array[(
               }
               match dty {
                 Some(dt) => {
-                  let call = eq_for_typed(dt, rl, rr, shape_known)
+                  let call = eq_for_typed(dt, rl, rr, dtd_eq_known_types)
                   if op == "==" {
                     call
                   } else {
@@ -13125,20 +13092,6 @@ fn eq_for_typed(fty0: TypeExpr, lhs: Expr, rhs: Expr, known_types: Array[String]
   match fty {
     TyName(n) => if n == "__EqAliasCycle" {
       ESeq(ECall(EIdent("assert_true", -1), Array::slice([EBool(false)], 0, 1), -1), EBool(false))
-    } else if n == "__EqUnknown" && !str_array_contains(known_types, n) {
-      // Codex round 2 on #2471: the syntactic-shape MARKER, not a declared
-      // name -- the #825 rung hands a shape a name set with the marker
-      // removed (`str_array_without`), so a `struct __EqUnknown` a program
-      // declares is absent here exactly when the position is unknown. The
-      // marker keeps the raw `==` it had before #2457; the declared struct,
-      // reached through a checker row, keeps the full set and takes its
-      // comparator below. Measured on the first stage2 of #2471 (FS lane,
-      // a generic `Some(x) == Some(y)`): with the struct declared the
-      // position dispatched to `__EqUnknown::equals` and answered
-      // `same_some(1, 2)` as `true`; with the name merely excluded from
-      // the set, the owner arm below failed closed and trapped a legal
-      // program (main trapped the same way).
-      EBinOp("==", lhs, rhs, -1)
     } else if str_array_contains(dtd_eq_type_owners, n) && str_array_contains(known_types, n) {
       // Codex round 17 on #2456: a source-owned spelling takes its declared
       // comparator BEFORE any builtin arm below can claim it. Measured: with
@@ -14448,7 +14401,7 @@ fn ty_to_eq_shape_expanded(t: TypeExpr) -> String {
 
 /// A constructor argument inside `{g:Head,...}`. Bare `Array`/`Map`/`Tuple`
 /// here are type constructors (`KBox[Array, Int]`), not complete values, so
-/// they must round-trip as `TyName` rather than the `__EqUnknown` marker
+/// they must round-trip as `TyName` rather than the `?EqUnknown` marker
 /// `shape_to_eq_ty` uses for an element-free array binding.
 fn shape_to_eq_ctor_arg(sh: String) -> TypeExpr {
   if sh == "Array" || sh == "Map" || sh == "Tuple" {
@@ -14459,14 +14412,14 @@ fn shape_to_eq_ctor_arg(sh: String) -> TypeExpr {
 }
 
 /// A shape string back into the TypeExpr `eq_for_typed` dispatches on. An
-/// unknown position becomes the `__EqUnknown` marker (raw `==`, the status
+/// unknown position becomes the `?EqUnknown` marker (raw `==`, the status
 /// quo for that position). A bare "Option"/"Result" head keeps its
 /// structural match with unknown payloads — the same upgrade the bare-`==`
 /// name path applies via `opt_eq_match` — while a bare "Array"/"Tuple"/"Map"
 /// head carries nothing to dispatch on and stays unknown.
 fn shape_to_eq_ty(sh: String) -> TypeExpr {
   if String::length(sh) == 0 {
-    TyName("__EqUnknown")
+    TyName("?EqUnknown")
   } else if sh == "{u}" {
     TyUnit
   } else if String::starts_with(sh, "(") {
@@ -14492,7 +14445,7 @@ fn shape_to_eq_ty(sh: String) -> TypeExpr {
         shape_to_eq_ty(Array::get(parts, 1))
       ], 0, 2))
     } else {
-      TyName("__EqUnknown")
+      TyName("?EqUnknown")
     }
   } else if String::starts_with(sh, "{r:") {
     let parts = shape_split(String::substring(sh, 3, String::length(sh) - 1))
@@ -14502,7 +14455,7 @@ fn shape_to_eq_ty(sh: String) -> TypeExpr {
         shape_to_eq_ty(Array::get(parts, 1))
       ], 0, 2))
     } else {
-      TyName("__EqUnknown")
+      TyName("?EqUnknown")
     }
   } else if String::starts_with(sh, "{g:") {
     let parts = shape_split(String::substring(sh, 3, String::length(sh) - 1))
@@ -14515,14 +14468,14 @@ fn shape_to_eq_ty(sh: String) -> TypeExpr {
       }
       TyApp(Array::get(parts, 0), args)
     } else {
-      TyName("__EqUnknown")
+      TyName("?EqUnknown")
     }
   } else if sh == "Option" {
-    TyApp("Option", Array::slice([TyName("__EqUnknown")], 0, 1))
+    TyApp("Option", Array::slice([TyName("?EqUnknown")], 0, 1))
   } else if sh == "Result" {
-    TyApp("Result", Array::slice([TyName("__EqUnknown"), TyName("__EqUnknown")], 0, 2))
+    TyApp("Result", Array::slice([TyName("?EqUnknown"), TyName("?EqUnknown")], 0, 2))
   } else if sh == "Array" || sh == "Tuple" || sh == "Map" {
-    TyName("__EqUnknown")
+    TyName("?EqUnknown")
   } else {
     TyName(sh)
   }
@@ -14601,7 +14554,7 @@ fn infer_eq_shape(e: Expr, struct_sets: Array[(String, Array[String])], var_type
     // #2431: a tuple LITERAL keeps its element types here. Without this arm it
     // fell to the `_` arm, whose `infer_shape` has no scalar cases at all --
     // every element came back "" and `let x = (0.0, 1)` recorded the shape
-    // `(,)`. That reads back as `(__EqUnknown, __EqUnknown)`, which
+    // `(,)`. That reads back as `(?EqUnknown, ?EqUnknown)`, which
     // `eq_operand_shape_ty` refuses, so the comparison dropped to the codegen
     // walk and compared each field with the generic `eq` builtin: raw bits on
     // bump and gc (so `0.0 == -0.0` was false and `nan == nan` true), and box
@@ -14613,7 +14566,7 @@ fn infer_eq_shape(e: Expr, struct_sets: Array[(String, Array[String])], var_type
     // The elements recurse through this same function, so a nested tuple, an
     // array element, a constructor payload and a scalar literal all resolve
     // exactly as they do at the top level. An element this classifier cannot
-    // name stays "" and becomes `__EqUnknown`, which keeps the whole shape out
+    // name stays "" and becomes `?EqUnknown`, which keeps the whole shape out
     // of the typed dispatch -- today's behaviour for that tuple, never a
     // guessed leaf type. Guessing one would be worse than the bug: a leaf
     // wrongly called Double routes an Int field through `Double::to_float`.
@@ -14671,9 +14624,9 @@ fn infer_eq_shape(e: Expr, struct_sets: Array[(String, Array[String])], var_type
     ECall(EIdent(fname, _), args, _) => if (fname == "Some" || fname == "Option::Some") && Array::length(args) == 1 {
       String::concat("{o:", String::concat(infer_eq_shape(Array::get(args, 0), struct_sets, var_types, fn_returns), "}"))
     } else if (fname == "Ok" || fname == "Result::Ok") && Array::length(args) == 1 {
-      String::concat("{r:", String::concat(infer_eq_shape(Array::get(args, 0), struct_sets, var_types, fn_returns), ",__EqUnknown}"))
+      String::concat("{r:", String::concat(infer_eq_shape(Array::get(args, 0), struct_sets, var_types, fn_returns), ",?EqUnknown}"))
     } else if (fname == "Err" || fname == "Result::Err") && Array::length(args) == 1 {
-      String::concat("{r:__EqUnknown,", String::concat(infer_eq_shape(Array::get(args, 0), struct_sets, var_types, fn_returns), "}"))
+      String::concat("{r:?EqUnknown,", String::concat(infer_eq_shape(Array::get(args, 0), struct_sets, var_types, fn_returns), "}"))
     } else {
       let local_shape = lookup_var_type(var_types, eq_shape_key(fname))
       match local_shape {
@@ -14714,7 +14667,7 @@ fn eq_operand_shape_ty(e: Expr, struct_sets: Array[(String, Array[String])], var
     let t = shape_to_eq_ty(sh)
     // A partial operand must not win merely because its container head is
     // dispatchable. In particular `{m:String,}` becomes
-    // `Map[String, __EqUnknown]`; accepting it here hides a complete shape on
+    // `Map[String, ?EqUnknown]`; accepting it here hides a complete shape on
     // the other operand and makes aggregate values fall back to identity.
     if ty_needs_typed_eq(t) && !ty_contains_eq_unknown(t) {
       Some(t)
@@ -14778,12 +14731,21 @@ fn infer_earray_elem_type(arr: Expr) -> Option[TypeExpr] {
   }
 }
 
-/// #825: does `t` contain the `__EqUnknown` marker anywhere? Used to keep the
+/// The unknown-position marker. Its spelling starts with `?`, which cannot
+/// begin an identifier, so no source declaration can produce the same
+/// `TyName` (Codex rounds 2-3 on #2471: spelled `__EqUnknown` it collided
+/// with a legal `struct __EqUnknown`, and every position the literal
+/// inference could not name dispatched to that struct's comparator over
+/// whatever word sat there). It never reaches generated source --
+/// `derive_array_helper_tparams_test.vibe` pins that -- and a leak would now
+/// fail to parse rather than name a user type.
+///
+/// #825: does `t` contain the `?EqUnknown` marker anywhere? Used to keep the
 /// marker out of generated `__arr_equals__<key>` helper names/annotations (an
 /// Array element type must be fully concrete to be usable).
 fn ty_contains_eq_unknown(t: TypeExpr) -> Bool {
   match t {
-    TyName(n) => n == "__EqUnknown",
+    TyName(n) => n == "?EqUnknown",
     TyApp(_, args) => {
       let mut i = 0
       let mut found = false
@@ -14865,7 +14827,7 @@ fn infer_generic_record_static(name: String, fields: Array[(String, Expr)], i: I
 /// `Some(Some(1)) == Some(Some(1))` / `([1,2], 0) == ([1,2], 0)` route through
 /// the fully-recursive `eq_for_typed` instead of identity-comparing aggregate
 /// payloads. A position whose type is not statically obvious yields the marker
-/// `TyName("__EqUnknown")` — never a scalar or declared type, so `eq_for_typed`
+/// `TyName("?EqUnknown")` — never a scalar or declared type, so `eq_for_typed`
 /// falls back to raw `==` there (exactly the status-quo behavior for that
 /// position). An Array element type must be marker-free (else the whole array
 /// is uninferable): the element type names the generated `__arr_equals__<key>`
@@ -14938,14 +14900,14 @@ fn infer_static_eq_type(e: Expr) -> Option[TypeExpr] {
       while i < Array::length(es) {
         match infer_static_eq_type(Array::get(es, i)) {
           Some(t) => Array::push(ts, t),
-          None => Array::push(ts, TyName("__EqUnknown"))
+          None => Array::push(ts, TyName("?EqUnknown"))
         }
         i = i + 1
       }
       Some(TyTuple(ts))
     },
     EIdent(n, _) => if n == "None" {
-      Some(TyApp("Option", Array::slice([TyName("__EqUnknown")], 0, 1)))
+      Some(TyApp("Option", Array::slice([TyName("?EqUnknown")], 0, 1)))
     } else {
       None
     },
@@ -14957,7 +14919,7 @@ fn infer_static_eq_type(e: Expr) -> Option[TypeExpr] {
       EIdent("Option::Some", _) => if Array::length(args) == 1 {
         let pt = match infer_static_eq_type(Array::get(args, 0)) {
           Some(t) => t,
-          None => TyName("__EqUnknown")
+          None => TyName("?EqUnknown")
         }
         Some(TyApp("Option", Array::slice([pt], 0, 1)))
       } else {
@@ -14966,25 +14928,25 @@ fn infer_static_eq_type(e: Expr) -> Option[TypeExpr] {
       EIdent("Result::Ok", _) => if Array::length(args) == 1 {
         let pt = match infer_static_eq_type(Array::get(args, 0)) {
           Some(t) => t,
-          None => TyName("__EqUnknown")
+          None => TyName("?EqUnknown")
         }
-        Some(TyApp("Result", Array::slice([pt, TyName("__EqUnknown")], 0, 2)))
+        Some(TyApp("Result", Array::slice([pt, TyName("?EqUnknown")], 0, 2)))
       } else {
         None
       },
       EIdent("Result::Err", _) => if Array::length(args) == 1 {
         let pt = match infer_static_eq_type(Array::get(args, 0)) {
           Some(t) => t,
-          None => TyName("__EqUnknown")
+          None => TyName("?EqUnknown")
         }
-        Some(TyApp("Result", Array::slice([TyName("__EqUnknown"), pt], 0, 2)))
+        Some(TyApp("Result", Array::slice([TyName("?EqUnknown"), pt], 0, 2)))
       } else {
         None
       },
       EIdent("Some", _) => if Array::length(args) == 1 {
         let pt = match infer_static_eq_type(Array::get(args, 0)) {
           Some(t) => t,
-          None => TyName("__EqUnknown")
+          None => TyName("?EqUnknown")
         }
         Some(TyApp("Option", Array::slice([pt], 0, 1)))
       } else {
@@ -14993,18 +14955,18 @@ fn infer_static_eq_type(e: Expr) -> Option[TypeExpr] {
       EIdent("Ok", _) => if Array::length(args) == 1 {
         let pt = match infer_static_eq_type(Array::get(args, 0)) {
           Some(t) => t,
-          None => TyName("__EqUnknown")
+          None => TyName("?EqUnknown")
         }
-        Some(TyApp("Result", Array::slice([pt, TyName("__EqUnknown")], 0, 2)))
+        Some(TyApp("Result", Array::slice([pt, TyName("?EqUnknown")], 0, 2)))
       } else {
         None
       },
       EIdent("Err", _) => if Array::length(args) == 1 {
         let pt = match infer_static_eq_type(Array::get(args, 0)) {
           Some(t) => t,
-          None => TyName("__EqUnknown")
+          None => TyName("?EqUnknown")
         }
-        Some(TyApp("Result", Array::slice([TyName("__EqUnknown"), pt], 0, 2)))
+        Some(TyApp("Result", Array::slice([TyName("?EqUnknown"), pt], 0, 2)))
       } else {
         None
       },
@@ -15017,7 +14979,7 @@ fn infer_static_eq_type(e: Expr) -> Option[TypeExpr] {
 /// #825 review follow-up: pick the static shape for `l == r` from whichever
 /// side is MORE concrete. A left-first choice masked a fully concrete right
 /// shape — `let xs = [1, 2]; Some(xs) == Some([1, 2])` inferred the left as
-/// `Option[__EqUnknown]` and the payload fell back to raw word `==`. Prefer a
+/// `Option[?EqUnknown]` and the payload fell back to raw word `==`. Prefer a
 /// marker-free shape; between two partial shapes keep the left one.
 fn infer_static_eq_type_binop(l: Expr, r: Expr) -> Option[TypeExpr] {
   let lt = infer_static_eq_type(l)
@@ -19909,7 +19871,7 @@ fn dtd_typed_eq_residual(op: String, rl: Expr, rr: Expr, boff: Int) -> Expr {
 /// itself (`eq_ty_field_is_content_comparable`, the one `dtd_eq_unsafe_types`
 /// is built from) rather than the push scan's `adoptable_pushed_elem_shape`:
 /// the scan leaves `Option` / `Result` out because a SHAPE string carries
-/// `__EqUnknown` positions, while a checker-typed TypeExpr has none, and
+/// `?EqUnknown` positions, while a checker-typed TypeExpr has none, and
 /// `eq_for_typed` has a structural arm for every head the field test admits
 /// (Codex P2 on #2456 -- `Array[Option[Int]]` filled through a function
 /// trapped under the scan's test although the documented allow-list admits

--- a/lib/@vibe/compiler/normalize/desugar_trait_dict.vibe
+++ b/lib/@vibe/compiler/normalize/desugar_trait_dict.vibe
@@ -256,6 +256,22 @@ fn empty_expr_array() -> Array[Expr] {
   array_empty()
 }
 
+/// `xs` minus every occurrence of `x`; a fresh array, `xs` untouched.
+fn str_array_without(xs: Array[String], x: String) -> Array[String] {
+  let out = empty_str_array()
+  let mut i = 0
+  while i < Array::length(xs) {
+    let s = Array::get(xs, i)
+    if s != x {
+      Array::push(out, s)
+    } else {
+      ()
+    }
+    i = i + 1
+  }
+  out
+}
+
 fn empty_str_array() -> Array[String] {
   array_empty()
 }
@@ -10847,9 +10863,26 @@ fn rewrite_expr(expr: Expr, gens: Array[DictGen], traits: Array[(String, Array[(
               // equated the two words. With the row, `Option[Int]` compares
               // the payload exactly; a lane with no rows keeps the syntactic
               // shape, whose leaf inference now names such an expression too.
-              let sty = match dtd_typed_eq_admitted_ty(boff) {
-                Some(te) => Some(te),
-                None => infer_static_eq_type_binop(l, r)
+              // Codex round 2 on #2471: the syntactic shape carries the
+              // `__EqUnknown` marker in every position the literal inference
+              // cannot name, and a program may legally declare
+              // `struct __EqUnknown`; with that name among the declared ones
+              // such a position dispatched to `__EqUnknown::equals` over
+              // whatever word sits there (measured: the FS lane called it on
+              // two Int words, the flat lane failed to compile). The shape's
+              // name set therefore omits the marker, and only the marker --
+              // every other declared name still reaches its comparator, as
+              // before #2457. A ROW never contains the marker, so it keeps
+              // the full set. The copy is made only when there is something
+              // to remove: a copy per site cost 5.2 MB of selfcompile heap
+              // (measured, 1,615,494,632 -> 1,620,653,296 bytes).
+              let (sty, shape_known) = match dtd_typed_eq_admitted_ty(boff) {
+                Some(te) => (Some(te), dtd_eq_known_types),
+                None => (infer_static_eq_type_binop(l, r), if str_array_contains(dtd_eq_known_types, "__EqUnknown") {
+                  str_array_without(dtd_eq_known_types, "__EqUnknown")
+                } else {
+                  dtd_eq_known_types
+                })
               }
               let dty = match sty {
                 Some(t) => if static_eq_dispatchable(t) {
@@ -10861,7 +10894,7 @@ fn rewrite_expr(expr: Expr, gens: Array[DictGen], traits: Array[(String, Array[(
               }
               match dty {
                 Some(dt) => {
-                  let call = eq_for_typed(dt, rl, rr, dtd_eq_known_types)
+                  let call = eq_for_typed(dt, rl, rr, shape_known)
                   if op == "==" {
                     call
                   } else {
@@ -13092,6 +13125,20 @@ fn eq_for_typed(fty0: TypeExpr, lhs: Expr, rhs: Expr, known_types: Array[String]
   match fty {
     TyName(n) => if n == "__EqAliasCycle" {
       ESeq(ECall(EIdent("assert_true", -1), Array::slice([EBool(false)], 0, 1), -1), EBool(false))
+    } else if n == "__EqUnknown" && !str_array_contains(known_types, n) {
+      // Codex round 2 on #2471: the syntactic-shape MARKER, not a declared
+      // name -- the #825 rung hands a shape a name set with the marker
+      // removed (`str_array_without`), so a `struct __EqUnknown` a program
+      // declares is absent here exactly when the position is unknown. The
+      // marker keeps the raw `==` it had before #2457; the declared struct,
+      // reached through a checker row, keeps the full set and takes its
+      // comparator below. Measured on the first stage2 of #2471 (FS lane,
+      // a generic `Some(x) == Some(y)`): with the struct declared the
+      // position dispatched to `__EqUnknown::equals` and answered
+      // `same_some(1, 2)` as `true`; with the name merely excluded from
+      // the set, the owner arm below failed closed and trapped a legal
+      // program (main trapped the same way).
+      EBinOp("==", lhs, rhs, -1)
     } else if str_array_contains(dtd_eq_type_owners, n) && str_array_contains(known_types, n) {
       // Codex round 17 on #2456: a source-owned spelling takes its declared
       // comparator BEFORE any builtin arm below can claim it. Measured: with

--- a/lib/@vibe/compiler/tests/derive_array_helper_tparams_test.vibe
+++ b/lib/@vibe/compiler/tests/derive_array_helper_tparams_test.vibe
@@ -223,7 +223,7 @@ test "kinded constructor Eq specializes Array fields" {
   let src = "struct KBox[F[_], A] { value: F[A] } derive (Eq)\nfn eq_it() -> Bool {\n  let a = KBox[Array, Int]::{ value: [1, 2] }\n  let b = KBox[Array, Int]::{ value: [1, 2] }\n  a == b\n}"
   let equals = generated_helper_sigs(src, "KBox::equals")
   assert(String::contains(equals, "KBox::equals"))
-  assert(!String::contains(equals, "__EqUnknown"))
+  assert(!String::contains(equals, "?EqUnknown"))
   let arrays = generated_helper_sigs(src, "__arr_equals__")
   assert(String::contains(arrays, "__arr_equals__"))
   inspect(desugared_check_message(src), content = "")

--- a/lib/@vibe/compiler/tests/eq_unknown_marker_owner_test.vibe
+++ b/lib/@vibe/compiler/tests/eq_unknown_marker_owner_test.vibe
@@ -1,18 +1,20 @@
 //# Functions
 
-// Codex round 2 on #2471 (#2457): the `==` desugar's syntactic-shape rung
-// writes the marker `__EqUnknown` into every position the literal inference
-// cannot name -- a generic payload `Some(x)` with `x: T`, a tuple element
-// bound to a formal. A program may legally declare `struct __EqUnknown`, and
-// with that name among the declared comparators the marker position
-// dispatched to `__EqUnknown::equals` over whatever word sat there.
+// Codex rounds 2-3 on #2471 (#2457): the `==` desugar's syntactic-shape rung
+// writes an unknown-position marker into every position the literal
+// inference cannot name -- a generic payload `Some(x)` with `x: T`, a tuple
+// element bound to a formal. That marker used to be spelled `__EqUnknown`,
+// which a program may legally declare; with such a struct declared, every
+// unknown position dispatched to `__EqUnknown::equals` over whatever word sat
+// there. Measured on the FS lane (the one `vibe test` takes), where a site
+// inside a generic function has no checker row: the stage2 built from main
+// at 7018aca trapped (`unreachable` in `same_some`); the first stage2 of
+// #2471 answered `same_some(1, 2)` as `true`.
 //
-// Measured on the FS lane (the one `vibe test` takes), where a site inside a
-// generic function has no checker row and so takes the syntactic shape:
-// the stage2 built from main at 7018aca trapped (`unreachable` in
-// `same_some`); the first stage2 of #2471 answered `same_some(1, 2)` as
-// `true`. The shape's name set now omits the marker, and only the marker,
-// so such a position keeps the raw `==` it had before #2457.
+// The marker is now spelled `?EqUnknown`, which no identifier can start with,
+// so a declared `__EqUnknown` is an ordinary struct: it takes its own
+// comparator where a row names it, and the generic sites below answer
+// exactly as they do for any other payload type.
 
 struct __EqUnknown {
   value: Int
@@ -28,17 +30,17 @@ fn same_pair[T](x: T, y: T) -> Bool {
 
 //# Tests
 
-test "#2471 r2: a generic Option payload ignores a declared __EqUnknown" {
+test "#2471 r2-3: a generic Option payload ignores a declared __EqUnknown" {
   inspect(same_some(1, 1), content = "true")
   inspect(same_some(1, 2), content = "false")
 }
 
-test "#2471 r2: a generic tuple element ignores a declared __EqUnknown" {
+test "#2471 r2-3: a generic tuple element ignores a declared __EqUnknown" {
   inspect(same_pair("a", "a"), content = "true")
   inspect(same_pair(1, 2), content = "false")
 }
 
-test "#2471 r2: the declared struct keeps its own comparator" {
+test "#2471 r2-3: the declared struct keeps its own comparator" {
   let a = __EqUnknown::{ value: 1 }
   let b = __EqUnknown::{ value: 1 }
   let c = __EqUnknown::{ value: 2 }

--- a/lib/@vibe/compiler/tests/eq_unknown_marker_owner_test.vibe
+++ b/lib/@vibe/compiler/tests/eq_unknown_marker_owner_test.vibe
@@ -1,0 +1,47 @@
+//# Functions
+
+// Codex round 2 on #2471 (#2457): the `==` desugar's syntactic-shape rung
+// writes the marker `__EqUnknown` into every position the literal inference
+// cannot name -- a generic payload `Some(x)` with `x: T`, a tuple element
+// bound to a formal. A program may legally declare `struct __EqUnknown`, and
+// with that name among the declared comparators the marker position
+// dispatched to `__EqUnknown::equals` over whatever word sat there.
+//
+// Measured on the FS lane (the one `vibe test` takes), where a site inside a
+// generic function has no checker row and so takes the syntactic shape:
+// the stage2 built from main at 7018aca trapped (`unreachable` in
+// `same_some`); the first stage2 of #2471 answered `same_some(1, 2)` as
+// `true`. The shape's name set now omits the marker, and only the marker,
+// so such a position keeps the raw `==` it had before #2457.
+
+struct __EqUnknown {
+  value: Int
+} derive (Eq)
+
+fn same_some[T](x: T, y: T) -> Bool {
+  Some(x) == Some(y)
+}
+
+fn same_pair[T](x: T, y: T) -> Bool {
+  (x, 1) == (y, 1)
+}
+
+//# Tests
+
+test "#2471 r2: a generic Option payload ignores a declared __EqUnknown" {
+  inspect(same_some(1, 1), content = "true")
+  inspect(same_some(1, 2), content = "false")
+}
+
+test "#2471 r2: a generic tuple element ignores a declared __EqUnknown" {
+  inspect(same_pair("a", "a"), content = "true")
+  inspect(same_pair(1, 2), content = "false")
+}
+
+test "#2471 r2: the declared struct keeps its own comparator" {
+  let a = __EqUnknown::{ value: 1 }
+  let b = __EqUnknown::{ value: 1 }
+  let c = __EqUnknown::{ value: 2 }
+  inspect(a == b, content = "true")
+  inspect(a == c, content = "false")
+}

--- a/lib/@vibe/compiler/tests/int_payload_eq_test.vibe
+++ b/lib/@vibe/compiler/tests/int_payload_eq_test.vibe
@@ -1,0 +1,99 @@
+//# Functions
+
+// #2457: an `Int` payload compared through a literal shape or a bare
+// `Option` / `Result` binding must be an exact i64 equality. The generic
+// `eq` builtin's string fall-back reads a word whose low 32 bits are zero
+// as a zero-length string when the high half is a plausible pointer, so two
+// distinct values of the form `k << 32` compared EQUAL through a ctor
+// literal, a tuple literal, and a call result.
+//
+// Measured on the stage2 built from main at 7018aca (2026-09-03), linear and
+// gc lanes alike: every `==` below that must be `false` answered `true`.
+//
+// Three paths, all pinned here:
+// - codegen's literal-shape walk (linear `emit_eq_shape_slots`, gc
+//   `emit_gc_{tuple,ctor}_struct_eq`): a leaf whose literal payload
+//   expression is intish compares with `i64.eq`;
+// - the desugar's bare-`Option` / `Result` rung: with a checker row for the
+//   site (the FS lane `vibe test` takes), the typed comparator compares the
+//   payload exactly (`(x + 0) == (y + 0)`, the round-6 marker of #2456);
+// - the equal-values cases, so the exact compare is a compare and not a
+//   constant.
+
+fn mk(v: Int) -> Option[Int] {
+  Some(v)
+}
+
+// `Result` is always a declared enum (#1324); this is the standard shape the
+// desugar's `Ok` / `Err` arm recognises.
+enum Result[T, E] {
+  Ok(T);
+  Err(E)
+}
+
+fn mk_res(v: Int) -> Result[Int, String] {
+  Ok(v)
+}
+
+fn big() -> Int {
+  64 << 32
+}
+
+fn other() -> Int {
+  65 << 32
+}
+
+test "#2457: Some(64 << 32) == Some(65 << 32) is false" {
+  inspect(Some(64 << 32) == Some(65 << 32), content = "false")
+  inspect(Some(64 << 32) != Some(65 << 32), content = "true")
+  inspect(Some(64 << 32) == Some(64 << 32), content = "true")
+}
+
+test "#2457: tuple literals with a bound Int element" {
+  let b = 64 << 32
+  let o = 65 << 32
+  inspect((b, 1) == (o, 1), content = "false")
+  inspect((b, 1) == (b, 1), content = "true")
+  inspect((64 << 32, "x") == (65 << 32, "x"), content = "false")
+  inspect((64 << 32, "x") == (64 << 32, "x"), content = "true")
+}
+
+test "#2457: nested ctor in a tuple literal" {
+  inspect((Some(64 << 32), 1) == (Some(65 << 32), 1), content = "false")
+  inspect((Some(64 << 32), 1) == (Some(64 << 32), 1), content = "true")
+}
+
+test "#2457: Option[Int] call results (bare binding rung)" {
+  let a = mk(big())
+  let b = mk(other())
+  let c = mk(big())
+  inspect(a == b, content = "false")
+  inspect(a != b, content = "true")
+  inspect(a == c, content = "true")
+  inspect(mk(7) == mk(7), content = "true")
+  inspect(mk(7) == mk(8), content = "false")
+}
+
+test "#2457: Result[Int, String] call results (bare binding rung)" {
+  let a = mk_res(big())
+  let b = mk_res(other())
+  let c = mk_res(big())
+  inspect(a == b, content = "false")
+  inspect(a == c, content = "true")
+}
+
+test "#2457: annotated tracked ctor literal" {
+  let a: Option[Int] = Some(64 << 32)
+  let b: Option[Int] = Some(65 << 32)
+  let c: Option[Int] = Some(64 << 32)
+  inspect(a == b, content = "false")
+  inspect(a == c, content = "true")
+}
+
+test "#2457: small payloads keep answering" {
+  inspect(Some(1) == Some(1), content = "true")
+  inspect(Some(1) == Some(2), content = "false")
+  inspect((1, "a") == (1, "a"), content = "true")
+  inspect((1, "a") == (2, "a"), content = "false")
+  inspect(Some("s") == Some("s"), content = "true")
+}

--- a/lib/@vibe/compiler/tests/int_payload_eq_test.vibe
+++ b/lib/@vibe/compiler/tests/int_payload_eq_test.vibe
@@ -36,31 +36,31 @@ fn mk_res(v: Int) -> Result[Int, String] {
 }
 
 fn big() -> Int {
-  64 << 32
+  64<<32
 }
 
 fn other() -> Int {
-  65 << 32
+  65<<32
 }
 
 test "#2457: Some(64 << 32) == Some(65 << 32) is false" {
-  inspect(Some(64 << 32) == Some(65 << 32), content = "false")
-  inspect(Some(64 << 32) != Some(65 << 32), content = "true")
-  inspect(Some(64 << 32) == Some(64 << 32), content = "true")
+  inspect(Some(64<<32) == Some(65<<32), content = "false")
+  inspect(Some(64<<32) != Some(65<<32), content = "true")
+  inspect(Some(64<<32) == Some(64<<32), content = "true")
 }
 
 test "#2457: tuple literals with a bound Int element" {
-  let b = 64 << 32
-  let o = 65 << 32
+  let b = 64<<32
+  let o = 65<<32
   inspect((b, 1) == (o, 1), content = "false")
   inspect((b, 1) == (b, 1), content = "true")
-  inspect((64 << 32, "x") == (65 << 32, "x"), content = "false")
-  inspect((64 << 32, "x") == (64 << 32, "x"), content = "true")
+  inspect((64<<32, "x") == (65<<32, "x"), content = "false")
+  inspect((64<<32, "x") == (64<<32, "x"), content = "true")
 }
 
 test "#2457: nested ctor in a tuple literal" {
-  inspect((Some(64 << 32), 1) == (Some(65 << 32), 1), content = "false")
-  inspect((Some(64 << 32), 1) == (Some(64 << 32), 1), content = "true")
+  inspect((Some(64<<32), 1) == (Some(65<<32), 1), content = "false")
+  inspect((Some(64<<32), 1) == (Some(64<<32), 1), content = "true")
 }
 
 test "#2457: Option[Int] call results (bare binding rung)" {
@@ -83,9 +83,9 @@ test "#2457: Result[Int, String] call results (bare binding rung)" {
 }
 
 test "#2457: annotated tracked ctor literal" {
-  let a: Option[Int] = Some(64 << 32)
-  let b: Option[Int] = Some(65 << 32)
-  let c: Option[Int] = Some(64 << 32)
+  let a: Option[Int] = Some(64<<32)
+  let b: Option[Int] = Some(65<<32)
+  let c: Option[Int] = Some(64<<32)
   inspect(a == b, content = "false")
   inspect(a == c, content = "true")
 }

--- a/lib/@vibe/compiler/tests/int_payload_eq_test.vibe
+++ b/lib/@vibe/compiler/tests/int_payload_eq_test.vibe
@@ -90,6 +90,23 @@ test "#2457: annotated tracked ctor literal" {
   inspect(a == c, content = "true")
 }
 
+fn mk_str(x: String) -> String {
+  String::concat(x, "b")
+}
+
+test "#2457 (Codex round 1 on #2471): a saved shape's field keeps its own binding's type" {
+  // `t`'s recorded shape is `(s, 1)`; the later `let s` rebinds the name to an
+  // Int. The String field must still compare by content (two run-time
+  // allocations), never through an `i64.eq` chosen from the newer `s`.
+  let s = mk_str("a")
+  let t = (s, 1)
+  let s = 64<<32
+  let u = (mk_str("a"), 1)
+  inspect(t == u, content = "true")
+  inspect(t == (mk_str("c"), 1), content = "false")
+  inspect(s == 64<<32, content = "true")
+}
+
 test "#2457: small payloads keep answering" {
   inspect(Some(1) == Some(1), content = "true")
   inspect(Some(1) == Some(2), content = "false")

--- a/tests/gates/early/run.sh
+++ b/tests/gates/early/run.sh
@@ -1943,7 +1943,10 @@ rm -rf "$eqtrapdir"; mkdir -p "$eqtrapdir"
 # #2456): a source-owned generic ENUM compared directly, not through the
 # untyped-empty arm -- its derived comparator reads a formal-typed payload by
 # reference, so an aggregate argument must fail closed on that path too.
-for eqtrap_src in fixtures/structural_eq_untyped_empty_*_trap.vibe fixtures/structural_eq_generic_enum_*_trap.vibe; do
+# `structural_eq_owned_scalar_*_trap.vibe` joins too (Codex round 4 on #2471):
+# a program that declares `struct Int` makes a literal-derived shape's `Int`
+# ambiguous with the struct, so the literal-shape rungs fail closed.
+for eqtrap_src in fixtures/structural_eq_untyped_empty_*_trap.vibe fixtures/structural_eq_generic_enum_*_trap.vibe fixtures/structural_eq_owned_scalar_*_trap.vibe; do
   eqtrap_name="$(basename "${eqtrap_src%.vibe}")"
   eqtrap_wasm="$eqtrapdir/$eqtrap_name.wasm"
   VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \


### PR DESCRIPTION
## What

#2457 (P0): three `==` shapes handed an `Int` payload word to the generic `eq` builtin, whose string fall-back reads a word with a zero low half as a zero-length string when the high half is a plausible pointer. Measured on the stage2 built from main at `7018aca`, linear and gc lanes alike (`_start` returns 1 when `==` says `true`):

| program | expected | main | this PR (FS lane) | this PR (gc) |
|---|---|---|---|---|
| `Some(64 << 32) == Some(65 << 32)` | `false` | **`true`** | `false` | `false` |
| `mk(64 << 32) == mk(65 << 32)`, `fn mk(v: Int) -> Option[Int]` | `false` | **`true`** | `false` | `false` |
| `(big, 1) == (other, 1)`, `let big = 64 << 32` | `false` | **`true`** | `false` | `false` |
| `let a = Some(64 << 32); let b = Some(65 << 32); a == b` | `false` | **`true`** | `false` | `false` |
| `let a: Wrap[Int] = W(64 << 32); a == b` (user `enum Wrap[T]`) | `false` | **`true`** | **`true`** (not closed here, see below) | **`true`** |
| equal values (`mk(big) == mk(big)`, `(big, 1) == (big, 1)`, `Some(7) == Some(7)`) | `true` | `true` | `true` | `true` |

## How

- **Desugar, the #825 static-shape rung** (`normalize/desugar_trait_dict.vibe`): `Some(64 << 32)` inferred `Option[?EqUnknown]` — a shift is not a literal that inference named — and the unknown payload position compared with the raw `==`. The rung now prefers the checker's row for the site when the declared-field allow-list admits it (`dtd_typed_eq_admitted_ty`; `Option[Int]`, `(Int, Int)`), so `eq_for_typed` compares the payload with its exact `(x + 0) == (y + 0)` form (#2456 round 6). Without a row, `infer_static_eq_type` now names an operator expression whose result is an Int / Bool word by construction: shifts, bitwise ops, `%`, comparisons, `~`, `!`, and `+ - * /` over two operands it already names `Int` (`1.5 + x` stays unnamed — a guessed Double leaf would be the worse bug).
- **Desugar, the bare-`Option` / `Result` rung**: `opt_eq_match` / `result_eq_match` compare payloads with a raw `==` on match binders, which codegen cannot classify. The same admitted row is consulted first, so a call result typed `Option[Int]` compares exactly; with no row, or a type the allow-list refuses, the match is unchanged.
- **Codegen literal-shape walks**: linear `emit_eq_shape_slots` compares a leaf whose literal payload expression is intish (`expr_is_intish`: literals, int operators, a `let`-bound int slot) with `i64.eq` instead of calling `eq`; the gc `emit_gc_{tuple,ctor}_struct_eq` now receive the literal's field expressions and do the same through `gc_expr_is_intish`. This is what answers on a lane with no typed rows.

## Codex rounds on this PR

- **Round 1 (P1), saved shapes** — a shape recorded at an earlier `let` (`agg_local_exprs`) carries identifiers from that scope; resolving one against the compare site's `local_names` would read whatever binding now owns the name. `emit_eq_shape_slots` takes a `live` flag: the operand literal written at the compare site may consult the scope, a saved shape classifies only a leaf that names nothing (`expr_names_nothing`: literals and operator trees over them), and a nested shape reached through a tracked identifier is never live. Six probe variants of the reported program (`let s = ...; let t = (s, 1); let s = 64 << 32; t == u`) did not reproduce on the first head — the disassembly shows both tuple fields going through `call eq`, because a saved shape's identifier leaf was never classified on that path — so the guard turns that accident into an invariant; the shadowed case is pinned in `int_payload_eq_test.vibe`.
- **Rounds 2-3 (P1), the unknown-position marker** — the syntactic shape writes a marker into every position the literal inference cannot name, and it was spelled `__EqUnknown`, a name a program may legally declare. Reproduced on the FS lane with a generic `fn same_some[T](x: T, y: T) { Some(x) == Some(y) }` (no checker row: type variables give none) and a declared `struct __EqUnknown`: the first head dispatched the payload to `__EqUnknown::equals`, answering `same_some(1, 2)` as `true` (main trapped there). Round 2 excluded the name from the shape's name set; round 3 pointed out that any spelling a source can declare still collides, so the marker is now `?EqUnknown` — `?` cannot begin an identifier — and the round-2 special cases are gone. A declared `__EqUnknown` is an ordinary struct everywhere. Pinned in `eq_unknown_marker_owner_test.vibe` (3 tests, linear and gc); `derive_array_helper_tparams_test.vibe` keeps asserting the marker never reaches generated source, now against the new spelling. Round 3's other observation — `same_some(Pt::{ v: 1 }, Pt::{ v: 1 })` answers `false` — is the pre-existing formal-payload gap: main answers the same for `Pt`, this PR does not change it, filed as #2474 (P0).
- **Round 4 (P1), a source-owned scalar spelling** — a program may declare `struct Int { value: String }` (#2456 round 17 lets such a spelling take its declared comparator). A literal-derived shape then cannot say which `Int` it means: the checker's row spells a literal's builtin `Int` and the struct the same way, and so does the syntactic inference. Measured on the FS lane at `44dd270`: `Some(1) == Some(2)` and `(1, "a") == (2, "a")` answered `true` (main trapped), `[1] == [2]` answered `true` on main as well. The #825 static-shape rung, the array rung and the bare `Option` / `Result` rung's row use now fail closed when the shape mentions a scalar spelling the source owns (`ty_mentions_owned_scalar`); a program that owns no scalar spelling never takes that branch. Pinned by `fixtures/structural_eq_owned_scalar_{some_literal,tuple_literal,array_literal,bare_option,literal_push}_trap.vibe` in the early gate's fail-closed loop (each answered `1` on the previous head). The price: the array rung also serves an untyped-empty array filled by the #2157 push scan, so under an owned `Int` a struct-literal push (`Array::push(xs, Int::{ value: "x" })`, which answered correctly on main) now traps as well — the scan spells it exactly like a pushed literal. Pushes by name keep answering through the checker's row (the round-17 fixture). Both push forms answering needs a builtin-scalar marker in the shape channel: #2475 (P0).

## Not closed here

- **A user generic enum instantiated at `Int`** (`let a: Wrap[Int] = W(64 << 32)`) still compares through the derived `Wrap::equals`, whose formal-typed payload is the erased `==`. Routing it through `eq_for_typed` would trap every `Wrap[Int]` compare (the generic-enum gate of #2456 fails closed for a formal payload), so the row is deliberately not applied there; the fix is the per-instantiation comparator of #2467, which I will take next. #2457 stays open for that row.
- **The flat single-source lane** (no checker rows, not the lane `vibe test` / `vibe run` take): a bound name inside a tuple literal (`(big, 1)`) and a call result keep the generic compare, since neither the literal-syntax inference nor the gc shape classifier reads a binding's type. Measured on this PR: `ctor_lit` and `tuple_pure` answer `false` there; `tuple_lit`, `call_result` and `ctor_bound` still answer `true`. The round-2 probe (`let a = big(); Some(a) == Some(b)` with `struct __EqUnknown` declared) is that same residual on the flat lane: main trapped, this PR answers as it does without the declaration.
- **A struct payload inside a generic body** (`fn same_some[T](x: T, y: T) { Some(x) == Some(y) }` applied to `Pt`) compares by reference on main and on this PR alike — #2474.
- **A source-owned scalar spelling in the untyped-empty push scan** (`struct Int` plus `Array::push(xs, 1)` or `Array::push(xs, Int::{ .. })`) traps on this PR where main answered `true` for the literal (wrong) and by content for the struct literal (right) — #2475.

## Red → Green

- `lib/@vibe/compiler/tests/int_payload_eq_test.vibe` (8 tests, linear and gc): every `==` that must be `false` answered `true` on the main stage2 (the first test failed the moment the file compiled); all pass on this PR's stage2 on both lanes. Equal-value cases pin that the exact compare is a compare, not a constant. The round-1 shadowed case passes on both heads (see above).
- `lib/@vibe/compiler/tests/eq_unknown_marker_owner_test.vibe` (3 tests, linear and gc): trap on main, `same_some(1, 2)` = `true` on the first head of this PR, green now with the marker undeclarable.
- `fixtures/structural_eq_owned_scalar_*_trap.vibe` (5, early gate): each returned `1` on `44dd270`, each traps now.

## Validation

- bundle regen; `generations.sh build --stage3`: stage2 == stage3
- `int_payload_eq_test.vibe` and `eq_unknown_marker_owner_test.vibe` linear and gc; `derive_array_helper_tparams_test.vibe`; `eq_typed_channel_untyped_empty_test.vibe` gc; the five owned-scalar trap fixtures trap on this head and answer on the previous one; the round-17 owned-`Int` fixture still answers
- `test_cli_core.sh`; typing-env-reuse oracle
- selfcompile KPI heap 1,616,918,536 bytes vs 1,615,173,808 on the main stage2 from the same checkout (+1.7 MB, +0.11%)
- 215/215 affected unit-test files (import-graph selection over the three changed compiler files); `compiler_gate.sh` early / mid / late lanes

Refs #2457, #2456, #2467, #2474, #2475.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QKZdvBvHVUagwg6Yih8er8