### PR TITLE
checker: the return-provenance lookup reads an index instead of scanning the type table (#2386)

### DIFF
--- a/lib/@vibe/compiler/checker/checker.vibe
+++ b/lib/@vibe/compiler/checker/checker.vibe
@@ -70,7 +70,7 @@ import ./builtins.vibe {
 }
 
 import @vibe/core {
-  array_empty
+  array_empty, struct MutMap
 }
 
 import ./checker_exhaustive.vibe {
@@ -3854,16 +3854,30 @@ fn return_provenance_key(id: Int) -> Int {
   0 - id - 1000000000
 }
 
+/// #2386: the return-provenance keys written to the type table of the check
+/// in progress. `return_provenance_was_written` scanned the WHOLE table --
+/// one row per recorded expression of the module -- once per function body
+/// checked, with no early exit; the only writer of such a key is
+/// `append_legacy_typed_occurrence` at its one ReturnProvenance site, and
+/// every program check starts from a fresh table, so the set is reset where
+/// the table is (`reset_return_provenance_index`, the three creation sites
+/// in checker_stmt.vibe) and marked where the row is pushed.
+let return_provenance_index: Array[MutMap[String, Int]] = [MutMap::new_string()]
+
+export fn reset_return_provenance_index() -> Unit {
+  Array::set(return_provenance_index, 0, MutMap::new_string())
+}
+
+fn mark_return_provenance_written(id: Int) -> Unit {
+  MutMap::set(Array::get(return_provenance_index, 0), __to_string(return_provenance_key(id)), 1)
+}
+
+/// True iff a ReturnProvenance row for `id` was pushed to the type table of
+/// the check in progress (the table itself is the authority the index
+/// mirrors; it is kept as the parameter for that reason).
 fn return_provenance_was_written(tytab: Array[(Int, Type)], id: Int) -> Bool {
-  let wanted = return_provenance_key(id)
-  let mut found = false
-  for entry in tytab {
-    let (off, _) = entry
-    if off == wanted {
-      found = true
-    }
-  }
-  found
+  let _ = tytab
+  MutMap::has(Array::get(return_provenance_index, 0), __to_string(return_provenance_key(id)))
 }
 
 fn is_enum_ctor_name(name: String, defs: Array[TypeDef]) -> Bool {
@@ -12442,6 +12456,7 @@ fn check_expr_capture_impl(expr: Expr, env: TypeEnv, defs: Array[TypeDef], s: Su
       }
       let s2 = match env_lookup(env, "__return_provenance__") {
         Some(CtVar(id)) => {
+          mark_return_provenance_written(id)
           append_legacy_typed_occurrence(tytab, return_provenance_key(id), CtUnit, capture, "ReturnProvenance", "SyntheticRewrite")
           let previous = subst_apply(s1, CtVar(id))
           let merged = match previous {

--- a/lib/@vibe/compiler/checker/checker_stmt.vibe
+++ b/lib/@vibe/compiler/checker/checker_stmt.vibe
@@ -90,6 +90,7 @@ import ./checker.vibe {
   report_map_key_types,
   report_unknown_type_names,
   report_unknown_type_names_deferred_validation,
+  reset_return_provenance_index,
   resolve_trait_bound_self_reference,
   trait_erased_type_param_env,
   trait_reference_display,
@@ -5323,6 +5324,7 @@ fn check_program_type_defs_observation_impl(stmts: Array[Stmt], capture: Option[
   }
   let seeded_env = env_cache(seeded_raw_env)
   let tytab = array_empty()
+  reset_return_provenance_index()
   // #986: labeled-argument name validation (unknown / out-of-order labels).
   // Must run after desugar_labeled_args above.
   check_labeled_arg_names_stmts(stmts, frozen_errors, false)
@@ -6939,6 +6941,7 @@ export fn check_program_type_table(stmts: Array[Stmt]) -> (Array[(Int, Type)], S
   let errors = ArrayBuilder::new()
   let frozen_errors = ArrayBuilder::freeze(errors)
   let tytab = array_empty()
+  reset_return_provenance_index()
   handle {
     let (_, final_s, _) = check_stmts(stmts, 0, seeded_env, empty_defs, SubstEmpty, 0, frozen_errors, tytab)
     (tytab, final_s)
@@ -6991,6 +6994,7 @@ fn check_program_with_env_type_defs_observation_impl(stmts: Array[Stmt], initial
       }
       let seeded_env = env_cache(seeded_raw_env)
       let tytab = array_empty()
+      reset_return_provenance_index()
       // #986: labeled-argument name validation (see check_program).
       check_labeled_arg_names_stmts(stmts, frozen_errors, false)
       // Keep CheckedProgram.checked_stmts as the original post-desugar source,

--- a/lib/@vibe/compiler/checker/index.vpkg
+++ b/lib/@vibe/compiler/checker/index.vpkg
@@ -342,3 +342,4 @@ fn file_tests_cacheable(stmts: Array[Stmt]) -> Bool
 fn file_entry_cacheable(stmts: Array[Stmt], entry_name: String) -> Bool
 fn check_mutability_expr(expr: Expr, mutable: Array[String]) -> Array[EffectError]
 fn check_mutability_stmts(stmts: Array[Stmt]) -> Array[EffectError]
+fn reset_return_provenance_index() -> Unit

--- a/lib/@vibe/compiler/tests/return_provenance_index_test.vibe
+++ b/lib/@vibe/compiler/tests/return_provenance_index_test.vibe
@@ -1,0 +1,42 @@
+//# #2386: the return-provenance lookup answers from an index instead of a
+//# scan of the whole type table. What it protects (the fixture
+//# `err_region_escape_early_return.vibe`, pinned by the late gate through
+//# the CLI): a callback's capture provenance handed back through an explicit
+//# `return` inside the function still reaches the call site, so a region
+//# value escaping through that path is rejected. Here the same program goes
+//# through the checker library directly, so the answer comes from the
+//# worktree's sources.
+
+import @vibe/compiler/runtime {
+  collect_all_diagnostics
+}
+
+import @vibe/compiler/checker {
+  set_error_row_checked
+}
+
+fn diags(src: String) -> Array[String] with Exception {
+  set_error_row_checked(true)
+  collect_all_diagnostics(src)
+}
+
+fn escape_program(return_path: Bool) -> String {
+  let head = if return_path {
+    "fn maybe_return(callback: () -> Array[Int]) -> () -> Array[Int] {\n  if true {\n    return () -> Array[Int] {\n      callback()\n    }\n  }\n  () -> Array[Int] {\n    []\n  }\n}\n\n"
+  } else {
+    "fn maybe_return(callback: () -> Array[Int]) -> () -> Array[Int] {\n  () -> Array[Int] {\n    callback()\n  }\n}\n\n"
+  }
+  String::concat(head, "fn use_it() -> Int {\n  let escaped = region r {\n    let values = MutList::empty(r)\n    maybe_return(() -> Array[Int] {\n      MutList::to_array(values)\n    })\n  }\n  let _ = escaped()\n  0\n}\n")
+}
+
+test "a region value escaping through an explicit-return callback is rejected" {
+  // Without the provenance row for the `return` path the region check sees a
+  // plain `() -> Array[Int]` and accepts the escape -- silently wrong.
+  let d = diags(escape_program(true))
+  assert_true(String::contains(String::join(d, " | "), "region escapes its scope"))
+}
+
+test "the tail-expression form is rejected the same way" {
+  let d = diags(escape_program(false))
+  assert_true(String::contains(String::join(d, " | "), "region escapes its scope"))
+}


### PR DESCRIPTION
## What

One checker slice of #2386 on the cold lane, byte-identical to main on every corpus. It was stacked on #2515, which merged while this commit was in validation, so it lands here on its own.

### `211d531` — the return-provenance lookup reads an index instead of scanning the type table

`return_provenance_was_written` answered "was a ReturnProvenance row pushed for this variable" by scanning the module's whole offset → type table — one row per recorded expression — with no early exit, once per function body checked: 0.21 s of table walking on a cold compiler-closure check. The keys are written at exactly one site (the `return e` funnel of `append_legacy_typed_occurrence`) and every program check starts from a fresh table, so the keys now live in a set that is reset where the table is created (the three creation sites in `checker_stmt.vibe`) and marked where the row is pushed; the query asks the set. The table stays the authority the set mirrors: no row is written without a mark, and no mark outlives its table.

`return_provenance_index_test.vibe` pins what the row protects: a region value escaping through a callback handed back by an explicit `return` (the shape of `fixtures/err_region_escape_early_return.vibe`, which the late gate checks through the CLI) is rejected with `region escapes its scope` through the checker library, in the explicit-return and the tail-expression forms. The file passes unchanged against the previous head's library; a mutation that pushes the row but never marks the index (the test compiles the worktree's library, so the Red run needs no compiler build) accepts the escape and fails the explicit-return case.

### Measured

Against #2515's head (same base), cache-isolated per the profiling skill, `codegen_lexer_test.vibe` over the full compiler closure, nine interleaved cold/warm pairs pooled from three N=3 rounds, idle machine:

| | #2515 head | this commit |
|---|---:|---:|
| `return_provenance_was_written` cold inclusive | 0.21 s | 0.00 s |
| `check_expr_capture_impl` / `check_module_impl` cold inclusive | 1.34 s / 3.07 s | 0.99 s / 2.61 s |
| cold wall, median of 9 (mean) | 8.57 s (8.72 s) | 8.43 s (8.42 s) — −1.7% median, 6 of 9 pairs faster |
| warm wall, median of 9 | 4.79 s | 4.84 s (noise; the pass runs on the cold lane) |
| heap_ptr cold / warm | 1,251,696,112 / 652,900,608 | 1,251,876,832 / 652,894,200 (+181 kB cold: the set) |

The wall delta sits at this machine's noise floor (single rounds ranged from −5% to +1%); the profile delta is the function's whole cost, measured on three builds (the third, on this exact tree: 0.21 s → 0.00 s, `check_module_impl` 3.07 s → 2.65 s). Byte-identical output on three closures and 22 rc fixtures.

## Validation

Chain on `211d531` (base `a59781f`, run in a staging worktree at that exact commit, tree hash checked against the pushed head): bundle regen; stage2 == stage3; output equivalence (three closures, 22 rc fixtures, byte-identical to a stage2 that predates #2514, so the `#cfg` change did not move the output either); `test_cli_core.sh`; selfcompile KPI heap_ptr 1,253,020,040 bytes; typing-env-reuse oracle; 202/202 affected unit-test files; `compiler_gate.sh` early / mid / late. The chain completed after the merge; the same chain was green before it on the pre-rebase commit `c4b5e4b` (same diff, parent = #2515's head): KPI heap_ptr 1,251,902,440 bytes, 202/202 affected files, gate early / mid / late.

`vibe_fmt.sh --check` is a fixpoint on every changed file.

Refs #2386.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QKZdvBvHVUagwg6Yih8er8