### PR TITLE
Let a constant enum recursion specialize; walk an enum's payloads only where dispatch specializes it (#2467)

### DIFF
--- a/fixtures/structural_eq_generic_enum_explicit_field_constant_recursion_typed.vibe
+++ b/fixtures/structural_eq_generic_enum_explicit_field_constant_recursion_typed.vibe
@@ -1,0 +1,42 @@
+//# Codex round 1 on #2477: an enum with a program-written `::equals` for the
+//# instantiation in use is never specialized -- `eq_for_typed_nonstandard_enum`
+//# dispatches to that comparator and records nothing -- so it is not a node of
+//# the specialization graph. The first finiteness walk of #2477 read its
+//# declaration anyway: `E[Int]` inside `S[Array[Int]]` holds `E[Array[T]]`,
+//# which looked like non-regular growth, and the constant recursion
+//# `S[String] -> S[Array[Int]] -> S[Array[Int]]` was reported infinite and
+//# trapped. It must ANSWER, through `E::equals` for the `E[Int]` payload.
+
+enum E[T] {
+  V(T);
+  Deep(E[Array[T]])
+}
+
+fn E::equals(a: E[Int], b: E[Int]) -> Bool {
+  match a {
+    V(x) => match b {
+      V(y) => (x + 0) == (y + 0),
+      _ => false
+    },
+    Deep(_) => match b {
+      Deep(_) => true,
+      _ => false
+    }
+  }
+}
+
+enum S[T] {
+  End(Int);
+  Next(S[Array[Int]], E[Int])
+}
+
+export fn _start() -> Int {
+  let a: S[String] = Next(End(1), V(64 << 32))
+  let b: S[String] = Next(End(1), V(64 << 32))
+  let c: S[String] = Next(End(1), V(65 << 32))
+  let d: S[String] = Next(End(2), V(64 << 32))
+  assert(a == b)
+  assert(a != c)
+  assert(a != d)
+  0
+}

--- a/fixtures/structural_eq_untyped_empty_constant_recursion_typed.vibe
+++ b/fixtures/structural_eq_untyped_empty_constant_recursion_typed.vibe
@@ -1,0 +1,30 @@
+//# Codex round 1 on #2477: a phantom-parameter enum whose recursion is
+//# CONSTANT -- `enum Stable[T] { End(Int); Next(Stable[Array[Int]]) }` --
+//# reaches a LARGER instantiation (`Stable[String]` holds a
+//# `Stable[Array[Int]]`) that then recurs into exactly itself, so its
+//# specialization graph closes. The declaration-level check admitted it
+//# (round 18 on #2456); the first per-instantiation predicate of #2477 read
+//# every size increase as non-regular recursion and trapped here. It must
+//# ANSWER: the larger node is rejected only when its own graph does not
+//# close (`generic_eq_specialization_graph_is_finite`).
+
+enum Stable[T] {
+  End(Int);
+  Next(Stable[Array[Int]])
+}
+
+fn fill(xs: Array[Stable[String]], v: Int) -> Unit {
+  Array::push(xs, Next(Next(End(v))))
+}
+
+export fn _start() -> Int {
+  let left = []
+  fill(left, 64 << 32)
+  let right = []
+  fill(right, 64 << 32)
+  let other = []
+  fill(other, 65 << 32)
+  assert(left == right)
+  assert(left != other)
+  0
+}

