### PR TITLE
checker: the async-effect walk asks the env once per entry, the throw-kind table is indexed, and the cacheability walks build the program index once (#2386)

### DIFF
--- a/lib/@vibe/compiler/checker/checker_effects.vibe
+++ b/lib/@vibe/compiler/checker/checker_effects.vibe
@@ -3913,8 +3913,15 @@ export fn check_perform_effects_expr_tx(root: Expr, root_declared: Array[String]
   // per-parameter table, which switches call-site row unification off and
   // restores the pre-#1485 exemption. Callers of this entry are unit-test and
   // non-stmts paths that have no call-graph parameter types to offer anyway.
+  check_perform_effects_expr_tx_indexed(root, root_declared, root_in_handle, fn_names, fn_effs, program_fn_index(fn_names), root_ov_names, root_ov_effs)
+}
+
+/// The same entry with the program table's index supplied by the caller
+/// (#2386 review): the cacheability walks below run it once per test block
+/// of a file, and an index rebuilt per block is `blocks x table` of memory
+/// the bump lane never frees.
+fn check_perform_effects_expr_tx_indexed(root: Expr, root_declared: Array[String], root_in_handle: Bool, fn_names: Array[String], fn_effs: Array[Array[String]], fn_index: MutMap[String, Int], root_ov_names: Array[String], root_ov_effs: Array[Array[String]]) -> Array[EffectError] {
   set_entry_user_effect_operations(array_empty())
-  let fn_index = program_fn_index(fn_names)
   check_perform_effects_expr_tx_in("", root, root_declared, root_in_handle, fn_names, fn_effs, fn_index, no_param_effs(), root_ov_names, root_ov_effs, no_kind_binds())
 }
 
@@ -5514,6 +5521,7 @@ export fn file_tests_cacheable(stmts: Array[Stmt]) -> Bool {
     m = m + 1
   }
   let empty_decl = array_empty()
+  let fn_index = program_fn_index(fn_names)
   let mut any_test = false
   let mut all_ok = true
   let mut i = 0
@@ -5521,7 +5529,7 @@ export fn file_tests_cacheable(stmts: Array[Stmt]) -> Bool {
     match Array::get(stmts, i) {
       STest(_, body) => {
         any_test = true
-        let errs = check_perform_effects_expr_tx(body, empty_decl, false, fn_names, fn_effs, no_str_labels(), no_ov_effs())
+        let errs = check_perform_effects_expr_tx_indexed(body, empty_decl, false, fn_names, fn_effs, fn_index, no_str_labels(), no_ov_effs())
         if Array::length(errs) != 0 {
           all_ok = false
         } else {
@@ -5630,7 +5638,7 @@ export fn file_entry_cacheable(stmts: Array[Stmt], entry_name: String) -> Bool {
           EFn(_, _, _, _, _, fn_body) => fn_body,
           _ => body
         }
-        let errs = check_perform_effects_expr_tx(exec_body, cache_safe_row, false, fn_names, fn_effs, no_str_labels(), no_ov_effs())
+        let errs = check_perform_effects_expr_tx_indexed(exec_body, cache_safe_row, false, fn_names, fn_effs, program_fn_index(fn_names), no_str_labels(), no_ov_effs())
         Array::length(errs) == 0
       }
     }

--- a/lib/@vibe/compiler/checker/checker_effects.vibe
+++ b/lib/@vibe/compiler/checker/checker_effects.vibe
@@ -338,7 +338,38 @@ export fn check_stdin_provider_direct_calls_stmts(stmts: Array[Stmt]) -> Array[E
 /// A name bound in `env` (a user/prelude function) is intentionally NOT treated
 /// as a primitive even if its type is `with Async`, except the four exact
 /// compiler-owned stdin provider names imported from their public contract.
+/// #2386: `is_async_primitive`'s answers for the walk in progress. The walk
+/// hands every call site the same env (nothing in it extends `env`; locals go
+/// through `afe_bind_*`), and the answer for a name is a full env miss for
+/// every user callee -- a chain walk per call site. Each exported entry
+/// clears it, so an entry with another env never reads a previous walk's
+/// answer. Values: 1 = async primitive, 0 = not.
+let afe_async_primitive_memo: Array[MutMap[String, Int]] = [
+  MutMap::new_string()
+]
+
+fn afe_reset_entry_memos() -> Unit {
+  Array::set(afe_async_primitive_memo, 0, MutMap::new_string())
+  Array::set(afe_builtin_async_iter_cell, 0, -1)
+}
+
 fn is_async_primitive(name: String, env: TypeEnv) -> Bool {
+  let memo = Array::get(afe_async_primitive_memo, 0)
+  match MutMap::get(memo, name) {
+    Some(v) => v == 1,
+    None => {
+      let answer = is_async_primitive_uncached(name, env)
+      MutMap::set(memo, name, if answer {
+        1
+      } else {
+        0
+      })
+      answer
+    }
+  }
+}
+
+fn is_async_primitive_uncached(name: String, env: TypeEnv) -> Bool {
   if is_stdin_provider_surface(name) {
     // Imported package contracts bind these exact public names in env, but
     // they remain compiler-owned primitives after canonical import rewriting.
@@ -747,10 +778,27 @@ fn afe_expand_constructor_alias(t: Type, env: TypeEnv, fuel: Int) -> Type {
   }
 }
 
+/// #2386: the `AsyncIter` provenance answer for the walk in progress
+/// (-1 = not asked yet, else 0 / 1); the env is constant across a walk and
+/// this was asked once per binding and per call head. Cleared per entry with
+/// the memo above.
+let afe_builtin_async_iter_cell: Array[Int] = [-1]
+
 fn afe_type_binding_is_builtin_async_iter(env: TypeEnv) -> Bool {
-  match env_lookup_binding(env, "AsyncIter") {
-    Some(binding) => afe_origin_is_builtin_async_iter(binding.origin),
-    None => false
+  let cached = Array::get(afe_builtin_async_iter_cell, 0)
+  if cached >= 0 {
+    cached == 1
+  } else {
+    let answer = match env_lookup_binding(env, "AsyncIter") {
+      Some(binding) => afe_origin_is_builtin_async_iter(binding.origin),
+      None => false
+    }
+    Array::set(afe_builtin_async_iter_cell, 0, if answer {
+      1
+    } else {
+      0
+    })
+    answer
   }
 }
 
@@ -1797,6 +1845,7 @@ fn afe_contains_for(expr: Expr) -> Bool {
 }
 
 export fn check_async_effects_expr(expr: Expr, env: TypeEnv, in_async: Bool) -> Array[EffectError] {
+  afe_reset_entry_memos()
   Array::truncate(afe_callable_bodies, 0)
   Array::truncate(afe_payload_call_stack, 0)
   Array::truncate(afe_reachability_keys, 0)
@@ -1919,6 +1968,7 @@ fn check_async_effects_stmt_lo(stmt: Stmt, env: TypeEnv) -> Array[EffectError] {
 }
 
 export fn check_async_effects_stmt(stmt: Stmt, env: TypeEnv) -> Array[EffectError] {
+  afe_reset_entry_memos()
   Array::truncate(afe_callable_bodies, 0)
   Array::truncate(afe_payload_call_stack, 0)
   Array::truncate(afe_reachability_keys, 0)
@@ -1937,6 +1987,7 @@ export fn check_async_effects_stmts(stmts: Array[Stmt], env: TypeEnv) -> Array[E
   afe_set_field_types(stmts, env)
   Array::truncate(afe_builtin_async_iter_import_names, 0)
   afe_record_builtin_async_iter_imports(stmts)
+  afe_reset_entry_memos()
   Array::truncate(afe_callable_bodies, 0)
   Array::truncate(afe_payload_call_stack, 0)
   Array::truncate(afe_reachability_keys, 0)
@@ -2270,6 +2321,12 @@ fn type_kind_name(t: Type) -> String {
 /// `throw(NotFound("x"))` wants the RESULT type of the constructor it applies.
 let throw_kind_cell: Array[(String, String, String)] = array_empty()
 
+/// #2386: name -> first slot of `throw_kind_cell`, rebuilt with the table.
+/// `throw_kind_lookup` scanned the table -- every kinded binding of the env
+/// -- per throw site; the first pushed entry (the innermost binding) wins,
+/// which is what the scan answered.
+let throw_kind_index: Array[MutMap[String, Int]] = [MutMap::new_string()]
+
 fn throw_kind_push(name: String, ty: Type) -> Unit {
   let fnty = match ty {
     CtForAll(_, _, body) => body,
@@ -2281,6 +2338,12 @@ fn throw_kind_push(name: String, ty: Type) -> Unit {
     _ => ""
   }
   if String::length(value_kind) > 0 || String::length(result_kind) > 0 {
+    let index = Array::get(throw_kind_index, 0)
+    if MutMap::has(index, name) {
+      ()
+    } else {
+      MutMap::set(index, name, Array::length(throw_kind_cell))
+    }
     Array::push(throw_kind_cell, (name, value_kind, result_kind))
   } else {
     ()
@@ -2293,6 +2356,7 @@ fn throw_kind_push(name: String, ty: Type) -> Unit {
 /// misclassify a same-named binding there.
 fn set_throw_kind_table(env: TypeEnv) -> Unit {
   Array::truncate(throw_kind_cell, 0)
+  Array::set(throw_kind_index, 0, MutMap::new_string())
   let mut cur = env
   let mut looping = true
   while looping {
@@ -2351,24 +2415,17 @@ fn set_throw_kind_table(env: TypeEnv) -> Unit {
 /// rather than its own. First match wins, matching the env's own innermost-
 /// first order.
 fn throw_kind_lookup(name: String, want_result: Bool) -> String {
-  let mut i = 0
-  let mut out = ""
-  let mut found = false
-  while i < Array::length(throw_kind_cell) && !found {
-    let (n, value_kind, result_kind) = Array::get(throw_kind_cell, i)
-    if n == name {
-      out = if want_result {
+  match MutMap::get(Array::get(throw_kind_index, 0), name) {
+    Some(i) => {
+      let (_, value_kind, result_kind) = Array::get(throw_kind_cell, i)
+      if want_result {
         result_kind
       } else {
         value_kind
       }
-      found = true
-    } else {
-      ()
-    }
-    i = i + 1
+    },
+    None => ""
   }
-  out
 }
 
 /// The LOCAL exception-kind scope: `(name, kind)` innermost-first, first match

--- a/lib/@vibe/compiler/tests/async_effect_entry_memo_test.vibe
+++ b/lib/@vibe/compiler/tests/async_effect_entry_memo_test.vibe
@@ -1,0 +1,90 @@
+//# #2386: the async-effect walk answers "is this callee an async primitive"
+//# and "does `AsyncIter` carry builtin provenance here" once per entry
+//# instead of once per call site and per binding -- the env is the same
+//# for the whole walk. What must not happen is an answer outliving its
+//# entry: each exported entry clears both memos, so the same program checked
+//# against two envs back to back, in either order, answers as it did when
+//# every question went to the env.
+
+import @vibe/compiler/core {
+  BindingOrigin, Expr, Stmt, Type, TypeDef, TypeEnv, TypeExpr, env_bind, env_preserve_type_definition_origins, env_value_binding_with_origin
+}
+
+import @vibe/core {
+  array_empty
+}
+
+import @vibe/compiler/checker {
+  EffectError, check_async_effects_expr, check_async_effects_stmt, check_async_effects_stmts
+}
+
+fn sleep_call() -> Expr {
+  ECall(EIdent("sleep", -1), [EInt(10)], -1)
+}
+
+fn sleep_fn() -> Expr {
+  EFn(array_empty(), array_empty(), array_empty(), None, None, sleep_call())
+}
+
+fn user_sleep_env() -> TypeEnv {
+  env_bind(EnvEmpty, "sleep", CtFn([CtInt], CtInt, None))
+}
+
+fn for_over(iterand: Expr) -> Expr {
+  EForIn("x", None, iterand, EIdent("x", -1))
+}
+
+fn holder_body() -> Expr {
+  EFn(array_empty(), array_empty(), [("holder", Some(TyName("Holder")))], None, None, for_over(EDot(EIdent("holder", -1), "stream", -1, -1)))
+}
+
+fn holder_defs(rest: TypeEnv) -> TypeEnv {
+  EnvTypeDefs([
+    TDStruct("Holder", [("stream", CtNamed("AsyncIter", [CtInt]))], [], []),
+    TDStruct("AsyncIter", [], [], ["T"])
+  ], ["Holder"], rest)
+}
+
+fn builtin_async_iter_env() -> TypeEnv {
+  let origin = BindingOriginModuleExport("/workspace/lib/@vibe/builtin/index.vpkg", "AsyncIter")
+  let source = EnvBind("AsyncIter", env_value_binding_with_origin(CtUnknown, origin), EnvEmpty)
+  env_preserve_type_definition_origins(holder_defs(EnvEmpty), source)
+}
+
+fn count(errors: Array[EffectError]) -> Int {
+  Array::length(errors)
+}
+
+test "an async-primitive answer does not outlive its entry (statements)" {
+  let stmts = [STest("t", sleep_call())]
+  assert_eq(count(check_async_effects_stmts(stmts, user_sleep_env())), 0)
+  assert_true(count(check_async_effects_stmts(stmts, EnvEmpty)) > 0)
+  assert_eq(count(check_async_effects_stmts(stmts, user_sleep_env())), 0)
+}
+
+test "an async-primitive answer does not outlive its entry (expression and statement entries)" {
+  assert_true(count(check_async_effects_expr(sleep_call(), EnvEmpty, false)) > 0)
+  assert_eq(count(check_async_effects_expr(sleep_call(), user_sleep_env(), false)), 0)
+  assert_true(count(check_async_effects_expr(sleep_call(), EnvEmpty, false)) > 0)
+  let stmt = SLet(false, false, "f", None, sleep_fn())
+  assert_eq(count(check_async_effects_stmt(stmt, user_sleep_env())), 0)
+  assert_true(count(check_async_effects_stmt(stmt, EnvEmpty)) > 0)
+  assert_eq(count(check_async_effects_stmt(stmt, user_sleep_env())), 0)
+}
+
+test "the same name is asked once per entry, not once per site" {
+  // Two sites of one name in one walk: the first answer is reused for the
+  // second, and both agree with the per-site answer.
+  let two = EFn(array_empty(), array_empty(), array_empty(), None, None, ELet("a", sleep_call(), sleep_call(), -1))
+  let stmts = [STest("t", two)]
+  assert_eq(count(check_async_effects_stmts(stmts, user_sleep_env())), 0)
+  assert_true(count(check_async_effects_stmts(stmts, EnvEmpty)) >= 2)
+}
+
+test "the AsyncIter provenance answer does not outlive its entry" {
+  let stmts = [STest("projected field", holder_body())]
+  assert_true(count(check_async_effects_stmts(stmts, builtin_async_iter_env())) > 0)
+  assert_eq(count(check_async_effects_stmts(stmts, holder_defs(EnvEmpty))), 0)
+  assert_true(count(check_async_effects_stmts(stmts, builtin_async_iter_env())) > 0)
+  assert_eq(count(check_async_effects_stmts(stmts, holder_defs(EnvEmpty))), 0)
+}


### PR DESCRIPTION
## What

The second checker slice of #2386 and the fix for the round-1 review finding on #2490, both on the cold lane of a compile, both byte-identical to main on every corpus. #2490 merged with its first commit while these two were in validation, so they land here, rebased onto that merge.

### 1. `f57b0ad` — the async-effect walk asks the env once per entry; the throw-kind table is indexed

Three more per-site lookups in the same checker passes, each answered from state that is constant for the whole walk:

- `is_async_primitive` asked the env whether a callee is bound, once per call site. The async walk never extends its env (locals travel in the `afe_bind_*` tables), and for every user callee the answer is a full env miss — a chain walk per call. The walk keeps a name → answer memo, cleared by each of the three exported entries, so a program checked against another env answers as before.
- `afe_type_binding_is_builtin_async_iter` looked `AsyncIter` up in the env once per binding and per call head; it is one question per walk and is now asked once, in a cell the same entries clear.
- `throw_kind_lookup` scanned the module's throw-kind table (every kinded binding of the env) per throw site; the table gets a name → first-slot index rebuilt with it, and the first pushed entry — the innermost binding — still wins.

`async_effect_entry_memo_test.vibe` pins that no answer outlives its entry: the same program checked against an env that binds `sleep` and against an empty env, back to back and in both orders, through all three exported entries; and the `AsyncIter` provenance answer likewise. The file passes unchanged against the previous head's library; a mutation that drops the per-entry reset (built as its own stage2) fails its first case (`an async-primitive answer does not outlive its entry (statements)`). The throw-kind resolution stays pinned by `checker_exception_kind_test.vibe` (the result-kind case through the table).

Measured the same way, against #2490's stage2 (the previous head):

| | #2490 head | this commit |
|---|---:|---:|
| `collect_async_effect_errors` cold inclusive | 0.68 s | 0.44 s |
| `is_async_primitive` / `afe_type_binding_is_builtin_async_iter` cold inclusive | 0.21 s / 0.05 s | 0.01 s / 0.00 s |
| `throw_kind_lookup` / `throw_payload_kind` cold inclusive | 0.05 s / 0.07 s | 0.00 s / 0.00 s |
| cold wall, mean of 3 | 9.26 s | 8.91 s (−3.8%; every run of this commit below every run of the previous head) |
| warm wall, mean of 3 | 4.95 s | 4.95 s |
| heap_ptr cold / warm | 1,403,594,768 / 700,926,936 | 1,405,218,728 / 700,929,376 (+1.6 MB: the memos and the index) |

Byte-identical output on the same ten closures and 22 rc fixtures.

### 2. `cab5a18` — the cacheability walks build the index once, not once per test block (Codex round 1 on #2490, P1)

The exported single-expression entry builds the index from the table its caller hands it, and `file_tests_cacheable` ran that entry once per `test` block of the file — under `VIBE_TESTMETA_OUT`, the `vibe test` cache verdict, on the bump lane that never frees. Measured on #2490's head with `codegen_heap_e2e_test.vibe` (163 blocks over the compiler closure): heap_ptr 1,963,477,800 bytes on main, 2,092,827,176 with the index rebuilt per block (+129 MB, about 0.8 MB per block). The two cacheability walks now build the index once after their table is final and hand it to an internal entry that takes it; the exported entry keeps its contract. The same compile on this head is 1,968,711,160 bytes (main plus the two per-module indexes and the async walk's memos), with the compiled output and the cache verdict byte-identical to main's.

## Validation

Chain on this head (`cab5a18`, base `a5ff199`, run in a staging worktree at that exact commit) is in progress at the time of opening — bundle regen, stage2 == stage3, twenty lane tests on linear, `test_cli_core.sh`, selfcompile KPI, typing-env-reuse oracle, the affected unit suite, `compiler_gate.sh` early / mid / late — and this section is updated with its results when it completes. The same chain ran green through the oracle on the pre-rebase tree (`0160190` + these two commits), whose only difference from this head is #2489's codegen change, which neither commit touches. Output equivalence (ten closures and 22 rc fixtures, byte-identical to #2490's head) and the Green runs of the three lane tests were on the fixed tree.

`vibe_fmt.sh --check` is a fixpoint on every changed file.

Refs #2386. Follow-up to #2490 (the Codex finding on https://github.com/mizchi/vibe-lang/pull/2490#discussion_r3933977807).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QKZdvBvHVUagwg6Yih8er8

---
_Generated by [Claude Code](https://claude.ai/code/session_01QKZdvBvHVUagwg6Yih8er8)_