### PR TITLE
checker: spine region gate once per sequence; core: builtin registry lookup through a sorted view (#2386)

### DIFF
--- a/lib/@vibe/compiler/checker/checker.vibe
+++ b/lib/@vibe/compiler/checker/checker.vibe
@@ -7851,6 +7851,12 @@ fn check_seq_spine(expr: Expr, env: TypeEnv, defs: Array[TypeDef], s: Subst, c: 
   let mut s1 = s
   let mut c1 = c
   let start_frame_depth = typed_occurrence_capture_frame_depth(capture)
+  // #2386: expression_aliases_outer_binding can only answer true inside a
+  // region block (its roots are the `#active_region` binder and the alias
+  // markers this spine writes when it answered true), and a spine's lets
+  // never open one -- a region body is checked in its own environment -- so
+  // the region state is asked once here, not two chain walks per let.
+  let spine_region_active = env_has_active_region(env)
   let mut done = false
   let mut result = (CtUnit, s, c)
   while !done {
@@ -7886,7 +7892,7 @@ fn check_seq_spine(expr: Expr, env: TypeEnv, defs: Array[TypeDef], s: Subst, c: 
         // binding's to quantify. See let_generalize for why those are two
         // rules and not one.
         let gen = let_generalize(val, vt, cenv, ns, None)
-        let aliases_outer = expression_aliases_outer_binding(val, cenv)
+        let aliases_outer = spine_region_active && expression_aliases_outer_binding(val, cenv)
         cenv = env_bind(cenv, name, gen)
         cenv = bind_function_dependency_contracts(cenv, name, val)
         if aliases_outer {

--- a/lib/@vibe/compiler/core/builtin_registry.vibe
+++ b/lib/@vibe/compiler/core/builtin_registry.vibe
@@ -15,6 +15,10 @@ import @vibe/core {
   array_empty
 }
 
+import ./sorted_index.vibe {
+  bsearch_leftmost, sort_perm_by_names
+}
+
 //# Functions
 
 // #415: the central declarative registry of func-table builtins across
@@ -730,17 +734,52 @@ export fn registry_builtin_param_type(name: String, i: Int) -> Option[Type] {
 /// B-2: the checker-facing lookup, consulted FIRST by
 /// checker/builtins.vibe::lookup_builtin. Only checker_visible rows resolve;
 /// codegen-internal names stay invisible to user code.
-export fn lookup_registry_builtin(name: String) -> Option[Type] {
-  let rows = builtin_registry_typed()
-  let mut i = 0
-  let mut found = None
-  while i < Array::length(rows) {
-    let (rname, ty, _, _, visible) = Array::get(rows, i)
-    if rname == name && visible {
-      found = Some(ty)
-      i = Array::length(rows)
-    } else {
+// #2386: a sorted view of the registry's names with the row each slot came
+// from, built once per process next to the erased rows (the registry is a
+// constant). lookup_registry_builtin used to scan every row per query --
+// the checker, the contract engine and the evidence pass ask it per call
+// site or per declaration -- and now binary-searches the view. The sort is
+// stable and the search leftmost, so the first visible row of a name wins
+// exactly as the scan answered.
+let registry_typed_sorted: Array[String] = []
+
+let registry_typed_sorted_pos: Array[Int] = []
+
+fn registry_typed_index() -> Unit {
+  if Array::length(registry_typed_sorted) == 0 {
+    let rows = builtin_registry_typed()
+    let names = array_empty()
+    let mut i = 0
+    while i < Array::length(rows) {
+      let (rname, _, _, _, _) = Array::get(rows, i)
+      Array::push(names, rname)
       i = i + 1
+    }
+    let perm = sort_perm_by_names(names)
+    i = 0
+    while i < Array::length(perm) {
+      let row = Array::get(perm, i)
+      Array::push(registry_typed_sorted, Array::get(names, row))
+      Array::push(registry_typed_sorted_pos, row)
+      i = i + 1
+    }
+  } else {
+    ()
+  }
+}
+
+export fn lookup_registry_builtin(name: String) -> Option[Type] {
+  registry_typed_index()
+  let rows = builtin_registry_typed()
+  let mut slot = bsearch_leftmost(registry_typed_sorted, name)
+  let mut found = None
+  while slot >= 0 && slot < Array::length(registry_typed_sorted) && Array::get(registry_typed_sorted, slot) == name {
+    let (_, ty, _, _, visible) = Array::get(rows, Array::get(registry_typed_sorted_pos, slot))
+    if visible {
+      found = Some(ty)
+      slot = -1
+    } else {
+      slot = slot + 1
     }
   }
   found

--- a/lib/@vibe/compiler/tests/region_write_gate_test.vibe
+++ b/lib/@vibe/compiler/tests/region_write_gate_test.vibe
@@ -21,3 +21,8 @@ test "a builtin's direct return type still answers, and a user fn of a builtin's
   assert(check_source_ok("fn f() -> Int {\n  let n: Int = String::length(\"abc\")\n  n\n}"))
   inspect(check_source_error_message("fn String::length(s: String) -> String {\n  s\n}\nfn f() -> Int {\n  let n: Int = String::length(\"abc\")\n  n\n}"), content = "binding type mismatch for a local let: expected Int, got String [@fn=n]")
 }
+
+test "an alias of an outer container taken inside a region still carries the outer-binding marker" {
+  let src = "fn build() -> Int {\n  let sink: Array[() -> Int] = []\n  region r {\n    let cell = MutList::empty(r)\n    let alias = sink\n    Array::push(alias, () -> Int {\n      MutList::length(cell)\n    })\n  }\n  0\n}"
+  inspect(check_source_error_message(src), content = "region escapes its scope: a container write stores a value that captures this region into an outer binding")
+}

--- a/lib/@vibe/compiler/tests/registry_lookup_index_test.vibe
+++ b/lib/@vibe/compiler/tests/registry_lookup_index_test.vibe
@@ -1,0 +1,54 @@
+import @vibe/compiler/core {
+  Type, builtin_registry_typed, lookup_registry_builtin, type_to_string
+}
+
+// #2386: lookup_registry_builtin answers from a sorted view of the registry
+// instead of scanning every row. It must give the scan's answer for every
+// registered name (the first VISIBLE row of that name) and None for a name
+// the registry does not hold.
+
+fn scan_reference(name: String) -> Option[Type] {
+  let rows = builtin_registry_typed()
+  let mut i = 0
+  let mut found = None
+  while i < Array::length(rows) {
+    let (rname, ty, _, _, visible) = Array::get(rows, i)
+    if rname == name && visible {
+      found = Some(ty)
+      i = Array::length(rows)
+    } else {
+      i = i + 1
+    }
+  }
+  found
+}
+
+fn render(answer: Option[Type]) -> String {
+  match answer {
+    Some(ty) => type_to_string(ty),
+    None => "<none>"
+  }
+}
+
+test "every registered name answers exactly like the scan" {
+  let rows = builtin_registry_typed()
+  let mut i = 0
+  let mut disagreements: Array[String] = []
+  while i < Array::length(rows) {
+    let (rname, _, _, _, _) = Array::get(rows, i)
+    if render(lookup_registry_builtin(rname)) != render(scan_reference(rname)) {
+      Array::push(disagreements, rname)
+    } else {
+      ()
+    }
+    i = i + 1
+  }
+  inspect(disagreements, content = "[]")
+  inspect(Array::length(rows) > 100, content = "true")
+}
+
+test "a known builtin answers and an unknown name does not" {
+  inspect(render(lookup_registry_builtin("Array::length")), content = "(Array[?]) -> Int")
+  inspect(render(lookup_registry_builtin("no::such_builtin")), content = "<none>")
+  inspect(render(lookup_registry_builtin("")), content = "<none>")
+}


### PR DESCRIPTION
## What

Two slices of #2386, byte-identical to main on every corpus: one on the checker lane (the cold, first-build path) and one lookup used by the checker, the contract engine and the evidence pass.

### `f4f4fa1` — the sequence spine asks for the active region once, not per let (checker lane)

`check_seq_spine` asked `expression_aliases_outer_binding` for every let's value: for a call value, an environment lookup of the callee and a second of its alias contract; for a name, a walk to the region binder; each a chain walk, ~40 ms of a cold self-compile. The answer can only be true inside a region block: its roots are the `#active_region` binder and the alias markers the spine itself writes when it answered true, and a spine's lets never open a region (a region body is checked in its own environment), so the region state is constant across the spine. The spine now asks `env_has_active_region` once at entry (an indexed hit through the cache's negative marker) and consults the alias probe only when it is set.

`region_write_gate_test.vibe` gains the case that must keep answering: an alias of an outer container taken inside a region still carries the marker, so a write through it that stores a region-capturing closure is reported. Red: never writing the marker fails it.

### Measured (cand38)

Cache-isolated per the profiling skill, `codegen_lexer_test.vibe` over the full compiler closure, against a stage2 built from the base tree (`9004877`, the head of #2531 and the tree of main after its merge), idle machine, four interleaved pairs in alternating order (ABBA):

| | base (`9004877`) | `f4f4fa1` |
|---|---:|---:|
| `expression_aliases_outer_binding` cold inclusive | 0.04 s | 0 |
| `env_has_active_region` cold inclusive | 0.02 s | 0.03 s |
| `check_seq_spine` cold inclusive | 0.49 s | 0.46 s |
| `check_expr_capture_impl` cold inclusive | 0.88 s | 0.83 s |
| cold wall, median of 4 | 6.95 s | 6.98 s (noise; the mean is +0.4%) |
| warm wall, median of 4 | 4.59 s | 4.43 s (noise; the warm lane does not run this code) |
| heap_ptr cold / warm | 1,045,561,296 / 650,965,608 | 1,045,501,728 / 650,969,864 (−60 KB / +4 KB) |

The ~40 ms this removes is below the wall clock's noise on this machine; the profile rows are the evidence.

Byte-identical output on three closures and 22 rc fixtures.

### `fe7b796` — `lookup_registry_builtin` binary-searches a sorted view of the registry

`lookup_registry_builtin` (`core/builtin_registry.vibe`) scanned every row of the typed builtin registry per query, comparing names as it went. The checker, the contract engine and the evidence pass ask it per call site or per declaration, so it showed as ~30 ms of a cold self-compile.

A sorted view of the registry's names, with the row each slot came from, is built once per process next to the erased rows (the registry is a constant). A lookup is one leftmost binary search and a forward read of the equal run for the first visible row — the same row the scan returned, since the sort is stable and the search leftmost. The view costs 15.6 KB of heap once.

`registry_lookup_index_test.vibe` pins it with inspect snapshots: every registered name answers exactly like a scan of the rows (rendered types compared, no disagreements over the 100+ rows), `Array::length` answers `(Array[?]) -> Int`, and an unknown or empty name answers nothing. Red: with the search landing one slot past the leftmost (mutation built into the worktree's library), the agreement case lists the names that answer another row's type.

### Measured (cand39)

Cache-isolated per the profiling skill, `codegen_lexer_test.vibe` over the full compiler closure, against a stage2 built from `f4f4fa1` (the first commit of this PR), idle machine, four interleaved pairs in alternating order (ABBA):

| | `f4f4fa1` | `fe7b796` |
|---|---:|---:|
| `lookup_registry_builtin` cold inclusive | 0.03 s | 0.01 s |
| `lookup_builtin` cold inclusive | 0.04 s | 0.03 s |
| cold wall, median of 4 | 6.98 s | 7.10 s (noise; the cold band on this machine is ±5%) |
| warm wall, median of 4 | 4.44 s | 4.41 s (noise) |
| heap_ptr cold / warm | 1,045,505,128 / 650,970,848 | 1,045,520,720 / 650,969,328 (+15.6 KB: the sorted view) |

Byte-identical output on three closures and 22 rc fixtures.

## Validation

Chain on `f4f4fa1` (base `6d79a2b`; run in a staging worktree on the identical tree, tree hash checked against the pushed head): bundle regen; stage2 == stage3; output equivalence; `test_cli_core.sh`; selfcompile KPI heap_ptr 1,045,532,544 bytes; typing-env-reuse oracle; 210/210 affected unit-test files (import-graph selection over the changed files); `compiler_gate.sh` early / mid / late.

Chain on `fe7b796` (same base, same protocol, tree hash checked against the pushed head): bundle regen; stage2 == stage3; output equivalence; `test_cli_core.sh`; selfcompile KPI heap_ptr 1,045,782,840 bytes (both KPI rows are against the shared default cache, so they are not comparable across chains; the cache-isolated rows above are the comparison); typing-env-reuse oracle; 330/330 affected unit-test files; `compiler_gate.sh` early / mid / late.

`vibe_fmt.sh --check` is a fixpoint on every changed file.

Refs #2386.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QKZdvBvHVUagwg6Yih8er8

---
_Generated by [Claude Code](https://claude.ai/code/session_01QKZdvBvHVUagwg6Yih8er8)_