### PR TITLE
core: the merge lane applies export renames and the private namespace in one rebuild (#2386)

### DIFF
--- a/lib/@vibe/compiler/core/core.vibe
+++ b/lib/@vibe/compiler/core/core.vibe
@@ -148,6 +148,7 @@ export ./import_alias_rewrite.vibe {
   make_import_alias_rewriter,
   namespace_exported_name,
   namespace_private_value_stmts,
+  namespace_private_value_stmts_after_renames,
   rewrite_import_alias_expr,
   rewrite_import_alias_stmt,
   rewrite_imported_value_stmt_to_local,

--- a/lib/@vibe/compiler/core/import_alias_rewrite.vibe
+++ b/lib/@vibe/compiler/core/import_alias_rewrite.vibe
@@ -2282,126 +2282,6 @@ fn collect_private_ctor_renames(path: String, stmts: Array[Stmt], type_renames: 
 }
 
 export fn namespace_private_value_stmts(path: String, stmts: Array[Stmt]) -> Array[Stmt] {
-  let namespace_private_type_ctor_stmt_local: (Stmt, Array[(String, String)], Array[(String, String)]) -> Stmt = (stmt, type_renames, ctor_renames) -> {
-    match stmt {
-      SLet(exported, is_rec, name, ty, body) => SLet(exported, is_rec, name, rewrite_private_type_opt(ty, type_renames), rewrite_private_type_ctor_expr(body, type_renames, alias_map_without_name(ctor_renames, name))),
-      SLetMut(name, ty, body) => SLetMut(name, rewrite_private_type_opt(ty, type_renames), rewrite_private_type_ctor_expr(body, type_renames, alias_map_without_name(ctor_renames, name))),
-      SEnum(exported, name, params, ctors, derives) => {
-        let next_name = if exported {
-          name
-        } else {
-          match lookup_alias(type_renames, name) {
-            Some(renamed) => renamed,
-            None => name
-          }
-        }
-        SEnum(exported, next_name, params, for ctor in ctors {
-          let (ctor_name, args) = ctor
-          let next_ctor = if exported {
-            ctor_name
-          } else {
-            match lookup_alias(ctor_renames, ctor_name) {
-              Some(renamed) => renamed,
-              None => ctor_name
-            }
-          }
-          (next_ctor, for arg in args {
-            rewrite_private_type_expr(arg, type_renames)
-          })
-        }, derives)
-      },
-      SSuberror(exported, name, ctors) => {
-        let next_name = if exported {
-          name
-        } else {
-          match lookup_alias(type_renames, name) {
-            Some(renamed) => renamed,
-            None => name
-          }
-        }
-        SSuberror(exported, next_name, for ctor in ctors {
-          let (ctor_name, args) = ctor
-          let next_ctor = if exported {
-            ctor_name
-          } else {
-            match lookup_alias(ctor_renames, ctor_name) {
-              Some(renamed) => renamed,
-              None => ctor_name
-            }
-          }
-          (next_ctor, for arg in args {
-            rewrite_private_type_expr(arg, type_renames)
-          })
-        })
-      },
-      SStruct(exported, name, fields, derives, mut_fields, tparams) => {
-        let next_name = if exported {
-          name
-        } else {
-          match lookup_alias(type_renames, name) {
-            Some(renamed) => renamed,
-            None => name
-          }
-        }
-        SStruct(exported, next_name, for field in fields {
-          let (field_name, field_ty) = field
-          (field_name, rewrite_private_type_expr(field_ty, type_renames))
-        }, derives, mut_fields, tparams)
-      },
-      STypeAlias(exported, name, params, target) => {
-        let next_name = if exported {
-          name
-        } else {
-          match lookup_alias(type_renames, name) {
-            Some(renamed) => renamed,
-            None => name
-          }
-        }
-        STypeAlias(exported, next_name, params, rewrite_private_type_expr(target, type_renames))
-      },
-      SImpl(tparams, bounds, trait_name, target) => SImpl(tparams, bounds, trait_name, rewrite_private_type_expr(target, alias_map_without_names(type_renames, tparams))),
-      SExternLet(name, ty) => SExternLet(name, rewrite_private_type_expr(ty, type_renames)),
-      STest(name, body) => STest(name, rewrite_private_type_ctor_expr(body, type_renames, ctor_renames)),
-      SBench(name, body) => SBench(name, rewrite_private_type_ctor_expr(body, type_renames, ctor_renames)),
-      SExpr(body) => SExpr(rewrite_private_type_ctor_expr(body, type_renames, ctor_renames)),
-      SLetPat(pat, body) => {
-        let next_pat = rewrite_private_type_ctor_pat(pat, type_renames, ctor_renames)
-        SLetPat(next_pat, rewrite_private_type_ctor_expr(body, type_renames, alias_map_without_pat(ctor_renames, next_pat)))
-      },
-      SModule(exported, name, body_stmts) => SModule(exported, name, namespace_private_value_stmts(name, body_stmts)),
-      SEffectDef(exported, name, params, ops) => SEffectDef(exported, name, params, for op in ops {
-        let (op_name, op_params, ret_ty) = op
-        (op_name, for param in op_params {
-          rewrite_private_type_expr(param, type_renames)
-        }, rewrite_private_type_expr(ret_ty, type_renames))
-      }),
-      _ => stmt
-    }
-  }
-  let namespace_private_stmt_local: (Stmt, AliasIdx) -> Stmt = (stmt, ram) -> {
-    match stmt {
-      SLet(exported, is_rec, name, ty, body) => {
-        let next_name = match MutMap::get(ram.idx, name) {
-          Some(renamed) => renamed,
-          None => name
-        }
-        SLet(exported, is_rec, next_name, ty, rewrite_alias_expr_ix(body, ram))
-      },
-      SLetMut(name, ty, body) => {
-        let next_name = match MutMap::get(ram.idx, name) {
-          Some(renamed) => renamed,
-          None => name
-        }
-        SLetMut(next_name, ty, rewrite_alias_expr_ix(body, ram))
-      },
-      STest(name, body) => STest(name, rewrite_alias_expr_ix(body, ram)),
-      SBench(name, body) => SBench(name, rewrite_alias_expr_ix(body, ram)),
-      SExpr(body) => SExpr(rewrite_alias_expr_ix(body, ram)),
-      SLetPat(pat, body) => SLetPat(pat, rewrite_alias_expr_ix(body, ram)),
-      SModule(exported, name, body_stmts) => SModule(exported, name, namespace_private_value_stmts(name, body_stmts)),
-      _ => stmt
-    }
-  }
   let namespace_suffix_box = [""]
   let exported = collect_exported_value_names(stmts)
   let renames = collect_private_value_renames(path, stmts, namespace_suffix_box, exported)
@@ -2410,9 +2290,174 @@ export fn namespace_private_value_stmts(path: String, stmts: Array[Stmt]) -> Arr
   } else {
     let ram = aliasidx_build(renames)
     for stmt in stmts {
-      namespace_private_stmt_local(stmt, ram)
+      namespace_private_stmt(stmt, ram)
     }
   }
+  namespace_private_type_ctor_stage(path, value_renamed, namespace_suffix_box, exported)
+}
+
+/// #2386: `namespace_private_value_stmts` applied to the statements the export
+/// pass (`apply_export_renames_stmts` with `export_renames`) would have
+/// produced -- the merge lane's pair for every non-entry file -- in ONE
+/// rebuild of the tree instead of two when the two rename maps compose as a
+/// single lookup, and through the two passes otherwise.
+///
+/// Both passes are the same walker over the same value positions, so their
+/// composition is one lookup exactly when no name can answer in both maps or
+/// be renamed twice: a private-rename key is neither a key nor a value of the
+/// export map, a qualified private key does not carry an export-renamed head,
+/// and a qualified export value does not carry a private-renamed head
+/// (`alias_renames_compose`). The private renames are collected from the
+/// statement heads as the export pass leaves them (a definition's name and an
+/// export list are the only spellings the collectors read), so they are the
+/// renames the second pass would have computed. Where the export pass and the
+/// private stage visit different statement kinds, the fused walker keeps each
+/// kind's own map (`namespace_private_stmt_after_renames`).
+export fn namespace_private_value_stmts_after_renames(path: String, stmts: Array[Stmt], export_renames: Array[(String, String)]) -> Array[Stmt] {
+  if Array::length(export_renames) == 0 {
+    namespace_private_value_stmts(path, stmts)
+  } else {
+    let exports = aliasidx_build(export_renames)
+    let heads = for stmt in stmts {
+      export_renamed_head(stmt, exports)
+    }
+    let namespace_suffix_box = [""]
+    let exported = collect_exported_value_names(heads)
+    let renames = collect_private_value_renames(path, heads, namespace_suffix_box, exported)
+    if !alias_renames_compose(exports, renames) {
+      namespace_private_value_stmts(path, apply_export_renames_stmts(stmts, export_renames))
+    } else {
+      let value_renamed = if Array::length(renames) == 0 {
+        apply_export_renames_stmts(stmts, export_renames)
+      } else {
+        let privates = aliasidx_build(renames)
+        let both = aliasidx_build(alias_entries_concat(export_renames, renames))
+        for stmt in stmts {
+          namespace_private_stmt_after_renames(stmt, exports, privates, both)
+        }
+      }
+      namespace_private_type_ctor_stage(path, value_renamed, namespace_suffix_box, exported)
+    }
+  }
+}
+
+/// The statement as `apply_export_renames_stmts` leaves its head: the
+/// definition name or export items renamed, the body shared.
+fn export_renamed_head(stmt: Stmt, exports: AliasIdx) -> Stmt {
+  match stmt {
+    SLet(exported, is_rec, name, ty, body) => SLet(exported, is_rec, aliasidx_rename(exports, name), ty, body),
+    SFnDecl(exported, name, body, requires, ensures) => SFnDecl(exported, aliasidx_rename(exports, name), body, requires, ensures),
+    SExport(items) => SExport(for item in items {
+      aliasidx_rename(exports, item)
+    }),
+    _ => stmt
+  }
+}
+
+fn aliasidx_rename(am: AliasIdx, name: String) -> String {
+  match MutMap::get(am.idx, name) {
+    Some(renamed) => renamed,
+    None => name
+  }
+}
+
+fn alias_entries_concat(first: Array[(String, String)], later: Array[(String, String)]) -> Array[(String, String)] {
+  let out = empty_aliases()
+  let mut i = 0
+  while i < Array::length(first) {
+    Array::push(out, Array::get(first, i))
+    i = i + 1
+  }
+  i = 0
+  while i < Array::length(later) {
+    Array::push(out, Array::get(later, i))
+    i = i + 1
+  }
+  out
+}
+
+fn qualified_head_of(name: String) -> String {
+  let qi = String::index_of(name, "::")
+  if qi < 0 {
+    ""
+  } else {
+    String::substring(name, 0, qi)
+  }
+}
+
+/// Whether rewriting with `first` and then with `later` answers every name
+/// exactly like one rewrite with their union (see
+/// `namespace_private_value_stmts_after_renames`). Every check is by the
+/// spellings the walker consults: a whole identifier against the keys, and
+/// the head of a qualified identifier against the keys (a trait-namespace
+/// marker key would change that head rule, so no key may be one).
+fn alias_renames_compose(first: AliasIdx, later: Array[(String, String)]) -> Bool {
+  let first_values = MutSet::new_string()
+  let later_keys = MutSet::new_string()
+  let mut ok = true
+  let mut i = 0
+  while ok && i < Array::length(first.entries) {
+    let (key, value) = Array::get(first.entries, i)
+    MutSet::add(first_values, value)
+    if String::contains(key, "::__vibe_trait_namespace_alias") {
+      ok = false
+    } else {
+      i = i + 1
+    }
+  }
+  i = 0
+  while ok && i < Array::length(later) {
+    let (key, _) = Array::get(later, i)
+    MutSet::add(later_keys, key)
+    let head = qualified_head_of(key)
+    if MutMap::has(first.idx, key) || MutSet::has(first_values, key) || String::contains(key, "::__vibe_trait_namespace_alias") || (head != "" && (MutMap::has(first.idx, head) || MutSet::has(first_values, head))) {
+      ok = false
+    } else {
+      i = i + 1
+    }
+  }
+  i = 0
+  while ok && i < Array::length(first.entries) {
+    let (_, value) = Array::get(first.entries, i)
+    let head = qualified_head_of(value)
+    if head != "" && MutSet::has(later_keys, head) {
+      ok = false
+    } else {
+      i = i + 1
+    }
+  }
+  ok
+}
+
+/// One statement through the export pass and the private stage at once.
+/// `both` is the union map for the positions both passes rewrite; a `let mut`
+/// name is renamed by the private stage only, and a bodyless declaration or
+/// an export list is visited by the export pass only -- each keeps its own
+/// map so the fused walk answers exactly like the pair.
+fn namespace_private_stmt_after_renames(stmt: Stmt, exports: AliasIdx, privates: AliasIdx, both: AliasIdx) -> Stmt {
+  match stmt {
+    SLet(exported, is_rec, name, ty, body) => SLet(exported, is_rec, aliasidx_rename(both, name), ty, rewrite_alias_expr_ix(body, both)),
+    SLetMut(name, ty, body) => SLetMut(aliasidx_rename(privates, name), ty, rewrite_alias_expr_ix(body, both)),
+    SFnDecl(exported, name, body, requires, ensures) => SFnDecl(exported, aliasidx_rename(exports, name), rewrite_alias_expr_ix(body, exports), for requirement in requires {
+      rewrite_alias_expr_ix(requirement, exports)
+    }, for guarantee in ensures {
+      rewrite_alias_expr_ix(guarantee, exports)
+    }),
+    SExport(items) => SExport(for item in items {
+      aliasidx_rename(exports, item)
+    }),
+    STest(name, body) => STest(name, rewrite_alias_expr_ix(body, both)),
+    SBench(name, body) => SBench(name, rewrite_alias_expr_ix(body, both)),
+    SExpr(body) => SExpr(rewrite_alias_expr_ix(body, both)),
+    SLetPat(pat, body) => SLetPat(pat, rewrite_alias_expr_ix(body, both)),
+    SModule(exported, name, stmts) => SModule(exported, name, namespace_private_value_stmts(name, stmts)),
+    _ => stmt
+  }
+}
+
+/// The type and constructor stage of `namespace_private_value_stmts`, over
+/// statements whose private values are already renamed.
+fn namespace_private_type_ctor_stage(path: String, value_renamed: Array[Stmt], namespace_suffix_box: Array[String], exported: Array[String]) -> Array[Stmt] {
   let type_renames = collect_private_type_renames(path, value_renamed, namespace_suffix_box, exported)
   let ctor_renames = collect_private_ctor_renames(path, value_renamed, type_renames, namespace_suffix_box, exported)
   if Array::length(type_renames) == 0 && Array::length(ctor_renames) == 0 {
@@ -2423,7 +2468,7 @@ export fn namespace_private_value_stmts(path: String, stmts: Array[Stmt]) -> Arr
       rewrite_impl_method_binding(stmt, owner_aliases)
     }
     for stmt in owner_renamed {
-      namespace_private_type_ctor_stmt_local(stmt, type_renames, ctor_renames)
+      namespace_private_type_ctor_stmt(stmt, type_renames, ctor_renames)
     }
   }
 }

