### PR TITLE
codegen: the borrow-param inference walks each fn body once for all of its parameters (#2386)

### DIFF
--- a/lib/@vibe/compiler/codegen/common_analysis/common_analysis.vibe
+++ b/lib/@vibe/compiler/codegen/common_analysis/common_analysis.vibe
@@ -2113,6 +2113,196 @@ fn md_cc_go(e: Expr, name: String, bfns: Array[String], bmasks: Array[Int]) -> I
   }
 }
 
+/// The `md_consume_count(e, n) == 0` question for every name of a body in ONE
+/// walk. `hits[i]` becomes 1 when `names[i]` has any counted consume in `e`
+/// under exactly md_cc_go's rules: a bare callee is invoked, a bare ident at
+/// a borrowed argument position or as a match/handle scrutinee is read, an
+/// interpolation is opaque, everything else is walked. A slot that is 1 on
+/// entry is never queried, so a caller pre-marks the positions it will not
+/// ask about, and the walk stops as soon as no slot is pending. #2386: the
+/// borrow-param inference asks this per parameter of every top-level fn;
+/// one walk per body replaces one per parameter, and the callee mask lookup
+/// (md_borrow_mask_of, most of md_cc_go's cost) runs once per call site
+/// instead of once per parameter. The exact count stays with md_cc_go, whose
+/// callers emit one dup per consume.
+export fn md_consumed_any(e: Expr, names: Array[String], bfns: Array[String], bmasks: Array[Int], hits: Array[Int]) -> Unit {
+  md_ca_go(e, names, bfns, bmasks, hits)
+}
+
+fn md_ca_pending(hits: Array[Int]) -> Bool {
+  let mut i = 0
+  let mut pending = false
+  while !pending && i < Array::length(hits) {
+    if Array::get(hits, i) == 0 {
+      pending = true
+    } else {
+      ()
+    }
+    i = i + 1
+  }
+  pending
+}
+
+fn md_ca_ident(n: String, names: Array[String], hits: Array[Int]) -> Unit {
+  let mut i = 0
+  while i < Array::length(names) {
+    if Array::get(hits, i) == 0 && Array::get(names, i) == n {
+      Array::set(hits, i, 1)
+    } else {
+      ()
+    }
+    i = i + 1
+  }
+}
+
+fn md_ca_list(items: Array[Expr], names: Array[String], bfns: Array[String], bmasks: Array[Int], hits: Array[Int]) -> Unit {
+  let mut i = 0
+  while i < Array::length(items) {
+    md_ca_go(Array::get(items, i), names, bfns, bmasks, hits)
+    i = i + 1
+  }
+}
+
+fn md_ca_fields(fields: Array[(String, Expr)], names: Array[String], bfns: Array[String], bmasks: Array[Int], hits: Array[Int]) -> Unit {
+  let mut i = 0
+  while i < Array::length(fields) {
+    let (_, v) = Array::get(fields, i)
+    md_ca_go(v, names, bfns, bmasks, hits)
+    i = i + 1
+  }
+}
+
+fn md_ca_arms(arms: Array[(Pat, Expr)], names: Array[String], bfns: Array[String], bmasks: Array[Int], hits: Array[Int]) -> Unit {
+  let mut i = 0
+  while i < Array::length(arms) {
+    let (_, v) = Array::get(arms, i)
+    md_ca_go(v, names, bfns, bmasks, hits)
+    i = i + 1
+  }
+}
+
+/// Enumerated like md_cc_go (no `_ =>` for the recursive shapes): a new
+/// `Expr` variant is a compile error here, not a silently unscanned subtree.
+fn md_ca_go(e: Expr, names: Array[String], bfns: Array[String], bmasks: Array[Int], hits: Array[Int]) -> Unit {
+  if !md_ca_pending(hits) {
+    ()
+  } else {
+    match e {
+      EInt(_) => (),
+      EFloat(_) => (),
+      EString(_) => (),
+      EBool(_) => (),
+      EUnit => (),
+      EStringInterp(_) => (),
+      EIdent(n, _) => md_ca_ident(n, names, hits),
+      ETuple(items) => md_ca_list(items, names, bfns, bmasks, hits),
+      EArray(items) => md_ca_list(items, names, bfns, bmasks, hits),
+      ERecord(_, fields, _) => md_ca_fields(fields, names, bfns, bmasks, hits),
+      EMap(fields) => {
+        let mut i = 0
+        while i < Array::length(fields) {
+          let (_, v) = Array::get(fields, i)
+          md_ca_go(v, names, bfns, bmasks, hits)
+          i = i + 1
+        }
+      },
+      EIf(c, t, el) => {
+        md_ca_go(c, names, bfns, bmasks, hits)
+        md_ca_go(t, names, bfns, bmasks, hits)
+        md_ca_go(el, names, bfns, bmasks, hits)
+      },
+      ELet(_, v, b, _) => {
+        md_ca_go(v, names, bfns, bmasks, hits)
+        md_ca_go(b, names, bfns, bmasks, hits)
+      },
+      ELetRec(_, v, b) => {
+        md_ca_go(v, names, bfns, bmasks, hits)
+        md_ca_go(b, names, bfns, bmasks, hits)
+      },
+      ELetMut(_, v, b, _) => {
+        md_ca_go(v, names, bfns, bmasks, hits)
+        md_ca_go(b, names, bfns, bmasks, hits)
+      },
+      EAssign(_, v, b) => {
+        md_ca_go(v, names, bfns, bmasks, hits)
+        md_ca_go(b, names, bfns, bmasks, hits)
+      },
+      EAssignOp(_, _, v, b) => {
+        md_ca_go(v, names, bfns, bmasks, hits)
+        md_ca_go(b, names, bfns, bmasks, hits)
+      },
+      ESeq(a, b) => {
+        md_ca_go(a, names, bfns, bmasks, hits)
+        md_ca_go(b, names, bfns, bmasks, hits)
+      },
+      EMatch(s, arms) => {
+        md_ca_arms(arms, names, bfns, bmasks, hits)
+        match s {
+          EIdent(_, _) => (),
+          _ => md_ca_go(s, names, bfns, bmasks, hits)
+        }
+      },
+      EHandle(s, arms) => {
+        md_ca_arms(arms, names, bfns, bmasks, hits)
+        match s {
+          EIdent(_, _) => (),
+          _ => md_ca_go(s, names, bfns, bmasks, hits)
+        }
+      },
+      EWhile(c, b) => {
+        md_ca_go(c, names, bfns, bmasks, hits)
+        md_ca_go(b, names, bfns, bmasks, hits)
+      },
+      ELoop(params, b) => {
+        md_ca_go(b, names, bfns, bmasks, hits)
+        md_ca_fields(params, names, bfns, bmasks, hits)
+      },
+      EForIn(_, _, it, b) => {
+        md_ca_go(it, names, bfns, bmasks, hits)
+        md_ca_go(b, names, bfns, bmasks, hits)
+      },
+      ECall(callee, args, _) => {
+        let bmask = match callee {
+          EIdent(f, _) => md_borrow_mask_of(f, bfns, bmasks),
+          _ => 0
+        }
+        match callee {
+          EIdent(_, _) => (),
+          _ => md_ca_go(callee, names, bfns, bmasks, hits)
+        }
+        let mut ri = 0
+        while ri < Array::length(args) {
+          let a = Array::get(args, ri)
+          if bmask_has(bmask, ri) {
+            match a {
+              EIdent(_, _) => (),
+              _ => md_ca_go(a, names, bfns, bmasks, hits)
+            }
+          } else {
+            md_ca_go(a, names, bfns, bmasks, hits)
+          }
+          ri = ri + 1
+        }
+      },
+      EBinOp(_, l, r, _) => {
+        md_ca_go(l, names, bfns, bmasks, hits)
+        md_ca_go(r, names, bfns, bmasks, hits)
+      },
+      EUnaryOp(_, x) => md_ca_go(x, names, bfns, bmasks, hits),
+      EFn(_, _, _, _, _, body) => md_ca_go(body, names, bfns, bmasks, hits),
+      EDot(x, _, _, _) => md_ca_go(x, names, bfns, bmasks, hits),
+      ELabeledArg(_, _, v) => md_ca_go(v, names, bfns, bmasks, hits),
+      EReturn(x) => md_ca_go(x, names, bfns, bmasks, hits),
+      EBreak(opt) => match opt {
+        Some(v) => md_ca_go(v, names, bfns, bmasks, hits),
+        None => ()
+      },
+      EContinue(args) => md_ca_list(args, names, bfns, bmasks, hits),
+      ESpread(x) => md_ca_go(x, names, bfns, bmasks, hits)
+    }
+  }
+}
+
 //# ADR-0091 zero_alloc (Phase 1)
 
 /// Builtins allowed inside a `#zero_alloc` fn. Allocation classification is
