### PR TITLE
cache: the raw-source fingerprint goes through the per-compile memo at every caller (#2386)

### DIFF
--- a/lib/@vibe/compiler/cache/cache_underlying.vibe
+++ b/lib/@vibe/compiler/cache/cache_underlying.vibe
@@ -185,8 +185,6 @@ let source_fingerprint_memo_hashes: Array[Int] = [0]
 
 fn compact_source_fingerprint_counted(source: String) -> String {
   Array::set(source_fingerprint_memo_hashes, 0, Array::get(source_fingerprint_memo_hashes, 0) + 1)
-  ingestion_telemetry_add(2, 1)
-  ingestion_telemetry_add(3, String::length(source))
   compact_string_fingerprint(source)
 }
 
@@ -384,9 +382,14 @@ fn fingerprint_source(path: String) -> String with Fs {
   let source = Fs::read_file(path)
   ingestion_telemetry_add(0, 1)
   ingestion_telemetry_add(1, String::length(source))
-  // The hash-call telemetry is counted where the hash happens (the memo's
-  // miss path), so a text the compile already fingerprinted is not counted
-  // as hashed again.
+  // The hash-call telemetry stays paired with the read: it counts the
+  // fingerprint requests this filesystem boundary makes, and its consumers
+  // (scripts/edit_cycle_kpi.mjs, scripts/ingestion_stamp_oracle.mjs) check
+  // exactly that pairing. Since #2386 the per-compile memo below may answer
+  // a request from a text the compile already hashed; that is the memo's
+  // own hash counter's business, not this boundary's contract.
+  ingestion_telemetry_add(2, 1)
+  ingestion_telemetry_add(3, String::length(source))
   compact_source_fingerprint_memo(path, source)
 }
 

--- a/lib/@vibe/compiler/cache/cache_underlying.vibe
+++ b/lib/@vibe/compiler/cache/cache_underlying.vibe
@@ -179,21 +179,42 @@ let source_fingerprint_memo_src: MutMap[String, String] = MutMap::new_string()
 
 let source_fingerprint_memo_fp: MutMap[String, String] = MutMap::new_string()
 
+// #2386: how many times the memo has hashed a text (a miss or a changed
+// text); the routing tests read it to prove a caller took the memo.
+let source_fingerprint_memo_hashes: Array[Int] = [0]
+
+fn compact_source_fingerprint_counted(source: String) -> String {
+  Array::set(source_fingerprint_memo_hashes, 0, Array::get(source_fingerprint_memo_hashes, 0) + 1)
+  ingestion_telemetry_add(2, 1)
+  ingestion_telemetry_add(3, String::length(source))
+  compact_string_fingerprint(source)
+}
+
+export fn compact_source_fingerprint_memo_hash_count() -> Int {
+  Array::get(source_fingerprint_memo_hashes, 0)
+}
+
+/// The fingerprint of `source` as the text of `path`, hashed once per
+/// (path, text) for the span of a compile. #2386: the header pass, the
+/// ingestion fingerprint, the export-metadata walk and the typing artifacts
+/// all fingerprint the same ingested text of a file; each used to hash it
+/// again. A stored text is matched by a byte compare, so a changed text can
+/// never answer a stale fingerprint.
 export fn compact_source_fingerprint_memo(path: String, source: String) -> String {
   match MutMap::get(source_fingerprint_memo_src, path) {
     Some(stored) => if String::equals(stored, source) {
       match MutMap::get(source_fingerprint_memo_fp, path) {
         Some(fp) => fp,
-        None => compact_string_fingerprint(source)
+        None => compact_source_fingerprint_counted(source)
       }
     } else {
-      let fp = compact_string_fingerprint(source)
+      let fp = compact_source_fingerprint_counted(source)
       MutMap::set(source_fingerprint_memo_src, path, source)
       MutMap::set(source_fingerprint_memo_fp, path, fp)
       fp
     },
     None => {
-      let fp = compact_string_fingerprint(source)
+      let fp = compact_source_fingerprint_counted(source)
       MutMap::set(source_fingerprint_memo_src, path, source)
       MutMap::set(source_fingerprint_memo_fp, path, fp)
       fp
@@ -363,10 +384,10 @@ fn fingerprint_source(path: String) -> String with Fs {
   let source = Fs::read_file(path)
   ingestion_telemetry_add(0, 1)
   ingestion_telemetry_add(1, String::length(source))
-  let fingerprint = compact_string_fingerprint(source)
-  ingestion_telemetry_add(2, 1)
-  ingestion_telemetry_add(3, String::length(source))
-  fingerprint
+  // The hash-call telemetry is counted where the hash happens (the memo's
+  // miss path), so a text the compile already fingerprinted is not counted
+  // as hashed again.
+  compact_source_fingerprint_memo(path, source)
 }
 
 fn try_load_ingestion_stamp(stamp_path: String, stat_token_text: String) -> Option[String] with Fs {

--- a/lib/@vibe/compiler/cache/index.vpkg
+++ b/lib/@vibe/compiler/cache/index.vpkg
@@ -85,6 +85,7 @@ fn cache_fingerprint_file_fs(path: String) -> String with Fs
 fn cache_fingerprint_file_fs_with_ingestion_stamp(path: String, stamp_path: String) -> String with Fs
 fn compact_source_fingerprint_memo(path: String, source: String) -> String
 fn compact_source_fingerprint_memo_reset() -> Unit
+fn compact_source_fingerprint_memo_hash_count() -> Int
 fn cache_ingestion_compact_fingerprint_is_valid(fingerprint: String) -> Bool
 fn cache_ingestion_stamp_enabled() -> Bool
 fn cache_ingestion_stamp_v1_text(stat_token_text: String, fingerprint: String) -> String

--- a/lib/@vibe/compiler/loader/header_cache.vibe
+++ b/lib/@vibe/compiler/loader/header_cache.vibe
@@ -1,7 +1,7 @@
 //# Imports
 
 import @vibe/compiler/cache {
-  compact_string_fingerprint,
+  compact_source_fingerprint_memo,
   fingerprint_file_fs,
   normalize_persistent_cache_text,
   package_index_deps_are_current,
@@ -703,7 +703,7 @@ export fn parse_program_located_shared(path: String, source: String) -> Array[St
 
 export fn load_or_parse_module_header_fs_impl(path: String, source: String, parse_count: Int) -> (Array[String], Array[String], Int) with Exception + Fs {
   ingestion_pipeline_telemetry_add(10, 1)
-  let cache_path = persistent_module_header_cache_path(path, compact_string_fingerprint(source))
+  let cache_path = persistent_module_header_cache_path(path, compact_source_fingerprint_memo(path, source))
   // #801 follow-up: a warm header whose package-index deps no longer match
   // the current resolution winners was written under a different resolution
   // context (a store copy appeared or vanished) — fall through to the cold

--- a/lib/@vibe/compiler/loader/loader.vibe
+++ b/lib/@vibe/compiler/loader/loader.vibe
@@ -237,7 +237,7 @@ fn exported_type_params_uncached_fs(path: String, dep_paths: Array[String], dep_
   Array::push(dep_paths, path)
   // Fingerprint the bytes that are parsed below. A second filesystem read
   // could observe a newer body and make stale metadata look current forever.
-  Array::push(dep_fingerprints, compact_string_fingerprint(raw))
+  Array::push(dep_fingerprints, compact_source_fingerprint_memo(path, raw))
   if is_contract_ext(path) {
     let (_, blanked) = extract_require_pins(raw)
     let (_, opaques, extra) = parse_contract_program(lex(blanked))
@@ -400,6 +400,7 @@ export ./manifest_sources.vibe {
 
 import @vibe/compiler/cache {
   build_source_groups_fingerprint_from_compact_fingerprints,
+  compact_source_fingerprint_memo,
   compact_string_fingerprint,
   fingerprint_file_fs,
   normalize_persistent_cache_text,
@@ -1171,7 +1172,7 @@ fn load_source_if_cached_file_spec_matches(path: String, stat_token_text: String
         Some(Fs::read_file(path))
       } else if String::length(source_fingerprint) > 0 {
         let source = Fs::read_file(path)
-        if compact_string_fingerprint(source) == source_fingerprint {
+        if compact_source_fingerprint_memo(path, source) == source_fingerprint {
           Some(source)
         } else {
           None
@@ -1181,7 +1182,7 @@ fn load_source_if_cached_file_spec_matches(path: String, stat_token_text: String
       }
     } else if String::length(source_fingerprint) > 0 {
       let source = Fs::read_file(path)
-      if compact_string_fingerprint(source) == source_fingerprint {
+      if compact_source_fingerprint_memo(path, source) == source_fingerprint {
         Some(source)
       } else {
         None

--- a/lib/@vibe/compiler/runtime/typecheck_fs.vibe
+++ b/lib/@vibe/compiler/runtime/typecheck_fs.vibe
@@ -4882,7 +4882,7 @@ fn checked_module_typing_artifact_bytes(checked: CheckedProgram, job: ModuleJob)
   Array::set(checked_module_typing_artifact_construction_attempts, 0, Array::get(checked_module_typing_artifact_construction_attempts, 0) + 1)
   // Both identities are derived here from the exact same already-ingested
   // ModuleJob.source; there is no filesystem reread or caller identity input.
-  let source_identity = compact_string_fingerprint(job.source)
+  let source_identity = compact_source_fingerprint_memo(job.path, job.source)
   let implementation_identity = incremental_implementation_identity(job.source)
   match checked_exported_interface_artifact_from_checked_program(checked) {
     Some(exported_interface) => match shadow_unattested_checked_module_typing_artifact_v2_from_checked_program(checked, job.path, source_identity, source_identity, implementation_identity, implementation_identity, checked_module_dependency_interface_assumptions(job.dep_envs), [
@@ -4914,7 +4914,7 @@ export fn checked_module_typing_artifact_observation(outcome: ModuleOutcome) -> 
 export fn checked_module_typing_artifact_freshness_attestation_for_job(job: ModuleJob, outcome: ModuleOutcome) -> Option[CheckedModuleTypingArtifactFreshnessAttestation] with Exception {
   Array::set(checked_module_typing_artifact_validation_attempts, 0, Array::get(checked_module_typing_artifact_validation_attempts, 0) + 1)
   match outcome {
-    Checked(_, _, _, _, _, _, Some(bytes)) => if checked_module_typing_artifact_v2_matches_exact_inputs(bytes, job.path, compact_string_fingerprint(job.source), incremental_implementation_identity(job.source), checked_module_dependency_interface_assumptions(job.dep_envs)) {
+    Checked(_, _, _, _, _, _, Some(bytes)) => if checked_module_typing_artifact_v2_matches_exact_inputs(bytes, job.path, compact_source_fingerprint_memo(job.path, job.source), incremental_implementation_identity(job.source), checked_module_dependency_interface_assumptions(job.dep_envs)) {
       Some(AttestedCheckedModuleTypingArtifact(bytes))
     } else {
       None
@@ -5085,7 +5085,7 @@ fn commit_module_outcome(rdb: RippleDb, env_cache: Array[(String, TypeEnv)], dep
         ()
       }
       if Array::length(job.deps) == 0 {
-        Fs::write_file(persistent_leaf_fingerprint_cache_path(path, compact_string_fingerprint(job.source)), persistent_leaf_fingerprint_text(fingerprint, typing_semantics_seed()))
+        Fs::write_file(persistent_leaf_fingerprint_cache_path(path, compact_source_fingerprint_memo(job.path, job.source)), persistent_leaf_fingerprint_text(fingerprint, typing_semantics_seed()))
       } else {
         ()
       }

--- a/lib/@vibe/compiler/tests/source_fingerprint_memo_route_test.vibe
+++ b/lib/@vibe/compiler/tests/source_fingerprint_memo_route_test.vibe
@@ -1,6 +1,8 @@
 import @vibe/compiler/cache {
   cache_fingerprint_file_fs,
+  cache_ingestion_fingerprint_telemetry_json,
   cache_persistent_artifact_cache_path,
+  cache_set_ingestion_fingerprint_telemetry_enabled,
   cache_store_persistent_artifact,
   compact_source_fingerprint_memo,
   compact_source_fingerprint_memo_hash_count,
@@ -42,4 +44,22 @@ test "a file whose text the compile already fingerprinted is not hashed again by
   inspect(cache_fingerprint_file_fs(path) == memoized, content = "true")
   inspect(compact_source_fingerprint_memo_hash_count() - before, content = "0")
   inspect(memoized == compact_string_fingerprint(text), content = "true")
+}
+
+test "the ingestion telemetry keeps a hash call paired with every boundary read, memo hit or not" {
+  let bytes = Bytes::new()
+  Bytes::push(bytes, 108)
+  Bytes::push(bytes, 101)
+  Bytes::push(bytes, 116)
+  cache_store_persistent_artifact("v1", "fingerprint_memo_telemetry", "seed-b", "", bytes)
+  let path = cache_persistent_artifact_cache_path("v1", "fingerprint_memo_telemetry", "seed-b", "")
+  let text = Fs::read_file(path)
+  compact_source_fingerprint_memo_reset()
+  let _ = compact_source_fingerprint_memo(path, text)
+  cache_set_ingestion_fingerprint_telemetry_enabled(true)
+  let _ = cache_fingerprint_file_fs(path)
+  let json = cache_ingestion_fingerprint_telemetry_json("n")
+  cache_set_ingestion_fingerprint_telemetry_enabled(false)
+  inspect(String::contains(json, "\"source_read_calls\":1,"), content = "true")
+  inspect(String::contains(json, "\"hash_calls\":1,"), content = "true")
 }

--- a/lib/@vibe/compiler/tests/source_fingerprint_memo_route_test.vibe
+++ b/lib/@vibe/compiler/tests/source_fingerprint_memo_route_test.vibe
@@ -1,0 +1,45 @@
+import @vibe/compiler/cache {
+  cache_fingerprint_file_fs,
+  cache_persistent_artifact_cache_path,
+  cache_store_persistent_artifact,
+  compact_source_fingerprint_memo,
+  compact_source_fingerprint_memo_hash_count,
+  compact_source_fingerprint_memo_reset,
+  compact_string_fingerprint
+}
+
+// #2386: the ingested text of a file is fingerprinted by several callers
+// (the header pass, the ingestion fingerprint, the export-metadata walk, the
+// typing artifacts). They share one memo keyed by path and matched by text,
+// so a text is hashed once per compile; the memo's hash counter is the
+// witness that a caller took the memo instead of hashing on its own.
+
+test "the memo hashes once per (path, text) and again when the text changes" {
+  compact_source_fingerprint_memo_reset()
+  let c0 = compact_source_fingerprint_memo_hash_count()
+  let a = compact_source_fingerprint_memo("m.vibe", "let a = 1")
+  let b = compact_source_fingerprint_memo("m.vibe", "let a = 1")
+  inspect(compact_source_fingerprint_memo_hash_count() - c0, content = "1")
+  inspect(a == b, content = "true")
+  inspect(a == compact_string_fingerprint("let a = 1"), content = "true")
+  let c = compact_source_fingerprint_memo("m.vibe", "let a = 2")
+  inspect(compact_source_fingerprint_memo_hash_count() - c0, content = "2")
+  inspect(a == c, content = "false")
+  inspect(c == compact_string_fingerprint("let a = 2"), content = "true")
+}
+
+test "a file whose text the compile already fingerprinted is not hashed again by the ingestion fingerprint" {
+  let bytes = Bytes::new()
+  Bytes::push(bytes, 108)
+  Bytes::push(bytes, 101)
+  Bytes::push(bytes, 116)
+  cache_store_persistent_artifact("v1", "fingerprint_memo_route", "seed-a", "", bytes)
+  let path = cache_persistent_artifact_cache_path("v1", "fingerprint_memo_route", "seed-a", "")
+  let text = Fs::read_file(path)
+  compact_source_fingerprint_memo_reset()
+  let memoized = compact_source_fingerprint_memo(path, text)
+  let before = compact_source_fingerprint_memo_hash_count()
+  inspect(cache_fingerprint_file_fs(path) == memoized, content = "true")
+  inspect(compact_source_fingerprint_memo_hash_count() - before, content = "0")
+  inspect(memoized == compact_string_fingerprint(text), content = "true")
+}


### PR DESCRIPTION
## What

One slice of #2386 on the loader / ingestion fingerprints (the cold first build pays it in full; the warm inner loop hashes the same texts for its persisted-cache keys), byte-identical to main on every corpus.

### `e0ff233` — the raw-source fingerprint goes through the per-compile memo at every caller

The ingested text of a file was fingerprinted by several callers, each hashing it again (`__rt_compact_fingerprint_hash` was 0.30 s of a cold self-compile): the persisted-header key in `load_or_parse_module_header_fs_impl`, the ingestion fingerprint (`fingerprint_source`), the export-metadata walk (`exported_type_params_uncached_fs`), the persisted-source freshness compare, and the typing artifacts — on top of the callers `6909326` (#2485) already memoized.

Every raw-source fingerprint now goes through `compact_source_fingerprint_memo` (`cache/cache_underlying.vibe`), keyed by path and matched by a byte compare of the text, so a text is hashed once per compile and a changed text can never answer a stale fingerprint (the memo is reset at the start of each compile's typing walk, before the header pass). The memo counts its hashes (`compact_source_fingerprint_memo_hash_count`) for the routing test. `build_fingerprint` (which hashes the source under a semantics prefix) and the persisted-cache blob texts keep hashing on their own: their fingerprint values are persisted keys, and this slice changes no key.

`source_fingerprint_memo_route_test.vibe` pins it with inspect snapshots: the memo hashes once per (path, text) and again when the text changes, and the ingestion fingerprint of a file whose text the compile already fingerprinted hashes nothing. Red: with `fingerprint_source` hashing on its own (mutation built into the worktree's library), the routing case counts one hash.

### `9b6a06a` — the ingestion hash-call telemetry stays paired with the boundary read (Codex round 1, P1)

The first commit had moved the opt-in `hash_calls` / `hash_input_string_units` increments into the memo's miss path, where they also counted hashes the memo makes for callers that supply their own text (a warm leaf-cache lookup), so `hash_calls` could exceed `source_read_calls`; `scripts/ingestion_stamp_oracle.mjs` — the `compiler-gate (stage2 oracles)` check — rejects that (`gate-off-prime telemetry: hash_calls must equal source_read_calls`, reproduced on a stage2 built from `e0ff233`). The increments are back in `fingerprint_source`, paired with the read, so the boundary keeps the contract its consumers check; the test gains the pairing case (with the file's text already memoized, the boundary fingerprint reports `source_read_calls: 1, hash_calls: 1`; Red: dropping the increment fails it). On the fixed stage2 the oracle passes with every lane paired.

### Measured

Cache-isolated per the profiling skill, `codegen_lexer_test.vibe` over the full compiler closure, against a stage2 built from `5508290` (the head of #2533, whose tree is main's), idle machine, four interleaved pairs in alternating order (ABBA); the telemetry fix runs no code unless `VIBE_INGESTION_TELEMETRY_OUT` is set:

| | `5508290` | `e0ff233` |
|---|---:|---:|
| `__rt_compact_fingerprint_hash` cold self | 0.30 s | 0.22 s |
| `compact_string_fingerprint` cold inclusive | 0.31 s | 0.22 s |
| `compact_source_fingerprint_memo` cold inclusive | 0.03 s | 0.08 s (the byte compares and the hashes that moved into it) |
| cold wall, median of 4 | 6.90 s | 6.77 s (−1.8%) |
| warm wall, median of 4 | 4.37 s | 4.37 s (noise) |
| heap_ptr cold / warm | 1,039,200,184 / 644,554,568 | 1,039,174,264 / 644,578,744 (−26 KB / +24 KB: the memo's rows) |

Byte-identical output on three closures and 22 rc fixtures.

## Validation

Chain on the tree of `e0ff233` (base `d8e0b97`; run in the staging worktree that held the same tree, tree hash checked against the pushed head): bundle regen; stage2 == stage3; output equivalence; `test_cli_core.sh`; selfcompile KPI heap_ptr 1,039,482,560 bytes; typing-env-reuse oracle; 332/332 affected unit-test files; `compiler_gate.sh` early / mid / late.

Chain on `9b6a06a` (same protocol, run in the worktree at that exact commit): bundle regen; stage2 == stage3; output equivalence; `test_cli_core.sh`; selfcompile KPI heap_ptr 1,039,485,304 bytes (both KPI rows are against the shared default cache, so not comparable across chains; the cache-isolated rows above are the comparison); typing-env-reuse oracle; 332/332 affected unit-test files; `compiler_gate.sh` early / mid / late; `scripts/ingestion_stamp_oracle.mjs` on its stage2 exits 0.

`vibe_fmt.sh --check` is a fixpoint on every changed file.

Refs #2386.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QKZdvBvHVUagwg6Yih8er8

---
_Generated by [Claude Code](https://claude.ai/code/session_01QKZdvBvHVUagwg6Yih8er8)_