### PR TITLE
checker: the return-provenance lookup reads an index; loader: one export-list memo entry per contract path (#2386)

### DIFF
--- a/lib/@vibe/compiler/loader/header_cache.vibe
+++ b/lib/@vibe/compiler/loader/header_cache.vibe
@@ -269,24 +269,39 @@ fn string_array_contains_hc(items: Array[String], target: String) -> Bool {
 /// (contract-)parses `resolved` exactly once instead, mirroring the same
 /// decls/opaques/collect_exports combination the contract-header branch above
 /// already uses for its own `exports` result.
-/// #2386: the export names of a contract, per (path, stat token), for the
-/// process. `validate_import_names_fs` asks for a dependency's export list
-/// once per IMPORTER of that dependency, and each ask read, lexed and parsed
-/// the contract again -- on a cold compiler-closure compile that was every
+/// #2386: the export names of a contract, one entry per path for the
+/// process, each stamped with the stat token it was read under.
+/// `validate_import_names_fs` asks for a dependency's export list once per
+/// IMPORTER of that dependency, and each ask read, lexed and parsed the
+/// contract again -- on a cold compiler-closure compile that was every
 /// package contract parsed once per member of every package importing it.
 /// The token is what every persistent cache on this lane keys freshness on,
 /// so an edited contract is re-read on the next compile that sees the new
-/// token. The list is handed out shared and never mutated by its reader
-/// (`string_array_contains_hc` only scans it).
-let export_names_memo: MutMap[String, Array[String]] = MutMap::new_string()
+/// token, and (review on #2512) the new reading REPLACES the path's entry
+/// rather than sitting next to it: a resident compiler holds one list per
+/// contract, however often the contract is edited. The list is handed out
+/// shared and never mutated by its reader (`string_array_contains_hc` only
+/// scans it).
+let export_names_memo: MutMap[String, (Int, Array[String])] = MutMap::new_string()
 
 fn resolved_export_names_fs(resolved: String) -> Array[String] with Exception + Fs {
-  let memo_key = String::concat(__to_string(Fs::stat_token(resolved)), String::concat("\n", resolved))
-  match MutMap::get(export_names_memo, memo_key) {
-    Some(hit) => hit,
+  let token = Fs::stat_token(resolved)
+  let fresh = match MutMap::get(export_names_memo, resolved) {
+    Some(entry) => {
+      let (seen_token, names) = entry
+      if seen_token == token {
+        Some(names)
+      } else {
+        None
+      }
+    },
+    None => None
+  }
+  match fresh {
+    Some(names) => names,
     None => {
       let computed = resolved_export_names_uncached_fs(resolved)
-      MutMap::set(export_names_memo, memo_key, computed)
+      MutMap::set(export_names_memo, resolved, (token, computed))
       computed
     }
   }


### PR DESCRIPTION
## What

The Codex round-1 finding on #2512 (P2), which merged while the fix was in validation, so it lands here on its own. Byte-identical to main on every corpus.

### `4d0b84a` — the memo holds one entry per contract path

#2512 keyed the export-list memo by (stat token, path), so in a resident compiler (`vibe --daemon`, the hosted component) every edit of a contract added a key and no key was ever dropped: one export list retained per historical version of every contract for the life of the process. The memo is keyed by path now and its value carries the stat token the list was read under — a hit under the same token answers, a different token re-reads the contract and replaces the path's entry, so a contract has one list in memory however often it is edited.

`export_names_memo_test`'s rewrite case (grown by a declaration, then shrunk back) goes through the replacement path twice with unchanged answers; the Red build without the token compare still fails it with the stale `"later_fn" is not exported by ./pkg`.

### Measured

Same protocol as #2512 (cache-isolated, `codegen_lexer_test.vibe` over the full compiler closure, N=3 interleaved, idle machine), against a stage2 built from main's tree before #2512 (`e898dcd`):

| | main before #2512 | this head |
|---|---:|---:|
| cold wall, mean of 3 | 8.38 s | 8.20 s |
| warm wall, mean of 3 | 4.57 s | 4.59 s |
| heap_ptr cold / warm | 1,357,485,272 / 652,896,776 | 1,251,696,112 / 652,900,608 |

#2512's −105.8 MB cold stands; against #2512's own head the rekey moves heap_ptr by −32 kB cold / +2.7 kB warm, wall within noise. Byte-identical output on three closures and 22 rc fixtures.

## Validation

Chain on the pre-rebase commit `4d81510` (same diff, parent `6463df6` = #2512's head): stage2 == stage3; `test_cli_core.sh`; selfcompile KPI heap_ptr 1,251,725,472 bytes; typing-env-reuse oracle; 110/110 affected unit-test files; `compiler_gate.sh` early / mid / late. The same chain was green on `c4b5e4b` (this commit on `ed4024b` plus the next checker slice, which merged-after moved to its own PR): stage2 == stage3, output equivalence, `test_cli_core.sh`, KPI, oracle, 202/202 affected files, gate early / mid / late.

`vibe_fmt.sh --check` is a fixpoint on the changed file.

Refs #2386. Follow-up to #2512 (https://github.com/mizchi/vibe-lang/pull/2512#discussion_r3935547097).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QKZdvBvHVUagwg6Yih8er8