### PR TITLE
loader: a dependency's export list is parsed once per contract, not once per importer (#2386)

### DIFF
--- a/lib/@vibe/compiler/loader/header_cache.vibe
+++ b/lib/@vibe/compiler/loader/header_cache.vibe
@@ -11,7 +11,7 @@ import @vibe/compiler/cache {
 }
 
 import @vibe/core {
-  array_empty
+  array_empty, struct MutMap
 }
 
 import ./ingestion_pipeline_telemetry.vibe {
@@ -269,7 +269,30 @@ fn string_array_contains_hc(items: Array[String], target: String) -> Bool {
 /// (contract-)parses `resolved` exactly once instead, mirroring the same
 /// decls/opaques/collect_exports combination the contract-header branch above
 /// already uses for its own `exports` result.
+/// #2386: the export names of a contract, per (path, stat token), for the
+/// process. `validate_import_names_fs` asks for a dependency's export list
+/// once per IMPORTER of that dependency, and each ask read, lexed and parsed
+/// the contract again -- on a cold compiler-closure compile that was every
+/// package contract parsed once per member of every package importing it.
+/// The token is what every persistent cache on this lane keys freshness on,
+/// so an edited contract is re-read on the next compile that sees the new
+/// token. The list is handed out shared and never mutated by its reader
+/// (`string_array_contains_hc` only scans it).
+let export_names_memo: MutMap[String, Array[String]] = MutMap::new_string()
+
 fn resolved_export_names_fs(resolved: String) -> Array[String] with Exception + Fs {
+  let memo_key = String::concat(__to_string(Fs::stat_token(resolved)), String::concat("\n", resolved))
+  match MutMap::get(export_names_memo, memo_key) {
+    Some(hit) => hit,
+    None => {
+      let computed = resolved_export_names_uncached_fs(resolved)
+      MutMap::set(export_names_memo, memo_key, computed)
+      computed
+    }
+  }
+}
+
+fn resolved_export_names_uncached_fs(resolved: String) -> Array[String] with Exception + Fs {
   let source = Fs::read_file(resolved)
   if is_contract_ext(resolved) && !String::starts_with(source, contract_facade_marker) {
     let (_, pin_blanked) = extract_require_pins(source)

--- a/lib/@vibe/compiler/tests/export_names_memo_test.vibe
+++ b/lib/@vibe/compiler/tests/export_names_memo_test.vibe
@@ -1,0 +1,85 @@
+//# #2386: the loader answers "what does this contract export" once per
+//# (path, stat token) per process instead of reading, lexing and parsing the
+//# contract again for every importer. What must not happen is an answer
+//# outliving the file: a contract rewritten under the same path is read
+//# again, and a second importer of the same contract is validated against
+//# the same list as the first.
+
+import @vibe/compiler/cache {
+  compact_string_fingerprint, persistent_module_header_cache_path
+}
+
+import @vibe/core {
+  array_empty
+}
+
+import @vibe/compiler/loader {
+  load_or_parse_module_header_fs
+}
+
+fn string_to_bytes(s: String) -> Bytes {
+  let out = array_empty()
+  let len = String::length(s)
+  let mut i = 0
+  while i < len {
+    Array::push(out, String::char_code_at(s, i))
+    i = i + 1
+  }
+  Bytes::from_array(out)
+}
+
+fn remove_file_if_exists(path: String) -> Unit with Fs {
+  if Fs::exists(path) {
+    Fs::remove(path)
+  } else {
+    ()
+  }
+}
+
+fn write_cold(path: String, source: String) -> Unit with Exception + Fs {
+  Fs::write_bytes(path, string_to_bytes(source))
+  remove_file_if_exists(persistent_module_header_cache_path(path, compact_string_fingerprint(source)))
+}
+
+fn setup_pkg(base_dir: String, contract: String) -> Unit with Exception + Fs {
+  let pkg_dir = String::concat(base_dir, "/pkg")
+  Fs::mkdir_p(pkg_dir)
+  write_cold(String::concat(pkg_dir, "/index.vpkg"), contract)
+  write_cold(String::concat(pkg_dir, "/impl.vibe"), "export fn pub_fn(x: Int) -> Int {\n  x + 1\n}\n\nexport fn later_fn(x: Int) -> Int {\n  x + 2\n}\n")
+}
+
+fn header_error_for(main_path: String, main_source: String) -> String with Fs {
+  handle {
+    let _ = load_or_parse_module_header_fs(main_path, main_source, 0)
+    ""
+  } with { Exception::Throw(msg) => msg }
+}
+
+fn check_main(base_dir: String, file: String, source: String) -> String with Exception + Fs {
+  let main_path = String::concat(base_dir, String::concat("/", file))
+  write_cold(main_path, source)
+  header_error_for(main_path, source)
+}
+
+test "two importers of one contract are validated against the same export list" {
+  let base_dir = "/tmp/vibe_compiler_export_names_memo_two_importers"
+  setup_pkg(base_dir, "version 0.0.1\n\nimport ./impl.vibe {}\n\nfn pub_fn(x: Int) -> Int\n")
+  assert_eq(check_main(base_dir, "a.vibe", "import ./pkg { pub_fn }\nexport fn run() -> Int {\n  pub_fn(1)\n}\n"), "")
+  let msg = check_main(base_dir, "b.vibe", "import ./pkg { later_fn }\nexport fn run() -> Int {\n  later_fn(1)\n}\n")
+  assert_true(String::contains(msg, "\"later_fn\" is not exported by"))
+  assert_eq(check_main(base_dir, "c.vibe", "import ./pkg { pub_fn }\nexport fn run() -> Int {\n  pub_fn(2)\n}\n"), "")
+}
+
+test "a contract rewritten under the same path is read again" {
+  let base_dir = "/tmp/vibe_compiler_export_names_memo_rewrite"
+  setup_pkg(base_dir, "version 0.0.1\n\nimport ./impl.vibe {}\n\nfn pub_fn(x: Int) -> Int\n")
+  let before = check_main(base_dir, "main.vibe", "import ./pkg { later_fn }\nexport fn run() -> Int {\n  later_fn(1)\n}\n")
+  assert_true(String::contains(before, "\"later_fn\" is not exported by"))
+  // The contract grows a declaration (and changes length) under the same path.
+  write_cold(String::concat(base_dir, "/pkg/index.vpkg"), "version 0.0.1\n\nimport ./impl.vibe {}\n\nfn pub_fn(x: Int) -> Int\nfn later_fn(x: Int) -> Int\n")
+  assert_eq(check_main(base_dir, "main2.vibe", "import ./pkg { later_fn }\nexport fn run() -> Int {\n  later_fn(1)\n}\n"), "")
+  // And shrinks back: the old answer must not come back either.
+  write_cold(String::concat(base_dir, "/pkg/index.vpkg"), "version 0.0.1\n\nimport ./impl.vibe {}\n\nfn pub_fn(x: Int) -> Int\n")
+  let after = check_main(base_dir, "main3.vibe", "import ./pkg { later_fn }\nexport fn run() -> Int {\n  later_fn(1)\n}\n")
+  assert_true(String::contains(after, "\"later_fn\" is not exported by"))
+}


### PR DESCRIPTION
## What

One slice of #2386 on the cold lane of a compile — the loader's import-name validation — byte-identical to main on every corpus.

### `6463df6` — a dependency's export list is parsed once per contract, not once per importer

`validate_import_names_fs` checks each lowercase import name against the dependency's export list, and asked for that list per **importer** (`resolved_export_names_fs`): read the contract, lex it, parse it, walk its declarations. On a cold compiler-closure compile that is every package contract parsed once per member of every package that imports it — all of it repeat work.

The list is memoized per (path, stat token) for the process. The token is what every persistent cache on this lane keys freshness on, so a contract rewritten under the same path is read again by the next compile that sees the new token, and the two importers of one contract are validated against the same list. The list is handed out shared; its only reader scans it.

`export_names_memo_test.vibe` pins both: two importers of one contract (the second and third validated from the memo, one of them against a name the contract does not declare), and a contract rewritten under the same path — grown by a declaration, then shrunk back — answering from the file each time. The file passes unchanged against main's library; a memo keyed without the stat token (built as its own stage2 from this tree) fails the rewrite case with the stale `"later_fn" is not exported by ./pkg`, so the test can tell a stale memo from the file.

The Codex round-1 finding here (the memo never dropped a superseded key) is fixed in #2515, which merged-after: the memo there holds one entry per contract path.

### Measured

Cache-isolated per the profiling skill, corpus `codegen_lexer_test.vibe` (the full compiler closure), N=3 interleaved against a stage2 built from main's tree (`e898dcd`), idle machine. The validation runs only on the cold lane (a warm compile replays the module headers from the persistent cache), so cold is the lane that moves.

| | main (`e898dcd`) | this head |
|---|---:|---:|
| `resolved_export_names_fs` / `validate_import_names_fs` cold inclusive | 0.36 s / 0.37 s | 0.02 s / 0.02 s |
| `load_or_parse_module_header_fs` cold inclusive | 1.07 s | 0.63 s |
| `collect_source_groups_fs` cold inclusive | 2.10 s | 1.65 s |
| cold wall, mean of 3 | 8.69 s | 8.50 s (−2.2%) |
| warm wall, mean of 3 | 4.70 s | 4.77 s (noise; the header cache answers warm) |
| heap_ptr cold / warm | 1,357,485,272 / 652,896,776 | 1,251,727,976 / 652,897,888 (−105.8 MB cold: the repeated parses were allocation too) |

Byte-identical output on ten closures and 22 rc fixtures.

## Validation

Chain on `6463df6` (base `d2c4fd3`, run in a staging worktree at that exact commit, tree hash checked against the pushed head): bundle regen; stage2 == stage3; eleven lane tests on linear (`export_names_memo_test`, `import_contract_check_test`, `type_db_cross_module_test`, `contract_vpkg_test`, `vpkg_scan_test`, `contract_vpkg_shared_scope_test`, `persistent_cache_test`, `unstable_import_diagnostics_test`, `package_header_scan_test`, `async_effect_entry_memo_test`, `effect_fn_table_index_test`); `test_cli_core.sh`; selfcompile KPI heap_ptr 1,251,754,904 bytes (−105.7 MB vs the previous head); typing-env-reuse oracle; 110/110 affected unit-test files (import-graph selection over the changed files); `compiler_gate.sh` early / mid / late.

`vibe_fmt.sh --check` is a fixpoint on both changed files.

Refs #2386.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QKZdvBvHVUagwg6Yih8er8