@@ -3422,6 +3612,15 @@ export fn compute_borrow_param_user_fns(stmts: Array[Stmt], exclude: Array[Strin
   }
   let names = array_empty()
   let masks: MutMap[String, Int] = MutMap::new_string()
+  // #2386: both rounds ask "is this parameter consumed anywhere in the
+  // body?" through ONE md_consumed_any walk per body instead of one
+  // md_consume_count walk per parameter. The rows are reused across bodies;
+  // a position a round will not ask about is pre-marked 1 so the walk never
+  // queries it and stops once every asked position has answered.
+  let bp_names: Array[String] = []
+  let bp_hits: Array[Int] = []
+  let bp_no_fns: Array[String] = []
+  let bp_no_masks: Array[Int] = []
   // Source-owned compiler intrinsics need an authoritative entry even when
   // their inferred mask is zero. Keep this as two scalar bits and collect it
   // during the analysis' existing statement pass: no extra compiler-sized
@@ -3457,10 +3656,23 @@ export fn compute_borrow_param_user_fns(stmts: Array[Stmt], exclude: Array[Strin
           } else {
             bmask_max_param()
           }
+          Array::truncate(bp_names, 0)
+          Array::truncate(bp_hits, 0)
           while pi < lim {
             let (praw, _) = Array::get(fps, pi)
             let pn = bp_param_base_name(praw)
-            if pn != "" && !bmask_has(owned_bits, pi) && md_consume_count(fbody, pn) == 0 && !is_mut_captured_in(fbody, pn) {
+            Array::push(bp_names, pn)
+            Array::push(bp_hits, if pn != "" && !bmask_has(owned_bits, pi) {
+              0
+            } else {
+              1
+            })
+            pi = pi + 1
+          }
+          md_consumed_any(fbody, bp_names, bp_no_fns, bp_no_masks, bp_hits)
+          pi = 0
+          while pi < lim {
+            if Array::get(bp_hits, pi) == 0 && !is_mut_captured_in(fbody, Array::get(bp_names, pi)) {
               mask = mask|(1<<pi)
             } else {
               ()
@@ -3517,10 +3729,23 @@ export fn compute_borrow_param_user_fns(stmts: Array[Stmt], exclude: Array[Strin
           } else {
             bmask_max_param()
           }
+          Array::truncate(bp_names, 0)
+          Array::truncate(bp_hits, 0)
           while pi < lim {
             let (praw, _) = Array::get(fps, pi)
             let pn = bp_param_base_name(praw)
-            if !bmask_has(mask, pi) && pn != "" && !bmask_has(owned_bits, pi) && md_consume_count_pre(fbody, pn, round0_names, body_masks) == 0 && !is_mut_captured_in(fbody, pn) {
+            Array::push(bp_names, pn)
+            Array::push(bp_hits, if !bmask_has(mask, pi) && pn != "" && !bmask_has(owned_bits, pi) {
+              0
+            } else {
+              1
+            })
+            pi = pi + 1
+          }
+          md_consumed_any(fbody, bp_names, round0_names, body_masks, bp_hits)
+          pi = 0
+          while pi < lim {
+            if Array::get(bp_hits, pi) == 0 && !is_mut_captured_in(fbody, Array::get(bp_names, pi)) {
               mask = mask|(1<<pi)
             } else {
               ()

--- a/lib/@vibe/compiler/codegen/common_analysis/index.vpkg
+++ b/lib/@vibe/compiler/codegen/common_analysis/index.vpkg
@@ -50,6 +50,7 @@ fn md_consume_count(e: Expr, name: String) -> Int
 fn md_consume_count_b(e: Expr, name: String, bfns: Array[String], bmasks: Array[Int]) -> Int
 fn md_shadow_zeroed_bmasks(e: Expr, bfns: Array[String], bmasks: Array[Int]) -> Array[Int]
 fn md_consume_count_pre(e: Expr, name: String, bfns: Array[String], bmasks_zeroed: Array[Int]) -> Int
+fn md_consumed_any(e: Expr, names: Array[String], bfns: Array[String], bmasks: Array[Int], hits: Array[Int]) -> Unit
 fn zero_alloc_check(stmts: Array[Stmt]) -> String
 fn zero_alloc_fn_summaries(stmts: Array[Stmt]) -> Array[(String, String, String)]
 fn typed_operator_alloc_kind(expr: Expr, names: Array[String], kinds: Array[String]) -> String

--- a/lib/@vibe/compiler/tests/borrow_param_one_walk_test.vibe
+++ b/lib/@vibe/compiler/tests/borrow_param_one_walk_test.vibe
@@ -1,0 +1,84 @@
+import @vibe/compiler/core {
+  Expr, Pat, Stmt, TypeExpr
+}
+
+import @vibe/compiler/codegen/common_analysis {
+  compute_borrow_param_user_fns, md_consumed_any
+}
+
+// #2386: the borrow-param inference asks "is this parameter consumed
+// anywhere in the body?" for every position of a fn through ONE
+// md_consumed_any walk. The answers must be the ones md_consume_count gave
+// per parameter: a bare callee is invoked, a bare ident at a borrowed
+// argument position or as a match scrutinee is read, everything else
+// consumes, and the walk's early exit never changes an answer.
+
+fn fn_decl(name: String, params: Array[String], body: Expr) -> Stmt {
+  let ps: Array[(String, Option[TypeExpr])] = []
+  let mut i = 0
+  while i < Array::length(params) {
+    Array::push(ps, (Array::get(params, i), None))
+    i = i + 1
+  }
+  SLet(false, false, name, None, EFn([], [], ps, None, None, body))
+}
+
+fn mask_of(stmts: Array[Stmt], name: String) -> Int {
+  let masks: Array[Int] = []
+  let names = compute_borrow_param_user_fns(stmts, [], masks)
+  let mut i = 0
+  let mut found = 0
+  while i < Array::length(names) {
+    if Array::get(names, i) == name {
+      found = Array::get(masks, i)
+    } else {
+      ()
+    }
+    i = i + 1
+  }
+  found
+}
+
+fn ident_of(n: String) -> Expr {
+  EIdent(n, -1)
+}
+
+fn call_of(f: String, args: Array[Expr]) -> Expr {
+  ECall(ident_of(f), args, -1)
+}
+
+test "a borrowed, a consumed and a borrowed position answer 5 from one walk" {
+  let body = ESeq(call_of("Array::length", [ident_of("xs")]), ESeq(ident_of("n"), call_of("Array::get", [
+    ident_of("ys"),
+    EInt(0)
+  ])))
+  inspect(mask_of([fn_decl("f", ["xs", "n", "ys"], body)], "f"), content = "5")
+}
+
+test "a bare callee is invoked, not consumed; its argument is consumed" {
+  let body = call_of("f", [ident_of("x")])
+  inspect(mask_of([fn_decl("g", ["f", "x"], body)], "g"), content = "1")
+}
+
+test "a bare match scrutinee is read; the arm value is consumed" {
+  let body = EMatch(ident_of("v"), [(PWild, ident_of("w"))])
+  inspect(mask_of([fn_decl("h", ["v", "w"], body)], "h"), content = "1")
+}
+
+test "a consume anywhere disqualifies the position, before or after a borrow" {
+  let after = ESeq(call_of("Array::length", [ident_of("a")]), ident_of("a"))
+  inspect(mask_of([fn_decl("k", ["a"], after)], "k"), content = "0")
+  // Both positions answer before the walk reaches the borrow: the early
+  // exit skips the rest of the body and the answer is unchanged.
+  let before = ESeq(ident_of("a"), ESeq(ident_of("b"), call_of("Array::length", [
+    ident_of("a")
+  ])))
+  inspect(mask_of([fn_decl("k2", ["a", "b"], before)], "k2"), content = "0")
+}
+
+test "md_consumed_any marks only the pending positions it finds" {
+  let hits = [1, 0, 0]
+  md_consumed_any(EBinOp("+", ident_of("a"), ident_of("b"), -1), ["a", "b", "c"], [
+  ], [], hits)
+  inspect(hits, content = "[1, 1, 0]")
+}


### PR DESCRIPTION
## What

One slice of #2386 on both codegen lanes, byte-identical to main on every corpus.

### `7ad6cf2` — the borrow-param inference walks each fn body once for all of its parameters

`compute_borrow_param_user_fns` (`codegen/common_analysis`) decides, per parameter of every top-level fn, whether the body ever consumes it, by asking `md_consume_count(fbody, pn) == 0` once per parameter in round 0 and `md_consume_count_pre` once per parameter in the transitive round. Each question is a full walk of the body, and 60% of that walk is `md_borrow_mask_of`: the callee's borrow mask (a binary search over the user borrow set, then the builtin ladder) looked up at every call site, once per parameter, although it does not depend on the parameter. On the compiler closure the two rounds were ~100 ms of a cold self-compile (~230 ms inclusive for the analysis), on both lanes.

`md_consumed_any` answers the question for every position of a body in one walk. It mirrors md_cc_go's rules arm for arm (a bare callee is invoked, a bare ident at a borrowed argument position or as a match/handle scrutinee is read, an interpolation is opaque, everything else is walked, enumerated with no catch-all so a new `Expr` variant fails to compile here too), marks a slot the moment its name is consumed, never queries a slot that is already marked, and stops as soon as no slot is pending. Both rounds pre-mark the positions they would not have asked about (an empty base name, a position some call site passes a temporary to, a position round 0 already borrowed) into two scratch rows reused across bodies, walk once, and read the answers back; `is_mut_captured_in` still runs only for the positions that answered "not consumed", in the same order. The exact count stays with `md_cc_go`: its other callers emit one dup per consume.

`borrow_param_one_walk_test.vibe` pins the rules through the analysis with `inspect` snapshots: a borrowed, a consumed and a borrowed position answer mask 5 from one walk; a bare callee is invoked while its argument is consumed; a bare match scrutinee is read; a consume before or after a borrow disqualifies the position (the early exit changes no answer); and a pre-marked slot is never touched. Red: walking the bare callee, dropping the borrowed-position skip, or walking the bare scrutinee each fails its case.

### Measured

Cache-isolated per the profiling skill, `codegen_lexer_test.vibe` over the full compiler closure, against a stage2 built from the base tree (`4a6b893`, the head of #2526 and the tree of main `185e15f`), idle machine, four interleaved pairs in alternating order (ABBA):

| | base (`4a6b893`) | this head |
|---|---:|---:|
| `compute_borrow_param_user_fns` cold inclusive | 0.23 s | 0.17 s |
| `md_cc_go` cold inclusive | 0.14 s | 0.03 s |
| `md_borrow_mask_of` cold inclusive | 0.13 s | 0.06 s |
| `md_consumed_any` cold inclusive | — | 0.03 s |
| cold wall, median of 4 | 7.25 s | 7.16 s (−1.2%) |
| warm wall, median of 4 | 4.49 s | 4.37 s (−2.5%) |
| heap_ptr cold / warm | 1,045,641,144 / 649,177,528 | 1,045,229,696 / 648,768,712 (−411 KB / −409 KB) |

The heap goes down because round 0 no longer allocates two empty arrays per parameter for `md_consume_count`'s builtin-only view; the scratch rows are four arrays per analysis.

Byte-identical output on three closures and 22 rc fixtures.

## Validation

Chain on `7ad6cf2` (base `185e15f`; run in a staging worktree on the identical tree, tree hash checked against the pushed head): bundle regen; stage2 == stage3; output equivalence; `test_cli_core.sh`; selfcompile KPI heap_ptr 1,047,041,016 bytes (this row runs against the shared default cache and is not comparable across chains; the cache-isolated rows above are the comparison); typing-env-reuse oracle; 238/238 affected unit-test files (import-graph selection over the changed files); `compiler_gate.sh` early / mid / late.

`vibe_fmt.sh --check` is a fixpoint on every changed file.

Refs #2386. The test's helpers are named `ident_of` / `call_of` because a helper named `id` or `call` returning `Expr` breaks the closure's compile (#2527, found while writing it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QKZdvBvHVUagwg6Yih8er8

---
_Generated by [Claude Code](https://claude.ai/code/session_01QKZdvBvHVUagwg6Yih8er8)_