### PR TITLE
checker: the effect passes walk with one error accumulator instead of an array per node (#2386)

### DIFF
--- a/lib/@vibe/compiler/checker/checker_effects.vibe
+++ b/lib/@vibe/compiler/checker/checker_effects.vibe
@@ -275,26 +275,31 @@ fn is_stdin_provider_surface(name: String) -> Bool {
 /// attempting the generic effect-flow propagation deliberately deferred by
 /// #1536. An explicitly effectful user wrapper remains an ordinary function.
 fn check_stdin_provider_direct_calls_expr(expr: Expr) -> Array[EffectError] {
-  let errors = array_empty()
+  let out = array_empty()
+  check_stdin_provider_direct_calls_expr_into(expr, out)
+  out
+}
+
+fn check_stdin_provider_direct_calls_expr_into(expr: Expr, out: Array[EffectError]) -> Unit {
   match expr {
     ECall(EIdent(name, _), args, _) => {
       if is_stdin_provider_surface(name) {
         let mut ai = 0
         while ai < Array::length(args) {
-          append_eff_errs(errors, check_stdin_provider_direct_calls_expr(Array::get(args, ai)))
+          check_stdin_provider_direct_calls_expr_into(Array::get(args, ai), out)
           ai = ai + 1
         }
       } else {
         let children = expr_children(expr)
         let mut i = 0
         while i < Array::length(children) {
-          append_eff_errs(errors, check_stdin_provider_direct_calls_expr(Array::get(children, i)))
+          check_stdin_provider_direct_calls_expr_into(Array::get(children, i), out)
           i = i + 1
         }
       }
     },
     EIdent(name, _) => if is_stdin_provider_surface(name) {
-      Array::push(errors, EEStdinProviderValueReference(name))
+      Array::push(out, EEStdinProviderValueReference(name))
     } else {
       ()
     },
@@ -302,12 +307,11 @@ fn check_stdin_provider_direct_calls_expr(expr: Expr) -> Array[EffectError] {
       let children = expr_children(expr)
       let mut i = 0
       while i < Array::length(children) {
-        append_eff_errs(errors, check_stdin_provider_direct_calls_expr(Array::get(children, i)))
+        check_stdin_provider_direct_calls_expr_into(Array::get(children, i), out)
         i = i + 1
       }
     }
   }
-  errors
 }
 
 fn check_stdin_provider_direct_calls_stmt(stmt: Stmt) -> Array[EffectError] {
@@ -1862,18 +1866,23 @@ export fn check_async_effects_expr(expr: Expr, env: TypeEnv, in_async: Bool) -> 
 /// in scope, so an async `for` can be recognised through an ordinary local
 /// (`let it = Array::iter(xs); for x in it`) and through a typed parameter.
 fn check_async_effects_expr_lo(expr: Expr, env: TypeEnv, in_async: Bool, locals: Array[(String, String)]) -> Array[EffectError] {
-  let errors = array_empty()
+  let out = array_empty()
+  check_async_effects_expr_lo_into(expr, env, in_async, locals, out)
+  out
+}
+
+fn check_async_effects_expr_lo_into(expr: Expr, env: TypeEnv, in_async: Bool, locals: Array[(String, String)], out: Array[EffectError]) -> Unit {
   // Preserve the legacy preorder diagnostic order: inspect a call before its
   // structural children, then delegate their enumeration to expr_children.
   match expr {
     ECall(EIdent(name, _), _, _) => if !in_async && is_async_primitive(name, env) {
-      Array::push(errors, EEEffectfulCallOutsideEffect(name))
+      Array::push(out, EEEffectfulCallOutsideEffect(name))
     } else {
       ()
     },
     EForIn(_, _, iter, _) => match afe_async_iterand(iter, env, locals) {
       Some(tn) => if !in_async {
-        Array::push(errors, EEEffectfulCallOutsideEffect(String::concat(tn, "::next (a `for` over an async iterator awaits every step -- add `with Async` or wrap the loop in a handler for it)")))
+        Array::push(out, EEEffectfulCallOutsideEffect(String::concat(tn, "::next (a `for` over an async iterator awaits every step -- add `with Async` or wrap the loop in a handler for it)")))
       } else {
         ()
       },
@@ -1885,11 +1894,11 @@ fn check_async_effects_expr_lo(expr: Expr, env: TypeEnv, in_async: Bool, locals:
     // Scope boundary: a lambda's explicit row replaces its enclosing Async
     // context. All other expression forms retain the context unchanged.
     EFn(_, _, params, _, effect, body) => {
-      append_eff_errs(errors, check_async_effects_expr_lo(body, env, effect_opt_is_async(effect), afe_bind_params(locals, params, env)))
+      check_async_effects_expr_lo_into(body, env, effect_opt_is_async(effect), afe_bind_params(locals, params, env), out)
     },
     EHandle(body, arms) => {
       let discharges_async = handle_arms_handle_async(arms)
-      append_eff_errs(errors, check_async_effects_expr_lo(body, env, in_async || discharges_async, locals))
+      check_async_effects_expr_lo_into(body, env, in_async || discharges_async, locals, out)
       let mut ai = 0
       while ai < Array::length(arms) {
         let (pat, arm_body) = Array::get(arms, ai)
@@ -1898,7 +1907,7 @@ fn check_async_effects_expr_lo(expr: Expr, env: TypeEnv, in_async: Bool, locals:
         } else {
           locals
         }
-        append_eff_errs(errors, check_async_effects_expr_lo(arm_body, env, in_async, arm_locals))
+        check_async_effects_expr_lo_into(arm_body, env, in_async, arm_locals, out)
         ai = ai + 1
       }
     },
@@ -1906,38 +1915,37 @@ fn check_async_effects_expr_lo(expr: Expr, env: TypeEnv, in_async: Bool, locals:
     // and only the body sees the new binding. ELetRec's value may reference
     // itself, so both sides see it.
     ELet(name, val, body, _) => {
-      append_eff_errs(errors, check_async_effects_expr_lo(val, env, in_async, locals))
-      append_eff_errs(errors, check_async_effects_expr_lo(body, env, in_async, afe_bind_value(locals, name, val, env)))
+      check_async_effects_expr_lo_into(val, env, in_async, locals, out)
+      check_async_effects_expr_lo_into(body, env, in_async, afe_bind_value(locals, name, val, env), out)
     },
     ELetMut(name, val, body, _) => {
-      append_eff_errs(errors, check_async_effects_expr_lo(val, env, in_async, locals))
-      append_eff_errs(errors, check_async_effects_expr_lo(body, env, in_async, afe_bind_value(locals, name, val, env)))
+      check_async_effects_expr_lo_into(val, env, in_async, locals, out)
+      check_async_effects_expr_lo_into(body, env, in_async, afe_bind_value(locals, name, val, env), out)
     },
     ELetRec(name, val, body) => {
       let rec_locals = afe_bind_value(locals, name, val, env)
-      append_eff_errs(errors, check_async_effects_expr_lo(val, env, in_async, rec_locals))
-      append_eff_errs(errors, check_async_effects_expr_lo(body, env, in_async, rec_locals))
+      check_async_effects_expr_lo_into(val, env, in_async, rec_locals, out)
+      check_async_effects_expr_lo_into(body, env, in_async, rec_locals, out)
     },
     EForIn(name, index_name, iter, body) => {
-      append_eff_errs(errors, check_async_effects_expr_lo(iter, env, in_async, locals))
+      check_async_effects_expr_lo_into(iter, env, in_async, locals, out)
       // The loop variables are ELEMENTS, never the iterator itself: bind them
       // to nothing so they shadow any same-named outer entry.
       let body_locals = match index_name {
         Some(idx) => afe_bind_local(afe_bind_local(locals, name, None), idx, None),
         None => afe_bind_local(locals, name, None)
       }
-      append_eff_errs(errors, check_async_effects_expr_lo(body, env, in_async, body_locals))
+      check_async_effects_expr_lo_into(body, env, in_async, body_locals, out)
     },
     _ => {
       let children = expr_children(expr)
       let mut i = 0
       while i < Array::length(children) {
-        append_eff_errs(errors, check_async_effects_expr_lo(Array::get(children, i), env, in_async, locals))
+        check_async_effects_expr_lo_into(Array::get(children, i), env, in_async, locals, out)
         i = i + 1
       }
     }
   }
-  errors
 }
 
 /// A function body runs in an `{Async}` context if EITHER the lambda's inline
@@ -5773,146 +5781,151 @@ fn mut_with_params(base: Array[String], params: Array[(String, Option[TypeExpr])
 }
 
 export fn check_mutability_expr(expr: Expr, mutable: Array[String]) -> Array[EffectError] {
-  let errors = array_empty()
+  let out = array_empty()
+  check_mutability_expr_into(expr, mutable, out)
+  out
+}
+
+fn check_mutability_expr_into(expr: Expr, mutable: Array[String], out: Array[EffectError]) -> Unit {
   match expr {
     ECall(callee, args, _) => {
-      append_eff_errs(errors, check_mutability_expr(callee, mutable))
+      check_mutability_expr_into(callee, mutable, out)
       let mut ai = 0
       while ai < Array::length(args) {
-        append_eff_errs(errors, check_mutability_expr(Array::get(args, ai), mutable))
+        check_mutability_expr_into(Array::get(args, ai), mutable, out)
         ai = ai + 1
       }
-      errors
+      ()
     },
     EFn(_, _, params, _, _, body) => {
-      append_eff_errs(errors, check_mutability_expr(body, mut_with_params(mutable, params)))
-      errors
+      check_mutability_expr_into(body, mut_with_params(mutable, params), out)
+      ()
     },
     EHandle(body, arms) => {
-      append_eff_errs(errors, check_mutability_expr(body, mutable))
+      check_mutability_expr_into(body, mutable, out)
       let mut ai = 0
       while ai < Array::length(arms) {
         let (pat, arm_body) = Array::get(arms, ai)
-        append_eff_errs(errors, check_mutability_expr(arm_body, mut_with_pat(mutable, pat)))
+        check_mutability_expr_into(arm_body, mut_with_pat(mutable, pat), out)
         ai = ai + 1
       }
-      errors
+      ()
     },
     ELet(_, val, body, _) => {
-      append_eff_errs(errors, check_mutability_expr(val, mutable))
-      append_eff_errs(errors, check_mutability_expr(body, mutable))
-      errors
+      check_mutability_expr_into(val, mutable, out)
+      check_mutability_expr_into(body, mutable, out)
+      ()
     },
     ELetRec(_, val, body) => {
-      append_eff_errs(errors, check_mutability_expr(val, mutable))
-      append_eff_errs(errors, check_mutability_expr(body, mutable))
-      errors
+      check_mutability_expr_into(val, mutable, out)
+      check_mutability_expr_into(body, mutable, out)
+      ()
     },
     ELetMut(name, val, body, _) => {
-      append_eff_errs(errors, check_mutability_expr(val, mutable))
-      append_eff_errs(errors, check_mutability_expr(body, mut_with(mutable, name)))
-      errors
+      check_mutability_expr_into(val, mutable, out)
+      check_mutability_expr_into(body, mut_with(mutable, name), out)
+      ()
     },
     ESeq(a, b) => {
-      append_eff_errs(errors, check_mutability_expr(a, mutable))
-      append_eff_errs(errors, check_mutability_expr(b, mutable))
-      errors
+      check_mutability_expr_into(a, mutable, out)
+      check_mutability_expr_into(b, mutable, out)
+      ()
     },
     EIf(cond, then_e, else_e) => {
-      append_eff_errs(errors, check_mutability_expr(cond, mutable))
-      append_eff_errs(errors, check_mutability_expr(then_e, mutable))
-      append_eff_errs(errors, check_mutability_expr(else_e, mutable))
-      errors
+      check_mutability_expr_into(cond, mutable, out)
+      check_mutability_expr_into(then_e, mutable, out)
+      check_mutability_expr_into(else_e, mutable, out)
+      ()
     },
     EMatch(scrutinee, arms) => {
-      append_eff_errs(errors, check_mutability_expr(scrutinee, mutable))
+      check_mutability_expr_into(scrutinee, mutable, out)
       let mut ai = 0
       while ai < Array::length(arms) {
         let (pat, arm_body) = Array::get(arms, ai)
-        append_eff_errs(errors, check_mutability_expr(arm_body, mut_with_pat(mutable, pat)))
+        check_mutability_expr_into(arm_body, mut_with_pat(mutable, pat), out)
         ai = ai + 1
       }
-      errors
+      ()
     },
     EWhile(cond, body) => {
-      append_eff_errs(errors, check_mutability_expr(cond, mutable))
-      append_eff_errs(errors, check_mutability_expr(body, mutable))
-      errors
+      check_mutability_expr_into(cond, mutable, out)
+      check_mutability_expr_into(body, mutable, out)
+      ()
     },
     ELoop(params, body) => {
       let loopmut = Array::slice(mutable, 0, Array::length(mutable))
       let mut i = 0
       while i < Array::length(params) {
         let (pname, init) = Array::get(params, i)
-        append_eff_errs(errors, check_mutability_expr(init, mutable))
+        check_mutability_expr_into(init, mutable, out)
         Array::push(loopmut, pname)
         i = i + 1
       }
-      append_eff_errs(errors, check_mutability_expr(body, loopmut))
-      errors
+      check_mutability_expr_into(body, loopmut, out)
+      ()
     },
     EForIn(name, index_name, iter, body) => {
-      append_eff_errs(errors, check_mutability_expr(iter, mutable))
+      check_mutability_expr_into(iter, mutable, out)
       let base = mut_with(mutable, name)
       let formut = match index_name {
         Some(idx) => mut_with(base, idx),
         None => base
       }
-      append_eff_errs(errors, check_mutability_expr(body, formut))
-      errors
+      check_mutability_expr_into(body, formut, out)
+      ()
     },
     EBinOp(_, left, right, _) => {
-      append_eff_errs(errors, check_mutability_expr(left, mutable))
-      append_eff_errs(errors, check_mutability_expr(right, mutable))
-      errors
+      check_mutability_expr_into(left, mutable, out)
+      check_mutability_expr_into(right, mutable, out)
+      ()
     },
-    EReturn(e) => check_mutability_expr(e, mutable),
-    EUnaryOp(_, operand) => check_mutability_expr(operand, mutable),
+    EReturn(e) => check_mutability_expr_into(e, mutable, out),
+    EUnaryOp(_, operand) => check_mutability_expr_into(operand, mutable, out),
     EAssign(name, val, cont) => {
       if !mut_has(mutable, name) {
-        Array::push(errors, EEAssignImmutable(name))
+        Array::push(out, EEAssignImmutable(name))
       } else {
         ()
       }
-      append_eff_errs(errors, check_mutability_expr(val, mutable))
-      append_eff_errs(errors, check_mutability_expr(cont, mutable))
-      errors
+      check_mutability_expr_into(val, mutable, out)
+      check_mutability_expr_into(cont, mutable, out)
+      ()
     },
     EAssignOp(name, _, val, cont) => {
       if !mut_has(mutable, name) {
-        Array::push(errors, EEAssignImmutable(name))
+        Array::push(out, EEAssignImmutable(name))
       } else {
         ()
       }
-      append_eff_errs(errors, check_mutability_expr(val, mutable))
-      append_eff_errs(errors, check_mutability_expr(cont, mutable))
-      errors
+      check_mutability_expr_into(val, mutable, out)
+      check_mutability_expr_into(cont, mutable, out)
+      ()
     },
-    EDot(obj, _, _, _) => check_mutability_expr(obj, mutable),
+    EDot(obj, _, _, _) => check_mutability_expr_into(obj, mutable, out),
     ETuple(elems) => {
       let mut ei = 0
       while ei < Array::length(elems) {
-        append_eff_errs(errors, check_mutability_expr(Array::get(elems, ei), mutable))
+        check_mutability_expr_into(Array::get(elems, ei), mutable, out)
         ei = ei + 1
       }
-      errors
+      ()
     },
     EArray(elems) => {
       let mut ei = 0
       while ei < Array::length(elems) {
-        append_eff_errs(errors, check_mutability_expr(Array::get(elems, ei), mutable))
+        check_mutability_expr_into(Array::get(elems, ei), mutable, out)
         ei = ei + 1
       }
-      errors
+      ()
     },
     ERecord(_, fields, _) => {
       let mut fi = 0
       while fi < Array::length(fields) {
         let (_, fval) = Array::get(fields, fi)
-        append_eff_errs(errors, check_mutability_expr(fval, mutable))
+        check_mutability_expr_into(fval, mutable, out)
         fi = fi + 1
       }
-      errors
+      ()
     },
     // #629 step 3-2: forms previously dropped to `_ => errors`, so an illegal
     // reassignment (`x = e` where x is an immutable `let`) sitting inside a map
@@ -5924,24 +5937,24 @@ export fn check_mutability_expr(expr: Expr, mutable: Array[String]) -> Array[Eff
       let mut mi = 0
       while mi < Array::length(entries) {
         let (_, mval) = Array::get(entries, mi)
-        append_eff_errs(errors, check_mutability_expr(mval, mutable))
+        check_mutability_expr_into(mval, mutable, out)
         mi = mi + 1
       }
-      errors
+      ()
     },
-    ELabeledArg(_, _, inner) => check_mutability_expr(inner, mutable),
-    ESpread(inner) => check_mutability_expr(inner, mutable),
+    ELabeledArg(_, _, inner) => check_mutability_expr_into(inner, mutable, out),
+    ESpread(inner) => check_mutability_expr_into(inner, mutable, out),
     EBreak(opt) => match opt {
-      Some(e) => check_mutability_expr(e, mutable),
-      None => errors
+      Some(e) => check_mutability_expr_into(e, mutable, out),
+      None => ()
     },
     EContinue(cargs) => {
       let mut ci = 0
       while ci < Array::length(cargs) {
-        append_eff_errs(errors, check_mutability_expr(Array::get(cargs, ci), mutable))
+        check_mutability_expr_into(Array::get(cargs, ci), mutable, out)
         ci = ci + 1
       }
-      errors
+      ()
     },
     // New structural forms keep the same binding context; scoped forms above
     // intentionally remain explicit so their boundary semantics are visible.
@@ -5949,10 +5962,10 @@ export fn check_mutability_expr(expr: Expr, mutable: Array[String]) -> Array[Eff
       let children = expr_children(expr)
       let mut i = 0
       while i < Array::length(children) {
-        append_eff_errs(errors, check_mutability_expr(Array::get(children, i), mutable))
+        check_mutability_expr_into(Array::get(children, i), mutable, out)
         i = i + 1
       }
-      errors
+      ()
     }
   }
 }

--- a/lib/@vibe/compiler/tests/effect_pass_accumulator_test.vibe
+++ b/lib/@vibe/compiler/tests/effect_pass_accumulator_test.vibe
@@ -1,0 +1,41 @@
+// #2386: the mutability, async-effect and stdin-provider passes walk an
+// expression with ONE error accumulator instead of returning a fresh array
+// per node and copying it upward. What must not change is the report itself:
+// every site is reported once, in preorder, through nested scopes -- pinned
+// here on a rendered join of the whole report.
+import @vibe/compiler/core {
+  TypeEnv
+}
+
+import @vibe/compiler/syntax {
+  lex, parse_program
+}
+
+import @vibe/compiler/checker {
+  EffectError, check_async_effects_stmts, check_mutability_stmts, check_stdin_provider_direct_calls_stmts, effect_error_to_string
+}
+
+fn rendered(errs: Array[EffectError]) -> String {
+  let mut out = ""
+  let mut i = 0
+  while i < Array::length(errs) {
+    out = String::concat(String::concat(out, effect_error_to_string(Array::get(errs, i))), " | ")
+    i = i + 1
+  }
+  out
+}
+
+test "mutability: one report per site, in preorder, through nested scopes" {
+  let src = "fn f() -> Int {\n  let a = 1\n  let c = 2\n  let d = 3\n  let e = 4\n  a = 10\n  let mut b = 0\n  b = 3\n  if true {\n    c = 11\n  } else {\n    b = 5\n  }\n  while false {\n    d = 12\n  }\n  let g = () -> Int {\n    e = 13\n    1\n  }\n  b\n}\n"
+  inspect(rendered(check_mutability_stmts(parse_program(lex(src)))), content = "cannot assign to immutable binding `a` (declare it with `let mut`) | cannot assign to immutable binding `c` (declare it with `let mut`) | cannot assign to immutable binding `d` (declare it with `let mut`) | cannot assign to immutable binding `e` (declare it with `let mut`) | ")
+}
+
+test "stdin provider: value references reported in preorder, direct calls checked argument by argument" {
+  let src = "fn s() -> Int {\n  let r = Stdin::read_via_stream\n  let t = [StdinStream::next]\n  StdinStream::read_chunk(StdinStream::close)\n  1\n}\n"
+  inspect(rendered(check_stdin_provider_direct_calls_stmts(parse_program(lex(src)))), content = "stdin provider operations are direct-call-only; wrap `Stdin::read_via_stream` in an explicitly effectful function | stdin provider operations are direct-call-only; wrap `StdinStream::next` in an explicitly effectful function | stdin provider operations are direct-call-only; wrap `StdinStream::close` in an explicitly effectful function | ")
+}
+
+test "async: every primitive call outside an Async row is reported, in preorder" {
+  let src = "fn h() -> Int {\n  let x = await(1)\n  if true {\n    await(2)\n  } else {\n    3\n  }\n}\n"
+  inspect(rendered(check_async_effects_stmts(parse_program(lex(src)), EnvEmpty)), content = "effectful call outside effectful context: await | effectful call outside effectful context: await | ")
+}


### PR DESCRIPTION
## What

One slice of #2386 on the checker lane, byte-identical to main on every corpus.

### `74a629c` — the effect passes walk with one error accumulator instead of an array per node

`check_mutability_expr`, `check_async_effects_expr_lo` and `check_stdin_provider_direct_calls_expr` (`checker/checker_effects.vibe`) each allocated a fresh error array at every expression node and copied every child's array into the parent's on the way up (`append_eff_errs`): ~85 ms of `array_empty` / push churn in a cold self-compile, for reports that are almost always empty (273 ms of the cold profile's `__rt_arr_new` sat under `array_empty`; these three passes were 84 ms of it).

Each pass now has an `_into` walker that pushes into one accumulator handed down from the statement; the exported array-returning entry points (`check_mutability_expr`, `check_mutability_stmts`, `check_async_effects_*`, `check_stdin_provider_direct_calls_stmts`) are wrappers around it. The push and recursion sequence of every arm is unchanged, so the report is the same, in the same order.

`effect_pass_accumulator_test.vibe` pins the rendered join of each pass's report over nested scopes (one entry per site, in preorder: an immutable assignment at the top level, in an `if` branch, in a `while` body and inside a lambda; three stdin-provider value references, one of them a direct call's argument; two `await` calls outside an Async row). The same snapshot passes on main's walkers. Red: pushing an assignment's own report after its continuation reorders the mutability snapshot.

### Measured

Cache-isolated per the profiling skill, `codegen_lexer_test.vibe` over the full compiler closure, against a stage2 built from the tree of `823834c` (the main this commit was measured on; `9d14ff0`, the base it is pushed on, adds #2539's call-lowering change, which these files do not touch), four interleaved pairs in alternating order (ABBA), on an idle machine:

| | `823834c` | `74a629c` |
|---|---:|---:|
| `check_mutability_expr` cold inclusive | 0.03 s | 0.01 s |
| `check_stdin_provider_direct_calls_expr` cold inclusive | 0.08 s | 0.05 s |
| `check_async_effects_expr_lo` cold inclusive | 0.12 s | 0.11 s |
| `array_empty` cold inclusive | 0.26 s | 0.15 s |
| `__rt_arr_new` cold inclusive | 0.37 s | 0.28 s |
| cold wall, median of 4 | 7.06 s | 6.72 s (every pair faster, mean −0.22 s) |
| warm wall, median of 4 | 4.38 s | 4.34 s (noise; the warm lane does not run the checker) |
| heap_ptr cold / warm | 1,039,043,608 / 644,615,536 | 1,000,603,904 / 644,614,920 (−38.4 MB / −0.6 KB) |

The heap row is deterministic on the bump lane. The wall row is the second of two ABBA runs: the first ran while test compiles for the next slice were loading the machine and read +3%, so it was discarded and re-run idle. A third run on an idle machine (after the merge) agrees: cold median 6.80 s → 6.56 s (three of four pairs faster, mean −0.27 s), warm 4.22 s → 4.03 s, the same heap bytes.

Byte-identical output on three closures and 22 rc fixtures.

## Validation

Chain on the tree of `74a629c` (base `9d14ff0`; run in the staging worktree that held the same tree, tree hash checked against the pushed head): bundle regen; stage2 == stage3; output equivalence; `test_cli_core.sh`; selfcompile KPI heap_ptr 999,975,808 bytes (against the shared default cache, so not comparable across chains; the cache-isolated rows above are the comparison); typing-env-reuse oracle; 212/212 affected unit-test files (import-graph selection over the changed files); `compiler_gate.sh` early / mid / late.

`vibe_fmt.sh --check` is a fixpoint on every changed file.

Refs #2386.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QKZdvBvHVUagwg6Yih8er8

---
_Generated by [Claude Code](https://claude.ai/code/session_01QKZdvBvHVUagwg6Yih8er8)_