### PR TITLE
cfg: the active #cfg flag set reaches every module and every cache key (#2513)

### DIFF
--- a/docs/build-cache.md
+++ b/docs/build-cache.md
@@ -41,6 +41,10 @@ v10 | cg-<codegen_fingerprint()>
   emitted wasm / runtime ABI changes the compiler source, hence this segment,
   hence the key — so a codegen change automatically invalidates stale artifacts
   with no manual bump (#630).
+- `cfg=<flags>` — present only when `VIBE_CFG` is set: the active `#cfg` flag
+  set, in the caller's spelling. A module parsed under one flag set keeps
+  different statements than under another, so each flag set is its own cache
+  universe; a build with no flags keeps the tag it always had (#2513).
 
 ## GC policy (#631)
 

--- a/docs/cheatsheet.md
+++ b/docs/cheatsheet.md
@@ -2170,11 +2170,11 @@ let run_mode = () -> Int { debug_dump(run()) }
 let run_mode = () -> Int { run() }
 ```
 
-- Activate flags at compile time: `VIBE_CFG=dev vibe build app.vibe` (comma-separated for multiple).
+- Activate flags at compile time: `VIBE_CFG=dev vibe build app.vibe` (comma-separated for multiple). The set applies to **every module of the program**, imports included, and is part of the build-cache key, so switching flags between two builds is a cache miss, never a replay (#2513).
 - A `#cfg(flag)` statement whose flag is inactive is parsed (syntax must stay valid, like Rust's `cfg`) and **dropped before checking/codegen** — zero bytes in the output binary.
 - Top-level statements only (`let` / `enum` / `struct` / `impl` / ...).
 - `vibe fmt` / normalize refuses `#cfg` sources (formatting would delete disabled code).
-- Not usable inside the compiler's own source until the seed compiler understands it (see docs/bootstrap.md).
+- The compiler's own sources may use it: the committed seed understands `#cfg`, and the flat self-build passes its flag set the same way.
 
 ## Allocation contract (`#zero_alloc`)
 

--- a/docs/cheatsheet.md
+++ b/docs/cheatsheet.md
@@ -2174,7 +2174,7 @@ let run_mode = () -> Int { run() }
 - A `#cfg(flag)` statement whose flag is inactive is parsed (syntax must stay valid, like Rust's `cfg`) and **dropped before checking/codegen** — zero bytes in the output binary.
 - Top-level statements only (`let` / `enum` / `struct` / `impl` / ...).
 - `vibe fmt` / normalize refuses `#cfg` sources (formatting would delete disabled code).
-- The compiler's own sources may use it: the committed seed understands `#cfg`, and the flat self-build passes its flag set the same way.
+- **Not usable inside the compiler's own sources yet.** The seed understands `#cfg` and the flag set reaches every module (#2513), but the flattened self-build (`scripts/generate_bundle.sh`, module-source emission) and the span-based tools (`vibe escapes` / `vibe grep` / `vibe type-at`) parse with `parse_program_spans`, which refuses every `#` directive except `#zero_alloc` (`# directives are not supported in module-source emission`). Teaching that path to select and preserve `#cfg` statements is the first step of #2497.
 
 ## Allocation contract (`#zero_alloc`)
 

--- a/lib/@vibe/cli/dispatch.vibe
+++ b/lib/@vibe/cli/dispatch.vibe
@@ -6,6 +6,7 @@ import ../compiler {
   check_linked_file, compile_release_file_mode, compile_release_file_mode_profiled,
   compile_release_file_mode_uncached, compile_release_file_mode_uncached_profiled,
   write_linked_debug_build, write_linked_debug_build_checked, strip_executable_wasm_env,
+  configure_cfg_flags,
   serve_handler_param_names, serve_handler_takes_body_stream, validate_serve_handler,
   wit_from_program,
   lex, parse_program
@@ -1108,6 +1109,10 @@ fn low_level_cli_main() -> Int with Exception + Fs + Env + Profiler {
 /// wraps this with the Profiler/Error handlers; the regression tests in
 /// dispatch_test.vibe drive it through that same wrapper.
 export fn selfhost_cli_dispatch_args(args: Array[String]) -> Int with Exception + Fs + Env + Profiler {
+  // #2513: the `#cfg` flag set for every module this invocation parses and
+  // every cache key it touches. Same call as cli_adapter.vibe's cli_main;
+  // this dispatcher never passes through that entry.
+  configure_cfg_flags()
   let first_arg = if Array::length(args) == 0 {
     ""
   } else {

--- a/lib/@vibe/compiler/cache/index.vpkg
+++ b/lib/@vibe/compiler/cache/index.vpkg
@@ -96,6 +96,7 @@ fn cache_stable_text_cache_path(version_tag: String, prefix: String, seed: Strin
 // --- persistent_cache (own wrappers)
 // Read-only artifact-input trace evidence; never a cache path/reuse input.
 fn persistent_cache_version_tag_for_observation() -> String
+fn set_persistent_cache_cfg_flags(flags_csv: String) -> Unit
 fn persistent_artifact_cache_path(kind: String, entry_name: String, fingerprint: String) -> String
 fn store_persistent_artifact(kind: String, entry_name: String, fingerprint: String, bytes: Bytes) -> Unit with Exception + Fs
 fn load_persistent_artifact(kind: String, entry_name: String, fingerprint: String) -> Option[Bytes] with Exception + Fs

--- a/lib/@vibe/compiler/cache/persistent_cache.vibe
+++ b/lib/@vibe/compiler/cache/persistent_cache.vibe
@@ -100,6 +100,28 @@ export ../../../../lib/@vibe/cache {
 ///    the bundle. So any codegen-source change automatically changes the key and
 ///    invalidates stale artifacts; no manual bump needed (#630). `vNN` is still a
 ///    manual knob for pure cache-FORMAT changes that don't change the source hash.
+/// The active `#cfg` flag set as a cache-key segment (#2513). A module parsed
+/// under one flag set keeps different statements than under another, so every
+/// persistent entry derived from a parse -- headers, source groups, typing
+/// environments, artifacts, codegen bodies -- lives in a namespace of its own
+/// per flag set. Set once per CLI invocation next to the parser's ambient set;
+/// empty (the default) leaves the tag exactly as before, so the no-flag lane
+/// keeps its cache.
+let persistent_cache_cfg_flags_cell: Array[String] = []
+
+export fn set_persistent_cache_cfg_flags(flags_csv: String) -> Unit {
+  Array::truncate(persistent_cache_cfg_flags_cell, 0)
+  Array::push(persistent_cache_cfg_flags_cell, flags_csv)
+}
+
+fn persistent_cache_cfg_segment() -> String {
+  if Array::length(persistent_cache_cfg_flags_cell) == 0 || Array::get(persistent_cache_cfg_flags_cell, 0) == "" {
+    ""
+  } else {
+    String::concat("|cfg=", Array::get(persistent_cache_cfg_flags_cell, 0))
+  }
+}
+
 fn persistent_cache_version_tag() -> String {
   // v23: TypeEnv v9 and TDRE9 preserve binding provenance across publication
   // and persistent cache hops. Every v22 entry cold-misses rather than losing
@@ -132,7 +154,7 @@ fn persistent_cache_version_tag() -> String {
   // (`.bin`, via Fs::write_bytes / Fs::read_bytes) — a cache FORMAT change, so
   // the manual `vNN` knob is bumped. Old `.hex` entries are now unreferenced
   // (different key + suffix) and reclaimable via `pkf run cache-clean` (#631).
-  String::concat("v23|cg-", codegen_fingerprint())
+  String::concat("v23|cg-", String::concat(codegen_fingerprint(), persistent_cache_cfg_segment()))
 }
 
 /// Read-only trace evidence for the exact existing persistent cache identity.

--- a/lib/@vibe/compiler/cli_adapter.vibe
+++ b/lib/@vibe/compiler/cli_adapter.vibe
@@ -53,7 +53,11 @@ import @vibe/compiler/runtime {
 }
 
 import @vibe/compiler/cache {
-  ingestion_fingerprint_telemetry_json, set_ingestion_fingerprint_telemetry_enabled
+  ingestion_fingerprint_telemetry_json, set_ingestion_fingerprint_telemetry_enabled, set_persistent_cache_cfg_flags
+}
+
+import @vibe/parser {
+  set_cfg_ambient_flags
 }
 
 import @vibe/compiler/loader {
@@ -607,11 +611,46 @@ fn profile_memory_mark(enabled: Bool) -> Unit with Env {
   }
 }
 
-/// #cfg activation: VIBE_CFG=flag1,flag2 appends `#cfg_enable(flag)` directive
-/// lines to the source (appending at the END keeps every original byte offset,
-/// so diagnostics/spans are unaffected). parse_program pre-scans for these and
-/// keeps the matching `#cfg(flag)` statements; with VIBE_CFG unset, every
-/// #cfg-guarded statement is parsed-and-dropped -- zero bytes in the output.
+/// #2513: the `#cfg` flag set is process-wide. `VIBE_CFG=flag1,flag2` is read
+/// once here, handed to the parser as its ambient set (so every module of the
+/// program -- the entry, its imports, contract facades -- sees the same
+/// active flags) and folded into the persistent cache version tag (so a module
+/// parsed under one flag set is never replayed under another). Whitespace
+/// around a flag is trimmed and empty items are dropped; the cache segment
+/// keeps the caller's order, so a re-spelling of the same set is a cache miss,
+/// which is the safe direction.
+fn cfg_flags_from_csv(cfg_csv: String) -> Array[String] {
+  let flags: Array[String] = []
+  if cfg_csv == "" {
+    flags
+  } else {
+    let parts = String::split(cfg_csv, ",")
+    let mut i = 0
+    while i < Array::length(parts) {
+      let flag = String::trim(Array::get(parts, i))
+      if String::length(flag) > 0 {
+        Array::push(flags, flag)
+      } else {
+        ()
+      }
+      i = i + 1
+    }
+    flags
+  }
+}
+
+fn configure_cfg_flags() -> Unit with Env {
+  let flags = cfg_flags_from_csv(Env::get("VIBE_CFG"))
+  set_cfg_ambient_flags(flags)
+  set_persistent_cache_cfg_flags(String::join(flags, ","))
+}
+
+/// #cfg activation on the single-file lane, kept for the byte-offset property:
+/// VIBE_CFG=flag1,flag2 appends `#cfg_enable(flag)` directive lines to the
+/// source (appending at the END keeps every original byte offset, so
+/// diagnostics/spans are unaffected). The ambient set configured by
+/// configure_cfg_flags already activates the same flags for every parse; this
+/// stays so the single-file source itself records what it was built with.
 fn apply_cfg_env(source: String, cfg_csv: String) -> String {
   if cfg_csv == "" {
     source
@@ -866,6 +905,10 @@ export fn cli_main() -> Int with Exception + Fs + Env + Stdin + Stdout {
   // build/codegen lanes stay conservative, and a prior check in a long-lived
   // instance cannot leak its policy into a later invocation.
   set_experimental_typing_dependency_env_reuse_enabled(false)
+  // #2513: the `#cfg` flag set, for every module this invocation parses and
+  // for every cache key it touches. Set before ANY lane runs, like the
+  // switches below.
+  configure_cfg_flags()
   // #944 (ADR-0073 stage B): checked-Error row discipline is ON by
   // default -- `Exception::Throw` propagates to the caller's row like any
   // other effect, dischargeable via `handle .. with Exception`.

--- a/lib/@vibe/compiler/cli_adapter.vibe
+++ b/lib/@vibe/compiler/cli_adapter.vibe
@@ -53,11 +53,7 @@ import @vibe/compiler/runtime {
 }
 
 import @vibe/compiler/cache {
-  ingestion_fingerprint_telemetry_json, set_ingestion_fingerprint_telemetry_enabled, set_persistent_cache_cfg_flags
-}
-
-import @vibe/parser {
-  set_cfg_ambient_flags
+  ingestion_fingerprint_telemetry_json, set_ingestion_fingerprint_telemetry_enabled
 }
 
 import @vibe/compiler/loader {
@@ -122,6 +118,7 @@ import ./cli_support.vibe {
   check_redundant_import_warnings_from_source_groups,
   check_unstable_surface_warnings_from_closure,
   check_unstable_surface_warnings_from_path,
+  configure_cfg_flags,
   strip_executable_wasm_env,
   unstable_closure_reset,
   unstable_surface_diagnostics,
@@ -609,40 +606,6 @@ fn profile_memory_mark(enabled: Bool) -> Unit with Env {
   } else {
     ()
   }
-}
-
-/// #2513: the `#cfg` flag set is process-wide. `VIBE_CFG=flag1,flag2` is read
-/// once here, handed to the parser as its ambient set (so every module of the
-/// program -- the entry, its imports, contract facades -- sees the same
-/// active flags) and folded into the persistent cache version tag (so a module
-/// parsed under one flag set is never replayed under another). Whitespace
-/// around a flag is trimmed and empty items are dropped; the cache segment
-/// keeps the caller's order, so a re-spelling of the same set is a cache miss,
-/// which is the safe direction.
-fn cfg_flags_from_csv(cfg_csv: String) -> Array[String] {
-  let flags: Array[String] = []
-  if cfg_csv == "" {
-    flags
-  } else {
-    let parts = String::split(cfg_csv, ",")
-    let mut i = 0
-    while i < Array::length(parts) {
-      let flag = String::trim(Array::get(parts, i))
-      if String::length(flag) > 0 {
-        Array::push(flags, flag)
-      } else {
-        ()
-      }
-      i = i + 1
-    }
-    flags
-  }
-}
-
-fn configure_cfg_flags() -> Unit with Env {
-  let flags = cfg_flags_from_csv(Env::get("VIBE_CFG"))
-  set_cfg_ambient_flags(flags)
-  set_persistent_cache_cfg_flags(String::join(flags, ","))
 }
 
 /// #cfg activation on the single-file lane, kept for the byte-offset property:

--- a/lib/@vibe/compiler/cli_support.vibe
+++ b/lib/@vibe/compiler/cli_support.vibe
@@ -16,6 +16,14 @@ import @vibe/compiler/core {
   Stmt, dir_of_path, is_contract_ext, unstable_package_note
 }
 
+import @vibe/compiler/cache {
+  set_persistent_cache_cfg_flags
+}
+
+import @vibe/parser {
+  set_cfg_ambient_flags
+}
+
 import @vibe/compiler/checker {
   detect_redundant_namespace_imports
 }
@@ -1085,6 +1093,43 @@ export fn strip_executable_wasm(wasm: Bytes, entry_name: String, strip_names: Bo
   } else {
     wasm
   }
+}
+
+/// #2513: the `#cfg` flag set is process-wide. `VIBE_CFG=flag1,flag2` is read
+/// once per CLI invocation -- by BOTH entries, `cli_adapter.vibe`'s `cli_main`
+/// (the compiler's own env-mode adapter) and `lib/@vibe/cli/dispatch.vibe`'s
+/// `selfhost_cli_dispatch_args` (the split CLI behind `vibe build`), which is
+/// why it lives here rather than in either -- handed to the parser as its ambient set (so every module of the
+/// program -- the entry, its imports, contract facades -- sees the same
+/// active flags) and folded into the persistent cache version tag (so a module
+/// parsed under one flag set is never replayed under another). Whitespace
+/// around a flag is trimmed and empty items are dropped; the cache segment
+/// keeps the caller's order, so a re-spelling of the same set is a cache miss,
+/// which is the safe direction.
+fn cfg_flags_from_csv(cfg_csv: String) -> Array[String] {
+  let flags: Array[String] = []
+  if cfg_csv == "" {
+    flags
+  } else {
+    let parts = String::split(cfg_csv, ",")
+    let mut i = 0
+    while i < Array::length(parts) {
+      let flag = String::trim(Array::get(parts, i))
+      if String::length(flag) > 0 {
+        Array::push(flags, flag)
+      } else {
+        ()
+      }
+      i = i + 1
+    }
+    flags
+  }
+}
+
+export fn configure_cfg_flags() -> Unit with Env {
+  let flags = cfg_flags_from_csv(Env::get("VIBE_CFG"))
+  set_cfg_ambient_flags(flags)
+  set_persistent_cache_cfg_flags(String::join(flags, ","))
 }
 
 /// Env-gated policy wrapper shared by the CLI adapter (env-mode interface) and

--- a/lib/@vibe/compiler/index.vpkg
+++ b/lib/@vibe/compiler/index.vpkg
@@ -527,6 +527,7 @@ fn unstable_surface_diagnostics(input_path: String, source: String) -> Array[Str
 fn unstable_surface_diagnostics_located(input_path: String, detected: String, located: String) -> Array[String] with Exception
 fn strip_executable_wasm(wasm: Bytes, entry_name: String, strip_names: Bool, filter_exports: Bool) -> Bytes
 fn strip_executable_wasm_env(wasm: Bytes, entry_name: String) -> Bytes with Env
+fn configure_cfg_flags() -> Unit with Env
 fn write_linked_debug_build(input_path: String, output_path: String, entry_name: String) -> Unit with Exception + Fs
 fn write_linked_debug_build_checked(input_path: String, output_path: String, entry_name: String, allow_unstable: Bool) -> Unit with Exception + Fs
 

--- a/lib/@vibe/parser/cfg_ambient_test.vibe
+++ b/lib/@vibe/parser/cfg_ambient_test.vibe
@@ -1,0 +1,22 @@
+import ./lexer.vibe {
+  lex
+}
+
+import ./parser.vibe {
+  parse_program, set_cfg_ambient_flags
+}
+
+// #2513: the ambient flag set the CLI fills from VIBE_CFG is active for every
+// parse, in union with the file's own `#cfg_enable` directives.
+test "ambient #cfg flags select guarded statements in any parsed module" {
+  let src = "#cfg(dev)\nlet a = 1\n#cfg(release)\nlet b = 2\nlet c = 3"
+  set_cfg_ambient_flags([])
+  inspect(Array::length(parse_program(lex(src))), "1")
+  set_cfg_ambient_flags(["dev"])
+  inspect(Array::length(parse_program(lex(src))), "2")
+  set_cfg_ambient_flags(["dev", "release"])
+  inspect(Array::length(parse_program(lex(src))), "3")
+  set_cfg_ambient_flags([])
+  inspect(Array::length(parse_program(lex(String::concat(src, "\n#cfg_enable(release)")))), "2")
+  set_cfg_ambient_flags([])
+}

--- a/lib/@vibe/parser/index.vpkg
+++ b/lib/@vibe/parser/index.vpkg
@@ -178,6 +178,7 @@ fn parse_stmt_with_binder_context(tokens: Array[Token], starts: Array[Int], pos:
 fn parse_stmt_preserving(tokens: Array[Token], starts: Array[Int], pos: Int) -> (Stmt, Int) with Exception
 fn parse_stmt_preserving_with_binder_context(tokens: Array[Token], starts: Array[Int], pos: Int, context: Option[ParserBinderContext]) -> (Stmt, Int) with Exception
 fn parse_program(tokens: Array[Token]) -> Array[Stmt] with Exception
+fn set_cfg_ambient_flags(flags: Array[String]) -> Unit
 fn parse_program_preserving(tokens: Array[Token]) -> Array[Stmt] with Exception
 fn parse_program_located(tokens: Array[Token], starts: Array[Int], src: String) -> Array[Stmt] with Exception
 // Explicit untrusted transport seam: caller context is forgeable and cannot

--- a/lib/@vibe/parser/parser.vibe
+++ b/lib/@vibe/parser/parser.vibe
@@ -742,6 +742,11 @@ fn parse_impl_methods(tokens: Array[Token], pos: Int, simpl: Stmt, context: Opti
 // never be imported. The same set has to be part of every persistent cache
 // key (persistent_cache_version_tag folds it in), or a module parsed under
 // one flag set is replayed under another.
+//
+// NOTE: the compiler's own sources still must not use `#cfg`: the flattened
+// self-build and the span-based tools go through `parse_program_spans`, which
+// refuses every `#` directive except `#zero_alloc` (see the THash arm there).
+// Lifting that is the first step of #2497.
 
 let cfg_ambient_flags: Array[String] = []
 

--- a/lib/@vibe/parser/parser.vibe
+++ b/lib/@vibe/parser/parser.vibe
@@ -732,8 +732,30 @@ fn parse_impl_methods(tokens: Array[Token], pos: Int, simpl: Stmt, context: Opti
 // at the END keeps every source offset -- and thus diagnostics -- unchanged).
 // A pre-scan collects the active set so `#cfg_enable` position is irrelevant.
 //
-// NOTE: `#cfg` must not be used in the compiler's own source until the seed
-// compiler understands it (docs/selfhost-bootstrap.md bump procedure).
+// The active set is the union of two sources: the `#cfg_enable` directives in
+// the file itself, and the AMBIENT set below, which the CLI fills once per
+// process from `VIBE_CFG` (#2513). Before the ambient set existed the flags
+// reached only the entry file: the CLI appended `#cfg_enable` to the entry
+// source, and every imported module scanned its own token stream, saw no
+// directive, and dropped all of its `#cfg` statements whatever `VIBE_CFG`
+// said. A dependency that spells `#cfg(dev) export fn f` could therefore
+// never be imported. The same set has to be part of every persistent cache
+// key (persistent_cache_version_tag folds it in), or a module parsed under
+// one flag set is replayed under another.
+
+let cfg_ambient_flags: Array[String] = []
+
+/// Replace the process-wide ambient `#cfg` flag set. Called once per CLI
+/// invocation from the environment; every subsequent parse of any module
+/// treats these flags as active in addition to the file's own `#cfg_enable`.
+export fn set_cfg_ambient_flags(flags: Array[String]) -> Unit {
+  Array::truncate(cfg_ambient_flags, 0)
+  let mut i = 0
+  while i < Array::length(flags) {
+    Array::push(cfg_ambient_flags, Array::get(flags, i))
+    i = i + 1
+  }
+}
 
 /// Parse the directive after a THash: `cfg(name)`, `cfg_enable(name)`,
 /// `zero_alloc`, or `deprecated` (#1262 ADR-0101 migration marker; optional
@@ -787,10 +809,16 @@ fn parse_cfg_directive(tokens: Array[Token], pos: Int) -> (String, String, Int) 
 }
 
 /// Pre-scan the whole token stream for `#cfg_enable(name)` directives and
-/// return the active flag set. O(tokens), with one fresh result allocation;
-/// the result does not grow unless a THash enables a flag.
+/// return the active flag set: the ambient set first, then the file's own
+/// directives. O(tokens), with one fresh result allocation; the result does
+/// not grow unless a THash enables a flag or the ambient set is non-empty.
 fn cfg_scan_enabled(tokens: Array[Token]) -> Array[String] with Exception {
   let out = ArrayBuilder::freeze(ArrayBuilder::new())
+  let mut a = 0
+  while a < Array::length(cfg_ambient_flags) {
+    Array::push(out, Array::get(cfg_ambient_flags, a))
+    a = a + 1
+  }
   let mut i = 0
   let n = Array::length(tokens)
   while i < n {

--- a/tests/gates/late/run.sh
+++ b/tests/gates/late/run.sh
@@ -7509,6 +7509,59 @@ SCEOF
   echo "[compiler-gate] the split CLI refuses an unstable dependency cold AND warm, and still builds clean programs ok (#2305)"
 fi
 
+# 127/127 (#2513). The #cfg flag set reaches IMPORTED modules through the split
+# CLI. This dispatcher (lib/@vibe/cli/dispatch.vibe) never passes through
+# cli_adapter's cli_main, so the process-wide flag configuration has to be made
+# in both entries: gate 40g (mid lane) covers the adapter, this covers the
+# dispatcher, on the split CLI core section 114 just built or was handed.
+# Three builds on one cache directory -- dev, release, dev -- the third proving
+# that a flag switch is a cache miss, not a replay; then a no-flag build must be
+# refused (the guarded `f` is then in neither arm), so the section also fails
+# if something starts enabling every flag.
+echo "[compiler-gate] 127/127 #cfg flags reach imported modules through the split CLI (#2513)"
+cfsdir="_build/_gate_split_cli_cfg"
+rm -rf "$cfsdir"; mkdir -p "$cfsdir"
+cat > "$cfsdir/dep.vibe" <<'SCEOF'
+#cfg(dev)
+export fn f(x: Int) -> Int { x + 100 }
+
+#cfg(release)
+export fn f(x: Int) -> Int { x + 1 }
+SCEOF
+cat > "$cfsdir/main.vibex" <<'SCEOF'
+import ./dep.vibe { f }
+
+fn main() -> Unit with Stdout {
+  println(Int::to_string(f(1)))
+}
+SCEOF
+cfs_got=""
+for cfs_flag in dev release dev; do
+  rm -f "$cfsdir/b.wasm"
+  env VIBE_CFG="$cfs_flag" VIBE_BUILD_CACHE_DIR="$cfsdir/cache" VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_IMPORT_ABI=raw \
+    bash scripts/run_wasm_vibe_host_runner.sh --invoke _start "$sc_abs" \
+    build "$cfsdir/main.vibex" -o "$cfsdir/b.wasm" >/dev/null 2>&1 || true
+  if [ -s "$cfsdir/b.wasm" ]; then
+    cfs_got="$cfs_got $(VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh "$cfsdir/b.wasm" 2>&1 | tail -1)"
+  else
+    cfs_got="$cfs_got nocompile"
+  fi
+done
+if [ "$cfs_got" != " 101 2 101" ]; then
+  echo "[compiler-gate] FAIL: #cfg through the split CLI (dev, release, warm dev) answered '$cfs_got', want ' 101 2 101' (#2513)" >&2
+  exit 1
+fi
+rm -f "$cfsdir/b.wasm"
+env -u VIBE_CFG VIBE_BUILD_CACHE_DIR="$cfsdir/cache" VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_IMPORT_ABI=raw \
+  bash scripts/run_wasm_vibe_host_runner.sh --invoke _start "$sc_abs" \
+  build "$cfsdir/main.vibex" -o "$cfsdir/b.wasm" >/dev/null 2>&1 || true
+if [ -s "$cfsdir/b.wasm" ]; then
+  echo "[compiler-gate] FAIL: with no VIBE_CFG the split CLI built a program whose only f is #cfg-guarded (#2513)" >&2
+  exit 1
+fi
+rm -rf "$cfsdir"
+echo "[compiler-gate] #cfg flags reach imported modules through the split CLI, and a flag switch is a cache miss ok (#2513)"
+
 # 115/115. `vibe lsp` publishDiagnostics carries the ADR-0068 opt-in (#2297).
 # Section 108 covers the boundary on `vibe check --single-file`, in both its
 # text and its `--json` form -- but the JSON form only reports it because the

--- a/tests/gates/mid/run.sh
+++ b/tests/gates/mid/run.sh
@@ -590,8 +590,42 @@ if [ "$cf_dev" != "102" ] || [ "$cf_rel" != "2" ]; then
   echo "[compiler-gate] FAIL: #cfg selection wrong (dev='$cf_dev' want 102, release='$cf_rel' want 2)" >&2
   exit 1
 fi
+# FS lane (#2513): the flag set must reach IMPORTED modules too (the flags used
+# to be appended to the entry source only, so a `#cfg` in a dependency was
+# dropped whatever VIBE_CFG said), and a warm compile after switching the flag
+# must be a cache miss, never a replay of the other flag's artifacts -- the
+# third compile below reuses the cache directory the first two filled.
+cat > "$cfdir/dep.vibe" <<'VIBE'
+#cfg(dev)
+export fn f(x: Int) -> Int { x + 100 }
+
+#cfg(release)
+export fn f(x: Int) -> Int { x + 1 }
+VIBE
+cat > "$cfdir/main.vibe" <<'VIBE'
+import ./dep.vibe { f }
+
+fn main() -> Int { f(1) }
+VIBE
+cf_fs_got=""
+for cf_flag in dev release dev; do
+  rm -f "$cfdir/fs.wasm" "$cfdir/fs.wasm.diag"
+  VIBE_CFG="$cf_flag" VIBE_FS_COMPILE=1 VIBE_BUILD_CACHE_DIR="$cfdir/cache" \
+    VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_IMPORT_ABI=raw \
+    bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
+    "$cfdir/main.vibe" "$cfdir/fs.wasm" main >/dev/null 2>&1 || true
+  if [ -s "$cfdir/fs.wasm" ]; then
+    cf_fs_got="$cf_fs_got $(VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh "$cfdir/fs.wasm" 2>&1 | tail -1)"
+  else
+    cf_fs_got="$cf_fs_got nocompile($(tr '\n' ' ' < "$cfdir/fs.wasm.diag" 2>/dev/null | cut -c1-80))"
+  fi
+done
+if [ "$cf_fs_got" != " 101 2 101" ]; then
+  echo "[compiler-gate] FAIL: #cfg on the FS lane (dev, release, warm dev) answered '$cf_fs_got', want ' 101 2 101' (#2513)" >&2
+  exit 1
+fi
 rm -rf "$cfdir"
-echo "[compiler-gate] #cfg conditional compilation ok (dev=102 release=2)"
+echo "[compiler-gate] #cfg conditional compilation ok (dev=102 release=2; FS lane + warm switch ok)"
 
 # 40h. wasm-gc backend smoke: the VIBE_BACKEND=gc lane (selfhost port of the
 #      gc backend, wired through the adapter) must compile and run the

--- a/tests/gates/registry.tsv
+++ b/tests/gates/registry.tsv
@@ -250,3 +250,4 @@ x-adr-0090-1937-exception-unwind-region-restore	late	ADR-0090 #1937 exception-un
 124/124	late	124/124 contract unknown type heads are refused by the full and buffer lanes (#2317)
 125/125	late	125/125 FS-lane Double call-result offsets ride the modular check (#2391)
 126/126	late	126/126 FS-lane String binop channel rides the modular check (#2391)
+127/127	late	127/127 #cfg flags reach imported modules through the split CLI (#2513)


### PR DESCRIPTION
## Summary

Fixes #2513, the prerequisite for the `#cfg` build-unit work under #2492 (#2497, #2502, #2504).

`VIBE_CFG=dev` used to reach the entry file only: `apply_cfg_env` appended `#cfg_enable` directives to the entry source, and every imported module's parse scanned its own token stream, saw no directive, and dropped all of its `#cfg` statements whatever the flag said. Measured on the seed with a two-file probe (`#cfg(dev) export fn f` in a dependency): both `dev` and `release` failed with `imported name 'f' is not exported`. So no library module could carry a `#cfg`.

## Change

- `lib/@vibe/parser/parser.vibe`: a process-wide ambient flag set (`set_cfg_ambient_flags`); `cfg_scan_enabled` returns the ambient set unioned with the file's own `#cfg_enable` directives, so every parse in an invocation sees the same active flags. The "must not be used in the compiler's own source" note stays, with its real remaining cause: `parse_program_spans` (module-source emission for the flattened self-build, and the span-based tools) still refuses every `#` directive except `#zero_alloc`; lifting that is the first step of #2497 (Codex review, third commit).
- `lib/@vibe/compiler/cache/persistent_cache.vibe`: `persistent_cache_version_tag()` gains a `|cfg=<flags>` segment, present only when `VIBE_CFG` is set. The tag prefixes every persistent key, so headers, source groups, typing environments, artifacts and codegen bodies parsed under one flag set are never replayed under another, and a no-flag build keeps the cache it had.
- `lib/@vibe/compiler/cli_support.vibe`: `configure_cfg_flags()` reads `VIBE_CFG` once and sets both. It is called first thing by **both** CLI entries: `cli_adapter.vibe`'s `cli_main` (the compiler's env-mode adapter) and `lib/@vibe/cli/dispatch.vibe`'s `selfhost_cli_dispatch_args` (the split CLI behind `vibe build`), which never passes through the former (Codex review, second commit). `apply_cfg_env` stays for the single-file source's own record.
- Gates: mid 40g (`tests/gates/mid/run.sh`) grows the two-file shape compiled under `dev`, `release`, then `dev` on one cache directory, expecting 101, 2, 101 (the third compile proves a flag switch is a cache miss, not a replay). New late 127/127 does the same through the split CLI core that section 114 builds, and additionally requires the no-flag build to be refused. Registry row added.
- `lib/@vibe/parser/cfg_ambient_test.vibe`: the ambient union in isolation.
- `docs/cheatsheet.md`, `docs/build-cache.md`: the final behavior.

## Validation

- stage2 rebuilt from the final sources via `scripts/generations.sh build` (stage1/stage2 validation passed).
- Two-file probe on the FS lane through that stage2: `dev` → 101, `release` → 2, warm `dev` on the same cache → 101. Single-file `fixtures/cfg_flag_test.vibe` still 102.
- Split CLI (`lib/@vibe/cli/main.vibex` built with the seed from these sources): `check` on the probe is clean under `dev` and `release` and reports `not exported` with no flag; the 127/127 block passes and fails (`nocompile nocompile nocompile`) with the flag name mutated. The 40g block likewise passes and fails when mutated.
- `scripts/experimental_typing_env_reuse_oracle.mjs`, `scripts/artifact_input_trace_oracle.mjs`, `scripts/ingestion_stamp_oracle.mjs` pass against the new stage2.
- `cfg_ambient_test`, `parser_smoke_test`, `dispatch_test` (49) and the cache test files pass against it via `VIBE_TEST_CLI_WASM`.
- `scripts/check_gate_registry.sh`, `vibe_fmt --check`, the two doc gates, and the pre-commit lint gates pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0135RDJv1VCvuJqYKF88kGhU