### PR TITLE
perceus: the reuse planner dedups drop and alias names through per-plan binding-id stamps (#2386)

### DIFF
--- a/lib/@vibe/compiler/perceus/perceus.vibe
+++ b/lib/@vibe/compiler/perceus/perceus.vibe
@@ -3036,19 +3036,69 @@ fn plan_reuse_pairs_walk(e: Expr, drop_names: Array[String], alias_names: Array[
   }
 }
 
+// #2386: the drop / alias name lists of a function are deduped through the
+// action's binding id -- dense per function, 0-based (`ctx.next_id`) -- so
+// a check is one read of a stamp table indexed by id instead of a scan of
+// every name collected so far (the compiler's larger bodies carry hundreds
+// of drop rows; `name_in` was 60 ms of a warm compile). The tables are two
+// process-wide `Array[Int]` cells stamped with a generation per plan: a
+// function allocates nothing for its dedup and the tables never grow past
+// the largest function's binding count. The generation is what keeps plans
+// apart: the previous plan's stamps have to count as absent for this one,
+// or the second function that drops `n` (the same id 0) would find it
+// "already listed", push nothing and silently lose its reuse rows. Two
+// bindings that share a name (shadowing) list the name twice; both lists
+// are read by membership only. A reuse row carries id -1 and is neither
+// kind, but an id below 0 takes the linear membership test anyway.
+let pr_drop_stamp: Array[Int] = []
+
+let pr_alias_stamp: Array[Int] = []
+
+let pr_seen_gen: Array[Int] = [0]
+
+fn pr_seen_begin() -> Unit {
+  Array::set(pr_seen_gen, 0, Array::get(pr_seen_gen, 0) + 1)
+}
+
+/// Push `name` onto `names` unless this plan already listed binding `id`:
+/// true iff pushed.
+fn pr_push_once(stamps: Array[Int], names: Array[String], id: Int, name: String) -> Bool {
+  if id < 0 {
+    if name_in(names, name) {
+      false
+    } else {
+      Array::push(names, name)
+      true
+    }
+  } else {
+    let gen = Array::get(pr_seen_gen, 0)
+    while Array::length(stamps) <= id {
+      Array::push(stamps, 0)
+    }
+    if Array::get(stamps, id) == gen {
+      false
+    } else {
+      Array::set(stamps, id, gen)
+      Array::push(names, name)
+      true
+    }
+  }
+}
+
 fn plan_reuse_pairs(body: Expr, actions: Array[PerceusAction], borrow_param_fns: Array[String], borrow_param_masks: Array[Int]) -> Unit {
   let drop_names: Array[String] = []
   let alias_names: Array[String] = []
+  pr_seen_begin()
   let mut i = 0
   while i < Array::length(actions) {
     let a = Array::get(actions, i)
-    if pa_is_drop(a) && !name_in(drop_names, a.name) {
-      Array::push(drop_names, a.name)
+    if pa_is_drop(a) {
+      let _ = pr_push_once(pr_drop_stamp, drop_names, a.binding_id, a.name)
     } else {
       ()
     }
-    if pa_is_alias_dup(a) && !name_in(alias_names, a.name) {
-      Array::push(alias_names, a.name)
+    if pa_is_alias_dup(a) {
+      let _ = pr_push_once(pr_alias_stamp, alias_names, a.binding_id, a.name)
     } else {
       ()
     }

--- a/lib/@vibe/compiler/tests/perceus_reuse_plan_gen_test.vibe
+++ b/lib/@vibe/compiler/tests/perceus_reuse_plan_gen_test.vibe
@@ -1,0 +1,40 @@
+//# Imports
+
+// #2386: the reuse planner dedups a function's drop / alias names through
+// process-wide maps stamped with a per-plan generation. Every function
+// planned in the same process must still see its own names -- the second
+// function that drops `n` pairs exactly like the first.
+
+import @vibe/compiler/runtime {
+  rc_plan_source
+}
+
+//# Functions
+
+fn plan_of(source: String) -> String with Exception {
+  rc_plan_source(source, "")
+}
+
+test "two functions that drop the same name both keep their reuse pairs" {
+  // `first` and `second` are the same rebuild shape over a scrutinee
+  // named `n`. The planner dedups names through a map that outlives one
+  // plan; if the generation stamp were not advanced per plan, `second`
+  // would find `n` "already listed", push nothing, and plan no reuse rows
+  // at all -- a silent loss of the optimization, not a wrong answer, but
+  // one the plan query has to show.
+  let src = "enum Node {\n  Leaf(Int);\n  Pair(Node, Node)\n}\nlet rec first: (Node) -> Node = (n) -> {\n  match n {\n    Pair(a, b) => {\n      let a2 = first(a)\n      let b2 = first(b)\n      Pair(a2, b2)\n    },\n    Leaf(v) => Leaf(v + 1)\n  }\n}\nlet rec second: (Node) -> Node = (n) -> {\n  match n {\n    Pair(a, b) => {\n      let a2 = second(a)\n      let b2 = second(b)\n      Pair(a2, b2)\n    },\n    Leaf(v) => Leaf(v + 2)\n  }\n}\nlet main: () -> Int = () -> {\n  match second(first(Pair(Leaf(1), Leaf(2)))) {\n    Pair(_, _) => 1,\n    Leaf(_) => 0\n  }\n}"
+  let plan = plan_of(src)
+  assert(String::contains(plan, "first n reuse_token:2 1"))
+  assert(String::contains(plan, "first n reuse_alloc:2 1"))
+  assert(String::contains(plan, "second n reuse_token:2 1"))
+  assert(String::contains(plan, "second n reuse_alloc:2 1"))
+}
+
+test "a repeated drop of one name is listed once and still pairs" {
+  // Two arms over the same scrutinee drop `n` twice; the dedup keeps one
+  // entry and the arity-keyed rows come out once per arm.
+  let src = "enum Node {\n  Uno(Node);\n  Duo(Node, Node);\n  Z(Int)\n}\nlet rec walk: (Node) -> Node = (n) -> {\n  match n {\n    Uno(x) => {\n      let x2 = walk(x)\n      Uno(x2)\n    },\n    Duo(a, b) => {\n      let a2 = walk(a)\n      let b2 = walk(b)\n      Duo(a2, b2)\n    },\n    _ => Z(0)\n  }\n}\nlet main: () -> Int = () -> {\n  match walk(Duo(Z(1), Z(2))) {\n    _ => 0\n  }\n}"
+  let plan = plan_of(src)
+  assert(String::contains(plan, "walk n reuse_token:1 1"))
+  assert(String::contains(plan, "walk n reuse_token:2 1"))
+}

--- a/lib/@vibe/compiler/tests/perceus_reuse_plan_gen_test.vibe
+++ b/lib/@vibe/compiler/tests/perceus_reuse_plan_gen_test.vibe
@@ -17,24 +17,19 @@ fn plan_of(source: String) -> String with Exception {
 
 test "two functions that drop the same name both keep their reuse pairs" {
   // `first` and `second` are the same rebuild shape over a scrutinee
-  // named `n`. The planner dedups names through a map that outlives one
-  // plan; if the generation stamp were not advanced per plan, `second`
-  // would find `n` "already listed", push nothing, and plan no reuse rows
-  // at all -- a silent loss of the optimization, not a wrong answer, but
-  // one the plan query has to show.
+  // named `n`. The planner dedups names through stamp tables that outlive
+  // one plan; if the generation were not advanced per plan, `second` would
+  // find its `n` "already listed", push nothing, and plan no reuse rows at
+  // all -- a silent loss of the optimization, not a wrong answer, but one
+  // the plan query has to show. The whole plan is the snapshot, so an
+  // extra or duplicated row fails it too.
   let src = "enum Node {\n  Leaf(Int);\n  Pair(Node, Node)\n}\nlet rec first: (Node) -> Node = (n) -> {\n  match n {\n    Pair(a, b) => {\n      let a2 = first(a)\n      let b2 = first(b)\n      Pair(a2, b2)\n    },\n    Leaf(v) => Leaf(v + 1)\n  }\n}\nlet rec second: (Node) -> Node = (n) -> {\n  match n {\n    Pair(a, b) => {\n      let a2 = second(a)\n      let b2 = second(b)\n      Pair(a2, b2)\n    },\n    Leaf(v) => Leaf(v + 2)\n  }\n}\nlet main: () -> Int = () -> {\n  match second(first(Pair(Leaf(1), Leaf(2)))) {\n    Pair(_, _) => 1,\n    Leaf(_) => 0\n  }\n}"
-  let plan = plan_of(src)
-  assert(String::contains(plan, "first n reuse_token:2 1"))
-  assert(String::contains(plan, "first n reuse_alloc:2 1"))
-  assert(String::contains(plan, "second n reuse_token:2 1"))
-  assert(String::contains(plan, "second n reuse_alloc:2 1"))
+  inspect(plan_of(src), content = "first n drop 1\nfirst n reuse_token:2 1\nfirst n reuse_alloc:2 1\nfirst n reuse_token:1 1\nfirst n reuse_alloc:1 1\nsecond n drop 1\nsecond n reuse_token:2 1\nsecond n reuse_alloc:2 1\nsecond n reuse_token:1 1\nsecond n reuse_alloc:1 1\nmain __m_scrut_0 drop 1\nNode::equals __shadow_1___b0 drop 1\nNode::equals __b1 drop 1\nNode::equals __shadow_0___a0 drop 1\nNode::equals __a1 drop 1\nNode::equals a drop 1\nNode::equals b drop 1")
 }
 
 test "a repeated drop of one name is listed once and still pairs" {
   // Two arms over the same scrutinee drop `n` twice; the dedup keeps one
-  // entry and the arity-keyed rows come out once per arm.
+  // entry and the arity-keyed rows come out exactly once per arm.
   let src = "enum Node {\n  Uno(Node);\n  Duo(Node, Node);\n  Z(Int)\n}\nlet rec walk: (Node) -> Node = (n) -> {\n  match n {\n    Uno(x) => {\n      let x2 = walk(x)\n      Uno(x2)\n    },\n    Duo(a, b) => {\n      let a2 = walk(a)\n      let b2 = walk(b)\n      Duo(a2, b2)\n    },\n    _ => Z(0)\n  }\n}\nlet main: () -> Int = () -> {\n  match walk(Duo(Z(1), Z(2))) {\n    _ => 0\n  }\n}"
-  let plan = plan_of(src)
-  assert(String::contains(plan, "walk n reuse_token:1 1"))
-  assert(String::contains(plan, "walk n reuse_token:2 1"))
+  inspect(plan_of(src), content = "walk n drop 1\nwalk n reuse_token:1 1\nwalk n reuse_alloc:1 1\nwalk n reuse_token:2 1\nwalk n reuse_alloc:2 1\nmain __m_scrut_0 drop 1\nNode::equals __b0 drop 1\nNode::equals __a0 drop 1\nNode::equals __shadow_1___b0 drop 1\nNode::equals __b1 drop 1\nNode::equals __shadow_0___a0 drop 1\nNode::equals __a1 drop 1\nNode::equals a drop 1\nNode::equals b drop 1")
 }


### PR DESCRIPTION
## What

One slice of #2386 on the RC codegen lane, byte-identical to main on every corpus.

### `307bc91` — the reuse planner dedups drop and alias names through per-plan binding-id stamps

`plan_reuse_pairs` (`perceus/perceus.vibe`) collected a function's droppable and alias-dup names with `name_in`, a linear scan of everything gathered so far, once per action. The compiler's larger bodies carry hundreds of drop rows (545 distinct drop names in one `checker.vibe` function), so the scan was quadratic per function and `name_in` showed as ~60 ms of a warm self-compile, nearly all of it from this dedup.

The dedup now keys on the action's binding id, which the count/emit passes assign densely per function from 0: two process-wide `Array[Int]` stamp tables, indexed by id and stamped with a per-plan generation, make a check one read. A function allocates nothing for its dedup, nothing is hashed, and the tables never grow past the largest function's binding count. A string-keyed map was tried first and measured +1.37 MB of heap on the self-compile (the distinct names of the whole closure, kept for the process); the stamps cost 125 KB. The generation is what keeps plans apart: a later function that drops `n` at the same id 0 must still list it, or it would silently lose its reuse rows. Two bindings that share a name list it twice — both lists are read by membership only. A reuse row carries id -1 and is neither kind, but an id below 0 takes the linear test anyway.

`perceus_reuse_plan_gen_test.vibe` pins it through `rc_plan_source`: two functions of the same rebuild shape over `n` both keep their `reuse_token:2` / `reuse_alloc:2` rows — with the generation never advanced (mutation built into the worktree's library) the second plan finds id 0 "already listed", pushes nothing and plans no reuse, and the test fails — and a repeated drop of one name still pairs once per arm.

### `a8e7485` — the test snapshots the whole plan (Codex P1)

Both cases `inspect` the whole `rc_plan_source` text instead of `String::contains` on a few rows, so an extra or duplicated row fails them and `vibe test --update` maintains them. The Red holds: with the generation never advanced, `second`'s five rows disappear from the first snapshot.

### Measured

Cache-isolated per the profiling skill, `codegen_lexer_test.vibe` over the full compiler closure, against a stage2 built from main (`76b6a28`), idle machine, four interleaved pairs in alternating order (ABBA):

| | main (`76b6a28`) | this head |
|---|---:|---:|
| `plan_reuse_pairs` cold inclusive | 0.13 s | 0.03 s |
| `name_in` cold self | 0.07 s | 0.01 s |
| `build_perceus_plan_in_ctx` cold inclusive | 0.34 s | 0.27 s |
| cold wall, median of 4 | 7.44 s | 7.44 s (noise) |
| warm wall, median of 4 | 4.60 s | 4.56 s (noise) |
| heap_ptr cold / warm | 1,041,776,184 / 646,993,456 | 1,041,901,112 / 647,120,400 (+125 KB: the stamp tables) |

Byte-identical output on three closures and 22 rc fixtures.

## Validation

Chain on `307bc91` (base `e05543e`, run in a staging worktree at that exact commit, tree hash checked against the pushed head): bundle regen; stage2 == stage3; output equivalence; `test_cli_core.sh`; selfcompile KPI heap_ptr 1,042,102,072 bytes (+299 KB vs the cand29 chain's 1,041,802,784 on the same corpus); typing-env-reuse oracle; 132/132 affected unit-test files (import-graph selection over the changed files); `compiler_gate.sh` early / mid / late. `a8e7485` changes one test file only; it was run Green and Red against the same stage2.

`vibe_fmt.sh --check` is a fixpoint on every changed file.

Refs #2386.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QKZdvBvHVUagwg6Yih8er8

---
_Generated by [Claude Code](https://claude.ai/code/session_01QKZdvBvHVUagwg6Yih8er8)_