### PR TITLE
loader: the unstable-surface scan lexes once and parses only what can report; the package-header scan stops copying at the first code line (#2386)

### DIFF
--- a/lib/@vibe/compiler/contract/contract.vibe
+++ b/lib/@vibe/compiler/contract/contract.vibe
@@ -2413,6 +2413,13 @@ fn scan_package_header(source: String) -> (Array[(String, String, String)], Stri
   let mut seen_description = false
   let mut seen_deps = false
   let mut seen_hash = false
+  // #2386: whether any directive line was blanked. Once the header ends the
+  // rest of the file is verbatim, so a source whose header blanked nothing
+  // IS its own blanked text, and one that did gets its tail in one piece --
+  // the line-by-line copy of every source (one substring and one push per
+  // line, per call, and this is called per file from a dozen sites) was
+  // 0.1 s and the copies of every compiler source on a warm compile.
+  let mut blanked_any = false
   while pos < len {
     let mut nl = pos
     while nl < len && String::char_code_at(source, nl) != 10 {
@@ -2434,6 +2441,7 @@ fn scan_package_header(source: String) -> (Array[(String, String, String)], Stri
       version = v
       seen_version = true
       StringBuilder::push(sb, blank_of(line))
+      blanked_any = true
     } else if String::starts_with(trimmed, "version ") {
       // Legacy bare `version x.y.z` (ADR-0065/#754), pre-#1128. Still
       // accepted, NOT an error: the compiler's own `lib/@vibe/compiler/**`
@@ -2460,6 +2468,7 @@ fn scan_package_header(source: String) -> (Array[(String, String, String)], Stri
       version = v
       seen_version = true
       StringBuilder::push(sb, blank_of(line))
+      blanked_any = true
     } else if String::starts_with(trimmed, "name =") {
       if seen_name {
         throw("duplicate name directive: \{trimmed}")
@@ -2471,6 +2480,7 @@ fn scan_package_header(source: String) -> (Array[(String, String, String)], Stri
       name = n
       seen_name = true
       StringBuilder::push(sb, blank_of(line))
+      blanked_any = true
     } else if String::starts_with(trimmed, "main =") {
       if seen_main {
         throw("duplicate main directive: \{trimmed}")
@@ -2485,6 +2495,7 @@ fn scan_package_header(source: String) -> (Array[(String, String, String)], Stri
       }
       seen_main = true
       StringBuilder::push(sb, blank_of(line))
+      blanked_any = true
     } else if String::starts_with(trimmed, "generated_hash =") {
       if seen_hash {
         throw("duplicate generated_hash directive: \{trimmed}")
@@ -2496,11 +2507,13 @@ fn scan_package_header(source: String) -> (Array[(String, String, String)], Stri
       generated_hash = gh
       seen_hash = true
       StringBuilder::push(sb, blank_of(line))
+      blanked_any = true
     } else if trimmed == "description =" {
       if seen_description {
         throw("duplicate description directive: \{trimmed}")
       } else ()
       StringBuilder::push(sb, blank_of(line))
+      blanked_any = true
       let (dtext, dpos, dblanked) = consume_description_block(source, len, nl + 1)
       description = dtext
       seen_description = true
@@ -2512,11 +2525,13 @@ fn scan_package_header(source: String) -> (Array[(String, String, String)], Stri
       } else ()
       seen_deps = true
       StringBuilder::push(sb, blank_of(line))
+      blanked_any = true
     } else if trimmed == "deps = {" {
       if seen_deps {
         throw("duplicate deps directive: \{trimmed}")
       } else ()
       StringBuilder::push(sb, blank_of(line))
+      blanked_any = true
       let (dentries, dpos, dblanked) = consume_deps_block(source, len, nl + 1)
       deps_extend(deps, dentries)
       seen_deps = true
@@ -2556,13 +2571,23 @@ fn scan_package_header(source: String) -> (Array[(String, String, String)], Stri
       }
       Array::push(pins, (rname, rver, pin_hash))
       StringBuilder::push(sb, blank_of(line))
+      blanked_any = true
     } else if String::length(trimmed) == 0 || String::starts_with(trimmed, "//") {
       StringBuilder::push(sb, line)
     } else {
       scanning = false
-      StringBuilder::push(sb, line)
+      if !blanked_any {
+        // Nothing to blank: every line so far went in verbatim, and so does
+        // everything from here.
+        return (pins, name, version, main, description, deps, generated_hash, source)
+      } else {
+        ()
+      }
+      // The verbatim tail, newlines included, in one piece.
+      StringBuilder::push(sb, String::substring(source, pos, len))
+      next_pos = len
     }
-    if nl < len {
+    if scanning && nl < len {
       StringBuilder::push(sb, "\n")
     } else ()
     pos = next_pos

--- a/lib/@vibe/compiler/loader/loader.vibe
+++ b/lib/@vibe/compiler/loader/loader.vibe
@@ -1451,7 +1451,26 @@ export fn unstable_candidates() -> Array[(String, String)] {
 
 fn record_unstable_candidate(path: String, ingested: String) -> Unit {
   if text_mentions_unstable_package(ingested) {
-    Array::push(unstable_candidate_cell, (path, ingested))
+    // #2386: the loader ingests a module more than once per compile (header
+    // cache, source-group collection), and every record was lexed and
+    // parsed by the closure scan on its own. The same (path, text) yields
+    // the same reports, which the scan already collapses, so it is recorded
+    // once; a path whose ingested text changed is still recorded again.
+    let mut i = 0
+    let mut dup = false
+    while !dup && i < Array::length(unstable_candidate_cell) {
+      let (p, t) = Array::get(unstable_candidate_cell, i)
+      if p == path && t == ingested {
+        dup = true
+      } else {
+        i = i + 1
+      }
+    }
+    if dup {
+      ()
+    } else {
+      Array::push(unstable_candidate_cell, (path, ingested))
+    }
   } else {
     ()
   }

--- a/lib/@vibe/compiler/runtime/typecheck_fs.vibe
+++ b/lib/@vibe/compiler/runtime/typecheck_fs.vibe
@@ -7252,6 +7252,11 @@ fn collect_all_diagnostics_on(input_path: String, source: String, pkg_version: S
 
 export fn checked_warning_stmts(input_path: String, source: String) -> Option[Array[Stmt]] with Exception {
   let (tokens, starts, _ends) = lex_with_offsets(source)
+  checked_warning_stmts_lexed(input_path, source, tokens, starts)
+}
+
+/// `checked_warning_stmts` over tokens the caller already has for `source`.
+fn checked_warning_stmts_lexed(input_path: String, source: String, tokens: Array[Token], starts: Array[Int]) -> Option[Array[Stmt]] with Exception {
   if is_contract_ext(input_path) {
     handle {
       let (_, _, stmts) = parse_contract_program(tokens)
@@ -7468,6 +7473,35 @@ fn unstable_count_pkg_stmts(stmts: Array[Stmt], pkg: String) -> Int {
 /// deficit would be off by one and a physical import would be reported as
 /// inherited, silently. Sharing the matcher makes that impossible instead of
 /// unlikely.
+/// Do the tokens carry `import` of ANY unstable package? The same
+/// `TImport` / `TIdent(pkg)` shape `unstable_import_offset` matches, with
+/// the package test `unstable_collect_pkgs` applies to a parsed import, so
+/// the three cannot disagree about what counts.
+fn unstable_tokens_import_any(tokens: Array[Token], starts: Array[Int]) -> Bool {
+  let n = Array::length(starts)
+  let mut i = 0
+  let mut found = false
+  while !found && i + 1 < n {
+    if token_to_string(Array::get(tokens, i)) == "TImport" {
+      let next = token_to_string(Array::get(tokens, i + 1))
+      if String::starts_with(next, "TIdent(") && String::ends_with(next, ")") {
+        let name = String::substring(next, 7, String::length(next) - 1)
+        if unstable_package_note(name) != "" {
+          found = true
+        } else {
+          ()
+        }
+      } else {
+        ()
+      }
+    } else {
+      ()
+    }
+    i = i + 1
+  }
+  found
+}
+
 fn unstable_count_pkg_tokens(tokens: Array[Token], starts: Array[Int], pkg: String) -> Int {
   let probe = [0]
   let mut count = 0
@@ -7554,7 +7588,26 @@ fn unstable_stmt_diagnostics(stmts: Array[Stmt], source: String, tokens: Array[T
 export fn unstable_import_diagnostics(input_path: String, detected: String, located: String) -> Array[String] with Exception {
   let out = array_empty()
   let (tokens, starts, _ends) = lex_with_offsets(located)
-  match checked_warning_stmts(input_path, detected) {
+  // #2386: when the ingested text IS the physical text, the statements the
+  // parse would yield come from exactly these tokens, so a physical token
+  // scan that finds no `import` of an unstable package proves the parse
+  // would report nothing -- and the compiler's own sources reach here by
+  // MENTIONING the package in comments (2.4 MB of them, each lexed twice and
+  // parsed per compile before this). The same tokens also serve the parse
+  // when it is needed, instead of lexing the same text a second time. A
+  // text that ingestion changed (an inherited import, a contract facade)
+  // keeps the full path: its statements are not the physical tokens.
+  let same_text = detected == located
+  let stmts_opt = if same_text {
+    if unstable_tokens_import_any(tokens, starts) {
+      checked_warning_stmts_lexed(input_path, detected, tokens, starts)
+    } else {
+      None
+    }
+  } else {
+    checked_warning_stmts(input_path, detected)
+  }
+  match stmts_opt {
     Some(stmts) => {
       // #2289: count before walking. The deficit per package is
       // (imports in the INGESTED statements) - (imports in the PHYSICAL

--- a/lib/@vibe/compiler/tests/package_header_scan_test.vibe
+++ b/lib/@vibe/compiler/tests/package_header_scan_test.vibe
@@ -1,0 +1,80 @@
+//# The package-header scan's blanked text (#2386). `extract_require_pins`
+//# returns the source with every header directive line replaced by spaces
+//# of the same length and everything after the header verbatim. The scan
+//# returns the source itself when the header blanked nothing, and appends
+//# the tail in one piece otherwise; every expectation below is the text
+//# the line-by-line copy produced.
+
+import @vibe/compiler/contract {
+  extract_require_pins
+}
+
+fn spaces(n: Int) -> String {
+  let sb = StringBuilder::new()
+  let mut i = 0
+  while i < n {
+    StringBuilder::push(sb, " ")
+    i = i + 1
+  }
+  StringBuilder::freeze(sb)
+}
+
+test "a source with no header is its own blanked text" {
+  let src = "fn main() -> Int {\n  1\n}\n"
+  let (pins, blanked) = extract_require_pins(src)
+  assert_eq(Array::length(pins), 0)
+  assert_eq(blanked, src)
+}
+
+test "leading comments and blank lines are kept verbatim, no trailing newline" {
+  let src = "// c\n\nfn main() -> Int {\n  1\n}"
+  let (pins, blanked) = extract_require_pins(src)
+  assert_eq(Array::length(pins), 0)
+  assert_eq(blanked, src)
+}
+
+test "a require line is blanked to its length and the body follows verbatim" {
+  let src = "require @a/b 1.2.3\nfn main() -> Int {\n  1\n}\n"
+  let (pins, blanked) = extract_require_pins(src)
+  assert_eq(Array::length(pins), 1)
+  let (rname, rver, rpin) = Array::get(pins, 0)
+  assert_eq(rname, "@a/b")
+  assert_eq(rver, "1.2.3")
+  assert_eq(rpin, "")
+  assert_eq(blanked, String::concat(spaces(18), "\nfn main() -> Int {\n  1\n}\n"))
+}
+
+test "header lines between directives stay, the tail keeps its newlines" {
+  let src = "version = 0.1.0\n// x\nrequire @a/b 1.2.3\n\nfn f() -> Int {\n  2\n}\n"
+  let (pins, blanked) = extract_require_pins(src)
+  assert_eq(Array::length(pins), 1)
+  assert_eq(blanked, String::concat(spaces(15), String::concat("\n// x\n", String::concat(spaces(18), "\n\nfn f() -> Int {\n  2\n}\n"))))
+}
+
+test "a header-only source is blanked line by line" {
+  let src = "name = @a/b\nversion = 0.0.1\n"
+  let (pins, blanked) = extract_require_pins(src)
+  assert_eq(Array::length(pins), 0)
+  assert_eq(blanked, String::concat(spaces(11), String::concat("\n", String::concat(spaces(15), "\n"))))
+}
+
+test "a directive after the first code line is not a header line" {
+  let src = "fn main() -> Int {\n  1\n}\nrequire @a/b 1.2.3\n"
+  let (pins, blanked) = extract_require_pins(src)
+  assert_eq(Array::length(pins), 0)
+  assert_eq(blanked, src)
+}
+
+test "a directive after a blanked header line, past code, stays verbatim" {
+  let src = "require @a/b 1.2.3\nfn main() -> Int {\n  1\n}\nversion = 9.9.9\n"
+  let (pins, blanked) = extract_require_pins(src)
+  assert_eq(Array::length(pins), 1)
+  assert_eq(blanked, String::concat(spaces(18), "\nfn main() -> Int {\n  1\n}\nversion = 9.9.9\n"))
+}
+
+test "the last header line without a trailing newline" {
+  let src = "require @a/b 1.2.3"
+  let (pins, blanked) = extract_require_pins(src)
+  assert_eq(Array::length(pins), 1)
+  assert_eq(blanked, spaces(18))
+}

--- a/lib/@vibe/compiler/tests/unstable_import_diagnostics_test.vibe
+++ b/lib/@vibe/compiler/tests/unstable_import_diagnostics_test.vibe
@@ -1,0 +1,67 @@
+//# ADR-0068 unstable-surface scan, the closure lane's per-candidate entry
+//# (#2386). When the ingested text is the physical text, the scan lexes it
+//# once and parses only when the physical tokens carry an `import` of an
+//# unstable package; a text ingestion changed keeps the full path. Every
+//# answer below is what the lex-twice-and-always-parse form gave.
+
+import @vibe/compiler/runtime {
+  unstable_import_diagnostics
+}
+
+fn count_mentions(diags: Array[String], needle: String) -> Int {
+  let mut n = 0
+  let mut i = 0
+  while i < Array::length(diags) {
+    if String::index_of(Array::get(diags, i), needle) >= 0 {
+      n = n + 1
+    }
+    i = i + 1
+  }
+  n
+}
+
+test "a comment mentioning the package reports nothing" {
+  let src = "// see @vibe/concurrent for the design\nfn main() -> Int {\n  1\n}\n"
+  let diags = unstable_import_diagnostics("main.vibe", src, src)
+  assert_eq(Array::length(diags), 0)
+}
+
+test "a string literal spelling the import reports nothing" {
+  let src = "fn main() -> String {\n  \"import @vibe/concurrent { Task }\"\n}\n"
+  let diags = unstable_import_diagnostics("main.vibe", src, src)
+  assert_eq(Array::length(diags), 0)
+}
+
+test "a physical import is reported at its line" {
+  let src = "// header\nimport @vibe/concurrent { Task }\nfn main() -> Int {\n  1\n}\n"
+  let diags = unstable_import_diagnostics("main.vibe", src, src)
+  assert_eq(Array::length(diags), 1)
+  assert_eq(count_mentions(diags, "line 2:1:"), 1)
+}
+
+test "an import written with a tab and leading spaces is reported (#2277)" {
+  let src = "  import\t@vibe/concurrent { Task }\nfn main() -> Int {\n  1\n}\n"
+  let diags = unstable_import_diagnostics("main.vibe", src, src)
+  assert_eq(Array::length(diags), 1)
+  assert_eq(count_mentions(diags, "line 1:3:"), 1)
+}
+
+test "an import of a sub-path of the package is reported" {
+  let src = "import @vibe/concurrent/channel { Sender }\nfn main() -> Int {\n  1\n}\n"
+  let diags = unstable_import_diagnostics("main.vibe", src, src)
+  assert_eq(Array::length(diags), 1)
+}
+
+test "an import only in the ingested text is reported as inherited" {
+  let located = "fn main() -> Int {\n  1\n}\n"
+  let detected = String::concat("import @vibe/concurrent { Task }\n", located)
+  let diags = unstable_import_diagnostics("main.vibe", detected, located)
+  assert_eq(Array::length(diags), 1)
+  assert_eq(count_mentions(diags, "index.vpkg"), 1)
+}
+
+test "a source that does not parse reports nothing" {
+  let src = "import @vibe/concurrent { Task }\nfn main( -> Int {\n"
+  let diags = unstable_import_diagnostics("main.vibe", src, src)
+  assert_eq(Array::length(diags), 0)
+}


### PR DESCRIPTION
## What

Two slices of #2386 on the loader side of a compile — the ADR-0068 unstable-surface scan and the package-header scan — byte-identical to main on every corpus, each measured on its own (cache-isolated per the profiling skill, corpus `codegen_lexer_test.vibe`, N=3 interleaved).

### 1. `e6c69b4` — the unstable-surface closure scan lexes a candidate once and parses only what can report

`check_unstable_surface_warnings_from_closure` confirms every module whose ingested text mentions `@vibe/concurrent`. The compiler's own sources mention it in comments — 2.4 MB of them, the largest files in the tree (`inline_direct_perform.vibe`, `linked_compile.vibe`, `typecheck_fs.vibe`, …) — and each candidate was recorded up to three times per compile (header cache, source-group collection), then lexed twice (the physical text for positions, the ingested text for the verdict) and parsed with the recovering parser: 0.28 s of a 4.84 s warm compile, for a scan that reports nothing on any of them.

Three changes, none of which can alter a report:

- the loader records a `(path, ingested text)` candidate once; the same pair yields the same reports, which the scan already collapsed (#2289). A path whose ingested text changed is still recorded again.
- when the ingested text **is** the physical text, the statements the parse would yield come from exactly the tokens already lexed for positions, so they are handed to the parse (`checked_warning_stmts_lexed`) instead of lexing the text a second time.
- in that same case, a physical token scan that finds no `import` of an unstable package (`unstable_tokens_import_any`: the `TImport` / `TIdent(pkg)` shape `unstable_import_offset` matches, with the package test `unstable_collect_pkgs` applies to a parsed import) proves the parse would report nothing, and it is skipped. A text ingestion changed — an inherited import, a contract facade — keeps the full path: its statements are not the physical tokens.

`unstable_import_diagnostics_test.vibe` pins both paths: a comment or a string literal spelling the import (nothing), a physical import (its line), one written with a tab and leading spaces (#2277), a sub-path of the package, an import only in the ingested text (reported as inherited), a source that does not parse (nothing). Every answer is what the lex-twice-and-always-parse form gives — the file passes unchanged against the previous head's library too. The late gate's #2277 / #2284 / #2289 cases ran in the chain below.

| | before (#2486 head) | after |
|---|---:|---:|
| `check_unstable_surface_warnings_from_closure` warm inclusive | 0.29 s | 0.08 s |
| `lex_with_offsets` / `parse_program` warm inclusive | 0.44 s / 0.42 s | 0.28 s / 0.35 s |
| warm wall, mean of 3 | 4.84 s | 4.52 s (−6.6%) |
| cold wall, mean of 3 | 8.93 s | 8.82 s (−1.2%) |
| heap_ptr cold / warm | 1,484,055,800 / 748,502,120 | 1,398,210,936 / 675,283,808 (−85.8 MB / −73.2 MB) |

### 2. `8256ea8` — the package-header scan stops copying at the first code line

`scan_package_header` blanks the header directives of a source and hands back the rest verbatim — and built that rest one line at a time, a substring and a push per line of every file, on every call. It is called per file from a dozen loader, header-cache and typecheck sites (`extract_require_pins` and the seven `package_*_of` readers all go through it), so a warm compile copied every compiler source through a `StringBuilder` several times over for a header that, on a `.vibe` file, blanks nothing. Once scanning stops (the first line that is not a directive, a comment or blank), the scan returns the source itself when no directive was blanked — every line so far went in verbatim, and so does everything after — and otherwise appends the tail in one substring. Same text by construction: the per-line copy pushed a line and its newline exactly when the source had one, which is what the tail substring holds. A header-only source still takes the loop.

`package_header_scan_test.vibe` pins the blanked text for a headerless source, leading comments without a trailing newline, a `require` line before code, directives with kept lines between them, a header-only source, a directive after the first code line (verbatim, not a pin), a blanked header followed by code and a late directive, and a header line with no trailing newline — each the text the per-line copy produced (the file passes unchanged against the previous head's library).

| | before (commit 1) | after |
|---|---:|---:|
| `scan_package_header` warm inclusive | 0.10 s | 0.00 s |
| `ingest_source_text_fs` / `collect_source_groups_fs` warm inclusive | 0.28 s / 0.35 s | 0.17 s / 0.23 s |
| heap_ptr cold / warm | 1,398,210,936 / 675,283,808 | 1,352,892,696 / 651,820,520 (−45.3 MB / −23.5 MB) |
| cold / warm wall, mean of 3 | 9.00 s / 4.67 s | 8.86 s / 4.75 s (both within noise) |

Byte-identical output on ten closures and 21 rc fixtures after each commit (no codegen path is touched).

## Tried and dropped (recorded so it is not retried blind)

| attempt | measured |
|---|---|
| a per-(vpkg, stat token) memo for `vpkg_directory_shared_import_prefix_fs` (every member of a directory recomputed the same prefix: fingerprint lookup, prefix-cache read) and the path → slot index for the plain `cache_fingerprint_file_fs` memo | byte-identical; the prefix 0.04 → 0.01 s and `ingest_source_text_fs` 0.17 → 0.14 s, but `cache_fingerprint_file_fs` unchanged (0.07 → 0.08 s: its cost is each file's first hash, not the memo scan), heap_ptr −1 MB, and wall within noise both ways (warm 4.72 → 4.75 s, cold 8.95 → 8.93 s) — below what this lane can measure |

## Validation

Chain on commit 1 (tree of `d8433b7` in the staging worktree): bundle regen; stage2 == stage3; thirteen lane tests on linear; `test_cli_core.sh`; selfcompile KPI heap_ptr 1,398,238,328 bytes (vs 1,484,013,488 on #2486's head, −85.8 MB); typing-env-reuse oracle; 109/109 affected unit-test files; `compiler_gate.sh` early / mid / late (the ADR-0068 cases included).

Chain on commit 2 (head `8256ea8`, base `b03e7ac`; the same tree as the staging worktree the chain ran in, tree hash checked): bundle regen; stage2 == stage3; seventeen lane tests on linear (`package_header_scan_test`, `contract_vpkg_test`, `vpkg_scan_test`, `contract_vpkg_shared_scope_test`, `unstable_import_diagnostics_test`, `perceus_pin_test`, `perceus_rc_test`, `perceus_reuse_e2e_test`, `perceus_reuse_plan_test`, `borrow_param_transitive_test`, `rc_shadow_regression_test`, `may_return_view_fns_test`, `checker_labeled_arg_test`, `optional_param_local_lambda_test`, `persistent_cache_test`, `borrow_returning_names_test`, `uniquify_shadowed_bindings_test`); `test_cli_core.sh`; selfcompile KPI heap_ptr 1,353,020,696 bytes (vs 1,484,013,488 on #2486's head, −131.0 MB over the two commits); typing-env-reuse oracle; 220/220 affected unit-test files (import-graph selection over every file the two commits touch); `compiler_gate.sh` early / mid / late.

`vibe_fmt.sh --check` is a fixpoint on every changed file.

Refs #2386.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QKZdvBvHVUagwg6Yih8er8

---
_Generated by [Claude Code](https://claude.ai/code/session_01QKZdvBvHVUagwg6Yih8er8)_