### PR TITLE
dce: the reference collector keeps one scope stack and dedups through a generation map (#2386)

### DIFF
--- a/lib/@vibe/compiler/core/dce.vibe
+++ b/lib/@vibe/compiler/core/dce.vibe
@@ -14,10 +14,6 @@ import @vibe/core {
 
 //# Functions
 
-fn clone_arr(arr: Array[String]) -> Array[String] {
-  Array::slice(arr, 0, Array::length(arr))
-}
-
 fn stmt_name(stmt: Stmt) -> Option[String] {
   match stmt {
     SLet(_, _, name, _, _) => Some(name),
@@ -43,16 +39,51 @@ fn dce_array_contains_str(arr: Array[String], s: String) -> Bool {
   search(0)
 }
 
-// `out` and `bound` are deduped/checked by linear scan on purpose: both stay
-// small (refs per def, binders per scope), and a per-def set would cost an
-// allocation per def -- the selfcompile heap KPI gate is tighter than the CPU
-// win. The quadratic scans #1259 removed were the per-queue-item def/reachable
-// lookups below, which are indexed via `def_idx` / `reachable_seen`.
+// #2386: `out` is deduped through ONE process-wide map stamped with a
+// generation per collection (`dce_refs_begin`), so a definition's refs cost
+// no allocation of their own -- the per-def set that #1259 rejected on the
+// selfcompile heap KPI -- and each identifier is one hash probe instead of a
+// scan of every name the definition referenced so far (the compiler's larger
+// bodies reference hundreds). `bound` stays a linear scan: it is the binders
+// in scope, a handful, and since #2386 it is one stack pushed and truncated
+// around each scope rather than a fresh copy per binder (the copy was the
+// allocation, per `let` / arm / lambda of every definition). The quadratic
+// scans #1259 removed were the per-queue-item def/reachable lookups below,
+// which are indexed via `def_idx` / `reachable_seen`.
+let dce_refs_seen: Array[MutMap[String, Int]] = [MutMap::new_string()]
+
+let dce_refs_gen: Array[Int] = [0]
+
+/// Start a new reference collection: names seen under an earlier generation
+/// are pushed again. Bounded for a resident compiler: the map holds every
+/// distinct name ever referenced, so past 65536 it is dropped.
+fn dce_refs_begin() -> Unit {
+  if MutMap::size(Array::get(dce_refs_seen, 0)) > 65536 {
+    Array::set(dce_refs_seen, 0, MutMap::new_string())
+  } else {
+    ()
+  }
+  Array::set(dce_refs_gen, 0, Array::get(dce_refs_gen, 0) + 1)
+}
+
+fn dce_refs_push_once(out: Array[String], name: String) -> Unit {
+  let seen = Array::get(dce_refs_seen, 0)
+  let gen = Array::get(dce_refs_gen, 0)
+  let already = match MutMap::get(seen, name) {
+    Some(stamp) => stamp == gen,
+    None => false
+  }
+  if already {
+    ()
+  } else {
+    MutMap::set(seen, name, gen)
+    Array::push(out, name)
+  }
+}
+
 fn add_ref(out: Array[String], bound: Array[String], name: String) -> Int {
   if not(dce_array_contains_str(bound, name)) {
-    if not(dce_array_contains_str(out, name)) {
-      Array::push(out, name)
-    }
+    dce_refs_push_once(out, name)
   }
   0
 }
@@ -109,10 +140,7 @@ fn collect_wat_callee_refs(callee: Expr, args: Array[Expr], bound: Array[String]
             // $helper))"` calls the fn and reads the param, and the assembler
             // already keeps those apart -- filtering by `bound` here dropped
             // the call edge and DCE then pruned the live helper.
-            let name = Array::get(names, i)
-            if not(dce_array_contains_str(out, name)) {
-              Array::push(out, name)
-            }
+            dce_refs_push_once(out, Array::get(names, i))
             i = i + 1
           }
           0
@@ -192,23 +220,26 @@ fn collect_refs_into(expr: Expr, bound: Array[String], out: Array[String]) -> In
     },
     ELet(name, val, body, _) => {
       collect_refs_into(val, bound, out)
-      let bound2 = clone_arr(bound)
-      Array::push(bound2, name)
-      collect_refs_into(body, bound2, out)
+      let mark = Array::length(bound)
+      Array::push(bound, name)
+      collect_refs_into(body, bound, out)
+      Array::truncate(bound, mark)
       0
     },
     ELetRec(name, val, body) => {
-      let bound2 = clone_arr(bound)
-      Array::push(bound2, name)
-      collect_refs_into(val, bound2, out)
-      collect_refs_into(body, bound2, out)
+      let mark = Array::length(bound)
+      Array::push(bound, name)
+      collect_refs_into(val, bound, out)
+      collect_refs_into(body, bound, out)
+      Array::truncate(bound, mark)
       0
     },
     ELetMut(name, val, body, _) => {
       collect_refs_into(val, bound, out)
-      let bound2 = clone_arr(bound)
-      Array::push(bound2, name)
-      collect_refs_into(body, bound2, out)
+      let mark = Array::length(bound)
+      Array::push(bound, name)
+      collect_refs_into(body, bound, out)
+      Array::truncate(bound, mark)
       0
     },
     EAssign(_, val, body) => {
@@ -231,9 +262,10 @@ fn collect_refs_into(expr: Expr, bound: Array[String], out: Array[String]) -> In
       let mut i = 0
       while i < Array::length(arms) {
         let (pat, body) = Array::get(arms, i)
-        let bound2 = clone_arr(bound)
-        collect_pat_bindings(pat, bound2)
-        collect_refs_into(body, bound2, out)
+        let mark = Array::length(bound)
+        collect_pat_bindings(pat, bound)
+        collect_refs_into(body, bound, out)
+        Array::truncate(bound, mark)
         i = i + 1
       }
       0
@@ -243,9 +275,10 @@ fn collect_refs_into(expr: Expr, bound: Array[String], out: Array[String]) -> In
       let mut i = 0
       while i < Array::length(arms) {
         let (pat, arm_body) = Array::get(arms, i)
-        let bound2 = clone_arr(bound)
-        collect_pat_bindings(pat, bound2)
-        collect_refs_into(arm_body, bound2, out)
+        let mark = Array::length(bound)
+        collect_pat_bindings(pat, bound)
+        collect_refs_into(arm_body, bound, out)
+        Array::truncate(bound, mark)
         i = i + 1
       }
       0
@@ -256,37 +289,40 @@ fn collect_refs_into(expr: Expr, bound: Array[String], out: Array[String]) -> In
       0
     },
     ELoop(params, body) => {
-      let bound2 = clone_arr(bound)
+      let mark = Array::length(bound)
       let mut i = 0
       while i < Array::length(params) {
         let (name, init) = Array::get(params, i)
-        collect_refs_into(init, bound2, out)
-        Array::push(bound2, name)
+        collect_refs_into(init, bound, out)
+        Array::push(bound, name)
         i = i + 1
       }
-      collect_refs_into(body, bound2, out)
+      collect_refs_into(body, bound, out)
+      Array::truncate(bound, mark)
       0
     },
     EForIn(name, index_name, iter, body) => {
       collect_refs_into(iter, bound, out)
-      let bound2 = clone_arr(bound)
-      Array::push(bound2, name)
+      let mark = Array::length(bound)
+      Array::push(bound, name)
       match index_name {
-        Some(index_name) => Array::push(bound2, index_name),
+        Some(index_name) => Array::push(bound, index_name),
         None => ()
       }
-      collect_refs_into(body, bound2, out)
+      collect_refs_into(body, bound, out)
+      Array::truncate(bound, mark)
       0
     },
     EFn(_, _, params, _, _, body) => {
-      let bound2 = clone_arr(bound)
+      let mark = Array::length(bound)
       let mut i = 0
       while i < Array::length(params) {
         let (pname, _) = Array::get(params, i)
-        Array::push(bound2, pname)
+        Array::push(bound, pname)
         i = i + 1
       }
-      collect_refs_into(body, bound2, out)
+      collect_refs_into(body, bound, out)
+      Array::truncate(bound, mark)
       0
     },
     EDot(obj, _, _, _) => {
@@ -315,6 +351,7 @@ fn collect_refs_into(expr: Expr, bound: Array[String], out: Array[String]) -> In
 }
 
 fn collect_refs(expr: Expr, bound: Array[String]) -> Array[String] {
+  dce_refs_begin()
   let out = array_empty()
   collect_refs_into(expr, bound, out)
   out
@@ -398,6 +435,7 @@ export fn dce_stmts(stmts: Array[Stmt], entry_names: Array[String]) -> Array[Stm
             // condition refs (requires/ensures execute inside the function
             // after lowering, so helpers they call must stay live).
             SFnDecl(_, _, fn_value, reqs, enss) => {
+              dce_refs_begin()
               let out = array_empty()
               let _ = collect_refs_into(fn_value, empty_bound, out)
               let mut cri = 0
@@ -508,6 +546,7 @@ fn dce_reachable_names(stmts: Array[Stmt], entry_names: Array[String]) -> Array[
           // condition refs (requires/ensures execute inside the function
           // after lowering, so helpers they call must stay live).
           SFnDecl(_, _, fn_value, reqs, enss) => {
+            dce_refs_begin()
             let out = array_empty()
             let _ = collect_refs_into(fn_value, empty_bound, out)
             let mut cri = 0

--- a/lib/@vibe/compiler/tests/dce_ref_collector_test.vibe
+++ b/lib/@vibe/compiler/tests/dce_ref_collector_test.vibe
@@ -1,0 +1,65 @@
+//# #2386: the DCE reference collector keeps the binders in scope on one
+//# stack (pushed and truncated around each scope) and dedups a definition's
+//# references through a generation-stamped map instead of a fresh copy of
+//# the scope per binder and a scan of the references so far per identifier.
+//# What must not happen: a binder outliving its scope (a later reference to
+//# a same-named global would be taken for the local and the global pruned),
+//# an arm's binder leaking into the next arm, and a generation that is not
+//# advanced between definitions (a name referenced by an earlier definition
+//# would be missing from a later one's references).
+
+import @vibe/compiler/syntax {
+  lex, parse_program
+}
+
+import @vibe/compiler/core {
+  Stmt, dce_keep_flags
+}
+
+fn keeps(src: String, entry: String, name: String) -> Bool with Exception {
+  let stmts: Array[Stmt] = parse_program(lex(src))
+  let flags = dce_keep_flags(stmts, [entry])
+  let mut kept = false
+  let mut i = 0
+  while i < Array::length(stmts) {
+    match Array::get(stmts, i) {
+      SFnDecl(_, n, _, _, _) => if n == name && Array::get(flags, i) {
+        kept = true
+      } else {
+        ()
+      },
+      SLet(_, _, n, _, _) => if n == name && Array::get(flags, i) {
+        kept = true
+      } else {
+        ()
+      },
+      _ => ()
+    }
+    i = i + 1
+  }
+  kept
+}
+
+test "a local binder does not outlive its scope: the same-named global stays reachable" {
+  // The `let` sits in an `if` branch: nothing but the `let` itself ends its
+  // scope before the global is referenced after the `if`.
+  let src = "fn target() -> Int {\n  1\n}\n\nfn unrelated() -> Int {\n  2\n}\n\nfn main() -> Int {\n  let x = if true {\n    let target = 3\n    target\n  } else {\n    0\n  }\n  x + target()\n}\n"
+  assert_true(keeps(src, "main", "target"))
+  assert_true(!keeps(src, "main", "unrelated"))
+}
+
+test "a match arm's binder does not leak into the next arm" {
+  let src = "fn target() -> Int {\n  1\n}\n\nfn main() -> Int {\n  match Some(2) {\n    Some(target) => target,\n    None => target()\n  }\n}\n"
+  assert_true(keeps(src, "main", "target"))
+}
+
+test "a name referenced by an earlier definition is still a reference of a later one" {
+  let src = "fn helper() -> Int {\n  1\n}\n\nfn a() -> Int {\n  helper()\n}\n\nfn b() -> Int {\n  helper()\n}\n"
+  assert_true(keeps(src, "b", "helper"))
+  assert_true(!keeps(src, "b", "a"))
+}
+
+test "a lambda's parameter shadows only inside the lambda" {
+  let src = "fn target() -> Int {\n  1\n}\n\nfn main() -> Int {\n  let g = (target: Int) -> Int {\n    target\n  }\n  g(1) + target()\n}\n"
+  assert_true(keeps(src, "main", "target"))
+}


### PR DESCRIPTION
## What

One slice of #2386 on the codegen prelude — it runs on both lanes — byte-identical to main on every corpus.

### `76b6a28` — the DCE reference collector keeps one scope stack and dedups through a generation map

`collect_refs_into` (`core/dce.vibe`) copied the whole in-scope binder array for every `let`, `let rec`, `let mut`, match and handle arm, loop, `for` and lambda it walked, and tested every referenced name against the references collected so far by a linear scan — O(refs²) per definition on the compiler's larger bodies, plus one array per binder. The pass runs under `effect_lowering_prelude` on both lanes (`evidence_dict_pass` and `dce_keep_flags`).

The binders in scope are one stack now: each scope records the length, pushes its binders, walks its body and truncates back, so a binder ends exactly where its scope does and nothing is copied. A definition's references are deduped through one process-wide map stamped with a generation that advances per collection (`collect_refs` and the two `SFnDecl` sites that assemble body plus contract refs), so the dedup costs no allocation of its own — the per-definition set that #1259 rejected on the selfcompile heap KPI — and an identifier is one probe. The map is dropped past 65536 names for a resident compiler. The membership test against `bound` stays linear: a handful of binders, and a stack has no cheap set.

`dce_ref_collector_test.vibe` pins the scope discipline and the generation through `dce_keep_flags`, each with a mutation built into the worktree's library that fails it: a `let` in an `if` branch shadowing a global referenced after the `if` keeps the global (dropping the `let`'s truncate fails it); a match arm's binder does not leak into the next arm (dropping the per-arm truncate fails it); a name referenced by an earlier definition is still a reference of a later one (never advancing the generation fails it); and a lambda parameter shadows only inside the lambda.

### Measured

Cache-isolated per the profiling skill, `codegen_lexer_test.vibe` over the full compiler closure, against a stage2 built from main (`12af55f`), idle machine, eight interleaved pairs in alternating order (ABBA):

| | main (`12af55f`) | this head |
|---|---:|---:|
| `collect_refs_into` warm inclusive | 0.20 s | 0.12 s |
| `dce_keep_flags` / `dce_reachable_names` warm inclusive | 0.21 s / 0.18 s | 0.12 s / 0.11 s |
| `evidence_dict_pass` warm inclusive | 0.40 s | 0.34 s |
| cold wall, median of 8 | 7.42 s | 7.44 s (noise) |
| warm wall, median of 8 | 4.43 s | 4.43 s (noise; 4 of 8 pairs each way) |
| heap_ptr cold / warm | 1,049,489,528 / 654,864,192 | 1,041,328,824 / 646,703,160 (−8.16 MB on both lanes: the scope copies) |

Byte-identical output on three closures and 22 rc fixtures.

## Validation

Chain on `76b6a28` (base `12af55f`, run in a staging worktree at that exact commit, tree hash checked against the pushed head): bundle regen; stage2 == stage3; output equivalence; `test_cli_core.sh`; selfcompile KPI heap_ptr 1,041,802,784 bytes (−7.7 MB vs main's 1,049,516,408 on the same corpus); typing-env-reuse oracle; 320/320 affected unit-test files (import-graph selection over the changed files — `core/dce.vibe` is imported widely); `compiler_gate.sh` early / mid / late.

`vibe_fmt.sh --check` is a fixpoint on every changed file.

Refs #2386.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QKZdvBvHVUagwg6Yih8er8

---
_Generated by [Claude Code](https://claude.ai/code/session_01QKZdvBvHVUagwg6Yih8er8)_