### PR TITLE
perceus: pin the borrow tables once per compile; a set for the borrow-returning fixpoint (#2386)

### DIFF
--- a/lib/@vibe/compiler/codegen/common_base/common_base.vibe
+++ b/lib/@vibe/compiler/codegen/common_base/common_base.vibe
@@ -1043,6 +1043,11 @@ export struct CompileCtx {
   // a `let`-bound float, instead of falling through to the integer-multiply
   // path and treating a boxed-float pointer as a scalar (OOB trap under RC).
   ctor_float_fields: Array[Int];
+  // #2386: the `perceus_pin_tables` token for the four borrow tables carried
+  // below (borrow_ret_names / borrow_param_user / borrow_param_mask /
+  // borrow_view_ret), 0 when nobody pinned them; a lambda's plan presents it
+  // so the perceus pass skips its per-function table compare.
+  perceus_pin: Int;
   // #2158: names of user functions whose DECLARED return type is
   // Double/Float. codegen is untyped, so a call `half(5.0)` is just an ECall
   // -- the syntactic cc_expr_is_floatish could not tell it from an Int-valued

--- a/lib/@vibe/compiler/codegen/expr/compile_lambda.vibe
+++ b/lib/@vibe/compiler/codegen/expr/compile_lambda.vibe
@@ -20,7 +20,7 @@ import @vibe/core {
 }
 
 import @vibe/compiler/perceus {
-  build_perceus_plan_with_params, pa_is_alias_dup, pa_is_drop, pa_is_dup, pa_is_reuse_token, param_is_heap_in_body
+  build_perceus_plan_pinned, pa_is_alias_dup, pa_is_drop, pa_is_dup, pa_is_reuse_token, param_is_heap_in_body
 }
 
 import @vibe/compiler/codegen/common_analysis {
@@ -383,7 +383,7 @@ export fn compile_lambda(buf: Bytes, params: Array[(String, Option[TypeExpr])], 
   let lam_reuse_names = array_empty()
   let lam_reuse_arities = array_empty()
   if ctx.enable_rc {
-    let lam_plan = build_perceus_plan_with_params(norm_params, fn_body, ctx.borrow_ret_names, ctx.borrow_param_user, ctx.borrow_param_mask, ctx.borrow_view_ret)
+    let lam_plan = build_perceus_plan_pinned(ctx.perceus_pin, norm_params, fn_body, ctx.borrow_ret_names, ctx.borrow_param_user, ctx.borrow_param_mask, ctx.borrow_view_ret)
     let mut ldi = 0
     while ldi < Array::length(lam_plan) {
       let lpa = Array::get(lam_plan, ldi)
@@ -460,6 +460,7 @@ export fn compile_lambda(buf: Bytes, params: Array[(String, Option[TypeExpr])], 
     ref_cell_names: lam_ref_cells,
     ctor_table: ctx.ctor_table,
     ctor_float_fields: ctx.ctor_float_fields,
+    perceus_pin: ctx.perceus_pin,
     float_ret_fns: ctx.float_ret_fns,
     float_call_offsets: ctx.float_call_offsets,
     int_render_offsets: ctx.int_render_offsets,

--- a/lib/@vibe/compiler/codegen/expr/compile_module_expr.vibe
+++ b/lib/@vibe/compiler/codegen/expr/compile_module_expr.vibe
@@ -235,6 +235,7 @@ export fn compile_module_expr_with_typed_offsets(stmts: Array[Stmt], checker_flo
         ref_cell_names: empty_ref_cells,
         ctor_table: empty_ctor_table,
         ctor_float_fields: fresh_int_array(),
+        perceus_pin: 0,
         // #2156 review: the same table the wasi and gc pre-passes build. This
         // was an empty array -- I added the field and initialized it here
         // without populating it, so a `-> Double` call in THIS lane (the

--- a/lib/@vibe/compiler/codegen/wasi/linked_compile.vibe
+++ b/lib/@vibe/compiler/codegen/wasi/linked_compile.vibe
@@ -41,8 +41,8 @@ import @vibe/compiler/normalize {
 import @vibe/compiler/perceus {
   PerceusAction,
   build_perceus_plan,
+  build_perceus_plan_pinned_split,
   build_perceus_plan_with_params,
-  build_perceus_plan_with_params_split,
   compute_borrow_returning_names,
   compute_heap_returning,
   compute_scalar_returning_names,
@@ -51,7 +51,8 @@ import @vibe/compiler/perceus {
   pa_is_drop,
   pa_is_dup,
   pa_is_reuse_token,
-  param_is_heap_in_body
+  param_is_heap_in_body,
+  perceus_pin_tables
 }
 
 import @vibe/compiler/codegen/builtin_bodies {
@@ -4569,6 +4570,10 @@ export fn compile_wasi_module_linked_impl_with_typed_offsets(stmts: Array[Stmt],
   } else {
     lc_fresh_string_array()
   }
+  // #2386: the perceus pass keeps one cached context for these four tables
+  // and used to re-compare all four, whole, at every function; pin them once
+  // and present the token per function (and per lambda, via CompileCtx).
+  let lc_perceus_pin = perceus_pin_tables(lc_borrow_ret_names, lc_borrow_param_user_srt, lc_borrow_param_mask, lc_borrow_view_ret)
   // #710: see CompileCtx.scalar_ret_names' doc comment (common_base/common_base.vibe).
   let lc_scalar_ret_names = sorted_names_of(compute_scalar_returning_names(stmts))
   let fn_names_list = lc_fresh_string_array()
@@ -7507,7 +7512,7 @@ export fn compile_wasi_module_linked_impl_with_typed_offsets(stmts: Array[Stmt],
         }
         if enable_rc {
           let bfn_drop_start_cell = lc_fresh_int_array()
-          let plan = build_perceus_plan_with_params_split(lc_norm_params, __bi_body, lc_borrow_ret_names, lc_borrow_param_user_srt, lc_borrow_param_mask, lc_borrow_view_ret, bfn_drop_start_cell)
+          let plan = build_perceus_plan_pinned_split(lc_perceus_pin, lc_norm_params, __bi_body, lc_borrow_ret_names, lc_borrow_param_user_srt, lc_borrow_param_mask, lc_borrow_view_ret, bfn_drop_start_cell)
           let bfn_drop_start = if Array::length(bfn_drop_start_cell) > 0 {
             Array::get(bfn_drop_start_cell, 0)
           } else {
@@ -7645,6 +7650,7 @@ export fn compile_wasi_module_linked_impl_with_typed_offsets(stmts: Array[Stmt],
             names_sorted_pos: lc_ctor_names_sorted_pos
           },
           ctor_float_fields: ctor_float_fields_list,
+          perceus_pin: lc_perceus_pin,
           float_ret_fns: float_ret_fn_names,
           float_call_offsets: float_call_offsets,
           int_render_offsets: int_render_offsets,

--- a/lib/@vibe/compiler/perceus/index.vpkg
+++ b/lib/@vibe/compiler/perceus/index.vpkg
@@ -84,6 +84,9 @@ fn pc_emit(ctx: PCtx, scope: Map[String, Int], expr: Expr) -> Int
 fn build_perceus_plan(body: Expr) -> Array[PerceusAction]
 fn build_perceus_plan_with_params(params: Array[(String, Option[TypeExpr])], body: Expr, borrow_ret_names: Array[String], borrow_param_fns: Array[String], borrow_param_masks: Array[Int], view_ret_fns: Array[String]) -> Array[PerceusAction]
 fn build_perceus_plan_with_params_split(params: Array[(String, Option[TypeExpr])], body: Expr, borrow_ret_names: Array[String], borrow_param_fns: Array[String], borrow_param_masks: Array[Int], view_ret_fns: Array[String], out_param_drop_start: Array[Int]) -> Array[PerceusAction]
+fn perceus_pin_tables(borrow_ret_names: Array[String], borrow_param_fns: Array[String], borrow_param_masks: Array[Int], view_ret_fns: Array[String]) -> Int
+fn build_perceus_plan_pinned(token: Int, params: Array[(String, Option[TypeExpr])], body: Expr, borrow_ret_names: Array[String], borrow_param_fns: Array[String], borrow_param_masks: Array[Int], view_ret_fns: Array[String]) -> Array[PerceusAction]
+fn build_perceus_plan_pinned_split(token: Int, params: Array[(String, Option[TypeExpr])], body: Expr, borrow_ret_names: Array[String], borrow_param_fns: Array[String], borrow_param_masks: Array[Int], view_ret_fns: Array[String], out_param_drop_start: Array[Int]) -> Array[PerceusAction]
 
 // --- heap-param elaboration (run at the head of the RC pipeline)
 fn elaborate_heap_params(stmts: Array[Stmt]) -> Array[Stmt]

--- a/lib/@vibe/compiler/perceus/perceus.vibe
+++ b/lib/@vibe/compiler/perceus/perceus.vibe
@@ -5,7 +5,7 @@ import @vibe/compiler/codegen/common_analysis {
 }
 
 import @vibe/core {
-  array_empty
+  array_empty, struct MutSet
 }
 
 import @vibe/compiler/core {
@@ -49,6 +49,11 @@ export enum PerceusActionKind {
 struct PCtx {
   mut next_id: Int;
   mut seq_id: Int;
+  // #2386: the token `perceus_pin_tables` handed out when it installed the
+  // four tables below, 0 when the cache holds tables nobody pinned. A caller
+  // presenting this token skips the four whole-table compares
+  // (`pctx_cache_matches`) that otherwise ran once per function.
+  mut pinned: Int;
   // The four table fields are `mut` for one reason only: on a pctx_cache
   // mismatch the cached PCtx is refilled in place by field assignment, which
   // drops the previous tables -- replacing the whole PCtx through Array::set
@@ -183,6 +188,7 @@ fn pctx_new(borrow_ret_names: Array[String], borrow_param_fns: Array[String], bo
   PCtx::{
     next_id: 0,
     seq_id: 0,
+    pinned: 0,
     pctx_names: Array::slice(borrow_ret_names, 0, Array::length(borrow_ret_names)),
     borrow_param_user: Array::slice(borrow_param_fns, 0, Array::length(borrow_param_fns)),
     borrow_param_mask: Array::slice(borrow_param_masks, 0, Array::length(borrow_param_masks)),
@@ -208,6 +214,9 @@ fn pctx_new(borrow_ret_names: Array[String], borrow_param_fns: Array[String], bo
 /// never depends on a set/reset discipline; a stale or half-built cache entry
 /// can only cause a miss, never a wrong table.
 let pctx_cache: Array[PCtx] = []
+
+/// #2386: the last token `perceus_pin_tables` issued (see PCtx.pinned).
+let pctx_pin_counter: Array[Int] = [0]
 
 fn same_str_table(a: Array[String], b: Array[String]) -> Bool {
   let la = Array::length(a)
@@ -646,7 +655,7 @@ fn collect_spine_let_vals(e0: Expr, names: Array[String], vals: Array[Expr], exc
 /// is peeled first so an annotated binding classifies as its value. Callee
 /// matching is one step at a time, and both loops are iterative -- see the
 /// shape workarounds documented on tail_is_borrow_ret_safe.
-fn spine_ident_returns_owned(known: Array[String], names: Array[String], vals: Array[Expr], excluded: Array[String], nm0: String) -> Bool {
+fn spine_ident_returns_owned(known: MutSet[String], names: Array[String], vals: Array[Expr], excluded: Array[String], nm0: String) -> Bool {
   let mut nm = nm0
   let mut hops = 0
   let mut owned = false
@@ -718,7 +727,7 @@ fn spine_ident_returns_owned(known: Array[String], names: Array[String], vals: A
           },
           ECall(c2, _, _) =>
           match c2 {
-            EIdent(f, _) => if f == "perform" || array_contains_str_pctx(known, f) {
+            EIdent(f, _) => if f == "perform" || MutSet::has(known, f) {
               done = true
             } else {
               owned = true
@@ -741,7 +750,7 @@ fn spine_ident_returns_owned(known: Array[String], names: Array[String], vals: A
   owned
 }
 
-fn tail_is_borrow_ret_safe(known: Array[String], e0: Expr, spine_names: Array[String], spine_vals: Array[Expr], spine_excluded: Array[String]) -> Bool {
+fn tail_is_borrow_ret_safe(known: MutSet[String], e0: Expr, spine_names: Array[String], spine_vals: Array[Expr], spine_excluded: Array[String]) -> Bool {
   // ADR-0090 / #1770: the worklist grows while being consumed in-place and
   // only the Bool verdict escapes, so its growth garbage goes to the region
   // arena (MutList) instead of the main heap. Bump lane only; under RC the
@@ -836,12 +845,12 @@ fn tail_is_borrow_ret_safe(known: Array[String], e0: Expr, spine_names: Array[St
             }
             if op_is_throw {
               ()
-            } else if !array_contains_str_pctx(known, callee) {
+            } else if !MutSet::has(known, callee) {
               all_safe = false
             } else {
               ()
             }
-          } else if !array_contains_str_pctx(known, callee) {
+          } else if !MutSet::has(known, callee) {
             all_safe = false
           } else {
             ()
@@ -943,12 +952,17 @@ export fn compute_borrow_returning_names(stmts: Array[Stmt]) -> Array[String] {
   // actually return a borrowed view.
   let builtin_names = borrow_ret_builtin_names()
   let known: Array[String] = []
+  // #2386: `known` is queried per statement per round and per callee inside
+  // `tail_is_borrow_ret_safe`; the set answers those, the array keeps the
+  // insertion order the result is read in.
+  let known_set = MutSet::new_string()
   let source_owned_mask = source_owned_shadowable_borrow_mask(stmts)
   let mut seed_i = 0
   while seed_i < Array::length(builtin_names) {
     let builtin_name = Array::get(builtin_names, seed_i)
     if !source_owns_shadowable_borrow_builtin(source_owned_mask, builtin_name) {
       Array::push(known, builtin_name)
+      MutSet::add(known_set, builtin_name)
     } else {
       ()
     }
@@ -961,7 +975,7 @@ export fn compute_borrow_returning_names(stmts: Array[Stmt]) -> Array[String] {
     while i < Array::length(stmts) {
       match Array::get(stmts, i) {
         SLet(_, _, name, _, value) =>
-        if !array_contains_str_pctx(known, name) {
+        if !MutSet::has(known_set, name) {
           match value {
             EFn(_, _, _, _, _, body) => {
               // A function is borrow-returning only if its (wrapper-stripped)
@@ -987,8 +1001,9 @@ export fn compute_borrow_returning_names(stmts: Array[Stmt]) -> Array[String] {
                 let sp_vals: Array[Expr] = []
                 let sp_excluded: Array[String] = []
                 let _ = collect_spine_let_vals(body, sp_names, sp_vals, sp_excluded)
-                if tail_is_borrow_ret_safe(known, top, sp_names, sp_vals, sp_excluded) {
+                if tail_is_borrow_ret_safe(known_set, top, sp_names, sp_vals, sp_excluded) {
                   Array::push(known, name)
+                  MutSet::add(known_set, name)
                   changed = true
                 } else {
                   ()
@@ -3051,7 +3066,10 @@ fn plan_reuse_pairs(body: Expr, actions: Array[PerceusAction], borrow_param_fns:
 /// machinery emits a PaDrop for a borrowed-only/unused heap param and a PaDup for
 /// one used in multiple owning positions. Heap-ness comes from the param's type
 /// annotation (scalar params get scalar=true so they are never dropped).
-export fn build_perceus_plan_with_params_split(params: Array[(String, Option[TypeExpr])], body: Expr, borrow_ret_names: Array[String], borrow_param_fns: Array[String], borrow_param_masks: Array[Int], view_ret_fns: Array[String], out_param_drop_start: Array[Int]) -> Array[PerceusAction] {
+/// The cached `PCtx` holding exactly these four tables, reset for a new
+/// function: installed fresh, kept when the tables compare equal, replaced
+/// (and unpinned) otherwise.
+fn pctx_cache_select(borrow_ret_names: Array[String], borrow_param_fns: Array[String], borrow_param_masks: Array[Int], view_ret_fns: Array[String]) -> PCtx {
   // Reuse the cached PCtx when the caller's four whole-program tables are
   // content-identical to the cached copies (the per-program common case: one
   // plan per function/lambda, all against the same tables); otherwise build a
@@ -3068,12 +3086,54 @@ export fn build_perceus_plan_with_params_split(params: Array[(String, Option[Typ
     // releasing the replaced element.
     let stale = Array::get(pctx_cache, 0)
     pctx_reset(stale)
+    stale.pinned = 0
     stale.pctx_names = Array::slice(borrow_ret_names, 0, Array::length(borrow_ret_names))
     stale.borrow_param_user = Array::slice(borrow_param_fns, 0, Array::length(borrow_param_fns))
     stale.borrow_param_mask = Array::slice(borrow_param_masks, 0, Array::length(borrow_param_masks))
     stale.view_ret_user = Array::slice(view_ret_fns, 0, Array::length(view_ret_fns))
   }
-  let ctx = Array::get(pctx_cache, 0)
+  Array::get(pctx_cache, 0)
+}
+
+/// #2386: install the four tables once per compile and hand back a token the
+/// per-function calls present (`build_perceus_plan_pinned*`). A token is
+/// valid exactly while the cache still holds the tables it was issued for:
+/// an unpinned call that replaces them clears it, and a pinned call whose
+/// token no longer matches falls back to the table compare, so the token can
+/// only skip work, never change an answer. Tokens are never reused.
+export fn perceus_pin_tables(borrow_ret_names: Array[String], borrow_param_fns: Array[String], borrow_param_masks: Array[Int], view_ret_fns: Array[String]) -> Int {
+  let ctx = pctx_cache_select(borrow_ret_names, borrow_param_fns, borrow_param_masks, view_ret_fns)
+  let tok = Array::get(pctx_pin_counter, 0) + 1
+  Array::set(pctx_pin_counter, 0, tok)
+  ctx.pinned = tok
+  tok
+}
+
+export fn build_perceus_plan_with_params_split(params: Array[(String, Option[TypeExpr])], body: Expr, borrow_ret_names: Array[String], borrow_param_fns: Array[String], borrow_param_masks: Array[Int], view_ret_fns: Array[String], out_param_drop_start: Array[Int]) -> Array[PerceusAction] {
+  let ctx = pctx_cache_select(borrow_ret_names, borrow_param_fns, borrow_param_masks, view_ret_fns)
+  build_perceus_plan_in_ctx(ctx, params, body, out_param_drop_start)
+}
+
+/// `build_perceus_plan_with_params_split` for a caller holding a
+/// `perceus_pin_tables` token: the same tables, the compare skipped while the
+/// token is current.
+export fn build_perceus_plan_pinned_split(token: Int, params: Array[(String, Option[TypeExpr])], body: Expr, borrow_ret_names: Array[String], borrow_param_fns: Array[String], borrow_param_masks: Array[Int], view_ret_fns: Array[String], out_param_drop_start: Array[Int]) -> Array[PerceusAction] {
+  let ctx = if token > 0 && Array::length(pctx_cache) > 0 && Array::get(pctx_cache, 0).pinned == token {
+    let c = Array::get(pctx_cache, 0)
+    pctx_reset(c)
+    c
+  } else {
+    pctx_cache_select(borrow_ret_names, borrow_param_fns, borrow_param_masks, view_ret_fns)
+  }
+  build_perceus_plan_in_ctx(ctx, params, body, out_param_drop_start)
+}
+
+export fn build_perceus_plan_pinned(token: Int, params: Array[(String, Option[TypeExpr])], body: Expr, borrow_ret_names: Array[String], borrow_param_fns: Array[String], borrow_param_masks: Array[Int], view_ret_fns: Array[String]) -> Array[PerceusAction] {
+  let ignored = array_empty()
+  build_perceus_plan_pinned_split(token, params, body, borrow_ret_names, borrow_param_fns, borrow_param_masks, view_ret_fns, ignored)
+}
+
+fn build_perceus_plan_in_ctx(ctx: PCtx, params: Array[(String, Option[TypeExpr])], body: Expr, out_param_drop_start: Array[Int]) -> Array[PerceusAction] {
   let mut scope: Map[String, Int] = Map::new()
   let mut pi = 0
   while pi < Array::length(params) {
@@ -3115,7 +3175,7 @@ export fn build_perceus_plan_with_params_split(params: Array[(String, Option[Typ
   // param-drop suffix -- out_param_drop_start's "drops from here on are the
   // params' own" contract only speaks about drops, and reuse rows are
   // neither drops nor dups, so every existing consumer skips them.
-  plan_reuse_pairs(body, ctx.actions, borrow_param_fns, borrow_param_masks)
+  plan_reuse_pairs(body, ctx.actions, ctx.borrow_param_user, ctx.borrow_param_mask)
   // An owned copy, NOT ctx.actions itself: the cached PCtx keeps (and later
   // resets) its own actions array, while callers hold the returned plan
   // across subsequent plan builds.

--- a/lib/@vibe/compiler/tests/perceus_pin_test.vibe
+++ b/lib/@vibe/compiler/tests/perceus_pin_test.vibe
@@ -1,0 +1,84 @@
+//# #2386: the perceus pass's pinned borrow tables.
+//#
+//# `perceus_pin_tables` installs the four whole-program tables once and hands
+//# back a token; `build_perceus_plan_pinned` presents it so the per-function
+//# call skips the element-by-element compare of all four tables. The token
+//# may only ever skip work: every plan below must equal the one the unpinned
+//# entry gives for the tables the call presents, including after another
+//# caller has replaced the cached tables.
+
+import @vibe/compiler/perceus {
+  PerceusAction, build_perceus_plan_pinned, build_perceus_plan_with_params, pa_is_drop, perceus_pin_tables
+}
+
+import @vibe/compiler/core {
+  Expr
+}
+
+fn count_drops(plan: Array[PerceusAction], name: String) -> Int {
+  let mut n = 0
+  let mut i = 0
+  while i < Array::length(plan) {
+    let a = Array::get(plan, i)
+    if pa_is_drop(a) && a.name == name {
+      n = n + 1
+    }
+    i = i + 1
+  }
+  n
+}
+
+/// `let result = Map::iter_get(1, 0); ()` -- `result` is dropped once when
+/// the callee returns an owned value and not at all when the tables say the
+/// callee returns a borrow. The two table sets below disagree on exactly that.
+fn iter_get_body() -> Expr {
+  let call = ECall(EIdent("Map::iter_get", -1), [EInt(1), EInt(0)], -1)
+  ELet("result", call, EUnit, -1)
+}
+
+test "a pinned plan equals the unpinned plan for the same tables" {
+  let body = iter_get_body()
+  let masks: Array[Int] = []
+  let borrowed = build_perceus_plan_with_params([], body, ["Map::iter_get"], [], masks, [
+  ])
+  let tok = perceus_pin_tables(["Map::iter_get"], [], masks, [])
+  let pinned = build_perceus_plan_pinned(tok, [], body, ["Map::iter_get"], [], masks, [
+  ])
+  assert(tok > 0)
+  assert(count_drops(borrowed, "result") == 0)
+  assert(count_drops(pinned, "result") == count_drops(borrowed, "result"))
+  assert(Array::length(pinned) == Array::length(borrowed))
+}
+
+test "a stale token answers for the tables the call presents, not the cached ones" {
+  let body = iter_get_body()
+  let masks: Array[Int] = []
+  let tok = perceus_pin_tables(["Map::iter_get"], [], masks, [])
+  // An unpinned call with different tables replaces the cache and clears
+  // the pin; `result` is owned under these tables.
+  let owned = build_perceus_plan_with_params([], body, [], [], masks, [])
+  assert(count_drops(owned, "result") == 1)
+  // The stale token must fall back to the compare and answer for the
+  // borrowed tables it presents -- reading the cached (owned) tables here
+  // would be the silently-wrong answer.
+  let pinned = build_perceus_plan_pinned(tok, [], body, ["Map::iter_get"], [], masks, [
+  ])
+  assert(count_drops(pinned, "result") == 0)
+}
+
+test "token 0 is the unpinned path" {
+  let body = iter_get_body()
+  let masks: Array[Int] = []
+  let plan = build_perceus_plan_pinned(0, [], body, ["Map::iter_get"], [], masks, [
+  ])
+  assert(count_drops(plan, "result") == 0)
+  let plan2 = build_perceus_plan_pinned(0, [], body, [], [], masks, [])
+  assert(count_drops(plan2, "result") == 1)
+}
+
+test "tokens are never reused" {
+  let masks: Array[Int] = []
+  let t1 = perceus_pin_tables(["Map::iter_get"], [], masks, [])
+  let t2 = perceus_pin_tables(["Map::iter_get"], [], masks, [])
+  assert(t2 > t1)
+}


### PR DESCRIPTION
## What

One more slice of #2386 on the perceus pass, byte-identical to main on the compiler closure and the corpora below, measured on its own (cache-isolated per the profiling skill, corpus `codegen_lexer_test.vibe`, N=3 interleaved).

### `3c5d195` — pin the four borrow tables once per compile; a set for the borrow-returning fixpoint's `known`

Two linear scans in the perceus pass, both over whole-program lists, both run once per function or per statement:

- `build_perceus_plan_with_params(_split)` keeps one cached `PCtx` and decided whether to reuse it by comparing the caller's four borrow tables against the cached copies element by element — thousands of string compares per function and per lambda, on the common path where they are always equal (`pctx_cache_matches` was 0.14 s of a 4.95 s warm compile, a quarter of the plan builder). `perceus_pin_tables` installs the tables once per compile and returns a token; the per-function calls (`build_perceus_plan_pinned(_split)`) present it and skip the compare while it is current. **The token can only skip work:** an unpinned call that replaces the tables clears it, and a pinned call whose token no longer matches falls back to the compare, so every answer is the one the compare would give. Tokens are never reused. `linked_compile` pins right after it builds the tables and hands the token to `CompileCtx` (`perceus_pin`) so a lambda's plan presents it too; `rc_query` and the tests keep the unpinned entry.
- `compute_borrow_returning_names`' fixpoint tested `known` by a linear scan per statement per round and per callee inside `tail_is_borrow_ret_safe`; a `MutSet` mirrors the list (the list keeps the order the result is read in).

`perceus_pin_test.vibe` pins the token contract: a pinned plan equals the unpinned one; a stale token (tables replaced by an unpinned call in between) still answers for the tables the call presents; token 0 is the unpinned path; tokens increase.

| | before (#2485 head) | after |
|---|---:|---:|
| `build_perceus_plan_*` warm inclusive | 0.54 s | 0.38 s |
| `compute_borrow_returning_names` warm inclusive | 0.12 s | 0.05 s |
| warm wall, mean of 3 | 5.09 s | 4.95 s (−2.8%) |
| cold wall, mean of 3 | 9.61 s | 9.52 s (noise) |
| heap_ptr cold / warm | 1,482,517,920 / 747,512,304 | 1,482,670,408 / 747,660,464 (+0.15 MB, the set) |

Byte-identical output on ten closures (`codegen_lexer_test`, `borrow_returning_names_test`, `type_db_cross_module_test`, `perceus_reuse_plan_test`, `perceus_rc_test`, `perceus_reuse_e2e_test`, `borrow_param_transitive_test`, `rc_shadow_regression_test`, `may_return_view_fns_test`) and 21 rc fixtures.

## Tried and dropped (recorded so they are not retried blind)

| attempt | measured |
|---|---|
| `is_heap_value`'s two `name_in` scans (`HeapInferCtx.ctors` / `heap_fns`) as sets | `name_in` unchanged, 0.06 → 0.07 s: its time is the small per-function drop / alias lists in `plan_reuse_pairs`, not these |
| the branch merges in `pc_count` / `pc_emit` through an undo log (log every count write as `(key, old)`, fold a branch's segment into a per-depth max/min, restore by walking it backwards) instead of `copy_ints` + `restore_prefix` per `if` / `match` / `handle` | byte-identical once the running max was kept per nesting depth (the single-array form let a branch nested in a later arm restart the enclosing arm's max — 14 function bodies differed on a test closure), but warm wall 4.86 → 4.98 s (+2.5%), heap_ptr +26 MB, plan builder 0.38 → 0.39 s: two pushes per count write cost more than the whole-table copies they replace (`copy_ints` was 0.05 s) once the table compare above is gone |

## Validation

Chain on this tree (head `3c5d195`, base `690b149`; the same tree as the staging worktree the chain ran in, tree hash checked): bundle regen; stage2 == stage3; twelve lane tests on linear (`perceus_pin_test`, `perceus_rc_test`, `perceus_reuse_e2e_test`, `perceus_reuse_plan_test`, `borrow_param_transitive_test`, `rc_shadow_regression_test`, `may_return_view_fns_test`, `checker_labeled_arg_test`, `optional_param_local_lambda_test`, `persistent_cache_test`, `borrow_returning_names_test`, `uniquify_shadowed_bindings_test`); `test_cli_core.sh`; selfcompile KPI heap_ptr 1,484,013,488 bytes (vs 1,482,551,952 on #2485's head, +1.5 MB); typing-env-reuse oracle; 128/128 affected unit-test files (import-graph selection over every file the commit touches); `compiler_gate.sh` early / mid / late. `vibe_fmt.sh --check` is a fixpoint on every changed file.

Refs #2386, #2479.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QKZdvBvHVUagwg6Yih8er8

---
_Generated by [Claude Code](https://claude.ai/code/session_01QKZdvBvHVUagwg6Yih8er8)_