### PR TITLE
Fail closed instead of answering by identity when `==` compares an erased aggregate (#2474)

### DIFF
--- a/fixtures/structural_eq_generic_body_option_struct_trap.vibe
+++ b/fixtures/structural_eq_generic_body_option_struct_trap.vibe
@@ -1,0 +1,28 @@
+//# #2474: inside a generic body the operand's type is an erased formal, so
+//# the checker's typed-`==` row is dropped (it mentions a scope formal) and
+//# the syntactic shape names the payload only as the unknown marker. The raw
+//# compare that used to be emitted there is the generic `eq` builtin, which
+//# reads a tagged heap pointer as a fat pointer (`ptr = v >> 32 = 0`,
+//# `len = the address`), lets the permissive looks-like-a-string test admit
+//# it, and answers `false` off `str_eq`'s length check -- reference identity
+//# wearing a content answer. A generic body is lowered exactly ONCE, so the
+//# same code serves `T = Int` and `T = Pt` and no per-instantiation
+//# comparator is reachable: this must FAIL CLOSED, not answer.
+//#
+//# Red before the guard: this returned 0 (two equal `Pt` compared unequal).
+
+struct Pt {
+  v: Int
+} derive (Eq)
+
+fn same_some[T](x: T, y: T) -> Bool {
+  Some(x) == Some(y)
+}
+
+export fn _start() -> Int {
+  if same_some(Pt::{ v: 1 }, Pt::{ v: 1 }) {
+    1
+  } else {
+    0
+  }
+}

--- a/fixtures/structural_eq_generic_body_tuple_array_trap.vibe
+++ b/fixtures/structural_eq_generic_body_tuple_array_trap.vibe
@@ -1,0 +1,18 @@
+//# #2474: the tuple spelling of the same defect, with an `Array` payload
+//# rather than a declared struct -- both decode to an RC block, which the
+//# generic `eq` builtin cannot compare by content. See the option/struct
+//# fixture beside this one for the mechanism.
+//#
+//# Red before the guard: this returned 0 (two equal arrays compared unequal).
+
+fn same_pair[T](x: T, y: T) -> Bool {
+  (x, 1) == (y, 1)
+}
+
+export fn _start() -> Int {
+  if same_pair([1, 2], [1, 2]) {
+    1
+  } else {
+    0
+  }
+}

--- a/lib/@vibe/compiler/codegen/builtin_bodies/bodies_core_a1a1_eq.vibe
+++ b/lib/@vibe/compiler/codegen/builtin_bodies/bodies_core_a1a1_eq.vibe
@@ -292,14 +292,13 @@ export fn gen_eq_body(str_eq_idx: Int, block_abort_idx: Int, block_prefix_fat: I
   // makes `str_eq`'s byte loop read out of bounds (the #664 class of bug, here
   // surfacing for `==`/`!=` on Int >= 2^32). Gate the fallback on both operands
   // looking like real strings; otherwise the values are simply not equal.
-  emit_looks_like_string(b, 0)
-  emit_looks_like_string(b, 1)
-  bytebuf_push(b, 113)
-  emit_if_i64(b)
-  emit_local_get(b, 0)
-  emit_local_get(b, 1)
-  emit_call(b, str_eq_idx)
-  emit_else(b)
+  // #2474: the block test must come BEFORE the string test, not after it.
+  // `emit_looks_like_string` here is the PERMISSIVE one (see its doc): a
+  // tagged heap pointer decodes as ptr = v >> 32 = 0 and len = the address,
+  // and `ptr(0) + len <= memory.size` is trivially true -- so two struct
+  // pointers both "look like strings", take the `str_eq` branch, and answer
+  // `false` off a length comparison of two zero-based non-strings. Measured:
+  // with the guard placed in the final `else` instead, it never fired.
   if block_abort_idx >= 0 {
     emit_is_rc_block(b, 0)
     emit_is_rc_block(b, 1)
@@ -314,6 +313,14 @@ export fn gen_eq_body(str_eq_idx: Int, block_abort_idx: Int, block_prefix_fat: I
   } else {
     ()
   }
+  emit_looks_like_string(b, 0)
+  emit_looks_like_string(b, 1)
+  bytebuf_push(b, 113)
+  emit_if_i64(b)
+  emit_local_get(b, 0)
+  emit_local_get(b, 1)
+  emit_call(b, str_eq_idx)
+  emit_else(b)
   emit_i64_const(b, 0)
   emit_end(b)
   emit_end(b)

--- a/lib/@vibe/compiler/codegen/builtin_bodies/bodies_core_a1a1_eq.vibe
+++ b/lib/@vibe/compiler/codegen/builtin_bodies/bodies_core_a1a1_eq.vibe
@@ -233,35 +233,12 @@ fn emit_looks_like_string(b: Bytes, slot: Int) -> Unit {
   emit_i64_le_s(b)
 }
 
-/// #2474: the comparison emitted at a `?EqUnknown` marker position -- the
-/// payload of `Some(x) == Some(y)` or the element of `(x, 1) == (y, 1)` inside
-/// a generic body, where the operand's type is an erased formal and neither
-/// the checker's typed-`==` row (dropped for mentioning a scope formal) nor the
-/// syntactic shape can name it.
+/// #2474: is `local` an RC block -- a struct, an enum payload, an array, a
+/// tuple, a boxed `Double`, a `Some(..)` -- rather than a value `eq` can read?
 ///
-/// The raw `eq` builtin is right for exactly the values it can read: a tagged
-/// scalar (`Int` / `Bool` / `Unit`, even by ADR-0055) compares by word, and a
-/// string/bytes fat pointer compares by content. For an RC BLOCK -- a struct, an
-/// enum payload, an array, a tuple, a boxed `Double`, a `Some(..)` -- it falls
-/// through to `0`, which is reference identity wearing the answer `false`.
-/// Measured inside a generic body before this guard: `Int` / `Bool` / `String` /
-/// `Unit` answered correctly; `Double`, `Array`, tuple, struct, enum, `Option`
-/// and `Bytes` all answered `false` for equal values.
-///
-/// A generic body is lowered exactly ONCE (`checker_stmt.vibe`'s
-/// eq-row producer says so), so the same code serves `T = Int` and `T = Pt`
-/// and no per-instantiation comparator is reachable. This guard therefore does
-/// not make the block case correct -- it makes it LOUD, which by the triage
-/// order (P0 silent-wrong above P1 crash) is the trade to take until `Eq`
-/// carries a real method and can be dispatched through a witness.
-///
-/// The block test is `rc_drop`'s, verbatim: odd (a heap pointer, since an `Int`
-/// is `n << 1`) AND high 32 bits zero (a fat pointer keeps its data offset
-/// there, so `(v >> 32) != 0` means a string/bytes leaf, not a block).
-/// Bit-equality is answered FIRST so comparing an aggregate with ITSELF still
-/// says `true` rather than aborting, and the abort needs BOTH operands to be
-/// blocks: a block against a scalar (`None` against `Some(1)`) is genuinely
-/// unequal, and `false` is the right answer there, not a trap.
+/// The test is `rc_drop`'s, verbatim: odd (a heap pointer, since an `Int` is
+/// `n << 1` by ADR-0055) AND high 32 bits zero (a fat pointer keeps its data
+/// offset there, so `(v >> 32) != 0` is a string/bytes leaf, not a block).
 fn emit_is_rc_block(b: Bytes, local: Int) -> Unit {
   // (v & 1) != 0
   emit_local_get(b, local)
@@ -278,32 +255,29 @@ fn emit_is_rc_block(b: Bytes, local: Int) -> Unit {
   bytebuf_push(b, 113)
 }
 
-export fn gen_eq_unknown_body(eq_idx: Int, abort_idx: Int, prefix_fat: Int) -> Bytes {
-  let b = bytebuf_new()
-  emit_local_get(b, 0)
-  emit_local_get(b, 1)
-  emit_i64_eq(b)
-  emit_if_i64(b)
-  emit_i64_const(b, 1)
-  emit_else(b)
-  emit_is_rc_block(b, 0)
-  emit_is_rc_block(b, 1)
-  // i32.and (0x71)
-  bytebuf_push(b, 113)
-  emit_if_void(b)
-  emit_i64_const(b, prefix_fat)
-  emit_local_get(b, 0)
-  emit_local_get(b, 1)
-  emit_call(b, abort_idx)
-  emit_end(b)
-  emit_local_get(b, 0)
-  emit_local_get(b, 1)
-  emit_call(b, eq_idx)
-  emit_end(b)
-  b
-}
-
-export fn gen_eq_body(str_eq_idx: Int) -> Bytes {
+/// #2474: `block_abort_idx >= 0` adds the fail-closed arm below. The raw
+/// builtin is right for exactly the values it can read -- a tagged scalar
+/// (`Int` / `Bool` / `Unit`) by word, a string/bytes fat pointer by content --
+/// and falls through to `0` for an RC block, which is reference identity
+/// wearing the answer `false`. Measured inside a generic body, where the
+/// operand type is an erased formal and no typed comparator is chosen:
+/// `Int` / `Bool` / `String` / `Unit` answered correctly; `Double`, `Array`,
+/// tuple, struct, enum, `Option` and `Bytes` all answered `false` for equal
+/// values.
+///
+/// A generic body is lowered exactly ONCE (`checker_stmt.vibe`'s eq-row
+/// producer says so), so one lowering serves `T = Int` and `T = Pt` alike and
+/// no per-instantiation comparator is reachable. The guard therefore does not
+/// make the block case CORRECT -- it makes it loud, which by the triage order
+/// (P0 silent-wrong above P1 crash) is the trade to take until `Eq` carries a
+/// real method and can dispatch through a witness (that root cause is its own
+/// issue).
+///
+/// It fires only when BOTH operands are blocks and the words differ: an
+/// aggregate compared with ITSELF is bit-equal and still answers `true`, and a
+/// block against a scalar (`None` against `Some(1)`) is genuinely unequal, so
+/// `false` stays the answer there rather than a trap.
+export fn gen_eq_body(str_eq_idx: Int, block_abort_idx: Int, block_prefix_fat: Int) -> Bytes {
   let b = bytebuf_new()
   emit_local_get(b, 0)
   emit_local_get(b, 1)
@@ -326,6 +300,20 @@ export fn gen_eq_body(str_eq_idx: Int) -> Bytes {
   emit_local_get(b, 1)
   emit_call(b, str_eq_idx)
   emit_else(b)
+  if block_abort_idx >= 0 {
+    emit_is_rc_block(b, 0)
+    emit_is_rc_block(b, 1)
+    // i32.and (0x71)
+    bytebuf_push(b, 113)
+    emit_if_void(b)
+    emit_i64_const(b, block_prefix_fat)
+    emit_local_get(b, 0)
+    emit_local_get(b, 1)
+    emit_call(b, block_abort_idx)
+    emit_end(b)
+  } else {
+    ()
+  }
   emit_i64_const(b, 0)
   emit_end(b)
   emit_end(b)

--- a/lib/@vibe/compiler/codegen/builtin_bodies/bodies_core_a1a1_eq.vibe
+++ b/lib/@vibe/compiler/codegen/builtin_bodies/bodies_core_a1a1_eq.vibe
@@ -233,6 +233,76 @@ fn emit_looks_like_string(b: Bytes, slot: Int) -> Unit {
   emit_i64_le_s(b)
 }
 
+/// #2474: the comparison emitted at a `?EqUnknown` marker position -- the
+/// payload of `Some(x) == Some(y)` or the element of `(x, 1) == (y, 1)` inside
+/// a generic body, where the operand's type is an erased formal and neither
+/// the checker's typed-`==` row (dropped for mentioning a scope formal) nor the
+/// syntactic shape can name it.
+///
+/// The raw `eq` builtin is right for exactly the values it can read: a tagged
+/// scalar (`Int` / `Bool` / `Unit`, even by ADR-0055) compares by word, and a
+/// string/bytes fat pointer compares by content. For an RC BLOCK -- a struct, an
+/// enum payload, an array, a tuple, a boxed `Double`, a `Some(..)` -- it falls
+/// through to `0`, which is reference identity wearing the answer `false`.
+/// Measured inside a generic body before this guard: `Int` / `Bool` / `String` /
+/// `Unit` answered correctly; `Double`, `Array`, tuple, struct, enum, `Option`
+/// and `Bytes` all answered `false` for equal values.
+///
+/// A generic body is lowered exactly ONCE (`checker_stmt.vibe`'s
+/// eq-row producer says so), so the same code serves `T = Int` and `T = Pt`
+/// and no per-instantiation comparator is reachable. This guard therefore does
+/// not make the block case correct -- it makes it LOUD, which by the triage
+/// order (P0 silent-wrong above P1 crash) is the trade to take until `Eq`
+/// carries a real method and can be dispatched through a witness.
+///
+/// The block test is `rc_drop`'s, verbatim: odd (a heap pointer, since an `Int`
+/// is `n << 1`) AND high 32 bits zero (a fat pointer keeps its data offset
+/// there, so `(v >> 32) != 0` means a string/bytes leaf, not a block).
+/// Bit-equality is answered FIRST so comparing an aggregate with ITSELF still
+/// says `true` rather than aborting, and the abort needs BOTH operands to be
+/// blocks: a block against a scalar (`None` against `Some(1)`) is genuinely
+/// unequal, and `false` is the right answer there, not a trap.
+fn emit_is_rc_block(b: Bytes, local: Int) -> Unit {
+  // (v & 1) != 0
+  emit_local_get(b, local)
+  emit_i64_const(b, 1)
+  emit_i64_and(b)
+  emit_i64_eqz(b)
+  emit_i32_eqz(b)
+  // && (v >> 32) == 0
+  emit_local_get(b, local)
+  emit_i64_const(b, 32)
+  emit_i64_shr_s(b)
+  emit_i64_eqz(b)
+  // i32.and (0x71)
+  bytebuf_push(b, 113)
+}
+
+export fn gen_eq_unknown_body(eq_idx: Int, abort_idx: Int, prefix_fat: Int) -> Bytes {
+  let b = bytebuf_new()
+  emit_local_get(b, 0)
+  emit_local_get(b, 1)
+  emit_i64_eq(b)
+  emit_if_i64(b)
+  emit_i64_const(b, 1)
+  emit_else(b)
+  emit_is_rc_block(b, 0)
+  emit_is_rc_block(b, 1)
+  // i32.and (0x71)
+  bytebuf_push(b, 113)
+  emit_if_void(b)
+  emit_i64_const(b, prefix_fat)
+  emit_local_get(b, 0)
+  emit_local_get(b, 1)
+  emit_call(b, abort_idx)
+  emit_end(b)
+  emit_local_get(b, 0)
+  emit_local_get(b, 1)
+  emit_call(b, eq_idx)
+  emit_end(b)
+  b
+}
+
 export fn gen_eq_body(str_eq_idx: Int) -> Bytes {
   let b = bytebuf_new()
   emit_local_get(b, 0)

--- a/lib/@vibe/compiler/codegen/builtin_bodies/index.vpkg
+++ b/lib/@vibe/compiler/codegen/builtin_bodies/index.vpkg
@@ -32,7 +32,7 @@ generated_hash =
 // spillover the way entry/source_compile and entry/compiler/fs_compile do.
 // No exported types (all signatures are Bool/Int/Bytes/Array).
 
-fn gen_eq_body(str_eq_idx: Int) -> Bytes
+fn gen_eq_body(str_eq_idx: Int, block_abort_idx: Int, block_prefix_fat: Int) -> Bytes
 fn gen_str_eq_body() -> Bytes
 fn gen_str_lex_diff_body(enable_rc: Bool) -> Bytes
 // #2199: oob_prefix_fat is the operation's message-prefix raw (ptr<<32)|len

--- a/lib/@vibe/compiler/codegen/gc/backend_body.vibe
+++ b/lib/@vibe/compiler/codegen/gc/backend_body.vibe
@@ -2285,7 +2285,13 @@ fn compile_wasi_module_gc_impl(stmts: Array[Stmt], entry_name: String, generated
   // a fresh non-zero pointer: every key comparison was TRUE (silent wrong Map
   // results). The gc string repr is the same packed (offset<<32)|len as the
   // linear backend, so the linear bodies are reused verbatim below.
-  push_gc_builtin(gen_eq_body(hbo + 4), 0, 0, 4)
+  // #2474: the block guard is OFF here (-1). It classifies an RC block by
+  // ADR-0055's tagging -- odd, high 32 bits zero -- and the gc lane does not
+  // represent aggregates that way, so the same test would misclassify. gc
+  // stays byte-identical and exactly as correct as it was, which is to say
+  // the generic-body case is still silently wrong on this lane; recorded as a
+  // measured residual on the issue rather than guessed at here.
+  push_gc_builtin(gen_eq_body(hbo + 4, 0 - 1, 0), 0, 0, 4)
   push_gc_builtin(gen_string_index_of_body(false, hbo + 3, hbo + 15, hbo + 4), 8, 0, 4)
   push_gc_builtin(gen_string_contains_body(false, hbo + 30), 0, 0, 4)
   push_gc_builtin(gen_string_starts_with_body(false, hbo + 3, hbo + 15, hbo + 4), 2, 1, 4)

--- a/lib/@vibe/compiler/codegen/wasi/linked_compile.vibe
+++ b/lib/@vibe/compiler/codegen/wasi/linked_compile.vibe
@@ -5140,6 +5140,17 @@ export fn compile_wasi_module_linked_impl_with_typed_offsets(stmts: Array[Stmt],
   if !array_contains_str(str_strs, "\n") {
     Array::push(str_strs, "\n")
   }
+  // #2474: the `eq` block guard's two fragments. Seeded unconditionally --
+  // the guard itself is gated on `enable_rc` at the push, but the string
+  // table is built before that decision is in hand here, and an unused
+  // fragment costs a few bytes of data section where a missing one is a
+  // "string not in table" build failure (measured).
+  if !array_contains_str(str_strs, "`==` cannot compare these two values by content: their type is not known where this comparison is lowered (typically an erased type parameter inside a generic body), so the raw compare would answer by reference identity. Compare at a concrete type, or take an explicit `(T, T) -> Bool`. left=") {
+    Array::push(str_strs, "`==` cannot compare these two values by content: their type is not known where this comparison is lowered (typically an erased type parameter inside a generic body), so the raw compare would answer by reference identity. Compare at a concrete type, or take an explicit `(T, T) -> Bool`. left=")
+  }
+  if !array_contains_str(str_strs, " right=") {
+    Array::push(str_strs, " right=")
+  }
   if rc_shadow {
     if !array_contains_str(str_strs, "dup of freed value at site ") {
       Array::push(str_strs, "dup of freed value at site ")
@@ -6190,6 +6201,23 @@ export fn compile_wasi_module_linked_impl_with_typed_offsets(stmts: Array[Stmt],
   } else {
     -1
   }
+  // #2474: the `?EqUnknown` marker-position comparison. Registered
+  // UNCONDITIONALLY and after every conditional builtin above, so it is always
+  // the last one and `max_builtin_func_idx` below is simply this.
+  // #2474: the `eq` block guard's abort. Its own, for the same reason
+  // #2427's is: the shared oob_abort_idx bakes in " out of bounds for
+  // length " as its middle fragment, which reads as nonsense between two
+  // compared operands. Registered UNCONDITIONALLY and after every
+  // conditional builtin above, so it is always the last one and
+  // max_builtin_func_idx below is simply this. `eq` itself sits far earlier
+  // and calls FORWARD to it, which module-wide function indices allow.
+  let eq_block_abort_idx = (if need_region_arena {
+    region_bytes_new_idx
+  } else if rc_shadow {
+    str_operand_abort_idx
+  } else {
+    bytes_compare_idx
+  }) + 1
   let env_get_idx = if env_get_import_idx >= 0 {
     env_get_import_idx
   } else {
@@ -6526,20 +6554,11 @@ export fn compile_wasi_module_linked_impl_with_typed_offsets(stmts: Array[Stmt],
   // from THIS constant, not from Array::length(bodies), so adding builtins
   // without updating this stale-by-construction line silently shifts every
   // user-function call target in the module by the number of builtins added).
-  let max_builtin_func_idx = if need_region_arena {
-    region_bytes_new_idx
-  } else if rc_shadow {
-    // #2427: the str-operand abort is registered after the UAF abort, so it,
-    // not shadow_uaf_abort_idx, is the last builtin on the shadow lane.
-    str_operand_abort_idx
-  } else {
-    // #2344: the bit primitives are the last UNCONDITIONAL builtins, so this
-    // is int_clz_idx, not oob_abort_idx. Leaving it stale made num_generated
-    // 3 short and shifted every user-function call target by 3 -- stage1
-    // trapped with `unreachable` while compiling a sample, exactly as the
-    // comment above says it would.
-    bytes_compare_idx
-  }
+  // #2474: the eq block guard's abort is registered unconditionally and last,
+  // after the shadow aborts (#2427) and the region arena bodies (ADR-0090),
+  // so it is the final builtin on EVERY lane. The per-lane branches this
+  // replaced are folded into eq_block_abort_idx's own definition.
+  let max_builtin_func_idx = eq_block_abort_idx
   let num_generated = (max_builtin_func_idx - num_imported_funcs) + 1
   let func_offset = num_imported_funcs + num_generated
   // #2388 step 3: record the layout facts this compile's bodies are emitted
@@ -7003,6 +7022,11 @@ export fn compile_wasi_module_linked_impl_with_typed_offsets(stmts: Array[Stmt],
   let oob_ccat_fat = oob_fat_of("String::byte_at: index ")
   let oob_mid_fat = oob_fat_of(" out of bounds for length ")
   let oob_nl_fat = oob_fat_of("\n")
+  // #2474: the message the `eq` block guard aborts with. Names the edit that
+  // fixes it, not the internals -- what the reader can do is compare at a
+  // concrete type or pass a comparison function; "the typed-`==` row was
+  // dropped for mentioning a scope formal" is true and useless at a trap.
+  let eq_block_abort_fat = oob_fat_of("`==` cannot compare these two values by content: their type is not known where this comparison is lowered (typically an erased type parameter inside a generic body), so the raw compare would answer by reference identity. Compare at a concrete type, or take an explicit `(T, T) -> Bool`. left=")
   if enable_rc {
     push_builtin(gen_arr_new_body(true, rc_alloc_idx), 1, 0, 5)
     push_builtin(gen_arr_len_body(true), 0, 0, 3)
@@ -7054,7 +7078,15 @@ export fn compile_wasi_module_linked_impl_with_typed_offsets(stmts: Array[Stmt],
   push_builtin(static_fs_stub_body(), 0, 0, 4)
   push_builtin(static_fs_write_bytes_stub_body(), 0, 0, 6)
   push_builtin(static_fs_write_bytes_stub_body(), 0, 0, 6)
-  push_builtin(gen_eq_body(str_eq_idx), 0, 0, 4)
+  push_builtin(gen_eq_body(str_eq_idx, if enable_rc {
+    eq_block_abort_idx
+  } else {
+    0 - 1
+  }, if enable_rc {
+    eq_block_abort_fat
+  } else {
+    0
+  }), 0, 0, 4)
   push_builtin(gen_string_ends_with_body(enable_rc, str_len_idx, str_substring_idx, str_eq_idx), 2, 1, 4)
   push_builtin(gen_string_last_index_of_body(enable_rc, str_len_idx, str_substring_idx, str_eq_idx), 3, 1, 4)
   if enable_rc {
@@ -7153,15 +7185,19 @@ export fn compile_wasi_module_linked_impl_with_typed_offsets(stmts: Array[Stmt],
   } else {
     ()
   }
-  // ADR-0090 (#1262): must stay LAST, in this order -- max_builtin_func_idx
-  // above names region_bytes_new_idx (= region_arr_new_idx + 1) as the final
-  // builtin, and num_generated/func_offset are derived from it.
+  // ADR-0090 (#1262): the region arena bodies are the last CONDITIONAL
+  // builtins, in this order -- eq_unknown_idx's definition names
+  // region_bytes_new_idx (= region_arr_new_idx + 1) as the builtin it follows
+  // when a region is present.
   if need_region_arena {
     push_builtin(gen_region_arr_new_body(region_ptr_addr, region_data_base, region_limit), 2, 0, 5)
     push_builtin(gen_region_bytes_new_body(region_ptr_addr, region_data_base, region_limit), 2, 0, 5)
   } else {
     ()
   }
+  // #2474: must stay LAST on every lane -- max_builtin_func_idx is
+  // eq_unknown_idx, and num_generated/func_offset are derived from it.
+  push_builtin(gen_oob_abort_body(print_str_idx, print_i64_raw_idx, oob_fat_of(" right="), oob_nl_fat), 0, 0, 7)
   // #708: one counter cell shared across every function's lift pass, so each
   // lift site gets a distinct `__m_scrut_N` name (see lift_match_scrutinees).
   let m_scrut_counter = [0]

--- a/tests/gates/early/run.sh
+++ b/tests/gates/early/run.sh
@@ -2008,7 +2008,13 @@ rm -rf "$eqtrapdir"; mkdir -p "$eqtrapdir"
 # `structural_eq_owned_scalar_*_trap.vibe` joins too (Codex round 4 on #2471):
 # a program that declares `struct Int` makes a literal-derived shape's `Int`
 # ambiguous with the struct, so the literal-shape rungs fail closed.
-for eqtrap_src in fixtures/structural_eq_untyped_empty_*_trap.vibe fixtures/structural_eq_generic_enum_*_trap.vibe fixtures/structural_eq_owned_scalar_*_trap.vibe; do
+# `structural_eq_generic_body_*_trap.vibe` joins (#2474): inside a generic body
+# the operand type is an erased formal, the typed-`==` row is dropped for
+# mentioning a scope formal, and the raw compare answered `false` for equal
+# aggregates. A generic body is lowered exactly once, so no per-instantiation
+# comparator is reachable and the only honest answer is to fail closed. Red
+# before the guard: both returned 0 rather than trapping.
+for eqtrap_src in fixtures/structural_eq_untyped_empty_*_trap.vibe fixtures/structural_eq_generic_enum_*_trap.vibe fixtures/structural_eq_owned_scalar_*_trap.vibe fixtures/structural_eq_generic_body_*_trap.vibe; do
   eqtrap_name="$(basename "${eqtrap_src%.vibe}")"
   eqtrap_wasm="$eqtrapdir/$eqtrap_name.wasm"
   VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \

--- a/tests/gates/early/run.sh
+++ b/tests/gates/early/run.sh
@@ -2008,13 +2008,7 @@ rm -rf "$eqtrapdir"; mkdir -p "$eqtrapdir"
 # `structural_eq_owned_scalar_*_trap.vibe` joins too (Codex round 4 on #2471):
 # a program that declares `struct Int` makes a literal-derived shape's `Int`
 # ambiguous with the struct, so the literal-shape rungs fail closed.
-# `structural_eq_generic_body_*_trap.vibe` joins (#2474): inside a generic body
-# the operand type is an erased formal, the typed-`==` row is dropped for
-# mentioning a scope formal, and the raw compare answered `false` for equal
-# aggregates. A generic body is lowered exactly once, so no per-instantiation
-# comparator is reachable and the only honest answer is to fail closed. Red
-# before the guard: both returned 0 rather than trapping.
-for eqtrap_src in fixtures/structural_eq_untyped_empty_*_trap.vibe fixtures/structural_eq_generic_enum_*_trap.vibe fixtures/structural_eq_owned_scalar_*_trap.vibe fixtures/structural_eq_generic_body_*_trap.vibe; do
+for eqtrap_src in fixtures/structural_eq_untyped_empty_*_trap.vibe fixtures/structural_eq_generic_enum_*_trap.vibe fixtures/structural_eq_owned_scalar_*_trap.vibe; do
   eqtrap_name="$(basename "${eqtrap_src%.vibe}")"
   eqtrap_wasm="$eqtrapdir/$eqtrap_name.wasm"
   VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
@@ -2033,6 +2027,39 @@ for eqtrap_src in fixtures/structural_eq_untyped_empty_*_trap.vibe fixtures/stru
 done
 rm -rf "$eqtrapdir"
 echo "[compiler-gate] structural equality untyped-empty mutation fail-closed ok (== + !=)"
+
+# #2474: the generic-body fail-closed contract, on the RC lane ONLY. The guard
+# classifies an RC block by ADR-0055's tagging (odd, high 32 bits zero); the
+# bump lane leaves an Int untagged, where that test would read an odd integer
+# as a block, so `gen_eq_body` takes the guard only under `enable_rc`. The loop
+# above runs at the `VIBE_RC=0` that `tests/gates/lib.sh` pins for every lane,
+# so these fixtures returned normally there -- measured, this exact wiring
+# failed the gate before it was split out. RC is selected inline in the
+# command, per the #2248 rule that a selector is never routed through a
+# variable.
+echo "[compiler-gate] generic-body equality fail-closed on the RC lane (#2474)"
+eqgbdir="_build/_gate_eq_generic_body"
+rm -rf "$eqgbdir"; mkdir -p "$eqgbdir"
+for eqgb_src in fixtures/structural_eq_generic_body_*_trap.vibe; do
+  [ -f "$eqgb_src" ] || { echo "[compiler-gate] FAIL: no generic-body trap fixtures matched (#2474)" >&2; exit 1; }
+  eqgb_name="$(basename "${eqgb_src%.vibe}")"
+  eqgb_wasm="$eqgbdir/$eqgb_name.wasm"
+  VIBE_RC=1 VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
+    bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
+    "$eqgb_src" "$eqgb_wasm" _start >/dev/null 2>&1 || true
+  if [ ! -s "$eqgb_wasm" ]; then
+    echo "[compiler-gate] FAIL: $eqgb_src did not compile on the RC lane (#2474)" >&2
+    cat "$eqgb_wasm.diag" 2>/dev/null >&2
+    exit 1
+  fi
+  if VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh \
+      --invoke _start "$eqgb_wasm" >/dev/null 2>&1; then
+    echo "[compiler-gate] FAIL: $eqgb_src returned normally on the RC lane; expected fail-closed trap (#2474)" >&2
+    exit 1
+  fi
+done
+rm -rf "$eqgbdir"
+echo "[compiler-gate] generic-body equality fail-closed on the RC lane ok (#2474)"
 
 # #2391 (after #2447): the other side of the same residual. The three shapes
 # that used to sit in the loop above as traps -- a pushed NAME, pushes made

--- a/tests/gates/registry.tsv
+++ b/tests/gates/registry.tsv
@@ -49,6 +49,7 @@ x-parser-binder-context-spine	bootstrap	parser binder-context spine
 15b/15	early	15b/15 extended derive (enum Ord/Show, Default, Eq, Hash + Map keys)
 x-structural-equality-untyped-empty-mutation-fail-	early	structural equality untyped-empty mutation fail-closed (#1681/#2157)
 x-untyped-empty-equality-answers-typed-channel	early	untyped-empty equality answers through the typed channel (#2391)
+x-generic-body-equality-fail-closed-rc	early	generic-body equality fail-closed on the RC lane (#2474)
 x-empty-array-hetero-use-rejected-import-lane	early	empty-array heterogeneous use is rejected on the import lane (#2447)
 x-nonregular-generic-equality-bounded	early	non-regular generic equality specialization is bounded
 x-untyped-empty-equality-answers-after-a-push	early	untyped-empty equality answers after a push (#2157)


### PR DESCRIPTION
Inside a generic body, `Some(x) == Some(y)` and `(x, 1) == (y, 1)` answered `false` for equal values. This does not make that case *correct* — it stops it being **silently** wrong.

Fixes half of #2474. The root cause is separate and larger; see the end.

## The defect is wider than the issue title

`Pt::{v:1} == Pt::{v:1}` was the reported symptom, but it is every non-scalar payload. Measured on a stage2 built from main at `0305c2945`, FS lane via `vibe test`:

| answers correctly | answered `false` for equal values |
|---|---|
| `Int`, near-2^62 `Int`, `Bool`, `String`, `Unit` | `Double`, `Array`, tuple, struct, enum, `Option`, `Bytes` |

Only the generic body is affected — `Some(p1) == Some(p2)` written directly, through names, through a call result, and `Some(ident(p1)) == Some(ident(p2))` all answer `true`. (The committed seed answers `false` for those too, because it has no typed-`==` rows; anyone reproducing must pass `VIBE_TEST_CLI_WASM`.)

## Mechanism

Three layers, each verified rather than assumed:

1. `dtd_typed_eq_admitted_ty` drops the checker's row when its `TypeExpr` mentions a scope formal. Inside `fn f[T]` the row is `Option[T]`, so the site falls to the syntactic shape, which names the payload only as the `?EqUnknown` marker, and a raw `==` is emitted.
2. That raw `==` reaches the generic `eq` builtin — established with a throwaway probe, since reading could not settle it. Making the fallback arm yield `7777` instead of `0` produced a compiler that misjudged a path with **no symlink anywhere in it** as a symlink. The arm executes.
3. `gen_eq_body` uses the **permissive** `emit_looks_like_string`, not `emit_looks_like_string_strict`. A tagged heap pointer decodes as a fat pointer with `ptr = v >> 32 = 0` and `len = the address`, and `ptr(0) + len <= memory.size` is trivially true — so two struct pointers both "look like strings", take the `str_eq` branch, and answer `false` off a length comparison of two zero-based non-strings.

Layer 3 is why the guard did nothing when it sat in the final `else`: that arm is never reached for aggregates. It now runs **before** the string test.

## Why fail closed rather than compare correctly

A generic body is lowered exactly **once** — `checker_stmt.vibe`'s eq-row producer says so in its own comment. One lowering serves `T = Int` and `T = Pt`, so no per-instantiation comparator is reachable. And emitting `N::equals` from a fallback is already forbidden (`desugar_trait_dict.vibe:15001`): it exists only when `N` derives `Eq`, so routing there turns programs that compile today into `undefined variable`.

By the triage order — P0 silent-wrong above P1 crash — a loud abort is the trade to take.

## What is checked

An RC block is `rc_drop`'s own test, verbatim: odd (a heap pointer, since an `Int` is `n << 1`) **and** high 32 bits zero (a fat pointer keeps its data offset there). It fires only when **both** operands are blocks and the words differ, so an aggregate compared with itself stays `true`, and a block against a scalar (`None` vs `Some(1)`) stays `false` rather than trapping. Ordering is safe in both directions: a real string has `ptr >= 64`, so its high 32 bits are non-zero and it can never satisfy the block test; a tagged `Int` / `Bool` / `Unit` and the packed empty string `(0, 0)` are all even.

The message names the edit, not the internals:

```
`==` cannot compare these two values by content: their type is not known where this
comparison is lowered (typically an erased type parameter inside a generic body), so
the raw compare would answer by reference identity. Compare at a concrete type, or
take an explicit `(T, T) -> Bool`. left=769 right=853
```

## Verification

**Red/green on two stage2 builds**, not asserted:

| fixture | stage2 from main | stage2 with the guard |
|---|---|---|
| `structural_eq_generic_body_option_struct_trap` | returned normally | **TRAPPED** |
| `structural_eq_generic_body_tuple_array_trap` | returned normally | **TRAPPED** |

- The six shapes that answered `false` — `Double`, `Array`, tuple, struct, enum, `Option` — now abort in both the `Option` and tuple spellings.
- The twelve correct cases are unchanged: `Int` (eq/ne), near-2^62 `Int` (eq/ne), `Bool` (eq/ne), `String` (eq/ne), `Unit`, and the tuple spelling of `Int` (eq/ne) and `String`.
- Committed regressions pinning the correct side pass: `eq_unknown_marker_owner_test` (3 tests), `int_payload_eq_test` (8 tests). The first pins `same_some(1, 1) == true` inside a generic body — exactly what must not break.
- `scripts/compiler_gate.sh`: **126/126, exit 0**, with both `#2474` lines in the log.

**The gate caught a defect in my own wiring**, which is worth recording. `tests/gates/lib.sh` pins `VIBE_RC=0` for every lane, so the fail-closed loop I first joined runs the **bump** allocator despite its "linear" label — and the guard is gated on `enable_rc` deliberately, because the bump lane leaves an `Int` untagged, where the block test would read an odd integer as a heap block and abort on `3 == 5`. The fixtures returned normally there and the gate failed. My earlier by-hand red/green was right but incomplete: I ran at the RC default and never at the setting the gate pins, so two runs of "the same" check were two different lanes. Split into a dedicated block selecting `VIBE_RC=1` inline, per #2426's precedent and the #2248 rule that a selector never travels through a variable. This does not change where the guard is live for users — `vibe test` and `vibe run` take `compile_file_fs_mode_rc`.

## What this does NOT fix

Both measured, neither papered over:

- **`Bytes` is not covered.** Its fat pointer carries the data offset in the high 32 bits, so it fails the block test and still answers `false` for equal content.
- **The gc lane is unchanged** (`-1` disables the guard there). It classifies blocks by ADR-0055 tagging, which gc does not use, so the same test would misclassify. gc stays byte-identical and as wrong as it was.
- **The root cause is untouched.** `Eq` is a **marker trait** — `lib/@vibe/builtin/builtin_traits.vibe:3` is a bare `export trait Eq` with impls only for `Int`/`Double`/`Bool`/`Char`/`String`. So `derive (Eq)` does not satisfy an `Eq` bound (`no impl \`Eq\` for \`Pt\``), and adding `impl Eq for Pt` makes **bare `x == y` under `[T: Eq]`** answer by reference identity — equal-distinct `false`, same-object `true`. That is the case `CLAUDE.md` currently documents as the correct witness-based one; measured, it is not. Filing separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FYMVd6D2o82suTfTwoJPMf

---
_Generated by [Claude Code](https://claude.ai/code/session_01FYMVd6D2o82suTfTwoJPMf)_