--- a/lib/@vibe/compiler/normalize/desugar_trait_dict.vibe
+++ b/lib/@vibe/compiler/normalize/desugar_trait_dict.vibe
@@ -13056,8 +13056,15 @@ fn generic_eq_graph_node_is_finite(head: String, args: Array[TypeExpr], visiting
     // non-regular enum recursion (`enum Nest[T] { N(Nest[Array[T]]); End }`)
     // must be caught here as a struct's is -- without this loop an enum head
     // found no declaration and every enum recursion was judged finite.
+    // An enum is a node only where `eq_for_typed_nonstandard_enum` would
+    // specialize it: a head with a program-written `::equals` dispatches
+    // there and records nothing, and an instantiation carrying a formal
+    // takes the declaration-level answer (Codex round 1 on #2477: walking
+    // such an enum's declaration made an unrelated `E[Int]` field, whose
+    // declaration holds `E[Array[T]]`, report a closing graph as infinite).
+    let enum_specialized = !eq_has_explicit_equals(head) && !eq_ty_has_formal(TyApp(head, args))
     let mut ei = 0
-    while ei < Array::length(dtd_eq_enum_decls) {
+    while enum_specialized && ei < Array::length(dtd_eq_enum_decls) {
       let edecl = Array::get(dtd_eq_enum_decls, ei)
       if edecl.0 == head && Array::length(edecl.1) == Array::length(args) && Array::length(edecl.1) > 0 {
         let mut vi = 0
@@ -13627,10 +13634,16 @@ let dtd_eq_enum_inst_check_stack: Array[TypeExpr] = empty_type_exprs()
 
 /// Where `inst` stands against the instantiations being walked: 1 when the
 /// same instantiation is already active (coinductive: answered by the
-/// comparator under examination), -1 when a LARGER instantiation of the same
-/// head is (a non-regular recursion -- `Nest[T]` holding `Nest[Array[T]]` --
-/// whose walk would never end, the same shape
-/// `generic_eq_graph_node_is_finite` rejects), 0 otherwise.
+/// comparator under examination); -1 when a LARGER instantiation of the same
+/// head is active AND the larger one's own specialization graph does not
+/// close -- the non-regular recursion `Nest[T]` holding `Nest[Array[T]]`,
+/// whose walk would never end. A larger node whose edges close on
+/// themselves (`enum Stable[T] { End(Int); Next(Stable[Array[Int]]) }`:
+/// `Stable[String]` reaches `Stable[Array[Int]]`, which reaches only itself)
+/// is finite and is walked (Codex round 1 on #2477: treating every size
+/// increase as non-regular made that phantom enum trap where it answered).
+/// The finiteness test is the one `generic_eq_is_expanding_recursion` uses,
+/// so the predicate and the dispatch agree. 0 otherwise.
 fn eq_enum_inst_stack_verdict(head: String, args: Array[TypeExpr]) -> Int {
   let key = generic_eq_name(head, args)
   let mut verdict = 0
@@ -13639,7 +13652,7 @@ fn eq_enum_inst_stack_verdict(head: String, args: Array[TypeExpr]) -> Int {
     match Array::get(dtd_eq_enum_inst_check_stack, i) {
       TyApp(active_head, active_args) => if generic_eq_name(active_head, active_args) == key {
         verdict = 1
-      } else if active_head == head && generic_eq_types_size(args) > generic_eq_types_size(active_args) && verdict == 0 {
+      } else if active_head == head && generic_eq_types_size(args) > generic_eq_types_size(active_args) && verdict == 0 && !generic_eq_specialization_graph_is_finite(head, args) {
         verdict = 0 - 1
       } else {
         ()

--- a/lib/@vibe/compiler/tests/eq_typed_channel_untyped_empty_test.vibe
+++ b/lib/@vibe/compiler/tests/eq_typed_channel_untyped_empty_test.vibe
@@ -354,3 +354,31 @@ test "#2467: a regular recursive enum compares its spine by content" {
   inspect(a == c, content = "false")
   inspect(a == d, content = "false")
 }
+
+//# Codex round 1 on #2477: constant recursion is finite
+
+// `enum Stable[T] { End(Int); Next(Stable[Array[Int]]) }` reaches a larger
+// instantiation that recurs into itself. The per-instantiation predicate
+// must walk it (its graph closes) rather than read the size increase as the
+// non-regular `Nest[T] -> Nest[Array[T]]` shape; on the first head of
+// #2477 this compare trapped.
+
+enum EqUeStable[T] {
+  SEnd(Int);
+  SNext(EqUeStable[Array[Int]])
+}
+
+fn fill_stable(xs: Array[EqUeStable[String]], v: Int) -> Unit {
+  Array::push(xs, SNext(SNext(SEnd(v))))
+}
+
+test "#2477 r1: constant enum recursion answers through the typed channel" {
+  let left = []
+  fill_stable(left, 64<<32)
+  let right = []
+  fill_stable(right, 64<<32)
+  let other = []
+  fill_stable(other, 65<<32)
+  inspect(left == right, content = "true")
+  inspect(left == other, content = "false")
+}


### PR DESCRIPTION
## What

Follow-up to #2477 (merged before its Codex round-1 fixes could land on it): the two findings Codex left there, both regressions of the per-instantiation generic-enum comparator against main, fixed and pinned. The review threads are on #2477 ([constant recursion](https://github.com/mizchi/vibe-lang/pull/2477#discussion_r3924717958), [explicit-comparator enums in the graph](https://github.com/mizchi/vibe-lang/pull/2477#discussion_r3924717967)).

| program | main before #2477 | #2477 as merged | this PR |
|---|---|---|---|
| `enum Stable[T] { End(Int); Next(Stable[Array[Int]]) }`, untyped-empty `Array[Stable[String]]` filled through a function | answers | **trap** | answers, `64 << 32` vs `65 << 32` exact |
| `enum E[T] { V(T); Deep(E[Array[T]]) }` with `fn E::equals(a: E[Int], b: E[Int])`, held by `enum S[T] { End(Int); Next(S[Array[Int]], E[Int]) }`, compared at `S[String]` | trap | trap | answers, the `E[Int]` payload through `E::equals` |
| `enum Nest[T] { N(Nest[Array[T]]); End(T) }`, two `N(..)` values | `1` (erased `==`) | trap | trap (non-regular recursion, fail-closed) |

## How

- **Constant recursion is finite.** `eq_generic_enum_instantiation_content_comparable`'s stack verdict read every larger instantiation of the same head as non-regular recursion. `Stable[String]` reaches the larger `Stable[Array[Int]]`, which recurs into exactly itself, so its graph closes; the larger node is now rejected only when `generic_eq_specialization_graph_is_finite` says its own graph does not close — the same test the dispatch's expanding-recursion guard uses, so predicate and dispatch agree.
- **An enum is a graph node only where dispatch specializes it.** `generic_eq_graph_node_is_finite` walked an enum's declaration whenever the head matched, but a head with a program-written `::equals` for the instantiation, or an instantiation carrying a formal, is never specialized (`eq_for_typed_nonstandard_enum` dispatches elsewhere), so its payloads are not edges. Walking them made an unrelated `E[Int]` payload, whose declaration holds `E[Array[T]]`, report a closing `S[String] -> S[Array[Int]]` graph as infinite.

## Red → Green

- `fixtures/structural_eq_untyped_empty_constant_recursion_typed.vibe`: answered on main, trapped on `dee6498`, answers here.
- `fixtures/structural_eq_generic_enum_explicit_field_constant_recursion_typed.vibe`: trapped on both, answers here.
- `fixtures/structural_eq_generic_enum_expanding_recursion_trap.vibe` still traps.
- `eq_typed_channel_untyped_empty_test.vibe` gains the `#2477 r1` constant-recursion test (trap on `dee6498`).

## Validation

Chain on the pre-rebase head (base `50801e0`; the rebase onto `d9665a5` applied cleanly, the compiler sources between the two bases are untouched by this change): stage2 == stage3; the lane tests linear and gc; `test_cli_core.sh`; typing-env-reuse oracle; selfcompile KPI 1,611,803,320 bytes vs 1,611,748,352 on main (+55 KB); 216/216 affected unit-test files; `compiler_gate.sh` early / mid / late.

Refs #2467, #2477.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QKZdvBvHVUagwg6Yih8er8

---
_Generated by [Claude Code](https://claude.ai/code/session_01QKZdvBvHVUagwg6Yih8er8)_