### PR TITLE
checker: the `Eq`-bound diagnostic names every binder, each at its own kind (#2474)

### DIFF
--- a/lib/@vibe/compiler/checker/checker.vibe
+++ b/lib/@vibe/compiler/checker/checker.vibe
@@ -4004,22 +4004,66 @@ fn eq_formal_row_of(vid: Int) -> Int {
   found
 }
 
-/// The rows a rigid `#hktformal.` mention can stand for: every RIGID binder
-/// spelled `name` whose declaration is still open. Two such binders share one
-/// spelling in the types (the rigid form carries the name only), so the
-/// mention cannot be attributed to one of them; each is reported, and
-/// bounding both is what makes the site check.
-fn eq_formal_rigid_rows(name: String, out: Array[Int]) -> Unit {
+/// The row a rigid `#hktformal.` mention stands for: the INNERMOST open rigid
+/// binder spelled `name` -- the one the spelling denotes where the site is
+/// written. The types carry the spelling only, so a value captured from an
+/// enclosing declaration whose own rigid `F[_]` shares it cannot be told
+/// apart; that case is named by `eq_formal_rigid_outer_exists` and surfaced
+/// as a hint rather than as an edit on a declaration the site may not use.
+fn eq_formal_rigid_row(name: String) -> Int {
   let mut i = 0
+  let mut best = 0 - 1
+  let mut best_d = 0 - 1
   while i < Array::length(eq_formal_vars) {
     let (_, n) = Array::get(eq_formal_vars, i)
-    if n == name && Array::get(eq_formal_rigid, i) && eq_group_is_open(Array::get(eq_formal_group, i)) && !int_array_has(out, i) {
-      Array::push(out, i)
+    if n == name && Array::get(eq_formal_rigid, i) && eq_group_is_open(Array::get(eq_formal_group, i)) {
+      let d = eq_group_distance(Array::get(eq_formal_group, i))
+      if best < 0 || d < best_d {
+        best = i
+        best_d = d
+      } else {
+        ()
+      }
     } else {
       ()
     }
     i = i + 1
   }
+  best
+}
+
+/// Whether an enclosing declaration also has an open rigid binder spelled
+/// `name` (other than row `chosen`).
+fn eq_formal_rigid_outer_exists(name: String, chosen: Int) -> Bool {
+  let mut i = 0
+  let mut found = false
+  while i < Array::length(eq_formal_vars) {
+    let (_, n) = Array::get(eq_formal_vars, i)
+    if i != chosen && n == name && Array::get(eq_formal_rigid, i) && eq_group_is_open(Array::get(eq_formal_group, i)) {
+      found = true
+      i = Array::length(eq_formal_vars)
+    } else {
+      i = i + 1
+    }
+  }
+  found
+}
+
+/// Whether a binder spelled `name` sits in an open declaration NEARER the
+/// site than distance `d` -- i.e. the spelling is genuinely shadowed there.
+fn eq_formal_name_shadowed_within(name: String, d: Int) -> Bool {
+  let mut i = 0
+  let mut found = false
+  while i < Array::length(eq_formal_vars) {
+    let (_, n) = Array::get(eq_formal_vars, i)
+    if n == name && eq_group_is_open(Array::get(eq_formal_group, i)) && eq_group_distance(Array::get(eq_formal_group, i)) < d {
+      found = true
+      i = Array::length(eq_formal_vars)
+    } else {
+      i = i + 1
+    }
+  }
+  found
 }
 
 fn int_array_has(items: Array[Int], wanted: Int) -> Bool {
@@ -4281,11 +4325,22 @@ fn eq_unbounded_formal_msg(op: String, resolved: Type, formals: Array[(Int, Stri
   // 1. entries -> table rows (a rigid mention fans out to every open
   //    higher-kinded binder of that spelling), in table order.
   let rows: Array[Int] = []
+  let rigid_hints: Array[String] = []
   let mut fi = 0
   while fi < Array::length(formals) {
     let (vid, name) = Array::get(formals, fi)
     if vid < 0 {
-      eq_formal_rigid_rows(name, rows)
+      let r = eq_formal_rigid_row(name)
+      if r >= 0 && !int_array_has(rows, r) {
+        Array::push(rows, r)
+        if eq_formal_rigid_outer_exists(name, r) && !string_array_has(rigid_hints, name) {
+          Array::push(rigid_hints, name)
+        } else {
+          ()
+        }
+      } else {
+        ()
+      }
     } else {
       let r = eq_formal_row_of(vid)
       if r >= 0 && !int_array_has(rows, r) {
@@ -4319,6 +4374,7 @@ fn eq_unbounded_formal_msg(op: String, resolved: Type, formals: Array[(Int, Stri
     gi = gi + 1
   }
   let multi = Array::length(groups) > 1
+  let single_enclosing = Array::length(sorted) == 1 && eq_group_distance(Array::get(eq_formal_group, Array::get(sorted, 0))) > 0
   // 3. mentions and per-declaration brackets.
   let mentions: Array[String] = []
   let mut mi = 0
@@ -4350,7 +4406,7 @@ fn eq_unbounded_formal_msg(op: String, resolved: Type, formals: Array[(Int, Stri
       ri = ri + 1
     }
     let bracket = String::concat("`[", String::concat(joined_names(spelled, ", "), "]`"))
-    Array::push(brackets, if multi {
+    Array::push(brackets, if multi || single_enclosing {
       String::concat(bracket, String::concat(" on ", eq_group_place(eq_group_distance(g))))
     } else {
       bracket
@@ -4362,8 +4418,11 @@ fn eq_unbounded_formal_msg(op: String, resolved: Type, formals: Array[(Int, Stri
   let params = if Array::length(sorted) == 1 {
     let r0 = Array::get(sorted, 0)
     let (_, name0) = Array::get(eq_formal_vars, r0)
-    if eq_group_distance(Array::get(eq_formal_group, r0)) > 0 {
+    let d0 = eq_group_distance(Array::get(eq_formal_group, r0))
+    if d0 > 0 && eq_formal_name_shadowed_within(name0, d0) {
       String::concat("the type parameter `", String::concat(name0, String::concat("` of an enclosing declaration has no `Eq` bound (an inner binder also spelled `", String::concat(name0, "` shadows it here, so the bound belongs on the outer one)"))))
+    } else if d0 > 0 {
+      String::concat("the type parameter `", String::concat(name0, "` of an enclosing declaration has no `Eq` bound"))
     } else {
       String::concat("the type parameter `", String::concat(name0, "` has no `Eq` bound"))
     }
@@ -4374,10 +4433,15 @@ fn eq_unbounded_formal_msg(op: String, resolved: Type, formals: Array[(Int, Stri
   } else {
     String::concat("the type parameters ", String::concat(joined_names(mentions, ", "), " have no `Eq` bound"))
   }
-  let bound_clause = if Array::length(brackets) == 0 {
-    "declare the `Eq` bound"
+  let hint = if Array::length(rigid_hints) > 0 {
+    String::concat("; an enclosing declaration also spells `", String::concat(joined_names(rigid_hints, "`, `"), "` as a higher-kinded binder, so a compared value captured from there needs the bound on that declaration instead"))
   } else {
-    String::concat("declare the bound (", String::concat(joined_names(brackets, ", "), ")"))
+    ""
+  }
+  let bound_clause = if Array::length(brackets) == 0 {
+    String::concat("declare the `Eq` bound", hint)
+  } else {
+    String::concat("declare the bound (", String::concat(joined_names(brackets, ", "), String::concat(")", hint)))
   }
   String::concat("`", String::concat(op, String::concat("` compares two values of type `", String::concat(eq_formal_display_type(resolved, s), String::concat("`, but ", String::concat(params, String::concat(", so they cannot be compared by content here; ", String::concat(bound_clause, String::concat(" or compare at a concrete type", off_marker(off))))))))))
 }

--- a/lib/@vibe/compiler/checker/checker.vibe
+++ b/lib/@vibe/compiler/checker/checker.vibe
@@ -4156,34 +4156,28 @@ fn joined_names(names: Array[String], sep: String) -> String {
 
 /// Is the recorded formal `vid`, spelled `name`, hidden at this site by an
 /// inner binder of the same spelling? The environment's binding for `name`
-/// is the innermost one; if it does not resolve to `vid`'s variable, the
-/// offending formal is an enclosing declaration's, and the edit the message
-/// names must go there (Codex on #2529: bounding the visible inner `T` would
-/// change nothing).
-fn eq_formal_is_shadowed(vid: Int, name: String, s: Subst, env: TypeEnv) -> Bool {
-  if vid < 0 {
-    // A rigid HKT formal: hidden when the visible binder of that name is no
-    // longer its own `#hktformal.` spelling (an inner `[F]` over an outer
-    // `[F[_]]`).
-    match env_lookup(env, name) {
-      Some(t) => match subst_apply(s, t) {
-        CtNamed(n, _) => n != String::concat("#hktformal.", name),
-        _ => true
+/// is the innermost binder's OWN variable (the `EFn` header binds the
+/// spelling to the fresh variable it allocated), so ownership is decided by
+/// comparing that variable's id with `vid` -- never through the current
+/// substitution: a bare `x == y` across an outer `T` and an inner `T` has
+/// already unified the two, and their shared representative would make both
+/// binders look like the visible one (Codex on #2530). If the offending
+/// formal is not the visible binder, it belongs to an enclosing declaration,
+/// and the edit the message names must go there.
+fn eq_formal_is_shadowed(vid: Int, name: String, env: TypeEnv) -> Bool {
+  match env_lookup(env, name) {
+    Some(t) => match t {
+      CtVar(id_env) => id_env != vid,
+      // The visible binder is the rigid HKT spelling: it IS the formal when
+      // `vid` is the rigid entry (-1), and hides any variable-bound one.
+      CtNamed(n, _) => if vid < 0 {
+        n != String::concat("#hktformal.", name)
+      } else {
+        true
       },
-      None => false
-    }
-  } else {
-    let own = match subst_apply(s, CtVar(vid)) {
-      CtVar(r) => r,
-      _ => 0 - 1
-    }
-    match env_lookup(env, name) {
-      Some(t) => match subst_apply(s, t) {
-        CtVar(r) => r != own && r != vid,
-        _ => true
-      },
-      None => false
-    }
+      _ => true
+    },
+    None => false
   }
 }
 
@@ -4228,7 +4222,7 @@ fn eq_unbounded_formal_msg(op: String, resolved: Type, formals: Array[(Int, Stri
     } else {
       eq_formal_arity_for_vid(vid)
     }
-    let shadowed = eq_formal_is_shadowed(vid, name, s, env)
+    let shadowed = eq_formal_is_shadowed(vid, name, env)
     let dup = eq_formals_name_count(formals, name) > 1
     let qual = if shadowed {
       " on the enclosing declaration"
@@ -4259,7 +4253,7 @@ fn eq_unbounded_formal_msg(op: String, resolved: Type, formals: Array[(Int, Stri
   }
   let params = if n == 1 {
     let (vid0, name0) = Array::get(formals, 0)
-    if eq_formal_is_shadowed(vid0, name0, s, env) {
+    if eq_formal_is_shadowed(vid0, name0, env) {
       String::concat("the type parameter `", String::concat(name0, String::concat("` of an enclosing declaration has no `Eq` bound (an inner binder also spelled `", String::concat(name0, "` shadows it here, so the bound belongs on the outer one)"))))
     } else {
       String::concat("the type parameter `", String::concat(name0, "` has no `Eq` bound"))

--- a/lib/@vibe/compiler/checker/checker.vibe
+++ b/lib/@vibe/compiler/checker/checker.vibe
@@ -3988,18 +3988,31 @@ fn record_eq_formal_var(vid: Int, name: String, arity: Int, gid: Int, rigid: Boo
   }
 }
 
-/// The table row recording binder `vid`, or -1.
+/// The table row recording binder `vid`, or -1. Scanned from the most recent
+/// row backwards and preferring a row whose declaration is still open: an
+/// auxiliary re-check (`check_resume_values` re-checks each `resume(..)`
+/// value of a handler arm with the same counter) can allocate one variable
+/// id to two sibling binders, and the closed sibling's row must not answer
+/// for the open one (Codex on #2530).
 fn eq_formal_row_of(vid: Int) -> Int {
-  let mut i = 0
+  let mut i = Array::length(eq_formal_vars) - 1
   let mut found = 0 - 1
-  while i < Array::length(eq_formal_vars) {
+  let mut found_open = false
+  while i >= 0 && !found_open {
     let (v, _) = Array::get(eq_formal_vars, i)
     if v == vid {
-      found = i
-      i = Array::length(eq_formal_vars)
+      if eq_group_is_open(Array::get(eq_formal_group, i)) {
+        found = i
+        found_open = true
+      } else if found < 0 {
+        found = i
+      } else {
+        ()
+      }
     } else {
-      i = i + 1
+      ()
     }
+    i = i - 1
   }
   found
 }

--- a/lib/@vibe/compiler/checker/checker.vibe
+++ b/lib/@vibe/compiler/checker/checker.vibe
@@ -3887,9 +3887,84 @@ let eq_formal_vars: Array[(Int, String)] = []
 /// and invalidate every `F[A]` annotation (Codex on #2529).
 let eq_formal_arity: Array[Int] = []
 
+/// Parallel to `eq_formal_vars`: the generic DECLARATION that introduced the
+/// binder -- one id per `EFn` header with type parameters. `eq_group_stack`
+/// holds the ids of the generic declarations whose bodies are being checked,
+/// innermost last, so a binder's distance from a `==` site is its group's
+/// position from the top: 0 is the declaration the site is written in, 1 the
+/// enclosing one, and so on. Ownership by declaration, not by spelling, is
+/// what lets the message place each edit (Codex on #2530: an outer `T` and an
+/// inner `U` are two declarations' edits, a value parameter spelled `T` is not
+/// a type binder, and two rigid `F[_]` binders are two binders).
+let eq_formal_group: Array[Int] = []
+
+/// Parallel to `eq_formal_vars`: whether the binder is rigid in its body (the
+/// `#hktformal.` spelling an unbounded HKT-related formal takes -- BOTH `F`
+/// and `A` of `F[A]`). A rigid mention in a type carries the spelling only,
+/// so it is attributed to every open rigid binder of that spelling.
+let eq_formal_rigid: Array[Bool] = []
+let eq_group_stack: Array[Int] = []
+let eq_group_next: Array[Int] = [0]
+
 export fn reset_eq_formal_vars() -> Unit {
   Array::truncate(eq_formal_vars, 0)
   Array::truncate(eq_formal_arity, 0)
+  Array::truncate(eq_formal_group, 0)
+  Array::truncate(eq_formal_rigid, 0)
+  Array::truncate(eq_group_stack, 0)
+  Array::set(eq_group_next, 0, 0)
+}
+
+/// Open a generic declaration: allocate its group id and push it.
+fn eq_group_begin() -> Int {
+  let gid = Array::get(eq_group_next, 0)
+  Array::set(eq_group_next, 0, gid + 1)
+  Array::push(eq_group_stack, gid)
+  gid
+}
+
+fn eq_group_end() -> Unit {
+  if Array::length(eq_group_stack) > 0 {
+    Array::truncate(eq_group_stack, Array::length(eq_group_stack) - 1)
+  } else {
+    ()
+  }
+}
+
+/// Distance of declaration `gid` from the site: 0 for the innermost open
+/// declaration, 1 for the one enclosing it, ...; 1 when the stack does not
+/// hold it (a binder that is not the visible one is at least enclosing).
+fn eq_group_distance(gid: Int) -> Int {
+  let n = Array::length(eq_group_stack)
+  let mut i = n - 1
+  let mut found = 0 - 1
+  while i >= 0 {
+    if Array::get(eq_group_stack, i) == gid {
+      found = n - 1 - i
+      i = 0 - 1
+    } else {
+      i = i - 1
+    }
+  }
+  if found < 0 {
+    1
+  } else {
+    found
+  }
+}
+
+fn eq_group_is_open(gid: Int) -> Bool {
+  let mut i = 0
+  let mut found = false
+  while i < Array::length(eq_group_stack) {
+    if Array::get(eq_group_stack, i) == gid {
+      found = true
+      i = Array::length(eq_group_stack)
+    } else {
+      i = i + 1
+    }
+  }
+  found
 }
 
 /// A `__Vfp_`-spelled formal is the desugar's re-spelling of a user formal
@@ -3902,23 +3977,25 @@ export fn reset_eq_formal_vars() -> Unit {
 /// synthesized copy is not recorded. The spelling is sound as the signal
 /// because the parser refuses a user-written `__Vfp_` type parameter
 /// (parse_type_param_kind) -- only AST the compiler built can carry it.
-fn record_eq_formal_var(vid: Int, name: String, arity: Int) -> Unit {
+fn record_eq_formal_var(vid: Int, name: String, arity: Int, gid: Int, rigid: Bool) -> Unit {
   if String::starts_with(name, "__Vfp_") {
     ()
   } else {
     Array::push(eq_formal_vars, (vid, name))
     Array::push(eq_formal_arity, arity)
+    Array::push(eq_formal_group, gid)
+    Array::push(eq_formal_rigid, rigid)
   }
 }
 
-/// The arity binder `vid` was recorded with (0 when it is not in the table).
-fn eq_formal_arity_for_vid(vid: Int) -> Int {
+/// The table row recording binder `vid`, or -1.
+fn eq_formal_row_of(vid: Int) -> Int {
   let mut i = 0
-  let mut found = 0
+  let mut found = 0 - 1
   while i < Array::length(eq_formal_vars) {
     let (v, _) = Array::get(eq_formal_vars, i)
     if v == vid {
-      found = Array::get(eq_formal_arity, i)
+      found = i
       i = Array::length(eq_formal_vars)
     } else {
       i = i + 1
@@ -3927,21 +4004,33 @@ fn eq_formal_arity_for_vid(vid: Int) -> Int {
   found
 }
 
-/// The arity of the most recent HIGHER-KINDED binder spelled `name`: the
-/// rigid `#hktformal.` spelling carries the name only, and only an
-/// unbounded binder of arity > 0 takes that spelling, so a same-named plain
-/// binder recorded later (an inner `[F]` shadowing an outer `[F[_]]`) must
-/// not answer for it.
-fn eq_formal_arity_of_rigid(name: String) -> Int {
-  let mut i = Array::length(eq_formal_vars) - 1
-  let mut found = 0
-  while i >= 0 {
+/// The rows a rigid `#hktformal.` mention can stand for: every RIGID binder
+/// spelled `name` whose declaration is still open. Two such binders share one
+/// spelling in the types (the rigid form carries the name only), so the
+/// mention cannot be attributed to one of them; each is reported, and
+/// bounding both is what makes the site check.
+fn eq_formal_rigid_rows(name: String, out: Array[Int]) -> Unit {
+  let mut i = 0
+  while i < Array::length(eq_formal_vars) {
     let (_, n) = Array::get(eq_formal_vars, i)
-    if n == name && Array::get(eq_formal_arity, i) > 0 {
-      found = Array::get(eq_formal_arity, i)
-      i = 0 - 1
+    if n == name && Array::get(eq_formal_rigid, i) && eq_group_is_open(Array::get(eq_formal_group, i)) && !int_array_has(out, i) {
+      Array::push(out, i)
     } else {
-      i = i - 1
+      ()
+    }
+    i = i + 1
+  }
+}
+
+fn int_array_has(items: Array[Int], wanted: Int) -> Bool {
+  let mut i = 0
+  let mut found = false
+  while i < Array::length(items) {
+    if Array::get(items, i) == wanted {
+      found = true
+      i = Array::length(items)
+    } else {
+      i = i + 1
     }
   }
   found
@@ -4154,123 +4243,25 @@ fn joined_names(names: Array[String], sep: String) -> String {
   out
 }
 
-fn eq_formal_binding_is(t: Type, vid: Int, name: String) -> Bool {
-  match t {
-    CtVar(id) => id == vid,
-    CtNamed(n, _) => vid < 0 && n == String::concat("#hktformal.", name),
-    _ => false
-  }
-}
-
-/// How many binders spelled `name` sit between this site and binder `vid`:
-/// 0 when it is the visible one, 1 when exactly one inner binder of that
-/// spelling hides it, and so on; -1 when the environment does not reach it.
-/// Walks the environment from the innermost binding outward (the `EFn`
-/// header binds each spelling to the fresh variable it allocated, so a
-/// binder is recognised by its own variable, never through the current
-/// substitution -- a bare `x == y` across an outer `T` and an inner `T` has
-/// already unified the two). Codex on #2530: two enclosing binders of one
-/// spelling are two different declarations, and the edit must say which.
-fn eq_formal_depth(vid: Int, name: String, env: TypeEnv) -> Int {
-  let mut cur = env
-  let mut depth = 0
-  let mut result = 0 - 1
-  let mut done = false
-  while !done {
-    match cur {
-      EnvEmpty => {
-        done = true
-      },
-      EnvBind(n, binding, rest) => {
-        if n == name {
-          if eq_formal_binding_is(binding.ty, vid, name) {
-            result = depth
-            done = true
-          } else {
-            depth = depth + 1
-          }
-        } else {
-          ()
-        }
-        if !done {
-          cur = rest
-        } else {
-          ()
-        }
-      },
-      EnvTraitDef(_, _, _, _, rest, _, _) => {
-        cur = rest
-      },
-      EnvTraitImpl(_, _, rest) => {
-        cur = rest
-      },
-      EnvTraitImplGen(_, _, _, _, rest) => {
-        cur = rest
-      },
-      EnvTypeDefs(_, _, rest) => {
-        cur = rest
-      },
-      EnvMutCell(_, _, rest) => {
-        cur = rest
-      },
-      EnvFlat(bindings) => {
-        let mut i = 0
-        while i < Array::length(bindings) && !done {
-          let (n, binding) = Array::get(bindings, i)
-          if n == name {
-            if eq_formal_binding_is(binding.ty, vid, name) {
-              result = depth
-              done = true
-            } else {
-              depth = depth + 1
-            }
-          } else {
-            ()
-          }
-          i = i + 1
-        }
-        done = true
-      },
-      EnvCached(_, _, rest) => {
-        cur = rest
-      }
-    }
-  }
-  result
-}
-
-/// Is the recorded formal `vid`, spelled `name`, hidden at this site by an
-/// inner binder of the same spelling? A depth the environment cannot
-/// establish counts as hidden: the visible binder is always reachable.
-fn eq_formal_is_shadowed(vid: Int, name: String, env: TypeEnv) -> Bool {
-  eq_formal_depth(vid, name, env) != 0
-}
-
-/// Where the edit goes, by depth: "" for the visible binder, then the
-/// enclosing declaration, then N binders out.
-fn eq_formal_depth_place(depth: Int) -> String {
-  if depth <= 0 {
-    ""
-  } else if depth == 1 {
+/// Where an edit goes, by its declaration's distance from the site.
+fn eq_group_place(d: Int) -> String {
+  if d <= 0 {
+    "the inner binder"
+  } else if d == 1 {
     "the enclosing declaration"
   } else {
-    String::concat("the declaration ", String::concat(__to_string(depth), " binders out"))
+    String::concat("the declaration ", String::concat(__to_string(d), " binders out"))
   }
 }
 
-fn eq_formals_name_count(formals: Array[(Int, String)], name: String) -> Int {
-  let mut i = 0
-  let mut n = 0
-  while i < Array::length(formals) {
-    let (_, fname) = Array::get(formals, i)
-    if fname == name {
-      n = n + 1
-    } else {
-      ()
-    }
-    i = i + 1
+fn eq_group_mention(d: Int) -> String {
+  if d <= 0 {
+    " (the inner binder's)"
+  } else if d == 1 {
+    " (an enclosing declaration's)"
+  } else {
+    String::concat(" (", String::concat(eq_group_place(d), "'s)"))
   }
-  n
 }
 
 /// #2474 (a): the diagnostic for `==` / `!=` on an operand type that mentions
@@ -4280,76 +4271,113 @@ fn eq_formals_name_count(formals: Array[(Int, String)], name: String) -> Int {
 /// `Option`, `Bytes`) answered `false` for equal values while `Int` / `String`
 /// answered correctly -- a silent wrong answer that depended on the caller.
 ///
-/// Rendered PER BINDER, not per spelling (Codex on #2529): two binders both
-/// spelled `T` -- an enclosing declaration's and an inner lambda's -- are two
-/// edits, each spelled at its own kind, and the message says which
-/// declaration each belongs on. When every binder is distinct and visible the
-/// edits collapse into one bracket (`[T: Eq, U: Eq]`).
+/// Rendered PER DECLARATION (Codex on #2529 / #2530): every offending binder
+/// is resolved to the table row of the declaration that introduced it, rows
+/// are grouped by declaration, each group becomes one bracket spelled at the
+/// binders' own kinds, and when more than one declaration is involved each
+/// bracket says which declaration it belongs on, by distance from the site.
+/// A single declaration collapses into one unqualified bracket.
 fn eq_unbounded_formal_msg(op: String, resolved: Type, formals: Array[(Int, String)], s: Subst, env: TypeEnv, off: Int) -> String {
-  let n = Array::length(formals)
-  let mentions: Array[String] = []
-  let edits: Array[String] = []
-  let plain_edits: Array[String] = []
-  let mut qualified = false
+  // 1. entries -> table rows (a rigid mention fans out to every open
+  //    higher-kinded binder of that spelling), in table order.
+  let rows: Array[Int] = []
   let mut fi = 0
-  while fi < n {
+  while fi < Array::length(formals) {
     let (vid, name) = Array::get(formals, fi)
-    let arity = if vid < 0 {
-      eq_formal_arity_of_rigid(name)
+    if vid < 0 {
+      eq_formal_rigid_rows(name, rows)
     } else {
-      eq_formal_arity_for_vid(vid)
+      let r = eq_formal_row_of(vid)
+      if r >= 0 && !int_array_has(rows, r) {
+        Array::push(rows, r)
+      } else {
+        ()
+      }
     }
-    let depth0 = eq_formal_depth(vid, name, env)
-    let depth = if depth0 < 0 {
-      1
-    } else {
-      depth0
-    }
-    let shadowed = depth != 0
-    let dup = eq_formals_name_count(formals, name) > 1
-    let qual = if shadowed {
-      String::concat(" on ", eq_formal_depth_place(depth))
-    } else if dup {
-      " on the inner binder"
-    } else {
-      ""
-    }
-    if String::length(qual) > 0 {
-      qualified = true
+    fi = fi + 1
+  }
+  let sorted: Array[Int] = []
+  let mut si = 0
+  while si < Array::length(eq_formal_vars) {
+    if int_array_has(rows, si) {
+      Array::push(sorted, si)
     } else {
       ()
     }
-    let mention_qual = if dup {
-      if depth == 1 {
-        " (an enclosing declaration's)"
-      } else if depth > 1 {
-        String::concat(" (", String::concat(eq_formal_depth_place(depth), "'s)"))
-      } else {
-        " (the inner binder's)"
-      }
+    si = si + 1
+  }
+  // 2. the declarations involved, in first-appearance order.
+  let groups: Array[Int] = []
+  let mut gi = 0
+  while gi < Array::length(sorted) {
+    let g = Array::get(eq_formal_group, Array::get(sorted, gi))
+    if !int_array_has(groups, g) {
+      Array::push(groups, g)
+    } else {
+      ()
+    }
+    gi = gi + 1
+  }
+  let multi = Array::length(groups) > 1
+  // 3. mentions and per-declaration brackets.
+  let mentions: Array[String] = []
+  let mut mi = 0
+  while mi < Array::length(sorted) {
+    let r = Array::get(sorted, mi)
+    let (_, name) = Array::get(eq_formal_vars, r)
+    let d = eq_group_distance(Array::get(eq_formal_group, r))
+    Array::push(mentions, String::concat("`", String::concat(name, String::concat("`", if multi {
+      eq_group_mention(d)
     } else {
       ""
-    }
-    Array::push(mentions, String::concat("`", String::concat(name, String::concat("`", mention_qual))))
-    let spelled = String::concat(eq_formal_binder_spelling(name, arity), ": Eq")
-    Array::push(plain_edits, spelled)
-    Array::push(edits, String::concat("`[", String::concat(spelled, String::concat("]`", qual))))
-    fi = fi + 1
+    }))))
+    mi = mi + 1
   }
-  let params = if n == 1 {
-    let (vid0, name0) = Array::get(formals, 0)
-    if eq_formal_is_shadowed(vid0, name0, env) {
+  let brackets: Array[String] = []
+  let mut bi = 0
+  while bi < Array::length(groups) {
+    let g = Array::get(groups, bi)
+    let spelled: Array[String] = []
+    let mut ri = 0
+    while ri < Array::length(sorted) {
+      let r = Array::get(sorted, ri)
+      if Array::get(eq_formal_group, r) == g {
+        let (_, name) = Array::get(eq_formal_vars, r)
+        Array::push(spelled, String::concat(eq_formal_binder_spelling(name, Array::get(eq_formal_arity, r)), ": Eq"))
+      } else {
+        ()
+      }
+      ri = ri + 1
+    }
+    let bracket = String::concat("`[", String::concat(joined_names(spelled, ", "), "]`"))
+    Array::push(brackets, if multi {
+      String::concat(bracket, String::concat(" on ", eq_group_place(eq_group_distance(g))))
+    } else {
+      bracket
+    })
+    bi = bi + 1
+  }
+  // 4. the sentence. One binder of one enclosing declaration keeps the
+  //    dedicated wording that says the visible binder is not the one to edit.
+  let params = if Array::length(sorted) == 1 {
+    let r0 = Array::get(sorted, 0)
+    let (_, name0) = Array::get(eq_formal_vars, r0)
+    if eq_group_distance(Array::get(eq_formal_group, r0)) > 0 {
       String::concat("the type parameter `", String::concat(name0, String::concat("` of an enclosing declaration has no `Eq` bound (an inner binder also spelled `", String::concat(name0, "` shadows it here, so the bound belongs on the outer one)"))))
     } else {
       String::concat("the type parameter `", String::concat(name0, "` has no `Eq` bound"))
     }
+  } else if Array::length(sorted) == 0 {
+    // Every mention resolved to no open binder (cannot happen for a recorded
+    // formal; kept so the message never indexes an empty table).
+    "a type parameter has no `Eq` bound"
   } else {
     String::concat("the type parameters ", String::concat(joined_names(mentions, ", "), " have no `Eq` bound"))
   }
-  let bound_clause = if qualified && n > 1 {
-    String::concat("declare the bound (", String::concat(joined_names(edits, ", "), ")"))
+  let bound_clause = if Array::length(brackets) == 0 {
+    "declare the `Eq` bound"
   } else {
-    String::concat("declare the bound (`[", String::concat(joined_names(plain_edits, ", "), "]`)"))
+    String::concat("declare the bound (", String::concat(joined_names(brackets, ", "), ")"))
   }
   String::concat("`", String::concat(op, String::concat("` compares two values of type `", String::concat(eq_formal_display_type(resolved, s), String::concat("`, but ", String::concat(params, String::concat(", so they cannot be compared by content here; ", String::concat(bound_clause, String::concat(" or compare at a concrete type", off_marker(off))))))))))
 }
@@ -12204,6 +12232,11 @@ fn check_expr_capture_impl(expr: Expr, env: TypeEnv, defs: Array[TypeDef], s: Su
         rti = rti + 1
       }
       let tplen = Array::length(tparams)
+      let eq_gid = if tplen > 0 {
+        eq_group_begin()
+      } else {
+        0 - 1
+      }
       let mut tp_env = env
       let mut scheme_env = env
       let mut s0 = s
@@ -12236,7 +12269,6 @@ fn check_expr_capture_impl(expr: Expr, env: TypeEnv, defs: Array[TypeDef], s: Su
           (tv, nc) => {
             let vid = nc - 1
             Array::push(tparam_ids, vid)
-            record_eq_formal_var(vid, tpname, type_param_arity(tpkey))
             let tblen = Array::length(tbounds)
             let mut bounds = array_empty()
             let mut tbi = 0
@@ -12259,6 +12291,10 @@ fn check_expr_capture_impl(expr: Expr, env: TypeEnv, defs: Array[TypeDef], s: Su
             } else {
               tv
             }
+            record_eq_formal_var(vid, tpname, type_param_arity(tpkey), eq_gid, match body_ty {
+              CtNamed(_, _) => true,
+              _ => false
+            })
             // Mask both kind markers from an outer generic that used the same
             // formal name. `CtBool` is an explicit false sentinel; the
             // signature scan below shadows it with `CtUnit` for a present use.
@@ -12418,6 +12454,11 @@ fn check_expr_capture_impl(expr: Expr, env: TypeEnv, defs: Array[TypeDef], s: Su
       let (return_provenance, return_c) = fresh_var(c1)
       let body_env = env_bind(annotated_body_env, "__return_provenance__", return_provenance)
       let (bt, s2, c2) = check_expr_capture(body, body_env, defs, s1, return_c, errors, tytab, capture, lane)
+      if eq_gid >= 0 {
+        eq_group_end()
+      } else {
+        ()
+      }
       let (base_ret, s3) = match ret_ty {
         Some(te) => {
           let resolved = resolve_type_expr_shadowed(te, defs, tparams)

--- a/lib/@vibe/compiler/checker/checker.vibe
+++ b/lib/@vibe/compiler/checker/checker.vibe
@@ -4154,30 +4154,107 @@ fn joined_names(names: Array[String], sep: String) -> String {
   out
 }
 
-/// Is the recorded formal `vid`, spelled `name`, hidden at this site by an
-/// inner binder of the same spelling? The environment's binding for `name`
-/// is the innermost binder's OWN variable (the `EFn` header binds the
-/// spelling to the fresh variable it allocated), so ownership is decided by
-/// comparing that variable's id with `vid` -- never through the current
-/// substitution: a bare `x == y` across an outer `T` and an inner `T` has
-/// already unified the two, and their shared representative would make both
-/// binders look like the visible one (Codex on #2530). If the offending
-/// formal is not the visible binder, it belongs to an enclosing declaration,
-/// and the edit the message names must go there.
-fn eq_formal_is_shadowed(vid: Int, name: String, env: TypeEnv) -> Bool {
-  match env_lookup(env, name) {
-    Some(t) => match t {
-      CtVar(id_env) => id_env != vid,
-      // The visible binder is the rigid HKT spelling: it IS the formal when
-      // `vid` is the rigid entry (-1), and hides any variable-bound one.
-      CtNamed(n, _) => if vid < 0 {
-        n != String::concat("#hktformal.", name)
-      } else {
-        true
+fn eq_formal_binding_is(t: Type, vid: Int, name: String) -> Bool {
+  match t {
+    CtVar(id) => id == vid,
+    CtNamed(n, _) => vid < 0 && n == String::concat("#hktformal.", name),
+    _ => false
+  }
+}
+
+/// How many binders spelled `name` sit between this site and binder `vid`:
+/// 0 when it is the visible one, 1 when exactly one inner binder of that
+/// spelling hides it, and so on; -1 when the environment does not reach it.
+/// Walks the environment from the innermost binding outward (the `EFn`
+/// header binds each spelling to the fresh variable it allocated, so a
+/// binder is recognised by its own variable, never through the current
+/// substitution -- a bare `x == y` across an outer `T` and an inner `T` has
+/// already unified the two). Codex on #2530: two enclosing binders of one
+/// spelling are two different declarations, and the edit must say which.
+fn eq_formal_depth(vid: Int, name: String, env: TypeEnv) -> Int {
+  let mut cur = env
+  let mut depth = 0
+  let mut result = 0 - 1
+  let mut done = false
+  while !done {
+    match cur {
+      EnvEmpty => {
+        done = true
       },
-      _ => true
-    },
-    None => false
+      EnvBind(n, binding, rest) => {
+        if n == name {
+          if eq_formal_binding_is(binding.ty, vid, name) {
+            result = depth
+            done = true
+          } else {
+            depth = depth + 1
+          }
+        } else {
+          ()
+        }
+        if !done {
+          cur = rest
+        } else {
+          ()
+        }
+      },
+      EnvTraitDef(_, _, _, _, rest, _, _) => {
+        cur = rest
+      },
+      EnvTraitImpl(_, _, rest) => {
+        cur = rest
+      },
+      EnvTraitImplGen(_, _, _, _, rest) => {
+        cur = rest
+      },
+      EnvTypeDefs(_, _, rest) => {
+        cur = rest
+      },
+      EnvMutCell(_, _, rest) => {
+        cur = rest
+      },
+      EnvFlat(bindings) => {
+        let mut i = 0
+        while i < Array::length(bindings) && !done {
+          let (n, binding) = Array::get(bindings, i)
+          if n == name {
+            if eq_formal_binding_is(binding.ty, vid, name) {
+              result = depth
+              done = true
+            } else {
+              depth = depth + 1
+            }
+          } else {
+            ()
+          }
+          i = i + 1
+        }
+        done = true
+      },
+      EnvCached(_, _, rest) => {
+        cur = rest
+      }
+    }
+  }
+  result
+}
+
+/// Is the recorded formal `vid`, spelled `name`, hidden at this site by an
+/// inner binder of the same spelling? A depth the environment cannot
+/// establish counts as hidden: the visible binder is always reachable.
+fn eq_formal_is_shadowed(vid: Int, name: String, env: TypeEnv) -> Bool {
+  eq_formal_depth(vid, name, env) != 0
+}
+
+/// Where the edit goes, by depth: "" for the visible binder, then the
+/// enclosing declaration, then N binders out.
+fn eq_formal_depth_place(depth: Int) -> String {
+  if depth <= 0 {
+    ""
+  } else if depth == 1 {
+    "the enclosing declaration"
+  } else {
+    String::concat("the declaration ", String::concat(__to_string(depth), " binders out"))
   }
 }
 
@@ -4222,10 +4299,16 @@ fn eq_unbounded_formal_msg(op: String, resolved: Type, formals: Array[(Int, Stri
     } else {
       eq_formal_arity_for_vid(vid)
     }
-    let shadowed = eq_formal_is_shadowed(vid, name, env)
+    let depth0 = eq_formal_depth(vid, name, env)
+    let depth = if depth0 < 0 {
+      1
+    } else {
+      depth0
+    }
+    let shadowed = depth != 0
     let dup = eq_formals_name_count(formals, name) > 1
     let qual = if shadowed {
-      " on the enclosing declaration"
+      String::concat(" on ", eq_formal_depth_place(depth))
     } else if dup {
       " on the inner binder"
     } else {
@@ -4237,8 +4320,10 @@ fn eq_unbounded_formal_msg(op: String, resolved: Type, formals: Array[(Int, Stri
       ()
     }
     let mention_qual = if dup {
-      if shadowed {
+      if depth == 1 {
         " (an enclosing declaration's)"
+      } else if depth > 1 {
+        String::concat(" (", String::concat(eq_formal_depth_place(depth), "'s)"))
       } else {
         " (the inner binder's)"
       }

--- a/lib/@vibe/compiler/checker/checker.vibe
+++ b/lib/@vibe/compiler/checker/checker.vibe
@@ -4374,7 +4374,12 @@ fn eq_unbounded_formal_msg(op: String, resolved: Type, formals: Array[(Int, Stri
     gi = gi + 1
   }
   let multi = Array::length(groups) > 1
-  let single_enclosing = Array::length(sorted) == 1 && eq_group_distance(Array::get(eq_formal_group, Array::get(sorted, 0))) > 0
+  // One owning declaration that is not the site's own: every edit goes there,
+  // however many formals it has (Codex on #2530: `[T, U]` outside, `[V]`
+  // inside, `(x, y) == (x, y)` -- an unplaced `[T: Eq, U: Eq]` would be read
+  // as an edit on the visible inner binder, which only declares two new
+  // shadowing formals).
+  let sole_group_enclosing = Array::length(groups) == 1 && eq_group_distance(Array::get(groups, 0)) > 0
   // 3. mentions and per-declaration brackets.
   let mentions: Array[String] = []
   let mut mi = 0
@@ -4406,7 +4411,7 @@ fn eq_unbounded_formal_msg(op: String, resolved: Type, formals: Array[(Int, Stri
       ri = ri + 1
     }
     let bracket = String::concat("`[", String::concat(joined_names(spelled, ", "), "]`"))
-    Array::push(brackets, if multi || single_enclosing {
+    Array::push(brackets, if multi || sole_group_enclosing {
       String::concat(bracket, String::concat(" on ", eq_group_place(eq_group_distance(g))))
     } else {
       bracket
@@ -4430,11 +4435,13 @@ fn eq_unbounded_formal_msg(op: String, resolved: Type, formals: Array[(Int, Stri
     // Every mention resolved to no open binder (cannot happen for a recorded
     // formal; kept so the message never indexes an empty table).
     "a type parameter has no `Eq` bound"
+  } else if sole_group_enclosing {
+    String::concat("the type parameters ", String::concat(joined_names(mentions, ", "), " of an enclosing declaration have no `Eq` bound"))
   } else {
     String::concat("the type parameters ", String::concat(joined_names(mentions, ", "), " have no `Eq` bound"))
   }
   let hint = if Array::length(rigid_hints) > 0 {
-    String::concat("; an enclosing declaration also spells `", String::concat(joined_names(rigid_hints, "`, `"), "` as a higher-kinded binder, so a compared value captured from there needs the bound on that declaration instead"))
+    String::concat("; an enclosing declaration also spells `", String::concat(joined_names(rigid_hints, "`, `"), "` as a higher-kinded binder, and a compared value captured from there needs the bound on that declaration as well"))
   } else {
     ""
   }

--- a/lib/@vibe/compiler/checker/checker.vibe
+++ b/lib/@vibe/compiler/checker/checker.vibe
@@ -3911,14 +3911,33 @@ fn record_eq_formal_var(vid: Int, name: String, arity: Int) -> Unit {
   }
 }
 
-/// The arity the most recent binder spelled `name` was recorded with (0 when
-/// none was): the rigid `#hktformal.` spelling carries the name only.
-fn eq_formal_arity_of(name: String) -> Int {
+/// The arity binder `vid` was recorded with (0 when it is not in the table).
+fn eq_formal_arity_for_vid(vid: Int) -> Int {
+  let mut i = 0
+  let mut found = 0
+  while i < Array::length(eq_formal_vars) {
+    let (v, _) = Array::get(eq_formal_vars, i)
+    if v == vid {
+      found = Array::get(eq_formal_arity, i)
+      i = Array::length(eq_formal_vars)
+    } else {
+      i = i + 1
+    }
+  }
+  found
+}
+
+/// The arity of the most recent HIGHER-KINDED binder spelled `name`: the
+/// rigid `#hktformal.` spelling carries the name only, and only an
+/// unbounded binder of arity > 0 takes that spelling, so a same-named plain
+/// binder recorded later (an inner `[F]` shadowing an outer `[F[_]]`) must
+/// not answer for it.
+fn eq_formal_arity_of_rigid(name: String) -> Int {
   let mut i = Array::length(eq_formal_vars) - 1
   let mut found = 0
   while i >= 0 {
     let (_, n) = Array::get(eq_formal_vars, i)
-    if n == name {
+    if n == name && Array::get(eq_formal_arity, i) > 0 {
       found = Array::get(eq_formal_arity, i)
       i = 0 - 1
     } else {
@@ -4143,7 +4162,16 @@ fn joined_names(names: Array[String], sep: String) -> String {
 /// change nothing).
 fn eq_formal_is_shadowed(vid: Int, name: String, s: Subst, env: TypeEnv) -> Bool {
   if vid < 0 {
-    false
+    // A rigid HKT formal: hidden when the visible binder of that name is no
+    // longer its own `#hktformal.` spelling (an inner `[F]` over an outer
+    // `[F[_]]`).
+    match env_lookup(env, name) {
+      Some(t) => match subst_apply(s, t) {
+        CtNamed(n, _) => n != String::concat("#hktformal.", name),
+        _ => true
+      },
+      None => false
+    }
   } else {
     let own = match subst_apply(s, CtVar(vid)) {
       CtVar(r) => r,
@@ -4159,45 +4187,92 @@ fn eq_formal_is_shadowed(vid: Int, name: String, s: Subst, env: TypeEnv) -> Bool
   }
 }
 
+fn eq_formals_name_count(formals: Array[(Int, String)], name: String) -> Int {
+  let mut i = 0
+  let mut n = 0
+  while i < Array::length(formals) {
+    let (_, fname) = Array::get(formals, i)
+    if fname == name {
+      n = n + 1
+    } else {
+      ()
+    }
+    i = i + 1
+  }
+  n
+}
+
 /// #2474 (a): the diagnostic for `==` / `!=` on an operand type that mentions
 /// a type parameter with no `Eq` bound. Leads with the edit: the bound, or a
 /// concrete type. Measured before this check existed, every aggregate
 /// instantiation of such a site (`Double`, `Array`, tuple, struct, enum,
 /// `Option`, `Bytes`) answered `false` for equal values while `Int` / `String`
 /// answered correctly -- a silent wrong answer that depended on the caller.
+///
+/// Rendered PER BINDER, not per spelling (Codex on #2529): two binders both
+/// spelled `T` -- an enclosing declaration's and an inner lambda's -- are two
+/// edits, each spelled at its own kind, and the message says which
+/// declaration each belongs on. When every binder is distinct and visible the
+/// edits collapse into one bracket (`[T: Eq, U: Eq]`).
 fn eq_unbounded_formal_msg(op: String, resolved: Type, formals: Array[(Int, String)], s: Subst, env: TypeEnv, off: Int) -> String {
-  let names: Array[String] = []
-  let mut shadowed = false
+  let n = Array::length(formals)
+  let mentions: Array[String] = []
+  let edits: Array[String] = []
+  let plain_edits: Array[String] = []
+  let mut qualified = false
   let mut fi = 0
-  while fi < Array::length(formals) {
+  while fi < n {
     let (vid, name) = Array::get(formals, fi)
-    if !string_array_has(names, name) {
-      Array::push(names, name)
+    let arity = if vid < 0 {
+      eq_formal_arity_of_rigid(name)
+    } else {
+      eq_formal_arity_for_vid(vid)
+    }
+    let shadowed = eq_formal_is_shadowed(vid, name, s, env)
+    let dup = eq_formals_name_count(formals, name) > 1
+    let qual = if shadowed {
+      " on the enclosing declaration"
+    } else if dup {
+      " on the inner binder"
+    } else {
+      ""
+    }
+    if String::length(qual) > 0 {
+      qualified = true
     } else {
       ()
     }
-    if eq_formal_is_shadowed(vid, name, s, env) {
-      shadowed = true
+    let mention_qual = if dup {
+      if shadowed {
+        " (an enclosing declaration's)"
+      } else {
+        " (the inner binder's)"
+      }
     } else {
-      ()
+      ""
     }
+    Array::push(mentions, String::concat("`", String::concat(name, String::concat("`", mention_qual))))
+    let spelled = String::concat(eq_formal_binder_spelling(name, arity), ": Eq")
+    Array::push(plain_edits, spelled)
+    Array::push(edits, String::concat("`[", String::concat(spelled, String::concat("]`", qual))))
     fi = fi + 1
   }
-  let bound_spelling = joined_names(for n in names {
-    String::concat(eq_formal_binder_spelling(n, eq_formal_arity_of(n)), ": Eq")
-  }, ", ")
-  let params = if Array::length(names) == 1 {
-    if shadowed {
-      String::concat("the type parameter `", String::concat(Array::get(names, 0), String::concat("` of an enclosing declaration has no `Eq` bound (an inner binder also spelled `", String::concat(Array::get(names, 0), "` shadows it here, so the bound belongs on the outer one)"))))
+  let params = if n == 1 {
+    let (vid0, name0) = Array::get(formals, 0)
+    if eq_formal_is_shadowed(vid0, name0, s, env) {
+      String::concat("the type parameter `", String::concat(name0, String::concat("` of an enclosing declaration has no `Eq` bound (an inner binder also spelled `", String::concat(name0, "` shadows it here, so the bound belongs on the outer one)"))))
     } else {
-      String::concat("the type parameter `", String::concat(Array::get(names, 0), "` has no `Eq` bound"))
+      String::concat("the type parameter `", String::concat(name0, "` has no `Eq` bound"))
     }
-  } else if shadowed {
-    String::concat("the type parameters `", String::concat(joined_names(names, "`, `"), "` have no `Eq` bound (at least one is an enclosing declaration's, shadowed here by an inner binder of the same spelling, so the bound belongs on the outer one)"))
   } else {
-    String::concat("the type parameters `", String::concat(joined_names(names, "`, `"), "` have no `Eq` bound"))
+    String::concat("the type parameters ", String::concat(joined_names(mentions, ", "), " have no `Eq` bound"))
   }
-  String::concat("`", String::concat(op, String::concat("` compares two values of type `", String::concat(eq_formal_display_type(resolved, s), String::concat("`, but ", String::concat(params, String::concat(", so they cannot be compared by content here; declare the bound (`[", String::concat(bound_spelling, String::concat("]`) or compare at a concrete type", off_marker(off))))))))))
+  let bound_clause = if qualified && n > 1 {
+    String::concat("declare the bound (", String::concat(joined_names(edits, ", "), ")"))
+  } else {
+    String::concat("declare the bound (`[", String::concat(joined_names(plain_edits, ", "), "]`)"))
+  }
+  String::concat("`", String::concat(op, String::concat("` compares two values of type `", String::concat(eq_formal_display_type(resolved, s), String::concat("`, but ", String::concat(params, String::concat(", so they cannot be compared by content here; ", String::concat(bound_clause, String::concat(" or compare at a concrete type", off_marker(off))))))))))
 }
 
 fn mark_return_provenance_written(id: Int) -> Unit {

--- a/lib/@vibe/compiler/tests/eq_unbounded_formal_test.vibe
+++ b/lib/@vibe/compiler/tests/eq_unbounded_formal_test.vibe
@@ -96,6 +96,22 @@ test "#2474: a higher-kinded binder keeps its kind in the suggested bound" {
   inspect(first_check_error(src), content = "`==` compares two values of type `F[A]`, but the type parameters `F`, `A` have no `Eq` bound, so they cannot be compared by content here; declare the bound (`[F[_]: Eq, A: Eq]`) or compare at a concrete type")
 }
 
+test "#2474: two binders spelled alike are two edits, each on its own declaration" {
+  // The outer `T` (captured `x`) and the inner lambda's `T` (`y`) are both
+  // unbounded; one `[T: Eq]` on the outer declaration would leave the inner
+  // binder as it was, so each is named with the declaration it belongs on.
+  let src = "fn outer[T](x: T) -> Bool {\n  let f = [T](y: T) -> Bool {\n    (x, y) == (x, y)\n  }\n  true\n}\n"
+  inspect(first_check_error(src), content = "`==` compares two values of type `(T, T)`, but the type parameters `T` (an enclosing declaration's), `T` (the inner binder's) have no `Eq` bound, so they cannot be compared by content here; declare the bound (`[T: Eq]` on the enclosing declaration, `[T: Eq]` on the inner binder) or compare at a concrete type")
+}
+
+test "#2474: a shadowed higher-kinded binder keeps its kind, the shadowing one keeps its own" {
+  // The outer `F[_]` is rigid in the body; the inner plain `F` is a
+  // different binder of kind `Type`. Neither may borrow the other's kind in
+  // the suggested edit.
+  let src = "fn outer[F[_], A](x: F[A]) -> Bool {\n  let g = [F](y: F) -> Bool {\n    (x, y) == (x, y)\n  }\n  true\n}\n"
+  inspect(first_check_error(src), content = "`==` compares two values of type `(F[A], F)`, but the type parameters `F` (an enclosing declaration's), `A`, `F` (the inner binder's) have no `Eq` bound, so they cannot be compared by content here; declare the bound (`[F[_]: Eq]` on the enclosing declaration, `[A: Eq]`, `[F: Eq]` on the inner binder) or compare at a concrete type")
+}
+
 //# Accepted
 
 test "#2474: the bound is the edit -- bare, Option, tuple, Array" {

--- a/lib/@vibe/compiler/tests/eq_unbounded_formal_test.vibe
+++ b/lib/@vibe/compiler/tests/eq_unbounded_formal_test.vibe
@@ -121,6 +121,14 @@ test "#2474: a bare compare that unifies the two binders still tells them apart"
   inspect(first_check_error(src), content = "`==` compares two values of type `T`, but the type parameters `T` (an enclosing declaration's), `T` (the inner binder's) have no `Eq` bound, so they cannot be compared by content here; declare the bound (`[T: Eq]` on the enclosing declaration, `[T: Eq]` on the inner binder) or compare at a concrete type")
 }
 
+test "#2474: three nested binders of one spelling are told apart by depth" {
+  // The innermost `T` (`z`) is not compared; the two outer ones are. One
+  // "enclosing declaration" label for both would leave the reader unable to
+  // tell the outermost from the immediately enclosing binder.
+  let src = "fn outer[T](x: T) -> Bool {\n  let g = [T](y: T) -> Bool {\n    let h = [T](z: T) -> Bool {\n      (x, y) == (x, y)\n    }\n    true\n  }\n  true\n}\n"
+  inspect(first_check_error(src), content = "`==` compares two values of type `(T, T)`, but the type parameters `T` (the declaration 2 binders out's), `T` (an enclosing declaration's) have no `Eq` bound, so they cannot be compared by content here; declare the bound (`[T: Eq]` on the declaration 2 binders out, `[T: Eq]` on the enclosing declaration) or compare at a concrete type")
+}
+
 //# Accepted
 
 test "#2474: the bound is the edit -- bare, Option, tuple, Array" {

--- a/lib/@vibe/compiler/tests/eq_unbounded_formal_test.vibe
+++ b/lib/@vibe/compiler/tests/eq_unbounded_formal_test.vibe
@@ -112,6 +112,15 @@ test "#2474: a shadowed higher-kinded binder keeps its kind, the shadowing one k
   inspect(first_check_error(src), content = "`==` compares two values of type `(F[A], F)`, but the type parameters `F` (an enclosing declaration's), `A`, `F` (the inner binder's) have no `Eq` bound, so they cannot be compared by content here; declare the bound (`[F[_]: Eq]` on the enclosing declaration, `[A: Eq]`, `[F: Eq]` on the inner binder) or compare at a concrete type")
 }
 
+test "#2474: a bare compare that unifies the two binders still tells them apart" {
+  // `x == y` unifies the outer `T` with the inner `T`, so under the final
+  // substitution both binders share one representative. Ownership is read
+  // off the binders' own variables, so the outer one is still reported as the
+  // enclosing declaration's and the inner one as the inner binder's.
+  let src = "fn outer[T](x: T) -> Bool {\n  let f = [T](y: T) -> Bool {\n    x == y\n  }\n  true\n}\n"
+  inspect(first_check_error(src), content = "`==` compares two values of type `T`, but the type parameters `T` (an enclosing declaration's), `T` (the inner binder's) have no `Eq` bound, so they cannot be compared by content here; declare the bound (`[T: Eq]` on the enclosing declaration, `[T: Eq]` on the inner binder) or compare at a concrete type")
+}
+
 //# Accepted
 
 test "#2474: the bound is the edit -- bare, Option, tuple, Array" {

--- a/lib/@vibe/compiler/tests/eq_unbounded_formal_test.vibe
+++ b/lib/@vibe/compiler/tests/eq_unbounded_formal_test.vibe
@@ -176,6 +176,15 @@ test "#2474: several formals of one enclosing declaration are placed there toget
   inspect(first_check_error(src), content = "`==` compares two values of type `(T, U)`, but the type parameters `T`, `U` of an enclosing declaration have no `Eq` bound, so they cannot be compared by content here; declare the bound (`[T: Eq, U: Eq]` on the enclosing declaration) or compare at a concrete type")
 }
 
+test "#2474: a re-checked handler arm does not place a sibling's binder as enclosing" {
+  // `check_resume_values` re-checks each `resume(..)` value with the same
+  // variable counter, so the two sibling lambdas can share a variable id. The
+  // second (unbounded) one must be reported as its own declaration, not as
+  // the closed first sibling's, and there is no enclosing generic here.
+  let src = "effect Ask {\n  Get() -> Int\n}\n\nfn ask() -> Int with Ask {\n  perform Ask::Get()\n}\n\nfn run(flag: Bool) -> Int {\n  handle { ask() } with {\n    Ask::Get() => if flag {\n      resume(if ([T: Eq](a: T, b: T) -> Bool { a == b })(1, 1) { 1 } else { 0 })\n    } else {\n      resume(if ([T](a: T, b: T) -> Bool { a == b })(2, 2) { 1 } else { 0 })\n    }\n  }\n}\n"
+  inspect(first_check_error(src), content = "`==` compares two values of type `T`, but the type parameter `T` has no `Eq` bound, so they cannot be compared by content here; declare the bound (`[T: Eq]`) or compare at a concrete type")
+}
+
 //# Accepted
 
 test "#2474: the bound is the edit -- bare, Option, tuple, Array" {

--- a/lib/@vibe/compiler/tests/eq_unbounded_formal_test.vibe
+++ b/lib/@vibe/compiler/tests/eq_unbounded_formal_test.vibe
@@ -86,7 +86,7 @@ test "#2474: a shadowed outer formal is named as the one to bound" {
   // on the binder they can see would change nothing, so the message says
   // which binder the edit belongs to.
   let src = "fn outer[T](x: T) -> Bool {\n  let f = [T: Eq](y: T) -> Bool {\n    (x, y) == (x, y)\n  }\n  true\n}\n"
-  inspect(first_check_error(src), content = "`==` compares two values of type `(T, T)`, but the type parameter `T` of an enclosing declaration has no `Eq` bound (an inner binder also spelled `T` shadows it here, so the bound belongs on the outer one), so they cannot be compared by content here; declare the bound (`[T: Eq]`) or compare at a concrete type")
+  inspect(first_check_error(src), content = "`==` compares two values of type `(T, T)`, but the type parameter `T` of an enclosing declaration has no `Eq` bound (an inner binder also spelled `T` shadows it here, so the bound belongs on the outer one), so they cannot be compared by content here; declare the bound (`[T: Eq]` on the enclosing declaration) or compare at a concrete type")
 }
 
 test "#2474: a higher-kinded binder keeps its kind in the suggested bound" {
@@ -145,12 +145,28 @@ test "#2474: a value binding spelled like a formal is not a type binder" {
   inspect(first_check_error(src), content = "`==` compares two values of type `T`, but the type parameters `T` (an enclosing declaration's), `T` (the inner binder's) have no `Eq` bound, so they cannot be compared by content here; declare the bound (`[T: Eq]` on the enclosing declaration, `[T: Eq]` on the inner binder) or compare at a concrete type")
 }
 
-test "#2474: two rigid higher-kinded binders of one spelling are two edits" {
-  // Both `F[_]` binders are rigid and spelled identically in the types, so
-  // the mention cannot be attributed to one of them; each open binder is
-  // reported with its own declaration, and bounding both makes the site check.
+test "#2474: a rigid higher-kinded mention is the innermost binder of that spelling" {
+  // The types carry the spelling only, so `F[A]` from the outer value and
+  // `F[A]` from the inner parameter read alike; the mention is attributed to
+  // the binder the spelling denotes here (the inner one), and the message
+  // says an enclosing declaration shares the spelling in case the compared
+  // value was captured from it.
   let src = "fn outer[F[_], A](x: F[A]) -> Bool {\n  let g = [F[_]](y: F[A]) -> Bool {\n    (x, y) == (x, y)\n  }\n  true\n}\n"
-  inspect(first_check_error(src), content = "`==` compares two values of type `(F[A], F[A])`, but the type parameters `F` (an enclosing declaration's), `A` (an enclosing declaration's), `F` (the inner binder's) have no `Eq` bound, so they cannot be compared by content here; declare the bound (`[F[_]: Eq, A: Eq]` on the enclosing declaration, `[F[_]: Eq]` on the inner binder) or compare at a concrete type")
+  inspect(first_check_error(src), content = "`==` compares two values of type `(F[A], F[A])`, but the type parameters `A` (an enclosing declaration's), `F` (the inner binder's) have no `Eq` bound, so they cannot be compared by content here; declare the bound (`[A: Eq]` on the enclosing declaration, `[F[_]: Eq]` on the inner binder); an enclosing declaration also spells `F` as a higher-kinded binder, so a compared value captured from there needs the bound on that declaration instead or compare at a concrete type")
+}
+
+test "#2474: an inner rigid binder used alone does not drag in the outer one" {
+  // Only the inner `F[_]` and `B` are compared; `[F[_]: Eq, B: Eq]` on the
+  // inner declaration is the whole edit, and the outer API is not constrained.
+  let src = "fn outer[F[_], A](x: F[A]) -> Bool {\n  let g = [F[_], B](y: F[B]) -> Bool {\n    y == y\n  }\n  true\n}\n"
+  inspect(first_check_error(src), content = "`==` compares two values of type `F[B]`, but the type parameters `F`, `B` have no `Eq` bound, so they cannot be compared by content here; declare the bound (`[F[_]: Eq, B: Eq]`); an enclosing declaration also spells `F` as a higher-kinded binder, so a compared value captured from there needs the bound on that declaration instead or compare at a concrete type")
+}
+
+test "#2474: an enclosing binder that nothing shadows is placed without a shadowing claim" {
+  // The inner declaration binds `U`, not `T`: the outer `T` is not shadowed,
+  // it is simply not the site's own declaration.
+  let src = "fn outer[T](x: T) -> Bool {\n  let f = [U](y: U) -> Bool {\n    x == x\n  }\n  true\n}\n"
+  inspect(first_check_error(src), content = "`==` compares two values of type `T`, but the type parameter `T` of an enclosing declaration has no `Eq` bound, so they cannot be compared by content here; declare the bound (`[T: Eq]` on the enclosing declaration) or compare at a concrete type")
 }
 
 //# Accepted

--- a/lib/@vibe/compiler/tests/eq_unbounded_formal_test.vibe
+++ b/lib/@vibe/compiler/tests/eq_unbounded_formal_test.vibe
@@ -152,14 +152,14 @@ test "#2474: a rigid higher-kinded mention is the innermost binder of that spell
   // says an enclosing declaration shares the spelling in case the compared
   // value was captured from it.
   let src = "fn outer[F[_], A](x: F[A]) -> Bool {\n  let g = [F[_]](y: F[A]) -> Bool {\n    (x, y) == (x, y)\n  }\n  true\n}\n"
-  inspect(first_check_error(src), content = "`==` compares two values of type `(F[A], F[A])`, but the type parameters `A` (an enclosing declaration's), `F` (the inner binder's) have no `Eq` bound, so they cannot be compared by content here; declare the bound (`[A: Eq]` on the enclosing declaration, `[F[_]: Eq]` on the inner binder); an enclosing declaration also spells `F` as a higher-kinded binder, so a compared value captured from there needs the bound on that declaration instead or compare at a concrete type")
+  inspect(first_check_error(src), content = "`==` compares two values of type `(F[A], F[A])`, but the type parameters `A` (an enclosing declaration's), `F` (the inner binder's) have no `Eq` bound, so they cannot be compared by content here; declare the bound (`[A: Eq]` on the enclosing declaration, `[F[_]: Eq]` on the inner binder); an enclosing declaration also spells `F` as a higher-kinded binder, and a compared value captured from there needs the bound on that declaration as well or compare at a concrete type")
 }
 
 test "#2474: an inner rigid binder used alone does not drag in the outer one" {
   // Only the inner `F[_]` and `B` are compared; `[F[_]: Eq, B: Eq]` on the
   // inner declaration is the whole edit, and the outer API is not constrained.
   let src = "fn outer[F[_], A](x: F[A]) -> Bool {\n  let g = [F[_], B](y: F[B]) -> Bool {\n    y == y\n  }\n  true\n}\n"
-  inspect(first_check_error(src), content = "`==` compares two values of type `F[B]`, but the type parameters `F`, `B` have no `Eq` bound, so they cannot be compared by content here; declare the bound (`[F[_]: Eq, B: Eq]`); an enclosing declaration also spells `F` as a higher-kinded binder, so a compared value captured from there needs the bound on that declaration instead or compare at a concrete type")
+  inspect(first_check_error(src), content = "`==` compares two values of type `F[B]`, but the type parameters `F`, `B` have no `Eq` bound, so they cannot be compared by content here; declare the bound (`[F[_]: Eq, B: Eq]`); an enclosing declaration also spells `F` as a higher-kinded binder, and a compared value captured from there needs the bound on that declaration as well or compare at a concrete type")
 }
 
 test "#2474: an enclosing binder that nothing shadows is placed without a shadowing claim" {
@@ -167,6 +167,13 @@ test "#2474: an enclosing binder that nothing shadows is placed without a shadow
   // it is simply not the site's own declaration.
   let src = "fn outer[T](x: T) -> Bool {\n  let f = [U](y: U) -> Bool {\n    x == x\n  }\n  true\n}\n"
   inspect(first_check_error(src), content = "`==` compares two values of type `T`, but the type parameter `T` of an enclosing declaration has no `Eq` bound, so they cannot be compared by content here; declare the bound (`[T: Eq]` on the enclosing declaration) or compare at a concrete type")
+}
+
+test "#2474: several formals of one enclosing declaration are placed there together" {
+  // Both unbounded formals belong to the outer declaration; the inner `[V]`
+  // is the site's own. One bracket, placed on the declaration that owns it.
+  let src = "fn outer[T, U](x: T, y: U) -> Bool {\n  let f = [V](z: V) -> Bool {\n    (x, y) == (x, y)\n  }\n  true\n}\n"
+  inspect(first_check_error(src), content = "`==` compares two values of type `(T, U)`, but the type parameters `T`, `U` of an enclosing declaration have no `Eq` bound, so they cannot be compared by content here; declare the bound (`[T: Eq, U: Eq]` on the enclosing declaration) or compare at a concrete type")
 }
 
 //# Accepted

--- a/lib/@vibe/compiler/tests/eq_unbounded_formal_test.vibe
+++ b/lib/@vibe/compiler/tests/eq_unbounded_formal_test.vibe
@@ -109,7 +109,7 @@ test "#2474: a shadowed higher-kinded binder keeps its kind, the shadowing one k
   // different binder of kind `Type`. Neither may borrow the other's kind in
   // the suggested edit.
   let src = "fn outer[F[_], A](x: F[A]) -> Bool {\n  let g = [F](y: F) -> Bool {\n    (x, y) == (x, y)\n  }\n  true\n}\n"
-  inspect(first_check_error(src), content = "`==` compares two values of type `(F[A], F)`, but the type parameters `F` (an enclosing declaration's), `A`, `F` (the inner binder's) have no `Eq` bound, so they cannot be compared by content here; declare the bound (`[F[_]: Eq]` on the enclosing declaration, `[A: Eq]`, `[F: Eq]` on the inner binder) or compare at a concrete type")
+  inspect(first_check_error(src), content = "`==` compares two values of type `(F[A], F)`, but the type parameters `F` (an enclosing declaration's), `A` (an enclosing declaration's), `F` (the inner binder's) have no `Eq` bound, so they cannot be compared by content here; declare the bound (`[F[_]: Eq, A: Eq]` on the enclosing declaration, `[F: Eq]` on the inner binder) or compare at a concrete type")
 }
 
 test "#2474: a bare compare that unifies the two binders still tells them apart" {
@@ -127,6 +127,30 @@ test "#2474: three nested binders of one spelling are told apart by depth" {
   // tell the outermost from the immediately enclosing binder.
   let src = "fn outer[T](x: T) -> Bool {\n  let g = [T](y: T) -> Bool {\n    let h = [T](z: T) -> Bool {\n      (x, y) == (x, y)\n    }\n    true\n  }\n  true\n}\n"
   inspect(first_check_error(src), content = "`==` compares two values of type `(T, T)`, but the type parameters `T` (the declaration 2 binders out's), `T` (an enclosing declaration's) have no `Eq` bound, so they cannot be compared by content here; declare the bound (`[T: Eq]` on the declaration 2 binders out, `[T: Eq]` on the enclosing declaration) or compare at a concrete type")
+}
+
+test "#2474: differently named binders of different declarations are separate edits" {
+  // Neither `T` nor `U` shadows the other, yet no single declaration owns
+  // both: one `[T: Eq, U: Eq]` bracket would leave one of them unbounded or
+  // declare a new shadowing formal wherever it was pasted.
+  let src = "fn outer[T](x: T) -> Bool {\n  let f = [U](y: U) -> Bool {\n    (x, y) == (x, y)\n  }\n  true\n}\n"
+  inspect(first_check_error(src), content = "`==` compares two values of type `(T, U)`, but the type parameters `T` (an enclosing declaration's), `U` (the inner binder's) have no `Eq` bound, so they cannot be compared by content here; declare the bound (`[T: Eq]` on the enclosing declaration, `[U: Eq]` on the inner binder) or compare at a concrete type")
+}
+
+test "#2474: a value binding spelled like a formal is not a type binder" {
+  // A parameter named `T` next to the type parameter `T` is legal
+  // (fixtures/typecheck/formal_application_value_shadow_ok.vibe); it must not
+  // count as a binder when the edits are placed.
+  let src = "fn outer[T](x: T) -> Bool {\n  let f = [T](T: T) -> Bool {\n    x == T\n  }\n  true\n}\n"
+  inspect(first_check_error(src), content = "`==` compares two values of type `T`, but the type parameters `T` (an enclosing declaration's), `T` (the inner binder's) have no `Eq` bound, so they cannot be compared by content here; declare the bound (`[T: Eq]` on the enclosing declaration, `[T: Eq]` on the inner binder) or compare at a concrete type")
+}
+
+test "#2474: two rigid higher-kinded binders of one spelling are two edits" {
+  // Both `F[_]` binders are rigid and spelled identically in the types, so
+  // the mention cannot be attributed to one of them; each open binder is
+  // reported with its own declaration, and bounding both makes the site check.
+  let src = "fn outer[F[_], A](x: F[A]) -> Bool {\n  let g = [F[_]](y: F[A]) -> Bool {\n    (x, y) == (x, y)\n  }\n  true\n}\n"
+  inspect(first_check_error(src), content = "`==` compares two values of type `(F[A], F[A])`, but the type parameters `F` (an enclosing declaration's), `A` (an enclosing declaration's), `F` (the inner binder's) have no `Eq` bound, so they cannot be compared by content here; declare the bound (`[F[_]: Eq, A: Eq]` on the enclosing declaration, `[F[_]: Eq]` on the inner binder) or compare at a concrete type")
 }
 
 //# Accepted


### PR DESCRIPTION
Follow-up to #2529, which merged at `f0118e6` just before the first of these commits was pushed to its branch. It makes the `Eq`-bound diagnostic's suggested edits name the declaration each one belongs on.

## What was wrong

The check itself was right, but the suggestion was rendered from spellings. Measured shapes where the suggested edit would not have fixed the program:

| shape | old suggestion | problem |
|---|---|---|
| outer `[T]`, inner `[T]` lambda, `(x, y) == (x, y)` | one `[T: Eq]` | two binders, one edit |
| outer `[T]`, inner `[U]`, `(x, y) == (x, y)` | `[T: Eq, U: Eq]` | no declaration owns both |
| outer `[T, U]`, inner `[V]`, `(x, y) == (x, y)` | unplaced `[T: Eq, U: Eq]` | reads as an edit on the inner binder |
| outer `[T]`, inner `[T]`, bare `x == y` | both "on the inner binder" | unify merged the two variables, so ownership read through the substitution was lost |
| three nested `[T]` | two identical "on the enclosing declaration" | outermost and immediately enclosing indistinguishable |
| outer `[T]`, inner `[U]`, `x == x` | "an inner binder shadows it" | nothing shadows `T` there |
| outer `[F[_]]`, inner `[F[_]]` | one `F[_]: Eq`, or both | the rigid spelling carries the name only |
| value parameter spelled `T` | shifted every outer `T` one level out | a value binding counted as a type binder |
| two sibling `resume(..)` values with `[T]` lambdas | second placed "on the enclosing declaration" | the re-check reuses the variable counter, so both binders share an id |

## What this does

- Every `EFn` header with type parameters opens a **declaration group**: a stack of open generic declarations, innermost last, popped after the body is checked. Each recorded binder carries its group, its arity and whether it is rigid.
- The message resolves every offending binder to its table row (preferring the row whose declaration is still open when a variable id was reused), groups rows by declaration, renders **one bracket per declaration** at the binders' own kinds (`[F[_]: Eq, A: Eq]`, not `[F: Eq]`), and places each bracket by the group's distance from the site: "the inner binder", "the enclosing declaration", "the declaration N binders out". A single owning declaration that is the site's own collapses into one unqualified bracket, so every message #2529 pinned is unchanged; a single owning declaration that is not the site's own is placed.
- Ownership never goes through the substitution, so a bare `x == y` that unifies an outer and an inner `T` still reports one enclosing edit and one inner edit. "Shadows it" is said only when a same-spelled binder actually sits between the site and the owner.
- A rigid `#hktformal.` mention is attributed to the innermost open rigid binder of that spelling, the one the name denotes where the site is written. The types carry the spelling only, so a value captured from an enclosing declaration whose own `F[_]` shares it cannot be told apart; the message adds a hint that the enclosing declaration needs the bound as well. Giving rigid binders distinct identities would settle this properly but changes what unifies, so it stays out of this PR.

## Verification

- `lib/@vibe/compiler/tests/eq_unbounded_formal_test.vibe`: 30/30 against a stage2 built from these sources. The 19 expectations from #2529 are unchanged in substance (two brackets gained an explicit placement); 11 new cases pin the shapes above.
- Checker-only change, no codegen effect; the perf report shows no size or fuel drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0135RDJv1VCvuJqYKF88kGhU