### PR TITLE
loader: parse each source once on the cold lane — re-export kinds, header pass, module check and contract members share one parse (#2386)

### DIFF
--- a/.claude/skills/compiler-perf-profiling/SKILL.md
+++ b/.claude/skills/compiler-perf-profiling/SKILL.md
@@ -56,6 +56,14 @@ Protocol for ANY before/after comparison on this lane:
   Both lanes matter: cold is CI / first build, warm is the dev inner loop.
 - **N≥3 runs per configuration** — single-run wall deltas under ~5% are
   noise on a shared machine.
+- **Alternate the order inside each interleaved pair (ABBA).** Measured
+  2026-09-04 on the export-kinds memo: with the baseline first in every
+  pair the candidate was slower in every pair (+3.7%); with the candidate
+  first it was faster in every pair. The second run of a pair pays ~0.3 s
+  on this machine, so a fixed order turns position into a result. Pool the
+  rounds and report the median next to the profile delta; a slice whose
+  whole cost is ~0.2 s sits at the wall noise floor and is judged on the
+  profile and the deterministic heap_ptr, not on wall.
 - `scripts/profile_compile.sh` does NOT isolate the cache; wrap it with
   `VIBE_BUILD_CACHE_DIR` yourself before trusting its wall/heap output.
 - Cross-check against the PR perf-report's deterministic rows (selfcompile

--- a/lib/@vibe/compiler/loader/header_cache.vibe
+++ b/lib/@vibe/compiler/loader/header_cache.vibe
@@ -506,6 +506,186 @@ export fn merge_impl_raws_dedupe(explicit: Array[String], discovered: Array[Stri
   out
 }
 
+/// #2386: one located parse per (path, exact source text) for the process,
+/// shared by the header pass above (a persisted-header MISS lexes and parses
+/// the whole file to find its imports and exports) and the typecheck walk's
+/// module check (`parse_program_with_path` in runtime/typecheck_fs.vibe),
+/// which used to keep its own memo and parse every module a second time on
+/// a cold compile. The two sites ran the identical `lex_with_offsets` +
+/// `parse_program_located` pair under the identical `<path>: <msg>` error
+/// wrapping, so one answer serves both.
+///
+/// Keyed by path, and each path keeps every source text it was asked with:
+/// a same-path re-ingest with different text is a real shape (#897's vpkg
+/// shared-import prefix marker), and the text is compared in full -- a
+/// compare is far cheaper than the parse it guards, and a fingerprint would
+/// make a collision a silent misparse.
+///
+/// The memo hands out a SHALLOW COPY of the top-level statement array, never
+/// the stored one: check_program mutates its argument in place at the top
+/// level (inject_trait_method_generics / desugar_railway_binds /
+/// desugar_labeled_args each `Array::set(stmts, i, ..)`), so the pristine
+/// array must not be shared. The Stmt values themselves are immutable.
+///
+/// A throwing parse is NOT memoized: a second caller re-parses and re-throws
+/// identically. The memo is bounded: `vibe --daemon` serves many compiles
+/// from one process and every edited source is a new (path, text) pair, so
+/// past 1024 texts the whole memo is dropped (one compile's worth of
+/// re-parsing, far above a self-compile's module count).
+/// `parse_program_located_shared_ran_parser` says whether the most recent
+/// call ran the parser; the typecheck walk's telemetry uses the
+/// first-semantic-use pair below instead (see `located_parse_memo_consumed`). Parallel arrays and a
+/// cell rather than tuples: the tuple-returning first draft trapped
+/// (`unreachable`) on the RC lane inside the first test that parsed.
+let located_parse_memo_sources: Array[MutMap[String, Array[String]]] = [
+  MutMap::new_string()
+]
+
+let located_parse_memo_stmts: Array[MutMap[String, Array[Array[Stmt]]]] = [
+  MutMap::new_string()
+]
+
+let located_parse_memo_size: Array[Int] = [0]
+
+let located_parse_memo_ran_parser: Array[Bool] = [false]
+
+/// Per version: whether a module check has consumed this parse yet. The
+/// typecheck walk's `current_source_parse_executions` counts the first
+/// semantic use of a (path, text) in the process -- the observable it had
+/// when the walk kept its own memo and always parsed on that first use --
+/// whether the parser ran in the check or, now, in the planning header
+/// pass. A version's flag lives beside it in `located_parse_memo_consumed`.
+let located_parse_memo_consumed: Array[MutMap[String, Array[Bool]]] = [
+  MutMap::new_string()
+]
+
+fn located_parse_consumed_versions(memo: MutMap[String, Array[Bool]], path: String) -> Array[Bool] {
+  match MutMap::get(memo, path) {
+    Some(found) => found,
+    None => array_empty()
+  }
+}
+
+/// True iff no module check has consumed the parse of (path, source) yet.
+/// Does not mark: a check marks with `parse_program_located_shared_mark_semantic`
+/// once its parse succeeded, so a throwing parse is asked about again.
+export fn parse_program_located_shared_semantic_pending(path: String, source: String) -> Bool {
+  let seen_sources = located_parse_versions(Array::get(located_parse_memo_sources, 0), path)
+  let hit = located_parse_version_index(seen_sources, source)
+  if hit < 0 {
+    true
+  } else {
+    let flags = located_parse_consumed_versions(Array::get(located_parse_memo_consumed, 0), path)
+    if hit < Array::length(flags) {
+      !Array::get(flags, hit)
+    } else {
+      true
+    }
+  }
+}
+
+export fn parse_program_located_shared_mark_semantic(path: String, source: String) -> Unit {
+  let seen_sources = located_parse_versions(Array::get(located_parse_memo_sources, 0), path)
+  let hit = located_parse_version_index(seen_sources, source)
+  if hit >= 0 {
+    let flags = located_parse_consumed_versions(Array::get(located_parse_memo_consumed, 0), path)
+    if hit < Array::length(flags) {
+      Array::set(flags, hit, true)
+    } else {
+      ()
+    }
+  } else {
+    ()
+  }
+}
+
+/// True iff the most recent `parse_program_located_shared` call ran the
+/// parser (a miss); false when it answered from the memo.
+export fn parse_program_located_shared_ran_parser() -> Bool {
+  Array::get(located_parse_memo_ran_parser, 0)
+}
+
+fn located_parse_versions(memo: MutMap[String, Array[String]], path: String) -> Array[String] {
+  match MutMap::get(memo, path) {
+    Some(found) => found,
+    None => array_empty()
+  }
+}
+
+fn located_parse_stmt_versions(memo: MutMap[String, Array[Array[Stmt]]], path: String) -> Array[Array[Stmt]] {
+  match MutMap::get(memo, path) {
+    Some(found) => found,
+    None => array_empty()
+  }
+}
+
+fn located_parse_version_index(seen_sources: Array[String], source: String) -> Int {
+  let mut hit = -1
+  let mut vi = 0
+  while vi < Array::length(seen_sources) && hit < 0 {
+    if Array::get(seen_sources, vi) == source {
+      hit = vi
+    } else {
+      ()
+    }
+    vi = vi + 1
+  }
+  hit
+}
+
+/// The parser call chain lives in its own function with no `match` in it:
+/// #708 (the RC-lane `unreachable` in `tk_name`) reproduces when
+/// lex_with_offsets/parse_program_located are compiled next to an Option
+/// match in the same function.
+fn located_parse_uncached(path: String, source: String) -> Array[Stmt] with Exception {
+  handle {
+    let (tokens, starts, _ends) = lex_with_offsets(source)
+    parse_program_located(tokens, starts, source)
+  } with { Exception::Throw(msg) => throw(String::concat(String::concat(path, ": "), msg)) }
+}
+
+fn located_parse_record(path: String, source: String, parsed: Array[Stmt]) -> Unit {
+  if Array::get(located_parse_memo_size, 0) >= 1024 {
+    Array::set(located_parse_memo_sources, 0, MutMap::new_string())
+    Array::set(located_parse_memo_stmts, 0, MutMap::new_string())
+    Array::set(located_parse_memo_consumed, 0, MutMap::new_string())
+    Array::set(located_parse_memo_size, 0, 0)
+  } else {
+    ()
+  }
+  let sources_now = Array::get(located_parse_memo_sources, 0)
+  let stmts_now = Array::get(located_parse_memo_stmts, 0)
+  let consumed_now = Array::get(located_parse_memo_consumed, 0)
+  if MutMap::has(sources_now, path) {
+    ()
+  } else {
+    MutMap::set(sources_now, path, array_empty())
+    MutMap::set(stmts_now, path, array_empty())
+    MutMap::set(consumed_now, path, array_empty())
+  }
+  Array::push(located_parse_versions(sources_now, path), source)
+  Array::push(located_parse_stmt_versions(stmts_now, path), parsed)
+  Array::push(located_parse_consumed_versions(consumed_now, path), false)
+  Array::set(located_parse_memo_size, 0, Array::get(located_parse_memo_size, 0) + 1)
+}
+
+export fn parse_program_located_shared(path: String, source: String) -> Array[Stmt] with Exception {
+  let seen_sources = located_parse_versions(Array::get(located_parse_memo_sources, 0), path)
+  let hit = located_parse_version_index(seen_sources, source)
+  if hit >= 0 {
+    Array::set(located_parse_memo_ran_parser, 0, false)
+    let cached = Array::get(located_parse_stmt_versions(Array::get(located_parse_memo_stmts, 0), path), hit)
+    Array::slice(cached, 0, Array::length(cached))
+  } else {
+    // Set before the parse: a throwing parse ran the parser too, and the
+    // exception leaves this function before anything after the call.
+    Array::set(located_parse_memo_ran_parser, 0, true)
+    let parsed = located_parse_uncached(path, source)
+    located_parse_record(path, source, parsed)
+    Array::slice(parsed, 0, Array::length(parsed))
+  }
+}
+
 export fn load_or_parse_module_header_fs_impl(path: String, source: String, parse_count: Int) -> (Array[String], Array[String], Int) with Exception + Fs {
   ingestion_pipeline_telemetry_add(10, 1)
   let cache_path = persistent_module_header_cache_path(path, compact_string_fingerprint(source))
@@ -637,10 +817,12 @@ export fn load_or_parse_module_header_fs_impl(path: String, source: String, pars
         None => (array_empty(), array_empty(), parse_count)
       }
     } else {
-      let (tokens, starts, _ends) = lex_with_offsets(source)
-      let stmts = handle {
-        parse_program_located(tokens, starts, source)
-      } with { Exception::Throw(msg) => throw(String::concat(path, String::concat(": ", msg))) }
+      // #2386: the located parse is shared with the typecheck walk (see
+      // parse_program_located_shared), so a source parsed here for its
+      // header is not parsed again for its check. `parse_count` still counts
+      // headers computed from source -- the number its callers report as
+      // header parse scans -- whether the memo answered or not.
+      let stmts = parse_program_located_shared(path, source)
       (collect_import_deps_from_stmts(stmts, dir_of_path(path), path, source), collect_exports(stmts), parse_count + 1)
     }
     let deps = header_result.0

--- a/lib/@vibe/compiler/loader/header_cache.vibe
+++ b/lib/@vibe/compiler/loader/header_cache.vibe
@@ -36,7 +36,7 @@ import @vibe/compiler/runtime/eval_loader {
 }
 
 import @vibe/compiler/syntax {
-  lex, lex_with_offsets, offset_to_line_col, parse_program, parse_program_located
+  cfg_ambient_flags_csv, lex, lex_with_offsets, offset_to_line_col, parse_program, parse_program_located
 }
 import @vibe/compiler/contract {
   classify_contract_stmts, contract_facade_marker, extract_package_version, extract_require_pins, parse_contract_program
@@ -515,7 +515,8 @@ export fn merge_impl_raws_dedupe(explicit: Array[String], discovered: Array[Stri
 /// `parse_program_located` pair under the identical `<path>: <msg>` error
 /// wrapping, so one answer serves both.
 ///
-/// Keyed by path, and each path keeps every source text it was asked with:
+/// Keyed by path, and each path keeps every (source text, ambient `#cfg`
+/// set) it was asked with:
 /// a same-path re-ingest with different text is a real shape (#897's vpkg
 /// shared-import prefix marker), and the text is compared in full -- a
 /// compare is far cheaper than the parse it guards, and a fingerprint would
@@ -545,6 +546,13 @@ let located_parse_memo_stmts: Array[MutMap[String, Array[Array[Stmt]]]] = [
   MutMap::new_string()
 ]
 
+/// Per version: the ambient `#cfg` set the text was parsed under. The parser
+/// keeps or drops `#cfg`-gated statements by that set, so the same text under
+/// another set is another parse (Codex review on #2520).
+let located_parse_memo_cfgs: Array[MutMap[String, Array[String]]] = [
+  MutMap::new_string()
+]
+
 let located_parse_memo_size: Array[Int] = [0]
 
 let located_parse_memo_ran_parser: Array[Bool] = [false]
@@ -571,7 +579,8 @@ fn located_parse_consumed_versions(memo: MutMap[String, Array[Bool]], path: Stri
 /// once its parse succeeded, so a throwing parse is asked about again.
 export fn parse_program_located_shared_semantic_pending(path: String, source: String) -> Bool {
   let seen_sources = located_parse_versions(Array::get(located_parse_memo_sources, 0), path)
-  let hit = located_parse_version_index(seen_sources, source)
+  let seen_cfgs = located_parse_versions(Array::get(located_parse_memo_cfgs, 0), path)
+  let hit = located_parse_version_index(seen_sources, seen_cfgs, source, cfg_ambient_flags_csv())
   if hit < 0 {
     true
   } else {
@@ -586,7 +595,8 @@ export fn parse_program_located_shared_semantic_pending(path: String, source: St
 
 export fn parse_program_located_shared_mark_semantic(path: String, source: String) -> Unit {
   let seen_sources = located_parse_versions(Array::get(located_parse_memo_sources, 0), path)
-  let hit = located_parse_version_index(seen_sources, source)
+  let seen_cfgs = located_parse_versions(Array::get(located_parse_memo_cfgs, 0), path)
+  let hit = located_parse_version_index(seen_sources, seen_cfgs, source, cfg_ambient_flags_csv())
   if hit >= 0 {
     let flags = located_parse_consumed_versions(Array::get(located_parse_memo_consumed, 0), path)
     if hit < Array::length(flags) {
@@ -619,11 +629,11 @@ fn located_parse_stmt_versions(memo: MutMap[String, Array[Array[Stmt]]], path: S
   }
 }
 
-fn located_parse_version_index(seen_sources: Array[String], source: String) -> Int {
+fn located_parse_version_index(seen_sources: Array[String], seen_cfgs: Array[String], source: String, cfg: String) -> Int {
   let mut hit = -1
   let mut vi = 0
   while vi < Array::length(seen_sources) && hit < 0 {
-    if Array::get(seen_sources, vi) == source {
+    if Array::get(seen_sources, vi) == source && vi < Array::length(seen_cfgs) && Array::get(seen_cfgs, vi) == cfg {
       hit = vi
     } else {
       ()
@@ -647,6 +657,7 @@ fn located_parse_uncached(path: String, source: String) -> Array[Stmt] with Exce
 fn located_parse_record(path: String, source: String, parsed: Array[Stmt]) -> Unit {
   if Array::get(located_parse_memo_size, 0) >= 1024 {
     Array::set(located_parse_memo_sources, 0, MutMap::new_string())
+    Array::set(located_parse_memo_cfgs, 0, MutMap::new_string())
     Array::set(located_parse_memo_stmts, 0, MutMap::new_string())
     Array::set(located_parse_memo_consumed, 0, MutMap::new_string())
     Array::set(located_parse_memo_size, 0, 0)
@@ -654,16 +665,19 @@ fn located_parse_record(path: String, source: String, parsed: Array[Stmt]) -> Un
     ()
   }
   let sources_now = Array::get(located_parse_memo_sources, 0)
+  let cfgs_now = Array::get(located_parse_memo_cfgs, 0)
   let stmts_now = Array::get(located_parse_memo_stmts, 0)
   let consumed_now = Array::get(located_parse_memo_consumed, 0)
   if MutMap::has(sources_now, path) {
     ()
   } else {
     MutMap::set(sources_now, path, array_empty())
+    MutMap::set(cfgs_now, path, array_empty())
     MutMap::set(stmts_now, path, array_empty())
     MutMap::set(consumed_now, path, array_empty())
   }
   Array::push(located_parse_versions(sources_now, path), source)
+  Array::push(located_parse_versions(cfgs_now, path), cfg_ambient_flags_csv())
   Array::push(located_parse_stmt_versions(stmts_now, path), parsed)
   Array::push(located_parse_consumed_versions(consumed_now, path), false)
   Array::set(located_parse_memo_size, 0, Array::get(located_parse_memo_size, 0) + 1)
@@ -671,7 +685,8 @@ fn located_parse_record(path: String, source: String, parsed: Array[Stmt]) -> Un
 
 export fn parse_program_located_shared(path: String, source: String) -> Array[Stmt] with Exception {
   let seen_sources = located_parse_versions(Array::get(located_parse_memo_sources, 0), path)
-  let hit = located_parse_version_index(seen_sources, source)
+  let seen_cfgs = located_parse_versions(Array::get(located_parse_memo_cfgs, 0), path)
+  let hit = located_parse_version_index(seen_sources, seen_cfgs, source, cfg_ambient_flags_csv())
   if hit >= 0 {
     Array::set(located_parse_memo_ran_parser, 0, false)
     let cached = Array::get(located_parse_stmt_versions(Array::get(located_parse_memo_stmts, 0), path), hit)

--- a/lib/@vibe/compiler/loader/index.vpkg
+++ b/lib/@vibe/compiler/loader/index.vpkg
@@ -125,6 +125,10 @@ fn check_deps_missing(root: String) -> Int with Exception + Fs
 fn contract_sibling_impl_raws(dir: String) -> Array[String] with Exception + Fs
 fn merge_impl_raws_dedupe(explicit: Array[String], discovered: Array[String]) -> Array[String]
 fn load_or_parse_module_header_fs_impl(path: String, source: String, parse_count: Int) -> (Array[String], Array[String], Int) with Exception + Fs
+fn parse_program_located_shared(path: String, source: String) -> Array[Stmt] with Exception
+fn parse_program_located_shared_ran_parser() -> Bool
+fn parse_program_located_shared_semantic_pending(path: String, source: String) -> Bool
+fn parse_program_located_shared_mark_semantic(path: String, source: String) -> Unit
 
 // --- manifest_sources.vibe
 fn join_path(base_dir: String, rel_path: String) -> String

--- a/lib/@vibe/compiler/loader/loader.vibe
+++ b/lib/@vibe/compiler/loader/loader.vibe
@@ -50,7 +50,7 @@ import @vibe/compiler/runtime/eval_loader {
 }
 
 import ./header_cache.vibe {
-  contract_sibling_impl_raws, load_or_parse_module_header_fs_impl, merge_impl_raws_dedupe
+  contract_sibling_impl_raws, load_or_parse_module_header_fs_impl, merge_impl_raws_dedupe, parse_program_located_shared
 }
 
 import @vibe/compiler/contract {
@@ -2366,7 +2366,10 @@ fn desugar_contract_source_fs(path: String, source: String) -> String with Excep
     // `.vibei` target is recursively desugared to its facade text instead of
     // being handed to parse_program as raw (bodyless) contract grammar.
     let impl_ingested = ingest_source_text_fs(resolved, resolved_content)
-    let impl_stmts = parse_program(lex(impl_ingested))
+    // #2386: the member is parsed through the shared located memo, so the
+    // header pass that later collects this member as a source (the same
+    // ingested text) answers from this parse instead of parsing it again.
+    let impl_stmts = parse_program_located_shared(resolved, impl_ingested)
     Array::push(impl_units, (raw, impl_stmts))
     // #847: a raw resolving to ANOTHER package's own index.vibei/index.vibe
     // (a cross-package or nested-boundary reference, e.g. `import ../pkgb

--- a/lib/@vibe/compiler/loader/loader.vibe
+++ b/lib/@vibe/compiler/loader/loader.vibe
@@ -102,15 +102,53 @@ import @vibe/compiler/contract {
 /// the same dependency set either way; a changed token re-reads. An answer
 /// is recorded only when the recursion beneath it met no `visiting` cycle,
 /// so a recorded answer never depends on the caller's `visiting` stack.
-/// Same blind spot as the persistent facade row it feeds: a change in path
-/// RESOLUTION with no file read changing (a new sibling shadowing a
-/// directory import) is not observed. One entry per path, replaced on a
-/// token change, so a resident compiler holds one answer per source.
-let exported_type_params_memo: MutMap[String, (Array[(String, Int)], Array[String], Array[(String, Array[String])])] = MutMap::new_string()
+/// A hit also re-runs every path resolution the recursion made (a nested
+/// `export ./target { T }` probing `target.vibe` before `target/index.vpkg`)
+/// and compares the answer, so a new file that now wins a resolution is
+/// observed even though no file that was read changed (Codex review on
+/// #2520). One entry per path, replaced on a token or resolution change, so
+/// a resident compiler holds one answer per source.
+let exported_type_params_memo: MutMap[String, (Array[(String, Int)], Array[String], Array[(String, Array[String])], Array[(String, String, String)])] = MutMap::new_string()
 
 let exported_type_params_read_log: Array[(String, Int)] = []
 
+let exported_type_params_resolve_log: Array[(String, String, String)] = []
+
 let exported_type_params_cycle_hits: Array[Int] = [0]
+
+/// A recorded answer is fresh when every file it read has the stat token it
+/// was read under and every path resolution it made answers the same. A plain
+/// function, not the match arm: `resolve_path_fs` discharges the Source
+/// effect with a handler, and that call chain inside an Option match arm is
+/// the #708 trap shape (it trapped here, `unreachable`, on the first hit
+/// with a recorded resolution).
+fn exported_type_params_entry_fresh(reads: Array[(String, Int)], resolves: Array[(String, String, String)]) -> Bool with Fs {
+  let mut same = true
+  let mut ri = 0
+  while ri < Array::length(reads) && same {
+    let (read_path, token) = Array::get(reads, ri)
+    // A file the answer read can be gone by now (a `target.vibe` that won a
+    // resolution, then deleted): absent is stale, and `Fs::stat_token` on a
+    // missing path traps rather than answering.
+    if !Fs::exists(read_path) || Fs::stat_token(read_path) != token {
+      same = false
+    } else {
+      ()
+    }
+    ri = ri + 1
+  }
+  let mut si = 0
+  while si < Array::length(resolves) && same {
+    let (base_dir, raw_path, resolved) = Array::get(resolves, si)
+    if resolve_path_fs(base_dir, raw_path) != resolved {
+      same = false
+    } else {
+      ()
+    }
+    si = si + 1
+  }
+  same
+}
 
 fn exported_type_params_fs(path: String, dep_paths: Array[String], dep_fingerprints: Array[String], visiting: Array[String]) -> Array[(String, Array[String])] with Exception + Fs {
   if contains_path(visiting, path) {
@@ -121,24 +159,14 @@ fn exported_type_params_fs(path: String, dep_paths: Array[String], dep_fingerpri
   }
   if Array::length(visiting) == 0 {
     Array::truncate(exported_type_params_read_log, 0)
+    Array::truncate(exported_type_params_resolve_log, 0)
   } else {
     ()
   }
   let fresh = match MutMap::get(exported_type_params_memo, path) {
     Some(entry) => {
-      let (reads, _, _) = entry
-      let mut same = true
-      let mut ri = 0
-      while ri < Array::length(reads) && same {
-        let (read_path, token) = Array::get(reads, ri)
-        if Fs::stat_token(read_path) != token {
-          same = false
-        } else {
-          ()
-        }
-        ri = ri + 1
-      }
-      if same {
+      let (reads, _, _, resolves) = entry
+      if exported_type_params_entry_fresh(reads, resolves) {
         Some(entry)
       } else {
         None
@@ -148,7 +176,7 @@ fn exported_type_params_fs(path: String, dep_paths: Array[String], dep_fingerpri
   }
   match fresh {
     Some(entry) => {
-      let (reads, fps, out) = entry
+      let (reads, fps, out, resolves) = entry
       let mut ri = 0
       while ri < Array::length(reads) {
         let (read_path, token) = Array::get(reads, ri)
@@ -157,17 +185,24 @@ fn exported_type_params_fs(path: String, dep_paths: Array[String], dep_fingerpri
         Array::push(exported_type_params_read_log, (read_path, token))
         ri = ri + 1
       }
+      let mut si = 0
+      while si < Array::length(resolves) {
+        Array::push(exported_type_params_resolve_log, Array::get(resolves, si))
+        si = si + 1
+      }
       out
     },
     None => {
       let log_mark = Array::length(exported_type_params_read_log)
+      let resolve_mark = Array::length(exported_type_params_resolve_log)
       let dep_mark = Array::length(dep_fingerprints)
       let hits_before = Array::get(exported_type_params_cycle_hits, 0)
       let out = exported_type_params_uncached_fs(path, dep_paths, dep_fingerprints, visiting)
       let reads = Array::slice(exported_type_params_read_log, log_mark, Array::length(exported_type_params_read_log))
       let fps = Array::slice(dep_fingerprints, dep_mark, Array::length(dep_fingerprints))
+      let resolves = Array::slice(exported_type_params_resolve_log, resolve_mark, Array::length(exported_type_params_resolve_log))
       if Array::get(exported_type_params_cycle_hits, 0) == hits_before && Array::length(reads) == Array::length(fps) {
-        MutMap::set(exported_type_params_memo, path, (reads, fps, out))
+        MutMap::set(exported_type_params_memo, path, (reads, fps, out, resolves))
       } else {
         ()
       }
@@ -239,6 +274,7 @@ fn exported_type_params_uncached_fs(path: String, dep_paths: Array[String], dep_
       match Array::get(stmts, si) {
         SReExport(raw_path, items) => {
           let resolved = resolve_path_fs(dir_of_path(path), raw_path)
+          Array::push(exported_type_params_resolve_log, (dir_of_path(path), raw_path, resolved))
           let source_types = exported_type_params_fs(resolved, dep_paths, dep_fingerprints, visiting)
           let mut ii = 0
           while ii < Array::length(items) {

--- a/lib/@vibe/compiler/loader/loader.vibe
+++ b/lib/@vibe/compiler/loader/loader.vibe
@@ -1,7 +1,7 @@
 //# Imports
 
 import @vibe/compiler/syntax {
-  lex, lex_with_offsets, parse_program, parse_program_preserving
+  cfg_ambient_flags_csv, lex, lex_with_offsets, parse_program, parse_program_preserving
 }
 
 import @vibe/core {
@@ -112,9 +112,21 @@ let exported_type_params_memo: MutMap[String, (Array[(String, Int)], Array[Strin
 
 let exported_type_params_read_log: Array[(String, Int)] = []
 
+/// The ambient `#cfg` set each recorded answer was parsed under: the parsers
+/// keep or drop `#cfg`-gated declarations by that set, so an answer is only
+/// fresh under the set it was made with (Codex review on #2520).
+let exported_type_params_memo_cfg: MutMap[String, String] = MutMap::new_string()
+
 let exported_type_params_resolve_log: Array[(String, String, String)] = []
 
 let exported_type_params_cycle_hits: Array[Int] = [0]
+
+fn exported_type_params_entry_cfg_matches(path: String, cfg: String) -> Bool {
+  match MutMap::get(exported_type_params_memo_cfg, path) {
+    Some(recorded) => recorded == cfg,
+    None => false
+  }
+}
 
 /// A recorded answer is fresh when every file it read has the stat token it
 /// was read under and every path resolution it made answers the same. A plain
@@ -166,7 +178,7 @@ fn exported_type_params_fs(path: String, dep_paths: Array[String], dep_fingerpri
   let fresh = match MutMap::get(exported_type_params_memo, path) {
     Some(entry) => {
       let (reads, _, _, resolves) = entry
-      if exported_type_params_entry_fresh(reads, resolves) {
+      if exported_type_params_entry_cfg_matches(path, cfg_ambient_flags_csv()) && exported_type_params_entry_fresh(reads, resolves) {
         Some(entry)
       } else {
         None
@@ -203,6 +215,7 @@ fn exported_type_params_fs(path: String, dep_paths: Array[String], dep_fingerpri
       let resolves = Array::slice(exported_type_params_resolve_log, resolve_mark, Array::length(exported_type_params_resolve_log))
       if Array::get(exported_type_params_cycle_hits, 0) == hits_before && Array::length(reads) == Array::length(fps) {
         MutMap::set(exported_type_params_memo, path, (reads, fps, out, resolves))
+        MutMap::set(exported_type_params_memo_cfg, path, cfg_ambient_flags_csv())
       } else {
         ()
       }

--- a/lib/@vibe/compiler/loader/loader.vibe
+++ b/lib/@vibe/compiler/loader/loader.vibe
@@ -5,7 +5,7 @@ import @vibe/compiler/syntax {
 }
 
 import @vibe/core {
-  array_empty, hex_decode, hex_encode
+  array_empty, hex_decode, hex_encode, struct MutMap
 }
 
 import @vibe/compiler/core {
@@ -91,16 +91,101 @@ import @vibe/compiler/contract {
 /// an unresolved export instead of unbounded recursion; every visited source
 /// is fingerprinted so the contract-facade cache observes changes at any
 /// depth of the chain.
+/// #2386: the answer for one source, per path for the process, stamped with
+/// the stat token of every file the recursion read. `desugar_contract_source_fs`
+/// asks for the kinds behind a re-export once per MEMBER unit of the
+/// contract, and each ask read, lexed and parsed the re-export's target
+/// (and its own re-export chain) again -- on a cold compiler-closure compile
+/// every re-exported source parsed once per member re-exporting it. A hit
+/// re-stats every recorded file and replays the same `dep_paths` /
+/// `dep_fingerprints` pushes the parse made, so the facade cache row observes
+/// the same dependency set either way; a changed token re-reads. An answer
+/// is recorded only when the recursion beneath it met no `visiting` cycle,
+/// so a recorded answer never depends on the caller's `visiting` stack.
+/// Same blind spot as the persistent facade row it feeds: a change in path
+/// RESOLUTION with no file read changing (a new sibling shadowing a
+/// directory import) is not observed. One entry per path, replaced on a
+/// token change, so a resident compiler holds one answer per source.
+let exported_type_params_memo: MutMap[String, (Array[(String, Int)], Array[String], Array[(String, Array[String])])] = MutMap::new_string()
+
+let exported_type_params_read_log: Array[(String, Int)] = []
+
+let exported_type_params_cycle_hits: Array[Int] = [0]
+
 fn exported_type_params_fs(path: String, dep_paths: Array[String], dep_fingerprints: Array[String], visiting: Array[String]) -> Array[(String, Array[String])] with Exception + Fs {
-  let out = array_empty()
   if contains_path(visiting, path) {
-    return out
+    Array::set(exported_type_params_cycle_hits, 0, Array::get(exported_type_params_cycle_hits, 0) + 1)
+    return array_empty()
   } else {
     ()
   }
+  if Array::length(visiting) == 0 {
+    Array::truncate(exported_type_params_read_log, 0)
+  } else {
+    ()
+  }
+  let fresh = match MutMap::get(exported_type_params_memo, path) {
+    Some(entry) => {
+      let (reads, _, _) = entry
+      let mut same = true
+      let mut ri = 0
+      while ri < Array::length(reads) && same {
+        let (read_path, token) = Array::get(reads, ri)
+        if Fs::stat_token(read_path) != token {
+          same = false
+        } else {
+          ()
+        }
+        ri = ri + 1
+      }
+      if same {
+        Some(entry)
+      } else {
+        None
+      }
+    },
+    None => None
+  }
+  match fresh {
+    Some(entry) => {
+      let (reads, fps, out) = entry
+      let mut ri = 0
+      while ri < Array::length(reads) {
+        let (read_path, token) = Array::get(reads, ri)
+        Array::push(dep_paths, read_path)
+        Array::push(dep_fingerprints, Array::get(fps, ri))
+        Array::push(exported_type_params_read_log, (read_path, token))
+        ri = ri + 1
+      }
+      out
+    },
+    None => {
+      let log_mark = Array::length(exported_type_params_read_log)
+      let dep_mark = Array::length(dep_fingerprints)
+      let hits_before = Array::get(exported_type_params_cycle_hits, 0)
+      let out = exported_type_params_uncached_fs(path, dep_paths, dep_fingerprints, visiting)
+      let reads = Array::slice(exported_type_params_read_log, log_mark, Array::length(exported_type_params_read_log))
+      let fps = Array::slice(dep_fingerprints, dep_mark, Array::length(dep_fingerprints))
+      if Array::get(exported_type_params_cycle_hits, 0) == hits_before && Array::length(reads) == Array::length(fps) {
+        MutMap::set(exported_type_params_memo, path, (reads, fps, out))
+      } else {
+        ()
+      }
+      out
+    }
+  }
+}
+
+fn exported_type_params_uncached_fs(path: String, dep_paths: Array[String], dep_fingerprints: Array[String], visiting: Array[String]) -> Array[(String, Array[String])] with Exception + Fs {
+  let out = array_empty()
   let visiting_mark = Array::length(visiting)
   Array::push(visiting, path)
+  // The token is taken BEFORE the read: a file rewritten between the two is
+  // parsed as its new body under the old token, so the next ask re-reads it;
+  // the other order would record the new token against the old parse.
+  let token = Fs::stat_token(path)
   let raw = Fs::read_file(path)
+  Array::push(exported_type_params_read_log, (path, token))
   Array::push(dep_paths, path)
   // Fingerprint the bytes that are parsed below. A second filesystem read
   // could observe a newer body and make stale metadata look current forever.

--- a/lib/@vibe/compiler/runtime/typecheck_fs.vibe
+++ b/lib/@vibe/compiler/runtime/typecheck_fs.vibe
@@ -119,7 +119,13 @@ import @vibe/compiler/contract {
 }
 
 import @vibe/compiler/loader {
-  ingest_source_text_fs, ingestion_pipeline_telemetry_add, load_or_parse_module_header_fs, vpkg_types_module_path_prefix
+  ingest_source_text_fs,
+  ingestion_pipeline_telemetry_add,
+  load_or_parse_module_header_fs,
+  parse_program_located_shared,
+  parse_program_located_shared_mark_semantic,
+  parse_program_located_shared_semantic_pending,
+  vpkg_types_module_path_prefix
 }
 
 import @vibe/compiler/incremental {
@@ -3845,90 +3851,40 @@ fn dep_visit_order(n: Int) -> Array[Int] {
     order
   }
 }
-/// #1100: process-local parse memo. A cold fs-mode compile parses the SAME
-/// source text TWICE -- once here for the typecheck walk (only on a
-/// persistent type-env cache MISS, see finish_typecheck_fs_impl) and once
-/// again for the merge (parse_sources_for_merge, file_compile.vibe). Both
-/// sites ran the identical `lex_with_offsets` + `parse_program_located` pair
-/// under the identical `<path>: <msg>` error wrapping, so the second parse
-/// was pure waste -- #1100's phase attribution measured the merge parse at
-/// 102 MB of a ~850 MB cold selfcompile.
+/// #2386: the ModuleJob parse goes through the loader's shared located-parse
+/// memo (`parse_program_located_shared`, header_cache.vibe), which the header
+/// pass fills during planning -- on a cold compile every module used to be
+/// lexed and parsed twice, once for its header and once here (#1100 measured
+/// the merge's third parse at 102 MB of a ~850 MB cold selfcompile; this
+/// removes the second). The contract is the memo's: keyed by (path, EXACT
+/// source text), a shallow top-level copy on every hand-out, a throwing
+/// parse never memoized, bounded for the daemon.
 ///
-/// Keyed by (path, EXACT source text). The source is compared in full rather
-/// than fingerprinted: a same-path re-ingest with different text is a real
-/// shape (#897's vpkg shared-import prefix marker), and a full compare is
-/// far cheaper than the parse it guards.
-///
-/// The memo hands out a SHALLOW COPY of the top-level statement array, never
-/// the stored one. check_program mutates its argument in place --
-/// inject_trait_method_generics / desugar_railway_binds / desugar_labeled_args
-/// each `Array::set(stmts, i, <rewritten>)` -- so handing out the pristine
-/// array directly would leak pre-desugared statements into the merge. Every one of those mutators writes only at the
-/// TOP level (verified: they rebuild each Stmt functionally and write it
-/// back by index), so a fresh top-level array is complete isolation; the
-/// Stmt values themselves are immutable enum payloads.
-///
-/// A throwing parse is NOT memoized: the cells stay untouched, so a second
-/// caller re-parses and re-throws identically.
-let parse_memo_paths: Array[String] = [] let parse_memo_sources: Array[String] = [
-] let parse_memo_stmts: Array[Array[Stmt]] = [] fn parse_program_with_path_impl(path: String, source: String, observe_current_source_parse: Bool) -> Array[Stmt] with Exception {
-  let n = Array::length(parse_memo_paths)
-  let mut i = 0
-  let mut hit = -1
-  while i < n && hit < 0 {
-    if Array::get(parse_memo_paths, i) == path && Array::get(parse_memo_sources, i) == source {
-      hit = i
-    } else {
-      ()
-    }
-    i = i + 1
-  }
-  if hit >= 0 {
-    let cached = Array::get(parse_memo_stmts, hit)
-    Array::slice(cached, 0, Array::length(cached))
+/// `current_source_parse_executions` (counter 5, and ingestion slot 15)
+/// keeps its observable: one per FIRST semantic use of a (path, text) in
+/// the process. With the walk's own memo that was exactly "this check
+/// parsed" -- the header pass never filled it, so the first check of a text
+/// always parsed, and a later check of the same text never did. The parser
+/// may now have run in planning instead, so the count is taken from the
+/// memo's consumed flag rather than from whether the parser ran here; the
+/// typing-env-reuse oracle and the cache probe pin it per scenario. Counted
+/// before the parse and marked after a successful one, as before: a
+/// throwing parse counts and is asked again.
+fn parse_program_with_path_impl(path: String, source: String, observe_current_source_parse: Bool) -> Array[Stmt] with Exception {
+  let first_use = observe_current_source_parse && parse_program_located_shared_semantic_pending(path, source)
+  if first_use {
+    incremental_typecheck_telemetry_add(5, 1)
+    ingestion_pipeline_telemetry_add(15, 1)
   } else {
-    if observe_current_source_parse {
-      incremental_typecheck_telemetry_add(5, 1)
-      ingestion_pipeline_telemetry_add(15, 1)
-    } else {
-      ()
-    }
-    let parsed = handle {
-      // Located lex+parse so EIdent (and other) nodes carry real source char
-      // offsets; the checker rides those offsets into type diagnostics via the
-      // [@off=N] marker (decoded by locate_type_error). The plain
-      // `parse_program(lex(source))` passed an empty starts array, leaving every
-      // offset at -1, so located type errors fell back to a first-occurrence scan.
-      let (tokens, starts, _ends) = lex_with_offsets(source)
-      parse_program_located(tokens, starts, source)
-    } with { Exception::Throw(msg) => throw(String::concat(String::concat(path, ": "), msg)) }
-    // Bound the memo. It is process-wide, and `vibe --daemon` (the #906
-    // worker transport reuses one) serves many compiles from one process:
-    // each edited source is a new (path, source) pair, so an unbounded memo
-    // grows monotonically in guest memory -- full source AND AST per entry
-    // -- and the linear scan above gets slower with every historical
-    // version retained.
-    //
-    // The win this memo exists for is WITHIN one compile: the typecheck
-    // walk parses every module, then the merge parses them all again, so
-    // the whole module set has to be resident at once. The cap is
-    // therefore set well above a self-compile's module count (264 manifest
-    // rows) rather than to some small number. Clearing outright instead of
-    // evicting one entry keeps this branch simple; at 1024 vs 264 it can
-    // only trigger after hundreds of edits in a single daemon, and it
-    // costs one compile's worth of re-parsing when it does.
-    if Array::length(parse_memo_paths) >= 1024 {
-      Array::truncate(parse_memo_paths, 0)
-      Array::truncate(parse_memo_sources, 0)
-      Array::truncate(parse_memo_stmts, 0)
-    } else {
-      ()
-    }
-    Array::push(parse_memo_paths, path)
-    Array::push(parse_memo_sources, source)
-    Array::push(parse_memo_stmts, parsed)
-    Array::slice(parsed, 0, Array::length(parsed))
+    ()
   }
+  let stmts = parse_program_located_shared(path, source)
+  if first_use {
+    parse_program_located_shared_mark_semantic(path, source)
+  } else {
+    ()
+  }
+  stmts
 }
 
 export fn parse_program_with_path(path: String, source: String) -> Array[Stmt] with Exception {

--- a/lib/@vibe/compiler/syntax/index.vpkg
+++ b/lib/@vibe/compiler/syntax/index.vpkg
@@ -67,6 +67,7 @@ fn parse_stmt_preserving(tokens: Array[Token], starts: Array[Int], pos: Int) -> 
 fn parse_program(tokens: Array[Token]) -> Array[Stmt] with Exception
 fn parse_program_preserving(tokens: Array[Token]) -> Array[Stmt] with Exception
 fn parse_program_located(tokens: Array[Token], starts: Array[Int], src: String) -> Array[Stmt] with Exception
+fn cfg_ambient_flags_csv() -> String
 fn parse_program_located_with_binder_context(tokens: Array[Token], starts: Array[Int], src: String) -> Array[Stmt] with Exception
 fn parse_program_recovering(tokens: Array[Token], starts: Array[Int], src: String) -> (Array[Stmt], Array[String]) with Exception
 fn parse_program_spans(tokens: Array[Token], starts: Array[Int], ends: Array[Int]) -> (Array[Stmt], Array[Int], Array[Int]) with Exception

--- a/lib/@vibe/compiler/syntax/syntax.vibe
+++ b/lib/@vibe/compiler/syntax/syntax.vibe
@@ -4,5 +4,5 @@
 // @vibe/parser contract package; this module is a re-export shim so the
 // compiler's existing import spellings keep working.
 export ../../../../lib/@vibe/parser {
-  Token, double_to_string_compiler, lex, lex_ok, lex_with_offsets, lex_with_offsets_recovering, offset_to_line_col, parse, parse_expr, parse_ok, parse_program, parse_program_located, parse_program_located_with_binder_context, parse_program_preserving, parse_program_recovering, parse_program_spans, parse_stmt, parse_stmt_preserving, print_expr, print_pat, print_program, print_stmt, print_type_expr, token_to_string, parse_type, peek, tk_name, skip_semi, collect_import_path, parse_fn_signature
+  Token, double_to_string_compiler, lex, lex_ok, lex_with_offsets, lex_with_offsets_recovering, offset_to_line_col, parse, parse_expr, parse_ok, parse_program, parse_program_located, parse_program_located_with_binder_context, parse_program_preserving, cfg_ambient_flags_csv, parse_program_recovering, parse_program_spans, parse_stmt, parse_stmt_preserving, print_expr, print_pat, print_program, print_stmt, print_type_expr, token_to_string, parse_type, peek, tk_name, skip_semi, collect_import_path, parse_fn_signature
 }

--- a/lib/@vibe/compiler/tests/contract_member_parse_memo_test.vibe
+++ b/lib/@vibe/compiler/tests/contract_member_parse_memo_test.vibe
@@ -1,0 +1,66 @@
+//# #2386: a contract member is parsed once. `desugar_contract_source_fs`
+//# parses every member for the conformance check and the facade, and the
+//# header pass later collects the same member as a source with the same
+//# ingested text; the member parse goes through the shared located memo so
+//# that second parse is a hit. What must not happen: the member's ingested
+//# text being parsed again by whoever asks next.
+
+import @vibe/compiler/cache {
+  compact_string_fingerprint, persistent_module_header_cache_path
+}
+
+import @vibe/core {
+  array_empty
+}
+
+import @vibe/compiler/loader {
+  ingest_source_text_fs, load_or_parse_module_header_fs, parse_program_located_shared, parse_program_located_shared_ran_parser
+}
+
+fn string_to_bytes(s: String) -> Bytes {
+  let out = array_empty()
+  let len = String::length(s)
+  let mut i = 0
+  while i < len {
+    Array::push(out, String::char_code_at(s, i))
+    i = i + 1
+  }
+  Bytes::from_array(out)
+}
+
+fn remove_file_if_exists(path: String) -> Unit with Fs {
+  if Fs::exists(path) {
+    Fs::remove(path)
+  } else {
+    ()
+  }
+}
+
+fn write_cold(path: String, source: String) -> Unit with Exception + Fs {
+  Fs::write_bytes(path, string_to_bytes(source))
+  remove_file_if_exists(persistent_module_header_cache_path(path, compact_string_fingerprint(source)))
+}
+
+test "a contract member's parse serves its header pass" {
+  let base_dir = "/tmp/vibe_compiler_contract_member_parse_memo"
+  let pkg_dir = String::concat(base_dir, "/pkg")
+  Fs::mkdir_p(pkg_dir)
+  // A per-run stamp in the member keeps the persistent facade row of an
+  // earlier run from answering for the parse this test is about.
+  let stamp = __to_string(Profiler::now_us())
+  let member_path = String::concat(pkg_dir, "/impl.vibe")
+  let member_raw = String::concat("// run ", String::concat(stamp, "\nexport fn pub_fn(x: Int) -> Int {\n  x + 1\n}\n"))
+  write_cold(member_path, member_raw)
+  let contract_path = String::concat(pkg_dir, "/index.vpkg")
+  write_cold(contract_path, "version 0.0.1\n\nimport ./impl.vibe {}\n\nfn pub_fn(x: Int) -> Int\n")
+  // Ingesting the contract parses the member for conformance ...
+  let _ = ingest_source_text_fs(contract_path, Fs::read_file(contract_path))
+  // ... and the member's header, asked with the same ingested text the
+  // loader collects, answers from that parse.
+  let member_ingested = ingest_source_text_fs(member_path, member_raw)
+  let (_, exports, _) = load_or_parse_module_header_fs(member_path, member_ingested, 0)
+  assert_eq(Array::get(exports, 0), "pub_fn")
+  assert_true(!parse_program_located_shared_ran_parser())
+  let _ = parse_program_located_shared(member_path, member_ingested)
+  assert_true(!parse_program_located_shared_ran_parser())
+}

--- a/lib/@vibe/compiler/tests/exported_type_params_memo_test.vibe
+++ b/lib/@vibe/compiler/tests/exported_type_params_memo_test.vibe
@@ -8,7 +8,11 @@
 //# re-export chain is observed even though no file that was read changed.
 
 import @vibe/compiler/cache {
-  compact_string_fingerprint, persistent_module_header_cache_path
+  compact_string_fingerprint, persistent_module_header_cache_path, set_persistent_cache_cfg_flags
+}
+
+import @vibe/parser {
+  set_cfg_ambient_flags
 }
 
 import @vibe/core {
@@ -143,4 +147,35 @@ test "resolution 3: the directory wins again once the file is gone" {
   remove_file_if_exists(resolution_shadow())
   restamp_parent(resolution_base_dir, String::concat(Array::get(resolution_stamp, 0), "-c"))
   assert_eq(ingest_error(String::concat(resolution_base_dir, "/parent/index.vpkg")), "")
+}
+
+/// What `configure_cfg_flags` does per CLI invocation: the parser's ambient
+/// set and the persistent caches' namespace move together.
+fn switch_cfg(flags: Array[String]) -> Unit {
+  set_cfg_ambient_flags(flags)
+  set_persistent_cache_cfg_flags(String::join(flags, ","))
+}
+
+test "an answer made under one ambient #cfg set does not serve another" {
+  let base_dir = "/tmp/vibe_compiler_exported_type_params_memo_cfg"
+  let parent_dir = String::concat(base_dir, "/parent")
+  Fs::mkdir_p(parent_dir)
+  // A plain re-export target (a contract file refuses `#cfg`) that declares
+  // `Container` only under `dev`.
+  write_cold(String::concat(base_dir, "/types.vibe"), "#cfg(dev)\nexport type Container[F[_]] = F[Int]\n")
+  let stamp = __to_string(Profiler::now_us())
+  write_cold(String::concat(parent_dir, "/index.vpkg"), String::concat("// run ", String::concat(stamp, "\nopaque type Container[F[_]]\n")))
+  write_cold(String::concat(parent_dir, "/mid.vibe"), "export ../types.vibe { Container }\n")
+  let contract_path = String::concat(parent_dir, "/index.vpkg")
+  switch_cfg(["dev"])
+  let under_dev = ingest_error(contract_path)
+  // Without `dev` the re-export finds no `Container`; the answer recorded
+  // under `dev` must not say otherwise. The parent is re-stamped so the
+  // persistent facade row (namespaced by the set anyway) does not answer.
+  switch_cfg([])
+  restamp_parent(base_dir, String::concat(stamp, "-b"))
+  let without_dev = ingest_error(contract_path)
+  switch_cfg([])
+  assert_eq(under_dev, "")
+  assert_true(String::contains(without_dev, "has no implementation"))
 }

--- a/lib/@vibe/compiler/tests/exported_type_params_memo_test.vibe
+++ b/lib/@vibe/compiler/tests/exported_type_params_memo_test.vibe
@@ -1,0 +1,88 @@
+//# #2386: the loader answers "what kinds does this source export" once per
+//# path per process instead of reading, lexing and parsing the re-export's
+//# target again for every member unit that re-exports it. What must not
+//# happen is an answer outliving a file: a target rewritten under the same
+//# path is read again (grown to a different kind, then restored), and the
+//# second member re-exporting one target is checked against the same answer
+//# as the first.
+
+import @vibe/compiler/cache {
+  compact_string_fingerprint, persistent_module_header_cache_path
+}
+
+import @vibe/core {
+  array_empty
+}
+
+import @vibe/compiler/loader {
+  ingest_source_text_fs
+}
+
+fn string_to_bytes(s: String) -> Bytes {
+  let out = array_empty()
+  let len = String::length(s)
+  let mut i = 0
+  while i < len {
+    Array::push(out, String::char_code_at(s, i))
+    i = i + 1
+  }
+  Bytes::from_array(out)
+}
+
+fn remove_file_if_exists(path: String) -> Unit with Fs {
+  if Fs::exists(path) {
+    Fs::remove(path)
+  } else {
+    ()
+  }
+}
+
+fn write_cold(path: String, source: String) -> Unit with Exception + Fs {
+  Fs::write_bytes(path, string_to_bytes(source))
+  remove_file_if_exists(persistent_module_header_cache_path(path, compact_string_fingerprint(source)))
+}
+
+fn ingest_error(contract_path: String) -> String with Fs {
+  handle {
+    let _ = ingest_source_text_fs(contract_path, Fs::read_file(contract_path))
+    ""
+  } with { Exception::Throw(error) => error }
+}
+
+/// A parent package whose two members both re-export `Container` from one
+/// source package. The contract carries a per-run stamp so the persistent
+/// facade row of an earlier run cannot answer for the parse this test is
+/// about.
+fn setup(base_dir: String) -> String with Exception + Fs + Profiler {
+  let source_dir = String::concat(base_dir, "/source")
+  let parent_dir = String::concat(base_dir, "/parent")
+  Fs::mkdir_p(source_dir)
+  Fs::mkdir_p(parent_dir)
+  write_cold(String::concat(source_dir, "/index.vpkg"), "opaque type Container[F[_]]\n")
+  write_cold(String::concat(source_dir, "/impl.vibe"), "export type Container[F[_]] = F[Int]\n")
+  let stamp = __to_string(Profiler::now_us())
+  write_cold(String::concat(parent_dir, "/index.vpkg"), String::concat("// run ", String::concat(stamp, "\nopaque type Container[F[_]]\n")))
+  write_cold(String::concat(parent_dir, "/mid_a.vibe"), "export ../source { Container }\n")
+  write_cold(String::concat(parent_dir, "/mid_b.vibe"), "export ../source { Container }\n")
+  String::concat(parent_dir, "/index.vpkg")
+}
+
+test "two members re-exporting one source are checked against the same answer" {
+  let base_dir = "/tmp/vibe_compiler_exported_type_params_memo_two_members"
+  let contract_path = setup(base_dir)
+  // The second member's ask is answered from the first member's parse; the
+  // conformance check passes for both.
+  assert_eq(ingest_error(contract_path), "")
+}
+
+test "a re-export target rewritten under the same path is read again" {
+  let base_dir = "/tmp/vibe_compiler_exported_type_params_memo_rewrite"
+  let contract_path = setup(base_dir)
+  assert_eq(ingest_error(contract_path), "")
+  // The source contract changes the kind of `Container` under the same path.
+  write_cold(String::concat(base_dir, "/source/index.vpkg"), "opaque type Container[F]\n")
+  assert_true(String::contains(ingest_error(contract_path), "kind mismatch"))
+  // And changes back: the stale answer must not come back either.
+  write_cold(String::concat(base_dir, "/source/index.vpkg"), "opaque type Container[F[_]]\n")
+  assert_eq(ingest_error(contract_path), "")
+}

--- a/lib/@vibe/compiler/tests/exported_type_params_memo_test.vibe
+++ b/lib/@vibe/compiler/tests/exported_type_params_memo_test.vibe
@@ -2,9 +2,10 @@
 //# path per process instead of reading, lexing and parsing the re-export's
 //# target again for every member unit that re-exports it. What must not
 //# happen is an answer outliving a file: a target rewritten under the same
-//# path is read again (grown to a different kind, then restored), and the
+//# path is read again (grown to a different kind, then restored), the
 //# second member re-exporting one target is checked against the same answer
-//# as the first.
+//# as the first, and a new file that now wins a resolution made inside the
+//# re-export chain is observed even though no file that was read changed.
 
 import @vibe/compiler/cache {
   compact_string_fingerprint, persistent_module_header_cache_path
@@ -85,4 +86,61 @@ test "a re-export target rewritten under the same path is read again" {
   // And changes back: the stale answer must not come back either.
   write_cold(String::concat(base_dir, "/source/index.vpkg"), "opaque type Container[F[_]]\n")
   assert_eq(ingest_error(contract_path), "")
+}
+
+/// A parent whose member re-exports through a facade directory, so the
+/// resolution of `../source` happens INSIDE the memoized recursion (the
+/// facade's own re-export), not at the member. The contract carries a
+/// per-run stamp for the same reason as `setup`.
+fn setup_chain(base_dir: String, stamp: String) -> String with Exception + Fs {
+  let source_dir = String::concat(base_dir, "/source")
+  let facade_dir = String::concat(base_dir, "/facade")
+  let parent_dir = String::concat(base_dir, "/parent")
+  Fs::mkdir_p(source_dir)
+  Fs::mkdir_p(facade_dir)
+  Fs::mkdir_p(parent_dir)
+  write_cold(String::concat(source_dir, "/index.vpkg"), "opaque type Container[F[_]]\n")
+  write_cold(String::concat(source_dir, "/impl.vibe"), "export type Container[F[_]] = F[Int]\n")
+  write_cold(String::concat(facade_dir, "/index.vibe"), "export ../source { Container }\n")
+  write_cold(String::concat(parent_dir, "/index.vpkg"), String::concat("// run ", String::concat(stamp, "\nopaque type Container[F[_]]\n")))
+  write_cold(String::concat(parent_dir, "/mid.vibe"), "export ../facade { Container }\n")
+  String::concat(parent_dir, "/index.vpkg")
+}
+
+/// Only the parent contract is rewritten: every file the first answer read
+/// keeps its stat token, which is what makes the stale answer possible.
+fn restamp_parent(base_dir: String, stamp: String) -> Unit with Exception + Fs {
+  write_cold(String::concat(base_dir, "/parent/index.vpkg"), String::concat("// run ", String::concat(stamp, "\nopaque type Container[F[_]]\n")))
+}
+
+let resolution_base_dir: String = "/tmp/vibe_compiler_exported_type_params_memo_resolution"
+
+let resolution_stamp: Array[String] = []
+
+fn resolution_shadow() -> String {
+  String::concat(resolution_base_dir, "/source.vibe")
+}
+
+test "resolution 1: the chain answers clean and its facade answer is recorded" {
+  remove_file_if_exists(resolution_shadow())
+  let stamp = __to_string(Profiler::now_us())
+  Array::push(resolution_stamp, stamp)
+  let contract_path = setup_chain(resolution_base_dir, stamp)
+  assert_eq(ingest_error(contract_path), "")
+}
+
+test "resolution 2: a new file that wins a resolution inside the chain is observed" {
+  // `source.vibe` now wins `../source` over `source/index.vpkg`; nothing the
+  // first answer READ has changed. The parent contract is re-stamped so the
+  // persistent facade row does not answer either.
+  write_cold(resolution_shadow(), "export type Container[F] = F\n")
+  restamp_parent(resolution_base_dir, String::concat(Array::get(resolution_stamp, 0), "-b"))
+  let msg = ingest_error(String::concat(resolution_base_dir, "/parent/index.vpkg"))
+  assert_true(String::contains(msg, "kind mismatch"))
+}
+
+test "resolution 3: the directory wins again once the file is gone" {
+  remove_file_if_exists(resolution_shadow())
+  restamp_parent(resolution_base_dir, String::concat(Array::get(resolution_stamp, 0), "-c"))
+  assert_eq(ingest_error(String::concat(resolution_base_dir, "/parent/index.vpkg")), "")
 }

--- a/lib/@vibe/compiler/tests/located_parse_memo_test.vibe
+++ b/lib/@vibe/compiler/tests/located_parse_memo_test.vibe
@@ -1,0 +1,113 @@
+//# #2386: one located parse per (path, exact source text) for the process,
+//# shared by the loader's header pass and the typecheck walk's module parse.
+//# What must not happen: an answer outliving its text (the same path asked
+//# with different text is parsed again, and the earlier text still answers
+//# as itself), a hand-out that aliases the stored array (a caller's top-level
+//# rewrite must not reach the next caller), and a throwing parse being
+//# remembered.
+
+import @vibe/compiler/cache {
+  compact_string_fingerprint, persistent_module_header_cache_path
+}
+
+import @vibe/core {
+  array_empty
+}
+
+import @vibe/compiler/core {
+  Stmt
+}
+
+import @vibe/compiler/loader {
+  load_or_parse_module_header_fs, parse_program_located_shared, parse_program_located_shared_ran_parser
+}
+
+import @vibe/compiler/runtime {
+  parse_program_with_path
+}
+
+fn string_to_bytes(s: String) -> Bytes {
+  let out = array_empty()
+  let len = String::length(s)
+  let mut i = 0
+  while i < len {
+    Array::push(out, String::char_code_at(s, i))
+    i = i + 1
+  }
+  Bytes::from_array(out)
+}
+
+fn remove_file_if_exists(path: String) -> Unit with Fs {
+  if Fs::exists(path) {
+    Fs::remove(path)
+  } else {
+    ()
+  }
+}
+
+fn parse_error(path: String, source: String) -> String {
+  handle {
+    let _ = parse_program_located_shared(path, source)
+    ""
+  } with { Exception::Throw(msg) => msg }
+}
+
+test "the same path asked with different text is parsed again, and each text keeps its own answer" {
+  let path = "/tmp/vibe_compiler_located_parse_memo/versions.vibe"
+  let one = "export let a: Int = 1\n"
+  let two = "export let a: Int = 1\nexport let b: Int = 2\n"
+  assert_eq(Array::length(parse_program_located_shared(path, one)), 1)
+  assert_true(parse_program_located_shared_ran_parser())
+  assert_eq(Array::length(parse_program_located_shared(path, two)), 2)
+  assert_true(parse_program_located_shared_ran_parser())
+  // Both texts answer from the memo now, each as itself.
+  assert_eq(Array::length(parse_program_located_shared(path, one)), 1)
+  assert_true(!parse_program_located_shared_ran_parser())
+  assert_eq(Array::length(parse_program_located_shared(path, two)), 2)
+  assert_true(!parse_program_located_shared_ran_parser())
+}
+
+test "a hand-out is a copy of the top-level array" {
+  let path = "/tmp/vibe_compiler_located_parse_memo/copy.vibe"
+  let source = "export let a: Int = 1\nexport let b: Int = 2\n"
+  let first = parse_program_located_shared(path, source)
+  assert_eq(Array::length(first), 2)
+  // A caller rewriting its array at the top level (what check_program does)
+  // must not be visible to the next caller.
+  Array::truncate(first, 1)
+  let second = parse_program_located_shared(path, source)
+  assert_eq(Array::length(second), 2)
+  assert_true(!parse_program_located_shared_ran_parser())
+  // The same for an answer that came from the memo.
+  Array::truncate(second, 1)
+  let third = parse_program_located_shared(path, source)
+  assert_eq(Array::length(third), 2)
+}
+
+test "a throwing parse is not remembered" {
+  let path = "/tmp/vibe_compiler_located_parse_memo/broken.vibe"
+  let source = "export let a: Int = \n"
+  let first = parse_error(path, source)
+  assert_true(String::starts_with(first, path))
+  let second = parse_error(path, source)
+  assert_eq(first, second)
+  assert_true(parse_program_located_shared_ran_parser())
+}
+
+test "the header pass and the module parse share one parse" {
+  let base_dir = "/tmp/vibe_compiler_located_parse_memo_shared"
+  let path = String::concat(base_dir, "/main.vibe")
+  let source = String::concat("export let _start: () -> Int = () -> { ", String::concat(__to_string(Profiler::now_us()), " }\n"))
+  Fs::mkdir_p(base_dir)
+  Fs::write_bytes(path, string_to_bytes(source))
+  remove_file_if_exists(persistent_module_header_cache_path(path, compact_string_fingerprint(source)))
+  // A persisted-header miss: the header pass parses the file ...
+  let (_, exports, parse_count) = load_or_parse_module_header_fs(path, source, 0)
+  assert_eq(parse_count, 1)
+  assert_eq(Array::get(exports, 0), "_start")
+  assert_true(parse_program_located_shared_ran_parser())
+  // ... and the module parse of the same text answers from that parse.
+  let stmts: Array[Stmt] = parse_program_with_path(path, source)
+  assert_eq(Array::length(stmts), 1)
+  assert_true(!parse_program_located_shared_ran_parser())
+}

--- a/lib/@vibe/compiler/tests/located_parse_memo_test.vibe
+++ b/lib/@vibe/compiler/tests/located_parse_memo_test.vibe
@@ -26,6 +26,10 @@ import @vibe/compiler/runtime {
   parse_program_with_path
 }
 
+import @vibe/parser {
+  set_cfg_ambient_flags
+}
+
 fn string_to_bytes(s: String) -> Bytes {
   let out = array_empty()
   let len = String::length(s)
@@ -110,4 +114,23 @@ test "the header pass and the module parse share one parse" {
   let stmts: Array[Stmt] = parse_program_with_path(path, source)
   assert_eq(Array::length(stmts), 1)
   assert_true(!parse_program_located_shared_ran_parser())
+}
+
+test "the same text under another ambient #cfg set is another parse" {
+  let path = "/tmp/vibe_compiler_located_parse_memo/cfg.vibe"
+  let source = "export let a: Int = 1\n#cfg(dev)\nexport let b: Int = 2\n"
+  set_cfg_ambient_flags([])
+  assert_eq(Array::length(parse_program_located_shared(path, source)), 1)
+  // The set changes: the gated statement is kept, and it is a fresh parse.
+  set_cfg_ambient_flags(["dev"])
+  assert_eq(Array::length(parse_program_located_shared(path, source)), 2)
+  assert_true(parse_program_located_shared_ran_parser())
+  // Each set keeps its own answer.
+  set_cfg_ambient_flags([])
+  assert_eq(Array::length(parse_program_located_shared(path, source)), 1)
+  assert_true(!parse_program_located_shared_ran_parser())
+  set_cfg_ambient_flags(["dev"])
+  assert_eq(Array::length(parse_program_located_shared(path, source)), 2)
+  assert_true(!parse_program_located_shared_ran_parser())
+  set_cfg_ambient_flags([])
 }

--- a/lib/@vibe/parser/index.vpkg
+++ b/lib/@vibe/parser/index.vpkg
@@ -179,6 +179,7 @@ fn parse_stmt_preserving(tokens: Array[Token], starts: Array[Int], pos: Int) -> 
 fn parse_stmt_preserving_with_binder_context(tokens: Array[Token], starts: Array[Int], pos: Int, context: Option[ParserBinderContext]) -> (Stmt, Int) with Exception
 fn parse_program(tokens: Array[Token]) -> Array[Stmt] with Exception
 fn set_cfg_ambient_flags(flags: Array[String]) -> Unit
+fn cfg_ambient_flags_csv() -> String
 fn parse_program_preserving(tokens: Array[Token]) -> Array[Stmt] with Exception
 fn parse_program_located(tokens: Array[Token], starts: Array[Int], src: String) -> Array[Stmt] with Exception
 // Explicit untrusted transport seam: caller context is forgeable and cannot

--- a/lib/@vibe/parser/parser.vibe
+++ b/lib/@vibe/parser/parser.vibe
@@ -750,6 +750,8 @@ fn parse_impl_methods(tokens: Array[Token], pos: Int, simpl: Stmt, context: Opti
 
 let cfg_ambient_flags: Array[String] = []
 
+let cfg_ambient_flags_csv_cell: Array[String] = [""]
+
 /// Replace the process-wide ambient `#cfg` flag set. Called once per CLI
 /// invocation from the environment; every subsequent parse of any module
 /// treats these flags as active in addition to the file's own `#cfg_enable`.
@@ -760,6 +762,15 @@ export fn set_cfg_ambient_flags(flags: Array[String]) -> Unit {
     Array::push(cfg_ambient_flags, Array::get(flags, i))
     i = i + 1
   }
+  Array::set(cfg_ambient_flags_csv_cell, 0, String::join(flags, ","))
+}
+
+/// The ambient set as one string, in the caller's order (the same spelling
+/// the persistent caches namespace by, #2513). A parse is a function of the
+/// text AND this set, so anything that remembers a parse across calls keys on
+/// both (#2386's loader memos, Codex review on #2520).
+export fn cfg_ambient_flags_csv() -> String {
+  Array::get(cfg_ambient_flags_csv_cell, 0)
 }
 
 /// Parse the directive after a THash: `cfg(name)`, `cfg_enable(name)`,


### PR DESCRIPTION
## What

Three loader slices of #2386 on the cold lane — all byte-identical to main on every corpus — plus a one-paragraph correction to the profiling skill that the first slice's measurement forced, and the fixes for the Codex findings here (round 1: resolutions; round 2: the `#cfg` set).

### `035c55c` — a re-export's kinds are parsed once per source, not once per member unit

`desugar_contract_source_fs` asks `exported_type_params_fs` for the kinds behind each member unit's re-exports, and every ask read, lexed and parsed the re-export's target (and its own re-export chain) again — on a cold compiler-closure compile every re-exported source parsed once per member re-exporting it.

The answer is memoized per path for the process, stamped with the stat token of every file the recursion read (taken before each read, so a rewrite between stat and read is re-read next time). A hit re-stats those files and replays the same `dep_paths` / `dep_fingerprints` pushes the parse made, so the facade cache row records the same dependency set either way; a changed token re-reads. An answer is recorded only when the recursion beneath it met no `visiting` cycle, so no recorded answer depends on the caller's `visiting` stack. One entry per path, replaced on a token change.

`exported_type_params_memo_test.vibe` pins both properties: two members re-exporting one source are checked against the same answer, and a source contract rewritten under the same path (kind changed, then restored) is read again each time. The file passes unchanged against main's library; a memo that never re-stats its files (built into the worktree's library, no compiler build needed) fails the rewrite case and also the existing `import_contract_check_test` kind case (#2338).

### `52cfee4` — the profiling skill: alternate the order inside interleaved pairs

Measured here: with the baseline first in every pair the candidate lost every pair (+3.7% cold); with the candidate first it won every pair. The second run of a pair pays about 0.3 s on this machine, so a fixed order turns position into a result. The skill now says to alternate (ABBA), pool the rounds, report the median, and judge a ~0.2 s slice on the profile and the deterministic heap_ptr rather than on wall.

### `ff42bd9` — the memo re-checks the resolutions its recursion made (Codex round 1 here, P1)

A hit re-stat'd every file the recursion read but not the path resolutions it made: a nested `export ./target { T }` resolves `target.vibe` ahead of `target/index.vpkg`, so creating `target.vibe` while every file already read stayed unchanged let a hit answer with the old target's kinds — a missing kind-mismatch diagnostic in a resident compiler. The recursion now logs each resolution it makes (base dir, raw path, answer) next to its reads; a hit re-runs every logged resolution and compares, and a nested hit replays its resolutions into the outer entry as it already did its reads. The member's own resolution was never affected: it happens at the caller and is the memo key. Two things the test found on the way: a file the answer read can be gone by the next ask (the `target.vibe` that won, then deleted) and `Fs::stat_token` on a missing path traps rather than answering, so absent is checked first and is stale; and the freshness check lives in a plain function, because `resolve_path_fs` (a Source handler) inside an Option match arm is the #708 trap shape.

`exported_type_params_memo_test` gains the shape as three steps: a member re-exporting through a facade directory whose own re-export resolves `../source` inside the recursion answers clean; creating `source.vibe` with another kind (nothing read changed, only the parent re-stamped so the persistent facade row does not answer) reports the kind mismatch; removing it answers clean again. The mutation that skips the re-check fails the second step. Measured against main the same way (four ABBA pairs): `exported_type_params_fs` cold inclusive 0.13 s as before (the re-check is one `resolve_path_fs` per recorded resolution per hit), heap_ptr cold 1,239,963,360 (+26 kB over the first commit: the resolution log), wall within noise.

### `05d10b4` — one located parse per source, shared by the header pass and the module check

On a cold compile every module was lexed and parsed twice: once by the loader's header pass (a persisted-header miss parses the whole file to find its imports and exports) and once by the typecheck walk's module check, which kept its own (path, source) memo in `runtime/typecheck_fs.vibe` — the same `lex_with_offsets` + `parse_program_located` pair under the same `<path>: <msg>` error wrapping.

The memo moves into the loader (`parse_program_located_shared`, header_cache.vibe), keyed by path with every text a path was asked with (a same-path re-ingest with different text is a real shape, #897), so the header pass fills it during planning and the module check answers from it. Its contract is unchanged: a shallow top-level copy on every hand-out (check_program rewrites its argument at the top level), a throwing parse never memoized, and a bound for the daemon. The linear scan over every memoized path becomes a map lookup. The parser call sits in a helper with no `match` in it (#708's RC-lane trap shape).

`current_source_parse_executions` (and ingestion slot 15) keeps its observable: one per first semantic use of a (path, text) in the process. With the walk's own memo that was exactly "this check parsed", since the header pass never filled it; the parser may now have run in planning, so the count comes from the memo's consumed flag rather than from whether the parser ran in the check. The typing-env-reuse oracle pins that counter in some forty scenarios and the cache probe in two, and both pass unchanged (the first draft counted parser runs and the oracle rejected it at its first scenario, 0 where it expects 2). Counted before the parse and marked after a successful one, as before. The header pass's `parse_count` is unchanged.

`located_parse_memo_test.vibe` pins the contract: the same path asked with different text is parsed again and each text keeps its own answer; a hand-out is a copy (on a miss and on a hit); a throwing parse is not remembered; and a header pass followed by the module parse of the same text runs the parser once. Two mutations built into the worktree's library each fail it: a memo that ignores the text fails the first case, and a hand-out of the stored array fails the copy case.

### `1a97d1d` — a contract member is parsed once, for conformance and for its header

`desugar_contract_source_fs` parsed every member unit of a contract for the conformance check and the facade (`parse_program(lex(..))` on the ingested text), and the header pass then lexed and parsed the same ingested text again when the member was collected as a source. The member parse goes through the shared located memo, so the header pass answers from it. A located AST carries source offsets on its nodes and nothing else; the conformance check reads names and kinds and the facade prints names, and the output is byte-identical on the compiler closure and the rc fixtures. A member that fails to parse now reports `<path>: <message>`, the wrapping every other parse of a source already used.

`contract_member_parse_memo_test.vibe` pins the sharing: after a contract is ingested, the member's header pass, asked with the same ingested text the loader collects, answers without running the parser. Parsing the member outside the memo (the previous line) fails it.

### `3ad4519` — the parse memos carry the ambient `#cfg` set they were made under (Codex round 2 here, P1 twice)

The parser keeps or drops a `#cfg`-gated statement by the process-wide ambient flag set (#2513), and the persistent caches namespace every entry by that set for exactly that reason — but the two in-process memos this PR adds keyed on path and text only. A resident compiler asked to compile under one set and then another would have planned `#cfg`-gated imports and exports, and answered a re-export's kinds, from the first set's parse. The parser exposes the set as one string in the caller's order (`cfg_ambient_flags_csv`, kept next to the set so a read is a load, not a join); the located-parse memo keeps a version per (text, set) the way it already kept one per text, and the export-kinds memo stamps each answer with the set it was made under and treats another set as a miss.

`located_parse_memo_test` gains the shape: the same text under `[]` and under `["dev"]` gives one and two statements, the second a fresh parse, and each set keeps its own answer afterwards. `exported_type_params_memo_test` gains a plain re-export target (a contract file refuses `#cfg`) that declares `Container` only under `dev`: ingested under `dev` the parent conforms; with the set cleared (and the parent re-stamped) the re-export has no implementation. The mutations that drop the set from either lookup fail their case. Measured against `1a97d1d` (four ABBA pairs): wall within noise, heap_ptr cold +76 kB (the per-version set strings), the three memo functions unchanged in the profile.

### Measured

Cache-isolated per the profiling skill, `codegen_lexer_test.vibe` over the full compiler closure, idle machine, interleaved pairs in alternating order; each slice measured against the commit before it.

| | main (`fe58fa8`) | `035c55c` | `05d10b4` | `1a97d1d` |
|---|---:|---:|---:|---:|
| `exported_type_params_fs` cold inclusive | 0.19 s | 0.13 s | — | — |
| `parse_program_with_path_impl` cold inclusive | 0.37 s | — | 0.00 s | — |
| `load_or_parse_module_header_fs_impl` cold inclusive | 0.54 s | — | 0.56 s | 0.21 s |
| `check_module_impl` cold inclusive | 2.98 s | — | 2.39 s | — |
| `collect_source_groups_fs` cold inclusive | 1.50 s | 1.44 s | 1.47 s | 1.15 s |
| cold wall, median vs previous | 8.11 s | 8.19 s (noise) | 7.69 s vs 7.94 s (−3.2%, 4 of 4 pairs) | 7.44 s vs 7.80 s (−4.7% mean, 4 of 4 pairs) |
| warm wall | 4.70 s | noise | noise | noise |
| heap_ptr cold | 1,254,412,296 | 1,239,937,384 (−14.5 MB) | 1,128,685,880 (−111.3 MB) | 1,049,327,808 (−79.4 MB) |

Head vs main: cold heap_ptr −205 MB (−16.3%), cold wall about −8%. Byte-identical output on three closures and 22 rc fixtures for every compiler commit.

## Validation

Chain on `3ad4519` (base `fe58fa8`, run in a staging worktree at that exact commit, tree hash checked against the pushed head): bundle regen; stage2 == stage3; output equivalence; `test_cli_core.sh`; selfcompile KPI heap_ptr 1,049,516,408 bytes (−204.9 MB vs main's 1,254,412,296 on the same corpus); typing-env-reuse oracle; 296/296 affected unit-test files (import-graph selection over the changed files — the parser package change widens the set); `compiler_gate.sh` early / mid / late. The same chain was green on each earlier head of this PR: `1a97d1d` (KPI heap_ptr 1,049,354,744, 115/115), `05d10b4` (1,128,713,264, 114/114), `ff42bd9` (1,239,991,448, 113/113) and `52cfee4` (1,239,962,984, 113/113).

`vibe_fmt.sh --check` is a fixpoint on every changed file.

Refs #2386.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QKZdvBvHVUagwg6Yih8er8