### PR TITLE
codegen: say why the Int/Bool render tables must NOT be filtered (#2427)

### DIFF
--- a/lib/@vibe/compiler/codegen/wasi/linked_compile.vibe
+++ b/lib/@vibe/compiler/codegen/wasi/linked_compile.vibe
@@ -4670,11 +4670,32 @@ export fn compile_wasi_module_linked_impl_with_typed_offsets(stmts: Array[Stmt],
   // rather than against whatever the entry handed the checker. Empty in, empty
   // out, without a walk.
   let float_call_offsets = unique_typed_lowering_offsets_in_stmts(stmts, checker_float_call_offsets)
-  // #2424: the Int render-argument table needs no uniqueness filter of its
-  // own. The checker already refuses an offset whose typed occurrences
-  // disagree, and #2429's per-file rebase (`+ base * 8` on the encoded value)
-  // keeps the merged offset spaces disjoint, so what arrives here is already
-  // the fail-closed set.
+  // #2424: the Int (tag 3) and Bool (tag 5) render-argument tables are
+  // installed RAW, and the filter above must not be extended to them.
+  //
+  // What makes the raw install honest is the checker's agreement rule: an
+  // offset is filed only when EVERY typed occurrence there resolves to the
+  // wanted type, so a call offset shared with the `CtFn` occurrence of its
+  // callee is dropped on disagreement.
+  //
+  // The reason NOT to filter is stronger than "it is unnecessary" -- the
+  // filter and these tables disagree about what a key is, so applying it
+  // deletes rows (#2427). `count_typed_lowering_offsets_expr` counts `ECall`
+  // and `EDot` and deliberately not `EIdent`, since a call's own offset IS its
+  // callee identifier's offset. But tags 3 and 5 key an argument by
+  // `typed_lowering_arg_offset`, which DOES answer for `EIdent`, and a bare
+  // name is the commonest render argument there is. Measured, one row each:
+  //
+  //   inspect(v, ..)    name        1 -> 0   dropped
+  //   inspect(n(), ..)  call        1 -> 1   kept
+  //   inspect(s.a, ..)  projection  1 -> 1   kept
+  //
+  // `inspect(<name>, ..)` is the repo's preferred assertion idiom, so the
+  // symmetric-looking hardening would delete most of the channel at its most
+  // common site and restore the syntactic classifier tags 3 and 5 exist to
+  // replace (#2462, #2464). The Double table is immune because
+  // `typed_lowering_float_key` answers -1 for `EIdent` and never files a
+  // name-keyed row. Pinned by tests/typed_lowering_filter_key_space_test.vibe.
   let int_render_offsets = checker_int_render_offsets
   let bool_render_offsets = checker_bool_render_offsets
   let fn_param_counts = lc_fresh_int_array()

--- a/lib/@vibe/compiler/tests/typed_lowering_filter_key_space_test.vibe
+++ b/lib/@vibe/compiler/tests/typed_lowering_filter_key_space_test.vibe
@@ -1,0 +1,118 @@
+//# #2427: why the Int/Bool render tables are installed WITHOUT the uniqueness
+//# filter the Double table gets, and what breaks if someone "fixes" that.
+//
+// `linked_compile` narrows the Double table with
+// `unique_typed_lowering_offsets_in_stmts` and installs the Int (tag 3) and
+// Bool (tag 5) tables raw. That asymmetry reads like an oversight, and the
+// obvious hardening -- route all three through the same filter -- is a silent
+// REGRESSION, because the filter and those tables do not agree on what a key
+// is.
+//
+// `count_typed_lowering_offsets_expr` counts `ECall` (own offset) and `EDot`
+// (field-name offset) and deliberately NOT `EIdent`: a call's own offset IS
+// its callee identifier's offset, so counting both would score every ordinary
+// `f(x)` as 2 and drop every call-result row. But tags 3 and 5 key an
+// argument by `typed_lowering_arg_offset`, which DOES answer for `EIdent` --
+// and a bare name is the commonest render argument there is. Such a row scores
+// 0, not 1, so the filter drops it.
+//
+// Measured, one row each through the three key kinds (`int before -> after`):
+//
+//   inspect(v, ..)    name       1 -> 0    dropped
+//   inspect(n(), ..)  call       1 -> 1    kept
+//   inspect(s.a, ..)  projection 1 -> 1    kept
+//
+// `inspect(<name>, ..)` is the repo's preferred assertion idiom, so applying
+// the filter would delete most of the channel at its most common site and put
+// back the syntactic classifier the tag-3/5 rows exist to replace (#2462,
+// #2464). The Double table is unaffected because
+// `typed_lowering_float_key` answers -1 for `EIdent` -- it never files a
+// name-keyed row in the first place.
+//
+// What keeps the raw install honest is NOT that the merge rebase makes offset
+// spaces disjoint. It is the checker's own agreement rule: an offset is filed
+// only when EVERY typed occurrence there resolves to the wanted type, so a
+// call offset shared with a `CtFn` occurrence for its callee is dropped on
+// disagreement.
+//
+// This test is a tripwire, not a specification of desirable behaviour. If it
+// fails because the counter learned about `EIdent`, that is progress: check
+// that a name-keyed row now scores 1 (not 2, via its enclosing call), then
+// delete this file and filter all three tables in `linked_compile`.
+
+//# Imports
+
+import @vibe/compiler/syntax {
+  lex_with_offsets, parse_program_located
+}
+
+import @vibe/compiler/checker {
+  check_program_double_call_result_located_observation, checked_bool_render_offsets, checked_int_render_offsets
+}
+
+import @vibe/compiler/codegen/common_analysis {
+  unique_typed_lowering_offsets_in_stmts
+}
+
+import @vibe/compiler/codegen/wasi {
+  effect_lowering_prelude
+}
+
+//# Helpers
+
+/// (int rows the checker filed, int rows that survive the filter, same for
+/// Bool), measured in the real lane's order: the prelude rewrites `stmts`
+/// first, and only then is uniqueness asked of the program codegen walks.
+fn render_rows_before_and_after_filter(src: String) -> (Int, Int, Int, Int) with Exception {
+  let (tokens, starts, _) = lex_with_offsets(src)
+  let stmts = parse_program_located(tokens, starts, src)
+  match check_program_double_call_result_located_observation(stmts) {
+    None => throw("the observation refused this program; it must be located and checkable"),
+    Some((checked, _, eq_offsets, eq_keys)) => {
+      let ints = checked_int_render_offsets(checked)
+      let bools = checked_bool_render_offsets(checked)
+      let int_before = Array::length(ints)
+      let bool_before = Array::length(bools)
+      let linked_imports: Array[(String, String, Int, Int)] = []
+      let inline_wasm_names: Array[String] = []
+      let inline_wasm_wats: Array[String] = []
+      let errors = effect_lowering_prelude(stmts, "main", linked_imports, inline_wasm_names, inline_wasm_wats, eq_offsets, eq_keys)
+      if Array::length(errors) > 0 {
+        throw("the prelude reported errors, so the measurement would be of a program codegen never sees")
+      } else {
+        ()
+      }
+      (int_before, Array::length(unique_typed_lowering_offsets_in_stmts(stmts, ints)), bool_before, Array::length(unique_typed_lowering_offsets_in_stmts(stmts, bools)))
+    }
+  }
+}
+
+//# Tests
+
+test "#2427: the Double filter drops a NAME-keyed Int render row" {
+  let (int_before, int_after, _, _) = render_rows_before_and_after_filter("test \"t\" {\n  let v = 1\n  inspect(v, \"1\")\n}\n")
+  // The checker files the row, and the filter cannot see the node it names.
+  assert_eq(int_before, 1)
+  assert_eq(int_after, 0)
+}
+
+test "#2427: the same filter keeps a CALL-keyed Int render row" {
+  let (int_before, int_after, _, _) = render_rows_before_and_after_filter("fn n() -> Int {\n  1\n}\ntest \"t\" {\n  inspect(n(), \"1\")\n}\n")
+  assert_eq(int_before, 1)
+  assert_eq(int_after, 1)
+}
+
+test "#2427: and a PROJECTION-keyed Int render row" {
+  let (int_before, int_after, _, _) = render_rows_before_and_after_filter("struct S {\n  a: Int\n}\ntest \"t\" {\n  let s = S::{ a: 1 }\n  inspect(s.a, \"1\")\n}\n")
+  assert_eq(int_before, 1)
+  assert_eq(int_after, 1)
+}
+
+test "#2427: the Bool table loses a name-keyed row the same way" {
+  // Tag 5 shares tag 3's key (`typed_lowering_arg_offset`), so it shares the
+  // incompatibility. Pinned separately because the two are produced by one
+  // folded walk and a future split could diverge.
+  let (_, _, bool_before, bool_after) = render_rows_before_and_after_filter("test \"t\" {\n  let v = true\n  inspect(v, \"true\")\n}\n")
+  assert_eq(bool_before, 1)
+  assert_eq(bool_after, 0)
+}


### PR DESCRIPTION
Continuing #2427 past the falsified offset-collision hypothesis (#2478). This is a **negative result plus a tripwire** — no behaviour change, a corrected comment and a new test.

## The suspect

`linked_compile` narrows the Double table with `unique_typed_lowering_offsets_in_stmts`, deliberately *after* `effect_lowering_prelude` has rewritten `stmts`, and installs the Int (tag 3) and Bool (tag 5) tables raw:

```vibe
let float_call_offsets = unique_typed_lowering_offsets_in_stmts(stmts, checker_float_call_offsets)
let int_render_offsets = checker_int_render_offsets
let bool_render_offsets = checker_bool_render_offsets
```

That asymmetry looks like an oversight, and it is exactly the shape #2427 describes: an offset-keyed classification reaching codegen without the property it depends on being established. So I measured it, and the first result looked like a confirmed P0 — routing the Int table through the same filter dropped rows on ordinary code (`int 6->4`, `int 1->0` on two of the first fixtures scanned).

## What it actually is

The rows were not being dropped because a node was duplicated. They were dropped because **the filter and these tables disagree about what a key is**.

`count_typed_lowering_offsets_expr` counts `ECall` (own offset) and `EDot` (field-name offset), and deliberately not `EIdent` — a call's own offset IS its callee identifier's offset, so counting both would score every ordinary `f(x)` as 2 and drop every call-result row. But tags 3 and 5 key an argument by `typed_lowering_arg_offset`, which **does** answer for `EIdent`. Such a row scores 0, not 1, and the filter drops it.

Measured, one row each through the three key kinds:

| source | key kind | int before → after |
|---|---|---|
| `inspect(v, ..)` | name | 1 → **0** — dropped |
| `inspect(n(), ..)` | call | 1 → 1 |
| `inspect(s.a, ..)` | projection | 1 → 1 |

Rendering a bare NAME through `inspect` is the repo's preferred assertion idiom, so the symmetric-looking hardening would have deleted most of the channel at its most common site and put back the syntactic classifier tags 3 and 5 exist to replace (#2462, #2464). The Double table is immune because `typed_lowering_float_key` answers `-1` for `EIdent` and never files a name-keyed row in the first place.

## What changes

**The comment.** It credited the merge's per-file rebase for keeping the offset spaces disjoint. That is the wrong reason twice over: `unique_typed_lowering_offsets_in_stmts`'s own doc says disjointness must be **established** rather than assumed from how some entry parsed, and the rebase is not what protects these tables. What does is the checker's agreement rule — an offset is filed only when every typed occurrence there resolves to the wanted type, so a call offset shared with its callee's `CtFn` occurrence is dropped on disagreement.

**A tripwire test.** `tests/typed_lowering_filter_key_space_test.vibe` pins all four measurements and says what to do if it fails: if the counter learned about `EIdent`, check that a name-keyed row scores 1 rather than 2 via its enclosing call, then delete the file and filter all three tables. It is deliberately a tripwire, not a specification of desirable behaviour.

Each case also asserts the *before* count, so none of them can pass vacuously — if the checker ever stopped filing the row, the test fails rather than quietly agreeing that 0 → 0.

Red-tested by adding an `EIdent` arm to the counter — the name-keyed case flips `0 -> 1` and the test fails naming the row.

## On #2427

Still open, and this narrows it further rather than closing it. The merge rebase is sound, the alias-collision clone already copies the provider's whole tag-encoded table into a fresh range, and the raw Int/Bool install is a necessity rather than a gap. Together with #2478's corpus scan, the offset-keyed channel is now accounted for on both lanes, and the `__rt_str_concat` corruption from #2425 remains unexplained.

The related improvement — a counter that scores a name-keyed row 1 by skipping a call's own callee ident, which would let all three tables be filtered — is deliberately **not** in this PR. It is a behaviour change to a hot codegen walk, and nothing measured here shows the current install is wrong.

## Verification

All 28 CI checks green on `38abcda`; perf `+0.00%` selfcompile heap with every deterministic and execution row `±0`. `vibe fmt --check` clean on both files.

The test's helper measures the real lane's order, which I checked rather than assumed: `check_program` desugars `inspect` itself (`checker_stmt.vibe:5314`, and `:6974` on the projected-env path) before checking, so the sequence really is desugar → check → prelude → filter, and the prelude's own `desugar_inspect_calls` is a no-op by then.

Note for reviewers: `float_call_offset_fs_lane_test.vibe` fails under `vibe_test.sh`'s default seed compiler and passes against a real stage2 — pre-existing on a clean tree, the documented "which compiler answered" caveat, not this change. Codex's review failed twice on this head with `An unknown error occurred` (a review-service error, not findings), so this PR has no bot review coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FYMVd6D2o82suTfTwoJPMf