### PR TITLE
normalize: the inspect desugar answers "binds inspect?" and "calls inspect?" in one census walk (#2386)

### DIFF
--- a/lib/@vibe/compiler/normalize/desugar_trait_dict.vibe
+++ b/lib/@vibe/compiler/normalize/desugar_trait_dict.vibe
@@ -18727,26 +18727,53 @@ fn dinsp_params_optional(params: Array[(String, Option[TypeExpr])]) -> Bool {
   found
 }
 
+/// Mode 0's predicate: this node is an `inspect(value, content)` call.
+fn dinsp_here_uses(expr: Expr) -> Bool {
+  match expr {
+    ECall(callee, args, _) => match callee {
+      EIdent(n, _) => n == "inspect" && Array::length(args) == 2,
+      _ => false
+    },
+    _ => false
+  }
+}
+
+/// Mode 1's predicate: this node binds the name `inspect`.
+fn dinsp_here_binds(expr: Expr) -> Bool {
+  match expr {
+    ELet(n, _, _, _) => n == "inspect",
+    ELetRec(n, _, _) => n == "inspect",
+    ELetMut(n, _, _, _) => n == "inspect",
+    EForIn(v, _, _, _) => v == "inspect",
+    EFn(_, _, params, _, _, _) => dinsp_params_bind(params, "inspect"),
+    EMatch(_, arms) => dinsp_arms_bind(arms, "inspect"),
+    EHandle(_, arms) => dinsp_arms_bind(arms, "inspect"),
+    _ => false
+  }
+}
+
+// #2386: mode 7 answers modes 0 and 1 in ONE walk. The bits are recorded
+// here as the walk finds them; the walk stops early only once both are
+// known. dinsp_expr_census resets the cell and reads it.
+let dinsp_census_cell = [0, 0]
+
 fn dinsp_scan(expr: Expr, mode: Int, name: String) -> Bool {
   let here = if mode == 0 {
-    match expr {
-      ECall(callee, args, _) => match callee {
-        EIdent(n, _) => n == "inspect" && Array::length(args) == 2,
-        _ => false
-      },
-      _ => false
-    }
+    dinsp_here_uses(expr)
   } else if mode == 1 {
-    match expr {
-      ELet(n, _, _, _) => n == "inspect",
-      ELetRec(n, _, _) => n == "inspect",
-      ELetMut(n, _, _, _) => n == "inspect",
-      EForIn(v, _, _, _) => v == "inspect",
-      EFn(_, _, params, _, _, _) => dinsp_params_bind(params, "inspect"),
-      EMatch(_, arms) => dinsp_arms_bind(arms, "inspect"),
-      EHandle(_, arms) => dinsp_arms_bind(arms, "inspect"),
-      _ => false
+    dinsp_here_binds(expr)
+  } else if mode == 7 {
+    if dinsp_here_uses(expr) {
+      Array::set(dinsp_census_cell, 0, 1)
+    } else {
+      ()
     }
+    if dinsp_here_binds(expr) {
+      Array::set(dinsp_census_cell, 1, 1)
+    } else {
+      ()
+    }
+    Array::get(dinsp_census_cell, 0) != 0 && Array::get(dinsp_census_cell, 1) != 0
   } else if mode == 2 {
     match expr {
       EIdent(n, _) => n == name,
@@ -18889,7 +18916,7 @@ fn dinsp_scan_fields(fields: Array[(String, Expr)], mode: Int, name: String) -> 
 ///
 /// Codex review on #1622 (P1): without this the shadow guard only saw binders
 /// spelled in expression position, so a `inspect` introduced by destructuring
-/// left `dinsp_binds_inspect` false and the rewrite went ahead and replaced the
+/// left the range's binder check false and the rewrite went ahead and replaced the
 /// user's own call with snapshot-assertion behaviour -- silently, since the
 /// program still compiled.
 fn dinsp_pat_binds(pat: Pat, name: String) -> Bool {
@@ -19155,34 +19182,72 @@ fn dinsp_stmts_copy(stmts: Array[Stmt]) -> Array[Stmt] {
   }
 }
 
-/// True when `expr` contains a two-argument `inspect(..)` call anywhere.
-///
-/// This is a READ-ONLY walk, and the reason it exists is measured, not
-/// speculative: `dinsp_children` rebuilds every node it visits, so running the
-/// rewrite unconditionally allocated a fresh copy of the whole AST for every
-/// file -- +1.34% on `selfcompile heap_ptr_bytes`, which the perf gate reports
-/// in its deterministic section where "any drift is real". Almost no file
-/// calls `inspect`, and no file in the compiler's own source does, so checking
-/// first and rebuilding only what needs it makes the pass free for them.
-/// `rewrite_alias_expr_ix` (core/import_alias_rewrite.vibe) carries the same
-/// guard for the same reason.
-fn dinsp_uses(expr: Expr) -> Bool {
-  dinsp_scan(expr, 0, "")
+/// Bit 1: the expression contains an `inspect(..)` call (mode 0); bit 2: it
+/// binds the name `inspect` somewhere (mode 1). One walk answers both.
+fn dinsp_expr_census(expr: Expr) -> Int {
+  Array::set(dinsp_census_cell, 0, 0)
+  Array::set(dinsp_census_cell, 1, 0)
+  let _ = dinsp_scan(expr, 7, "")
+  let uses = if Array::get(dinsp_census_cell, 0) != 0 {
+    1
+  } else {
+    0
+  }
+  let binds = if Array::get(dinsp_census_cell, 1) != 0 {
+    2
+  } else {
+    0
+  }
+  uses|binds
 }
 
-fn dinsp_stmt_uses(stmt: Stmt) -> Bool {
+/// The same bits for a statement: exactly dinsp_stmt_uses (bit 1) and
+/// dinsp_stmt_binds (bit 2), computed together.
+fn dinsp_stmt_census(stmt: Stmt) -> Int {
   match stmt {
-    SLet(_, _, _, _, body) => dinsp_uses(body),
-    SLetMut(_, _, body) => dinsp_uses(body),
-    SLetPat(_, body) => dinsp_uses(body),
-    STest(_, body) => dinsp_uses(body),
-    SBench(_, body) => dinsp_uses(body),
-    SExample(_, body) => dinsp_uses(body),
-    SExpr(body) => dinsp_uses(body),
-    SFnDecl(_, _, body, _, _) => dinsp_uses(body),
-    SModule(_, _, body) => dinsp_stmts_use(body),
-    _ => false
+    SImport(_, items) => if dinsp_import_binds(items) {
+      2
+    } else {
+      0
+    },
+    SReExport(_, items) => if dinsp_import_binds(items) {
+      2
+    } else {
+      0
+    },
+    SLet(_, _, name, _, body) => dinsp_expr_census(body)|dinsp_name_binds_bit(name),
+    SLetMut(name, _, body) => dinsp_expr_census(body)|dinsp_name_binds_bit(name),
+    SLetPat(pat, body) => dinsp_expr_census(body)|(if dinsp_pat_binds(pat, "inspect") {
+      2
+    } else {
+      0
+    }),
+    SFnDecl(_, name, body, _, _) => dinsp_expr_census(body)|dinsp_name_binds_bit(name),
+    STest(_, body) => dinsp_expr_census(body),
+    SBench(_, body) => dinsp_expr_census(body),
+    SExample(_, body) => dinsp_expr_census(body),
+    SExpr(body) => dinsp_expr_census(body),
+    SModule(_, _, body) => dinsp_stmts_census(body),
+    _ => 0
   }
+}
+
+fn dinsp_name_binds_bit(name: String) -> Int {
+  if name == "inspect" {
+    2
+  } else {
+    0
+  }
+}
+
+fn dinsp_stmts_census(stmts: Array[Stmt]) -> Int {
+  let mut bits = 0
+  let mut i = 0
+  while bits != 3 && i < Array::length(stmts) {
+    bits = bits|dinsp_stmt_census(Array::get(stmts, i))
+    i = i + 1
+  }
+  bits
 }
 
 fn import_items_bind_name(items: Array[ImportItem], name: String) -> Bool {
@@ -19386,41 +19451,6 @@ export fn validate_serializable_reexport_references(stmts: Array[Stmt]) -> Unit 
   }
 }
 
-fn dinsp_stmts_use(stmts: Array[Stmt]) -> Bool {
-  let mut i = 0
-  let mut found = false
-  while !found && i < Array::length(stmts) {
-    found = dinsp_stmt_uses(Array::get(stmts, i))
-    i = i + 1
-  }
-  found
-}
-
-/// True when the file binds the name `inspect` anywhere -- an import (under
-/// either spelling), a declaration, or any local binder or parameter.
-///
-/// The whole rewrite stands down for such a file. `inspect` is meant to be
-/// reachable when nothing DEFINES it; where something does, that definition is
-/// what the program meant, and quietly replacing a user function's body with
-/// snapshot-assertion behaviour would be a silent change of meaning. This is
-/// deliberately whole-file rather than scope-accurate: it is the conservative
-/// direction (it can only decline to rewrite), and a file that binds `inspect`
-/// at all is rare enough not to be worth a scope tracker that could get the
-/// direction wrong.
-///
-/// It also puts `@vibe/core`'s library `inspect` and its importers back on
-/// their original path -- assert.vibe binds the name, so its body is live
-/// again, and `import @vibe/core { inspect }` still calls it.
-fn dinsp_binds_inspect(stmts: Array[Stmt]) -> Bool {
-  let mut i = 0
-  let mut found = false
-  while !found && i < Array::length(stmts) {
-    found = dinsp_stmt_binds(Array::get(stmts, i))
-    i = i + 1
-  }
-  found
-}
-
 fn dinsp_blocker_names_inspect(names: Array[String]) -> Bool {
   let mut i = 0
   let mut found = false
@@ -19431,28 +19461,41 @@ fn dinsp_blocker_names_inspect(names: Array[String]) -> Bool {
   found
 }
 
-fn dinsp_range_binds_inspect(stmts: Array[Stmt], start: Int, end: Int) -> Bool {
-  let mut i = start
-  let mut found = false
-  while !found && i < end {
-    found = dinsp_stmt_binds(Array::get(stmts, i))
-    i = i + 1
-  }
-  found
-}
+// #2386: the two questions the range asks of every statement -- "does it
+// bind `inspect`?" (which blocks the whole range) and "does it call
+// `inspect`?" (which selects the statements to rewrite) -- used to be two
+// walks per statement. One census walk answers both; the bits are kept in
+// a scratch row refilled per range so nothing is allocated.
+let dinsp_census_row = [0]
 
 fn dinsp_rewrite_range(stmts: Array[Stmt], start: Int, end: Int) -> Bool {
-  let mut changed = false
+  Array::truncate(dinsp_census_row, 0)
+  let mut binds = false
   let mut i = start
   while i < end {
-    let stmt = Array::get(stmts, i)
-    if dinsp_stmt_uses(stmt) {
-      Array::set(stmts, i, dinsp_stmt(stmt))
-      changed = true
+    let bits = dinsp_stmt_census(Array::get(stmts, i))
+    Array::push(dinsp_census_row, bits)
+    if (bits&2) != 0 {
+      binds = true
     } else {
       ()
     }
     i = i + 1
+  }
+  let mut changed = false
+  if binds {
+    ()
+  } else {
+    i = start
+    while i < end {
+      if (Array::get(dinsp_census_row, i - start)&1) != 0 {
+        Array::set(stmts, i, dinsp_stmt(Array::get(stmts, i)))
+        changed = true
+      } else {
+        ()
+      }
+      i = i + 1
+    }
   }
   changed
 }
@@ -19478,7 +19521,7 @@ fn dinsp_rewrite_merged_source_ranges(stmts: Array[Stmt]) -> Bool {
         while end < Array::length(stmts) && merged_source_boundary_local_names(Array::get(stmts, end)) == None {
           end = end + 1
         }
-        if !dinsp_blocker_names_inspect(local_names) && !dinsp_range_binds_inspect(stmts, start, end) {
+        if !dinsp_blocker_names_inspect(local_names) {
           if dinsp_rewrite_range(stmts, start, end) {
             changed = true
           } else {
@@ -19513,45 +19556,16 @@ fn dinsp_import_binds(items: Array[ImportItem]) -> Bool {
   found
 }
 
-fn dinsp_stmt_binds(stmt: Stmt) -> Bool {
-  match stmt {
-    SImport(_, items) => dinsp_import_binds(items),
-    // Direct/single-source checking sees the original re-export. The FS merge
-    // replaces it with a source-boundary marker consumed by the range-aware
-    // path above, so unrelated modules keep their builtin (#2287).
-    SReExport(_, items) => dinsp_import_binds(items),
-    SLet(_, _, name, _, body) => name == "inspect" || dinsp_mentions_binder(body),
-    SLetMut(name, _, body) => name == "inspect" || dinsp_mentions_binder(body),
-    SLetPat(pat, body) => dinsp_pat_binds(pat, "inspect") || dinsp_mentions_binder(body),
-    SFnDecl(_, name, body, _, _) => name == "inspect" || dinsp_mentions_binder(body),
-    STest(_, body) => dinsp_mentions_binder(body),
-    SBench(_, body) => dinsp_mentions_binder(body),
-    SExample(_, body) => dinsp_mentions_binder(body),
-    SExpr(body) => dinsp_mentions_binder(body),
-    SModule(_, _, body) => dinsp_binds_inspect(body),
-    _ => false
-  }
-}
-
-/// A binder named `inspect` INSIDE an expression (a `let`, a lambda parameter,
-/// a `for` variable, or a match/handle arm's pattern). A bare reference does
-/// not count -- that is the call this pass exists to rewrite.
-fn dinsp_mentions_binder(expr: Expr) -> Bool {
-  dinsp_scan(expr, 1, "")
-}
-
 /// In-place, like the other desugars in this file: `check_program` hands the
 /// SAME array to the checker and then on to codegen, so a fresh array would be
 /// dropped on the floor.
 ///
 /// Only statements that actually contain an `inspect(..)` call are rebuilt --
-/// see dinsp_uses for why that guard is load-bearing rather than cosmetic.
+/// see dinsp_stmt_census for why that guard is load-bearing rather than cosmetic.
 export fn desugar_inspect_calls_reporting_change(stmts: Array[Stmt]) -> Bool {
   let mut changed = false
   if dinsp_has_reexport_source_boundaries(stmts) {
     changed = dinsp_rewrite_merged_source_ranges(stmts)
-  } else if dinsp_binds_inspect(stmts) {
-    ()
   } else {
     changed = dinsp_rewrite_range(stmts, 0, Array::length(stmts))
   }

--- a/lib/@vibe/compiler/tests/inspect_census_test.vibe
+++ b/lib/@vibe/compiler/tests/inspect_census_test.vibe
@@ -1,0 +1,34 @@
+import @vibe/compiler/normalize {
+  desugar_inspect_calls_reporting_change
+}
+
+import @vibe/compiler/syntax {
+  lex, parse_program, print_program
+}
+
+// #2386: the inspect desugar asks two questions of every statement of a
+// range -- does it bind `inspect` (which blocks the range) and does it call
+// `inspect` (which selects it for the rewrite) -- in one census walk. The
+// answers must be the two walks' answers: a binder anywhere in the range,
+// even inside a later statement's lambda, blocks every rewrite; without one,
+// exactly the calling statements are rewritten.
+
+test "a binder inside a later statement's lambda blocks the whole range" {
+  let stmts = parse_program(lex("let main = () -> { inspect(1, \"1\") }\nlet other = () -> { let f = (inspect) -> { inspect }; f(1) }\n"))
+  inspect(desugar_inspect_calls_reporting_change(stmts), content = "false")
+  inspect(String::contains(print_program(stmts), "inspect(1, \"1\")"), content = "true")
+}
+
+test "without a binder, the calling statements are rewritten and the others are untouched" {
+  let stmts = parse_program(lex("let a = () -> { inspect(1, \"1\") }\nlet b = () -> { 2 }\nlet c = () -> { inspect(3, \"3\") }\n"))
+  inspect(desugar_inspect_calls_reporting_change(stmts), content = "true")
+  let printed = print_program(stmts)
+  inspect(String::contains(printed, "inspect("), content = "false")
+  inspect(String::contains(printed, "let b = () -> { 2 }"), content = "true")
+  inspect(desugar_inspect_calls_reporting_change(stmts), content = "false")
+}
+
+test "a statement that both calls and binds inspect blocks itself and its range" {
+  let stmts = parse_program(lex("let main = () -> { let inspect = (x, y) -> { x }; inspect(1, \"1\") }\nlet other = () -> { inspect(2, \"2\") }\n"))
+  inspect(desugar_inspect_calls_reporting_change(stmts), content = "false")
+}


### PR DESCRIPTION
## What

One slice of #2386 on both lanes (the FS merge and the checker both run the inspect desugar), byte-identical to main on every corpus.

### `8de40ff` — the inspect desugar answers "binds inspect?" and "calls inspect?" in one census walk

`desugar_inspect_calls` (`normalize/desugar_trait_dict.vibe`) asked two whole-walk questions of every statement of a range: `dinsp_stmt_binds` (does the statement bind the name `inspect` anywhere, which blocks the whole range) and `dinsp_stmt_uses` (does it call `inspect`, which selects it for the rewrite) — two full walks per statement of every program, ~25 ms of a cold self-compile and the same on the warm lane.

`dinsp_scan` gains mode 7, which records both predicates in one walk and stops early only once both are known. `dinsp_stmt_census` gives a statement's two bits exactly as the two walks did (imports and re-exports, definition names, pattern binders, module bodies), and `dinsp_rewrite_range` keeps the bits in a scratch row refilled per range so nothing is allocated: a binder anywhere in the range blocks it, and otherwise exactly the calling statements are rewritten. The two-walk helpers (`dinsp_stmt_binds`, `dinsp_range_binds_inspect`, `dinsp_stmts_use`, `dinsp_mentions_binder` and their expression walkers) are gone.

The census cell is an `Int` pair, not a `Bool` pair: a module-level `let cell = [false, false]` makes the next top-level item a parse error (#2535, filed from this slice).

`inspect_census_test.vibe` pins it with inspect snapshots: a binder inside a later statement's lambda blocks the whole range; without a binder exactly the calling statements are rewritten, and a second run changes nothing; a statement that both calls and binds blocks itself and its range. Red: a census that never reports a binder fails the first and third cases. `normalize_transform_change_status_test.vibe`'s fifteen cases keep answering.

### Measured

Cache-isolated per the profiling skill, `codegen_lexer_test.vibe` over the full compiler closure, against a stage2 built from the tree of `22ebe6e` (main; the tree of #2536's head), idle machine, four interleaved pairs in alternating order (ABBA):

| | main (`22ebe6e`) | `8de40ff` |
|---|---:|---:|
| `dinsp_scan` cold inclusive | 0.08 s | 0.06 s |
| `dinsp_range_binds_inspect` cold inclusive | 0.02 s | 0 (gone) |
| `desugar_inspect_calls_reporting_change` cold inclusive | 0.05 s | 0.04 s |
| `effect_lowering_prelude` cold inclusive | 1.31 s | 1.26 s |
| cold wall, median of 4 | 6.80 s | 6.75 s (noise) |
| warm wall, median of 4 | 4.33 s | 4.29 s (noise) |
| heap_ptr cold / warm | 1,039,028,368 / 644,599,384 | 1,039,043,584 / 644,615,512 (+15 KB / +16 KB) |

The ~25 ms this removes per lane is below the wall clock's noise on this machine; the profile rows are the evidence. Byte-identical output on three closures and 22 rc fixtures.

## Validation

Chain on the tree of `8de40ff` (base `22ebe6e`, whose tree is `3123b33`'s; run in the staging worktree that held the same tree, tree hash checked against the pushed head): bundle regen; stage2 == stage3; output equivalence; `test_cli_core.sh`; selfcompile KPI heap_ptr 1,039,312,592 bytes (against the shared default cache, so not comparable across chains; the cache-isolated rows above are the comparison); typing-env-reuse oracle; 234/234 affected unit-test files (import-graph selection over the changed files); `compiler_gate.sh` early / mid / late.

`vibe_fmt.sh --check` is a fixpoint on every changed file.

Refs #2386. Refs #2535.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QKZdvBvHVUagwg6Yih8er8

---
_Generated by [Claude Code](https://claude.ai/code/session_01QKZdvBvHVUagwg6Yih8er8)_