### PR TITLE
codegen: retire the linear name-array membership scans on the codegen lane (#2479)

### DIFF
--- a/lib/@vibe/compiler/codegen/common_analysis/common_analysis.vibe
+++ b/lib/@vibe/compiler/codegen/common_analysis/common_analysis.vibe
@@ -58,26 +58,26 @@ fn common_analysis_fresh_string_array() -> Array[String] {
 /// constructor / tuple / or / struct sub-patterns. #603: codegen now tests a
 /// `PString` sub-pattern of a `PCtor`, so its literal must be registered in the
 /// string table (previously only top-level `PString` arms were collected).
-fn collect_strings_pat(pat: Pat, out: Array[String]) -> Int {
+/// `seen` is shared with `collect_strings_expr`: a literal first met as a
+/// pattern and again as an expression is ONE table entry. (Measured while
+/// #2479 was built with the set on the expression side only: every such
+/// literal -- `canonical_builtin_name`'s match arms and the same names in an
+/// array literal -- was emitted twice, shifting every later string's address.)
+fn collect_strings_pat(pat: Pat, out: Array[String], seen: MutSet[String]) -> Int {
   match pat {
     PString(s) => {
-      let mut pf = false
-      let mut pi = 0
-      while pi < Array::length(out) {
-        if Array::get(out, pi) == s {
-          pf = true
-        }
-        pi = pi + 1
-      }
-      if !pf {
+      if !MutSet::has(seen, s) {
+        MutSet::add(seen, s)
         Array::push(out, s)
+      } else {
+        ()
       }
       0
     },
     PCtor(_, args) => {
       let mut i = 0
       while i < Array::length(args) {
-        let _ = collect_strings_pat(Array::get(args, i), out)
+        let _ = collect_strings_pat(Array::get(args, i), out, seen)
         i = i + 1
       }
       0
@@ -85,21 +85,21 @@ fn collect_strings_pat(pat: Pat, out: Array[String]) -> Int {
     PTuple(pats) => {
       let mut i = 0
       while i < Array::length(pats) {
-        let _ = collect_strings_pat(Array::get(pats, i), out)
+        let _ = collect_strings_pat(Array::get(pats, i), out, seen)
         i = i + 1
       }
       0
     },
     POr(l, r) => {
-      let _ = collect_strings_pat(l, out)
-      let _ = collect_strings_pat(r, out)
+      let _ = collect_strings_pat(l, out, seen)
+      let _ = collect_strings_pat(r, out, seen)
       0
     },
     PStruct(_, fields) => {
       let mut i = 0
       while i < Array::length(fields) {
         let (_, fp) = Array::get(fields, i)
-        let _ = collect_strings_pat(fp, out)
+        let _ = collect_strings_pat(fp, out, seen)
         i = i + 1
       }
       0
@@ -108,34 +108,33 @@ fn collect_strings_pat(pat: Pat, out: Array[String]) -> Int {
   }
 }
 
-export fn collect_strings_expr(expr: Expr, out: Array[String]) -> Int {
+/// #2479: `seen` is the membership side of `out` -- `out` keeps the first-
+/// occurrence order the string table is laid out in, the set answers "is it
+/// there" in O(1). The old form scanned `out` for every `EString`, O(literals²)
+/// over a compiler-sized program (162 ms of a 5.77 s warm compile).
+export fn collect_strings_expr(expr: Expr, out: Array[String], seen: MutSet[String]) -> Int {
   match expr {
     EString(s) => {
-      let mut found = false
-      let mut i = 0
-      while i < Array::length(out) {
-        if Array::get(out, i) == s {
-          found = true
-        }
-        i = i + 1
-      }
-      if !found {
+      if !MutSet::has(seen, s) {
+        MutSet::add(seen, s)
         Array::push(out, s)
+      } else {
+        ()
       }
       0
     },
     EBinOp(_, lhs, rhs, _) => {
-      collect_strings_expr(lhs, out)
-      collect_strings_expr(rhs, out)
+      collect_strings_expr(lhs, out, seen)
+      collect_strings_expr(rhs, out, seen)
     },
-    EUnaryOp(_, operand) => collect_strings_expr(operand, out),
+    EUnaryOp(_, operand) => collect_strings_expr(operand, out, seen),
     EIf(cond, then_e, else_e) => {
-      collect_strings_expr(cond, out)
-      collect_strings_expr(then_e, out)
-      collect_strings_expr(else_e, out)
+      collect_strings_expr(cond, out, seen)
+      collect_strings_expr(then_e, out, seen)
+      collect_strings_expr(else_e, out, seen)
     },
     ECall(callee, args, _) => {
-      collect_strings_expr(callee, out)
+      collect_strings_expr(callee, out, seen)
       // #784: the bool→string codegen path (compile_call.vibe) synthesizes
       // `if b { "true" } else { "false" }` for a statically-boolean `__to_string`
       // arg. Those EString nodes are created during codegen — AFTER this
@@ -146,8 +145,8 @@ export fn collect_strings_expr(expr: Expr, out: Array[String]) -> Int {
       // strings.
       match callee {
         EIdent(nm, _) => if nm == "__to_string" {
-          collect_strings_expr(EString("true"), out)
-          collect_strings_expr(EString("false"), out)
+          collect_strings_expr(EString("true"), out, seen)
+          collect_strings_expr(EString("false"), out, seen)
         } else {
           0
         },
@@ -155,47 +154,47 @@ export fn collect_strings_expr(expr: Expr, out: Array[String]) -> Int {
       }
       let mut i = 0
       while i < Array::length(args) {
-        collect_strings_expr(Array::get(args, i), out)
+        collect_strings_expr(Array::get(args, i), out, seen)
         i = i + 1
       }
       0
     },
     ELet(_, value, body, _) => {
-      collect_strings_expr(value, out)
-      collect_strings_expr(body, out)
+      collect_strings_expr(value, out, seen)
+      collect_strings_expr(body, out, seen)
     },
     ELetRec(_, value, body) => {
-      collect_strings_expr(value, out)
-      collect_strings_expr(body, out)
+      collect_strings_expr(value, out, seen)
+      collect_strings_expr(body, out, seen)
     },
     ELetMut(_, value, body, _) => {
-      collect_strings_expr(value, out)
-      collect_strings_expr(body, out)
+      collect_strings_expr(value, out, seen)
+      collect_strings_expr(body, out, seen)
     },
     EAssign(_, value, body) => {
-      collect_strings_expr(value, out)
-      collect_strings_expr(body, out)
+      collect_strings_expr(value, out, seen)
+      collect_strings_expr(body, out, seen)
     },
     EAssignOp(_, _, value, body) => {
-      collect_strings_expr(value, out)
-      collect_strings_expr(body, out)
+      collect_strings_expr(value, out, seen)
+      collect_strings_expr(body, out, seen)
     },
     ESeq(first, second) => {
-      collect_strings_expr(first, out)
-      collect_strings_expr(second, out)
+      collect_strings_expr(first, out, seen)
+      collect_strings_expr(second, out, seen)
     },
     EWhile(cond, body) => {
-      collect_strings_expr(cond, out)
-      collect_strings_expr(body, out)
+      collect_strings_expr(cond, out, seen)
+      collect_strings_expr(body, out, seen)
     },
     EForIn(_, _, iter_e, body) => {
-      collect_strings_expr(iter_e, out)
-      collect_strings_expr(body, out)
+      collect_strings_expr(iter_e, out, seen)
+      collect_strings_expr(body, out, seen)
     },
     ETuple(elems) => {
       let mut i = 0
       while i < Array::length(elems) {
-        collect_strings_expr(Array::get(elems, i), out)
+        collect_strings_expr(Array::get(elems, i), out, seen)
         i = i + 1
       }
       0
@@ -203,24 +202,24 @@ export fn collect_strings_expr(expr: Expr, out: Array[String]) -> Int {
     EArray(elems) => {
       let mut i = 0
       while i < Array::length(elems) {
-        collect_strings_expr(Array::get(elems, i), out)
+        collect_strings_expr(Array::get(elems, i), out, seen)
         i = i + 1
       }
       0
     },
     EMatch(scrutinee, arms) => {
-      collect_strings_expr(scrutinee, out)
+      collect_strings_expr(scrutinee, out, seen)
       let mut i = 0
       while i < Array::length(arms) {
         let (pat, arm_expr) = Array::get(arms, i)
-        let _ = collect_strings_pat(pat, out)
-        collect_strings_expr(arm_expr, out)
+        let _ = collect_strings_pat(pat, out, seen)
+        collect_strings_expr(arm_expr, out, seen)
         i = i + 1
       }
       0
     },
-    EFn(_, _, _, _, _, body) => collect_strings_expr(body, out),
-    EReturn(msg) => collect_strings_expr(msg, out),
+    EFn(_, _, _, _, _, body) => collect_strings_expr(body, out, seen),
+    EReturn(msg) => collect_strings_expr(msg, out, seen),
     EStringInterp(parts) => {
       let mut si_p = 0
       while si_p < Array::length(parts) {
@@ -245,11 +244,11 @@ export fn collect_strings_expr(expr: Expr, out: Array[String]) -> Int {
       0
     },
     EHandle(body, arms) => {
-      collect_strings_expr(body, out)
+      collect_strings_expr(body, out, seen)
       let mut hi = 0
       while hi < Array::length(arms) {
         let (_, arm_expr) = Array::get(arms, hi)
-        collect_strings_expr(arm_expr, out)
+        collect_strings_expr(arm_expr, out, seen)
         hi = hi + 1
       }
       0
@@ -269,7 +268,7 @@ export fn collect_strings_expr(expr: Expr, out: Array[String]) -> Int {
         if !kf {
           Array::push(out, key)
         }
-        collect_strings_expr(val, out)
+        collect_strings_expr(val, out, seen)
         mi = mi + 1
       }
       0
@@ -278,13 +277,13 @@ export fn collect_strings_expr(expr: Expr, out: Array[String]) -> Int {
       let mut ri = 0
       while ri < Array::length(fields) {
         let (_, fval) = Array::get(fields, ri)
-        collect_strings_expr(fval, out)
+        collect_strings_expr(fval, out, seen)
         ri = ri + 1
       }
       0
     },
-    EDot(obj, _, _, _) => collect_strings_expr(obj, out),
-    ELabeledArg(_, _, val) => collect_strings_expr(val, out),
+    EDot(obj, _, _, _) => collect_strings_expr(obj, out, seen),
+    ELabeledArg(_, _, val) => collect_strings_expr(val, out, seen),
     _ => 0
   }
 }
@@ -538,10 +537,11 @@ export fn stmts_contain_exceptions(stmts: Array[Stmt]) -> Bool {
 
 export fn collect_strings_stmts(stmts: Array[Stmt]) -> Array[String] {
   let out = common_analysis_fresh_string_array()
+  let seen: MutSet[String] = MutSet::new_string()
   let mut i = 0
   while i < Array::length(stmts) {
     match Array::get(stmts, i) {
-      SLet(_, _, _, _, expr) => collect_strings_expr(expr, out),
+      SLet(_, _, _, _, expr) => collect_strings_expr(expr, out, seen),
       _ => 0
     }
     i = i + 1
@@ -1643,10 +1643,13 @@ export fn mut_needs_ref_cell(body: Expr, name: String) -> Bool {
 
 /// Builtins whose arg0 is BORROWED (read in place, not consumed/dropped). Kept
 /// in sync with is_borrow_arg0_call in perceus/index.vibe.
+/// Kept as a compare chain on purpose (#2479 measured the alternative): a
+/// module-level `MutSet` lookup hashes the whole callee name per call site,
+/// while `__rt_str_eq` length-gates almost every mismatch, and the set form
+/// measured SLOWER (0.09 s -> 0.14 s warm inclusive).
 export fn md_is_borrow_arg0_call(f: String) -> Bool {
   f == "__index" || f == "Array::get" || f == "Array::length" || f == "Array::set" || f == "Array::push" || f == "Array::push_all" || f == "ArrayBuilder::push" || f == "MutList::push" || f == "MutList::get" || f == "MutList::length" || f == "MutList::truncate" || f == "MutBytes::push" || f == "MutBytes::length" || f == "StringBuilder::push" || f == "MapBuilder::set" || f == "MapBuilder::has_key" || f == "MapBuilder::get" || f == "Map::get" || f == "Map::iter_get" || f == "Map::__iter_get_unchecked" || f == "Map::keys" || f == "Map::has_key" || f == "Map::set" || f == "Bytes::push" || f == "Bytes::set" || f == "Bytes::get" || f == "Bytes::length" || f == "Bytes::index_of" || f == "Bytes::count" || f == "Bytes::last_index_of" || f == "Bytes::index_of_bytes" || f == "Bytes::compare" || f == "FrozenArray::get" || f == "FrozenArray::length" || f == "FixedArray::get" || f == "FixedArray::set" || f == "FixedArray::length" || f == "String::join" || f == "eq" || f == "__rec_field"
 }
-
 fn md_max(a: Int, b: Int) -> Int {
   if a > b {
     a

--- a/lib/@vibe/compiler/codegen/common_analysis/index.vpkg
+++ b/lib/@vibe/compiler/codegen/common_analysis/index.vpkg
@@ -26,7 +26,7 @@ generated_hash =
 // precedent — no re-import needed here). No `version` binding existed
 // (compiler-internal package).
 
-fn collect_strings_expr(expr: Expr, out: Array[String]) -> Int
+fn collect_strings_expr(expr: Expr, out: Array[String], seen: MutSet[String]) -> Int
 fn get_func_param_names(stmt: Stmt) -> Array[String] with Exception
 fn expr_contains_exceptions(expr: Expr) -> Bool
 fn stmts_contain_exceptions(stmts: Array[Stmt]) -> Bool

--- a/lib/@vibe/compiler/codegen/common_base/inline_direct_perform.vibe
+++ b/lib/@vibe/compiler/codegen/common_base/inline_direct_perform.vibe
@@ -16,7 +16,7 @@ import @vibe/compiler/core {
 }
 
 import @vibe/core {
-  array_empty
+  array_empty, struct MutSet
 }
 
 //# Functions
@@ -2380,14 +2380,18 @@ fn edp_body_calls_any(expr: Expr, names: Array[String]) -> Bool {
   edp_rq_fold(RQCallsAny(names), expr) > 0
 }
 
+/// #2479: the dedup used to scan `out` per definition (O(fns²), 56 ms of a
+/// warm compiler-closure compile); `seen` is its membership side.
 fn edp_all_fn_names(fn_defs: Array[(Int, Bool, Bool, String, Option[TypeExpr], String)]) -> Array[String] {
   let out = empty_str_array()
+  let seen: MutSet[String] = MutSet::new_string()
   let mut i = 0
   while i < Array::length(fn_defs) {
     let (_, _, _, nm, _, _) = Array::get(fn_defs, i)
-    if edp_str_array_contains(out, nm) {
+    if MutSet::has(seen, nm) {
       ()
     } else {
+      MutSet::add(seen, nm)
       Array::push(out, nm)
     }
     i = i + 1

--- a/lib/@vibe/compiler/codegen/wasi/linked_helpers.vibe
+++ b/lib/@vibe/compiler/codegen/wasi/linked_helpers.vibe
@@ -5,7 +5,7 @@ import @vibe/compiler/core {
 }
 
 import @vibe/core {
-  array_empty
+  array_empty, struct MutSet
 }
 
 import @vibe/compiler/core {
@@ -59,30 +59,46 @@ export fn stmts_use_builtin(stmts: Array[Stmt], fn_names: Array[String], target:
 /// compiler-closure compile profiles. Same semantics: a name counts as "used"
 /// only where it is FREE (not a user fn, not locally bound), and the flag
 /// reads compare canonical names exactly like expr_uses_builtin did.
-fn push_free_canonical(expr: Expr, fn_name_index: Array[String], sink: Array[(String, Bool)]) -> Unit {
+fn push_free_canonical(expr: Expr, fn_name_index: Array[String], sink: Array[(String, Bool)], seen_raw: MutSet[String]) -> Unit {
   // #1348: collect_free_vars_USED_BUILTINS, not ..._indexed. The capture
   // variant drops inlined-builtin call callees, which is right for closure
   // capture and exactly wrong here -- the dropped name is the only evidence
   // that the builtin's host import must be reserved. See the doc comment on
   // collect_free_vars_used_builtins (codegen/common_analysis).
+  //
+  // #2479: a name is canonicalized ONCE per program. Every top-level body
+  // used to push every free name it saw, so `canonical_builtin_name` (a
+  // 40-arm string match) and the final map insert ran once per OCCURRENCE
+  // across the whole program; `seen_raw` cuts that to once per distinct name.
   let fvs = collect_free_vars_used_builtins(expr, array_empty(), fn_name_index)
   let mut j = 0
   while j < Array::length(fvs) {
-    Array::push(sink, (canonical_builtin_name(Array::get(fvs, j)), true))
+    let raw = Array::get(fvs, j)
+    if MutSet::has(seen_raw, raw) {
+      ()
+    } else {
+      MutSet::add(seen_raw, raw)
+      Array::push(sink, (canonical_builtin_name(raw), true))
+    }
     j = j + 1
   }
 }
 
 export fn collect_used_builtin_names_into(stmts: Array[Stmt], fn_names: Array[String], fn_name_index: Array[String], sink: Array[(String, Bool)]) -> Unit {
+  let seen_raw: MutSet[String] = MutSet::new_string()
+  collect_used_builtin_names_into_seen(stmts, fn_names, fn_name_index, sink, seen_raw)
+}
+
+fn collect_used_builtin_names_into_seen(stmts: Array[Stmt], fn_names: Array[String], fn_name_index: Array[String], sink: Array[(String, Bool)], seen_raw: MutSet[String]) -> Unit {
   let mut i = 0
   while i < Array::length(stmts) {
     match Array::get(stmts, i) {
-      SLet(_, _, _, _, expr) => push_free_canonical(expr, fn_name_index, sink),
-      SLetMut(_, _, expr) => push_free_canonical(expr, fn_name_index, sink),
-      STest(_, expr) => push_free_canonical(expr, fn_name_index, sink),
-      SBench(_, expr) => push_free_canonical(expr, fn_name_index, sink),
-      SExpr(expr) => push_free_canonical(expr, fn_name_index, sink),
-      SModule(_, _, inner) => collect_used_builtin_names_into(inner, fn_names, fn_name_index, sink),
+      SLet(_, _, _, _, expr) => push_free_canonical(expr, fn_name_index, sink, seen_raw),
+      SLetMut(_, _, expr) => push_free_canonical(expr, fn_name_index, sink, seen_raw),
+      STest(_, expr) => push_free_canonical(expr, fn_name_index, sink, seen_raw),
+      SBench(_, expr) => push_free_canonical(expr, fn_name_index, sink, seen_raw),
+      SExpr(expr) => push_free_canonical(expr, fn_name_index, sink, seen_raw),
+      SModule(_, _, inner) => collect_used_builtin_names_into_seen(inner, fn_names, fn_name_index, sink, seen_raw),
       _ => ()
     }
     i = i + 1

--- a/lib/@vibe/compiler/core/expr_children.vibe
+++ b/lib/@vibe/compiler/core/expr_children.vibe
@@ -68,7 +68,33 @@ export fn typed_lowering_float_key(expr: Expr) -> Int {
   }
 }
 
+/// #2479: the child list is READ-ONLY for every caller (measured: no call
+/// site mutates it), so a leaf answers one shared empty array and a node
+/// whose children ARE an array it already holds (`ETuple`, `EArray`,
+/// `EContinue`) answers that array. The rest still build a fresh list.
+/// Before this, every node of every walk allocated -- 104 ms of
+/// `__rt_arr_new` under `expr_children` on a warm compiler-closure compile,
+/// most of it for leaves.
+let expr_children_none: Array[Expr] = []
+
 export fn expr_children(expr: Expr) -> Array[Expr] {
+  match expr {
+    EInt(_) => expr_children_none,
+    EFloat(_) => expr_children_none,
+    EString(_) => expr_children_none,
+    EBool(_) => expr_children_none,
+    EIdent(_, _) => expr_children_none,
+    EStringInterp(_) => expr_children_none,
+    EUnit => expr_children_none,
+    EBreak(None) => expr_children_none,
+    ETuple(elems) => elems,
+    EArray(elems) => elems,
+    EContinue(args) => args,
+    _ => expr_children_built(expr)
+  }
+}
+
+fn expr_children_built(expr: Expr) -> Array[Expr] {
   let children = array_empty()
   match expr {
     ETuple(elems) => append_exprs(children, elems),

--- a/lib/@vibe/compiler/core/import_alias_rewrite.vibe
+++ b/lib/@vibe/compiler/core/import_alias_rewrite.vibe
@@ -2716,20 +2716,6 @@ fn resolve_known_import_path(known_paths: Array[String], base_dir: String, raw_p
   }
 }
 
-fn plan_triple_lookup(tpaths: Array[String], tnames: Array[String], tvalues: Array[String], path: String, name: String) -> Option[String] {
-  let mut i = 0
-  let mut found = None
-  while i < Array::length(tpaths) {
-    if Array::get(tpaths, i) == path && Array::get(tnames, i) == name {
-      found = Some(Array::get(tvalues, i))
-      i = Array::length(tpaths)
-    } else {
-      i = i + 1
-    }
-  }
-  found
-}
-
 /// Re-export edges of one file: `export ./dep.vibe { a, b as c }` plus the
 /// `import { x } ... export { x }` facade idiom (an `export {}` item with no
 /// local declaration but a matching import). Pushed as parallel arrays
@@ -2859,18 +2845,38 @@ export fn build_export_rename_plan(paths: Array[String], stmts_list: Array[Array
   // export names of a linked library / component entry) and stay bare.
   let excluded_paths = empty_strings()
   let excluded_names = empty_strings()
-  let file_idx_of: (String) -> Int = (path) -> {
-    let mut i = 0
-    let mut found = -1
-    while i < file_count {
-      if Array::get(paths, i) == path {
-        found = i
-        i = file_count
-      } else {
-        i = i + 1
-      }
+  // #2479: the three lookups below used to scan their parallel arrays per
+  // edge (`file_idx_of` over `paths`, `plan_triple_lookup` over the edge
+  // arrays and over the exclusions) -- 150 ms of a warm compiler-closure
+  // compile. Index each once; `plan_triple_lookup` answered the FIRST match,
+  // so an index entry is written only when absent.
+  let path_idx: MutMap[String, Int] = MutMap::new_string()
+  let mut pi = 0
+  while pi < file_count {
+    if !MutMap::has(path_idx, Array::get(paths, pi)) {
+      MutMap::set(path_idx, Array::get(paths, pi), pi)
+    } else {
+      ()
     }
-    found
+    pi = pi + 1
+  }
+  let edge_idx: MutMap[String, Int] = MutMap::new_string()
+  let mut ei2 = 0
+  while ei2 < Array::length(edge_from) {
+    let ekey = plan_rename_key(Array::get(edge_from, ei2), Array::get(edge_pub, ei2))
+    if !MutMap::has(edge_idx, ekey) {
+      MutMap::set(edge_idx, ekey, ei2)
+    } else {
+      ()
+    }
+    ei2 = ei2 + 1
+  }
+  let excluded_idx: MutMap[String, Bool] = MutMap::new_string()
+  let file_idx_of: (String) -> Int = (path) -> {
+    match MutMap::get(path_idx, path) {
+      Some(i) => i,
+      None => -1
+    }
   }
   let mut xi = 0
   while xi < Array::length(edge_from) {
@@ -2888,20 +2894,14 @@ export fn build_export_rename_plan(paths: Array[String], stmts_list: Array[Array
         if is_def {
           Array::push(excluded_paths, cur_path)
           Array::push(excluded_names, cur_name)
+          MutMap::set(excluded_idx, plan_rename_key(cur_path, cur_name), true)
           depth = 16
         } else {
-          match plan_triple_lookup(edge_from, edge_pub, edge_tpath, cur_path, cur_name) {
-            Some(next_path) => {
-              match plan_triple_lookup(edge_from, edge_pub, edge_tname, cur_path, cur_name) {
-                Some(next_name) => {
-                  cur_path = next_path
-                  cur_name = next_name
-                  depth = depth + 1
-                },
-                None => {
-                  depth = 16
-                }
-              }
+          match MutMap::get(edge_idx, plan_rename_key(cur_path, cur_name)) {
+            Some(eidx) => {
+              cur_path = Array::get(edge_tpath, eidx)
+              cur_name = Array::get(edge_tname, eidx)
+              depth = depth + 1
             },
             None => {
               depth = 16
@@ -2918,6 +2918,29 @@ export fn build_export_rename_plan(paths: Array[String], stmts_list: Array[Array
   let rename_names = empty_strings()
   let rename_mangled = empty_strings()
   let rename_idx: MutMap[String, String] = MutMap::new_string()
+  // #2479: the facade-closure fixpoint below scans every rename entry per
+  // edge for the ones on the edge's target path (O(passes x edges x
+  // renames); the whole of this function's 0.2 s on a warm
+  // compiler-closure compile). `rename_by_path` keeps each path's entry
+  // indices in insertion order, so that scan reads one bucket. Every push to
+  // the three parallel arrays goes through `add_rename`, which also appends
+  // to the bucket -- an entry appended while a bucket is being walked lands
+  // at its end, exactly where the array scan would have met it.
+  let rename_by_path: MutMap[String, Array[Int]] = MutMap::new_string()
+  let add_rename: (String, String, String) -> Unit = (rpath, rname, rmangled) -> {
+    let ridx = Array::length(rename_paths)
+    Array::push(rename_paths, rpath)
+    Array::push(rename_names, rname)
+    Array::push(rename_mangled, rmangled)
+    match MutMap::get(rename_by_path, rpath) {
+      Some(bucket) => Array::push(bucket, ridx),
+      None => {
+        let bucket: Array[Int] = []
+        Array::push(bucket, ridx)
+        MutMap::set(rename_by_path, rpath, bucket)
+      }
+    }
+  }
   let mut ri = 0
   while ri < file_count {
     let path = Array::get(paths, ri)
@@ -2928,17 +2951,12 @@ export fn build_export_rename_plan(paths: Array[String], stmts_list: Array[Array
       let mut ni = 0
       while ni < Array::length(def_names) {
         let name = Array::get(def_names, ni)
-        let excluded = match plan_triple_lookup(excluded_paths, excluded_names, excluded_names, path, name) {
-          Some(_) => true,
-          None => false
-        }
+        let excluded = MutMap::has(excluded_idx, plan_rename_key(path, name))
         if excluded {
           ()
         } else {
           let mangled = namespace_exported_def_name(path, name)
-          Array::push(rename_paths, path)
-          Array::push(rename_names, name)
-          Array::push(rename_mangled, mangled)
+          add_rename(path, name, mangled)
           let key = plan_rename_key(path, name)
           if !MutMap::has(rename_idx, key) {
             MutMap::set(rename_idx, key, mangled)
@@ -2959,9 +2977,7 @@ export fn build_export_rename_plan(paths: Array[String], stmts_list: Array[Array
       while ci < Array::length(trait_collision_renames) {
         let (name, mangled) = Array::get(trait_collision_renames, ci)
         if string_array_contains(exported_names, name) {
-          Array::push(rename_paths, path)
-          Array::push(rename_names, name)
-          Array::push(rename_mangled, mangled)
+          add_rename(path, name, mangled)
           let key = plan_rename_key(path, name)
           if !MutMap::has(rename_idx, key) {
             MutMap::set(rename_idx, key, mangled)
@@ -2995,9 +3011,7 @@ export fn build_export_rename_plan(paths: Array[String], stmts_list: Array[Array
             if MutMap::has(rename_idx, from_key) {
               ()
             } else {
-              Array::push(rename_paths, from)
-              Array::push(rename_names, pub_name)
-              Array::push(rename_mangled, mangled)
+              add_rename(from, pub_name, mangled)
               MutMap::set(rename_idx, from_key, mangled)
               changed = true
             }
@@ -3012,27 +3026,30 @@ export fn build_export_rename_plan(paths: Array[String], stmts_list: Array[Array
         let target_name = Array::get(edge_tname, ci)
         let target_prefix = String::concat(target_name, "::")
         let public_prefix = String::concat(pub_name, "::")
-        let mut ri2 = 0
-        while ri2 < Array::length(rename_paths) {
-          let source_path = Array::get(rename_paths, ri2)
-          let source_name = Array::get(rename_names, ri2)
-          if source_path == target_path && String::starts_with(source_name, target_prefix) {
-            let from_name = String::concat(public_prefix, String::substring(source_name, String::length(target_prefix), String::length(source_name)))
-            let from_key = plan_rename_key(from, from_name)
-            if !MutMap::has(rename_idx, from_key) {
-              let mangled = Array::get(rename_mangled, ri2)
-              Array::push(rename_paths, from)
-              Array::push(rename_names, from_name)
-              Array::push(rename_mangled, mangled)
-              MutMap::set(rename_idx, from_key, mangled)
-              changed = true
-            } else {
-              ()
+        match MutMap::get(rename_by_path, target_path) {
+          Some(bucket) => {
+            let mut bi = 0
+            while bi < Array::length(bucket) {
+              let ri2 = Array::get(bucket, bi)
+              let source_name = Array::get(rename_names, ri2)
+              if String::starts_with(source_name, target_prefix) {
+                let from_name = String::concat(public_prefix, String::substring(source_name, String::length(target_prefix), String::length(source_name)))
+                let from_key = plan_rename_key(from, from_name)
+                if !MutMap::has(rename_idx, from_key) {
+                  let mangled = Array::get(rename_mangled, ri2)
+                  add_rename(from, from_name, mangled)
+                  MutMap::set(rename_idx, from_key, mangled)
+                  changed = true
+                } else {
+                  ()
+                }
+              } else {
+                ()
+              }
+              bi = bi + 1
             }
-          } else {
-            ()
-          }
-          ri2 = ri2 + 1
+          },
+          None => ()
         }
       }
       ci = ci + 1

--- a/lib/@vibe/compiler/tests/collect_strings_dedup_test.vibe
+++ b/lib/@vibe/compiler/tests/collect_strings_dedup_test.vibe
@@ -1,0 +1,40 @@
+//# Functions
+
+// #2479: `collect_strings_stmts` builds the string table -- every literal
+// once, in first-occurrence order -- and both its collectors (expression
+// literals and `PString` patterns) dedup through ONE membership set. Measured
+// while the set was on the expression side only: a literal first met as a
+// match-arm pattern and again as an expression (`canonical_builtin_name`'s
+// arms, then the same names in an array literal) was emitted twice, and every
+// later string's address shifted -- the output wasm of an unchanged program
+// changed. The table is program ABI for string constants, so this pins it.
+
+import @vibe/compiler/codegen/common_analysis {
+  collect_strings_stmts
+}
+
+import @vibe/parser {
+  lex, parse_program
+}
+
+fn table(src: String) -> String with Exception {
+  String::join(collect_strings_stmts(parse_program(lex(src))), "|")
+}
+
+//# Tests
+
+test "#2479: an array literal dedups repeated strings in first-occurrence order" {
+  inspect(table("let ops = [\"Fs::ReadFile\", \"Fs::WriteFile\", \"Env::Get\", \"Fs::ReadFile\"]"), content = "Fs::ReadFile|Fs::WriteFile|Env::Get")
+}
+
+test "#2479: a pattern literal and an expression literal are one entry" {
+  inspect(table("fn f(s: String) -> Int { match s { \"a\" => 1, \"b\" => 2, _ => 0 } }\nlet t = [\"b\", \"c\"]"), content = "a|b|c")
+}
+
+test "#2479: an expression literal then the same pattern is one entry" {
+  inspect(table("let t = [\"b\"]\nfn f(s: String) -> Int { match s { \"a\" => 1, \"b\" => 2, _ => 0 } }"), content = "b|a")
+}
+
+test "#2479: literals across functions dedup" {
+  inspect(table("fn g() -> String { \"Map::has\" }\nfn h() -> Array[String] { [\"Map::has\", \"Map::set\"] }"), content = "Map::has|Map::set")
+}


### PR DESCRIPTION
## What

#2479 (a slice of #2386): the codegen lane's linear name-array membership and dedup scans — the shape #2386 names, "linear String scan + defensive copy" — become set lookups, and one walk stops allocating an empty list per leaf. Four sites take `MutSet[String]` / `MutMap` from `@vibe/core`, carried next to the ordered array wherever the array's order is the result and membership is the question; the fifth shares an array:

| site | before | after |
|---|---|---|
| `collect_strings_expr` / `collect_strings_pat` (`codegen/common_analysis`) | every `EString` / `PString` scans the whole `out` table before pushing, O(literals²) | one shared `seen` set |
| `edp_all_fn_names` (`codegen/common_base/inline_direct_perform.vibe`) | dedup by scanning `out` per definition | `seen` set |
| `build_export_rename_plan` (`core/import_alias_rewrite.vibe`) | `file_idx_of` linear over paths and `plan_triple_lookup` linear over the edge / exclusion arrays per edge; the facade-closure fixpoint scans every rename entry per edge per pass | `MutMap` indexes built once (first-match semantics kept: an entry is written only when absent); rename entries bucketed by path, the fixpoint walks one bucket; `plan_triple_lookup` deleted |
| `push_free_canonical` (`codegen/wasi/linked_helpers.vibe`) | every top-level body pushed every free name it saw, so `canonical_builtin_name` (a 40-arm string match) and the final map insert ran once per occurrence across the program | a raw name is canonicalized once per program (`seen_raw`) |
| `expr_children` (`core/expr_children.vibe`) | every node of every walk allocated a fresh child list, most of them empty (104 ms of `__rt_arr_new` under it on a warm compile) | a leaf answers one shared empty array; `ETuple` / `EArray` / `EContinue` answer the array they hold. No caller mutates the result (52 binding sites checked; the callees it is passed to only read) |

Two more were tried and dropped on measurement, recorded here so the next attempt starts from the data:

| site | tried | measured | kept |
|---|---|---|---|
| `md_is_borrow_arg0_call` | one module-level `MutSet` instead of a 40-way `f == "..."` chain | 0.09 s → 0.14 s warm inclusive: `hash_string` walks the whole callee name per call site, while `__rt_str_eq` length-gates almost every mismatch | the chain, with a comment saying why |
| `plan_reuse_pairs` (`perceus`) | two `MutSet`s beside `drop_names` / `alias_names` | −0.05 s warm, but an empty `MutSet[String]` costs 660 bytes (`Profiler::heap_bytes`, 1,304 at 10 entries) and the plan runs per function, so two per plan was most of a +12.7 MB heap_ptr regression | the `name_in` scans |

Pure optimization: the output wasm is byte-identical to main's on five corpora — the full compiler closure (`codegen_lexer_test.vibe`, 3,967,930 bytes), `borrow_returning_names_test.vibe`, `type_db_cross_module_test.vibe`, `perceus_reuse_plan_test.vibe` and `fixtures/generic_derive_eq_test.vibe` — compiled by both stage2s under identical, cache-isolated environments.

## Measured

Protocol from `.claude/skills/compiler-perf-profiling` §0.5: `VIBE_BUILD_CACHE_DIR=$(mktemp -d)` per pair (cold = fresh dir, warm = second run in it), main and candidate interleaved, N=3, idle machine, corpus `lib/@vibe/compiler/tests/codegen_lexer_test.vibe`, both stage2s built with `VIBE_WASM_NAMES=1` from their own sources.

| | main (`50801e0`) | this PR | Δ |
|---|---:|---:|---:|
| cold wall, mean of 3 | 10.76 s (10.43 / 10.61 / 11.25) | 10.14 s (9.87 / 9.97 / 10.59) | **−5.7%** |
| warm wall, mean of 3 | 6.48 s (6.44 / 6.23 / 6.78) | 5.90 s (5.79 / 5.64 / 6.28) | **−8.9%** |
| cold heap_ptr | 1,611,820,736 | 1,531,333,960 | −80.5 MB |
| warm heap_ptr | 819,983,080 | 786,375,192 | −33.6 MB |

Warm inclusive time per site (`--cpu-prof`, subtree aggregation):

| function | main | this PR |
|---|---:|---:|
| `collect_strings_expr` | 0.23 s | 0.02 s |
| `edp_all_fn_names` | 0.10 s | 0.01 s |
| `build_export_rename_plan` | 0.20 s | 0.03 s |
| `expr_children` | 0.23 s | 0.14 s |
| `md_is_borrow_arg0_call` (unchanged) | 0.09 s | 0.10 s |
| `effect_lowering_prelude` (the #2386 target) | 1.93 s | 1.55 s |

The heap drop is `expr_children`: the shared empty list removes one allocation per leaf per walk, and the set-based sites cost less than the arrays they replace. The earlier candidate without it was +2.1 MB.

## One thing found on the way

The first build shared the set on the expression side only. `collect_strings_pat` kept its own scan of `out`, so a literal first met as a match-arm pattern and again as an expression (`canonical_builtin_name`'s arms, then the same names in `append_builtin_deprecated`'s array literal) was pushed twice, every later string's address shifted, and the output of an unchanged program differed (21 duplicate entries, 137 function bodies differing only in `i64.const` string words). The byte-equality check caught it; `lib/@vibe/compiler/tests/collect_strings_dedup_test.vibe` pins the pattern/expression dedup contract (measured `a|b|b|c` on that build).

## Validation

Chain on this head (`b64c62b`, base `c400c40`): bundle regen; stage2 == stage3; `collect_strings_dedup_test.vibe` on linear (no gc run: the test imports the compiler's parser and `common_analysis`, whose closure performs `Source::Exists`, a host import the gc lane does not map); `test_cli_core.sh`; selfcompile KPI heap_ptr 1,532,439,368 bytes vs 1,611,835,352 on main (−79.4 MB, the deterministic twin of the table above); typing-env-reuse oracle; 308/308 affected unit-test files (import-graph selection over the six changed compiler files); `compiler_gate.sh` early / mid / late. `vibe_fmt.sh --check` is a fixpoint on all seven files.

## Review round 1 (`a8feccd`)

Codex: the `EMap` key arm and the interpolation-segment arm pushed into `out` after their own scan without recording the text in `seen`, so a later `EString` of the same text was appended again. Measured on the pre-fix source: `Map::from_pairs([("a", "a")])` gave `a|a`. `collect_strings_note` is now the one insertion path and two map cases join `collect_strings_dedup_test.vibe`; the interpolation case pins the desugared program (the parser resolves `\{..}` before the collector runs). Chain on `a8feccd`: stage2 == stage3; the dedup test on linear; `test_cli_core.sh`; selfcompile KPI 1,532,352,208 bytes; oracle; 138/138 affected unit-test files; `compiler_gate.sh` early / mid / late.

Refs #2479, #2386.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QKZdvBvHVUagwg6Yih8er8