### PR TITLE
checker: an imported or re-exported Show wrapper files render rows too (#2468 follow-up)

### DIFF
--- a/lib/@vibe/builtin/builtin_traits_test.vibe
+++ b/lib/@vibe/builtin/builtin_traits_test.vibe
@@ -62,6 +62,40 @@ test "to_string generic" {
   assert(to_string(true) == "true")
 }
 
+test "#2468: an IMPORTED to_string renders like __to_string" {
+  // `to_string` is a one-parameter `__to_string` pass-through, so these are
+  // one lowering with two spellings and must not disagree. The argument is
+  // the #2462 shape -- a lambda bound by a `let` INSIDE a function body,
+  // which `collect_fn_returns` (a statement walk) cannot see -- so no
+  // syntactic rule reaches it and the typed-lowering row is the whole
+  // mechanism.
+  //
+  // This is the IMPORTED wrapper, which is the normal way anyone writes it
+  // and the case the local-wrapper tests do not cover: the checker sees the
+  // call but not the callee's body, in another file. Measured with only the
+  // local shape scan:
+  //
+  //   __to_string(l()) -> "true"      to_string(l()) -> "1"
+  //
+  // The literal `to_string(true)` above cannot catch this -- every classifier
+  // already answers a Bool LITERAL.
+  let l = () -> Bool {
+    1 < 2
+  }
+  assert(__to_string(l()) == "true")
+  assert(to_string(l()) == "true")
+  // The controls, so a row that claimed every imported call's argument was a
+  // Bool would be caught here rather than look like a fix.
+  let n = () -> Int {
+    7
+  }
+  assert(to_string(n()) == "7")
+  let d = () -> Double {
+    1.5
+  }
+  assert(to_string(d()) == "1.5")
+}
+
 test "default trait bound generic" {
   assert(eq(default_require(42), 42))
   assert(default_require("ok") == "ok")

--- a/lib/@vibe/builtin/reexported_show_wrapper_test.vibe
+++ b/lib/@vibe/builtin/reexported_show_wrapper_test.vibe
@@ -1,0 +1,47 @@
+//# #2468: a Show wrapper reached through a RE-EXPORT.
+//
+// `export <path> { name }` binds `name` locally as well as re-publishing it,
+// which is why `collect_import_value_renames`
+// (core/import_alias_rewrite.vibe) handles `SReExport` alongside `SImport`.
+// The typed-lowering producer's wrapper scan did not, so this module could
+// call `to_string` while filing no row for the argument -- and the merged
+// normalize pass still rewrote the call to `__to_string`, leaving the
+// consumer to look up an offset that was never published.
+//
+// Codex P1 on the PR that added the `SImport` arm. Measured before the
+// `SReExport` one:
+//
+//   __to_string(l()) -> "true"      to_string(l()) -> "1"
+//
+// The file is its own fixture: it must both re-export the wrapper and call
+// it, which is the shape the bug needs and the reason it does not live in
+// builtin_traits_test.vibe (that file imports).
+
+//# Imports
+
+export ./builtin_traits.vibe {
+  to_string
+}
+
+//# Misc
+
+test "#2468: a re-exported to_string renders like __to_string" {
+  // The #2462 shape: a lambda bound by a `let` INSIDE the block, which
+  // `collect_fn_returns` (a statement walk) cannot see. Nothing syntactic
+  // classifies it, so the typed-lowering row is the whole mechanism.
+  let l = () -> Bool {
+    1 < 2
+  }
+  assert(__to_string(l()) == "true")
+  assert(to_string(l()) == "true")
+  // Controls: a row that claimed every re-exported call's argument was a
+  // Bool would be caught here rather than look like a fix.
+  let n = () -> Int {
+    7
+  }
+  assert(to_string(n()) == "7")
+  let d = () -> Double {
+    1.5
+  }
+  assert(to_string(d()) == "1.5")
+}

--- a/lib/@vibe/compiler/checker/checker_stmt.vibe
+++ b/lib/@vibe/compiler/checker/checker_stmt.vibe
@@ -6164,6 +6164,41 @@ fn irc_show_shim_names(stmts: Array[Stmt]) -> Array[String] {
       } else {
         ()
       },
+      // #2468 (Codex P1 on this PR): a wrapper the module IMPORTS -- the
+      // prelude's `to_string` above all -- has its body in another file, which
+      // this check cannot see. Measured before this arm, on the FS lane:
+      //
+      //   import ./builtin_traits.vibe { to_string }
+      //   let l = () -> Bool { 1 < 2 }
+      //   __to_string(l()) -> "true"      to_string(l()) -> "1"
+      //
+      // So every imported local name joins the set, without a shape test. That
+      // is an OVER-approximation, and it is safe for the reason stated above:
+      // a row is a TYPE fact, not a render fact. It says "the expression at
+      // this offset resolved to Bool", which the agreement rule verified, and
+      // codegen reads the table ONLY when it is lowering a render argument
+      // (`bool_offset_says_bool` inside `cc_expr_is_boolish`, and its two
+      // twins). A row filed for an ordinary imported call is therefore inert:
+      // nothing looks it up. It can never be a wrong classification, because
+      // there is no way for a true statement about an expression's type to
+      // become one.
+      //
+      // The alternative -- resolving each imported name to its definition and
+      // shape-testing it -- means carrying wrapper metadata across the module
+      // boundary, and doing it in a way that survives a cache hit that skips
+      // the dependency's check. Getting that wrong renders the same program
+      // differently warm and cold, which is worse than an inert row. #2471.
+      SImport(_, items) => {
+        let mut j = 0
+        while j < Array::length(items) {
+          let item = Array::get(items, j)
+          match item.alias {
+            Some(alias) => Array::push(out, alias),
+            None => Array::push(out, item.name)
+          }
+          j = j + 1
+        }
+      },
       _ => ()
     }
     i = i + 1

--- a/lib/@vibe/compiler/checker/checker_stmt.vibe
+++ b/lib/@vibe/compiler/checker/checker_stmt.vibe
@@ -6187,7 +6187,9 @@ fn irc_show_shim_names(stmts: Array[Stmt]) -> Array[String] {
       // shape-testing it -- means carrying wrapper metadata across the module
       // boundary, and doing it in a way that survives a cache hit that skips
       // the dependency's check. Getting that wrong renders the same program
-      // differently warm and cold, which is worse than an inert row. #2471.
+      // differently warm and cold, which is worse than an inert row. The
+      // measured price of not having that metadata is +0.28% selfcompile
+      // heap; the design is #2472.
       SImport(_, items) => {
         let mut j = 0
         while j < Array::length(items) {

--- a/lib/@vibe/compiler/checker/checker_stmt.vibe
+++ b/lib/@vibe/compiler/checker/checker_stmt.vibe
@@ -6129,6 +6129,20 @@ fn irc_is_show_shim_value(v: Expr) -> Bool {
   }
 }
 
+/// The local names an import / re-export item list binds: the alias when there
+/// is one, else the imported name.
+fn irc_push_bound_import_names(items: Array[ImportItem], out: Array[String]) -> Unit {
+  let mut j = 0
+  while j < Array::length(items) {
+    let item = Array::get(items, j)
+    match item.alias {
+      Some(alias) => Array::push(out, alias),
+      None => Array::push(out, item.name)
+    }
+    j = j + 1
+  }
+}
+
 /// #2468: the program's Show-wrapper names, from its top-level declarations.
 ///
 /// Only the TOP level, and both statement spellings. `parse_program` and
@@ -6190,17 +6204,21 @@ fn irc_show_shim_names(stmts: Array[Stmt]) -> Array[String] {
       // differently warm and cold, which is worse than an inert row. The
       // measured price of not having that metadata is +0.28% selfcompile
       // heap; the design is #2472.
-      SImport(_, items) => {
-        let mut j = 0
-        while j < Array::length(items) {
-          let item = Array::get(items, j)
-          match item.alias {
-            Some(alias) => Array::push(out, alias),
-            None => Array::push(out, item.name)
-          }
-          j = j + 1
-        }
-      },
+      SImport(_, items) => irc_push_bound_import_names(items, out),
+      // A re-export binds its items LOCALLY too, so the module can call them
+      // (`collect_import_value_renames`, core/import_alias_rewrite.vibe,
+      // handles `SReExport` alongside `SImport` for exactly that reason).
+      // Codex P1 on this PR, measured before this arm:
+      //
+      //   export ./builtin_traits.vibe { to_string }
+      //   let l = () -> Bool { 1 < 2 }
+      //   __to_string(l()) -> "true"      to_string(l()) -> "1"
+      //
+      // The merged normalize pass still rewrites that call to `__to_string`,
+      // so the consumer looks the argument's offset up and finds nothing --
+      // the same silent "1" the `SImport` arm above exists to prevent, one
+      // statement keyword away.
+      SReExport(_, items) => irc_push_bound_import_names(items, out),
       _ => ()
     }
     i = i + 1


### PR DESCRIPTION
Two Codex P1s on #2468, one on that PR and one on this one. They are the same defect reached through two statement keywords, and #2470 merged before either fix was pushed, so both land here.

## The gap

#2470 taught the typed-lowering producer about Show wrappers — a one-parameter function whose body is exactly `__to_string(param)`, which the lowering treats like `__to_string` itself (`is_show_shim_call`, `normalize/desugar_trait_dict.vibe`). But the shape scan only saw the module's **own** statements. A wrapper whose body lives in another file — the prelude's `to_string`, which is how anyone actually writes it — was never recognized.

Measured, each isolated so the failing line is unambiguous (the `__to_string` control in the same module passes in both):

| module says | call | before | after |
|---|---|---|---|
| `import ./builtin_traits.vibe { to_string }` | `to_string(l())` | `"1"` | `"true"` |
| `export ./builtin_traits.vibe { to_string }` | `to_string(l())` | `"1"` | `"true"` |

The argument is the #2462 shape — a lambda bound by a `let` **inside** a block, which `collect_fn_returns` (a statement walk) cannot see — so nothing syntactic reaches it and the row is the whole mechanism. In both cases the merged normalize pass still rewrites the call to `__to_string`, so the consumer looks up an offset that was never published.

Nothing in #2470 covered either: its producer tests use single-file source strings, and its parity fixture declares its wrapper locally. I described that local declaration in the PR as deliberately proving shape-matching. It was that, and it was also the reason the normal path went untested.

## The fix

`SImport` and `SReExport` both add their bound local names — alias when there is one, else the imported name — through one shared `irc_push_bound_import_names`. Those are the two statements that bind an outside name locally; `collect_import_value_renames` (`core/import_alias_rewrite.vibe`) handles exactly that pair for the same reason, and is the reference this scan is now checked against.

No shape test. That is an **over-approximation**, and it is safe for the reason the file already states: a row is a **type** fact, not a render fact. It says "the expression at this offset resolved to Bool", which the producer's fail-closed agreement rule verified, and codegen reads the table **only** while lowering a render argument (`bool_offset_says_bool` inside `cc_expr_is_boolish`, and its two twins). A row filed for an ordinary imported call is therefore inert — nothing looks it up — and a true statement about an expression's type cannot become a wrong classification.

Resolving each name to its definition and shape-testing it is the precise version. Its hard part is not the scan but **cache state**: the module walk checks dependencies before importers, but a cache hit *skips* the dependency's check. If the importer's wrapper set depended on whether that hit occurred, the same program would render differently warm and cold — the failure `rebind_module_typed_lowering_offsets` and `ensure_module_typed_lowering_offsets` exist to prevent (#2425, #2449), and worse than an inert row. Designed in #2472.

## Cost

`codegen_lexer_test.vibe`, `VIBE_BUILD_CACHE_DIR` isolation per run, N=3, `heap_ptr` byte-identical across every run of each configuration — and the CI perf report's deterministic row agrees to the digit:

| producer | selfcompile heap_ptr | Δ |
|---|---:|---:|
| local-shape scan only (#2470 as merged) | 1,602,688,560 | — |
| plus imported names | 1,607,232,240 | +0.28% |
| plus re-exported names (this PR) | — | **+0.29%** (CI) |

Against `origin/main` before #2470 (1,614,358,984) the two PRs together are still **−0.44%**, because #2470's producer-walk fold more than pays for this. Every other deterministic row is ±0.

## Tests

- `lib/@vibe/builtin/builtin_traits_test.vibe` — the imported wrapper, next to the wrapper it imports.
- `lib/@vibe/builtin/reexported_show_wrapper_test.vibe` — the re-exported one. Its own file because the shape needs a module that *both* re-exports the wrapper and calls it, which a file that imports cannot host.

Both carry Int and Double controls, so a row claiming every bound call's argument is a Bool would be caught rather than look like a fix. The existing `to_string(true)` in `builtin_traits_test.vibe` could never have caught this — every classifier already answers a Bool **literal**, which is exactly why the bug survived a test named "to_string generic".

## Verification

On a stage2 built from the final change:

- `reexported_show_wrapper_test.vibe` passes; `builtin_traits_test.vibe` 9/9.
- Gate lanes `early`, `mid`, `late`: all `ok`.
- Unit suite: **1106/1106**.
- CI green on the head.

## A note on how this went

Two findings of the same shape on the same scan. I widened the candidate set to the one binding form I had a failing case for — twice. The correction is not a third guess but a reference: the arm list is now checked against the function that already answers "which statements bind an outside name locally", rather than against the next example I happened to think of.

Follow-up: #2472.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FYMVd6D2o82suTfTwoJPMf