### PR TITLE
compiler: five #2386 slices — a callee-edge worklist, set membership, a fingerprint memo, a gated relabel walk, one env copy per let (#2479)

### DIFF
--- a/lib/@vibe/compiler/cache/cache_underlying.vibe
+++ b/lib/@vibe/compiler/cache/cache_underlying.vibe
@@ -11,6 +11,10 @@
 // determinism_test failure). Real wrapper functions survive the strip: their
 // bodies call the @vibe/cache definitions by their own exported names, which
 // the merge resolves. Keep this file alias-free.
+import @vibe/core {
+  struct MutMap
+}
+
 import @vibe/cache {
   compact_string_fingerprint,
   load_artifact_envelope_at,
@@ -155,6 +159,57 @@ let fingerprint_file_memo_paths = []
 let fingerprint_file_memo_tokens = []
 
 let fingerprint_file_memo_fps = []
+
+/// #2386: index over fingerprint_file_memo_paths -- the memo used to find a
+/// path by scanning the parallel arrays, one string compare per memoized
+/// file per lookup.
+let fingerprint_file_memo_index: MutMap[String, Int] = MutMap::new_string()
+
+/// #2386: per-run memo of compact_string_fingerprint over a module's SOURCE
+/// TEXT, keyed by path and verified by text equality. Four callers hashed
+/// the same text of every module once each per compile (the leaf
+/// fingerprint, the dep-list cache path twice, the merge's per-file table:
+/// ~150 ms of a warm compiler-closure compile), each with only the path
+/// and the text in hand. A hit compares the stored text to the offered one
+/// (a byte compare, cheaper than the hash it replaces) so a path whose text
+/// changed between calls -- an in-process test lane compiling many programs
+/// -- can never answer a stale fingerprint. Reset at the start of each
+/// compile's typing walk so the memo spans one compile.
+let source_fingerprint_memo_src: MutMap[String, String] = MutMap::new_string()
+
+let source_fingerprint_memo_fp: MutMap[String, String] = MutMap::new_string()
+
+export fn compact_source_fingerprint_memo(path: String, source: String) -> String {
+  match MutMap::get(source_fingerprint_memo_src, path) {
+    Some(stored) => if String::equals(stored, source) {
+      match MutMap::get(source_fingerprint_memo_fp, path) {
+        Some(fp) => fp,
+        None => compact_string_fingerprint(source)
+      }
+    } else {
+      let fp = compact_string_fingerprint(source)
+      MutMap::set(source_fingerprint_memo_src, path, source)
+      MutMap::set(source_fingerprint_memo_fp, path, fp)
+      fp
+    },
+    None => {
+      let fp = compact_string_fingerprint(source)
+      MutMap::set(source_fingerprint_memo_src, path, source)
+      MutMap::set(source_fingerprint_memo_fp, path, fp)
+      fp
+    }
+  }
+}
+
+export fn compact_source_fingerprint_memo_reset() -> Unit {
+  let keys = MutMap::keys(source_fingerprint_memo_src)
+  let mut i = 0
+  while i < Array::length(keys) {
+    let _ = MutMap::delete(source_fingerprint_memo_src, Array::get(keys, i))
+    let _ = MutMap::delete(source_fingerprint_memo_fp, Array::get(keys, i))
+    i = i + 1
+  }
+}
 
 // #1379: opt-in, compiler-owned observations for the fingerprint helper.
 // They deliberately do not overlap runner-owned host_fs_scope: these counters
@@ -366,10 +421,8 @@ export fn cache_ingestion_stamp_enabled() -> Bool {
 export fn cache_fingerprint_file_fs_with_ingestion_stamp(path: String, stamp_path: String) -> String with Fs {
   let token = Fs::stat_token(path)
   let token_text = __to_string(token)
-  let n = Array::length(fingerprint_file_memo_paths)
-  let mut i = 0
-  while i < n {
-    if Array::get(fingerprint_file_memo_paths, i) == path {
+  match MutMap::get(fingerprint_file_memo_index, path) {
+    Some(i) => {
       if Array::get(fingerprint_file_memo_tokens, i) == token {
         return Array::get(fingerprint_file_memo_fps, i)
       } else {
@@ -385,10 +438,8 @@ export fn cache_fingerprint_file_fs_with_ingestion_stamp(path: String, stamp_pat
         Array::set(fingerprint_file_memo_fps, i, fingerprint)
         return fingerprint
       }
-    } else {
-      ()
-    }
-    i = i + 1
+    },
+    None => ()
   }
   let fingerprint = match try_load_ingestion_stamp(stamp_path, token_text) {
     Some(hit) => hit,
@@ -398,6 +449,7 @@ export fn cache_fingerprint_file_fs_with_ingestion_stamp(path: String, stamp_pat
       fresh
     }
   }
+  MutMap::set(fingerprint_file_memo_index, path, Array::length(fingerprint_file_memo_paths))
   Array::push(fingerprint_file_memo_paths, path)
   Array::push(fingerprint_file_memo_tokens, token)
   Array::push(fingerprint_file_memo_fps, fingerprint)

--- a/lib/@vibe/compiler/cache/index.vpkg
+++ b/lib/@vibe/compiler/cache/index.vpkg
@@ -6,6 +6,7 @@ deps = {
   @vibe/cache : 0.0.1
   @vibe/compiler/checker : 0.0.1
   @vibe/compiler/core : 0.0.1
+  @vibe/core : 0.2.0
 }
 
 generated_hash =
@@ -82,6 +83,8 @@ fn cache_persistent_manifest_header_cache_path(version_tag: String, entry_path: 
 fn cache_persistent_leaf_fingerprint_cache_path(version_tag: String, path: String, source_fingerprint: String) -> String
 fn cache_fingerprint_file_fs(path: String) -> String with Fs
 fn cache_fingerprint_file_fs_with_ingestion_stamp(path: String, stamp_path: String) -> String with Fs
+fn compact_source_fingerprint_memo(path: String, source: String) -> String
+fn compact_source_fingerprint_memo_reset() -> Unit
 fn cache_ingestion_compact_fingerprint_is_valid(fingerprint: String) -> Bool
 fn cache_ingestion_stamp_enabled() -> Bool
 fn cache_ingestion_stamp_v1_text(stat_token_text: String, fingerprint: String) -> String

--- a/lib/@vibe/compiler/cache/persistent_cache.vibe
+++ b/lib/@vibe/compiler/cache/persistent_cache.vibe
@@ -33,7 +33,9 @@ import ./cache_underlying.vibe {
   cache_persistent_type_env_cache_path,
   cache_set_ingestion_fingerprint_telemetry_enabled,
   cache_stable_text_cache_path,
-  cache_store_persistent_artifact
+  cache_store_persistent_artifact,
+  compact_source_fingerprint_memo,
+  compact_source_fingerprint_memo_reset
 }
 
 import ./codegen_fingerprint.vibe {

--- a/lib/@vibe/compiler/codegen/common_analysis/common_analysis.vibe
+++ b/lib/@vibe/compiler/codegen/common_analysis/common_analysis.vibe
@@ -3609,7 +3609,7 @@ fn mrv_is_fresh_name(fresh_names: MutMap[String, Int], tainted: MutMap[String, I
 /// Bindings are recorded flat (no scope popping): a name REBOUND to a
 /// non-fresh value taints itself, so collisions only ever push toward
 /// view -- the safe direction.
-fn mrv_fresh(e: Expr, fresh_names: MutMap[String, Int], tainted: MutMap[String, Int], bound: Array[String], gen: Int, user_fns_srt: Array[String], view_set: MutSet[String], ret_view: Array[Int]) -> Bool {
+fn mrv_fresh(e: Expr, fresh_names: MutMap[String, Int], tainted: MutMap[String, Int], bound: Array[String], gen: Int, user_fns_srt: Array[String], view_set: MutSet[String], ret_view: Array[Int], callees: Array[String]) -> Bool {
   match e {
     EInt(_) => true,
     EFloat(_) => true,
@@ -3621,7 +3621,7 @@ fn mrv_fresh(e: Expr, fresh_names: MutMap[String, Int], tainted: MutMap[String, 
     ETuple(items) => {
       let mut i = 0
       while i < Array::length(items) {
-        let _ = mrv_fresh(Array::get(items, i), fresh_names, tainted, bound, gen, user_fns_srt, view_set, ret_view)
+        let _ = mrv_fresh(Array::get(items, i), fresh_names, tainted, bound, gen, user_fns_srt, view_set, ret_view, callees)
         i = i + 1
       }
       true
@@ -3629,7 +3629,7 @@ fn mrv_fresh(e: Expr, fresh_names: MutMap[String, Int], tainted: MutMap[String, 
     EArray(items) => {
       let mut i = 0
       while i < Array::length(items) {
-        let _ = mrv_fresh(Array::get(items, i), fresh_names, tainted, bound, gen, user_fns_srt, view_set, ret_view)
+        let _ = mrv_fresh(Array::get(items, i), fresh_names, tainted, bound, gen, user_fns_srt, view_set, ret_view, callees)
         i = i + 1
       }
       true
@@ -3638,7 +3638,7 @@ fn mrv_fresh(e: Expr, fresh_names: MutMap[String, Int], tainted: MutMap[String, 
       let mut i = 0
       while i < Array::length(fields) {
         let (_, v) = Array::get(fields, i)
-        let _ = mrv_fresh(v, fresh_names, tainted, bound, gen, user_fns_srt, view_set, ret_view)
+        let _ = mrv_fresh(v, fresh_names, tainted, bound, gen, user_fns_srt, view_set, ret_view, callees)
         i = i + 1
       }
       true
@@ -3647,62 +3647,62 @@ fn mrv_fresh(e: Expr, fresh_names: MutMap[String, Int], tainted: MutMap[String, 
       let mut i = 0
       while i < Array::length(fields) {
         let (_, v) = Array::get(fields, i)
-        let _ = mrv_fresh(v, fresh_names, tainted, bound, gen, user_fns_srt, view_set, ret_view)
+        let _ = mrv_fresh(v, fresh_names, tainted, bound, gen, user_fns_srt, view_set, ret_view, callees)
         i = i + 1
       }
       true
     },
     EIf(c, t, el) => {
-      let _ = mrv_fresh(c, fresh_names, tainted, bound, gen, user_fns_srt, view_set, ret_view)
-      let tf = mrv_fresh(t, fresh_names, tainted, bound, gen, user_fns_srt, view_set, ret_view)
-      let ef = mrv_fresh(el, fresh_names, tainted, bound, gen, user_fns_srt, view_set, ret_view)
+      let _ = mrv_fresh(c, fresh_names, tainted, bound, gen, user_fns_srt, view_set, ret_view, callees)
+      let tf = mrv_fresh(t, fresh_names, tainted, bound, gen, user_fns_srt, view_set, ret_view, callees)
+      let ef = mrv_fresh(el, fresh_names, tainted, bound, gen, user_fns_srt, view_set, ret_view, callees)
       tf && ef
     },
     ELet(n, v, b, _) => {
-      let vf = mrv_fresh(v, fresh_names, tainted, bound, gen, user_fns_srt, view_set, ret_view)
+      let vf = mrv_fresh(v, fresh_names, tainted, bound, gen, user_fns_srt, view_set, ret_view, callees)
       Array::push(bound, n)
       if vf {
         MutMap::set(fresh_names, n, gen)
       } else {
         MutMap::set(tainted, n, gen)
       }
-      mrv_fresh(b, fresh_names, tainted, bound, gen, user_fns_srt, view_set, ret_view)
+      mrv_fresh(b, fresh_names, tainted, bound, gen, user_fns_srt, view_set, ret_view, callees)
     },
     ELetMut(n, v, b, _) => {
-      let vf = mrv_fresh(v, fresh_names, tainted, bound, gen, user_fns_srt, view_set, ret_view)
+      let vf = mrv_fresh(v, fresh_names, tainted, bound, gen, user_fns_srt, view_set, ret_view, callees)
       Array::push(bound, n)
       if vf {
         MutMap::set(fresh_names, n, gen)
       } else {
         MutMap::set(tainted, n, gen)
       }
-      mrv_fresh(b, fresh_names, tainted, bound, gen, user_fns_srt, view_set, ret_view)
+      mrv_fresh(b, fresh_names, tainted, bound, gen, user_fns_srt, view_set, ret_view, callees)
     },
     ELetRec(n, v, b) => {
-      let _ = mrv_fresh(v, fresh_names, tainted, bound, gen, user_fns_srt, view_set, ret_view)
+      let _ = mrv_fresh(v, fresh_names, tainted, bound, gen, user_fns_srt, view_set, ret_view, callees)
       Array::push(bound, n)
       MutMap::set(fresh_names, n, gen)
-      mrv_fresh(b, fresh_names, tainted, bound, gen, user_fns_srt, view_set, ret_view)
+      mrv_fresh(b, fresh_names, tainted, bound, gen, user_fns_srt, view_set, ret_view, callees)
     },
     EAssign(n, v, b) => {
-      let vf = mrv_fresh(v, fresh_names, tainted, bound, gen, user_fns_srt, view_set, ret_view)
+      let vf = mrv_fresh(v, fresh_names, tainted, bound, gen, user_fns_srt, view_set, ret_view, callees)
       if vf {
         ()
       } else {
         MutMap::set(tainted, n, gen)
       }
-      mrv_fresh(b, fresh_names, tainted, bound, gen, user_fns_srt, view_set, ret_view)
+      mrv_fresh(b, fresh_names, tainted, bound, gen, user_fns_srt, view_set, ret_view, callees)
     },
     EAssignOp(_, _, v, b) => {
-      let _ = mrv_fresh(v, fresh_names, tainted, bound, gen, user_fns_srt, view_set, ret_view)
-      mrv_fresh(b, fresh_names, tainted, bound, gen, user_fns_srt, view_set, ret_view)
+      let _ = mrv_fresh(v, fresh_names, tainted, bound, gen, user_fns_srt, view_set, ret_view, callees)
+      mrv_fresh(b, fresh_names, tainted, bound, gen, user_fns_srt, view_set, ret_view, callees)
     },
     ESeq(a, b) => {
-      let _ = mrv_fresh(a, fresh_names, tainted, bound, gen, user_fns_srt, view_set, ret_view)
-      mrv_fresh(b, fresh_names, tainted, bound, gen, user_fns_srt, view_set, ret_view)
+      let _ = mrv_fresh(a, fresh_names, tainted, bound, gen, user_fns_srt, view_set, ret_view, callees)
+      mrv_fresh(b, fresh_names, tainted, bound, gen, user_fns_srt, view_set, ret_view, callees)
     },
     EMatch(s, arms) => {
-      let _ = mrv_fresh(s, fresh_names, tainted, bound, gen, user_fns_srt, view_set, ret_view)
+      let _ = mrv_fresh(s, fresh_names, tainted, bound, gen, user_fns_srt, view_set, ret_view, callees)
       let mut all = true
       let mut i = 0
       while i < Array::length(arms) {
@@ -3710,7 +3710,7 @@ fn mrv_fresh(e: Expr, fresh_names: MutMap[String, Int], tainted: MutMap[String, 
         // Pattern payloads are interior views of the scrutinee: bound but
         // never fresh.
         let _ = collect_pattern_bindings(p, bound)
-        if mrv_fresh(v, fresh_names, tainted, bound, gen, user_fns_srt, view_set, ret_view) {
+        if mrv_fresh(v, fresh_names, tainted, bound, gen, user_fns_srt, view_set, ret_view, callees) {
           ()
         } else {
           all = false
@@ -3720,13 +3720,13 @@ fn mrv_fresh(e: Expr, fresh_names: MutMap[String, Int], tainted: MutMap[String, 
       all
     },
     EHandle(s, arms) => {
-      let _ = mrv_fresh(s, fresh_names, tainted, bound, gen, user_fns_srt, view_set, ret_view)
+      let _ = mrv_fresh(s, fresh_names, tainted, bound, gen, user_fns_srt, view_set, ret_view, callees)
       let mut all = true
       let mut i = 0
       while i < Array::length(arms) {
         let (p, v) = Array::get(arms, i)
         let _ = collect_pattern_bindings(p, bound)
-        if mrv_fresh(v, fresh_names, tainted, bound, gen, user_fns_srt, view_set, ret_view) {
+        if mrv_fresh(v, fresh_names, tainted, bound, gen, user_fns_srt, view_set, ret_view, callees) {
           ()
         } else {
           all = false
@@ -3736,37 +3736,37 @@ fn mrv_fresh(e: Expr, fresh_names: MutMap[String, Int], tainted: MutMap[String, 
       all
     },
     EWhile(c, b) => {
-      let _ = mrv_fresh(c, fresh_names, tainted, bound, gen, user_fns_srt, view_set, ret_view)
-      let _ = mrv_fresh(b, fresh_names, tainted, bound, gen, user_fns_srt, view_set, ret_view)
+      let _ = mrv_fresh(c, fresh_names, tainted, bound, gen, user_fns_srt, view_set, ret_view, callees)
+      let _ = mrv_fresh(b, fresh_names, tainted, bound, gen, user_fns_srt, view_set, ret_view, callees)
       true
     },
     ELoop(params, b) => {
       let mut i = 0
       while i < Array::length(params) {
         let (pn, pv) = Array::get(params, i)
-        let _ = mrv_fresh(pv, fresh_names, tainted, bound, gen, user_fns_srt, view_set, ret_view)
+        let _ = mrv_fresh(pv, fresh_names, tainted, bound, gen, user_fns_srt, view_set, ret_view, callees)
         Array::push(bound, pn)
         i = i + 1
       }
-      let _ = mrv_fresh(b, fresh_names, tainted, bound, gen, user_fns_srt, view_set, ret_view)
+      let _ = mrv_fresh(b, fresh_names, tainted, bound, gen, user_fns_srt, view_set, ret_view, callees)
       // A loop's value flows out of `break v` sites we do not track: view.
       false
     },
     EForIn(n1, n2, it, b) => {
-      let _ = mrv_fresh(it, fresh_names, tainted, bound, gen, user_fns_srt, view_set, ret_view)
+      let _ = mrv_fresh(it, fresh_names, tainted, bound, gen, user_fns_srt, view_set, ret_view, callees)
       Array::push(bound, n1)
       match n2 {
         Some(n2s) => Array::push(bound, n2s),
         None => ()
       }
-      let _ = mrv_fresh(b, fresh_names, tainted, bound, gen, user_fns_srt, view_set, ret_view)
+      let _ = mrv_fresh(b, fresh_names, tainted, bound, gen, user_fns_srt, view_set, ret_view, callees)
       true
     },
     ECall(callee, args, _) => {
       let mut arg0_fresh = false
       let mut i = 0
       while i < Array::length(args) {
-        let af = mrv_fresh(Array::get(args, i), fresh_names, tainted, bound, gen, user_fns_srt, view_set, ret_view)
+        let af = mrv_fresh(Array::get(args, i), fresh_names, tainted, bound, gen, user_fns_srt, view_set, ret_view, callees)
         if i == 0 {
           arg0_fresh = af
         } else {
@@ -3779,6 +3779,10 @@ fn mrv_fresh(e: Expr, fresh_names: MutMap[String, Int], tainted: MutMap[String, 
           // A locally-bound closure: its return is untrackable.
           false
         } else if bsearch_leftmost(user_fns_srt, f) >= 0 {
+          // #2386: the ONE cross-function dependency of this walk. Record
+          // it so the fixpoint driver re-walks this function only when `f`
+          // enters the view set later.
+          Array::push(callees, f)
           !MutSet::has(view_set, f)
         } else if borrow_ret_builtin_name(f) {
           false
@@ -3812,23 +3816,23 @@ fn mrv_fresh(e: Expr, fresh_names: MutMap[String, Int], tainted: MutMap[String, 
           if ident_ret {
             arg0_fresh
           } else {
-            let _ = mrv_fresh(callee, fresh_names, tainted, bound, gen, user_fns_srt, view_set, ret_view)
+            let _ = mrv_fresh(callee, fresh_names, tainted, bound, gen, user_fns_srt, view_set, ret_view, callees)
             false
           }
         },
         _ => {
-          let _ = mrv_fresh(callee, fresh_names, tainted, bound, gen, user_fns_srt, view_set, ret_view)
+          let _ = mrv_fresh(callee, fresh_names, tainted, bound, gen, user_fns_srt, view_set, ret_view, callees)
           false
         }
       }
     },
     EBinOp(_, l, r, _) => {
-      let _ = mrv_fresh(l, fresh_names, tainted, bound, gen, user_fns_srt, view_set, ret_view)
-      let _ = mrv_fresh(r, fresh_names, tainted, bound, gen, user_fns_srt, view_set, ret_view)
+      let _ = mrv_fresh(l, fresh_names, tainted, bound, gen, user_fns_srt, view_set, ret_view, callees)
+      let _ = mrv_fresh(r, fresh_names, tainted, bound, gen, user_fns_srt, view_set, ret_view, callees)
       true
     },
     EUnaryOp(_, x) => {
-      let _ = mrv_fresh(x, fresh_names, tainted, bound, gen, user_fns_srt, view_set, ret_view)
+      let _ = mrv_fresh(x, fresh_names, tainted, bound, gen, user_fns_srt, view_set, ret_view, callees)
       true
     },
     EFn(_, _, fps, _, _, body) => {
@@ -3842,16 +3846,16 @@ fn mrv_fresh(e: Expr, fresh_names: MutMap[String, Int], tainted: MutMap[String, 
         i = i + 1
       }
       let dummy_ret = [0]
-      let _ = mrv_fresh(body, fresh_names, tainted, bound, gen, user_fns_srt, view_set, dummy_ret)
+      let _ = mrv_fresh(body, fresh_names, tainted, bound, gen, user_fns_srt, view_set, dummy_ret, callees)
       true
     },
     EDot(x, _, _, _) => {
-      let _ = mrv_fresh(x, fresh_names, tainted, bound, gen, user_fns_srt, view_set, ret_view)
+      let _ = mrv_fresh(x, fresh_names, tainted, bound, gen, user_fns_srt, view_set, ret_view, callees)
       false
     },
-    ELabeledArg(_, _, v) => mrv_fresh(v, fresh_names, tainted, bound, gen, user_fns_srt, view_set, ret_view),
+    ELabeledArg(_, _, v) => mrv_fresh(v, fresh_names, tainted, bound, gen, user_fns_srt, view_set, ret_view, callees),
     EReturn(x) => {
-      if mrv_fresh(x, fresh_names, tainted, bound, gen, user_fns_srt, view_set, ret_view) {
+      if mrv_fresh(x, fresh_names, tainted, bound, gen, user_fns_srt, view_set, ret_view, callees) {
         ()
       } else {
         Array::set(ret_view, 0, 1)
@@ -3860,7 +3864,7 @@ fn mrv_fresh(e: Expr, fresh_names: MutMap[String, Int], tainted: MutMap[String, 
     },
     EBreak(opt) => {
       let _ = match opt {
-        Some(v) => mrv_fresh(v, fresh_names, tainted, bound, gen, user_fns_srt, view_set, ret_view),
+        Some(v) => mrv_fresh(v, fresh_names, tainted, bound, gen, user_fns_srt, view_set, ret_view, callees),
         None => true
       }
       true
@@ -3868,12 +3872,12 @@ fn mrv_fresh(e: Expr, fresh_names: MutMap[String, Int], tainted: MutMap[String, 
     EContinue(args) => {
       let mut i = 0
       while i < Array::length(args) {
-        let _ = mrv_fresh(Array::get(args, i), fresh_names, tainted, bound, gen, user_fns_srt, view_set, ret_view)
+        let _ = mrv_fresh(Array::get(args, i), fresh_names, tainted, bound, gen, user_fns_srt, view_set, ret_view, callees)
         i = i + 1
       }
       true
     },
-    ESpread(x) => mrv_fresh(x, fresh_names, tainted, bound, gen, user_fns_srt, view_set, ret_view)
+    ESpread(x) => mrv_fresh(x, fresh_names, tainted, bound, gen, user_fns_srt, view_set, ret_view, callees)
   }
 }
 
@@ -3890,76 +3894,111 @@ fn mrv_fresh(e: Expr, fresh_names: MutMap[String, Int], tainted: MutMap[String, 
 /// (the codegen_heap_e2e_test over-release). Iterated to a fixpoint so a
 /// view propagates through wrapper functions whose tail is a call.
 export fn compute_may_return_view_fns(stmts: Array[Stmt]) -> Array[String] {
+  // #2386: a callee-edge worklist instead of whole-program rounds. The old
+  // driver re-walked EVERY not-yet-classified function body on each round
+  // until a round added nothing (0.32 s warm on the compiler closure, one
+  // full walk per round). A function's verdict depends on its own body and
+  // on which of its user-fn callees are in the view set (mrv_fresh's one
+  // cross-function read), so after its first walk it needs another only
+  // when one of its callees enters the set. The first walk records each
+  // function's callees; a reverse index turns "f entered the view set"
+  // into "re-walk f's callers". Same fixpoint, same set.
   let user_fns = array_empty()
+  let fn_bodies = array_empty()
+  let fn_params = array_empty()
   let mut ci = 0
   while ci < Array::length(stmts) {
     match Array::get(stmts, ci) {
       SLet(_, _, fname, _, fval) => match fval {
-        EFn(_, _, _, _, _, _) => Array::push(user_fns, fname),
+        EFn(_, _, fps, _, _, fbody) => {
+          Array::push(user_fns, fname)
+          Array::push(fn_params, fps)
+          Array::push(fn_bodies, fbody)
+        },
         _ => ()
       },
       _ => ()
     }
     ci = ci + 1
   }
-  // ADR-0092 / #1259 perf: `user_fns` holds EVERY user function in the
-  // program (~5000 when the compiler compiles itself) and never changes, but
-  // it was linearly scanned once per identifier CALL, inside a fixpoint loop
-  // that re-walks every body up to 10 times. That single lookup accounted for
-  // 2.0s of an 8.4s selfcompile profile. Sorted once here, binary-searched at
-  // the call site.
   let user_fns_srt = sorted_names_of(user_fns)
-  // The returned array keeps the discovery order; `view_seen` is a parallel
-  // membership index (the per-callee scan of the growing view set was the
-  // hottest single lookup of a selfcompile profile after the user_fns sort
-  // above -- #1259).
   let view_set = array_empty()
   let view_seen = MutSet::new_string()
   let fresh_names: MutMap[String, Int] = MutMap::new_string()
   let tainted: MutMap[String, Int] = MutMap::new_string()
-  // `bound` is a shared flat array reset per walk via truncate (the
-  // collect_free_vars push/truncate pattern): membership is only checked for
-  // call heads and stays function-local-small, while a per-walk table costs
-  // an allocation per binder insert -- the selfcompile heap KPI gate is
-  // tighter than that CPU win (#1259 follow-up).
   let bound = array_empty()
+  // callers_of[name] = indices (into user_fns) of the functions that call it;
+  // filled from the first walk of each function.
+  let callers_of: MutMap[String, Array[Int]] = MutMap::new_string()
+  let nfn = Array::length(user_fns)
+  // Every function is walked once, in declaration order (the same order the
+  // round-based driver used for its first round). `queued` marks a function
+  // that is on the worklist so it is never pushed twice.
+  let work = array_empty()
+  let queued = array_empty()
+  let mut wi0 = 0
+  while wi0 < nfn {
+    Array::push(work, wi0)
+    Array::push(queued, true)
+    wi0 = wi0 + 1
+  }
   let mut gen = 0
-  let mut changed = true
-  let mut rounds = 0
-  while changed && rounds < 10 {
-    changed = false
-    let mut si = 0
-    while si < Array::length(stmts) {
-      match Array::get(stmts, si) {
-        SLet(_, _, fname, _, fval) => match fval {
-          EFn(_, _, fps, _, _, fbody) => if MutSet::has(view_seen, fname) {
-            ()
-          } else {
-            gen = gen + 1
-            Array::truncate(bound, 0)
-            let mut pi = 0
-            while pi < Array::length(fps) {
-              let (pn, _) = Array::get(fps, pi)
-              Array::push(bound, pn)
-              pi = pi + 1
-            }
-            let ret_view = [0]
-            let tail_fresh = mrv_fresh(fbody, fresh_names, tainted, bound, gen, user_fns_srt, view_seen, ret_view)
-            if !tail_fresh || Array::get(ret_view, 0) == 1 {
-              Array::push(view_set, fname)
-              MutSet::add(view_seen, fname)
-              changed = true
-            } else {
-              ()
+  let mut wi = 0
+  while wi < Array::length(work) {
+    let fi = Array::get(work, wi)
+    Array::set(queued, fi, false)
+    let fname = Array::get(user_fns, fi)
+    if MutSet::has(view_seen, fname) {
+      ()
+    } else {
+      gen = gen + 1
+      Array::truncate(bound, 0)
+      let fps = Array::get(fn_params, fi)
+      let mut pi = 0
+      while pi < Array::length(fps) {
+        let (pn, _) = Array::get(fps, pi)
+        Array::push(bound, pn)
+        pi = pi + 1
+      }
+      let ret_view = [0]
+      let callees = array_empty()
+      let tail_fresh = mrv_fresh(Array::get(fn_bodies, fi), fresh_names, tainted, bound, gen, user_fns_srt, view_seen, ret_view, callees)
+      // Reverse edges from this walk (recorded once; later walks of the
+      // same body see the same callees, so re-recording would only add
+      // duplicate callers, which the `queued` mark absorbs anyway).
+      let mut ki = 0
+      while ki < Array::length(callees) {
+        let callee = Array::get(callees, ki)
+        match MutMap::get(callers_of, callee) {
+          Some(lst) => Array::push(lst, fi),
+          None => MutMap::set(callers_of, callee, [fi])
+        }
+        ki = ki + 1
+      }
+      if !tail_fresh || Array::get(ret_view, 0) == 1 {
+        Array::push(view_set, fname)
+        MutSet::add(view_seen, fname)
+        match MutMap::get(callers_of, fname) {
+          Some(lst) => {
+            let mut li = 0
+            while li < Array::length(lst) {
+              let cf = Array::get(lst, li)
+              if Array::get(queued, cf) || MutSet::has(view_seen, Array::get(user_fns, cf)) {
+                ()
+              } else {
+                Array::push(work, cf)
+                Array::set(queued, cf, true)
+              }
+              li = li + 1
             }
           },
-          _ => ()
-        },
-        _ => ()
+          None => ()
+        }
+      } else {
+        ()
       }
-      si = si + 1
     }
-    rounds = rounds + 1
+    wi = wi + 1
   }
   view_set
 }

--- a/lib/@vibe/compiler/codegen/common_analysis/common_analysis.vibe
+++ b/lib/@vibe/compiler/codegen/common_analysis/common_analysis.vibe
@@ -3405,8 +3405,21 @@ export fn compute_borrow_param_user_fns(stmts: Array[Stmt], exclude: Array[Strin
     }
     ni = ni + 1
   }
-  let valued_srt = sorted_names_of(valued)
-  let excluded_srt = sorted_names_of(exclude)
+  // #2386: membership only -- a set instead of two sorted copies queried by
+  // binary search per function (sorting `valued` was 0.09 s of a warm
+  // compiler-closure compile; the analysis never reads the order).
+  let valued_set: MutSet[String] = MutSet::new_string()
+  let mut vsi = 0
+  while vsi < Array::length(valued) {
+    MutSet::add(valued_set, Array::get(valued, vsi))
+    vsi = vsi + 1
+  }
+  let excluded_set: MutSet[String] = MutSet::new_string()
+  let mut esi = 0
+  while esi < Array::length(exclude) {
+    MutSet::add(excluded_set, Array::get(exclude, esi))
+    esi = esi + 1
+  }
   let names = array_empty()
   let masks: MutMap[String, Int] = MutMap::new_string()
   // Source-owned compiler intrinsics need an authoritative entry even when
@@ -3431,7 +3444,7 @@ export fn compute_borrow_param_user_fns(stmts: Array[Stmt], exclude: Array[Strin
     }
     match stmt {
       SLet(_, _, fname, _, fval) => match fval {
-        EFn(_, _, fps, _, _, fbody) => if bsearch_leftmost(valued_srt, fname) < 0 && bsearch_leftmost(excluded_srt, fname) < 0 {
+        EFn(_, _, fps, _, _, fbody) => if !MutSet::has(valued_set, fname) && !MutSet::has(excluded_set, fname) {
           let owned_bits = match MutMap::get(nonident, fname) {
             Some(m) => m,
             None => 0
@@ -3486,7 +3499,7 @@ export fn compute_borrow_param_user_fns(stmts: Array[Stmt], exclude: Array[Strin
   while si < Array::length(stmts) {
     match Array::get(stmts, si) {
       SLet(_, _, fname, _, fval) => match fval {
-        EFn(_, _, fps, _, _, fbody) => if bsearch_leftmost(valued_srt, fname) < 0 && bsearch_leftmost(excluded_srt, fname) < 0 && bp_calls_round0_borrow(fbody, round0_names) {
+        EFn(_, _, fps, _, _, fbody) => if !MutSet::has(valued_set, fname) && !MutSet::has(excluded_set, fname) && bp_calls_round0_borrow(fbody, round0_names) {
           let owned_bits = match MutMap::get(nonident, fname) {
             Some(m) => m,
             None => 0

--- a/lib/@vibe/compiler/entry/compiler/file_compile/file_compile.vibe
+++ b/lib/@vibe/compiler/entry/compiler/file_compile/file_compile.vibe
@@ -108,6 +108,7 @@ import @vibe/compiler/cache {
   build_file_compile_wasi_artifact_fingerprint_for_entry_path,
   build_file_compile_wasi_artifact_fingerprint_from_group_fingerprint_for_entry_path,
   build_source_groups_fingerprint,
+  compact_source_fingerprint_memo,
   compact_string_fingerprint,
   load_persistent_artifact,
   persistent_cache_version_tag_for_observation,
@@ -792,7 +793,7 @@ fn build_grouped_merged_stmts_counted(source_groups: Array[(String, Array[(Strin
     Array::push(located_file_stmts, shift_stmts_offsets(Array::get(file_stmts, source_idx), offset_base))
     let (flat_path, flat_source) = Array::get(flat_sources, source_idx)
     Array::push(out_paths, flat_path)
-    Array::push(out_fps, compact_string_fingerprint(flat_source))
+    Array::push(out_fps, compact_source_fingerprint_memo(flat_path, flat_source))
     Array::push(out_bases, offset_base)
     offset_base = offset_base + String::length(flat_source) + 1
     source_idx = source_idx + 1

--- a/lib/@vibe/compiler/normalize/desugar_trait_dict.vibe
+++ b/lib/@vibe/compiler/normalize/desugar_trait_dict.vibe
@@ -17031,13 +17031,6 @@ fn optional_flags_for_call(fname: String, shadows: Array[String]) -> Option[Arra
   }
 }
 
-fn stmts_have_optional_fn(_stmts: Array[Stmt]) -> Bool {
-  // Nested `let o = (a, b?) ->` leaves no top-level table entry. Walking
-  // every statement is cheap next to typecheck and is what makes #1952
-  // work in a file that has no top-level optional fn.
-  true
-}
-
 /// #1899/#1952: the labels and optional flags of lambdas bound by a `let`
 /// INSIDE a block, which the two top-level tables above cannot see.
 ///
@@ -18657,6 +18650,34 @@ fn relabel_stmt_paired(stmt: Stmt, tbl: Array[(String, Array[String])], node: Bi
 /// relabel_stmt rebuild per top-level statement,
 /// since collect_fn_param_labels now indexes EVERY top-level function and the
 /// old `tbl empty -> skip` fast path no longer fires for ordinary programs.
+/// #2386: the walk_all replacement -- see dinsp_scan mode 6. Only meaningful
+/// after optional_param_tbl_set has published the program's table.
+fn stmt_calls_optional_fn(stmt: Stmt) -> Bool {
+  match stmt {
+    SLet(_, _, _, _, body) => dinsp_scan(body, 6, ""),
+    SFnDecl(_, _, body, _, _) => dinsp_scan(body, 6, ""),
+    SLetMut(_, _, body) => dinsp_scan(body, 6, ""),
+    STest(_, body) => dinsp_scan(body, 6, ""),
+    SBench(_, body) => dinsp_scan(body, 6, ""),
+    SExpr(e) => dinsp_scan(e, 6, ""),
+    SLetPat(_, e) => dinsp_scan(e, 6, ""),
+    SModule(_, _, ms) => {
+      let mut found = false
+      let mut i = 0
+      while i < Array::length(ms) {
+        if found {
+          i = Array::length(ms)
+        } else {
+          found = stmt_calls_optional_fn(Array::get(ms, i))
+          i = i + 1
+        }
+      }
+      found
+    },
+    _ => false
+  }
+}
+
 fn stmt_has_labeled_arg(stmt: Stmt) -> Bool {
   match stmt {
     SLet(_, _, _, _, body) => dinsp_scan(body, 3, ""),
@@ -18756,8 +18777,9 @@ fn dinsp_scan(expr: Expr, mode: Int, name: String) -> Bool {
     // declares an optional parameter is the other (#1952). Without the second,
     // a statement whose only feature is a block-local `(a: Int, b?: Int)` was
     // skipped outright, and the omitted argument reached the checker as an
-    // arity error. The top-level equivalent is handled by `walk_all`, which is
-    // computed from collect_optional_param_fns and so cannot see this one.
+    // arity error. The top-level equivalent is mode 6 (a call to a top-level
+    // optional-parameter fn by name), consulted by desugar_labeled_args when
+    // collect_optional_param_fns found any.
     match expr {
       ELabeledArg(_, _, _) => true,
       EFn(_, _, params, _, _, _) => dinsp_params_optional(params),
@@ -18768,6 +18790,25 @@ fn dinsp_scan(expr: Expr, mode: Int, name: String) -> Bool {
       EIdent(n, _) => n == name,
       EAssign(n, _, _) => n == name,
       EAssignOp(n, _, _, _) => n == name,
+      _ => false
+    }
+  } else if mode == 6 {
+    // #2386: "does this statement call a TOP-LEVEL optional-parameter fn by
+    // name?" -- the third and last reason the relabel walk can change a
+    // statement (an omitted optional leaves no syntactic trace at the call,
+    // but the callee's NAME is one; relabel_expr's ECall arm fills only
+    // calls whose callee is an ident it can resolve). Reads the same table
+    // the walk reads (optional_param_tbl_set runs before the scan). Used
+    // with mode 3, it replaces the `walk_all` that rebuilt EVERY statement
+    // of a program declaring any optional parameter.
+    match expr {
+      ECall(callee, _, _) => match callee {
+        EIdent(n, _) => match optional_param_flags(n) {
+          Some(_) => true,
+          None => false
+        },
+        _ => false
+      },
       _ => false
     }
   } else {
@@ -19550,7 +19591,15 @@ export fn desugar_labeled_args(stmts: Array[Stmt]) -> Unit {
   // stmt_has_labeled_arg finds.
   let opt_tbl = collect_optional_param_fns(stmts)
   optional_param_tbl_set(opt_tbl)
-  let walk_all = Array::length(opt_tbl) > 0 || stmts_have_optional_fn(stmts)
+  // #2386: `walk_all` used to be true for every program that declared an
+  // optional parameter anywhere (the compiler's own closure does), so every
+  // statement was rebuilt on every compile (0.23 s of a warm compiler-closure
+  // compile). The two syntactic reasons the walk can change a statement are
+  // already scanned by stmt_has_labeled_arg (a labeled argument, a lambda
+  // with an optional parameter); the third -- a call to a top-level
+  // optional-parameter fn -- is stmt_calls_optional_fn, consulted only when
+  // the table is non-empty.
+  let has_opt_tbl = Array::length(opt_tbl) > 0
   // No `if Array::length(tbl) == 0` early-out. It was an optimisation that had
   // become a correctness hole once local lambdas got labels of their own
   // (#1899/#1952): collect_fn_param_labels indexes `SLet`s, so a file whose
@@ -19561,7 +19610,7 @@ export fn desugar_labeled_args(stmts: Array[Stmt]) -> Unit {
   // where nothing needs relabelling.
   let mut i = 0
   while i < Array::length(stmts) {
-    if walk_all || stmt_has_labeled_arg(Array::get(stmts, i)) {
+    if stmt_has_labeled_arg(Array::get(stmts, i)) || (has_opt_tbl && stmt_calls_optional_fn(Array::get(stmts, i))) {
       Array::set(stmts, i, relabel_stmt(Array::get(stmts, i), tbl))
     } else {
       ()

--- a/lib/@vibe/compiler/normalize/desugar_trait_dict.vibe
+++ b/lib/@vibe/compiler/normalize/desugar_trait_dict.vibe
@@ -4249,14 +4249,12 @@ fn infer_impl_target_key(arg: Expr, struct_sets: Array[(String, Array[String])],
   }
 }
 
-fn bind_impl_target_key(var_types: Array[(String, String)], name: String, value: Expr, struct_sets: Array[(String, Array[String])], fn_returns: Array[(String, String)]) -> Array[(String, String)] {
-  match infer_impl_target_key(value, struct_sets, var_types, fn_returns) {
-    Some(key) => {
-      let out = clone_var_types(var_types)
-      Array::push(out, (impl_target_var_key(name), key))
-      out
-    },
-    None => var_types
+/// In-place form of `bind_impl_target_key` for `bind_let_env`: `out` is the
+/// environment the binding extends, already cloned by the caller.
+fn bind_impl_target_key_into(out: Array[(String, String)], name: String, value: Expr, struct_sets: Array[(String, Array[String])], fn_returns: Array[(String, String)]) -> Unit {
+  match infer_impl_target_key(value, struct_sets, out, fn_returns) {
+    Some(key) => Array::push(out, (impl_target_var_key(name), key)),
+    None => ()
   }
 }
 
@@ -5251,14 +5249,10 @@ fn array_elem_type_of(var_types: Array[(String, String)], name: String) -> Optio
 ///
 /// Only writes when there IS a live entry to mask, so the common binding pays
 /// nothing.
-fn mask_stale_array_elem(var_types: Array[(String, String)], name: String) -> Array[(String, String)] {
-  match array_elem_type_of(var_types, name) {
-    Some(_) => {
-      let out = clone_var_types(var_types)
-      Array::push(out, (array_elem_key(name), ""))
-      out
-    },
-    None => var_types
+fn mask_stale_array_elem_into(out: Array[(String, String)], name: String) -> Unit {
+  match array_elem_type_of(out, name) {
+    Some(_) => Array::push(out, (array_elem_key(name), "")),
+    None => ()
   }
 }
 
@@ -5338,19 +5332,15 @@ fn dtd_array_elem_of_ann(ty: TypeExpr) -> Option[String] {
   }
 }
 
-fn array_elem_bind(var_types: Array[(String, String)], name: String, val: Expr, struct_sets: Array[(String, Array[String])], fn_returns: Array[(String, String)]) -> Array[(String, String)] {
+fn array_elem_bind_into(out: Array[(String, String)], name: String, val: Expr, struct_sets: Array[(String, Array[String])], fn_returns: Array[(String, String)]) -> Unit {
   // #1880: an explicit `Array[T]` annotation is the most reliable element type
   // there is, so it is consulted before the value's shape. `array_elem_key` is
-  // the older sentinel -- `shape_bind` runs after this and its record wins for
-  // rendering -- but this one is read by call-site dict synthesis (#1199), so
-  // an annotated binding has to reach it too.
+  // the older sentinel -- `shape_bind_into` runs after this and its record wins
+  // for rendering -- but this one is read by call-site dict synthesis (#1199),
+  // so an annotated binding has to reach it too.
   match dtd_array_elem_of_ann_opt(dtd_ascribed_type(val)) {
-    Some(elem) => {
-      let out = clone_var_types(var_types)
-      Array::push(out, (array_elem_key(name), elem))
-      out
-    },
-    None => array_elem_bind_by_shape(var_types, name, val, struct_sets, fn_returns)
+    Some(elem) => Array::push(out, (array_elem_key(name), elem)),
+    None => array_elem_bind_by_shape_into(out, name, val, struct_sets, fn_returns)
   }
 }
 
@@ -5361,26 +5351,17 @@ fn dtd_array_elem_of_ann_opt(ann: Option[TypeExpr]) -> Option[String] {
   }
 }
 
-fn array_elem_bind_by_shape(var_types: Array[(String, String)], name: String, val: Expr, struct_sets: Array[(String, Array[String])], fn_returns: Array[(String, String)]) -> Array[(String, String)] {
+fn array_elem_bind_by_shape_into(out: Array[(String, String)], name: String, val: Expr, struct_sets: Array[(String, Array[String])], fn_returns: Array[(String, String)]) -> Unit {
   match val {
     EArray(elems) => if Array::length(elems) > 0 {
-      match infer_arg_type_name(Array::get(elems, 0), struct_sets, var_types, fn_returns) {
-        Some(elemty) => {
-          let out = array_empty()
-          let mut i = 0
-          while i < Array::length(var_types) {
-            Array::push(out, Array::get(var_types, i))
-            i = i + 1
-          }
-          Array::push(out, (array_elem_key(name), elemty))
-          out
-        },
-        None => mask_stale_array_elem(var_types, name)
+      match infer_arg_type_name(Array::get(elems, 0), struct_sets, out, fn_returns) {
+        Some(elemty) => Array::push(out, (array_elem_key(name), elemty)),
+        None => mask_stale_array_elem_into(out, name)
       }
     } else {
-      mask_stale_array_elem(var_types, name)
+      mask_stale_array_elem_into(out, name)
     },
-    _ => mask_stale_array_elem(var_types, name)
+    _ => mask_stale_array_elem_into(out, name)
   }
 }
 
@@ -5538,56 +5519,48 @@ fn dtd_tuple_elem_names_of_array_get(val: Expr, var_types: Array[(String, String
 /// #1445: record a let-bound TUPLE literal's shape. Sibling of
 /// `array_elem_bind` -- same "only a bare literal RHS" scope, for the same
 /// reason (this is a syntax-directed pass, not type inference).
-fn tuple_shape_bind(var_types: Array[(String, String)], name: String, val: Expr, struct_sets: Array[(String, Array[String])], fn_returns: Array[(String, String)]) -> Array[(String, String)] {
+fn tuple_shape_bind_into(out: Array[(String, String)], name: String, val: Expr, struct_sets: Array[(String, Array[String])], fn_returns: Array[(String, String)]) -> Unit {
   // #2128: an explicit `(A, B)` annotation is the most reliable element list
-  // there is -- the same reason `array_elem_bind` consults one first (#1880).
-  // A local `let t: (String, String) = (..)` is NOT annotation-free: the
-  // parser rewrites it to `((__asc: T) -> __asc)(v)`, which also hides the
+  // there is -- the same reason `array_elem_bind_into` consults one first
+  // (#1880). A local `let t: (String, String) = (..)` is NOT annotation-free:
+  // the parser rewrites it to `((__asc: T) -> __asc)(v)`, which also hides the
   // `ETuple` from the match below, so before this an annotated tuple recorded
   // NOTHING and `t.0 < t.1` stayed an address comparison.
   match dtd_tuple_elem_names_of_ann(dtd_ascribed_type(val)) {
-    Some(sentinel) => {
-      let out = clone_var_types(var_types)
-      Array::push(out, (tuple_shape_key(name), sentinel))
-      return out
-    },
-    None => ()
-  }
-  // #2128: `let p = Array::get(ps, i)` where `ps` is an array OF tuples.
-  // `infer_shape` does not project an array element, so `shape_bind` records a
-  // non-composite shape for `p` and `p.0` had nothing to read. The element
-  // types are in the ARRAY's own `__shape$` record.
-  let from_elem = dtd_tuple_elem_names_of_array_get(val, var_types)
-  if String::length(from_elem) > 0 {
-    let out = clone_var_types(var_types)
-    Array::push(out, (tuple_shape_key(name), from_elem))
-    return out
-  } else {
-    ()
-  }
-  match val {
-    ETuple(items) => if Array::length(items) > 0 {
-      let mut acc = ""
-      let mut i = 0
-      while i < Array::length(items) {
-        let tn = match infer_arg_type_name(Array::get(items, i), struct_sets, var_types, fn_returns) {
-          Some(t) => t,
-          None => ""
+    Some(sentinel) => Array::push(out, (tuple_shape_key(name), sentinel)),
+    None => {
+      // #2128: `let p = Array::get(ps, i)` where `ps` is an array OF tuples.
+      // `infer_shape` does not project an array element, so `shape_bind_into`
+      // records a non-composite shape for `p` and `p.0` had nothing to read.
+      // The element types are in the ARRAY's own `__shape$` record.
+      let from_elem = dtd_tuple_elem_names_of_array_get(val, out)
+      if String::length(from_elem) > 0 {
+        Array::push(out, (tuple_shape_key(name), from_elem))
+      } else {
+        match val {
+          ETuple(items) => if Array::length(items) > 0 {
+            let mut acc = ""
+            let mut i = 0
+            while i < Array::length(items) {
+              let tn = match infer_arg_type_name(Array::get(items, i), struct_sets, out, fn_returns) {
+                Some(t) => t,
+                None => ""
+              }
+              acc = if i == 0 {
+                tn
+              } else {
+                String::concat(acc, String::concat(",", tn))
+              }
+              i = i + 1
+            }
+            Array::push(out, (tuple_shape_key(name), acc))
+          } else {
+            ()
+          },
+          _ => ()
         }
-        acc = if i == 0 {
-          tn
-        } else {
-          String::concat(acc, String::concat(",", tn))
-        }
-        i = i + 1
       }
-      let out = clone_var_types(var_types)
-      Array::push(out, (tuple_shape_key(name), acc))
-      out
-    } else {
-      var_types
-    },
-    _ => var_types
+    }
   }
 }
 
@@ -5595,15 +5568,22 @@ fn tuple_shape_bind(var_types: Array[(String, String)], name: String, val: Expr,
 /// a later `match` on that variable can type its binder. The parameter-side
 /// counterpart lives in `seed_var_types`, which has a real `TypeExpr`
 /// (`Option[P]`) to read the payload off.
-fn ctor_payload_bind(var_types: Array[(String, String)], name: String, val: Expr, struct_sets: Array[(String, Array[String])], fn_returns: Array[(String, String)]) -> Array[(String, String)] {
+fn ctor_payload_bind_into(out: Array[(String, String)], name: String, val: Expr, struct_sets: Array[(String, Array[String])], fn_returns: Array[(String, String)]) -> Unit {
   match val {
     ECall(callee, cargs, _) => match callee {
       EIdent(cn, _) => if Array::length(cargs) >= 1 && starts_upper(cn) {
-        let out = clone_var_types(var_types)
+        // Every payload shape is read off the environment BEFORE any payload
+        // key is appended, exactly as the chained form read them off its
+        // input, so a later slot cannot observe an earlier slot's record.
+        let shapes = empty_str_array()
         let mut i = 0
-        let mut wrote = false
         while i < Array::length(cargs) {
-          let sh = infer_shape(Array::get(cargs, i), struct_sets, var_types, fn_returns)
+          Array::push(shapes, infer_shape(Array::get(cargs, i), struct_sets, out, fn_returns))
+          i = i + 1
+        }
+        i = 0
+        while i < Array::length(cargs) {
+          let sh = Array::get(shapes, i)
           if String::length(sh) == 0 {
             ()
           } else {
@@ -5616,21 +5596,15 @@ fn ctor_payload_bind(var_types: Array[(String, String)], name: String, val: Expr
               ctor_payload_idx_key(name, cn, i)
             }
             Array::push(out, (key, sh))
-            wrote = true
           }
           i = i + 1
         }
-        if wrote {
-          out
-        } else {
-          var_types
-        }
       } else {
-        var_types
+        ()
       },
-      _ => var_types
+      _ => ()
     },
-    _ => var_types
+    _ => ()
   }
 }
 
@@ -6072,9 +6046,8 @@ fn infer_shape_by_syntax(e: Expr, struct_sets: Array[(String, Array[String])], v
 /// Record a binding's recursive shape, when there is one worth recording. A
 /// plain name adds nothing the existing entries do not already carry, so only
 /// composites are stored.
-fn shape_bind(var_types: Array[(String, String)], name: String, val: Expr, struct_sets: Array[(String, Array[String])], fn_returns: Array[(String, String)]) -> Array[(String, String)] {
-  let sh = infer_shape(val, struct_sets, var_types, fn_returns)
-  let out = clone_var_types(var_types)
+fn shape_bind_into(out: Array[(String, String)], name: String, val: Expr, struct_sets: Array[(String, Array[String])], fn_returns: Array[(String, String)]) -> Unit {
+  let sh = infer_shape(val, struct_sets, out, fn_returns)
   // ALWAYS record, even for a non-composite binding (recording ""). Skipping
   // those would leave a SHADOWED name's old shape as the live answer:
   // `extend_var_types` appends and `lookup_var_type` returns the LAST match
@@ -6090,18 +6063,45 @@ fn shape_bind(var_types: Array[(String, String)], name: String, val: Expr, struc
   // call-site dict synthesis too, so appending empties there would change
   // #1199's behaviour).
   Array::push(out, (shape_key(name), sh))
-  out
 }
 
 /// #1445: every binding-site shape record, applied in one place so `ELet` and
 /// `ELetMut` cannot drift apart.
 fn bind_shapes(var_types: Array[(String, String)], name: String, val: Expr, struct_sets: Array[(String, Array[String])], fn_returns: Array[(String, String)]) -> Array[(String, String)] {
-  let a = array_elem_bind(var_types, name, val, struct_sets, fn_returns)
-  let b = tuple_shape_bind(a, name, val, struct_sets, fn_returns)
-  let c = ctor_payload_bind(b, name, val, struct_sets, fn_returns)
+  let out = clone_var_types(var_types)
+  bind_shapes_into(out, name, val, struct_sets, fn_returns)
+  out
+}
+
+/// The four records appended in place. `out` is a private copy of the
+/// environment the binding extends; each stage reads `out` as it stands, which
+/// is exactly the environment the previous stage returned when every stage
+/// cloned for itself (#2386: those copies were up to six per `let`, all but
+/// the first redundant).
+fn bind_shapes_into(out: Array[(String, String)], name: String, val: Expr, struct_sets: Array[(String, Array[String])], fn_returns: Array[(String, String)]) -> Unit {
+  array_elem_bind_into(out, name, val, struct_sets, fn_returns)
+  tuple_shape_bind_into(out, name, val, struct_sets, fn_returns)
+  ctor_payload_bind_into(out, name, val, struct_sets, fn_returns)
   // LAST: infer_shape reads the sentinels the three above just wrote, so a
   // binding whose elements are themselves named bindings resolves in one pass.
-  shape_bind(c, name, val, struct_sets, fn_returns)
+  shape_bind_into(out, name, val, struct_sets, fn_returns)
+}
+
+/// The whole binding-site environment of a `let` / `let mut` / the equality
+/// walk's `bound_var_types`, built on ONE copy of `var_types`: the inferred
+/// head type when there is one (what `extend_var_types` records), the
+/// impl-target key, the four shape records, then the equality shape. Same
+/// entries in the same order as the former chain of per-stage clones.
+fn bind_let_env(var_types: Array[(String, String)], name: String, val: Expr, inferred: Option[String], struct_sets: Array[(String, Array[String])], fn_returns: Array[(String, String)]) -> Array[(String, String)] {
+  let out = clone_var_types(var_types)
+  match inferred {
+    Some(tname) => Array::push(out, (name, tname)),
+    None => ()
+  }
+  bind_impl_target_key_into(out, name, val, struct_sets, fn_returns)
+  bind_shapes_into(out, name, val, struct_sets, fn_returns)
+  eq_shape_bind_into(out, name, val, struct_sets, fn_returns)
+  out
 }
 
 /// Equality keeps a deeper type shape than the general rendering/type-head
@@ -6110,7 +6110,7 @@ fn bind_shapes(var_types: Array[(String, String)], name: String, val: Expr, stru
 /// shape for both `let` and `let mut`; their contents may still mutate, so
 /// comparison has a runtime fail-closed guard below. Empty entries are answers
 /// too: they mask an outer binding's equality/call-result shape on shadowing.
-fn eq_shape_bind(var_types: Array[(String, String)], name: String, val: Expr, struct_sets: Array[(String, Array[String])], fn_returns: Array[(String, String)]) -> Array[(String, String)] {
+fn eq_shape_bind_into(out: Array[(String, String)], name: String, val: Expr, struct_sets: Array[(String, Array[String])], fn_returns: Array[(String, String)]) -> Unit {
   // #2218: read a LOCAL annotation directly. `let m: Map[String, Int] = mk()`
   // is parsed as `((__asc: Map[String, Int]) -> __asc)(mk())`, so the type is
   // in the AST -- but the arms below see the ascription WRAPPER, not the call,
@@ -6142,24 +6142,22 @@ fn eq_shape_bind(var_types: Array[(String, String)], name: String, val: Expr, st
         None => if Array::length(tparams) > 0 {
           ""
         } else {
-          infer_shape(fn_body_tail_expr(fbody), struct_sets, var_types, fn_returns)
+          infer_shape(fn_body_tail_expr(fbody), struct_sets, out, fn_returns)
         }
       },
       EArray(items) => if Array::length(items) == 0 {
         "[__EqEmpty]"
       } else {
-        infer_eq_shape(val, struct_sets, var_types, fn_returns)
+        infer_eq_shape(val, struct_sets, out, fn_returns)
       },
-      _ => infer_eq_shape(val, struct_sets, var_types, fn_returns)
+      _ => infer_eq_shape(val, struct_sets, out, fn_returns)
     }
   }
-  let out = clone_var_types(var_types)
   Array::push(out, (eq_shape_key(name), if shape_is_composite(sh) {
     sh
   } else {
     ""
   }))
-  out
 }
 
 // ---- #2157: an unannotated `let xs = []` gets its element type from a push ----
@@ -6631,9 +6629,7 @@ fn self_describing_fallback(v: Expr, struct_sets: Array[(String, Array[String])]
 /// The same binding-site records `rewrite_expr` makes at an `ELet`/`ELetMut`,
 /// so the walk above reads names the way the comparison site will.
 fn bound_var_types(var_types: Array[(String, String)], n: String, val: Expr, struct_sets: Array[(String, Array[String])], fn_returns: Array[(String, String)]) -> Array[(String, String)] {
-  let inferred = extend_var_types(var_types, n, anon_or_infer(val, struct_sets, var_types, fn_returns))
-  let base = bind_impl_target_key(inferred, n, val, struct_sets, fn_returns)
-  eq_shape_bind(bind_shapes(base, n, val, struct_sets, fn_returns), n, val, struct_sets, fn_returns)
+  bind_let_env(var_types, n, val, anon_or_infer(val, struct_sets, var_types, fn_returns), struct_sets, fn_returns)
 }
 
 /// The value `e` pushes onto the array bound to `name`. Only the qualified
@@ -10593,14 +10589,11 @@ fn rewrite_expr(expr: Expr, gens: Array[DictGen], traits: Array[(String, Array[(
       } else {
         anon_or_infer(val, struct_sets, var_types, fn_returns)
       }
-      let inferred_vars = if Array::get(dtd_constructor_tracking, 0) && inferred == None && constructor_binding_has_evidence(var_types, name) {
-        constructor_rewrite_var_types(var_types, name, inferred)
+      let body_vars2 = if Array::get(dtd_constructor_tracking, 0) && inferred == None && constructor_binding_has_evidence(var_types, name) {
+        bind_let_env(constructor_rewrite_var_types(var_types, name, inferred), name, val, None, struct_sets, fn_returns)
       } else {
-        extend_var_types(var_types, name, inferred)
+        bind_let_env(var_types, name, val, inferred, struct_sets, fn_returns)
       }
-      let body_vars0 = bind_impl_target_key(inferred_vars, name, val, struct_sets, fn_returns)
-      let body_vars1 = bind_shapes(body_vars0, name, val, struct_sets, fn_returns)
-      let body_vars2 = eq_shape_bind(body_vars1, name, val, struct_sets, fn_returns)
       // #2157: an unannotated `let xs = []` reads its element type off the
       // pushes in its own body, so it compares like the annotated form.
       let body_vars3 = empty_array_shape_from_body(body_vars2, name, body, struct_sets, fn_returns)
@@ -10622,14 +10615,11 @@ fn rewrite_expr(expr: Expr, gens: Array[DictGen], traits: Array[(String, Array[(
       } else {
         anon_or_infer(val, struct_sets, var_types, fn_returns)
       }
-      let inferred_vars = if Array::get(dtd_constructor_tracking, 0) && inferred == None && constructor_binding_has_evidence(var_types, name) {
-        constructor_rewrite_var_types(var_types, name, inferred)
+      let body_vars2 = if Array::get(dtd_constructor_tracking, 0) && inferred == None && constructor_binding_has_evidence(var_types, name) {
+        bind_let_env(constructor_rewrite_var_types(var_types, name, inferred), name, val, None, struct_sets, fn_returns)
       } else {
-        extend_var_types(var_types, name, inferred)
+        bind_let_env(var_types, name, val, inferred, struct_sets, fn_returns)
       }
-      let body_vars0 = bind_impl_target_key(inferred_vars, name, val, struct_sets, fn_returns)
-      let body_vars1 = bind_shapes(body_vars0, name, val, struct_sets, fn_returns)
-      let body_vars2 = eq_shape_bind(body_vars1, name, val, struct_sets, fn_returns)
       let body_vars3 = empty_array_shape_from_body(body_vars2, name, body, struct_sets, fn_returns)
       let body_vars = extend_local_fn_return(body_vars3, name, val)
       ELetMut(name, new_val, rewrite_expr(body, gens, traits, struct_sets, dict_binds, body_vars, fn_returns), soff)

--- a/lib/@vibe/compiler/runtime/persistent_env_codec.vibe
+++ b/lib/@vibe/compiler/runtime/persistent_env_codec.vibe
@@ -1,6 +1,7 @@
 //# Imports
 
 import @vibe/compiler/cache {
+  compact_source_fingerprint_memo,
   compact_string_fingerprint,
   normalize_persistent_cache_text,
   package_index_deps_are_current,
@@ -1022,7 +1023,7 @@ export fn persistent_dep_list_text(deps: Array[String]) -> String {
 }
 
 export fn load_persistent_dep_list(path: String, source: String) -> Option[Array[String]] with Exception + Fs {
-  let cache_path = persistent_dep_list_cache_path(path, compact_string_fingerprint(source))
+  let cache_path = persistent_dep_list_cache_path(path, compact_source_fingerprint_memo(path, source))
   if !(Fs::exists(cache_path)) {
     None
   } else {
@@ -1114,7 +1115,7 @@ export fn persistent_type_env_cache_text(env: TypeEnv) -> String {
 }
 
 export fn load_persistent_leaf_fingerprint(path: String, source: String, typing_semantics_seed: String) -> Option[String] with Exception + Fs {
-  let cache_path = persistent_leaf_fingerprint_cache_path(path, compact_string_fingerprint(source))
+  let cache_path = persistent_leaf_fingerprint_cache_path(path, compact_source_fingerprint_memo(path, source))
   if !(Fs::exists(cache_path)) {
     None
   } else {

--- a/lib/@vibe/compiler/runtime/typecheck_fs.vibe
+++ b/lib/@vibe/compiler/runtime/typecheck_fs.vibe
@@ -1,6 +1,8 @@
 //# Imports
 
 import @vibe/compiler/cache {
+  compact_source_fingerprint_memo,
+  compact_source_fingerprint_memo_reset,
   compact_string_fingerprint,
   normalize_persistent_cache_text,
   persistent_dep_list_cache_path,
@@ -4146,7 +4148,7 @@ fn write_typing_dependency_env_reuse_sidecar(input_key: String, target_fingerpri
 }
 
 fn write_persistent_dep_list_if_missing(path: String, source: String, deps: Array[String]) -> Unit with Fs {
-  let dep_cache_path = persistent_dep_list_cache_path(path, compact_string_fingerprint(source))
+  let dep_cache_path = persistent_dep_list_cache_path(path, compact_source_fingerprint_memo(path, source))
   if !(Fs::exists(dep_cache_path)) {
     Fs::write_file(dep_cache_path, persistent_dep_list_text(deps))
   } else {
@@ -6050,6 +6052,8 @@ export fn ensure_fingerprint_fs_impl(rdb: RippleDb, env_cache: Array[(String, Ty
   // earlier compile of a since-edited file, without any eviction policy that
   // could drop a row the ACTIVE compile still needs.
   module_typed_lowering_memo_reset()
+  // #2386: the source-text fingerprint memo spans one compile too.
+  compact_source_fingerprint_memo_reset()
   let (plan_leaf_fps, plan_edges, planned_parse_count, plan_diags) = plan_import_graph_fs(rdb, dep_source_cache, parse_count, path)
   // #1239 step 4(A): an import cycle is rejected HERE -- before a single
   // module is checked, committed, or written to the persistent cache --


### PR DESCRIPTION
## What

Five more slices of #2386, each byte-identical to the previous head on the compiler closure and the corpora named below, each measured on its own (cache-isolated per the profiling skill, corpus `codegen_lexer_test.vibe`, N=3 interleaved).

### 1. `3c957f6` — the may-return-view fixpoint as a callee-edge worklist (`compute_may_return_view_fns`)

The round-based driver re-walked every not-yet-classified function body on each round until a round added nothing. A function's verdict depends on its body and on which of its user-fn callees are in the view set (the walk's one cross-function read), so the first walk now records each function's callees, a reverse index turns "f entered the set" into "re-walk f's callers", and nothing else is re-walked. Same fixpoint (the old 10-round cap could only truncate it). `compute_may_return_view_fns` 0.31 s → 0.13 s warm; byte-identical on six corpora including `may_return_view_fns_test.vibe`; `may_return_view_fns_test` and `erase_ascription_test` pass.

### 2. `b8487f9` — borrow-param analysis membership as sets (`compute_borrow_param_user_fns`)

`valued` and `exclude` were sorted into two copies and queried by binary search twice per function; the analysis never reads the order, so two `MutSet`s replace the sort. `sorted_names_of` 0.08 s → 0.02 s warm. A multi-name form of the per-parameter consume-count walks was assessed and not attempted: `EIf` / `EMatch` merge counts by max, so it would need per-branch count arrays — the heap shape of #2484's dropped queue.

### 3. `6909326` — a per-compile source-fingerprint memo; an index for the file-fingerprint memo (`cache_underlying.vibe`)

Four callers hashed the same source text of every module once each per compile (the leaf fingerprint, the dep-list cache path written and read, the merge's per-file table); `compact_source_fingerprint_memo(path, source)` answers from a per-compile map keyed by path and verified by text equality (a byte compare, cheaper than the hash), reset at the start of each compile's typing walk. `cache_fingerprint_file_fs_with_ingestion_stamp` found its memo entry by a linear scan over parallel arrays; it has a path → slot map now. `compact_string_fingerprint` 0.16 s → 0.11 s warm; a warm rerun's output equals the cold one (no cache key touched); `persistent_cache_test` and `persistent_fs_compile_cache_test` pass. The `MutMap` import makes `@vibe/core` a dependency of `@vibe/compiler/cache`, declared in its `index.vpkg` (the gate's deps-missing-for-imports scan caught the omission in the first chain).

### 4. `d3eb47e` — the labeled-argument relabel walk runs only on statements it can change (`desugar_labeled_args`)

`stmts_have_optional_fn` answered true unconditionally, so `walk_all` rebuilt every top-level statement's AST on every compile. The walk changes a statement for a labeled argument, a lambda declaring an optional parameter (both already scanned by `stmt_has_labeled_arg`), or a call to a top-level optional-parameter fn by name — the new `dinsp_scan` mode 6 / `stmt_calls_optional_fn`, consulted when `collect_optional_param_fns` found any. The binder-authority paired lane is unchanged. Byte-identical on the closure and on every labeled- and optional-argument test file, which also pass.

| | before | after |
|---|---:|---:|
| `desugar_labeled_args` warm inclusive | 0.12 s | 0.02 s |
| warm wall, mean of 3 | 5.07 s | 4.82 s |
| heap_ptr cold / warm | 1,529,244,248 / 783,362,080 | 1,506,791,152 / 772,149,984 |

### 5. `d5abcb1` — one environment copy per `let` in the trait-dict pass (`bind_let_env`)

Every binding-site record in `desugar_trait_dict.vibe` cloned the rewrite environment for itself — `extend_var_types`, `bind_impl_target_key`, `array_elem_bind`, `tuple_shape_bind`, `ctor_payload_bind`, `shape_bind`, `eq_shape_bind` each took `Array::slice` of the whole env and pushed one entry — so a `let` whose value was a tuple literal made up to seven copies of an environment that grows with every enclosing binding, and any binding made at least two (`shape_bind` and `eq_shape_bind` cloned unconditionally). `bind_let_env` takes the one copy and the stages append in place (`*_into`); each stage reads the array as it stands, which is exactly the environment the previous stage returned in the chained form, so the entries and their order are unchanged (`ctor_payload_bind_into` reads every payload shape before appending any key, as the chained form read them off its input). Byte-identical on the closure, on 94 shape / interpolation / structural-`==` fixtures and on the seven unit files that pin those records (`string_lt_type_dependence_test`, `tuple_destr_test`, `desugar_test`, `constructor_indexed_trait_dict_test`, `interp_show_single_file_diag_test`, `structural_eq_contexts_test`, `generic_derive_eq_test`), all of which pass.

| | before | after |
|---|---:|---:|
| heap_ptr cold / warm | 1,506,791,152 / 772,149,984 | 1,481,766,472 / 747,127,496 (−25.0 MB both) |
| warm wall, mean of 3 | 5.12 s | 5.08 s (noise) |
| `clone_var_types` warm self | 0.06 s | 0.02 s |

## Tried and dropped (recorded so they are not retried blind)

| attempt | measured |
|---|---|
| a whole-program binder set for the evidence pass's two shadow checks | two walks hashing ~50k binder names cost 0.11 s and +4.4 MB where the per-needing-name walks cost 0.07 s: `needing` is small and `str_eq` is length-gated |
| a pre-scan to skip `uniquify_shadowed_bindings` on functions with no repeated binder name | most compiler functions reuse `i` / `out` in sibling scopes, so the walk still runs: 0.12 → 0.10 s minus a 0.03 s scan, −2.7 MB only; the same gate on `lift_match_scrutinees` was a pure cost |

## Validation

Chain on this tree (head `d5abcb1`, base `ff2b091`; the same tree as the staging worktree the chain ran in, tree hash checked): bundle regen; stage2 == stage3; ten lane tests on linear (`string_lt_type_dependence_test`, `tuple_destr_test`, `desugar_test`, `constructor_indexed_trait_dict_test`, `may_return_view_fns_test`, `checker_labeled_arg_test`, `optional_param_local_lambda_test`, `persistent_cache_test`, `borrow_returning_names_test`, `uniquify_shadowed_bindings_test`); `test_cli_core.sh`; selfcompile KPI heap_ptr 1,482,551,952 bytes (vs 1,529,664,000 on #2484's head, −47.1 MB); typing-env-reuse oracle; 226/226 affected unit-test files (import-graph selection over every compiler file the five commits touch); `compiler_gate.sh` early / mid / late. The first chain failed exactly one gate — 60, the deps-missing-for-imports scan, on `cache/index.vpkg` — which is the `@vibe/core` declaration now in commit 3. `vibe_fmt.sh --check` is a fixpoint on every changed file.

Refs #2386, #2479.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QKZdvBvHVUagwg6Yih8er8

---
_Generated by [Claude Code](https://claude.ai/code/session_01QKZdvBvHVUagwg6Yih8er8)_