### PR TITLE
Name the operand when __rt_str_concat is handed a non-string (#2427)

### DIFF
--- a/lib/@vibe/compiler/codegen/builtin_bodies/bodies_core_b.vibe
+++ b/lib/@vibe/compiler/codegen/builtin_bodies/bodies_core_b.vibe
@@ -511,49 +511,61 @@ export fn gen_arr_concat_body() -> Bytes {
 /// Trap unless `ptr_local`/`len_local` describe a live string. Reports the
 /// pair, so the caller sees the operand rather than a memory fault.
 ///
-/// `(ptr=0, len=0)` is EXEMPT: that is the legal packed empty-string
-/// encoding `compile_call`'s `__to_string` arm names explicitly, and
-/// concatenating it copies zero bytes. Measured, I could NOT get it to reach
-/// this builtin from in-language code -- `String::join([], sep)` (the case
-/// that comment cites), the `"[\{...}]"` interpolation it gives as the
-/// example, and concat with an empty operand on either side all pass the
-/// unexempted guard, on both lanes. The exemption is kept because the
-/// encoding is legal by that comment's own statement and a zero-byte copy is
-/// correct, and because a boundary path -- a component trampoline forwarding
-/// a canonical `(ptr, len)` from a host -- is not reachable from a fixture
-/// here. It is a correctness argument, not a reproduction (#2489 review).
+/// Three tests, and each one is load-bearing for a different case:
 ///
-/// All tests are UNSIGNED, because these are addresses: a decoded `ptr` can
-/// exceed 2^31 once the heap passes 2 GiB, and a "negative" length is just a
-/// large unsigned one.
+///   - `ptr <u 64` -- #973's bound, established for exactly this situation
+///     (concatenating a value that might be an int): every ordinary small
+///     `Int` implies a `ptr` of 0..63, while a real string's address is >= 64.
+///   - `len >u frontier` -- a string cannot be longer than the guest heap it
+///     was built in. This is the test that catches #2427, whose operand was a
+///     tagged `Int` decoding to a 3.04 GiB "length".
+///   - `ptr + len > memory.size` in **i64** -- the #664 out-of-bounds guard,
+///     spelled as `emit_looks_like_string` spells it. i64 because the i32 form
+///     WRAPS: with a 2.5 GiB frontier, `ptr` and `len` both 2.3 GiB sum to
+///     644 MB in i32 and sail through (#2489 review).
 ///
-/// The end-of-range test is `ptr >u frontier - len`, NOT `ptr + len >u
-/// frontier`: the sum is i32 and WRAPS. With a 2.5 GiB frontier, `ptr` and
-/// `len` both 2.3 GiB pass the first two tests and their sum wraps to 0.6 GiB,
-/// passing the third -- so the bad operand sails through and `memory.copy`
-/// produces the anonymous trap this guard exists to replace (#2489 review).
-/// The subtraction cannot underflow where its result matters: when
-/// `len >u frontier` the second term has already made the disjunction true,
-/// and the wrapped difference only ever makes this term false.
+/// The end-range test deliberately bounds by MEMORY, not by the frontier.
+/// Under `VIBE_WASM_HOST_ALLOC_MODE=arena` the runner allocates host-returned
+/// strings at `__heap_ptr + guard` and advances only its own private pointer,
+/// never `global 0` -- so a perfectly good `Fs::read_file` result lives ABOVE
+/// the frontier, and a frontier-bounded test would reject every one of them
+/// (#2489 review). Bounding by memory accepts them and still rejects anything
+/// unaddressable.
+///
+/// `(ptr=0, len=0)` is EXEMPT: the legal packed empty-string encoding
+/// `compile_call`'s `__to_string` arm names, which copies zero bytes.
+/// Measured, I could not get it to reach this builtin from in-language code --
+/// `String::join([], sep)`, the `"[\{...}]"` interpolation that comment gives
+/// as its example, and concat with an empty operand on either side all pass
+/// the unexempted guard on both lanes. It is kept as a correctness argument,
+/// not a reproduction.
 fn emit_str_operand_guard(b: Bytes, ptr_local: Int, len_local: Int, abort_idx: Int, prefix_fat: Int) -> Unit {
-  // bad = (64 >u ptr || len >u frontier || ptr >u frontier - len)
-  //       && !(ptr | len == 0)
+  // 64 >u ptr
   emit_i32_const(b, 64)
   emit_local_get(b, ptr_local)
   emit_i32_gt_u(b)
+  // || len >u frontier
   emit_local_get(b, len_local)
   emit_global_get(b, 0)
   emit_i32_gt_u(b)
   // i32.or (0x72)
   bytebuf_push(b, 114)
+  // || (i64)ptr + (i64)len > memory.size * 65536
   emit_local_get(b, ptr_local)
-  emit_global_get(b, 0)
+  emit_i64_extend_i32_u(b)
   emit_local_get(b, len_local)
-  emit_i32_sub(b)
-  emit_i32_gt_u(b)
+  emit_i64_extend_i32_u(b)
+  emit_i64_add(b)
+  // memory.size (0x3F 0x00) in bytes, as emit_mem_size_bytes does
+  bytebuf_push(b, 63)
+  bytebuf_push(b, 0)
+  emit_i64_extend_i32_u(b)
+  emit_i64_const(b, 65536)
+  emit_i64_mul(b)
+  emit_i64_gt_s(b)
   // i32.or (0x72)
   bytebuf_push(b, 114)
-  // !(the packed empty string)
+  // && !(the packed empty string)
   emit_local_get(b, ptr_local)
   emit_local_get(b, len_local)
   // i32.or (0x72)

--- a/lib/@vibe/compiler/codegen/builtin_bodies/bodies_core_b.vibe
+++ b/lib/@vibe/compiler/codegen/builtin_bodies/bodies_core_b.vibe
@@ -508,7 +508,55 @@ export fn gen_arr_concat_body() -> Bytes {
   b
 }
 
-export fn gen_str_concat_body() -> Bytes {
+/// Trap unless `ptr_local`/`len_local` describe a live string. Reports the
+/// pair, so the caller sees the operand rather than a memory fault.
+///
+/// All three tests are UNSIGNED, because these are addresses: a decoded `ptr`
+/// can exceed 2^31 once the heap passes 2 GiB, and a "negative" length is just
+/// a large unsigned one. The separate `len > frontier` test is what catches a
+/// length so large that `ptr + len` wraps back into range.
+fn emit_str_operand_guard(b: Bytes, ptr_local: Int, len_local: Int, abort_idx: Int, prefix_fat: Int) -> Unit {
+  // bad = 64 >u ptr || len >u frontier || ptr + len >u frontier
+  emit_i32_const(b, 64)
+  emit_local_get(b, ptr_local)
+  emit_i32_gt_u(b)
+  emit_local_get(b, len_local)
+  emit_global_get(b, 0)
+  emit_i32_gt_u(b)
+  // i32.or (0x72)
+  bytebuf_push(b, 114)
+  emit_local_get(b, ptr_local)
+  emit_local_get(b, len_local)
+  emit_i32_add(b)
+  emit_global_get(b, 0)
+  emit_i32_gt_u(b)
+  // i32.or (0x72)
+  bytebuf_push(b, 114)
+  emit_if_void(b)
+  emit_i64_const(b, prefix_fat)
+  emit_local_get(b, ptr_local)
+  emit_i64_extend_i32_u(b)
+  emit_local_get(b, len_local)
+  emit_i64_extend_i32_u(b)
+  emit_call(b, abort_idx)
+  emit_end(b)
+}
+
+/// #2427: `rc_shadow` adds a plausibility check on both operands.
+///
+/// This body decodes `ptr = v >> 32` and `len = v & 0xFFFFFFFF` from whatever
+/// i64 it is handed. A value that is not a string at all -- a tagged `Int`
+/// (`n << 1`), a pointer, a stale word read out of a block that was freed and
+/// re-issued -- decodes into a wild ptr/len and traps inside `memory.copy`
+/// with a bare "memory access out of bounds" that names nothing. Under shadow
+/// the operand is printed instead, and its bits say what it really was.
+///
+/// A live string satisfies `ptr >= 64` (static string data starts at 64) and
+/// `ptr + len <= global 0` (the bump frontier that both string buffers and
+/// `__rc_alloc` allocate from). String buffers carry no header and are never
+/// freed, so there is no shadow slot to consult here -- this is a range check,
+/// not a mark check, which is why it is a separate abort from the UAF one.
+export fn gen_str_concat_body(rc_shadow: Bool, str_operand_abort_idx: Int, bad_operand_fat: Int) -> Bytes {
   let b = bytebuf_new()
   emit_local_get(b, 0)
   emit_i64_const(b, 4294967295)
@@ -530,6 +578,12 @@ export fn gen_str_concat_body() -> Bytes {
   emit_i64_shr_s(b)
   emit_i32_wrap_i64(b)
   emit_local_set(b, 5)
+  if rc_shadow {
+    emit_str_operand_guard(b, 4, 2, str_operand_abort_idx, bad_operand_fat)
+    emit_str_operand_guard(b, 5, 3, str_operand_abort_idx, bad_operand_fat)
+  } else {
+    ()
+  }
   emit_local_get(b, 2)
   emit_local_get(b, 3)
   emit_i32_add(b)

--- a/lib/@vibe/compiler/codegen/builtin_bodies/bodies_core_b.vibe
+++ b/lib/@vibe/compiler/codegen/builtin_bodies/bodies_core_b.vibe
@@ -593,11 +593,12 @@ fn emit_str_operand_guard(b: Bytes, ptr_local: Int, len_local: Int, abort_idx: I
 /// with a bare "memory access out of bounds" that names nothing. Under shadow
 /// the operand is printed instead, and its bits say what it really was.
 ///
-/// A live string satisfies `ptr >= 64` (static string data starts at 64) and
-/// `ptr + len <= global 0` (the bump frontier that both string buffers and
-/// `__rc_alloc` allocate from). String buffers carry no header and are never
-/// freed, so there is no shadow slot to consult here -- this is a range check,
-/// not a mark check, which is why it is a separate abort from the UAF one.
+/// A live string satisfies `ptr >= 64` (static string data starts at 64),
+/// `len <= global 0` (the bump frontier), and `ptr + len <= memory.size` --
+/// see `emit_str_operand_guard` for why the end is bounded by memory rather
+/// than by the frontier. String buffers carry no header and are never freed,
+/// so there is no shadow slot to consult here -- this is a range check, not a
+/// mark check, which is why it is a separate abort from the UAF one.
 export fn gen_str_concat_body(rc_shadow: Bool, str_operand_abort_idx: Int, bad_operand_fat: Int) -> Bytes {
   let b = bytebuf_new()
   emit_local_get(b, 0)

--- a/lib/@vibe/compiler/codegen/builtin_bodies/bodies_core_b.vibe
+++ b/lib/@vibe/compiler/codegen/builtin_bodies/bodies_core_b.vibe
@@ -511,12 +511,33 @@ export fn gen_arr_concat_body() -> Bytes {
 /// Trap unless `ptr_local`/`len_local` describe a live string. Reports the
 /// pair, so the caller sees the operand rather than a memory fault.
 ///
-/// All three tests are UNSIGNED, because these are addresses: a decoded `ptr`
-/// can exceed 2^31 once the heap passes 2 GiB, and a "negative" length is just
-/// a large unsigned one. The separate `len > frontier` test is what catches a
-/// length so large that `ptr + len` wraps back into range.
+/// `(ptr=0, len=0)` is EXEMPT: that is the legal packed empty-string
+/// encoding `compile_call`'s `__to_string` arm names explicitly, and
+/// concatenating it copies zero bytes. Measured, I could NOT get it to reach
+/// this builtin from in-language code -- `String::join([], sep)` (the case
+/// that comment cites), the `"[\{...}]"` interpolation it gives as the
+/// example, and concat with an empty operand on either side all pass the
+/// unexempted guard, on both lanes. The exemption is kept because the
+/// encoding is legal by that comment's own statement and a zero-byte copy is
+/// correct, and because a boundary path -- a component trampoline forwarding
+/// a canonical `(ptr, len)` from a host -- is not reachable from a fixture
+/// here. It is a correctness argument, not a reproduction (#2489 review).
+///
+/// All tests are UNSIGNED, because these are addresses: a decoded `ptr` can
+/// exceed 2^31 once the heap passes 2 GiB, and a "negative" length is just a
+/// large unsigned one.
+///
+/// The end-of-range test is `ptr >u frontier - len`, NOT `ptr + len >u
+/// frontier`: the sum is i32 and WRAPS. With a 2.5 GiB frontier, `ptr` and
+/// `len` both 2.3 GiB pass the first two tests and their sum wraps to 0.6 GiB,
+/// passing the third -- so the bad operand sails through and `memory.copy`
+/// produces the anonymous trap this guard exists to replace (#2489 review).
+/// The subtraction cannot underflow where its result matters: when
+/// `len >u frontier` the second term has already made the disjunction true,
+/// and the wrapped difference only ever makes this term false.
 fn emit_str_operand_guard(b: Bytes, ptr_local: Int, len_local: Int, abort_idx: Int, prefix_fat: Int) -> Unit {
-  // bad = 64 >u ptr || len >u frontier || ptr + len >u frontier
+  // bad = (64 >u ptr || len >u frontier || ptr >u frontier - len)
+  //       && !(ptr | len == 0)
   emit_i32_const(b, 64)
   emit_local_get(b, ptr_local)
   emit_i32_gt_u(b)
@@ -526,12 +547,21 @@ fn emit_str_operand_guard(b: Bytes, ptr_local: Int, len_local: Int, abort_idx: I
   // i32.or (0x72)
   bytebuf_push(b, 114)
   emit_local_get(b, ptr_local)
-  emit_local_get(b, len_local)
-  emit_i32_add(b)
   emit_global_get(b, 0)
+  emit_local_get(b, len_local)
+  emit_i32_sub(b)
   emit_i32_gt_u(b)
   // i32.or (0x72)
   bytebuf_push(b, 114)
+  // !(the packed empty string)
+  emit_local_get(b, ptr_local)
+  emit_local_get(b, len_local)
+  // i32.or (0x72)
+  bytebuf_push(b, 114)
+  emit_i32_eqz(b)
+  emit_i32_eqz(b)
+  // i32.and (0x71)
+  bytebuf_push(b, 113)
   emit_if_void(b)
   emit_i64_const(b, prefix_fat)
   emit_local_get(b, ptr_local)

--- a/lib/@vibe/compiler/codegen/builtin_bodies/index.vpkg
+++ b/lib/@vibe/compiler/codegen/builtin_bodies/index.vpkg
@@ -76,7 +76,7 @@ fn gen_print_i64_raw_body() -> Bytes
 fn gen_oob_abort_body(print_str_idx: Int, print_i64_raw_idx: Int, oob_mid_fat: Int, oob_nl_fat: Int) -> Bytes
 fn gen_print_str_body() -> Bytes
 fn gen_arr_concat_body() -> Bytes
-fn gen_str_concat_body() -> Bytes
+fn gen_str_concat_body(rc_shadow: Bool, str_operand_abort_idx: Int, bad_operand_fat: Int) -> Bytes
 fn gen_string_join_body(enable_rc: Bool, arr_len_idx: Int, arr_get_idx: Int, str_concat_idx: Int) -> Bytes
 fn gen_arr_truncate_body(enable_rc: Bool) -> Bytes
 fn gen_double_to_int_body() -> Bytes

--- a/lib/@vibe/compiler/codegen/wasi/linked_compile.vibe
+++ b/lib/@vibe/compiler/codegen/wasi/linked_compile.vibe
@@ -5156,6 +5156,22 @@ export fn compile_wasi_module_linked_impl_with_typed_offsets(stmts: Array[Stmt],
     } else {
       ()
     }
+    // #2427: `__rt_str_concat` decodes `ptr = v >> 32` / `len = v & 0xFFFFFFFF`
+    // from whatever i64 it is handed, so a value that is not a string at all
+    // -- a tagged `Int`, a pointer, a stale word out of a re-issued block --
+    // decodes into a wild ptr/len and traps inside `memory.copy` with a bare
+    // "memory access out of bounds" naming nothing. These two fragments let
+    // the shadow lane print the operand instead.
+    if !array_contains_str(str_strs, "String::concat operand is not a live string: ptr=") {
+      Array::push(str_strs, "String::concat operand is not a live string: ptr=")
+    } else {
+      ()
+    }
+    if !array_contains_str(str_strs, ", len=") {
+      Array::push(str_strs, ", len=")
+    } else {
+      ()
+    }
   } else {
     ()
   }
@@ -6149,12 +6165,20 @@ export fn compile_wasi_module_linked_impl_with_typed_offsets(stmts: Array[Stmt],
   } else {
     0 - 1
   }
+  // #2427: shadow-only "this operand is not a string" abort. Same
+  // gen_oob_abort_body with its own middle fragment, registered right after
+  // the UAF abort so a non-shadow build's indices are untouched.
+  let str_operand_abort_idx = if rc_shadow {
+    shadow_uaf_abort_idx + 1
+  } else {
+    0 - 1
+  }
   // ADR-0090 (#1262) region arena bodies. Registered LAST and only when the
   // module has a region, so a module without one is byte-identical to what it
   // was before the arena existed (and max_builtin_func_idx below follows).
   let region_arr_new_idx = if need_region_arena {
     (if rc_shadow {
-      shadow_uaf_abort_idx
+      str_operand_abort_idx
     } else {
       bytes_compare_idx
     }) + 1
@@ -6505,7 +6529,9 @@ export fn compile_wasi_module_linked_impl_with_typed_offsets(stmts: Array[Stmt],
   let max_builtin_func_idx = if need_region_arena {
     region_bytes_new_idx
   } else if rc_shadow {
-    shadow_uaf_abort_idx
+    // #2427: the str-operand abort is registered after the UAF abort, so it,
+    // not shadow_uaf_abort_idx, is the last builtin on the shadow lane.
+    str_operand_abort_idx
   } else {
     // #2344: the bit primitives are the last UNCONDITIONAL builtins, so this
     // is int_clz_idx, not oob_abort_idx. Leaving it stale made num_generated
@@ -6953,15 +6979,23 @@ export fn compile_wasi_module_linked_impl_with_typed_offsets(stmts: Array[Stmt],
   }, 0, 0, 3)
   // #748: SIMD chunk compare needs the extra chunk_limit local (meta_i32 6).
   push_builtin(gen_str_eq_body(), 6, 0, 4)
-  push_builtin(gen_str_concat_body(), 6, 0, 4)
   // #2199: raw (ptr<<32)|len string-table constants for the OOB abort
   // message fragments, exactly the shape __rt_print_str's parameter takes
   // (no RC tag on either lane). The strings were seeded above, so the
   // lookups cannot miss.
+  //
+  // Defined before the str_concat push (#2427) because its shadow-lane
+  // operand guard needs one of these fragments; moving the PUSH instead
+  // would reorder the builtins and shift every function index.
   let oob_fat_of: (String) -> Int = (frag) -> {
     let fi = str_table_lookup(str_strs, frag)
     (Array::get(str_offsets, fi)<<32)|Array::get(str_lengths, fi)
   }
+  push_builtin(gen_str_concat_body(rc_shadow, str_operand_abort_idx, if rc_shadow {
+    oob_fat_of("String::concat operand is not a live string: ptr=")
+  } else {
+    0
+  }), 6, 0, 4)
   let oob_arr_get_fat = oob_fat_of("Array::get: index ")
   let oob_arr_set_fat = oob_fat_of("Array::set: index ")
   let oob_bytes_get_fat = oob_fat_of("Bytes::get: index ")
@@ -7112,6 +7146,10 @@ export fn compile_wasi_module_linked_impl_with_typed_offsets(stmts: Array[Stmt],
   push_builtin(gen_bytes_compare_body(enable_rc), 2, 4, 4)
   if rc_shadow {
     push_builtin(gen_oob_abort_body(print_str_idx, print_i64_raw_idx, oob_fat_of("; freed at site "), oob_nl_fat), 0, 0, 7)
+    // #2427: same body, ", len=" as the middle fragment -- see
+    // str_operand_abort_idx. Registered immediately after the UAF abort so
+    // max_builtin_func_idx stays the last push.
+    push_builtin(gen_oob_abort_body(print_str_idx, print_i64_raw_idx, oob_fat_of(", len="), oob_nl_fat), 0, 0, 7)
   } else {
     ()
   }


### PR DESCRIPTION
A shadow-lane diagnostic. It is what finally identified #2427, after three investigations reached memory-shaped answers because the failure message contained no information.

## The failure it addresses

`__rt_str_concat` decodes `ptr = v >> 32` and `len = v & 0xFFFFFFFF` from whatever i64 it is handed. A value that is not a string at all — a tagged `Int` (`n << 1`), a pointer, a stale word — decodes into a wild ptr/len and faults inside `memory.copy`:

```
RuntimeError: memory access out of bounds
    at wasm-function[23]
```

That names nothing. Not the operand, not its value, not even which of the two it was. #2427 sat on that message through an offset-table audit, a key-collision scan, and an RC investigation.

Under `VIBE_RC=shadow` both operands are now range-checked and the bad one is printed:

```
String::concat operand is not a live string: ptr=94773756, len=3262112080
```

## Red proof

That is not a constructed example — it is the real #2427 build. Reassembling `(ptr << 32) | len` gives `0x05A621FC_C26FE150`, which is **even**; by ADR-0055 an `Int` is `n << 1` and every heap pointer is odd, so the operand is a tagged `Int`, and `v >> 1` sits inside the `(1<<60)-1` mask that build's checksum uses. `__to_string` had been elided at that call site and the integer flowed through unconverted.

One run, and the four-investigation question was answered. The measurements are on #2427.

**There is no in-language red test, and I would rather say so than add a gate that cannot fail.** Forging a bad fat pointer is not expressible in safe vibe — that is the point of the type system — so the "it fires" direction can only be demonstrated against a real defect, which is what the above is. A committed gate could only assert the no-false-positive direction, and by `CLAUDE.md`'s own standard ("a gate is worth nothing until you know it can fail") that is not worth adding. The guard is a diagnostic, not an invariant.

## What is checked

Three tests, all **unsigned** — a decoded `ptr` can exceed 2^31 once the heap passes 2 GiB, and a "negative" length is just a large unsigned one:

- `ptr >= 64` — static string data starts at 64.
- `len <= global 0`, the bump frontier. This is the test that catches #2427, whose operand decoded to a 3.04 GiB "length".
- `ptr + len <= memory.size`, computed in **i64** — the #664/#678/#973 out-of-bounds form, spelled as `emit_looks_like_string` / `emit_mem_size_bytes` spell it.

Two of these were reshaped by review, and both changes are load-bearing:

- The end range is bounded by **memory, not the frontier**. Under `VIBE_WASM_HOST_ALLOC_MODE=arena` the runner allocates host-returned strings at `__heap_ptr + guard` and advances only its own private pointer, never `global 0` — so a valid `Fs::read_file` result lives *above* the frontier and a frontier-bounded end test would reject every one of them.
- It is computed in **i64** because the i32 form wraps: with a 2.5 GiB frontier, `ptr` and `len` both 2.3 GiB sum to 644 MB in i32 and sail through. The shadow lane starts its heap at 1.5 GiB, so this is inside the region where it actually runs.

Bounding by memory *alone* would not have caught #2427 — that operand's `ptr + len` is 3.36 GiB, inside the fixture's 4.06 GiB pre-grown memory; the original trap came from `memory.copy`'s destination side. The frontier-bounded `len` test is what rejects it, which is why it stays.

`(ptr=0, len=0)` is exempt: the legal packed empty-string encoding, which copies zero bytes. I could not reach it from in-language code (the measurements are in the code comment); it is kept as a correctness argument, not a reproduction.

This is a **range** check, not a mark check, and deliberately a separate abort from the UAF one. String buffers are bump-allocated with no header and never freed (`gen_str_concat_body` bumps `global 0` directly; `rc_drop` skips string/bytes fat pointers at its entry), so there is no shadow slot here to consult. An earlier suggestion of mine on #2427 to check the shadow mark in this builtin cannot work for that reason; the correction is recorded there.

## Verification

- **The default lane is byte-identical.** `fixtures/structural_eq_contexts_test.vibe` compiles to identical wasm through a stage2 built before and after. This is the check that matters most here: the change registers a new builtin, and `max_builtin_func_idx`'s own comment says adding one without updating it "silently shifts every user-function call target". It is updated, and this proves it.
- The #715 shape corpus (gate 40f) still answers `25297489` — the shadow marks still detect.
- `fixtures/rc_shadow_large_heap.vibe` (gate 40f1a) still answers `418804` — the guard does not fire on valid strings, across ~400 MB of them.

All three were re-run on a fresh build after the review fixes.

Every branch added is under `if rc_shadow`; the abort's index is `-1` otherwise and the fragments are not seeded.

## Note on #2427 itself

It no longer reproduces on main — the v2 shape rebuilt there passes the CLI-core gate — consistent with #2424 routing `__to_string` on the checked type rather than syntactically. This PR does not fix that; it makes the *next* value of this kind name itself on the first run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FYMVd6D2o82suTfTwoJPMf