### PR TITLE
checker: poison a disagreeing Double call-result offset collision (#2427)

### DIFF
--- a/lib/@vibe/compiler/checker/checker_stmt.vibe
+++ b/lib/@vibe/compiler/checker/checker_stmt.vibe
@@ -5728,17 +5728,45 @@ fn double_call_result_offsets_from_capture(checked: CheckedProgram, capture: Typ
       }
       i = i + 1
     }
-    // Nothing to check when no offset was claimed as Double: the sort is the
-    // only super-linear step here and this is the common case.
+    // Sort the SMALL side and scan the large one against it (Codex round 2 on
+    // this PR). `irc_sorted_unique` is an insertion sort -- its own comment
+    // says it is sized for a small candidate set -- so sorting `others`, which
+    // holds every non-Double primary call, would have been quadratic on a
+    // compiler-sized input: the very cost the two-pass shape was meant to
+    // remove. `out` is one entry per DISTINCT Double offset, and it was
+    // already deduplicated by the same O(D^2) scan the original code ran, so
+    // sorting it adds no order this function did not already pay.
+    //
+    // Nothing to check when no offset was claimed as Double, which is the
+    // common case and stays fully linear.
     let kept = if Array::length(out) == 0 {
       out
     } else {
-      let sorted_others = irc_sorted_unique(others)
+      let sorted_doubles = irc_sorted_unique(out)
+      let poisoned: Array[Bool] = []
+      let mut d = 0
+      while d < Array::length(sorted_doubles) {
+        Array::push(poisoned, false)
+        d = d + 1
+      }
+      let mut o = 0
+      while o < Array::length(others) {
+        let idx = irc_index_of(sorted_doubles, Array::get(others, o))
+        if idx >= 0 {
+          Array::set(poisoned, idx, true)
+        } else {
+          ()
+        }
+        o = o + 1
+      }
+      // Emitted in `out`'s original first-seen order, not the sorted one:
+      // the sort exists for the lookup, and changing the table's order would
+      // be an unrelated behavioural change to everything downstream of it.
       let keep: Array[Int] = []
       let mut k = 0
       while k < Array::length(out) {
         let off = Array::get(out, k)
-        if irc_index_of(sorted_others, off) < 0 {
+        if !Array::get(poisoned, irc_index_of(sorted_doubles, off)) {
           Array::push(keep, off)
         } else {
           ()

--- a/lib/@vibe/compiler/checker/checker_stmt.vibe
+++ b/lib/@vibe/compiler/checker/checker_stmt.vibe
@@ -5671,12 +5671,19 @@ fn double_call_result_offsets_from_capture(checked: CheckedProgram, capture: Typ
     None
   } else {
     let out: Array[Int] = []
-    // #2427: one row per CLAIMED offset, with the verdict every claimant
-    // agreed on -- not a deduplicated list of the Double ones. See the doc
-    // comment above for why the difference is the bug.
-    let keys: Array[Int] = []
-    let verdicts: Array[Int] = []
-    let poisoned: Array[Bool] = []
+    // #2427: the Double claimants (deduplicated, as before) and the offsets
+    // some primary call resolved to something ELSE. An offset in both is a
+    // disagreeing collision and is dropped below.
+    //
+    // Two passes with a sorted lookup, not one pass with a linear scan
+    // (Codex round 1 on this PR). The scan would have run for EVERY primary
+    // call against a key list that grows to all of them -- quadratic on the
+    // minified bundle, and quadratic even for a program with no Double calls
+    // at all. The comment twenty lines below records what that costs here:
+    // an earlier version of this loop took one file from 6.1s to 77.5s.
+    // These two pushes are linear, and the sort is skipped entirely when
+    // there is no Double candidate to check.
+    let others: Array[Int] = []
     let mut primary_calls = 0
     let mut located_primary_calls = 0
     let mut i = 0
@@ -5696,29 +5703,22 @@ fn double_call_result_offsets_from_capture(checked: CheckedProgram, capture: Typ
         primary_calls = primary_calls + 1
         if off >= 0 {
           located_primary_calls = located_primary_calls + 1
-          let verdict = if subst_resolves_to_double(checked.final_subst, raw_ty) {
-            1
-          } else {
-            0
-          }
-          let mut idx = 0 - 1
-          let mut j = 0
-          while j < Array::length(keys) {
-            if Array::get(keys, j) == off {
-              idx = j
-              j = Array::length(keys)
-            } else {
-              j = j + 1
+          if subst_resolves_to_double(checked.final_subst, raw_ty) {
+            let mut seen = false
+            let mut j = 0
+            while j < Array::length(out) {
+              if Array::get(out, j) == off {
+                seen = true
+                j = Array::length(out)
+              } else {
+                j = j + 1
+              }
             }
-          }
-          if idx < 0 {
-            Array::push(keys, off)
-            Array::push(verdicts, verdict)
-            Array::push(poisoned, false)
-          } else if Array::get(verdicts, idx) != verdict {
-            Array::set(poisoned, idx, true)
+            if !seen {
+              Array::push(out, off)
+            }
           } else {
-            ()
+            Array::push(others, off)
           }
         } else {
           ()
@@ -5728,16 +5728,26 @@ fn double_call_result_offsets_from_capture(checked: CheckedProgram, capture: Typ
       }
       i = i + 1
     }
-    let mut k = 0
-    while k < Array::length(keys) {
-      if Array::get(verdicts, k) == 1 && !Array::get(poisoned, k) {
-        Array::push(out, Array::get(keys, k))
-      } else {
-        ()
+    // Nothing to check when no offset was claimed as Double: the sort is the
+    // only super-linear step here and this is the common case.
+    let kept = if Array::length(out) == 0 {
+      out
+    } else {
+      let sorted_others = irc_sorted_unique(others)
+      let keep: Array[Int] = []
+      let mut k = 0
+      while k < Array::length(out) {
+        let off = Array::get(out, k)
+        if irc_index_of(sorted_others, off) < 0 {
+          Array::push(keep, off)
+        } else {
+          ()
+        }
+        k = k + 1
       }
-      k = k + 1
+      keep
     }
-    Some((out, primary_calls, located_primary_calls))
+    Some((kept, primary_calls, located_primary_calls))
   }
 }
 
@@ -6614,14 +6624,31 @@ export fn typed_lowering_enc_tag(enc: Int) -> Int {
 /// question that matters is whether the claimants AGREE. Two claimants that
 /// agree still collapse to one row, exactly as before.
 ///
-/// What this does NOT do is find the colliding claimants. #2427 reports the
-/// symptom on the minified bundle, where an unlucky anchoring coincidence
-/// shifts with any edit; no naturally colliding pair was found in today's
-/// bundle while writing this, and a curried `f()()` -- the obvious candidate
-/// -- anchors its two calls four bytes apart. The rule closes the hole
-/// whether or not an instance is live, and degrades to the syntactic
-/// classifiers when it fires, which is the channel's standing fail-closed
-/// direction.
+/// Poisoning does NOT make a mixed collision harmless, and the choice is
+/// measured rather than assumed (Codex round 1 on this PR). Dropping the row
+/// costs the Double claimant its classification too. What decides the
+/// direction is that the two claimants do not lose the same things:
+///
+///   `__to_string(fd())`   tag-4 render row present  -- a DIFFERENT key
+///   `fd() + 1.0`          no tag-4 row              -- this table only
+///
+/// A Double call result reaching the RENDERER is keyed by
+/// `typed_lowering_arg_offset` on the enclosing `__to_string` call, so it
+/// keeps its classification when this row is poisoned. That is the path
+/// #2427 reports -- a corrupt `(ptr|len)` into `__rt_str_concat` -- so after
+/// the poison NEITHER claimant's render is misclassified, where before the
+/// Int claimant's was. Arithmetic and comparison have no second channel and
+/// do change hands: the Double claimant's `fd() + 1.0` goes unclassified
+/// where the Int claimant's used to be read as an f64. Wrong either way, and
+/// the residue is the reason #2427 stays open.
+///
+/// The real fix is node identity in the key, which an offset-keyed consumer
+/// cannot express; that is #2427's remaining step, the audit of the #2231
+/// anchoring rules for shapes whose recorded offset can equal another node's.
+///
+/// No colliding pair was found in today's bundle while writing this, and a
+/// curried `f()()` -- the obvious candidate -- anchors its two calls four
+/// bytes apart. The rule closes the hole whether or not an instance is live.
 fn check_program_double_call_result_observation_impl(stmts: Array[Stmt]) -> Option[(CheckedProgram, Array[Int], Int, Int, Array[Int], Array[String])] with Exception {
   let capture = reset_double_call_capture()
   let checked = check_program_type_defs_observation_impl(stmts, None, Some(capture)).checked_program

--- a/lib/@vibe/compiler/checker/checker_stmt.vibe
+++ b/lib/@vibe/compiler/checker/checker_stmt.vibe
@@ -5671,6 +5671,12 @@ fn double_call_result_offsets_from_capture(checked: CheckedProgram, capture: Typ
     None
   } else {
     let out: Array[Int] = []
+    // #2427: one row per CLAIMED offset, with the verdict every claimant
+    // agreed on -- not a deduplicated list of the Double ones. See the doc
+    // comment above for why the difference is the bug.
+    let keys: Array[Int] = []
+    let verdicts: Array[Int] = []
+    let poisoned: Array[Bool] = []
     let mut primary_calls = 0
     let mut located_primary_calls = 0
     let mut i = 0
@@ -5690,20 +5696,27 @@ fn double_call_result_offsets_from_capture(checked: CheckedProgram, capture: Typ
         primary_calls = primary_calls + 1
         if off >= 0 {
           located_primary_calls = located_primary_calls + 1
-          if subst_resolves_to_double(checked.final_subst, raw_ty) {
-            let mut seen = false
-            let mut j = 0
-            while j < Array::length(out) {
-              if Array::get(out, j) == off {
-                seen = true
-                j = Array::length(out)
-              } else {
-                j = j + 1
-              }
+          let verdict = if subst_resolves_to_double(checked.final_subst, raw_ty) {
+            1
+          } else {
+            0
+          }
+          let mut idx = 0 - 1
+          let mut j = 0
+          while j < Array::length(keys) {
+            if Array::get(keys, j) == off {
+              idx = j
+              j = Array::length(keys)
+            } else {
+              j = j + 1
             }
-            if !seen {
-              Array::push(out, off)
-            }
+          }
+          if idx < 0 {
+            Array::push(keys, off)
+            Array::push(verdicts, verdict)
+            Array::push(poisoned, false)
+          } else if Array::get(verdicts, idx) != verdict {
+            Array::set(poisoned, idx, true)
           } else {
             ()
           }
@@ -5714,6 +5727,15 @@ fn double_call_result_offsets_from_capture(checked: CheckedProgram, capture: Typ
         ()
       }
       i = i + 1
+    }
+    let mut k = 0
+    while k < Array::length(keys) {
+      if Array::get(verdicts, k) == 1 && !Array::get(poisoned, k) {
+        Array::push(out, Array::get(keys, k))
+      } else {
+        ()
+      }
+      k = k + 1
     }
     Some((out, primary_calls, located_primary_calls))
   }
@@ -6570,6 +6592,36 @@ export fn typed_lowering_enc_tag(enc: Int) -> Int {
 /// has no Double call results. A caller that cannot tell those apart wires the
 /// channel up green and inert; `check_program_double_call_result_located_observation`
 /// below is the caller-facing form that refuses the first case.
+///
+/// #2427: an offset claimed by MORE THAN ONE primary call result is kept only
+/// when every claimant resolves the same way, and POISONED otherwise -- the
+/// rule `string_binop_offsets_from_capture` below has carried since Codex
+/// round 1 on #2429, and the one this extraction was missing.
+///
+/// The difference is not academic. The consumer is keyed by OFFSET, so an
+/// offset in the table classifies EVERY call node anchored there. Filing an
+/// offset because one claimant is Double, while another claimant at the same
+/// offset is an `Int`, tells codegen the Int call returns a float; the first
+/// consumer that renders it hands `__rt_str_concat` a corrupt `(ptr|len)`.
+/// Measured by forcing the collision (two top-level `let`s whose call offsets
+/// are rewritten to one value, `fn fd() -> Double` and `fn fi() -> Int`):
+///
+///   distinct offsets   table [59]    -- correct
+///   both at 777        table [777]   -- the Int call is now "a Double call"
+///
+/// Deduplication was the old shape and it cannot express this: it asks "did I
+/// already push this offset", which is a question about the OUTPUT, when the
+/// question that matters is whether the claimants AGREE. Two claimants that
+/// agree still collapse to one row, exactly as before.
+///
+/// What this does NOT do is find the colliding claimants. #2427 reports the
+/// symptom on the minified bundle, where an unlucky anchoring coincidence
+/// shifts with any edit; no naturally colliding pair was found in today's
+/// bundle while writing this, and a curried `f()()` -- the obvious candidate
+/// -- anchors its two calls four bytes apart. The rule closes the hole
+/// whether or not an instance is live, and degrades to the syntactic
+/// classifiers when it fires, which is the channel's standing fail-closed
+/// direction.
 fn check_program_double_call_result_observation_impl(stmts: Array[Stmt]) -> Option[(CheckedProgram, Array[Int], Int, Int, Array[Int], Array[String])] with Exception {
   let capture = reset_double_call_capture()
   let checked = check_program_type_defs_observation_impl(stmts, None, Some(capture)).checked_program

--- a/lib/@vibe/compiler/checker/checker_stmt.vibe
+++ b/lib/@vibe/compiler/checker/checker_stmt.vibe
@@ -5671,19 +5671,6 @@ fn double_call_result_offsets_from_capture(checked: CheckedProgram, capture: Typ
     None
   } else {
     let out: Array[Int] = []
-    // #2427: the Double claimants (deduplicated, as before) and the offsets
-    // some primary call resolved to something ELSE. An offset in both is a
-    // disagreeing collision and is dropped below.
-    //
-    // Two passes with a sorted lookup, not one pass with a linear scan
-    // (Codex round 1 on this PR). The scan would have run for EVERY primary
-    // call against a key list that grows to all of them -- quadratic on the
-    // minified bundle, and quadratic even for a program with no Double calls
-    // at all. The comment twenty lines below records what that costs here:
-    // an earlier version of this loop took one file from 6.1s to 77.5s.
-    // These two pushes are linear, and the sort is skipped entirely when
-    // there is no Double candidate to check.
-    let others: Array[Int] = []
     let mut primary_calls = 0
     let mut located_primary_calls = 0
     let mut i = 0
@@ -5718,7 +5705,7 @@ fn double_call_result_offsets_from_capture(checked: CheckedProgram, capture: Typ
               Array::push(out, off)
             }
           } else {
-            Array::push(others, off)
+            ()
           }
         } else {
           ()
@@ -5728,17 +5715,31 @@ fn double_call_result_offsets_from_capture(checked: CheckedProgram, capture: Typ
       }
       i = i + 1
     }
-    // Sort the SMALL side and scan the large one against it (Codex round 2 on
-    // this PR). `irc_sorted_unique` is an insertion sort -- its own comment
-    // says it is sized for a small candidate set -- so sorting `others`, which
-    // holds every non-Double primary call, would have been quadratic on a
-    // compiler-sized input: the very cost the two-pass shape was meant to
-    // remove. `out` is one entry per DISTINCT Double offset, and it was
-    // already deduplicated by the same O(D^2) scan the original code ran, so
-    // sorting it adds no order this function did not already pay.
+    // #2427 second pass: which of those candidate offsets is ALSO claimed by
+    // a primary call that is NOT a Double.
     //
-    // Nothing to check when no offset was claimed as Double, which is the
-    // common case and stays fully linear.
+    // Pass 1 above is byte-for-byte the original loop, so a program with no
+    // Double call result allocates nothing new and does no extra work -- the
+    // block below is skipped entirely. That property is the point: Codex
+    // round 1 on this PR replaced the dedup with a linear scan over a key
+    // list holding EVERY primary call, which was quadratic on the minified
+    // bundle and quadratic even with no Double present. The comment above
+    // records what a quadratic costs in this exact loop: 6.1s -> 77.5s on
+    // one file.
+    //
+    // Round 2 caught the sequel: the first repair sorted the non-Double
+    // offsets, and `irc_sorted_unique` is an INSERTION sort whose own comment
+    // says it is sized for a small candidate set. So the sorted side is the
+    // SMALL one -- one entry per distinct Double offset, already deduplicated
+    // by the same O(D^2) scan the original ran -- and the large side is
+    // scanned against it.
+    //
+    // The offset test comes FIRST and the type resolution second, for the
+    // same reason pass 1 orders them that way: a binary search is cheap and
+    // `subst_resolves_to_double` is not, so the resolution runs only for the
+    // occurrences that sit at a candidate offset. Nothing is accumulated in
+    // between -- an earlier cut collected every non-Double offset into an
+    // array, which the CI perf report priced at +0.20% selfcompile heap.
     let kept = if Array::length(out) == 0 {
       out
     } else {
@@ -5749,18 +5750,23 @@ fn double_call_result_offsets_from_capture(checked: CheckedProgram, capture: Typ
         Array::push(poisoned, false)
         d = d + 1
       }
-      let mut o = 0
-      while o < Array::length(others) {
-        let idx = irc_index_of(sorted_doubles, Array::get(others, o))
-        if idx >= 0 {
-          Array::set(poisoned, idx, true)
+      let mut p = 0
+      while p < Array::length(checked.typed_occurrences) {
+        let (poff, praw) = Array::get(checked.typed_occurrences, p)
+        if Array::get(capture.entries_flags, p) == 1 && poff >= 0 {
+          let idx = irc_index_of(sorted_doubles, poff)
+          if idx >= 0 && !subst_resolves_to_double(checked.final_subst, praw) {
+            Array::set(poisoned, idx, true)
+          } else {
+            ()
+          }
         } else {
           ()
         }
-        o = o + 1
+        p = p + 1
       }
-      // Emitted in `out`'s original first-seen order, not the sorted one:
-      // the sort exists for the lookup, and changing the table's order would
+      // Emitted in `out`'s original first-seen order, not the sorted one: the
+      // sort exists for the lookup, and reordering the published table would
       // be an unrelated behavioural change to everything downstream of it.
       let keep: Array[Int] = []
       let mut k = 0

--- a/lib/@vibe/compiler/checker/checker_stmt.vibe
+++ b/lib/@vibe/compiler/checker/checker_stmt.vibe
@@ -6658,27 +6658,36 @@ export fn typed_lowering_enc_tag(enc: Int) -> Int {
 /// question that matters is whether the claimants AGREE. Two claimants that
 /// agree still collapse to one row, exactly as before.
 ///
-/// Poisoning does NOT make a mixed collision harmless, and the choice is
-/// measured rather than assumed (Codex round 1 on this PR). Dropping the row
-/// costs the Double claimant its classification too. What decides the
-/// direction is that the two claimants do not lose the same things:
+/// Poisoning does NOT make a mixed collision harmless. It is a SWAP: before
+/// it the Double claimant kept its row and the Int claimant was misclassified;
+/// after it neither is classified and both fall to the syntactic classifiers.
+/// Measured on the collision itself (Codex rounds 1 and 3 on this PR -- an
+/// earlier claim that the render path survives was measured BESIDE the
+/// collision, on an uncollided source, and was wrong):
 ///
-///   `__to_string(fd())`   tag-4 render row present  -- a DIFFERENT key
-///   `fd() + 1.0`          no tag-4 row              -- this table only
+///   natural    tag0=1  tag4=1
+///   collided   tag0=0  tag4=0
 ///
-/// A Double call result reaching the RENDERER is keyed by
-/// `typed_lowering_arg_offset` on the enclosing `__to_string` call, so it
-/// keeps its classification when this row is poisoned. That is the path
-/// #2427 reports -- a corrupt `(ptr|len)` into `__rt_str_concat` -- so after
-/// the poison NEITHER claimant's render is misclassified, where before the
-/// Int claimant's was. Arithmetic and comparison have no second channel and
-/// do change hands: the Double claimant's `fd() + 1.0` goes unclassified
-/// where the Int claimant's used to be read as an f64. Wrong either way, and
-/// the residue is the reason #2427 stays open.
+/// The tag-4 render row does not rescue the Double claimant, because
+/// `typed_lowering_float_key` keys a call-result argument on the call's OWN
+/// offset -- the colliding one -- and `irc_render_arg_offsets` drops a
+/// candidate whose occurrences disagree. (That producer answers 0 there
+/// without this change too; its agreement rule is older.)
 ///
-/// The real fix is node identity in the key, which an offset-keyed consumer
-/// cannot express; that is #2427's remaining step, the audit of the #2231
-/// anchoring rules for shapes whose recorded offset can equal another node's.
+/// The reason to prefer the swap is not that it hurts less. It is that an
+/// offset whose claimants disagree has no single true answer, and this
+/// channel's contract is "absent, never wrong": filing the offset asserts
+/// Double for EVERY node anchored there, which is knowably false for one of
+/// them. Every sibling channel already fails closed the same way -- tags 3, 4
+/// and 5 emit an offset only when every occurrence there agrees, and the
+/// String binops poison a disagreeing anchor. Tag 0 was the only one asserting
+/// an answer it could not know, which is exactly what
+/// `typed_lowering_float_key`'s own comment says when it explains why the
+/// FLOAT key needs a restriction the Int key does not.
+///
+/// The residue is real and is pinned in the test: a mixed collision leaves the
+/// Double claimant unclassified. Node identity in the key is the fix, and an
+/// offset-keyed consumer cannot express it -- #2427's remaining step.
 ///
 /// No colliding pair was found in today's bundle while writing this, and a
 /// curried `f()()` -- the obvious candidate -- anchors its two calls four

--- a/lib/@vibe/compiler/tests/double_call_offset_collision_test.vibe
+++ b/lib/@vibe/compiler/tests/double_call_offset_collision_test.vibe
@@ -28,7 +28,7 @@ import @vibe/compiler/syntax {
 }
 
 import @vibe/compiler/checker {
-  check_program_double_call_result_located_observation
+  check_program_double_call_result_located_observation, check_program_result, checked_double_render_offsets
 }
 
 import @vibe/compiler/core {
@@ -73,6 +73,15 @@ fn rows(src: String, k: Int) -> Int {
   } with { Exception::Throw(_) => 0 - 2 }
 }
 
+/// Rows in the tag-4 render/`eq` ARGUMENT table -- the other producer that
+/// reaches the same Double array, under a different key.
+fn tag4_rows(src: String) -> Int {
+  handle {
+    let (toks, starts, _) = lex_with_offsets(src)
+    Array::length(checked_double_render_offsets(check_program_result(parse_program_located(toks, starts, src))))
+  } with { Exception::Throw(_) => 0 - 1 }
+}
+
 //# Tests
 
 test "#2427: a disagreeing offset collision is poisoned" {
@@ -104,4 +113,27 @@ test "#2427: an offset no claimant calls Double files nothing" {
   let both_int = "fn fi() -> Int {\n  1\n}\nfn fj() -> Int {\n  2\n}\nlet a = fi()\nlet b = fj()\n"
   inspect(rows(both_int, 0 - 1), content = "0")
   inspect(rows(both_int, 777), content = "0")
+}
+
+test "#2427: poisoning does not cost the RENDER path its classification" {
+  // Why dropping the row is the right direction, measured rather than
+  // assumed (Codex round 1). Poisoning costs the Double claimant its
+  // call-result row too, so the choice only makes sense if the two claimants
+  // do not lose the same things -- and they do not.
+  //
+  // A Double reaching the RENDERER is keyed by `typed_lowering_arg_offset` on
+  // the enclosing `__to_string` call, which is a different key from the call
+  // result's own offset. So it survives the poison, and the render path is
+  // exactly the one #2427 reports (a corrupt `(ptr|len)` into
+  // `__rt_str_concat`). After the poison NEITHER claimant's render is
+  // misclassified; before it, the Int claimant's was.
+  let render = "fn fd() -> Double {\n  1.5\n}\nlet s = __to_string(fd())\n"
+  inspect(tag4_rows(render), content = "1")
+  // Arithmetic has no second channel, so it genuinely changes hands: the
+  // Double claimant's `fd() + 1.0` goes unclassified where the Int
+  // claimant's used to be read as an f64. Wrong either way -- this row is
+  // the residue that keeps #2427 open, and it is pinned so a later fix has
+  // to notice it rather than inherit it.
+  let arith = "fn fd() -> Double {\n  1.5\n}\nlet v = fd() + 1.0\n"
+  inspect(tag4_rows(arith), content = "0")
 }

--- a/lib/@vibe/compiler/tests/double_call_offset_collision_test.vibe
+++ b/lib/@vibe/compiler/tests/double_call_offset_collision_test.vibe
@@ -44,7 +44,19 @@ fn collide(stmts: Array[Stmt], k: Int) -> Array[Stmt] {
   while i < Array::length(stmts) {
     match Array::get(stmts, i) {
       SLet(a, b, name, ty, value) => match value {
-        ECall(callee, args, _) => Array::push(out, SLet(a, b, name, ty, ECall(callee, args, k))),
+        // A one-argument call whose argument is itself a call is the render
+        // shape (`__to_string(fd())`): the offset that collides is the INNER
+        // one, because that is the call whose result the channel classifies.
+        ECall(callee, args, off) => if Array::length(args) == 1 {
+          match Array::get(args, 0) {
+            ECall(icallee, iargs, _) => Array::push(out, SLet(a, b, name, ty, ECall(callee, [
+              ECall(icallee, iargs, k)
+            ], off))),
+            _ => Array::push(out, SLet(a, b, name, ty, ECall(callee, args, k)))
+          }
+        } else {
+          Array::push(out, SLet(a, b, name, ty, ECall(callee, args, k)))
+        },
         _ => Array::push(out, Array::get(stmts, i))
       },
       _ => Array::push(out, Array::get(stmts, i))
@@ -75,10 +87,16 @@ fn rows(src: String, k: Int) -> Int {
 
 /// Rows in the tag-4 render/`eq` ARGUMENT table -- the other producer that
 /// reaches the same Double array, under a different key.
-fn tag4_rows(src: String) -> Int {
+fn tag4_rows(src: String, k: Int) -> Int {
   handle {
     let (toks, starts, _) = lex_with_offsets(src)
-    Array::length(checked_double_render_offsets(check_program_result(parse_program_located(toks, starts, src))))
+    let parsed = parse_program_located(toks, starts, src)
+    let stmts = if k < 0 {
+      parsed
+    } else {
+      collide(parsed, k)
+    }
+    Array::length(checked_double_render_offsets(check_program_result(stmts)))
   } with { Exception::Throw(_) => 0 - 1 }
 }
 
@@ -115,25 +133,37 @@ test "#2427: an offset no claimant calls Double files nothing" {
   inspect(rows(both_int, 777), content = "0")
 }
 
-test "#2427: poisoning does not cost the RENDER path its classification" {
-  // Why dropping the row is the right direction, measured rather than
-  // assumed (Codex round 1). Poisoning costs the Double claimant its
-  // call-result row too, so the choice only makes sense if the two claimants
-  // do not lose the same things -- and they do not.
+test "#2427: a mixed collision costs the Double claimant BOTH channels" {
+  // The residue, measured on the collision itself rather than beside it.
   //
-  // A Double reaching the RENDERER is keyed by `typed_lowering_arg_offset` on
-  // the enclosing `__to_string` call, which is a different key from the call
-  // result's own offset. So it survives the poison, and the render path is
-  // exactly the one #2427 reports (a corrupt `(ptr|len)` into
-  // `__rt_str_concat`). After the poison NEITHER claimant's render is
-  // misclassified; before it, the Int claimant's was.
-  let render = "fn fd() -> Double {\n  1.5\n}\nlet s = __to_string(fd())\n"
-  inspect(tag4_rows(render), content = "1")
-  // Arithmetic has no second channel, so it genuinely changes hands: the
-  // Double claimant's `fd() + 1.0` goes unclassified where the Int
-  // claimant's used to be read as an f64. Wrong either way -- this row is
-  // the residue that keeps #2427 open, and it is pinned so a later fix has
-  // to notice it rather than inherit it.
-  let arith = "fn fd() -> Double {\n  1.5\n}\nlet v = fd() + 1.0\n"
-  inspect(tag4_rows(arith), content = "0")
+  // An earlier cut of this test called `tag4_rows` on the UNCOLLIDED source,
+  // saw a row, and concluded the render path survives the poison. It does
+  // not, and the test could never have shown it: `typed_lowering_float_key`
+  // keys a call-result argument on the call's OWN offset -- the colliding one
+  // -- and `irc_render_arg_offsets` drops a candidate whose occurrences
+  // disagree, which is exactly what a mixed collision makes them do.
+  //
+  //   natural    tag0=1  tag4=1
+  //   collided   tag0=0  tag4=0
+  //
+  // So poisoning is a SWAP, not a rescue: before it the Double claimant kept
+  // its row and the Int claimant was misclassified; after it neither is
+  // classified and both fall to the syntactic classifiers. The reason to
+  // prefer that is not that it hurts less -- it is that an offset whose
+  // claimants disagree has no single true answer, and this channel's contract
+  // is "absent, never wrong". Every sibling channel already fails closed the
+  // same way: tags 3, 4 and 5 emit an offset only when EVERY occurrence there
+  // agrees, and the String binops poison a disagreeing anchor. Tag 0 was the
+  // only one asserting an answer it could not know, which is what
+  // `typed_lowering_float_key`'s own comment says when it explains why the
+  // FLOAT key needs a restriction the Int key does not.
+  let render = "fn fd() -> Double {\n  1.5\n}\nfn fi() -> Int {\n  1\n}\nlet s = __to_string(fd())\nlet b = fi()\n"
+  inspect(tag4_rows(render, 0 - 1), content = "1")
+  inspect(rows(render, 0 - 1), content = "1")
+  // Both channels gone once the two calls share an offset. tag4 answers 0
+  // here WITHOUT this PR too -- that producer's agreement rule is
+  // pre-existing -- so this row is the residue #2427 keeps open, not
+  // something this change introduced.
+  inspect(tag4_rows(render, 777), content = "0")
+  inspect(rows(render, 777), content = "0")
 }

--- a/lib/@vibe/compiler/tests/double_call_offset_collision_test.vibe
+++ b/lib/@vibe/compiler/tests/double_call_offset_collision_test.vibe
@@ -1,0 +1,107 @@
+//# #2427: an offset claimed by two primary call results that DISAGREE must be
+//# poisoned, not filed.
+//
+// The Double call-result table is keyed by OFFSET, so an offset in it
+// classifies every call node anchored there. The extraction used to
+// deduplicate -- "did I already push this offset" -- which answers a question
+// about the OUTPUT. The question that matters is whether the claimants AGREE:
+// if one claimant is a `Double` call and another at the same offset is an
+// `Int` call, filing the offset tells codegen the Int call returns a float,
+// and the first consumer that renders it hands `__rt_str_concat` a corrupt
+// `(ptr|len)`. That is #2427's reported symptom on the minified bundle.
+//
+// `string_binop_offsets_from_capture` has carried this poison rule since Codex
+// round 1 on #2429. This is the same rule on the sibling table.
+//
+// The collision is CONSTRUCTED here rather than found. #2427 describes an
+// anchoring coincidence in the bundle's offset space that shifts with any
+// edit; no naturally colliding pair turned up in today's bundle, and the
+// obvious candidate -- a curried `f()()` -- anchors its two calls four bytes
+// apart (measured: 81 and 85). Rewriting two top-level call offsets to one
+// value reproduces the extraction's input exactly, which is what this rule is
+// about; it does not depend on which source shape produces the coincidence.
+
+//# Imports
+
+import @vibe/compiler/syntax {
+  lex_with_offsets, parse_program_located
+}
+
+import @vibe/compiler/checker {
+  check_program_double_call_result_located_observation
+}
+
+import @vibe/compiler/core {
+  Expr, Stmt
+}
+
+//# Functions
+
+/// Force every top-level `let x = <call>` to anchor at ONE offset.
+fn collide(stmts: Array[Stmt], k: Int) -> Array[Stmt] {
+  let out: Array[Stmt] = []
+  let mut i = 0
+  while i < Array::length(stmts) {
+    match Array::get(stmts, i) {
+      SLet(a, b, name, ty, value) => match value {
+        ECall(callee, args, _) => Array::push(out, SLet(a, b, name, ty, ECall(callee, args, k))),
+        _ => Array::push(out, Array::get(stmts, i))
+      },
+      _ => Array::push(out, Array::get(stmts, i))
+    }
+    i = i + 1
+  }
+  out
+}
+
+/// Rows in the Double call-result table. -1 = the located observation refused
+/// the AST, which is a different answer from "no rows" and must not be
+/// confused with one.
+fn rows(src: String, k: Int) -> Int {
+  handle {
+    let (toks, starts, _) = lex_with_offsets(src)
+    let parsed = parse_program_located(toks, starts, src)
+    let stmts = if k < 0 {
+      parsed
+    } else {
+      collide(parsed, k)
+    }
+    match check_program_double_call_result_located_observation(stmts) {
+      Some((_, offs, _, _)) => Array::length(offs),
+      None => 0 - 1
+    }
+  } with { Exception::Throw(_) => 0 - 2 }
+}
+
+//# Tests
+
+test "#2427: a disagreeing offset collision is poisoned" {
+  let mixed = "fn fd() -> Double {\n  1.5\n}\nfn fi() -> Int {\n  1\n}\nlet a = fd()\nlet b = fi()\n"
+  // Control: left where the parser put them, the two calls anchor apart and
+  // the Double one files its row. This is the case that must NOT change --
+  // a rule that dropped every collision would also pass the assertion below,
+  // and this is what separates the two.
+  inspect(rows(mixed, 0 - 1), content = "1")
+  // The bug: both calls forced onto offset 777. Measured before the poison
+  // rule, this answered 1 -- the row filed by `fd()` also claimed `fi()`.
+  inspect(rows(mixed, 777), content = "0")
+}
+
+test "#2427: an AGREEING offset collision still files its row" {
+  // Two Double call results at one offset are not a conflict: every claimant
+  // says the same thing, so the row is true for the offset and codegen
+  // classifies both correctly. Poisoning here would turn the fix into a
+  // silent loss of the channel wherever two Double calls happened to
+  // coincide, which is the over-correction this pins against.
+  let both_double = "fn fd() -> Double {\n  1.5\n}\nfn fe() -> Double {\n  2.5\n}\nlet a = fd()\nlet b = fe()\n"
+  inspect(rows(both_double, 0 - 1), content = "2")
+  inspect(rows(both_double, 777), content = "1")
+}
+
+test "#2427: an offset no claimant calls Double files nothing" {
+  // The fail-closed direction from the other side: agreement on NOT-Double is
+  // still agreement, and it files no row either way.
+  let both_int = "fn fi() -> Int {\n  1\n}\nfn fj() -> Int {\n  2\n}\nlet a = fi()\nlet b = fj()\n"
+  inspect(rows(both_int, 0 - 1), content = "0")
+  inspect(rows(both_int, 777), content = "0")
+}


### PR DESCRIPTION
#2427's mechanism, narrowed. Not closed — see **What this does not do**, and note the open design question at the bottom.

## The hole

The Double call-result table is keyed by **offset**, so an offset in it classifies *every* call node anchored there. `double_call_result_offsets_from_capture` deduplicated — "did I already push this offset" — which answers a question about the **output**. The question that matters is whether the claimants **agree**.

So an offset claimed by two primary call results, one `Double` and one `Int`, was filed on the strength of the Double one. Codegen then treats the Int call's result as floatish, and the first consumer that renders it hands `__rt_str_concat` a corrupt `(ptr|len)` — the trap #2427 reports on the minified bundle, where the anchoring coincidence shifts with any edit.

Tag 0 was the **only** channel in this family without an agreement rule. Tags 3, 4 and 5 emit an offset only when every occurrence there agrees; the String binops poison a disagreeing anchor (Codex round 1 on #2429). `typed_lowering_float_key`'s own comment says so, while explaining why the *float* key needs a restriction the Int key does not:

> The Int channel does not have this problem and does not use this key: its producer emits an offset only when EVERY typed occurrence there resolves to `Int` [...] Tag 0's producer is the call-result capture instead, which has no such agreement rule, so the restriction lives here.

This gives tag 0 that rule.

## The fix

A key is kept only when every claimant resolves the same way. Two claimants that **agree** still collapse to one row, so nothing that worked stops working.

Measured, two top-level calls (`fn fd() -> Double`, `fn fi() -> Int`):

| | table |
|---|---|
| distinct offsets (as parsed) | `[59]` → `[59]` |
| both forced to 777 | **`[777]`** → `[]` |

Pass 1 is byte-for-byte the original loop. The second pass tests the **offset** first — a binary search against the small sorted candidate set — and only then calls `subst_resolves_to_double`, so the expensive resolution runs solely at candidate offsets, and a program with no Double call skips the block entirely.

That shape took three tries, all caught in review, and the CI perf report priced each one:

| version | selfcompile heap_ptr |
|---|---:|
| linear scan over a growing key list | +0.28% |
| sorting `others` (an insertion sort — still quadratic) | +0.20% |
| allocation-free, offset test before type resolution | +0.07% |
| current head | **+0.00%** |

Every execution row (fuel, per-scenario heap, B/op, wasm bytes) is ±0.

## What poisoning costs, measured

Dropping the row costs the **Double** claimant its classification too. Earlier revisions of this description claimed otherwise — first that the collision became "harmless", then that the tag-4 render channel rescued the Double side. Both were wrong, and the second was wrong because it was measured *beside* the collision rather than on it:

| | tag 0 | tag 4 |
|---|---|---|
| natural | 1 | 1 |
| collided | 0 | **0** |

`typed_lowering_float_key` keys a call-result argument on the call's **own** offset — the colliding one — and `irc_render_arg_offsets` drops a candidate whose occurrences disagree. (That producer answers 0 there without this change too; its agreement rule is older.)

So this is a **swap**: before, the Double claimant kept its row and the Int claimant was misclassified; after, neither is classified and both fall to the syntactic classifiers. The reason to prefer it is not that it hurts less — it is that an offset whose claimants disagree has no single true answer, and filing it asserts `Double` for every node anchored there, which is knowably false for one of them.

## Tests

`lib/@vibe/compiler/tests/double_call_offset_collision_test.vibe`, four cases:

1. **The bug** — a disagreeing collision is poisoned, with the natural (distinct-offset) case as the control that must not change.
2. **An agreeing collision still files its row.** Its own test on purpose: a rule that dropped *every* collision would pass case 1 while silently losing the channel wherever two `Double` calls coincided.
3. **No claimant calls it Double → no row**, the fail-closed direction from the other side.
4. **A mixed collision costs the Double claimant both channels** — tag 0 and tag 4 together, natural and collided, so the residue is a recorded fact rather than an assumption.

Red-tested: the committed test file fails on the unfixed extraction (`actual: 1, expected: 0`) and passes with the fix.

## Verification

On a stage2 built from the final head:

- Gate lanes `early`, `mid`, `late` — all `ok`.
- Unit suite: **1107/1107**.
- CI green on every intermediate head.

## What this does not do

**No live instance was found.** The collision in the test is *constructed* — call offsets rewritten to one value, which reproduces the extraction's input exactly. No naturally colliding pair turned up in today's bundle, and the obvious candidate, a curried `f()()`, anchors its two calls four bytes apart (measured: 81 and 85). This closes the hole whether or not an instance is live; it does not establish that today's bundle was hitting it.

**A node-specific key is the real fix**, and it is not available here: the consumer looks the table up by `get_ecall_off(e)`, so the key space *is* the offset space, and a checker-side node identity codegen cannot reproduce would file rows nobody can read.

**#2427 stays open** for its step 2 — the audit of the #2231 offset-anchoring rules for a shape whose recorded offset can equal a different node's key.

## Open question for the author

Two review threads on the swap are deliberately left unresolved. The choice is between tag 0 remaining the one channel that asserts a type it cannot know, and a mixed collision leaving both claimants unclassified. I prefer the second — consistency with every sibling channel, and a recorded residue — but it is a judgement call about which wrong answer to prefer in a case nobody has yet observed live, and it is yours to make.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FYMVd6D2o82suTfTwoJPMf