### PR TITLE
codegen: one walk per body for the boundary call keys, a direct str_eq for literal compares, and the #2482 review fix (#2479, #2483)

### DIFF
--- a/lib/@vibe/compiler/codegen/common_analysis/common_analysis.vibe
+++ b/lib/@vibe/compiler/codegen/common_analysis/common_analysis.vibe
@@ -63,15 +63,25 @@ fn common_analysis_fresh_string_array() -> Array[String] {
 /// #2479 was built with the set on the expression side only: every such
 /// literal -- `canonical_builtin_name`'s match arms and the same names in an
 /// array literal -- was emitted twice, shifting every later string's address.)
+/// The ONE insertion path of the string table: `out` keeps first-occurrence
+/// order, `seen` is its membership. Every collector arm that can put a text
+/// into the table (`EString`, `PString`, a nonempty interpolation segment, an
+/// `EMap` key) goes through here -- #2482 review: the segment and key arms
+/// used to push after their own scan of `out` without recording the text in
+/// `seen`, so a later `EString` of the same text was appended again.
+fn collect_strings_note(s: String, out: Array[String], seen: MutSet[String]) -> Unit {
+  if !MutSet::has(seen, s) {
+    MutSet::add(seen, s)
+    Array::push(out, s)
+  } else {
+    ()
+  }
+}
+
 fn collect_strings_pat(pat: Pat, out: Array[String], seen: MutSet[String]) -> Int {
   match pat {
     PString(s) => {
-      if !MutSet::has(seen, s) {
-        MutSet::add(seen, s)
-        Array::push(out, s)
-      } else {
-        ()
-      }
+      collect_strings_note(s, out, seen)
       0
     },
     PCtor(_, args) => {
@@ -115,12 +125,7 @@ fn collect_strings_pat(pat: Pat, out: Array[String], seen: MutSet[String]) -> In
 export fn collect_strings_expr(expr: Expr, out: Array[String], seen: MutSet[String]) -> Int {
   match expr {
     EString(s) => {
-      if !MutSet::has(seen, s) {
-        MutSet::add(seen, s)
-        Array::push(out, s)
-      } else {
-        ()
-      }
+      collect_strings_note(s, out, seen)
       0
     },
     EBinOp(_, lhs, rhs, _) => {
@@ -226,17 +231,9 @@ export fn collect_strings_expr(expr: Expr, out: Array[String], seen: MutSet[Stri
         if si_p % 2 == 0 {
           let part = Array::get(parts, si_p)
           if String::length(part) > 0 {
-            let mut found = false
-            let mut fi2 = 0
-            while fi2 < Array::length(out) {
-              if Array::get(out, fi2) == part {
-                found = true
-              }
-              fi2 = fi2 + 1
-            }
-            if !found {
-              Array::push(out, part)
-            }
+            collect_strings_note(part, out, seen)
+          } else {
+            ()
           }
         }
         si_p = si_p + 1
@@ -257,17 +254,7 @@ export fn collect_strings_expr(expr: Expr, out: Array[String], seen: MutSet[Stri
       let mut mi = 0
       while mi < Array::length(fields) {
         let (key, val) = Array::get(fields, mi)
-        let mut kf = false
-        let mut ki = 0
-        while ki < Array::length(out) {
-          if Array::get(out, ki) == key {
-            kf = true
-          }
-          ki = ki + 1
-        }
-        if !kf {
-          Array::push(out, key)
-        }
+        collect_strings_note(key, out, seen)
         collect_strings_expr(val, out, seen)
         mi = mi + 1
       }

--- a/lib/@vibe/compiler/codegen/common_base/common_base.vibe
+++ b/lib/@vibe/compiler/codegen/common_base/common_base.vibe
@@ -2699,6 +2699,49 @@ export fn func_table_user_index_of(ft: FuncTable, name: String, num_user_funcs: 
   found
 }
 
+/// #2483: the wasm index of the generated BUILTIN registered as `name`, or
+/// -1. The complement of func_table_user_index_of: builtins are appended
+/// after the program's functions, so the builtin entry is the match at a
+/// table position >= num_user_funcs. Needed where codegen wants the runtime
+/// helper itself regardless of a same-named program function -- the prelude
+/// defines `String::equals`, so in any closure that carries it a lookup by
+/// name may answer the program's entry (a different arity on the linked
+/// lane), and `==` never meant that function. O(log N) through the sorted
+/// view (duplicates of one name are adjacent there), linear before the view
+/// exists.
+export fn func_table_builtin_index_of(ft: FuncTable, name: String, num_user_funcs: Int) -> Int {
+  let n = Array::length(ft.names)
+  let base = if num_user_funcs < 0 {
+    0
+  } else {
+    num_user_funcs
+  }
+  let mut found = 0 - 1
+  if Array::length(ft.names_sorted) == n && n > 0 {
+    let mut slot = bsearch_leftmost(ft.names_sorted, name)
+    while slot >= 0 && slot < n && Array::get(ft.names_sorted, slot) == name {
+      let pos = Array::get(ft.names_sorted_pos, slot)
+      if pos >= base {
+        found = Array::get(ft.indices, pos)
+        slot = n
+      } else {
+        slot = slot + 1
+      }
+    }
+  } else {
+    let mut i = base
+    while i < n {
+      if Array::get(ft.names, i) == name {
+        found = Array::get(ft.indices, i)
+        i = n
+      } else {
+        i = i + 1
+      }
+    }
+  }
+  found
+}
+
 export fn resolve_func(ft: FuncTable, name: String) -> (Int, Int, Int) with Exception {
   let found = func_table_index_of(ft, name)
   if found < 0 {

--- a/lib/@vibe/compiler/codegen/common_base/index.vpkg
+++ b/lib/@vibe/compiler/codegen/common_base/index.vpkg
@@ -171,6 +171,7 @@ fn is_ctor_call(value: Expr, ct: CtorTable) -> Bool
 fn resolve_func(ft: FuncTable, name: String) -> (Int, Int, Int) with Exception
 fn func_table_index_of(ft: FuncTable, name: String) -> Int
 fn func_table_user_index_of(ft: FuncTable, name: String, num_user_funcs: Int) -> Int
+fn func_table_builtin_index_of(ft: FuncTable, name: String, num_user_funcs: Int) -> Int
 fn emit_binop_op(buf: Bytes, op: String) -> Unit with Exception
 fn emit_wrap63_untagged(buf: Bytes) -> Unit
 fn emit_arith_wrap_int(buf: Bytes, enable_rc: Bool, op: String) -> Unit

--- a/lib/@vibe/compiler/codegen/expr/compile_expr.vibe
+++ b/lib/@vibe/compiler/codegen/expr/compile_expr.vibe
@@ -224,7 +224,7 @@ import @vibe/compiler/codegen/wasm_emit {
 }
 
 import ./compile_call.vibe {
-  compile_call
+  cc_expr_is_stringish, compile_call
 }
 
 import ./compile_expr_tail.vibe {
@@ -859,16 +859,27 @@ fn emit_eq_value(buf: Bytes, lhs: Expr, rhs: Expr, local_names: Array[String], n
     emit_i64_eq(buf)
     emit_i64_extend_i32_s(buf)
     nl2
-  } else if (is_estring(lhs) || is_estring(rhs)) && func_table_builtin_index_of(ctx.func_table, "String::equals", ctx.num_user_funcs) >= 0 {
-    // #2483: a string-LITERAL operand is the string twin of the intish case.
-    // The checker guarantees the other side is a String, so both operands
-    // are genuine fat pointers and `eq`'s answer for them is exactly
-    // `str_eq`'s -- `eq` only reaches `str_eq` after an i64 compare and two
-    // looks-like-a-string range checks, per call. The compiler's own name
-    // ladders (`f == "Array::get" || f == ...`, ~7,000 literal compares in
-    // its sources) paid that every time: `__rt_eq` was 6.5% of a warm
+  } else if ((is_estring(lhs) && cc_expr_is_stringish(rhs, local_names, ctx)) || (is_estring(rhs) && cc_expr_is_stringish(lhs, local_names, ctx))) && func_table_builtin_index_of(ctx.func_table, "String::equals", ctx.num_user_funcs) >= 0 {
+    // #2483: a string-LITERAL operand against a VERIFIED String operand is
+    // the string twin of the intish case: both are genuine fat pointers, so
+    // `eq`'s answer is exactly `str_eq`'s -- `eq` only reaches `str_eq`
+    // after an i64 compare and two looks-like-a-string range checks, per
+    // call. The compiler's own name ladders (`f == "Array::get" || f ==
+    // ...`, ~7,000 literal compares in its sources, `f` a String-annotated
+    // param) paid that every time: `__rt_eq` was 6.5% of a warm
     // compiler-closure compile, and its top callers were all such ladders.
     // Same operand compilation, same 0/1 i64 result, a different callee.
+    //
+    // "Verified" is cc_expr_is_stringish's answer (a literal, a kind-2
+    // slot -- String-annotated param or `let`-bound stringish value -- a
+    // `: String` ascription, a String-returning builtin), NOT the mere
+    // presence of the literal: infer_binop_type tolerates a failed equality
+    // unification while either side is still a rigid named type parameter
+    // (#829, `checker.vibe`), so a generic callee's result compared with a
+    // literal type-checks and may be an Int at runtime. That operand must
+    // keep the generic path, whose looks-like-a-string guard is what makes
+    // the compare a plain "not equal" instead of a read through the Int's
+    // bits (Codex on #2484).
     //
     // The callee is the BUILTIN entry, found positionally (#2309): the
     // prelude defines a program-level `String::equals`, and a lookup by

--- a/lib/@vibe/compiler/codegen/expr/compile_expr.vibe
+++ b/lib/@vibe/compiler/codegen/expr/compile_expr.vibe
@@ -54,6 +54,7 @@ import @vibe/compiler/codegen/common_base {
   emit_unbox_float,
   expr_tag,
   float_log_reset_above,
+  func_table_builtin_index_of,
   func_table_index_of,
   get_arm_body,
   get_arm_pat,
@@ -752,6 +753,13 @@ fn expr_names_nothing(e: Expr) -> Bool {
   }
 }
 
+fn is_estring(e: Expr) -> Bool {
+  match e {
+    EString(_) => true,
+    _ => false
+  }
+}
+
 /// #672: emit the equality test for `lhs == rhs`, leaving a raw i64 0/1 on the
 /// stack (1 = equal). Routes through the structural comparators when an operand
 /// is a tuple / ctor literal (non-rc), else the generic runtime `eq`. Every `==`
@@ -850,6 +858,26 @@ fn emit_eq_value(buf: Bytes, lhs: Expr, rhs: Expr, local_names: Array[String], n
     let nl2 = ce(buf, rhs, local_names, nl1, ctx, ld)
     emit_i64_eq(buf)
     emit_i64_extend_i32_s(buf)
+    nl2
+  } else if (is_estring(lhs) || is_estring(rhs)) && func_table_builtin_index_of(ctx.func_table, "String::equals", ctx.num_user_funcs) >= 0 {
+    // #2483: a string-LITERAL operand is the string twin of the intish case.
+    // The checker guarantees the other side is a String, so both operands
+    // are genuine fat pointers and `eq`'s answer for them is exactly
+    // `str_eq`'s -- `eq` only reaches `str_eq` after an i64 compare and two
+    // looks-like-a-string range checks, per call. The compiler's own name
+    // ladders (`f == "Array::get" || f == ...`, ~7,000 literal compares in
+    // its sources) paid that every time: `__rt_eq` was 6.5% of a warm
+    // compiler-closure compile, and its top callers were all such ladders.
+    // Same operand compilation, same 0/1 i64 result, a different callee.
+    //
+    // The callee is the BUILTIN entry, found positionally (#2309): the
+    // prelude defines a program-level `String::equals`, and a lookup by
+    // name in a closure that carries it answered that function -- three
+    // parameters on the linked lane -- so the emitted two-argument call
+    // failed to validate. `==` never meant the program's function.
+    let nl1 = ce(buf, lhs, local_names, next_local, ctx, ld)
+    let nl2 = ce(buf, rhs, local_names, nl1, ctx, ld)
+    emit_call(buf, func_table_builtin_index_of(ctx.func_table, "String::equals", ctx.num_user_funcs))
     nl2
   } else {
     let nl1 = ce(buf, lhs, local_names, next_local, ctx, ld)

--- a/lib/@vibe/compiler/codegen/wasi/linked_compile.vibe
+++ b/lib/@vibe/compiler/codegen/wasi/linked_compile.vibe
@@ -934,12 +934,47 @@ fn lc_validate_stdin_provider_stmts(stmts: Array[Stmt]) -> String {
   err
 }
 
-/// #1539: direct provider calls are retargeted to compiler-owned wrapper
-/// functions because the raw imports do not accept the closure-environment ABI
-/// used by ordinary functions. The canonical compile-boundary validator above
-/// has rejected every value-position public reference, so this is strictly
-/// direct-call lowering and does not provide first-class alias transport.
-/// Wrapper bodies alone spell the checker-hidden raw names.
+/// Does any of `names` occur as an identifier in `stmts`? Same statement
+/// coverage as collect_used_builtin_names_into (SLet / SLetMut / STest /
+/// SBench / SExpr, recursing into SModule); the expression side is
+/// lc_mark_calls in mentions mode. Stops after the first statement that hits.
+fn lc_stmts_mention_any(stmts: Array[Stmt], names: Array[String]) -> Bool {
+  let hits: Array[Bool] = []
+  let mut n = 0
+  while n < Array::length(names) {
+    Array::push(hits, false)
+    n = n + 1
+  }
+  let mut hit = false
+  let mut i = 0
+  while !hit && i < Array::length(stmts) {
+    match Array::get(stmts, i) {
+      SLet(_, _, _, _, e) => lc_mark_calls(e, names, hits, true),
+      SLetMut(_, _, e) => lc_mark_calls(e, names, hits, true),
+      STest(_, e) => lc_mark_calls(e, names, hits, true),
+      SBench(_, e) => lc_mark_calls(e, names, hits, true),
+      SExpr(e) => lc_mark_calls(e, names, hits, true),
+      SModule(_, _, inner) => if lc_stmts_mention_any(inner, names) {
+        Array::set(hits, 0, true)
+      } else {
+        ()
+      },
+      _ => ()
+    }
+    let mut k = 0
+    while k < Array::length(hits) {
+      if Array::get(hits, k) {
+        hit = true
+      } else {
+        ()
+      }
+      k = k + 1
+    }
+    i = i + 1
+  }
+  hit
+}
+
 fn lc_inject_stdin_surface_wrappers(stmts: Array[Stmt]) -> Bool {
   let public_names = [
     "Stdin::read_via_stream",
@@ -959,8 +994,13 @@ fn lc_inject_stdin_surface_wrappers(stmts: Array[Stmt]) -> Bool {
     (Array::get(public_names, 2), Array::get(raw_names, 2)),
     (Array::get(public_names, 3), Array::get(raw_names, 3))
   ]
-  let mentions = collect_used_builtin_names(stmts, lc_fresh_string_array())
-  let needed = Map::has_key(mentions, Array::get(public_names, 0)) || Map::has_key(mentions, Array::get(public_names, 1)) || Map::has_key(mentions, Array::get(public_names, 2)) || Map::has_key(mentions, Array::get(public_names, 3))
+  // #2386: this used to run collect_used_builtin_names over the WHOLE
+  // program (131 ms warm on the compiler closure) and read four keys out of
+  // the map. With an empty fn_names list that walk counts every identifier
+  // occurrence that is not locally bound, and a `::`-qualified name cannot
+  // be bound locally, so "any of the four names occurs as an identifier" is
+  // the same question, answered by a stoppable presence scan.
+  let needed = lc_stmts_mention_any(stmts, public_names)
   if needed {
     let mut i = 0
     while i < Array::length(stmts) {
@@ -1620,89 +1660,101 @@ fn lc_pairs_have_async_handle(pairs: Array[(String, Expr)]) -> Bool {
   hit
 }
 
-/// Deep scan: does `e` contain a call whose callee is the bare identifier
-/// `target`? Shadow-BLIND on purpose -- this is only the cheap enablement
+/// Deep scan: which of `targets` does `e` call with the bare identifier as
+/// the callee? Shadow-BLIND on purpose -- this is only the cheap enablement
 /// key for the sleep / host-future machinery below (the retarget walk
 /// itself is shadow-aware), and a false positive merely enables machinery
 /// that then rewrites nothing.
-fn lc_expr_calls_name(e: Expr, target: String) -> Bool {
+///
+/// #2386: ONE walk marks every `targets[k]` found in `e` (`hits[k] = true`;
+/// `hits` is never cleared, so one array accumulates across bodies). With
+/// `mentions = false` a name counts only in callee position -- the question
+/// `lc_expr_calls_name` answered, and `lc_inject_async_sleep_boundary` used
+/// to ask it eleven times per top-level body, one full walk per name; the
+/// traversal was the cost, not the compares (69 ms warm on the compiler
+/// closure, 98% of it self time in the walker). With `mentions = true` any
+/// identifier occurrence counts (`lc_stmts_mention_any`). The arms are
+/// exactly the ones the per-name predicate walked (every `Expr` variant;
+/// the leaves fall to `_`), so every single-target answer is unchanged, and
+/// the walk allocates nothing.
+fn lc_mark_calls(e: Expr, targets: Array[String], hits: Array[Bool], mentions: Bool) -> Unit {
   match e {
+    EIdent(nm, _) => if mentions {
+      lc_mark_call_name(nm, targets, hits)
+    } else {
+      ()
+    },
     ECall(callee, args, _) => {
-      let callee_hit = match callee {
-        EIdent(nm, _) => nm == target,
-        _ => lc_expr_calls_name(callee, target)
+      match callee {
+        EIdent(nm, _) => lc_mark_call_name(nm, targets, hits),
+        _ => lc_mark_calls(callee, targets, hits, mentions)
       }
-      let mut hit = callee_hit
       let mut i = 0
       while i < Array::length(args) {
-        if lc_expr_calls_name(Array::get(args, i), target) {
-          hit = true
-        } else {
-          ()
-        }
+        lc_mark_calls(Array::get(args, i), targets, hits, mentions)
         i = i + 1
       }
-      hit
     },
-    ELet(_, v, b, _) => lc_expr_calls_name(v, target) || lc_expr_calls_name(b, target),
-    ELetMut(_, v, b, _) => lc_expr_calls_name(v, target) || lc_expr_calls_name(b, target),
-    ELetRec(_, v, b) => lc_expr_calls_name(v, target) || lc_expr_calls_name(b, target),
-    ESeq(a, b) => lc_expr_calls_name(a, target) || lc_expr_calls_name(b, target),
-    EIf(c, t, el) => lc_expr_calls_name(c, target) || lc_expr_calls_name(t, target) || lc_expr_calls_name(el, target),
+    ELet(_, v, b, _) => {
+      lc_mark_calls(v, targets, hits, mentions)
+      lc_mark_calls(b, targets, hits, mentions)
+    },
+    ELetMut(_, v, b, _) => {
+      lc_mark_calls(v, targets, hits, mentions)
+      lc_mark_calls(b, targets, hits, mentions)
+    },
+    ELetRec(_, v, b) => {
+      lc_mark_calls(v, targets, hits, mentions)
+      lc_mark_calls(b, targets, hits, mentions)
+    },
+    ESeq(a, b) => {
+      lc_mark_calls(a, targets, hits, mentions)
+      lc_mark_calls(b, targets, hits, mentions)
+    },
+    EIf(c, t, el) => {
+      lc_mark_calls(c, targets, hits, mentions)
+      lc_mark_calls(t, targets, hits, mentions)
+      lc_mark_calls(el, targets, hits, mentions)
+    },
     EMatch(s, arms) => {
-      let mut hit = lc_expr_calls_name(s, target)
-      let mut i = 0
-      while i < Array::length(arms) {
-        let (_, ab) = Array::get(arms, i)
-        if lc_expr_calls_name(ab, target) {
-          hit = true
-        } else {
-          ()
-        }
-        i = i + 1
-      }
-      hit
+      lc_mark_calls(s, targets, hits, mentions)
+      lc_mark_calls_arms(arms, targets, hits, mentions)
     },
     EHandle(b, arms) => {
-      let mut hit = lc_expr_calls_name(b, target)
-      let mut i = 0
-      while i < Array::length(arms) {
-        let (_, ab) = Array::get(arms, i)
-        if lc_expr_calls_name(ab, target) {
-          hit = true
-        } else {
-          ()
-        }
-        i = i + 1
-      }
-      hit
+      lc_mark_calls(b, targets, hits, mentions)
+      lc_mark_calls_arms(arms, targets, hits, mentions)
     },
-    EFn(_, _, _, _, _, b) => lc_expr_calls_name(b, target),
-    EWhile(c, b) => lc_expr_calls_name(c, target) || lc_expr_calls_name(b, target),
-    EForIn(_, _, it, b) => lc_expr_calls_name(it, target) || lc_expr_calls_name(b, target),
+    EFn(_, _, _, _, _, b) => lc_mark_calls(b, targets, hits, mentions),
+    EWhile(c, b) => {
+      lc_mark_calls(c, targets, hits, mentions)
+      lc_mark_calls(b, targets, hits, mentions)
+    },
+    EForIn(_, _, it, b) => {
+      lc_mark_calls(it, targets, hits, mentions)
+      lc_mark_calls(b, targets, hits, mentions)
+    },
     ELoop(pairs, b) => {
-      let mut hit = lc_expr_calls_name(b, target)
-      let mut i = 0
-      while i < Array::length(pairs) {
-        let (_, pv) = Array::get(pairs, i)
-        if lc_expr_calls_name(pv, target) {
-          hit = true
-        } else {
-          ()
-        }
-        i = i + 1
-      }
-      hit
+      lc_mark_calls(b, targets, hits, mentions)
+      lc_mark_calls_fields(pairs, targets, hits, mentions)
     },
-    EBinOp(_, l, r, _) => lc_expr_calls_name(l, target) || lc_expr_calls_name(r, target),
-    EUnaryOp(_, a) => lc_expr_calls_name(a, target),
-    EAssign(_, v, b) => lc_expr_calls_name(v, target) || lc_expr_calls_name(b, target),
-    EAssignOp(_, _, v, b) => lc_expr_calls_name(v, target) || lc_expr_calls_name(b, target),
-    EReturn(a) => lc_expr_calls_name(a, target),
-    EDot(o, _, _, _) => lc_expr_calls_name(o, target),
-    ELabeledArg(_, _, v) => lc_expr_calls_name(v, target),
-    ETuple(items) => lc_exprs_call_name(items, target),
-    EArray(items) => lc_exprs_call_name(items, target),
+    EBinOp(_, l, r, _) => {
+      lc_mark_calls(l, targets, hits, mentions)
+      lc_mark_calls(r, targets, hits, mentions)
+    },
+    EUnaryOp(_, a) => lc_mark_calls(a, targets, hits, mentions),
+    EAssign(_, v, b) => {
+      lc_mark_calls(v, targets, hits, mentions)
+      lc_mark_calls(b, targets, hits, mentions)
+    },
+    EAssignOp(_, _, v, b) => {
+      lc_mark_calls(v, targets, hits, mentions)
+      lc_mark_calls(b, targets, hits, mentions)
+    },
+    EReturn(a) => lc_mark_calls(a, targets, hits, mentions),
+    EDot(o, _, _, _) => lc_mark_calls(o, targets, hits, mentions),
+    ELabeledArg(_, _, v) => lc_mark_calls(v, targets, hits, mentions),
+    ETuple(items) => lc_mark_calls_exprs(items, targets, hits, mentions),
+    EArray(items) => lc_mark_calls_exprs(items, targets, hits, mentions),
     // #1337 Codex review: these four containers were missing, so a call
     // nested in a record/map literal or a break/continue argument was
     // invisible to every key computed from this walk. Harmless for the
@@ -1711,59 +1763,54 @@ fn lc_expr_calls_name(e: Expr, target: String) -> Bool {
     // lc_expr_collect_hf_names -- reserving a per-name import while the
     // boundary machinery stays off leaves the await with nothing to settle
     // it.
-    ERecord(_, fields, _) => lc_fields_call_name(fields, target),
-    EMap(fields) => lc_fields_call_name(fields, target),
+    ERecord(_, fields, _) => lc_mark_calls_fields(fields, targets, hits, mentions),
+    EMap(fields) => lc_mark_calls_fields(fields, targets, hits, mentions),
     EBreak(opt) => match opt {
-      Some(a) => lc_expr_calls_name(a, target),
-      None => false
+      Some(a) => lc_mark_calls(a, targets, hits, mentions),
+      None => ()
     },
-    EContinue(args) => lc_exprs_call_name(args, target),
-    ESpread(a) => lc_expr_calls_name(a, target),
-    _ => false
+    EContinue(args) => lc_mark_calls_exprs(args, targets, hits, mentions),
+    ESpread(a) => lc_mark_calls(a, targets, hits, mentions),
+    _ => ()
   }
 }
 
-fn lc_fields_call_name(fields: Array[(String, Expr)], target: String) -> Bool {
-  let mut hit = false
+fn lc_mark_call_name(nm: String, targets: Array[String], hits: Array[Bool]) -> Unit {
+  let mut k = 0
+  while k < Array::length(targets) {
+    if nm == Array::get(targets, k) {
+      Array::set(hits, k, true)
+    } else {
+      ()
+    }
+    k = k + 1
+  }
+}
+
+fn lc_mark_calls_arms(arms: Array[(Pat, Expr)], targets: Array[String], hits: Array[Bool], mentions: Bool) -> Unit {
+  let mut i = 0
+  while i < Array::length(arms) {
+    let (_, ab) = Array::get(arms, i)
+    lc_mark_calls(ab, targets, hits, mentions)
+    i = i + 1
+  }
+}
+
+fn lc_mark_calls_fields(fields: Array[(String, Expr)], targets: Array[String], hits: Array[Bool], mentions: Bool) -> Unit {
   let mut i = 0
   while i < Array::length(fields) {
     let (_, fv) = Array::get(fields, i)
-    if lc_expr_calls_name(fv, target) {
-      hit = true
-    } else {
-      ()
-    }
+    lc_mark_calls(fv, targets, hits, mentions)
     i = i + 1
   }
-  hit
 }
 
-fn lc_exprs_call_name(es: Array[Expr], target: String) -> Bool {
-  let mut hit = false
+fn lc_mark_calls_exprs(es: Array[Expr], targets: Array[String], hits: Array[Bool], mentions: Bool) -> Unit {
   let mut i = 0
   while i < Array::length(es) {
-    if lc_expr_calls_name(Array::get(es, i), target) {
-      hit = true
-    } else {
-      ()
-    }
+    lc_mark_calls(Array::get(es, i), targets, hits, mentions)
     i = i + 1
   }
-  hit
-}
-
-fn lc_expr_calls_sleep(e: Expr) -> Bool {
-  lc_expr_calls_name(e, "sleep")
-}
-
-/// ADR-0089 step 4 (#1218): enablement key for the host-future boundary
-/// machinery -- does the program call `host_future_get` anywhere?
-fn lc_expr_calls_host_future(e: Expr) -> Bool {
-  // ADR-0089 (c) (#1218): `host_future_named` fires the SAME machinery --
-  // the boundary's `__entry_settle` waitable arm and the wait import are
-  // shared by every host future, named or not; only the per-name GET import
-  // differs.
-  lc_expr_calls_name(e, "host_future_get") || lc_expr_calls_name(e, "host_future_named")
 }
 
 /// ADR-0089 (c) (#1218): every component import name a `host_future_named`
@@ -1779,8 +1826,8 @@ fn lc_expr_calls_host_future(e: Expr) -> Bool {
 ///    (measured: `let r = record { p: host_future_named("price") }` gave
 ///    `undefined variable (local): vibe_hf_get_raw$price`). Hence this
 ///    mirrors lc_rename_sleep_calls -- the file's one traversal that is
-///    already total -- rather than the deliberately partial
-///    lc_expr_calls_name.
+///    already total -- rather than the deliberately shadow-blind
+///    lc_mark_calls.
 ///  - SHADOW-AWARE (`active`). A local named `host_future_named` makes the
 ///    call an ordinary closure call that compile_call does not lower, so
 ///    collecting its argument would reserve a component import the program
@@ -2013,23 +2060,6 @@ fn lc_hs_req_base() -> Int {
   2048
 }
 
-/// ADR-0089 Decision 3 (#1218): enablement key for the host-stream boundary
-/// machinery -- does the program call `host_stream_named` (create),
-/// `host_stream_next` (read) or `host_stream_close` (drop) anywhere? Any of
-/// them implies the boundary's stream settle arm and the shared
-/// `vibe.host_stream_read` import.
-fn lc_expr_calls_host_stream(e: Expr) -> Bool {
-  lc_expr_calls_name(e, "host_stream_named") || lc_expr_calls_name(e, "host_stream_next") || lc_expr_calls_name(e, "host_stream_close") || lc_expr_calls_name(e, "HostStream::next") || lc_expr_calls_name(e, "HostStream::close")
-}
-
-fn lc_expr_calls_host_stream_close(e: Expr) -> Bool {
-  lc_expr_calls_name(e, "host_stream_close") || lc_expr_calls_name(e, "HostStream::close")
-}
-
-fn lc_expr_calls_host_stream_option_next(e: Expr) -> Bool {
-  lc_expr_calls_name(e, "HostStream::next")
-}
-
 /// ADR-0089 Decision 3 (#1218): every component import name a
 /// `host_stream_named` call in `e` asks for, appended to `out`. The stream
 /// sibling of lc_expr_collect_hf_names, with the SAME two hard
@@ -2222,29 +2252,27 @@ fn lc_collect_host_stream_names_go(stmts: Array[Stmt]) -> Array[String] {
   out
 }
 
-/// Program-level version of lc_expr_calls_host_future, for the passes that
+/// Program-level host-future key (ADR-0089 step 4, #1218), for the passes that
 /// need the key BEFORE lc_inject_async_sleep_boundary's own scan runs
 /// (await_poll_pass selects the waitable-aware __aw_poll form with it).
 fn lc_stmts_call_host_future(stmts: Array[Stmt]) -> Bool {
-  let mut hit = false
+  // #2386: the two names in one walk per statement (lc_mark_calls); ADR-0089
+  // (c): `host_future_named` fires the same machinery as `host_future_get`.
+  let hf_targets: Array[String] = ["host_future_get", "host_future_named"]
+  let hf_hits: Array[Bool] = [false, false]
   let mut i = 0
   while i < Array::length(stmts) {
-    let se = match Array::get(stmts, i) {
-      SLet(_, _, _, _, v) => lc_expr_calls_host_future(v),
-      SLetMut(_, _, v) => lc_expr_calls_host_future(v),
-      SExpr(v) => lc_expr_calls_host_future(v),
-      STest(_, v) => lc_expr_calls_host_future(v),
-      SBench(_, v) => lc_expr_calls_host_future(v),
-      _ => false
-    }
-    if se {
-      hit = true
-    } else {
-      ()
+    match Array::get(stmts, i) {
+      SLet(_, _, _, _, v) => lc_mark_calls(v, hf_targets, hf_hits, false),
+      SLetMut(_, _, v) => lc_mark_calls(v, hf_targets, hf_hits, false),
+      SExpr(v) => lc_mark_calls(v, hf_targets, hf_hits, false),
+      STest(_, v) => lc_mark_calls(v, hf_targets, hf_hits, false),
+      SBench(_, v) => lc_mark_calls(v, hf_targets, hf_hits, false),
+      _ => ()
     }
     i = i + 1
   }
-  hit
+  Array::get(hf_hits, 0) || Array::get(hf_hits, 1)
 }
 
 /// True when `target` appears as a binder or identifier reference. The
@@ -2823,22 +2851,45 @@ fn lc_inject_async_sleep_boundary(stmts: Array[Stmt], entry_name: String) -> Str
   let mut user_defines_sleep = false
   let mut has_async_decl = false
   let mut has_async_handle = false
-  let mut calls_sleep = false
-  let mut calls_host_future = false
   let mut user_defines_host_future = false
-  let mut calls_host_stream = false
   // ADR-0089 Decision 3 follow-up (#1218): tracked SEPARATELY from
   // calls_host_stream, because the injected `__hs_close` is what references
   // `vibe_hs_close_raw` -- injecting it for every stream program would
   // reserve the close import in programs that only ever drain, which is
   // exactly the byte-compat property this surface is supposed to keep.
-  let mut calls_host_stream_close = false
   // The public Option-returning helper is a second suspend function. Keep it
   // out of raw-scalar programs: besides preserving their component bytes, the
   // suspend pass must not classify an unused helper as another boundary path.
-  let mut calls_host_stream_option_next = false
   let mut user_defines_host_stream = false
   let mut has_spawn_suspend = false
+  // #2386: the five call keys come out of ONE walk per top-level body
+  // (lc_mark_calls) instead of eleven; the flags are read off `boundary_hits`
+  // after the loop. Index order is the targets' order. ADR-0089 (#1218):
+  // `host_future_named` fires the same machinery as `host_future_get` (the
+  // boundary's `__entry_settle` waitable arm and the wait import are shared;
+  // only the per-name GET import differs), and any of the five stream names
+  // implies the stream settle arm plus the shared `vibe.host_stream_read`
+  // import -- hence the ORs below.
+  let boundary_targets: Array[String] = [
+    "sleep",
+    "host_future_get",
+    "host_future_named",
+    "host_stream_named",
+    "host_stream_next",
+    "host_stream_close",
+    "HostStream::next",
+    "HostStream::close"
+  ]
+  let boundary_hits: Array[Bool] = [
+    false,
+    false,
+    false,
+    false,
+    false,
+    false,
+    false,
+    false
+  ]
   let mut has_aw_poll = false
   let mut i = 0
   while i < Array::length(stmts) {
@@ -2864,38 +2915,14 @@ fn lc_inject_async_sleep_boundary(stmts: Array[Stmt], entry_name: String) -> Str
         } else {
           ()
         }
-        if lc_expr_calls_sleep(fbody) {
-          calls_sleep = true
-        } else {
-          ()
-        }
+        lc_mark_calls(fbody, boundary_targets, boundary_hits, false)
         if name == "host_future_get" || name == "host_future_named" {
           user_defines_host_future = true
         } else {
           ()
         }
-        if lc_expr_calls_host_future(fbody) {
-          calls_host_future = true
-        } else {
-          ()
-        }
         if name == "host_stream_named" || name == "host_stream_next" || name == "host_stream_close" || name == "HostStream::next" || name == "HostStream::close" {
           user_defines_host_stream = true
-        } else {
-          ()
-        }
-        if lc_expr_calls_host_stream(fbody) {
-          calls_host_stream = true
-        } else {
-          ()
-        }
-        if lc_expr_calls_host_stream_close(fbody) {
-          calls_host_stream_close = true
-        } else {
-          ()
-        }
-        if lc_expr_calls_host_stream_option_next(fbody) {
-          calls_host_stream_option_next = true
         } else {
           ()
         }
@@ -2926,31 +2953,7 @@ fn lc_inject_async_sleep_boundary(stmts: Array[Stmt], entry_name: String) -> Str
         } else {
           ()
         }
-        if lc_expr_calls_sleep(sv) {
-          calls_sleep = true
-        } else {
-          ()
-        }
-        if lc_expr_calls_host_future(sv) {
-          calls_host_future = true
-        } else {
-          ()
-        }
-        if lc_expr_calls_host_stream(sv) {
-          calls_host_stream = true
-        } else {
-          ()
-        }
-        if lc_expr_calls_host_stream_close(sv) {
-          calls_host_stream_close = true
-        } else {
-          ()
-        }
-        if lc_expr_calls_host_stream_option_next(sv) {
-          calls_host_stream_option_next = true
-        } else {
-          ()
-        }
+        lc_mark_calls(sv, boundary_targets, boundary_hits, false)
       },
       SLetMut(_, _, mv) => {
         if lc_expr_has_async_handle(mv) {
@@ -2958,31 +2961,7 @@ fn lc_inject_async_sleep_boundary(stmts: Array[Stmt], entry_name: String) -> Str
         } else {
           ()
         }
-        if lc_expr_calls_sleep(mv) {
-          calls_sleep = true
-        } else {
-          ()
-        }
-        if lc_expr_calls_host_future(mv) {
-          calls_host_future = true
-        } else {
-          ()
-        }
-        if lc_expr_calls_host_stream(mv) {
-          calls_host_stream = true
-        } else {
-          ()
-        }
-        if lc_expr_calls_host_stream_close(mv) {
-          calls_host_stream_close = true
-        } else {
-          ()
-        }
-        if lc_expr_calls_host_stream_option_next(mv) {
-          calls_host_stream_option_next = true
-        } else {
-          ()
-        }
+        lc_mark_calls(mv, boundary_targets, boundary_hits, false)
       },
       SExpr(se) => {
         if lc_expr_has_async_handle(se) {
@@ -2990,31 +2969,7 @@ fn lc_inject_async_sleep_boundary(stmts: Array[Stmt], entry_name: String) -> Str
         } else {
           ()
         }
-        if lc_expr_calls_sleep(se) {
-          calls_sleep = true
-        } else {
-          ()
-        }
-        if lc_expr_calls_host_future(se) {
-          calls_host_future = true
-        } else {
-          ()
-        }
-        if lc_expr_calls_host_stream(se) {
-          calls_host_stream = true
-        } else {
-          ()
-        }
-        if lc_expr_calls_host_stream_close(se) {
-          calls_host_stream_close = true
-        } else {
-          ()
-        }
-        if lc_expr_calls_host_stream_option_next(se) {
-          calls_host_stream_option_next = true
-        } else {
-          ()
-        }
+        lc_mark_calls(se, boundary_targets, boundary_hits, false)
       },
       STest(_, te) => {
         if lc_expr_has_async_handle(te) {
@@ -3022,31 +2977,7 @@ fn lc_inject_async_sleep_boundary(stmts: Array[Stmt], entry_name: String) -> Str
         } else {
           ()
         }
-        if lc_expr_calls_sleep(te) {
-          calls_sleep = true
-        } else {
-          ()
-        }
-        if lc_expr_calls_host_future(te) {
-          calls_host_future = true
-        } else {
-          ()
-        }
-        if lc_expr_calls_host_stream(te) {
-          calls_host_stream = true
-        } else {
-          ()
-        }
-        if lc_expr_calls_host_stream_close(te) {
-          calls_host_stream_close = true
-        } else {
-          ()
-        }
-        if lc_expr_calls_host_stream_option_next(te) {
-          calls_host_stream_option_next = true
-        } else {
-          ()
-        }
+        lc_mark_calls(te, boundary_targets, boundary_hits, false)
       },
       SBench(_, be) => {
         if lc_expr_has_async_handle(be) {
@@ -3054,31 +2985,7 @@ fn lc_inject_async_sleep_boundary(stmts: Array[Stmt], entry_name: String) -> Str
         } else {
           ()
         }
-        if lc_expr_calls_sleep(be) {
-          calls_sleep = true
-        } else {
-          ()
-        }
-        if lc_expr_calls_host_future(be) {
-          calls_host_future = true
-        } else {
-          ()
-        }
-        if lc_expr_calls_host_stream(be) {
-          calls_host_stream = true
-        } else {
-          ()
-        }
-        if lc_expr_calls_host_stream_close(be) {
-          calls_host_stream_close = true
-        } else {
-          ()
-        }
-        if lc_expr_calls_host_stream_option_next(be) {
-          calls_host_stream_option_next = true
-        } else {
-          ()
-        }
+        lc_mark_calls(be, boundary_targets, boundary_hits, false)
       },
       SEffectDef(_, ename, _, _) => if ename == "Async" {
         has_async_decl = true
@@ -3089,6 +2996,11 @@ fn lc_inject_async_sleep_boundary(stmts: Array[Stmt], entry_name: String) -> Str
     }
     i = i + 1
   }
+  let calls_sleep = Array::get(boundary_hits, 0)
+  let calls_host_future = Array::get(boundary_hits, 1) || Array::get(boundary_hits, 2)
+  let calls_host_stream = Array::get(boundary_hits, 3) || Array::get(boundary_hits, 4) || Array::get(boundary_hits, 5) || Array::get(boundary_hits, 6) || Array::get(boundary_hits, 7)
+  let calls_host_stream_close = Array::get(boundary_hits, 5) || Array::get(boundary_hits, 7)
+  let calls_host_stream_option_next = Array::get(boundary_hits, 6)
   // #1342: key the guard on the machinery that is actually INJECTED, not on
   // "the program mentions one of these names somewhere". The three predicates
   // below are the same ones the injection uses further down, hoisted so the

--- a/lib/@vibe/compiler/codegen/wasi/linked_compile.vibe
+++ b/lib/@vibe/compiler/codegen/wasi/linked_compile.vibe
@@ -7817,6 +7817,14 @@ export fn compile_wasi_module_linked_impl_with_typed_offsets(stmts: Array[Stmt],
                     Array::push(compile_ctx.int_local_slots, psi * 4 + 3)
                   } else if ptn == "Int" {
                     Array::push(compile_ctx.int_local_slots, psi * 4 + 1)
+                  } else if ptn == "String" {
+                    // #2483: a String-annotated param is a VERIFIED String
+                    // (kind 2), the operand the literal-compare fast path in
+                    // emit_eq_value may pair a string literal with. Without
+                    // this entry the compiler's own name ladders
+                    // (`f == "Array::get" || ...`, `f: String`) stayed on the
+                    // generic `eq` path.
+                    Array::push(compile_ctx.int_local_slots, psi * 4 + 2)
                   } else {
                     ()
                   },

--- a/lib/@vibe/compiler/tests/collect_strings_dedup_test.vibe
+++ b/lib/@vibe/compiler/tests/collect_strings_dedup_test.vibe
@@ -38,3 +38,24 @@ test "#2479: an expression literal then the same pattern is one entry" {
 test "#2479: literals across functions dedup" {
   inspect(table("fn g() -> String { \"Map::has\" }\nfn h() -> Array[String] { [\"Map::has\", \"Map::set\"] }"), content = "Map::has|Map::set")
 }
+
+// #2482 review: the `EMap` key arm (a `Map::from_pairs` literal with string
+// keys) is a string-table insertion too. It used to push after its own scan
+// of `out` without recording the key in `seen`, so a later `EString` of the
+// same text was appended again (measured `a|a` and `k|k` on the first build
+// of #2482). Every insertion goes through one path now. The interpolation-
+// segment arm had the same shape, but the parser desugars `\{..}` before
+// the collector runs (the `__to_string` it introduces is what seeds `true`
+// / `false` below), so that case pins the desugared program.
+
+test "#2482: a map key and a value literal of the same text are one entry" {
+  inspect(table("let m = Map::from_pairs([(\"a\", \"a\")])"), content = "a")
+}
+
+test "#2482: a map key then the same expression literal is one entry" {
+  inspect(table("let m = Map::from_pairs([(\"k\", 1)])\nlet t = [\"k\"]"), content = "k")
+}
+
+test "#2482: interpolation segments then the same expression literals are one entry each" {
+  inspect(table("let n = 1\nlet s = \"pre\\{n}post\"\nlet t = [\"pre\", \"post\"]"), content = "pre|true|false|post")
+}

--- a/lib/@vibe/compiler/tests/string_literal_eq_prelude_test.vibe
+++ b/lib/@vibe/compiler/tests/string_literal_eq_prelude_test.vibe
@@ -1,0 +1,44 @@
+//# Imports
+
+// #2483: `x == "literal"` lowers to a direct call of the string-equality
+// BUILTIN. The prelude (`@vibe/builtin/string.vibe`) also defines a
+// program-level `String::equals`, so any closure that pulls the prelude in
+// holds two entries under that name in the function table, and a lookup by
+// NAME may answer the program's (a different arity on the linked lane --
+// measured: the first build emitted a call with two arguments to a
+// three-parameter function, and the module failed to instantiate:
+// "not enough arguments on the stack for call (need 3, got 2)"). The
+// builtin entry is found positionally, past the user prefix (#2309), so
+// this file, which imports the prelude, must compile and answer.
+import @vibe/builtin {
+  ord_clamp
+}
+
+//# Functions
+
+fn tag_of(s: String) -> Int {
+  if s == "one" {
+    1
+  } else if s == "two" {
+    2
+  } else {
+    0
+  }
+}
+
+//# Tests
+
+test "#2483: literal == in a closure that carries the prelude's String::equals" {
+  assert(tag_of("one") == 1)
+  assert(tag_of("two") == 2)
+  assert(tag_of("three") == 0)
+  assert("foo" + "bar" == "foobar")
+  assert(ord_clamp(5, 0, 10) == 5)
+}
+
+test "#2483: != and the negated form agree with the direct builtin" {
+  let s = "abc"
+  assert(s != "abd")
+  assert(not(s == "abd"))
+  assert(String::equals(s, "abc"))
+}

--- a/lib/@vibe/compiler/tests/string_literal_eq_rigid_generic_test.vibe
+++ b/lib/@vibe/compiler/tests/string_literal_eq_rigid_generic_test.vibe
@@ -1,0 +1,57 @@
+//# Functions
+
+// #2483 review (Codex P1): the literal-compare fast path (emit_eq_value)
+// fires only when the OTHER operand is a verified String -- a literal, a
+// String-annotated param or `let`-bound stringish value (a kind-2 slot), a
+// `: String` ascription, a String-returning builtin. The checker's
+// infer_binop_type tolerates a failed equality unification while either
+// side is still a rigid named type parameter (#829), and such an operand
+// may be an Int at runtime; it has no kind-2 verdict, so it keeps the
+// generic `eq` path, whose looks-like-a-string guard makes the compare a
+// plain "not equal". Measured 2026-09-03: no source shape reached that
+// tolerance through this compiler -- `fn f[T: Eq](x: T) { x == "a" }`, a
+// generic struct field `b.v == "a"`, a generic effect operation's result,
+// and the #829 `Array::get(ArrayView::to_array(v), 0)` form are all
+// grounded (or rejected) by the checker before codegen -- so this file
+// pins the verified side and the guard stays defensive.
+
+fn tag_of(s: String) -> Int {
+  if s == "one" {
+    1
+  } else if s == "two" {
+    2
+  } else {
+    0
+  }
+}
+
+fn generic_eq[T: Eq](a: T, b: T) -> Bool {
+  a == b
+}
+
+fn ascribed(x: Int) -> Bool {
+  let s: String = __to_string(x)
+  s == "42"
+}
+
+//# Tests
+
+test "#2483: String-annotated params and let-bound strings against literals" {
+  assert(tag_of("one") == 1)
+  assert(tag_of("two") == 2)
+  assert(tag_of("three") == 0)
+  let s = "abc"
+  assert(s == "abc")
+  assert(s != "abd")
+  assert("lit" == "lit")
+  assert(not("lit" == "lot"))
+}
+
+test "#2483: an erased generic compare and an ascribed String keep answering" {
+  assert(generic_eq("a", "a"))
+  assert(not(generic_eq("a", "b")))
+  assert(generic_eq(1, 1))
+  assert(not(generic_eq(4294967296 + 7, 4294967296 + 8)))
+  assert(ascribed(42))
+  assert(not(ascribed(43)))
+}


### PR DESCRIPTION
## What

Three commits on the codegen lane, each measured on its own; the first is a review fix for the just-merged #2482, the other two are the next two slices of #2386. A fourth (`23a1e9d`) is the review round below.

### 1. `05f3a83` — every string-table insertion goes through the shared `seen` set (#2479, Codex round 1 on #2482)

Codex's finding on #2482 ([thread](https://github.com/mizchi/vibe-lang/pull/2482#discussion_r3927122363)) landed after that PR had merged: the `EMap` key arm and the interpolation-segment arm of `collect_strings_expr` pushed into `out` after their own scan without recording the text in `seen`, so a later `EString` of the same text was appended again — a duplicate table entry that shifts every later string's offset. Measured on the pre-fix source: `Map::from_pairs([("a", "a")])` gave `a|a`. `collect_strings_note` is now the one insertion path (`EString`, `PString`, segment, key); two map cases join `collect_strings_dedup_test.vibe`. The interpolation case pins the desugared program: the parser resolves `\{..}` before the collector runs, so that arm cannot be reached from source and is kept consistent only.

### 2. `e633ab1` — one walk per body for the async-boundary call keys; the stdin injection stops walking the program (#2479)

| site | before | after |
|---|---|---|
| `lc_inject_async_sleep_boundary` | eleven `lc_expr_calls_name` walks per top-level body (sleep, two host-future names, five host-stream names, three derived keys) | `lc_mark_calls`: one traversal with a target list marks every target met in callee position; the keys are read off the hit array after the loop. Same arms as the per-name predicate (all 33 `Expr` variants), so each single-target answer is unchanged |
| `lc_stmts_call_host_future` | two walks per statement | the same walker with its two names |
| `lc_inject_stdin_surface_wrappers` | `collect_used_builtin_names` over the whole program to test four names, map discarded | `lc_stmts_mention_any` — `lc_mark_calls` in mentions mode (any identifier occurrence marks); with an empty `fn_names` list the old walk counted every identifier not locally bound, and a `::`-qualified name cannot be bound locally, so the question is the same. Allocates nothing, stops at the first statement that hits |

The first build used a breadth-first queue over `expr_children` for the stdin scan: it pushed every node of the program and cost +10.5 MB heap_ptr for a wash in wall time. The mentions mode replaced it.

Byte-identical output on five corpora (compiler closure included) and on the 44 programs of `scripts/test_wasi_cli_stdin_provider_source_component_gate.sh` that compile (rc 0/1 × fs 0/1; the 112 rejected ones are rejected by both compilers).

### 3. `ebb3950` — a `==` against a string literal calls `str_eq` directly (#2483)

`emit_eq_value` had an integer fast path (`expr_is_intish` → `i64.eq`) and no string one, so every `x == "literal"` called the generic `eq` builtin: `i64.eq`, then two looks-like-a-string range checks, then `str_eq`. With the other operand verified as `String` (see the review round), both are genuine fat pointers and `eq`'s answer is exactly `str_eq`'s; the new branch compiles the operands the same way and calls the `str_eq` builtin. The compiler's own sources hold ~7,000 such compares (the builtin-name ladders), which is why `__rt_eq` was 6.5% of a warm compiler-closure compile with those ladders as its top callers.

The callee is the **builtin** entry, found positionally past the user prefix (`func_table_builtin_index_of`, the complement of #2309's `func_table_user_index_of`, O(log N) through the sorted view). The first build resolved `String::equals` by name: the prelude (`@vibe/builtin/string.vibe`) defines a program-level `String::equals`, so in every closure that carries it the lookup answered that function — three parameters on the linked lane — and the emitted two-argument call failed to validate (`not enough arguments on the stack for call (need 3, got 2)`; four unit-test files that import the prelude regressed in the first chain). `string_literal_eq_prelude_test.vibe` pins it: Red on that build, green here.

Not byte-identical by construction: the callee index at each such site changes. The nine `bench/exec` programs have no literal compares and compile identically, so the perf report's fuel rows will read ±0 for this one.

## Measured

Protocol from `.claude/skills/compiler-perf-profiling` §0.5 (`VIBE_BUILD_CACHE_DIR=$(mktemp -d)` per pair, interleaved, idle machine, corpus `codegen_lexer_test.vibe`, `VIBE_WASM_NAMES=1` stage2s built from each commit's sources).

| step | cold wall | warm wall | heap_ptr | evidence |
|---|---:|---:|---:|---|
| #2482 head → commit 2 (N=3) | 10.23 s → 9.83 s (−3.8%) | 5.78 s → 5.60 s (−3.0%) | −4.0 MB cold and warm | `lc_inject_stdin_surface_wrappers` 0.13 → 0.03 s, `lc_inject_async_sleep_boundary` 0.07 → 0.04 s, `collect_used_builtin_names` 0.19 → 0.06 s warm inclusive |
| commit 2 → commit 3 (N=6, literal-alone form) | 10.12 s → 9.73 s (−3.8%, sd 0.41 / 0.27) | 5.56 s → 5.37 s (−3.5%; medians 5.44 → 5.40) | ±0 | `__rt_eq` + `__rt_str_eq` self 711 ms → 630 ms warm |

The third row is a small effect inside the noise band at this N; the profile delta is the reliable number. It was measured on the literal-alone form; the verified-operand form of the review round covers the same name ladders through the kind-2 parameter entries.

## Validation

Chain on `ebb3950` (base `acf4d07`): bundle regen; stage2 == stage3; `collect_strings_dedup_test.vibe` and `string_literal_eq_prelude_test.vibe` on linear; `test_cli_core.sh`; selfcompile KPI heap_ptr 1,528,901,840 bytes (vs 1,532,439,368 on #2482's head, −3.5 MB); typing-env-reuse oracle; 139/139 affected unit-test files (import-graph selection over every compiler file the three commits touch); `compiler_gate.sh` early / mid / late. The first chain, with the by-name lookup, failed exactly the four prelude-importing files (`checker_trait_bound_binop_test`, `fixture_test`, `fixture_roundtrip_test`, `fixture_real_compile_test`), which is how the prelude shadowing was found. `vibe_fmt.sh --check` is a fixpoint on every changed file.

## Review round 1 (`23a1e9d`)

Codex (P1): `infer_binop_type` tolerates a failed equality unification while either side is still a rigid named type parameter (#829), so a generic callee's result compared with a string literal type-checks and may be an Int at runtime; the fast path fired on the literal alone. It now pairs the literal with `cc_expr_is_stringish`'s verdict on the other operand (a literal, a kind-2 slot, a `: String` ascription, a String-returning builtin), and String-annotated parameters are recorded as kind-2 slots at function entry (only Int / Bool / Float were) so the name ladders stay on the fast path. That entry is also seen by the other kind-2 consumer, the `__to_string` dispatch (#950: a statically-String argument is the result), so the compiler closure's output shrinks by 15.8 KB. Measured: no source shape reaches the tolerance on this compiler (`fn f[T: Eq](x: T) { x == "a" }`, a generic struct field, a generic effect operation's result, and the #829 `ArrayView::to_array` form are all grounded or rejected by the checker), so `string_literal_eq_rigid_generic_test.vibe` pins the verified side and records those shapes; the guard is defensive. Chain on this head: stage2 == stage3; both lane tests; `test_cli_core.sh`; selfcompile KPI 1,529,664,000 bytes; oracle; 125/125 affected unit-test files; `compiler_gate.sh` early / mid / late.

Refs #2479, #2483, #2386.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QKZdvBvHVUagwg6Yih8er8