### PR TITLE
core: every registry reader takes the sorted view; the value-form arity skips the spelling ladder for bare names (#2386)

### DIFF
--- a/lib/@vibe/compiler/core/builtin_name.vibe
+++ b/lib/@vibe/compiler/core/builtin_name.vibe
@@ -7,6 +7,22 @@ import ./builtin_registry.vibe {
 //# Functions
 
 export fn canonical_builtin_name(name: String) -> String {
+  // #2386: every legacy spelling below starts with `F`, `E`, `P` or `S`, so
+  // any other first byte (a bare user name, `Array::`, `MutMap::`, ...) is
+  // its own canonical spelling without the 25 compares of the ladder.
+  let first = if String::length(name) == 0 {
+    0
+  } else {
+    String::char_code_at(name, 0)
+  }
+  if first != 'F' && first != 'E' && first != 'P' && first != 'S' {
+    name
+  } else {
+    canonical_builtin_name_ladder(name)
+  }
+}
+
+fn canonical_builtin_name_ladder(name: String) -> String {
   match name {
     "Fs::ReadFile" => "Fs::read_file",
     "Fs::WriteFile" => "Fs::write_file",
@@ -113,11 +129,13 @@ export fn canonical_builtin_name(name: String) -> String {
 /// mention no unknown and reach the same property every other row does. The
 /// annotated spelling still compiles; the unannotated one is now rejected.
 export fn builtin_value_form_arity(name: String) -> Int {
-  let n = canonical_builtin_name(name)
-  if !String::contains(n, "::") {
+  // #2386: canonicalization maps qualified spellings to qualified spellings,
+  // so a bare name is answered before the ladder; the lambda-site count asks
+  // this for every identifier of the program.
+  if !String::contains(name, "::") {
     0 - 1
   } else {
-    registry_builtin_pure_arity(n)
+    registry_builtin_pure_arity(canonical_builtin_name(name))
   }
 }
 

--- a/lib/@vibe/compiler/core/builtin_registry.vibe
+++ b/lib/@vibe/compiler/core/builtin_registry.vibe
@@ -531,24 +531,19 @@ export fn builtin_registry_typed() -> Array[(String, Type, Bool, Bool, Bool)] {
 /// same message the direct call gives, instead of checking clean and printing
 /// garbage.
 export fn registry_builtin_scheme(name: String) -> Option[Type] {
-  let mut i = 0
-  let mut found: Option[Type] = None
-  while i < Array::length(registry_typed_rows) {
-    let (rname, ty, _, _, visible) = Array::get(registry_typed_rows, i)
-    if rname == name && visible {
-      let vars: Array[Int] = []
-      collect_type_var_ids(ty, vars)
-      found = if Array::length(vars) == 0 {
-        Some(ty)
-      } else {
-        Some(CtForAll(vars, empty_registry_var_bounds(), ty))
-      }
-      i = Array::length(registry_typed_rows)
+  let row = registry_first_visible_row(name)
+  if row < 0 {
+    None
+  } else {
+    let (_, ty, _, _, _) = Array::get(registry_typed_rows, row)
+    let vars: Array[Int] = []
+    collect_type_var_ids(ty, vars)
+    if Array::length(vars) == 0 {
+      Some(ty)
     } else {
-      i = i + 1
+      Some(CtForAll(vars, empty_registry_var_bounds(), ty))
     }
   }
-  found
 }
 
 /// A registry row's variables carry no trait bounds: the rows describe wasm
@@ -605,22 +600,16 @@ export fn builtin_registry() -> Array[(String, Int, Int, Bool, Bool)] {
 /// stack for fallthru`, no source position). Which builtins got checked was the
 /// maintenance state of that list, not a rule of the language.
 export fn registry_builtin_arity(name: String) -> Int {
-  let rows = builtin_registry_typed()
-  let mut i = 0
-  let mut found = 0 - 1
-  while i < Array::length(rows) {
-    let (rname, ty, _, _, visible) = Array::get(rows, i)
-    if rname == name && visible {
-      found = match ty {
-        CtFn(params, _, _) => Array::length(params),
-        _ => 0 - 1
-      }
-      i = Array::length(rows)
-    } else {
-      i = i + 1
+  let row = registry_first_visible_row(name)
+  if row < 0 {
+    0 - 1
+  } else {
+    let (_, ty, _, _, _) = Array::get(builtin_registry_typed(), row)
+    match ty {
+      CtFn(params, _, _) => Array::length(params),
+      _ => 0 - 1
     }
   }
-  found
 }
 
 /// #2442: the parameter count of a checker-visible registry row whose type is
@@ -658,29 +647,23 @@ export fn registry_builtin_pure_arity(name: String) -> Int {
   // #2451: the UN-erased rows. A row spelled with `reg_var` mentions no
   // unknown, so it passes the test below and gains a value form; the erased
   // view would put `CtUnknown` back and refuse every one of them.
-  let rows = registry_typed_rows
-  let mut i = 0
-  let mut found = 0 - 1
-  while i < Array::length(rows) {
-    let (rname, ty, _, _, visible) = Array::get(rows, i)
-    if rname == name && visible {
-      found = match ty {
-        CtFn(params, ret, eff) => match eff {
-          Some(_) => 0 - 1,
-          None => if types_mention_unknown(params) || type_has_unknown(ret) {
-            0 - 1
-          } else {
-            Array::length(params)
-          }
-        },
-        _ => 0 - 1
-      }
-      i = Array::length(rows)
-    } else {
-      i = i + 1
+  let row = registry_first_visible_row(name)
+  if row < 0 {
+    0 - 1
+  } else {
+    let (_, ty, _, _, _) = Array::get(registry_typed_rows, row)
+    match ty {
+      CtFn(params, ret, eff) => match eff {
+        Some(_) => 0 - 1,
+        None => if types_mention_unknown(params) || type_has_unknown(ret) {
+          0 - 1
+        } else {
+          Array::length(params)
+        }
+      },
+      _ => 0 - 1
     }
   }
-  found
 }
 
 fn types_mention_unknown(ts: Array[Type]) -> Bool {
@@ -709,26 +692,20 @@ fn types_mention_unknown(ts: Array[Type]) -> Bool {
 /// tolerate-on-unknown rule) in the checker, which is the only place that knows
 /// what an "unchecked" head means.
 export fn registry_builtin_param_type(name: String, i: Int) -> Option[Type] {
-  let rows = builtin_registry_typed()
-  let mut ri = 0
-  let mut found = None
-  while ri < Array::length(rows) {
-    let (rname, ty, _, _, visible) = Array::get(rows, ri)
-    if rname == name && visible {
-      found = match ty {
-        CtFn(params, _, _) => if i >= 0 && i < Array::length(params) {
-          Some(Array::get(params, i))
-        } else {
-          None
-        },
-        _ => None
-      }
-      ri = Array::length(rows)
-    } else {
-      ri = ri + 1
+  let row = registry_first_visible_row(name)
+  if row < 0 {
+    None
+  } else {
+    let (_, ty, _, _, _) = Array::get(builtin_registry_typed(), row)
+    match ty {
+      CtFn(params, _, _) => if i >= 0 && i < Array::length(params) {
+        Some(Array::get(params, i))
+      } else {
+        None
+      },
+      _ => None
     }
   }
-  found
 }
 
 /// B-2: the checker-facing lookup, consulted FIRST by
@@ -768,21 +745,39 @@ fn registry_typed_index() -> Unit {
   }
 }
 
-export fn lookup_registry_builtin(name: String) -> Option[Type] {
+/// The index of the first checker-visible row named `name`, or -1: one
+/// leftmost binary search of the sorted view and a forward read of the equal
+/// run. The erased rows are built one-to-one from the un-erased rows in the
+/// same order, so the index reads either table. #2386: every "first visible
+/// row" scan (lookup, arity, pure arity, parameter type, scheme) goes through
+/// it; `registry_builtin_pure_arity` alone was asked per identifier by the
+/// lambda-site count.
+fn registry_first_visible_row(name: String) -> Int {
   registry_typed_index()
   let rows = builtin_registry_typed()
   let mut slot = bsearch_leftmost(registry_typed_sorted, name)
-  let mut found = None
+  let mut found = 0 - 1
   while slot >= 0 && slot < Array::length(registry_typed_sorted) && Array::get(registry_typed_sorted, slot) == name {
-    let (_, ty, _, _, visible) = Array::get(rows, Array::get(registry_typed_sorted_pos, slot))
+    let row = Array::get(registry_typed_sorted_pos, slot)
+    let (_, _, _, _, visible) = Array::get(rows, row)
     if visible {
-      found = Some(ty)
+      found = row
       slot = -1
     } else {
       slot = slot + 1
     }
   }
   found
+}
+
+export fn lookup_registry_builtin(name: String) -> Option[Type] {
+  let row = registry_first_visible_row(name)
+  if row < 0 {
+    None
+  } else {
+    let (_, ty, _, _, _) = Array::get(builtin_registry_typed(), row)
+    Some(ty)
+  }
 }
 
 /// Every registry effect label must have standard provider or entry-execution

--- a/lib/@vibe/compiler/tests/registry_lookup_index_test.vibe
+++ b/lib/@vibe/compiler/tests/registry_lookup_index_test.vibe
@@ -1,5 +1,13 @@
 import @vibe/compiler/core {
-  Type, builtin_registry_typed, lookup_registry_builtin, type_to_string
+  Type,
+  builtin_registry_typed,
+  builtin_value_form_arity,
+  canonical_builtin_name,
+  lookup_registry_builtin,
+  registry_builtin_arity,
+  registry_builtin_param_type,
+  registry_builtin_pure_arity,
+  type_to_string
 }
 
 // #2386: lookup_registry_builtin answers from a sorted view of the registry
@@ -51,4 +59,63 @@ test "a known builtin answers and an unknown name does not" {
   inspect(render(lookup_registry_builtin("Array::length")), content = "(Array[?]) -> Int")
   inspect(render(lookup_registry_builtin("no::such_builtin")), content = "<none>")
   inspect(render(lookup_registry_builtin("")), content = "<none>")
+}
+
+// #2386 (second slice): the arity and parameter-type readers take the same
+// first-visible-row lookup; each must agree with a scan of the rows.
+
+fn arity_reference(name: String) -> Int {
+  match scan_reference(name) {
+    Some(ty) => match ty {
+      CtFn(params, _, _) => Array::length(params),
+      _ => 0 - 1
+    },
+    None => 0 - 1
+  }
+}
+
+fn param_reference(name: String, i: Int) -> String {
+  match scan_reference(name) {
+    Some(ty) => match ty {
+      CtFn(params, _, _) => if i >= 0 && i < Array::length(params) {
+        type_to_string(Array::get(params, i))
+      } else {
+        "<none>"
+      },
+      _ => "<none>"
+    },
+    None => "<none>"
+  }
+}
+
+test "every registered name's arity and first parameter answer exactly like the scan" {
+  let rows = builtin_registry_typed()
+  let mut i = 0
+  let mut disagreements: Array[String] = []
+  while i < Array::length(rows) {
+    let (rname, _, _, _, _) = Array::get(rows, i)
+    if registry_builtin_arity(rname) != arity_reference(rname) || render(registry_builtin_param_type(rname, 0)) != param_reference(rname, 0) {
+      Array::push(disagreements, rname)
+    } else {
+      ()
+    }
+    i = i + 1
+  }
+  inspect(disagreements, content = "[]")
+}
+
+test "the pure arity is the parameter count of an effect-free row without unknowns" {
+  inspect(registry_builtin_pure_arity("String::substring"), content = "3")
+  inspect(registry_builtin_pure_arity("String::length"), content = "1")
+  inspect(registry_builtin_pure_arity("Fs::read_file"), content = "-1")
+  inspect(registry_builtin_pure_arity("no::such_builtin"), content = "-1")
+}
+
+test "a bare name has no value form and a legacy spelling answers like its canonical one" {
+  inspect(builtin_value_form_arity("substring"), content = "-1")
+  inspect(builtin_value_form_arity("String::byte_at") == builtin_value_form_arity("String::char_code_at"), content = "true")
+  inspect(builtin_value_form_arity("String::byte_at"), content = "2")
+  inspect(canonical_builtin_name("Fs::ReadFile"), content = "Fs::read_file")
+  inspect(canonical_builtin_name("Array::get"), content = "Array::get")
+  inspect(canonical_builtin_name(""), content = "")
 }


### PR DESCRIPTION
## What

One slice of #2386 on the codegen lane (both the cold first build and the warm inner loop run the lambda-site count), byte-identical to main on every corpus.

### `3123b33` — every registry reader takes the sorted view; the value-form arity skips the spelling ladder for bare names

The lambda-site count (`count_lambda_sites_expr`, `codegen/common_analysis`) asks `builtin_value_form_arity` for every identifier of the program. Each ask walked `canonical_builtin_name`'s 25-arm string match (43 ms of `__rt_eq` in a cold self-compile) and, for a qualified name, scanned the un-erased registry rows in `registry_builtin_pure_arity` (18 ms) — 67 ms on both lanes, since the count runs in codegen.

`builtin_value_form_arity` answers a bare name before the ladder: canonicalization maps qualified spellings to qualified spellings, so the `::` test does not depend on it. `canonical_builtin_name` gates the ladder on the first byte — every legacy spelling starts with `F`, `E`, `P` or `S`, so any other first byte is its own canonical spelling. The five "first visible row of this name" readers (`lookup_registry_builtin`, `registry_builtin_arity`, `registry_builtin_pure_arity`, `registry_builtin_param_type`, `registry_builtin_scheme`) share `registry_first_visible_row`: one leftmost binary search of the sorted view from #2532 and a forward read of the equal run; the erased rows are built one-to-one from the un-erased rows in the same order, so the index reads either table.

`registry_lookup_index_test.vibe` gains inspect snapshots: every registered name's arity and first parameter answer exactly like a scan of the rows, the pure arity of effect-free / effectful / unknown names, a bare name has no value form, a legacy spelling answers like its canonical one, and `canonical_builtin_name` on a non-legacy and an empty name. Red: landing one slot past the leftmost (mutation built into the worktree's library) fails the agreement cases; a gate that drops `S` fails the legacy-spelling case.

### Measured

Cache-isolated per the profiling skill, `codegen_lexer_test.vibe` over the full compiler closure, against a stage2 built from `ce7b21c` (the cand41 head this commit was measured on; the tree of `9b6a06a`, now main's, differs from it only by the opt-in telemetry placement, which runs no code in a measured compile), idle machine, four interleaved pairs in alternating order (ABBA):

| | `ce7b21c` | `3123b33` |
|---|---:|---:|
| `builtin_value_form_arity` cold inclusive | 0.07 s | 0.01 s |
| `canonical_builtin_name` cold inclusive | 0.06 s | 0.01 s |
| `count_lambda_sites_expr` cold inclusive | 0.07 s | 0.02 s |
| cold wall, median of 4 | 6.96 s | 6.94 s (noise) |
| warm wall, median of 4 | 4.48 s | 4.46 s (noise) |
| heap_ptr cold / warm | 1,039,174,264 / 644,578,744 | 1,039,024,664 / 644,597,448 (−150 KB / +19 KB) |

The ~60 ms this removes per lane is below the wall clock's noise on this machine; the profile rows are the evidence. Byte-identical output on three closures and 22 rc fixtures.

## Validation

Chain on the tree of `3123b33` (base `f371ed4`, whose tree is `9b6a06a`'s; run in the staging worktree that held the same tree, tree hash checked against the pushed head): bundle regen; stage2 == stage3; output equivalence; `test_cli_core.sh`; selfcompile KPI heap_ptr 1,039,305,512 bytes (against the shared default cache, so not comparable across chains; the cache-isolated rows above are the comparison); typing-env-reuse oracle; 332/332 affected unit-test files (import-graph selection over the changed files); `compiler_gate.sh` early / mid / late.

`vibe_fmt.sh --check` is a fixpoint on every changed file.

Refs #2386.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QKZdvBvHVUagwg6Yih8er8

---
_Generated by [Claude Code](https://claude.ai/code/session_01QKZdvBvHVUagwg6Yih8er8)_