### PR TITLE
checker/codegen: import projection trait rows, the evidence pass's one-walk shadow census, and two call-site gates that ask the cheap question first (#2386)

### DIFF
--- a/lib/@vibe/compiler/checker/checker.vibe
+++ b/lib/@vibe/compiler/checker/checker.vibe
@@ -6412,12 +6412,20 @@ fn direct_builtin_return(name: String) -> Option[Type] {
 }
 
 fn direct_call_return(env: TypeEnv, name: String) -> Option[Type] {
-  match env_lookup(env, name) {
-    Some(_) => None,
-    None => if env_has_reexport_surface_binding(env, name) {
-      None
-    } else {
-      direct_builtin_return(canonical_builtin_name(name))
+  // #2386: the builtin table answers first. A callee it does not know
+  // returns None whatever the environment says, so the two chain walks
+  // (the lookup, and on a miss the surface-binding probe, which reads the
+  // whole chain) run only for the names that can be shadowed builtins.
+  // Every user-defined callee used to pay both per call site.
+  match direct_builtin_return(canonical_builtin_name(name)) {
+    None => None,
+    Some(ret) => match env_lookup(env, name) {
+      Some(_) => None,
+      None => if env_has_reexport_surface_binding(env, name) {
+        None
+      } else {
+        Some(ret)
+      }
     }
   }
 }
@@ -7793,7 +7801,11 @@ fn retaining_write_argument_mask(source_name: String) -> Int {
 /// Check every stored argument against the same region lifetime rule as
 /// `EAssign`; skip the duplicate type walk entirely outside a region.
 fn retaining_write_region_check(name: String, args: Array[Expr], env: TypeEnv, defs: Array[TypeDef], s: Subst, c: Int, errors: Array[String], ce: (Expr, TypeEnv, Array[TypeDef], Subst, Int, Array[String], Array[(Int, Type)]) -> (Type, Subst, Int)) -> Unit {
-  if env_has_active_region(env) && Array::length(args) > 0 {
+  // #2386: the name test is a compare ladder; the region test is a chain
+  // lookup. Asking the ladder first keeps the lookup off every call site
+  // whose callee retains nothing -- nearly all of them -- and the check
+  // itself does nothing for those either way.
+  if Array::length(args) > 0 && retaining_write_argument_mask(name) != 0 && env_has_active_region(env) {
     let retained = retaining_write_argument_mask(name)
     let mut value_index = 1
     while value_index <= 2 {

--- a/lib/@vibe/compiler/codegen/common_base/index.vpkg
+++ b/lib/@vibe/compiler/codegen/common_base/index.vpkg
@@ -275,6 +275,7 @@ fn lower_optional_performs(stmts: Array[Stmt], resolution: Array[(String, String
 
 // --- evidence_dict_pass
 fn evidence_dict_pass(stmts: Array[Stmt], entry_name: String) -> Array[String]
+fn edp_bind_census(stmts: Array[Stmt], names: Array[String]) -> Array[Bool]
 
 // --- forin_discard_pass (#1916): wrap every discard-position `for` as
 // `ESeq(for .., EUnit)` so the linear ESeq lowering compiles it without the

--- a/lib/@vibe/compiler/codegen/common_base/inline_direct_perform.vibe
+++ b/lib/@vibe/compiler/codegen/common_base/inline_direct_perform.vibe
@@ -16,7 +16,7 @@ import @vibe/compiler/core {
 }
 
 import @vibe/core {
-  array_empty, struct MutSet
+  array_empty, struct MutMap, struct MutSet
 }
 
 //# Functions
@@ -2961,38 +2961,283 @@ fn edp_ar_expr(expr: Expr, seed: Array[String], env_names: Array[String], env_re
 /// so post-rename a prefixed name is compiler-generated iff the walk ran and
 /// the name is NOT in `user_prefixed` (Codex review, PR #1594: culprit
 /// diagnostics must not strip a prefix the user spelled themselves).
+/// #2386: the shadow census behind edp_alpha_rename_shadowed. One walk over
+/// the top-level bodies marks which of the asked names is bound ANYWHERE,
+/// under exactly the rules edp_expr_binds_name (RQEdpBindsName through
+/// edp_rq_fold) answers with: a let / let mut / let rec binder, a for-in
+/// name and its index, an fn parameter without its `~`, a loop parameter, a
+/// match or handle pattern binder; an interpolation is opaque, everything
+/// else is walked. The pass used to walk the whole program once per needing
+/// name of every effect. `asked` maps a name to its slot in `marked`, which
+/// holds 1 after the walk when the name is bound somewhere.
+fn edp_bc_mark(name: String, asked: MutMap[String, Int], marked: Array[Int]) -> Unit {
+  match MutMap::get(asked, name) {
+    Some(slot) => Array::set(marked, slot, 1),
+    None => ()
+  }
+}
+
+/// Mirrors scps_pat_binds_name: every binder of the pattern is marked.
+fn edp_bc_pat(p: Pat, asked: MutMap[String, Int], marked: Array[Int]) -> Unit {
+  match p {
+    PBind(n) => edp_bc_mark(n, asked, marked),
+    PCtor(_, ps) => edp_bc_pats(ps, asked, marked),
+    PTuple(ps) => edp_bc_pats(ps, asked, marked),
+    POr(a, b) => {
+      edp_bc_pat(a, asked, marked)
+      edp_bc_pat(b, asked, marked)
+    },
+    PStruct(_, fields) => {
+      let mut i = 0
+      while i < Array::length(fields) {
+        let (_, fp) = Array::get(fields, i)
+        edp_bc_pat(fp, asked, marked)
+        i = i + 1
+      }
+    },
+    _ => ()
+  }
+}
+
+fn edp_bc_pats(ps: Array[Pat], asked: MutMap[String, Int], marked: Array[Int]) -> Unit {
+  let mut i = 0
+  while i < Array::length(ps) {
+    edp_bc_pat(Array::get(ps, i), asked, marked)
+    i = i + 1
+  }
+}
+
+fn edp_bc_exprs(es: Array[Expr], asked: MutMap[String, Int], marked: Array[Int]) -> Unit {
+  let mut i = 0
+  while i < Array::length(es) {
+    edp_bc_expr(Array::get(es, i), asked, marked)
+    i = i + 1
+  }
+}
+
+/// `names_bind` as in edp_rq_pairs: loop parameters bind, record and map
+/// fields do not.
+fn edp_bc_pairs(pairs: Array[(String, Expr)], names_bind: Bool, asked: MutMap[String, Int], marked: Array[Int]) -> Unit {
+  let mut i = 0
+  while i < Array::length(pairs) {
+    let (name, value) = Array::get(pairs, i)
+    if names_bind {
+      edp_bc_mark(name, asked, marked)
+    } else {
+      ()
+    }
+    edp_bc_expr(value, asked, marked)
+    i = i + 1
+  }
+}
+
+fn edp_bc_arms(arms: Array[(Pat, Expr)], asked: MutMap[String, Int], marked: Array[Int]) -> Unit {
+  let mut i = 0
+  while i < Array::length(arms) {
+    let (pat, body) = Array::get(arms, i)
+    edp_bc_pat(pat, asked, marked)
+    edp_bc_expr(body, asked, marked)
+    i = i + 1
+  }
+}
+
+/// Enumerated like edp_rq_fold (no `_ =>` for the recursive shapes): a new
+/// `Expr` variant is a compile error here, not a silently unscanned subtree.
+fn edp_bc_expr(e: Expr, asked: MutMap[String, Int], marked: Array[Int]) -> Unit {
+  match e {
+    EInt(_) => (),
+    EFloat(_) => (),
+    EString(_) => (),
+    EBool(_) => (),
+    EIdent(_, _) => (),
+    EStringInterp(_) => (),
+    EUnit => (),
+    ETuple(items) => edp_bc_exprs(items, asked, marked),
+    EArray(items) => edp_bc_exprs(items, asked, marked),
+    ERecord(_, fields, _) => edp_bc_pairs(fields, false, asked, marked),
+    EMap(fields) => edp_bc_pairs(fields, false, asked, marked),
+    EIf(c, t, other) => {
+      edp_bc_expr(c, asked, marked)
+      edp_bc_expr(t, asked, marked)
+      edp_bc_expr(other, asked, marked)
+    },
+    ELet(name, value, body, _) => {
+      edp_bc_mark(name, asked, marked)
+      edp_bc_expr(value, asked, marked)
+      edp_bc_expr(body, asked, marked)
+    },
+    ELetRec(name, value, body) => {
+      edp_bc_mark(name, asked, marked)
+      edp_bc_expr(value, asked, marked)
+      edp_bc_expr(body, asked, marked)
+    },
+    ELetMut(name, value, body, _) => {
+      edp_bc_mark(name, asked, marked)
+      edp_bc_expr(value, asked, marked)
+      edp_bc_expr(body, asked, marked)
+    },
+    EAssign(_, value, body) => {
+      edp_bc_expr(value, asked, marked)
+      edp_bc_expr(body, asked, marked)
+    },
+    EAssignOp(_, _, value, body) => {
+      edp_bc_expr(value, asked, marked)
+      edp_bc_expr(body, asked, marked)
+    },
+    ESeq(a, b) => {
+      edp_bc_expr(a, asked, marked)
+      edp_bc_expr(b, asked, marked)
+    },
+    EMatch(subject, arms) => {
+      edp_bc_expr(subject, asked, marked)
+      edp_bc_arms(arms, asked, marked)
+    },
+    EHandle(body, arms) => {
+      edp_bc_expr(body, asked, marked)
+      edp_bc_arms(arms, asked, marked)
+    },
+    EWhile(cond, body) => {
+      edp_bc_expr(cond, asked, marked)
+      edp_bc_expr(body, asked, marked)
+    },
+    ELoop(pairs, body) => {
+      edp_bc_pairs(pairs, true, asked, marked)
+      edp_bc_expr(body, asked, marked)
+    },
+    EForIn(name, index, iter, body) => {
+      edp_bc_mark(name, asked, marked)
+      match index {
+        Some(i) => edp_bc_mark(i, asked, marked),
+        None => ()
+      }
+      edp_bc_expr(iter, asked, marked)
+      edp_bc_expr(body, asked, marked)
+    },
+    ECall(callee, args, _) => {
+      edp_bc_expr(callee, asked, marked)
+      edp_bc_exprs(args, asked, marked)
+    },
+    EBinOp(_, left, right, _) => {
+      edp_bc_expr(left, asked, marked)
+      edp_bc_expr(right, asked, marked)
+    },
+    EUnaryOp(_, value) => edp_bc_expr(value, asked, marked),
+    EFn(_, _, params, _, _, body) => {
+      let mut i = 0
+      while i < Array::length(params) {
+        let (pn, _) = Array::get(params, i)
+        edp_bc_mark(edp_strip_tilde(pn), asked, marked)
+        i = i + 1
+      }
+      edp_bc_expr(body, asked, marked)
+    },
+    EDot(owner, _, _, _) => edp_bc_expr(owner, asked, marked),
+    ELabeledArg(_, _, value) => edp_bc_expr(value, asked, marked),
+    EReturn(value) => edp_bc_expr(value, asked, marked),
+    EBreak(value) => match value {
+      Some(v) => edp_bc_expr(v, asked, marked),
+      None => ()
+    },
+    EContinue(args) => edp_bc_exprs(args, asked, marked),
+    ESpread(value) => edp_bc_expr(value, asked, marked)
+  }
+}
+
+/// The statement kinds edp_alpha_rename_shadowed and edp_drop_shadowed_needing
+/// scan: the values of let / let mut / expression / test / bench statements.
+fn edp_bc_stmts(stmts: Array[Stmt], asked: MutMap[String, Int], marked: Array[Int]) -> Unit {
+  let mut si = 0
+  while si < Array::length(stmts) {
+    match Array::get(stmts, si) {
+      SLet(_, _, _, _, sv) => edp_bc_expr(sv, asked, marked),
+      SLetMut(_, _, sv) => edp_bc_expr(sv, asked, marked),
+      SExpr(sv) => edp_bc_expr(sv, asked, marked),
+      STest(_, sv) => edp_bc_expr(sv, asked, marked),
+      SBench(_, sv) => edp_bc_expr(sv, asked, marked),
+      _ => ()
+    }
+    si = si + 1
+  }
+}
+
+/// For every name, whether some scanned top-level body binds it: the census
+/// as a table, one entry per name in the order given (a repeated name answers
+/// the same each time). Exported for the test; the pass reads the census
+/// through the slot map directly.
+export fn edp_bind_census(stmts: Array[Stmt], names: Array[String]) -> Array[Bool] {
+  let asked: MutMap[String, Int] = MutMap::new_string()
+  let marked: Array[Int] = []
+  let mut i = 0
+  while i < Array::length(names) {
+    let nm = Array::get(names, i)
+    if MutMap::has(asked, nm) {
+      ()
+    } else {
+      MutMap::set(asked, nm, Array::length(marked))
+      Array::push(marked, 0)
+    }
+    i = i + 1
+  }
+  if Array::length(marked) > 0 {
+    edp_bc_stmts(stmts, asked, marked)
+  } else {
+    ()
+  }
+  let out: Array[Bool] = []
+  i = 0
+  while i < Array::length(names) {
+    Array::push(out, match MutMap::get(asked, Array::get(names, i)) {
+      Some(slot) => Array::get(marked, slot) == 1,
+      None => false
+    })
+    i = i + 1
+  }
+  out
+}
+
 fn edp_alpha_rename_shadowed(stmts: Array[Stmt], effect_defs: Array[(String, Array[(String, Array[TypeExpr], TypeExpr)])], fn_defs: Array[(Int, Bool, Bool, String, Option[TypeExpr], String)], user_prefixed: Array[String], row_labels: Array[Array[String]]) -> Bool {
   let seed = empty_str_array()
+  // #2386: one shadow census (edp_bc_stmts) for every needing name of every
+  // effect, then the seed is read off it in the same (effect, needing) order
+  // the per-name program walks pushed it in.
+  let needing_tabs: Array[Array[String]] = []
+  let asked: MutMap[String, Int] = MutMap::new_string()
+  let marked: Array[Int] = []
   let mut ei = 0
   while ei < Array::length(effect_defs) {
     let (ename, _) = Array::get(effect_defs, ei)
     let needing = edp_needing_names_tab(fn_defs, row_labels, ename)
+    Array::push(needing_tabs, needing)
+    let mut ni = 0
+    while ni < Array::length(needing) {
+      let nm = Array::get(needing, ni)
+      if MutMap::has(asked, nm) {
+        ()
+      } else {
+        MutMap::set(asked, nm, Array::length(marked))
+        Array::push(marked, 0)
+      }
+      ni = ni + 1
+    }
+    ei = ei + 1
+  }
+  if Array::length(marked) > 0 {
+    edp_bc_stmts(stmts, asked, marked)
+  } else {
+    ()
+  }
+  ei = 0
+  while ei < Array::length(needing_tabs) {
+    let needing = Array::get(needing_tabs, ei)
     let mut ni = 0
     while ni < Array::length(needing) {
       let nm = Array::get(needing, ni)
       if edp_str_array_contains(seed, nm) {
         ()
       } else {
-        let mut shadowed = false
-        let mut si = 0
-        while si < Array::length(stmts) && !shadowed {
-          let sv_opt = match Array::get(stmts, si) {
-            SLet(_, _, _, _, sv) => Some(sv),
-            SLetMut(_, _, sv) => Some(sv),
-            SExpr(sv) => Some(sv),
-            STest(_, sv) => Some(sv),
-            SBench(_, sv) => Some(sv),
-            _ => None
-          }
-          match sv_opt {
-            Some(sv) => if edp_expr_binds_name(sv, nm) {
-              shadowed = true
-            } else {
-              ()
-            },
-            None => ()
-          }
-          si = si + 1
+        let shadowed = match MutMap::get(asked, nm) {
+          Some(slot) => Array::get(marked, slot) == 1,
+          None => false
         }
         if shadowed {
           Array::push(seed, nm)

--- a/lib/@vibe/compiler/core/core.vibe
+++ b/lib/@vibe/compiler/core/core.vibe
@@ -95,6 +95,8 @@ export ./types.vibe {
   env_lookup_binding,
   env_lookup_flat,
   env_selectable_type_defs,
+  env_trait_def_names,
+  env_trait_def_names_into,
   env_type_defs,
   env_value_binding,
   env_value_binding_with_origin,

--- a/lib/@vibe/compiler/core/index.vpkg
+++ b/lib/@vibe/compiler/core/index.vpkg
@@ -257,6 +257,8 @@ fn type_erase_vars(ty: Type) -> Type
 fn type_has_unknown(ty: Type) -> Bool
 fn subst_resolves_to_string(s: Subst, ty: Type) -> Bool
 fn trait_defined(env: TypeEnv, name: String) -> Bool
+fn env_trait_def_names(env: TypeEnv) -> Array[String]
+fn env_trait_def_names_into(env: TypeEnv, out: Array[String]) -> Unit
 fn trait_decl_params(env: TypeEnv, name: String) -> Option[Array[String]]
 fn type_to_string(ty: Type) -> String
 fn env_lookup_flat(bindings: Array[(String, Type)], name: String) -> Option[Type]

--- a/lib/@vibe/compiler/core/types.vibe
+++ b/lib/@vibe/compiler/core/types.vibe
@@ -2177,6 +2177,58 @@ export fn trait_defined(env: TypeEnv, name: String) -> Bool {
   }
 }
 
+/// Every trait name the chain defines, innermost first, in one walk. The
+/// answer to `trait_defined(env, n)` for any `n` is whether this list holds
+/// `trait_ref_name(n)`; a caller with many names to ask (the import
+/// projection asks per imported name, per bound label and per supertrait)
+/// walks the chain once and probes the list instead of walking it per name
+/// (#2386). Stops where trait_defined stops: an EnvFlat is terminal.
+export fn env_trait_def_names(env: TypeEnv) -> Array[String] {
+  let out = array_empty()
+  env_trait_def_names_into(env, out)
+  out
+}
+
+/// env_trait_def_names into a caller-owned row: `out` is emptied and refilled,
+/// so a caller that asks per edge can reuse one row and allocate nothing.
+export fn env_trait_def_names_into(env: TypeEnv, out: Array[String]) -> Unit {
+  Array::truncate(out, 0)
+  let mut cur = env
+  let mut done = false
+  while !done {
+    match cur {
+      EnvEmpty => {
+        done = true
+      },
+      EnvBind(_, _, rest) => {
+        cur = rest
+      },
+      EnvTraitDef(tname, _, _, _, rest, _, _) => {
+        Array::push(out, tname)
+        cur = rest
+      },
+      EnvTraitImpl(_, _, rest) => {
+        cur = rest
+      },
+      EnvMutCell(_, _, rest) => {
+        cur = rest
+      },
+      EnvTraitImplGen(_, _, _, _, rest) => {
+        cur = rest
+      },
+      EnvTypeDefs(_, _, rest) => {
+        cur = rest
+      },
+      EnvFlat(_) => {
+        done = true
+      },
+      EnvCached(_, _, rest) => {
+        cur = rest
+      }
+    }
+  }
+}
+
 export fn trait_decl_params(env: TypeEnv, name: String) -> Option[Array[String]] {
   match env {
     EnvEmpty => None,

--- a/lib/@vibe/compiler/runtime/typecheck_fs.vibe
+++ b/lib/@vibe/compiler/runtime/typecheck_fs.vibe
@@ -70,6 +70,7 @@ import @vibe/compiler/core {
   env_lookup_flat,
   env_preserve_type_definition_origins,
   env_selectable_type_defs,
+  env_trait_def_names_into,
   env_type_defs,
   env_value_binding,
   has_standard_effect_policy,
@@ -84,7 +85,6 @@ import @vibe/compiler/core {
   resolve_import_path,
   resolve_import_path_candidates,
   str_lt,
-  trait_defined,
   unstable_package_note
 }
 
@@ -217,6 +217,19 @@ fn valid_persistent_leaf_fingerprint(path: String, source: String) -> Option[Str
 // the sidecar yet, so a worker-checked module is re-checked by the next
 // in-driver compile rather than silently losing its offsets.
 
+// #2386: scratch rows for the import projection. Each row belongs to ONE
+// non-recursive function (bi_ = bind_import_names_from_cache_collecting,
+// pra_ = prepend_reexport_alias_declarations, ipt_ =
+// interface_public_trait_names), is refilled at that function's start and
+// read only inside it, so an edge allocates nothing for its trait-name list
+// and its uppercase binding slots. The three owners never run inside one
+// another: the import binder is driven by a loop over a module's import
+// statements, and the interface projection runs after a module is checked.
+let bi_trait_names: Array[String] = []
+let bi_upper_slots: Array[Int] = []
+let pra_trait_names: Array[String] = []
+let pra_upper_slots: Array[Int] = []
+let ipt_trait_names: Array[String] = []
 let module_typed_lowering_memo_paths: Array[String] = []
 
 let module_typed_lowering_memo_fps: Array[String] = []
@@ -1225,6 +1238,52 @@ fn trait_projection_claim_mappings(claims: Array[(String, String, Bool, String)]
   }
 }
 
+/// `trait_defined(env, name)` against the row env_trait_def_names_into
+/// filled from `env` (#2386): the import projection asks it for every
+/// imported name, every bound label and every supertrait of an edge, and
+/// each answer used to walk the whole chain. The row holds a module's trait
+/// names -- tens at most -- so a scan is the cheapest probe. An empty row
+/// answers before normalizing the name: trait_ref_name allocates its parsed
+/// reference, and most dependencies define no trait at all (the walk never
+/// reached a compare there; measured +0.8 MB of cold heap when this
+/// normalized unconditionally).
+fn trait_in_list(traits: Array[String], name: String) -> Bool {
+  if Array::length(traits) == 0 {
+    false
+  } else {
+    let base = trait_ref_name(name)
+    let mut i = 0
+    let mut found = false
+    while !found && i < Array::length(traits) {
+      if Array::get(traits, i) == base {
+        found = true
+      } else {
+        ()
+      }
+      i = i + 1
+    }
+    found
+  }
+}
+
+/// Slots of `bindings` whose name starts uppercase, into a caller-owned row:
+/// the companions and types the projection's per-name candidate scan can
+/// ever select. Filled once per edge so the scan per imported name skips
+/// the lowercase majority.
+fn uppercase_binding_slots_into(bindings: Array[(String, Type)], out: Array[Int]) -> Unit {
+  Array::truncate(out, 0)
+  let mut i = 0
+  while i < Array::length(bindings) {
+    let (name, _) = Array::get(bindings, i)
+    if starts_with_upper(name) {
+      Array::push(out, i)
+    } else {
+      ()
+    }
+    i = i + 1
+  }
+}
+
 fn trait_projection_supers(env: TypeEnv, name: String) -> Array[String] {
   match env {
     EnvEmpty => array_empty(),
@@ -1243,13 +1302,13 @@ fn trait_projection_supers(env: TypeEnv, name: String) -> Array[String] {
   }
 }
 
-fn trait_projection_collect_generic_impl_bounds(dep_env: TypeEnv, trait_name: String, mappings: Array[(String, String)]) -> Unit {
+fn trait_projection_collect_generic_impl_bounds(dep_env: TypeEnv, trait_name: String, mappings: Array[(String, String)], traits: Array[String]) -> Unit {
   match dep_env {
     EnvEmpty => (),
-    EnvBind(_, _, rest) => trait_projection_collect_generic_impl_bounds(rest, trait_name, mappings),
-    EnvTraitDef(_, _, _, _, rest, _, _) => trait_projection_collect_generic_impl_bounds(rest, trait_name, mappings),
-    EnvTraitImpl(_, _, rest) => trait_projection_collect_generic_impl_bounds(rest, trait_name, mappings),
-    EnvMutCell(_, _, rest) => trait_projection_collect_generic_impl_bounds(rest, trait_name, mappings),
+    EnvBind(_, _, rest) => trait_projection_collect_generic_impl_bounds(rest, trait_name, mappings, traits),
+    EnvTraitDef(_, _, _, _, rest, _, _) => trait_projection_collect_generic_impl_bounds(rest, trait_name, mappings, traits),
+    EnvTraitImpl(_, _, rest) => trait_projection_collect_generic_impl_bounds(rest, trait_name, mappings, traits),
+    EnvMutCell(_, _, rest) => trait_projection_collect_generic_impl_bounds(rest, trait_name, mappings, traits),
     EnvTraitImplGen(candidate, _, bounds, _, rest) => {
       if trait_ref_name(candidate) == trait_ref_name(trait_name) {
         let mut i = 0
@@ -1259,7 +1318,7 @@ fn trait_projection_collect_generic_impl_bounds(dep_env: TypeEnv, trait_name: St
           while j < Array::length(labels) {
             let label = Array::get(labels, j)
             let base = trait_ref_name(label)
-            if trait_defined(dep_env, label) {
+            if trait_in_list(traits, label) {
               trait_projection_add_mapping(mappings, base, base)
             } else {
               ()
@@ -1271,15 +1330,15 @@ fn trait_projection_collect_generic_impl_bounds(dep_env: TypeEnv, trait_name: St
       } else {
         ()
       }
-      trait_projection_collect_generic_impl_bounds(rest, trait_name, mappings)
+      trait_projection_collect_generic_impl_bounds(rest, trait_name, mappings, traits)
     },
-    EnvTypeDefs(_, _, rest) => trait_projection_collect_generic_impl_bounds(rest, trait_name, mappings),
+    EnvTypeDefs(_, _, rest) => trait_projection_collect_generic_impl_bounds(rest, trait_name, mappings, traits),
     EnvFlat(_) => (),
-    EnvCached(_, _, rest) => trait_projection_collect_generic_impl_bounds(rest, trait_name, mappings)
+    EnvCached(_, _, rest) => trait_projection_collect_generic_impl_bounds(rest, trait_name, mappings, traits)
   }
 }
 
-fn trait_projection_collect_type_bounds(ty: Type, mappings: Array[(String, String)], dep_env: TypeEnv) -> Unit {
+fn trait_projection_collect_type_bounds(ty: Type, mappings: Array[(String, String)], traits: Array[String]) -> Unit {
   match ty {
     CtForAll(_, bounds, body) => {
       let mut i = 0
@@ -1289,7 +1348,7 @@ fn trait_projection_collect_type_bounds(ty: Type, mappings: Array[(String, Strin
         while j < Array::length(labels) {
           let label = Array::get(labels, j)
           let base = trait_ref_name(label)
-          if trait_defined(dep_env, label) {
+          if trait_in_list(traits, label) {
             trait_projection_add_mapping(mappings, base, base)
           } else {
             ()
@@ -1298,29 +1357,29 @@ fn trait_projection_collect_type_bounds(ty: Type, mappings: Array[(String, Strin
         }
         i = i + 1
       }
-      trait_projection_collect_type_bounds(body, mappings, dep_env)
+      trait_projection_collect_type_bounds(body, mappings, traits)
     },
     CtFn(args, ret, _) => {
       let mut i = 0
       while i < Array::length(args) {
-        trait_projection_collect_type_bounds(Array::get(args, i), mappings, dep_env)
+        trait_projection_collect_type_bounds(Array::get(args, i), mappings, traits)
         i = i + 1
       }
-      trait_projection_collect_type_bounds(ret, mappings, dep_env)
+      trait_projection_collect_type_bounds(ret, mappings, traits)
     },
     CtTuple(items) => {
       let mut i = 0
       while i < Array::length(items) {
-        trait_projection_collect_type_bounds(Array::get(items, i), mappings, dep_env)
+        trait_projection_collect_type_bounds(Array::get(items, i), mappings, traits)
         i = i + 1
       }
     },
-    CtArray(item) => trait_projection_collect_type_bounds(item, mappings, dep_env),
-    CtOption(item) => trait_projection_collect_type_bounds(item, mappings, dep_env),
+    CtArray(item) => trait_projection_collect_type_bounds(item, mappings, traits),
+    CtOption(item) => trait_projection_collect_type_bounds(item, mappings, traits),
     CtNamed(_, args) => {
       let mut i = 0
       while i < Array::length(args) {
-        trait_projection_collect_type_bounds(Array::get(args, i), mappings, dep_env)
+        trait_projection_collect_type_bounds(Array::get(args, i), mappings, traits)
         i = i + 1
       }
     },
@@ -1372,7 +1431,7 @@ fn trait_projection_map_type_bounds(ty: Type, mappings: Array[(String, String)])
 /// values. A second pass then imports only traits required by selected value
 /// schemes. Conflicting aliases fail closed instead of making import order an
 /// unobservable authority choice.
-fn dependency_trait_projection_mappings(dep_env: TypeEnv, dep_bindings: Array[(String, Type)], names: Array[ImportItem], unresolved: Array[String]) -> Array[(String, String)] {
+fn dependency_trait_projection_mappings(dep_env: TypeEnv, dep_bindings: Array[(String, Type)], dep_traits: Array[String], upper_slots: Array[Int], names: Array[ImportItem], unresolved: Array[String]) -> Array[(String, String)] {
   let mappings = array_empty()
   let mut i = 0
   // Pass one: reserve explicit trait aliases before inspecting value bounds.
@@ -1380,7 +1439,7 @@ fn dependency_trait_projection_mappings(dep_env: TypeEnv, dep_bindings: Array[(S
     let item = Array::get(names, i)
     let name = item.name
     let alias = item.alias
-    if trait_defined(dep_env, name) {
+    if trait_in_list(dep_traits, name) {
       let local_name = match alias {
         Some(value) => value,
         None => name
@@ -1408,24 +1467,24 @@ fn dependency_trait_projection_mappings(dep_env: TypeEnv, dep_bindings: Array[(S
   i = 0
   while i < Array::length(names) {
     let name = Array::get(names, i).name
-    if !trait_defined(dep_env, name) {
+    if !trait_in_list(dep_traits, name) {
       match env_lookup_flat(dep_bindings, name) {
-        Some(ty) => trait_projection_collect_type_bounds(ty, mappings, dep_env),
+        Some(ty) => trait_projection_collect_type_bounds(ty, mappings, dep_traits),
         None => ()
       }
       // Companions (`Set::add`) carry `[T: Hash]` even when the type `Set`
       // itself does not. Walk them the same way bind_enum_constructor_companions
       // selects them, or importing `{ Set }` drops `impl Hash for Int`.
       let qual_prefix = String::concat(name, "::")
-      let mut bi = 0
-      while bi < Array::length(dep_bindings) {
-        let (candidate_name, candidate_ty) = Array::get(dep_bindings, bi)
-        if candidate_name != name && starts_with_upper(candidate_name) && (String::starts_with(candidate_name, qual_prefix) || type_returns_name(candidate_ty, name)) {
-          trait_projection_collect_type_bounds(candidate_ty, mappings, dep_env)
+      let mut ui = 0
+      while ui < Array::length(upper_slots) {
+        let (candidate_name, candidate_ty) = Array::get(dep_bindings, Array::get(upper_slots, ui))
+        if candidate_name != name && (String::starts_with(candidate_name, qual_prefix) || type_returns_name(candidate_ty, name)) {
+          trait_projection_collect_type_bounds(candidate_ty, mappings, dep_traits)
         } else {
           ()
         }
-        bi = bi + 1
+        ui = ui + 1
       }
     } else {
       ()
@@ -1438,11 +1497,11 @@ fn dependency_trait_projection_mappings(dep_env: TypeEnv, dep_bindings: Array[(S
   while cursor < Array::length(mappings) {
     let (canonical, _) = Array::get(mappings, cursor)
     let supers = trait_projection_supers(dep_env, canonical)
-    trait_projection_collect_generic_impl_bounds(dep_env, canonical, mappings)
+    trait_projection_collect_generic_impl_bounds(dep_env, canonical, mappings, dep_traits)
     let mut j = 0
     while j < Array::length(supers) {
       let super_name = Array::get(supers, j)
-      if trait_defined(dep_env, super_name) {
+      if trait_in_list(dep_traits, super_name) {
         let super_base = trait_ref_name(super_name)
         trait_projection_add_mapping(mappings, super_base, super_base)
       } else {
@@ -1799,6 +1858,8 @@ fn bind_import_names_from_cache_collecting(acc: TypeEnv, resolved: String, raw_p
     None => EnvEmpty
   }
   let dep_bindings = env_flat_bindings(dep_env)
+  env_trait_def_names_into(dep_env, bi_trait_names)
+  uppercase_binding_slots_into(dep_bindings, bi_upper_slots)
   let dep_selectable_type_defs = env_selectable_type_defs(dep_env)
   // Kind advice is useful only for names the module actually publishes. A
   // private declaration may remain in the TypeDef closure solely to describe
@@ -1807,7 +1868,7 @@ fn bind_import_names_from_cache_collecting(acc: TypeEnv, resolved: String, raw_p
   let mut kii = 0
   while kii < Array::length(names) {
     let item = Array::get(names, kii)
-    if contains_str(dep_selectable_type_defs, item.name) || trait_defined(dep_env, item.name) || env_lookup_flat(dep_bindings, item.name) != None {
+    if contains_str(dep_selectable_type_defs, item.name) || trait_in_list(bi_trait_names, item.name) || env_lookup_flat(dep_bindings, item.name) != None {
       Array::push(kind_items, item)
     } else {
       ()
@@ -1822,7 +1883,7 @@ fn bind_import_names_from_cache_collecting(acc: TypeEnv, resolved: String, raw_p
   }
   // Explicit trait aliases must be known before values are bound: a selected
   // value can mention the trait before its `trait X as Local` row appears.
-  let trait_mappings = dependency_trait_projection_mappings(dep_env, dep_bindings, names, unresolved)
+  let trait_mappings = dependency_trait_projection_mappings(dep_env, dep_bindings, bi_trait_names, bi_upper_slots, names, unresolved)
   trait_projection_claim_mappings(trait_claims, resolved, dep_env, trait_mappings, unresolved)
   // Whether the dependency was CHECKED, not whether it happens to bind any
   // values. A module that exports only types or only traits is checked and
@@ -1859,7 +1920,7 @@ fn bind_import_names_from_cache_collecting(acc: TypeEnv, resolved: String, raw_p
           // Declaration authority travels explicitly in EnvTypeDefs, so
           // uppercase is never evidence that an import is valid. Effects and
           // effectsets use the same selected declaration channel.
-          if dep_known && !contains_str(dep_selectable_type_defs, name) && !trait_defined(dep_env, name) {
+          if dep_known && !contains_str(dep_selectable_type_defs, name) && !trait_in_list(bi_trait_names, name) {
             Array::push(unresolved, String::concat(String::concat(String::concat("imported name '", name), "' is not exported by '"), String::concat(raw_path, "'")))
           } else {
             ()
@@ -1869,7 +1930,7 @@ fn bind_import_names_from_cache_collecting(acc: TypeEnv, resolved: String, raw_p
       }
       let with_name = match imported_ty {
         Some(_) => env_bind_with_origin(nacc, bound_name, ty, binding_origin),
-        None => if contains_str(dep_selectable_type_defs, name) || trait_defined(dep_env, name) {
+        None => if contains_str(dep_selectable_type_defs, name) || trait_in_list(bi_trait_names, name) {
           // Declaration aliases travel in the separate publication projection
           // below. Retain the declaration's origin on its existing unknown
           // value-space marker so semantic checks can distinguish a projected
@@ -1890,7 +1951,7 @@ fn bind_import_names_from_cache_collecting(acc: TypeEnv, resolved: String, raw_p
       bind_names(j + 1, with_companions)
     }
   }
-  let declaration_trait_mappings = dependency_trait_projection_mappings(dep_env, dep_bindings, declaration_names, array_empty())
+  let declaration_trait_mappings = dependency_trait_projection_mappings(dep_env, dep_bindings, bi_trait_names, bi_upper_slots, declaration_names, array_empty())
   bind_names(0, prepend_dependency_trait_nodes(dep_env, declaration_trait_mappings, prepend_dependency_type_defs(dep_env, declaration_names, acc)))
 }
 
@@ -1920,8 +1981,10 @@ fn prepend_reexport_alias_declarations(acc: TypeEnv, resolved: String, names: Ar
     None => EnvEmpty
   }
   let dep_bindings = env_flat_bindings(dep_env)
+  env_trait_def_names_into(dep_env, pra_trait_names)
+  uppercase_binding_slots_into(dep_bindings, pra_upper_slots)
   let ignored = array_empty()
-  let mappings = dependency_trait_projection_mappings(dep_env, dep_bindings, names, ignored)
+  let mappings = dependency_trait_projection_mappings(dep_env, dep_bindings, pra_trait_names, pra_upper_slots, names, ignored)
   prepend_dependency_trait_nodes(dep_env, mappings, prepend_dependency_type_defs(dep_env, names, acc))
 }
 
@@ -3071,6 +3134,7 @@ fn interface_public_value_names(stmts: Array[Stmt]) -> Array[String] {
 /// typedef or effect transport.
 fn interface_public_trait_names(stmts: Array[Stmt], checked_env: TypeEnv) -> Array[String] {
   let mappings = array_empty()
+  env_trait_def_names_into(checked_env, ipt_trait_names)
   let mut i = 0
   while i < Array::length(stmts) {
     match Array::get(stmts, i) {
@@ -3079,7 +3143,7 @@ fn interface_public_trait_names(stmts: Array[Stmt], checked_env: TypeEnv) -> Arr
         let mut j = 0
         while j < Array::length(items) {
           let name = Array::get(items, j)
-          if trait_defined(checked_env, name) {
+          if trait_in_list(ipt_trait_names, name) {
             trait_projection_add_mapping(mappings, name, name)
           } else {
             ()
@@ -3097,7 +3161,7 @@ fn interface_public_trait_names(stmts: Array[Stmt], checked_env: TypeEnv) -> Arr
             Some(value) => value,
             None => source_name
           }
-          if trait_defined(checked_env, local_name) {
+          if trait_in_list(ipt_trait_names, local_name) {
             trait_projection_add_mapping(mappings, local_name, local_name)
           } else {
             ()
@@ -3113,7 +3177,7 @@ fn interface_public_trait_names(stmts: Array[Stmt], checked_env: TypeEnv) -> Arr
   i = 0
   while i < Array::length(values) {
     match env_lookup(checked_env, Array::get(values, i)) {
-      Some(ty) => trait_projection_collect_type_bounds(ty, mappings, checked_env),
+      Some(ty) => trait_projection_collect_type_bounds(ty, mappings, ipt_trait_names),
       None => ()
     }
     i = i + 1
@@ -3122,11 +3186,11 @@ fn interface_public_trait_names(stmts: Array[Stmt], checked_env: TypeEnv) -> Arr
   while cursor < Array::length(mappings) {
     let (name, _) = Array::get(mappings, cursor)
     let supers = trait_projection_supers(checked_env, name)
-    trait_projection_collect_generic_impl_bounds(checked_env, name, mappings)
+    trait_projection_collect_generic_impl_bounds(checked_env, name, mappings, ipt_trait_names)
     let mut j = 0
     while j < Array::length(supers) {
       let super_name = Array::get(supers, j)
-      if trait_defined(checked_env, super_name) {
+      if trait_in_list(ipt_trait_names, super_name) {
         trait_projection_add_mapping(mappings, super_name, super_name)
       } else {
         ()

--- a/lib/@vibe/compiler/tests/env_trait_def_names_test.vibe
+++ b/lib/@vibe/compiler/tests/env_trait_def_names_test.vibe
@@ -1,0 +1,72 @@
+import @vibe/core {
+  array_empty
+}
+
+import @vibe/compiler/core {
+  Type, TypeEnv, TypeExpr, env_trait_def_names, env_trait_def_names_into, env_value_binding, trait_defined
+}
+
+// #2386: env_trait_def_names is the one-walk form of trait_defined. The
+// import projection builds a set from it once per edge instead of walking
+// the whole chain once per name.
+
+fn trait_node(name: String, rest: TypeEnv) -> TypeEnv {
+  let no_supers: Array[String] = []
+  let no_methods: Array[(String, Array[TypeExpr], TypeExpr)] = []
+  EnvTraitDef(name, no_supers, false, no_methods, rest, array_empty(), array_empty())
+}
+
+fn names_contain(names: Array[String], name: String) -> Bool {
+  let mut i = 0
+  let mut found = false
+  while i < Array::length(names) {
+    if Array::get(names, i) == name {
+      found = true
+    } else {
+      ()
+    }
+    i = i + 1
+  }
+  found
+}
+
+fn sample_env() -> TypeEnv {
+  let inner = trait_node("Eq", EnvTraitImpl("Eq", CtInt, EnvEmpty))
+  let bound = EnvBind("x", env_value_binding(CtInt), inner)
+  EnvCached(array_empty(), array_empty(), trait_node("Show", bound))
+}
+
+test "every EnvTraitDef of the chain is listed, innermost first, through binds, impls and a cache node" {
+  inspect(env_trait_def_names(sample_env()), content = "[Show, Eq]")
+}
+
+test "the list answers exactly like trait_defined" {
+  let env = sample_env()
+  let names = env_trait_def_names(env)
+  let asked = ["Show", "Eq", "Ord", "x"]
+  let via_walk: Array[Bool] = []
+  let via_list: Array[Bool] = []
+  let mut i = 0
+  while i < Array::length(asked) {
+    Array::push(via_walk, trait_defined(env, Array::get(asked, i)))
+    Array::push(via_list, names_contain(names, Array::get(asked, i)))
+    i = i + 1
+  }
+  inspect(via_walk, content = "[true, true, false, false]")
+  inspect(via_list, content = "[true, true, false, false]")
+}
+
+test "an EnvFlat is terminal for both" {
+  let flat: Array[(String, EnvValueBinding)] = []
+  let env = trait_node("A", EnvFlat(flat))
+  inspect(env_trait_def_names(env), content = "[A]")
+  inspect(env_trait_def_names(EnvFlat(flat)), content = "[]")
+}
+
+test "the row form empties a reused row before refilling it" {
+  let row = ["stale", "rows"]
+  env_trait_def_names_into(sample_env(), row)
+  inspect(row, content = "[Show, Eq]")
+  env_trait_def_names_into(EnvEmpty, row)
+  inspect(row, content = "[]")
+}

--- a/lib/@vibe/compiler/tests/evidence_shadow_census_test.vibe
+++ b/lib/@vibe/compiler/tests/evidence_shadow_census_test.vibe
@@ -1,0 +1,50 @@
+import @vibe/compiler/core {
+  Expr, Pat, Stmt
+}
+
+import @vibe/compiler/codegen/common_base {
+  edp_bind_census
+}
+
+// #2386: the evidence pass's shadow census answers, in one walk over the
+// top-level bodies, what edp_expr_binds_name answered per name: which of
+// the asked names some body binds anywhere.
+
+fn ident_of(n: String) -> Expr {
+  EIdent(n, -1)
+}
+
+fn top_let(name: String, value: Expr) -> Stmt {
+  SLet(false, false, name, None, value)
+}
+
+fn sample_body() -> Expr {
+  // let a = 1; (fn(p~) -> match x { Some(m) => loop(l = 0) { for i, q in [] { () } } }); b
+  let inner_loop = ELoop([("l", EInt(0))], EForIn("i", Some("q"), EArray([]), EUnit))
+  let arm = (PCtor("Some", [PBind("m")]), inner_loop)
+  let closure = EFn([], [], [("p~", None)], None, None, EMatch(ident_of("x"), [
+    arm
+  ]))
+  ESeq(ELet("a", EInt(1), closure, -1), ident_of("b"))
+}
+
+test "every binder kind marks its name; a mention does not" {
+  let stmts = [top_let("f", sample_body())]
+  let asked = ["a", "b", "x", "p", "p~", "m", "l", "i", "q"]
+  inspect(edp_bind_census(stmts, asked), content = "[true, false, false, true, false, true, true, true, true]")
+}
+
+test "only let, let mut, expression, test and bench statements are scanned" {
+  let stmts = [
+    SFnDecl(false, "g", ELet("z", EInt(1), EUnit, -1), [], []),
+    STest("t", ELet("t", EInt(2), EUnit, -1)),
+    SExpr(ELetMut("u", EInt(3), EUnit, -1))
+  ]
+  inspect(edp_bind_census(stmts, ["z", "t", "u"]), content = "[false, true, true]")
+}
+
+test "a repeated name answers the same each time and an empty ask walks nothing" {
+  let stmts = [top_let("f", sample_body())]
+  inspect(edp_bind_census(stmts, ["a", "b", "a"]), content = "[true, false, true]")
+  inspect(edp_bind_census(stmts, []), content = "[]")
+}

--- a/lib/@vibe/compiler/tests/region_write_gate_test.vibe
+++ b/lib/@vibe/compiler/tests/region_write_gate_test.vibe
@@ -1,0 +1,23 @@
+import ./checker_parity_test_support.vibe {
+  check_source_error_message, check_source_ok
+}
+
+// #2386: retaining_write_region_check asks whether the callee retains an
+// argument before it asks the environment for the active region, and
+// direct_call_return asks the builtin table before it walks the chain.
+// Both are pure reorders; these pin the answers they must keep giving.
+
+test "a container write that stores a region-capturing closure into an outer binding is still reported" {
+  let src = "fn build() -> Int {\n  let sink: Array[() -> Int] = []\n  region r {\n    let cell = MutList::empty(r)\n    Array::push(sink, () -> Int {\n      MutList::length(cell)\n    })\n  }\n  0\n}"
+  inspect(check_source_error_message(src), content = "region escapes its scope: a container write stores a value that captures this region into an outer binding")
+}
+
+test "the same write outside a region, and a non-retaining call inside one, are fine" {
+  assert(check_source_ok("fn build() -> Int {\n  let sink: Array[Int] = []\n  Array::push(sink, 1)\n  Array::length(sink)\n}"))
+  assert(check_source_ok("fn build() -> Int {\n  region r {\n    let cell = MutList::empty(r)\n    MutList::length(cell)\n  }\n}"))
+}
+
+test "a builtin's direct return type still answers, and a user fn of a builtin's name still shadows it" {
+  assert(check_source_ok("fn f() -> Int {\n  let n: Int = String::length(\"abc\")\n  n\n}"))
+  inspect(check_source_error_message("fn String::length(s: String) -> String {\n  s\n}\nfn f() -> Int {\n  let n: Int = String::length(\"abc\")\n  n\n}"), content = "binding type mismatch for a local let: expected Int, got String [@fn=n]")
+}


### PR DESCRIPTION
## What

Three slices of #2386, byte-identical to main on every corpus: two on the checker lane (the cold, first-build path), one on both codegen lanes.

### `3e89d7a` — the import projection reads a dependency's trait names from one chain walk per edge

`dependency_trait_projection_mappings` (`runtime/typecheck_fs.vibe`), the import binder around it and the public interface projection asked `trait_defined` once per imported name (twice: pass one and pass two), once per bound label of every reachable type scheme and once per supertrait, and every answer walked the dependency's whole environment chain to its end. The companion scan of pass two then ran over every binding of the dependency once per imported value name, testing the uppercase-start predicate per (name, binding) pair before the prefix and return-type tests. On the compiler closure the projection was ~140 ms of a cold self-compile, `trait_defined` alone ~60 ms.

`env_trait_def_names_into` (`core/types.vibe`) collects the chain's `EnvTraitDef` names in one walk into a caller-owned row, stopping where `trait_defined` stops (an `EnvFlat` is terminal). Each of the three owners (the import binder, the re-export alias projection, the interface projection) refills one module-level row per edge and probes it through `trait_ref_name`, the same normalization `trait_defined` applied to the asked name; an empty row answers before normalizing. The uppercase binding slots go into a second row once per edge, and the per-name candidate scan iterates only those, in the same order, so the bounds are collected in exactly the order they were. The rows belong to one non-recursive function each and are read only inside it (the binder is driven by a loop over a module's import statements; the interface projection runs after a module is checked), so no call can observe another's fill. Nothing else changes shape: the mappings, their order, and the diagnostics are the same.

`env_trait_def_names_test.vibe` pins the collector with `inspect` snapshots: every trait def is listed innermost first through binds, impls and a cache node; the list answers exactly like `trait_defined` for defined, undefined and non-trait names; an `EnvFlat` is terminal for both; the row form empties a reused row before refilling it. Red: stopping at a cache node, or at the first trait def, each fails the first case.

### `d8be015` — the evidence pass takes its shadow census in one walk over the program

`edp_alpha_rename_shadowed` (`codegen/common_base/inline_direct_perform.vibe`) decides which effect-needing functions are shadowed by a local binder somewhere in the program by asking `edp_expr_binds_name(body, name)` for every needing name of every effect over every top-level body: a full program walk per name, once per `evidence_dict_pass`. ~72 ms of a cold self-compile, on both lanes.

`edp_bc_stmts` walks the scanned statement kinds once with the needing names in a slot map and marks the ones some body binds, under exactly the `RQEdpBindsName` rules the per-name query answered with (a let / let mut / let rec binder, a for-in name and its index, an fn parameter without its `~`, a loop parameter, a match or handle pattern binder; an interpolation is opaque; enumerated with no catch-all so a new `Expr` variant fails to compile here too). The seed is then read off the census in the same (effect, needing) order the per-name walks pushed it in, so the rename that follows runs on the same names in the same order. The needing tables are computed once per effect as before and kept for the replay.

`evidence_shadow_census_test.vibe` pins the census through the exported `edp_bind_census` with `inspect` snapshots: every binder kind marks its name and a mention does not; only let / let mut / expression / test / bench statements are scanned; a repeated name answers the same each time and an empty ask walks nothing. Red: comparing fn params with their tilde, skipping arm pattern binders, or skipping the for-in index each flips its slot.

### `9004877` — two call-site gates in the checker ask the cheap question first (checker lane)

`retaining_write_region_check` (`checker/checker.vibe`) asked `env_has_active_region(env)` for every call site with arguments before testing whether the callee retains any argument at all: a chain lookup of `#active_region` per call, ~125 ms of a cold self-compile, for a check that does nothing unless the callee is one of the container writers (`Array::push`, `Array::set`, `MutMap::set` and their kin). The name test, a compare ladder, now comes first, so the lookup runs only for those.

`direct_call_return` looked the callee up in the environment and, on a miss, probed the whole chain for a surface-only binding before consulting the builtin return table; a callee the table does not know answers `None` either way, so the two walks now run only for names the table knows. Every user-defined callee used to pay both per call site (~100 ms cold).

Both are pure reorders of pure tests and give the same answer in every case. `region_write_gate_test.vibe` pins them with `inspect` snapshots: the container write that stores a region-capturing closure into an outer binding is still reported; the same write outside a region and a non-retaining call inside one are fine; a builtin's direct return type still answers and a user fn of a builtin's name still shadows it. Red: never running the region check, or answering from the table without the environment, each fails its case.

### Measured

Cache-isolated per the profiling skill, `codegen_lexer_test.vibe` over the full compiler closure, against a stage2 built from main at `185e15f` (main has since gained #2529 and f0118e6, neither of which touches the import projection), idle machine, four interleaved pairs in alternating order (ABBA):

| | main (`185e15f`) | `3e89d7a` |
|---|---:|---:|
| `dependency_trait_projection_mappings` cold inclusive | 0.14 s | 0.05 s |
| `bind_import_names_from_cache_collecting` cold inclusive | 0.22 s | 0.12 s |
| `trait_defined` cold inclusive | 0.07 s | 0 |
| cold wall, median of 4 | 7.28 s | 7.17 s (−1.5%) |
| warm wall, median of 4 | 4.51 s | 4.55 s (noise; the warm lane does not run this code) |
| heap_ptr cold / warm | 1,047,427,224 / 650,278,616 | 1,046,858,896 / 650,278,976 (−568 KB / +360 B) |

Two earlier cuts were measured and rejected on the same corpus: a `MutSet` plus fresh arrays per edge (+3.4 MB of cold heap, ~3000 edges), and the rows without the empty-row fast path (+0.8 MB: `trait_ref_name` allocates its parsed reference, and `trait_defined` only normalized once it reached an `EnvTraitDef`, which most dependencies never have). The rows themselves allocate nothing: 2000 truncate-and-refill rounds of a 40-entry row measure 0 bytes on the bump lane, against 2.04 MB for fresh arrays.

The second commit, measured the same way against the first (`3e89d7a`), on the same machine:

| | `3e89d7a` | `d8be015` |
|---|---:|---:|
| `edp_alpha_rename_shadowed` cold inclusive | 0.07 s | 0.03 s |
| `edp_expr_binds_name` cold inclusive | 0.07 s | 0 |
| `edp_bc_stmts` cold inclusive | — | 0.03 s |
| `evidence_dict_pass` cold inclusive | 0.35 s | 0.31 s |
| cold wall, median of 4 | 6.97 s | 7.06 s (noise: one 7.46 s outlier; the mean is +0.9%) |
| warm wall, median of 4 | 4.40 s | 4.41 s (noise; the mean is −0.8%) |
| heap_ptr cold / warm | 1,046,833,000 / 649,976,008 | 1,046,876,992 / 650,016,792 (+44 KB / +41 KB) |

The ~40 ms this removes is below the wall clock's noise on this machine (±3% across four pairs); the profile rows are the evidence. The heap is the slot map and the kept needing tables, once per evidence pass.

The third commit, measured the same way against the second (`d8be015`), on the same machine:

| | `d8be015` | `9004877` |
|---|---:|---:|
| `retaining_write_region_check` cold inclusive | 0.13 s | 0.03 s |
| `env_has_active_region` cold inclusive | 0.13 s | 0.02 s |
| `direct_call_return` cold inclusive | 0.17 s | 0.12 s |
| `env_lookup` cold inclusive | 0.57 s | 0.41 s |
| `check_expr_capture_impl` cold inclusive | 1.01 s | 0.88 s |
| cold wall, median of 4 | 7.06 s | 6.99 s (−0.9%; the mean is −0.7%) |
| warm wall, median of 4 | 4.30 s | 4.42 s (+2.9%, with an identical warm heap and no checker on that lane: the four warm runs of each side sit within their own ±2% band, so this is the noise between two binaries, not a path) |
| heap_ptr cold / warm | 1,048,640,952 / 650,972,752 | 1,045,561,296 / 650,965,608 (−3.08 MB / −7 KB) |

The cold heap drops because every skipped `#active_region` lookup used to box its answer; the checker lane asked it once per call site.

Byte-identical output on three closures and 22 rc fixtures, each commit against its base.

## Validation

Chain on `3e89d7a` (base `3a71caf`): bundle regen; stage2 == stage3; output equivalence; `test_cli_core.sh`; selfcompile KPI heap_ptr 1,046,859,952 bytes; typing-env-reuse oracle; 329/329 affected unit-test files; `compiler_gate.sh` early / mid / late. Chain on `d8be015` (run in a staging worktree on the identical tree, tree hash checked against the pushed head): bundle regen; stage2 == stage3; output equivalence; `test_cli_core.sh`; selfcompile KPI heap_ptr 1,048,669,216 bytes (the KPI rows run against the shared default cache and are not comparable across chains; the cache-isolated rows above are the comparison); typing-env-reuse oracle; 330/330 affected unit-test files (import-graph selection over the changed files); `compiler_gate.sh` early / mid / late. Chain on `9004877` (identical tree, hash checked against the pushed head): bundle regen; stage2 == stage3; output equivalence; `test_cli_core.sh`; selfcompile KPI heap_ptr 1,045,587,384 bytes; typing-env-reuse oracle; 331/331 affected unit-test files; `compiler_gate.sh` early / mid / late.

`vibe_fmt.sh --check` is a fixpoint on every changed file.

Refs #2386.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QKZdvBvHVUagwg6Yih8er8

---
_Generated by [Claude Code](https://claude.ai/code/session_01QKZdvBvHVUagwg6Yih8er8)_