--- a/lib/@vibe/compiler/core/index.vpkg
+++ b/lib/@vibe/compiler/core/index.vpkg
@@ -307,6 +307,7 @@ fn append_import_alias_rewritten_non_import_stmts_skipping(merged: Array[Stmt], 
 fn append_import_alias_rewritten_non_import_stmts(merged: Array[Stmt], stmts: Array[Stmt]) -> Unit
 fn rewrite_imported_value_stmt_to_local(stmt: Stmt, original: String, local: String) -> Option[Stmt]
 fn namespace_private_value_stmts(path: String, stmts: Array[Stmt]) -> Array[Stmt]
+fn namespace_private_value_stmts_after_renames(path: String, stmts: Array[Stmt], export_renames: Array[(String, String)]) -> Array[Stmt]
 // #2205: source spelling of a merge-renamed private type/ctor name, for
 // derive(Show) output (returns the input unchanged when never renamed).
 fn namespace_rename_original(name: String) -> String

--- a/lib/@vibe/compiler/entry/compiler/file_compile/file_compile.vibe
+++ b/lib/@vibe/compiler/entry/compiler/file_compile/file_compile.vibe
@@ -35,6 +35,7 @@ import @vibe/compiler/core {
   import_value_rename_locals,
   merged_source_boundary_names,
   namespace_private_value_stmts,
+  namespace_private_value_stmts_after_renames,
   namespace_rename_originals_reset,
   resolution_env_seed,
   resolve_import_path,
@@ -253,7 +254,7 @@ fn append_import_alias_collision_defs_from_sources(merged: Array[Stmt], current_
           // copy already carries the provider file's rebased offsets; reparsing
           // the raw source here would silently return to source-relative
           // offsets only for alias-collision fallback definitions.
-          let provider_stmts = namespace_private_value_stmts(resolved, apply_export_renames_stmts(parsed_source_stmts, export_plan_renames_for(plan, resolved)))
+          let provider_stmts = namespace_private_value_stmts_after_renames(resolved, parsed_source_stmts, export_plan_renames_for(plan, resolved))
           let mut j = 0
           let mut done = false
           while j < Array::length(provider_stmts) && !done {
@@ -369,15 +370,10 @@ fn append_merged_stmts_for_file(merged: Array[Stmt], path: String, stmts: Array[
     trait_import_local_operation_renames(stmts, path)
   }
   let collision_renamed = apply_export_renames_stmts(stmts, collision_renames)
-  let export_renamed = if is_entry_source {
+  let namespaced_stmts = if is_entry_source {
     collision_renamed
   } else {
-    apply_export_renames_stmts(collision_renamed, export_plan_renames_for(plan, path))
-  }
-  let namespaced_stmts = if is_entry_source {
-    export_renamed
-  } else {
-    namespace_private_value_stmts(path, export_renamed)
+    namespace_private_value_stmts_after_renames(path, collision_renamed, export_plan_renames_for(plan, path))
   }
   if stmts_have_import_deep(stmts) {
     let skipped_locals = collect_import_alias_collision_locals(stmts)

--- a/lib/@vibe/compiler/entry/source_compile/wasi_only/merge_sources.vibe
+++ b/lib/@vibe/compiler/entry/source_compile/wasi_only/merge_sources.vibe
@@ -41,6 +41,7 @@ import @vibe/compiler/core {
   import_value_rename_locals,
   is_builtin_iterator_serialized_boundary_path,
   namespace_private_value_stmts,
+  namespace_private_value_stmts_after_renames,
   namespace_rename_originals_reset,
   path_set_add,
   path_set_contains,
@@ -107,7 +108,7 @@ fn append_fs_import_local_def(merged: Array[Stmt], current_path: String, raw_pat
   // Builtin read + ingest, same as collect_parsed_sources_recursive
   // (flatten-lane wiring constraint / #741).
   let source = ingest_source_text_fs(resolved, Fs::read_file(resolved))
-  let source_stmts = namespace_private_value_stmts(resolved, apply_export_renames_stmts(parse_program(lex(source)), export_plan_renames_for(plan, resolved)))
+  let source_stmts = namespace_private_value_stmts_after_renames(resolved, parse_program(lex(source)), export_plan_renames_for(plan, resolved))
   let mut i = 0
   let mut done = false
   while i < Array::length(source_stmts) && !done {
@@ -294,15 +295,10 @@ fn transformed_file_stmts(entry_path: String, path: String, stmts: Array[Stmt], 
     trait_import_local_operation_renames(stmts, path)
   }
   let collision_renamed = apply_export_renames_stmts(stmts, collision_renames)
-  let export_renamed = if path == entry_path {
+  if path == entry_path {
     collision_renamed
   } else {
-    apply_export_renames_stmts(collision_renamed, export_plan_renames_for(plan, path))
-  }
-  if path == entry_path {
-    export_renamed
-  } else {
-    namespace_private_value_stmts(path, export_renamed)
+    namespace_private_value_stmts_after_renames(path, collision_renamed, export_plan_renames_for(plan, path))
   }
 }
 

--- a/lib/@vibe/compiler/runtime/runtime.vibe
+++ b/lib/@vibe/compiler/runtime/runtime.vibe
@@ -25,6 +25,7 @@ import @vibe/compiler/core {
   is_builtin_iterator_serialized_boundary_path,
   merged_source_boundary_names,
   namespace_private_value_stmts,
+  namespace_private_value_stmts_after_renames,
   namespace_rename_originals_reset,
   record_namespace_rename_originals_for_file,
   reject_user_iterator_serialized_boundaries,
@@ -649,7 +650,7 @@ fn append_import_alias_collision_defs_from_sources(merged: Array[Stmt], current_
       let resolved = resolve_import_path(base_dir, raw_path)
       match lookup_source_by_path(sources, resolved) {
         Some(source) => {
-          let source_stmts = namespace_private_value_stmts(resolved, apply_export_renames_stmts(parse_program_with_path(resolved, source), export_plan_renames_for(plan, resolved)))
+          let source_stmts = namespace_private_value_stmts_after_renames(resolved, parse_program_with_path(resolved, source), export_plan_renames_for(plan, resolved))
           let mut j = 0
           let mut done = false
           while j < Array::length(source_stmts) && !done {
@@ -721,15 +722,10 @@ fn build_merged_source_with_plan(entry_path: String, sources: Array[(String, Str
       trait_import_local_operation_renames(stmts, path)
     }
     let collision_renamed = apply_export_renames_stmts(stmts, collision_renames)
-    let export_renamed = if is_entry_source {
+    let namespaced_stmts = if is_entry_source {
       collision_renamed
     } else {
-      apply_export_renames_stmts(collision_renamed, export_plan_renames_for(plan, path))
-    }
-    let namespaced_stmts = if is_entry_source {
-      export_renamed
-    } else {
-      namespace_private_value_stmts(path, export_renamed)
+      namespace_private_value_stmts_after_renames(path, collision_renamed, export_plan_renames_for(plan, path))
     }
     if stmts_have_import_deep(stmts) {
       let skipped_locals = collect_import_alias_collision_locals(stmts)

--- a/lib/@vibe/compiler/tests/namespace_after_renames_test.vibe
+++ b/lib/@vibe/compiler/tests/namespace_after_renames_test.vibe
@@ -1,0 +1,65 @@
+import @vibe/compiler/core {
+  apply_export_renames_stmts, namespace_private_value_stmts, namespace_private_value_stmts_after_renames
+}
+
+import @vibe/compiler/syntax {
+  lex, parse_program, print_program
+}
+
+// #2386: the merge lane rewrites a non-entry file with the export plan's
+// renames and then namespaces its private values. The fused entry point must
+// print exactly what the two passes print, whether it fuses them (the maps
+// compose) or falls back to the pair (a private name the export map also
+// touches).
+
+fn sequential(path: String, source: String, renames: Array[(String, String)]) -> String with Exception {
+  one_line(print_program(namespace_private_value_stmts(path, apply_export_renames_stmts(parse_program(lex(source)), renames))))
+}
+
+fn fused(path: String, source: String, renames: Array[(String, String)]) -> String with Exception {
+  one_line(print_program(namespace_private_value_stmts_after_renames(path, parse_program(lex(source)), renames)))
+}
+
+// The printed program on one line, so a snapshot reads as a row.
+fn one_line(s: String) -> String {
+  let parts = String::split(s, "\n")
+  let mut acc = ""
+  let mut i = 0
+  while i < Array::length(parts) {
+    if Array::get(parts, i) != "" {
+      acc = String::concat(String::concat(acc, Array::get(parts, i)), " | ")
+    } else {
+      ()
+    }
+    i = i + 1
+  }
+  acc
+}
+
+let program: String = "fn helper(x: Int) -> Int { x + 1 }\nlet mut counter = 0\nexport fn caller(x: Int) -> Int { helper(x) + counter }\nexport fn again(x: Int) -> Int { caller(helper(x)) }\n"
+
+test "an export rename and the private namespace land in one rebuild" {
+  let renames = [("caller", "caller_exp_dep")]
+  let out = fused("dep.vibe", program, renames)
+  inspect(out == sequential("dep.vibe", program, renames), content = "true")
+  inspect(out, content = "let rec helper_dep_dep_vibe = (x: Int) -> Int { (x + 1) } | let mut counter_dep_dep_vibe = 0 | export let rec caller_exp_dep = (x: Int) -> Int { (helper_dep_dep_vibe(x) + counter_dep_dep_vibe) } | export let rec again = (x: Int) -> Int { caller_exp_dep(helper_dep_dep_vibe(x)) } | ")
+}
+
+test "an export rename of a private name is renamed twice, through the two passes" {
+  let renames = [("helper", "helper_exp_dep")]
+  let out = fused("dep.vibe", program, renames)
+  inspect(out == sequential("dep.vibe", program, renames), content = "true")
+  inspect(out, content = "let rec helper_exp_dep_dep_dep_vibe = (x: Int) -> Int { (x + 1) } | let mut counter_dep_dep_vibe = 0 | export let rec caller = (x: Int) -> Int { (helper_exp_dep_dep_dep_vibe(x) + counter_dep_dep_vibe) } | export let rec again = (x: Int) -> Int { caller(helper_exp_dep_dep_dep_vibe(x)) } | ")
+}
+
+test "an export value spelled like a private definition takes the two passes" {
+  let renames = [("caller", "helper")]
+  let out = fused("dep.vibe", program, renames)
+  inspect(out == sequential("dep.vibe", program, renames), content = "true")
+  inspect(out, content = "let rec helper = (x: Int) -> Int { (x + 1) } | let mut counter_dep_dep_vibe = 0 | export let rec helper = (x: Int) -> Int { (helper(x) + counter_dep_dep_vibe) } | export let rec again = (x: Int) -> Int { helper(helper(x)) } | ")
+}
+
+test "no export renames is the private namespace alone" {
+  let out = fused("dep.vibe", program, [])
+  inspect(out == one_line(print_program(namespace_private_value_stmts("dep.vibe", parse_program(lex(program))))), content = "true")
+}


### PR DESCRIPTION
## What

One slice of #2386 on the merge lane (both the cold first build and the warm inner loop run it), byte-identical to main on every corpus.

(The second commit this PR briefly carried, `ce7b21c` — raw-source fingerprints through the per-compile memo — was pushed after this PR's merge was already in flight and is not part of the merge; it is submitted as its own PR.)

### `5508290` — the merge lane applies export renames and the private namespace in one rebuild

Every non-entry file went through the same rename walker twice in a row (`core/import_alias_rewrite.vibe`): `apply_export_renames_stmts` for the export plan's mangled names, then the private-value stage of `namespace_private_value_stmts` — each rebuilding the whole tree. The pair cost 62 ms + 49 ms of a cold self-compile and the same warm (the merge runs on both lanes), plus one full copy of every module's AST.

`namespace_private_value_stmts_after_renames` does both in one rebuild when the two rename maps compose as a single lookup — no private key is a key or a value of the export map, no qualified key or value carries a head the other map renames, no key is a trait-namespace marker (`alias_renames_compose`) — and falls back to the pair otherwise, so the fused path is exact by construction. The private renames are collected from the statement heads as the export pass leaves them (a definition's name and an export list are the only spellings the collectors read), so they are the renames the second pass would have computed; where the passes visit different statement kinds (a `let mut` name, a bodyless declaration, an export list) the fused walker keeps each kind's own map. The private stage's two local lambdas, which duplicated the top-level `namespace_private_stmt` and `namespace_private_type_ctor_stmt`, are gone; the type and constructor stage is shared as `namespace_private_type_ctor_stage`. Six call sites (the FS merge, the flat merge, the runtime merge, and each one's alias-collision provider path) take the fused entry.

`namespace_after_renames_test.vibe` pins it with inspect snapshots: a composing pair prints exactly what the two passes print (one rebuild), an export rename of a private name — which the pair renames twice — takes the fallback and prints the same, an export value spelled like a private definition does too, and no export renames is the private namespace alone. Red: with `alias_renames_compose` forced true (mutation built into the worktree's library), the fallback case prints a definition renamed once where the pair renames it twice, and the equality snapshot fails.

### Measured

Cache-isolated per the profiling skill, `codegen_lexer_test.vibe` over the full compiler closure, against a stage2 built from `fe7b796` (the head of #2532, whose tree is main's), idle machine, four interleaved pairs in alternating order (ABBA):

| | `fe7b796` | `5508290` |
|---|---:|---:|
| `apply_export_renames_stmts` cold inclusive | 0.07 s | 0 |
| `namespace_private_value_stmts` cold inclusive | 0.09 s | — (0.12 s as `namespace_private_value_stmts_after_renames`, the one rebuild) |
| `rewrite_alias_expr_ix` cold inclusive | 0.17 s | 0.13 s |
| `append_merged_stmts_for_file` cold inclusive | 0.32 s | 0.30 s |
| cold wall, median of 4 | 7.03 s | 6.96 s (−1.0%) |
| warm wall, median of 4 | 4.40 s | 4.42 s (noise) |
| heap_ptr cold / warm | 1,045,756,856 / 651,108,960 | 1,039,200,184 / 644,554,568 (−6.56 MB / −6.55 MB: one copy of every module's AST) |

Byte-identical output on three closures and 22 rc fixtures.

## Validation

Chain on the tree of `5508290` (base `5584822`, whose tree is `fe7b796`'s; run in a staging worktree on the identical tree, tree hash checked against the pushed head): bundle regen; stage2 == stage3; output equivalence; `test_cli_core.sh`; selfcompile KPI heap_ptr 1,039,510,000 bytes (against the shared default cache, so not comparable across chains; the cache-isolated rows above are the comparison); typing-env-reuse oracle; 331/331 affected unit-test files (import-graph selection over the changed files); `compiler_gate.sh` early / mid / late.

`vibe_fmt.sh --check` is a fixpoint on every changed file.

Refs #2386.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QKZdvBvHVUagwg6Yih8er8

---
_Generated by [Claude Code](https://claude.ai/code/session_01QKZdvBvHVUagwg6Yih8er8)_