### PR TITLE
checker: clear the async walk's entry memos before the field-type table is built (#2386)

### DIFF
--- a/lib/@vibe/compiler/checker/checker_effects.vibe
+++ b/lib/@vibe/compiler/checker/checker_effects.vibe
@@ -1845,6 +1845,10 @@ fn afe_contains_for(expr: Expr) -> Bool {
 }
 
 export fn check_async_effects_expr(expr: Expr, env: TypeEnv, in_async: Bool) -> Array[EffectError] {
+  // #2386 review: the memos are cleared before ANYTHING of this entry asks
+  // them -- `afe_set_field_types` below consults the `AsyncIter` provenance
+  // cell while building the field-type table, so a reset placed after it
+  // would let the previous entry's answer into this program's table.
   afe_reset_entry_memos()
   Array::truncate(afe_callable_bodies, 0)
   Array::truncate(afe_payload_call_stack, 0)
@@ -1968,6 +1972,10 @@ fn check_async_effects_stmt_lo(stmt: Stmt, env: TypeEnv) -> Array[EffectError] {
 }
 
 export fn check_async_effects_stmt(stmt: Stmt, env: TypeEnv) -> Array[EffectError] {
+  // #2386 review: the memos are cleared before ANYTHING of this entry asks
+  // them -- `afe_set_field_types` below consults the `AsyncIter` provenance
+  // cell while building the field-type table, so a reset placed after it
+  // would let the previous entry's answer into this program's table.
   afe_reset_entry_memos()
   Array::truncate(afe_callable_bodies, 0)
   Array::truncate(afe_payload_call_stack, 0)
@@ -1978,6 +1986,11 @@ export fn check_async_effects_stmt(stmt: Stmt, env: TypeEnv) -> Array[EffectErro
 }
 
 export fn check_async_effects_stmts(stmts: Array[Stmt], env: TypeEnv) -> Array[EffectError] {
+  // #2386 review: the memos are cleared before ANYTHING of this entry asks
+  // them -- `afe_set_field_types` below consults the `AsyncIter` provenance
+  // cell while building the field-type table, so a reset placed after it
+  // would let the previous entry's answer into this program's table.
+  afe_reset_entry_memos()
   // Enforce direct-call-only before ordinary Async row checks. These errors are
   // checker diagnostics, so no artifact reaches codegen for an opaque flow.
   let errors = check_stdin_provider_direct_calls_stmts(stmts)
@@ -1987,7 +2000,6 @@ export fn check_async_effects_stmts(stmts: Array[Stmt], env: TypeEnv) -> Array[E
   afe_set_field_types(stmts, env)
   Array::truncate(afe_builtin_async_iter_import_names, 0)
   afe_record_builtin_async_iter_imports(stmts)
-  afe_reset_entry_memos()
   Array::truncate(afe_callable_bodies, 0)
   Array::truncate(afe_payload_call_stack, 0)
   Array::truncate(afe_reachability_keys, 0)

--- a/lib/@vibe/compiler/tests/async_effect_entry_memo_test.vibe
+++ b/lib/@vibe/compiler/tests/async_effect_entry_memo_test.vibe
@@ -88,3 +88,56 @@ test "the AsyncIter provenance answer does not outlive its entry" {
   assert_true(count(check_async_effects_stmts(stmts, builtin_async_iter_env())) > 0)
   assert_eq(count(check_async_effects_stmts(stmts, holder_defs(EnvEmpty))), 0)
 }
+
+// #2495 review: the field-type table is built at the very start of an entry,
+// before the memos of the previous entry are cleared -- so the clear must
+// come first. These shapes route a projected `AsyncIter` field through the
+// table (a struct declared in the program itself, a call result, a `let`),
+// checked right after an entry whose env carried builtin provenance.
+
+fn call_body() -> Expr {
+  EFn(array_empty(), array_empty(), array_empty(), None, None, for_over(EDot(ECall(EIdent("mk", -1), [
+  ], -1), "stream", -1, -1)))
+}
+
+fn let_body() -> Expr {
+  EFn(array_empty(), array_empty(), array_empty(), None, None, ELet("h", ECall(EIdent("mk", -1), [
+  ], -1), for_over(EDot(EIdent("h", -1), "stream", -1, -1)), -1))
+}
+
+fn holder_stmts() -> Array[Stmt] {
+  [
+    SStruct(false, "AsyncIter", [], [], [], ["T"]),
+    SStruct(false, "Holder", [("stream", TyApp("AsyncIter", [TyName("Int")]))], [
+    ], [], []),
+    STest("projected field", holder_body())
+  ]
+}
+
+fn mk_env(rest: TypeEnv) -> TypeEnv {
+  env_bind(rest, "mk", CtFn([], CtNamed("Holder", []), None))
+}
+
+fn builtin_mk_env() -> TypeEnv {
+  let origin = BindingOriginModuleExport("/workspace/lib/@vibe/builtin/index.vpkg", "AsyncIter")
+  let source = EnvBind("AsyncIter", env_value_binding_with_origin(CtUnknown, origin), EnvEmpty)
+  env_preserve_type_definition_origins(mk_env(holder_defs(EnvEmpty)), source)
+}
+
+test "a program declaring its own AsyncIter is synchronous right after a builtin-provenance entry" {
+  assert_true(count(check_async_effects_stmts([
+    STest("projected field", holder_body())
+  ], builtin_async_iter_env())) > 0)
+  assert_eq(count(check_async_effects_stmts(holder_stmts(), EnvEmpty)), 0)
+  assert_eq(count(check_async_effects_stmts(holder_stmts(), EnvEmpty)), 0)
+  assert_true(count(check_async_effects_stmts([
+    STest("projected field", holder_body())
+  ], builtin_async_iter_env())) > 0)
+}
+
+test "a call-result or let-bound projection is classified by its own entry's env" {
+  assert_true(count(check_async_effects_stmts([STest("call", call_body())], builtin_mk_env())) > 0)
+  assert_eq(count(check_async_effects_stmts([STest("call", call_body())], mk_env(holder_defs(EnvEmpty)))), 0)
+  assert_true(count(check_async_effects_stmts([STest("let", let_body())], builtin_mk_env())) > 0)
+  assert_eq(count(check_async_effects_stmts([STest("let", let_body())], mk_env(holder_defs(EnvEmpty)))), 0)
+}


### PR DESCRIPTION
## What

The fix for the round-1 review finding on #2495 (https://github.com/mizchi/vibe-lang/pull/2495#discussion_r3934629095), which merged while the fix was in validation. One commit, `e898dcd`, on the cold lane of a compile, byte-identical to main on every corpus.

`check_async_effects_stmts` built the struct field-type table (`afe_set_field_types`) before clearing the memos the previous entry left, and the table builder consults the `AsyncIter` provenance cell (`afe_field_head_with_origin`), so on paper a program whose env declares a synchronous `AsyncIter` could inherit the previous entry's builtin answer into its table. The clear is now the first statement of each of the three exported entries, ahead of anything that can ask a memo.

Measured on the previous head through three projected-field shapes — a struct declared in the program's own statements, a call result `mk().stream`, a `let h = mk()` projection — each checked immediately after an entry whose env carried builtin `AsyncIter` provenance: no stale answer was observable (builtin entry rejected, user entry 0 errors, in both orders; the use sites re-derive the head). So `async_effect_entry_memo_test.vibe` gains the three shapes in both orders as structural pins, and the reorder makes the property hold by construction rather than by that accident.

## Validation

Chain on this head's tree (`e898dcd` on `04f7c20`; the same tree as `4d6f712` in the staging worktree, tree hash checked) is in progress at the time of opening — bundle regen, stage2 == stage3, twenty lane tests on linear, `test_cli_core.sh`, selfcompile KPI, typing-env-reuse oracle, the affected unit suite, `compiler_gate.sh` early / mid / late — and this section is updated with its results when it completes. The Green run of the extended test and output equivalence (ten closures and 22 rc fixtures) run in the same pipeline ahead of the chain.

`vibe_fmt.sh --check` is a fixpoint on both changed files.

Refs #2386. Follow-up to #2495.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QKZdvBvHVUagwg6Yih8er8

---
_Generated by [Claude Code](https://claude.ai/code/session_01QKZdvBvHVUagwg6Yih8er8)_