### PR TITLE
Three #2386 slices: lazy mismatch subjects, perceus scratch-stack snapshots, constructor-matched unstable-import scans

### DIFF
--- a/lib/@vibe/compiler/checker/checker.vibe
+++ b/lib/@vibe/compiler/checker/checker.vibe
@@ -5165,6 +5165,15 @@ fn rigid_applied_mismatch(expected: Type, actual: Type) -> Bool {
 }
 
 export fn check_assignable(expected: Type, actual: Type, s: Subst, errors: Array[String], what: String, off: Int) -> Subst {
+  check_assignable_for(expected, actual, s, errors, what, "", off)
+}
+
+/// #2386: `check_assignable` with the report's subject split in two so the
+/// message is built only when a mismatch is reported. Every call site with a
+/// per-call subject (`"argument type mismatch for " ++ label`) used to build
+/// the string first: ~25 ms of `__rt_str_concat` under `unify_call_args` in a
+/// cold self-compile, for calls that almost always agree.
+export fn check_assignable_for(expected: Type, actual: Type, s: Subst, errors: Array[String], what_head: String, what_tail: String, off: Int) -> Subst {
   match unify(expected, actual, s) {
     Some(su) => su,
     None => {
@@ -5218,7 +5227,7 @@ export fn check_assignable(expected: Type, actual: Type, s: Subst, errors: Array
       // stays on the historical tolerate path.
       let named_vs_scalar = (type_fully_concrete(expected) && is_fully_concrete_named(expected_zonked) && is_builtin_scalar(actual_zonked)) || (is_builtin_scalar(expected_zonked) && is_fully_concrete_named(actual_zonked))
       if stdin_stream_conflict || nominal_conflict || rigid_applied_conflict || (named_vs_scalar && !structural) {
-        Array::push(errors, String::concat(what, String::concat(": expected ", String::concat(type_to_string(expected_zonked), String::concat(", got ", String::concat(type_to_string(actual_zonked), off_marker(off)))))))
+        Array::push(errors, String::concat(String::concat(what_head, what_tail), String::concat(": expected ", String::concat(type_to_string(expected_zonked), String::concat(", got ", String::concat(type_to_string(actual_zonked), off_marker(off)))))))
         s
       } else if structural {
         // #939: the structural retry tolerated EVERY effect-only difference,
@@ -5230,7 +5239,7 @@ export fn check_assignable(expected: Type, actual: Type, s: Subst, errors: Array
         // stay tolerated (see effect_row_dropped).
         match effect_row_dropped(subst_apply(s, expected), subst_apply(s, actual)) {
           Some(lbl) => {
-            Array::push(errors, String::concat(what, String::concat(": effect row mismatch: a value of type ", String::concat(type_to_string(subst_apply(s, actual)), String::concat(" cannot be used where ", String::concat(type_to_string(subst_apply(s, expected)), String::concat(" is expected (the { ", String::concat(lbl, String::concat(" } effect would be dropped — no handler could ever run)", off_marker(off))))))))))
+            Array::push(errors, String::concat(String::concat(what_head, what_tail), String::concat(": effect row mismatch: a value of type ", String::concat(type_to_string(subst_apply(s, actual)), String::concat(" cannot be used where ", String::concat(type_to_string(subst_apply(s, expected)), String::concat(" is expected (the { ", String::concat(lbl, String::concat(" } effect would be dropped — no handler could ever run)", off_marker(off))))))))))
             s
           },
           None => s
@@ -5259,12 +5268,12 @@ export fn check_assignable(expected: Type, actual: Type, s: Subst, errors: Array
         // calls. A monomorphic signature (the #981 hole) is concrete without
         // any substitution, so the genuine cases all keep reporting.
         if type_fully_concrete(expected) {
-          detect_narrowed_generic_mismatch(expected, actual, s, errors, what, off)
+          detect_narrowed_generic_mismatch_for(expected, actual, s, errors, what_head, what_tail, off)
         } else {
           s
         }
       } else {
-        Array::push(errors, String::concat(what, String::concat(": expected ", String::concat(type_to_string(subst_apply(s, expected)), String::concat(", got ", String::concat(type_to_string(subst_apply(s, actual)), off_marker(off)))))))
+        Array::push(errors, String::concat(String::concat(what_head, what_tail), String::concat(": expected ", String::concat(type_to_string(subst_apply(s, expected)), String::concat(", got ", String::concat(type_to_string(subst_apply(s, actual)), off_marker(off)))))))
         s
       }
     }
@@ -5521,6 +5530,10 @@ fn is_fully_concrete_named(t: Type) -> Bool {
 /// flagged -- only a same-name mismatch where both sides are already fully
 /// resolved concrete types.
 export fn detect_narrowed_generic_mismatch(expected: Type, actual: Type, s: Subst, errors: Array[String], what: String, off: Int) -> Subst {
+  detect_narrowed_generic_mismatch_for(expected, actual, s, errors, what, "", off)
+}
+
+fn detect_narrowed_generic_mismatch_for(expected: Type, actual: Type, s: Subst, errors: Array[String], what_head: String, what_tail: String, off: Int) -> Subst {
   let e2 = subst_apply(s, expected)
   let a2 = subst_apply(s, actual)
   match e2 {
@@ -5529,7 +5542,7 @@ export fn detect_narrowed_generic_mismatch(expected: Type, actual: Type, s: Subs
         match unify(e2, a2, s) {
           Some(_) => s,
           None => {
-            Array::push(errors, String::concat(what, String::concat(": expected ", String::concat(type_to_string(e2), String::concat(", got ", String::concat(type_to_string(a2), off_marker(off)))))))
+            Array::push(errors, String::concat(String::concat(what_head, what_tail), String::concat(": expected ", String::concat(type_to_string(e2), String::concat(", got ", String::concat(type_to_string(a2), off_marker(off)))))))
             s
           }
         }
@@ -5812,7 +5825,7 @@ fn check_record_fields(defs: Array[TypeDef], actual: Array[(String, Type)], s: S
       let (fname, declared_ty) = Array::get(matched_fields, i)
       match lookup_actual_field_ty(actual, fname) {
         Some(actual_ty) => {
-          out = check_assignable(declared_ty, subst_apply(out, actual_ty), out, errors, String::concat("struct field type mismatch for ", fname), 0 - 1)
+          out = check_assignable_for(declared_ty, subst_apply(out, actual_ty), out, errors, "struct field type mismatch for ", fname, 0 - 1)
         },
         None => ()
       }
@@ -5913,7 +5926,7 @@ fn unify_call_args(param_tys: Array[Type], arg_tys: Array[Type], s: Subst, error
         None => out
       }
     } else {
-      check_assignable(pty, aty, out, errors, String::concat("argument type mismatch for ", label), off)
+      check_assignable_for(pty, aty, out, errors, "argument type mismatch for ", label, off)
     }
     ui = ui + 1
   }
@@ -9484,7 +9497,7 @@ fn check_expr_capture_impl(expr: Expr, env: TypeEnv, defs: Array[TypeDef], s: Su
                         } else {
                           let mut vi = 0
                           while vi < oalen {
-                            s1 = check_assignable(subst_apply(s1, Array::get(sig_params, vi)), subst_apply(s1, Array::get(oparg_tys, vi)), s1, errors, String::concat("perform argument type mismatch for ", op_qname), op_off)
+                            s1 = check_assignable_for(subst_apply(s1, Array::get(sig_params, vi)), subst_apply(s1, Array::get(oparg_tys, vi)), s1, errors, "perform argument type mismatch for ", op_qname, op_off)
                             vi = vi + 1
                           }
                         }
@@ -10096,11 +10109,11 @@ fn check_expr_capture_impl(expr: Expr, env: TypeEnv, defs: Array[TypeDef], s: Su
           // checked against Int, same #985 discipline as FixedArray::get above.
           let (fa_ty, s1, c1) = check_expr_capture(Array::get(args, 0), env, defs, s, c, errors, tytab, capture, lane)
           let (idx_ty2, s2, c2) = check_expr_capture(Array::get(args, 1), env, defs, s1, c1, errors, tytab, capture, lane)
-          let s2b = check_assignable(CtInt, subst_apply(s2, idx_ty2), s2, errors, String::concat("index must be Int for ", name), call_off)
+          let s2b = check_assignable_for(CtInt, subst_apply(s2, idx_ty2), s2, errors, "index must be Int for ", name, call_off)
           let (v_ty, s3, c3) = check_expr_capture(Array::get(args, 2), env, defs, s2b, c2, errors, tytab, capture, lane)
           let s4 = match subst_apply(s3, fa_ty) {
             CtNamed(fan2, faargs2) => if fan2 == "FixedArray" && Array::length(faargs2) == 1 {
-              check_assignable(subst_apply(s3, Array::get(faargs2, 0)), subst_apply(s3, v_ty), s3, errors, String::concat("value type mismatch for ", name), call_off)
+              check_assignable_for(subst_apply(s3, Array::get(faargs2, 0)), subst_apply(s3, v_ty), s3, errors, "value type mismatch for ", name, call_off)
             } else {
               s3
             },
@@ -11365,7 +11378,7 @@ fn check_expr_capture_impl(expr: Expr, env: TypeEnv, defs: Array[TypeDef], s: Su
       // The assigned value must be assignable to the variable's type
       // (previously unchecked — `y = "s"` for `let mut y = 1` was accepted).
       let s1b = match env_lookup(env, name) {
-        Some(var_ty) => check_assignable(var_ty, subst_apply(s1, vt), s1, errors, String::concat("assignment type mismatch for ", name), tail_expr_off(val)),
+        Some(var_ty) => check_assignable_for(var_ty, subst_apply(s1, vt), s1, errors, "assignment type mismatch for ", name, tail_expr_off(val)),
         None => s1
       }
       check_expr_capture(body, env, defs, s1b, c1, errors, tytab, capture, lane)
@@ -12933,7 +12946,7 @@ fn check_expr_capture_impl(expr: Expr, env: TypeEnv, defs: Array[TypeDef], s: Su
                 match lookup_actual_field_ty(field_tys, dn) {
                   Some(aty) => {
                     // Value type check (ground-gated like check_record_fields).
-                    s1 = check_assignable(dty, subst_apply(s1, aty), s1, errors, String::concat("struct field type mismatch for ", dn), lookup_field_expr_off(fields, dn))
+                    s1 = check_assignable_for(dty, subst_apply(s1, aty), s1, errors, "struct field type mismatch for ", dn, lookup_field_expr_off(fields, dn))
                   },
                   None => Array::push(errors, String::concat("missing field `", String::concat(dn, String::concat("` in construction of struct ", rn))))
                 }

--- a/lib/@vibe/compiler/checker/checker_stmt.vibe
+++ b/lib/@vibe/compiler/checker/checker_stmt.vibe
@@ -73,6 +73,7 @@ import ./checker.vibe {
   attach_unlocated_decl_name_marker,
   bind_function_dependency_contracts,
   check_assignable,
+  check_assignable_for,
   check_expr,
   check_expr_capture,
   collect_formal_applications_by,
@@ -2277,7 +2278,7 @@ fn check_stmts_with_binders(raw_stmts: Array[Stmt], i: Int, env: TypeEnv, defs: 
             // `defs` and would be reported as unknown. Inside the
             // `ann_err_before` window so the binder name anchors it.
             report_unknown_type_names(te, defs, array_empty(), env, array_empty(), String::concat(String::concat("the annotation of `", name), "`"), errors)
-            let ns_b = check_assignable(resolved_te, actual_v, ns0, errors, String::concat("binding type mismatch for ", name), top_stmt_expr_off(val))
+            let ns_b = check_assignable_for(resolved_te, actual_v, ns0, errors, "binding type mismatch for ", name, top_stmt_expr_off(val))
             // #1941: a literal value carries no offset, so anchor the binder
             // name instead of emitting the one unlocated diagnostic left in
             // this lane.
@@ -2313,7 +2314,7 @@ fn check_stmts_with_binders(raw_stmts: Array[Stmt], i: Int, env: TypeEnv, defs: 
         let (vt, ns0, nc) = check_expr_capture(val, env, defs, s, c, errors, tytab, role_lane_capture, "Primary")
         attach_unlocated_decl_name_marker(errors, err_before, name)
         let ns = match ann {
-          Some(te) => check_assignable(resolve_type_expr(te, defs), subst_apply(ns0, vt), ns0, errors, String::concat("binding type mismatch for ", name), 0 - 1),
+          Some(te) => check_assignable_for(resolve_type_expr(te, defs), subst_apply(ns0, vt), ns0, errors, "binding type mismatch for ", name, 0 - 1),
           None => ns0
         }
         let t = match ann {

--- a/lib/@vibe/compiler/checker/index.vpkg
+++ b/lib/@vibe/compiler/checker/index.vpkg
@@ -133,6 +133,7 @@ fn trait_reference_display(key: String) -> String
 fn resolve_trait_bound_self_reference(key: String, self_ty: Type, s: Subst, defs: Array[TypeDef]) -> String
 fn validate_trait_reference(env: TypeEnv, key: String, context: String, errors: Array[String]) -> Unit
 fn check_assignable(expected: Type, actual: Type, s: Subst, errors: Array[String], what: String, off: Int) -> Subst
+fn check_assignable_for(expected: Type, actual: Type, s: Subst, errors: Array[String], what_head: String, what_tail: String, off: Int) -> Subst
 fn detect_narrowed_generic_mismatch(expected: Type, actual: Type, s: Subst, errors: Array[String], what: String, off: Int) -> Subst
 fn preserve_generic_instantiation(resolved: Type, actual: Type) -> Type
 fn report_unknown_type_names(te: TypeExpr, defs: Array[TypeDef], shadow: Array[String], env: TypeEnv, row_binders: Array[String], where_label: String, errors: Array[String]) -> Unit

--- a/lib/@vibe/compiler/perceus/perceus.vibe
+++ b/lib/@vibe/compiler/perceus/perceus.vibe
@@ -286,6 +286,58 @@ fn copy_ints(src: Array[Int]) -> Array[Int] {
   Array::slice(src, 0, Array::length(src))
 }
 
+/// #2386: the branch snapshots `pc_count` / `pc_emit` take of the per-binding
+/// tables (`uses`, `borrows`, `remaining`) live on ONE scratch stack instead
+/// of a fresh array per `if` / `match` / `handle`. A snapshot is the offset
+/// of its first slot; the construct that took it truncates the stack back to
+/// its own first snapshot when it is done, so nested constructs stack and
+/// every slot a construct reads is below anything its children push.
+/// Measured: the per-construct copies were 49 ms of `__rt_arr_slice` (plus
+/// the `zeros` tables) in a cold self-compile, on both lanes.
+let pc_scratch: Array[Int] = []
+
+/// Push a copy of `src`; answer its first slot.
+fn pc_snap(src: Array[Int]) -> Int {
+  let mark = Array::length(pc_scratch)
+  let mut i = 0
+  while i < Array::length(src) {
+    Array::push(pc_scratch, Array::get(src, i))
+    i = i + 1
+  }
+  mark
+}
+
+/// Push a copy of the `n` scratch slots starting at `at`; answer the first.
+fn pc_snap_slots(at: Int, n: Int) -> Int {
+  let mark = Array::length(pc_scratch)
+  let mut i = 0
+  while i < n {
+    Array::push(pc_scratch, Array::get(pc_scratch, at + i))
+    i = i + 1
+  }
+  mark
+}
+
+/// Push `n` zero slots; answer the first.
+fn pc_snap_zeros(n: Int) -> Int {
+  let mark = Array::length(pc_scratch)
+  let mut i = 0
+  while i < n {
+    Array::push(pc_scratch, 0)
+    i = i + 1
+  }
+  mark
+}
+
+/// Copy the `n` slots at `at` back over the prefix of `dst`.
+fn pc_snap_restore(dst: Array[Int], at: Int, n: Int) -> Unit {
+  let mut i = 0
+  while i < n {
+    Array::set(dst, i, Array::get(pc_scratch, at + i))
+    i = i + 1
+  }
+}
+
 export fn pa_is_dup(a: PerceusAction) -> Bool {
   match a.kind {
     PaDup => true,
@@ -1936,7 +1988,8 @@ export fn pc_emit(ctx: PCtx, scope: Map[String, Int], expr: Expr) -> Int {
           _ => 0
         }
       } else {
-        let snap = copy_ints(ctx.remaining)
+        let n = Array::length(ctx.remaining)
+        let snap = pc_snap(ctx.remaining)
         pc_emit(ctx, scope, then_e)
         // #1100 alloc cut: swap the prefix instead of taking a SECOND copy —
         // one pass both restores `remaining` to the pre-branch values (what
@@ -1946,10 +1999,10 @@ export fn pc_emit(ctx: PCtx, scope: Map[String, Int], expr: Expr) -> Int {
         // branch-snapshot copies were the plan's largest allocation source
         // on a full-closure compile.
         let mut sw = 0
-        while sw < Array::length(snap) {
+        while sw < n {
           let then_v = Array::get(ctx.remaining, sw)
-          Array::set(ctx.remaining, sw, Array::get(snap, sw))
-          Array::set(snap, sw, then_v)
+          Array::set(ctx.remaining, sw, Array::get(pc_scratch, snap + sw))
+          Array::set(pc_scratch, snap + sw, then_v)
           sw = sw + 1
         }
         pc_emit(ctx, scope, else_e)
@@ -1962,14 +2015,15 @@ export fn pc_emit(ctx: PCtx, scope: Map[String, Int], expr: Expr) -> Int {
         // of the consuming path double-freeing (crash). Prefix-only (outer ids).
         // (`snap` holds the THEN branch's values after the swap above.)
         let mut i = 0
-        while i < Array::length(snap) {
-          if Array::get(snap, i) < Array::get(ctx.remaining, i) {
-            Array::set(ctx.remaining, i, Array::get(snap, i))
+        while i < n {
+          if Array::get(pc_scratch, snap + i) < Array::get(ctx.remaining, i) {
+            Array::set(ctx.remaining, i, Array::get(pc_scratch, snap + i))
           } else {
             ()
           }
           i = i + 1
         }
+        Array::truncate(pc_scratch, snap)
         0
       }
     },
@@ -2101,16 +2155,17 @@ export fn pc_emit(ctx: PCtx, scope: Map[String, Int], expr: Expr) -> Int {
         }
         0
       } else {
-        let snap = copy_ints(ctx.remaining)
+        let n = Array::length(ctx.remaining)
+        let snap = pc_snap(ctx.remaining)
         // #705: track the MIN remaining over all arms (see EIf). An arm that
         // consumes an outer binding (e.g. a param re-stored into a ctor) leaves it
         // at a lower remaining; leaving the LAST arm's (higher) value made the
         // scope-end drop double-free that binding on the arm that consumed it.
-        let minrem = copy_ints(snap)
+        let minrem = pc_snap_slots(snap, n)
         let mut a = 0
         while a < Array::length(arms) {
           let arm = Array::get(arms, a)
-          restore_prefix(ctx.remaining, snap)
+          pc_snap_restore(ctx.remaining, snap, n)
           let pnames: Array[String] = []
           pat_names(arm.0, pnames)
           let mut s = scope
@@ -2130,9 +2185,9 @@ export fn pc_emit(ctx: PCtx, scope: Map[String, Int], expr: Expr) -> Int {
             j = j + 1
           }
           let mut mi = 0
-          while mi < Array::length(snap) {
-            if Array::get(ctx.remaining, mi) < Array::get(minrem, mi) {
-              Array::set(minrem, mi, Array::get(ctx.remaining, mi))
+          while mi < n {
+            if Array::get(ctx.remaining, mi) < Array::get(pc_scratch, minrem + mi) {
+              Array::set(pc_scratch, minrem + mi, Array::get(ctx.remaining, mi))
             } else {
               ()
             }
@@ -2140,18 +2195,20 @@ export fn pc_emit(ctx: PCtx, scope: Map[String, Int], expr: Expr) -> Int {
           }
           a = a + 1
         }
-        restore_prefix(ctx.remaining, minrem)
+        pc_snap_restore(ctx.remaining, minrem, n)
+        Array::truncate(pc_scratch, snap)
         0
       }
     },
     EHandle(hbody, arms) => {
-      let snap = copy_ints(ctx.remaining)
+      let n = Array::length(ctx.remaining)
+      let snap = pc_snap(ctx.remaining)
       pc_emit(ctx, scope, hbody)
-      let minrem = copy_ints(ctx.remaining)
+      let minrem = pc_snap(ctx.remaining)
       let mut a = 0
       while a < Array::length(arms) {
         let arm = Array::get(arms, a)
-        restore_prefix(ctx.remaining, snap)
+        pc_snap_restore(ctx.remaining, snap, n)
         let pnames: Array[String] = []
         pat_names(arm.0, pnames)
         let mut s = scope
@@ -2171,9 +2228,9 @@ export fn pc_emit(ctx: PCtx, scope: Map[String, Int], expr: Expr) -> Int {
           j = j + 1
         }
         let mut mi = 0
-        while mi < Array::length(snap) {
-          if Array::get(ctx.remaining, mi) < Array::get(minrem, mi) {
-            Array::set(minrem, mi, Array::get(ctx.remaining, mi))
+        while mi < n {
+          if Array::get(ctx.remaining, mi) < Array::get(pc_scratch, minrem + mi) {
+            Array::set(pc_scratch, minrem + mi, Array::get(ctx.remaining, mi))
           } else {
             ()
           }
@@ -2181,7 +2238,8 @@ export fn pc_emit(ctx: PCtx, scope: Map[String, Int], expr: Expr) -> Int {
         }
         a = a + 1
       }
-      restore_prefix(ctx.remaining, minrem)
+      pc_snap_restore(ctx.remaining, minrem, n)
+      Array::truncate(pc_scratch, snap)
       0
     },
     _ => 0
@@ -2302,21 +2360,22 @@ export fn pc_count(ctx: PCtx, scope: Map[String, Int], expr: Expr) -> Int {
     },
     EIf(cond, then_e, else_e) => {
       pc_count(ctx, scope, cond)
-      let snap_u = copy_ints(ctx.uses)
-      let snap_b = copy_ints(ctx.borrows)
+      let n = Array::length(ctx.uses)
+      let snap_u = pc_snap(ctx.uses)
+      let snap_b = pc_snap(ctx.borrows)
       pc_count(ctx, scope, then_e)
       // #1100 alloc cut: swap the prefixes instead of taking SECOND copies
       // (`then_u`/`then_b`) — one pass restores uses/borrows to the
       // pre-branch values and captures the then-branch's values into the
       // snap buffers. 2 allocations per `if` instead of 4.
       let mut sw = 0
-      while sw < Array::length(snap_u) {
+      while sw < n {
         let tu = Array::get(ctx.uses, sw)
-        Array::set(ctx.uses, sw, Array::get(snap_u, sw))
-        Array::set(snap_u, sw, tu)
+        Array::set(ctx.uses, sw, Array::get(pc_scratch, snap_u + sw))
+        Array::set(pc_scratch, snap_u + sw, tu)
         let tb = Array::get(ctx.borrows, sw)
-        Array::set(ctx.borrows, sw, Array::get(snap_b, sw))
-        Array::set(snap_b, sw, tb)
+        Array::set(ctx.borrows, sw, Array::get(pc_scratch, snap_b + sw))
+        Array::set(pc_scratch, snap_b + sw, tb)
         sw = sw + 1
       }
       pc_count(ctx, scope, else_e)
@@ -2326,11 +2385,12 @@ export fn pc_count(ctx: PCtx, scope: Map[String, Int], expr: Expr) -> Int {
       // the swap above, snap_u/snap_b hold the THEN branch's values and
       // ctx.uses/ctx.borrows hold the ELSE branch's.
       let mut id = 0
-      while id < Array::length(snap_u) {
-        Array::set(ctx.uses, id, int_max(Array::get(snap_u, id), Array::get(ctx.uses, id)))
-        Array::set(ctx.borrows, id, int_max(Array::get(snap_b, id), Array::get(ctx.borrows, id)))
+      while id < n {
+        Array::set(ctx.uses, id, int_max(Array::get(pc_scratch, snap_u + id), Array::get(ctx.uses, id)))
+        Array::set(ctx.borrows, id, int_max(Array::get(pc_scratch, snap_b + id), Array::get(ctx.borrows, id)))
         id = id + 1
       }
+      Array::truncate(pc_scratch, snap_u)
       0
     },
     EWhile(cond, body) => {
@@ -2402,15 +2462,16 @@ export fn pc_count(ctx: PCtx, scope: Map[String, Int], expr: Expr) -> Int {
         pc_count(ctx, s, arm.1)
         0
       } else {
-        let snap_u = copy_ints(ctx.uses)
-        let snap_b = copy_ints(ctx.borrows)
-        let max_u = zeros(Array::length(snap_u))
-        let max_b = zeros(Array::length(snap_b))
+        let n = Array::length(ctx.uses)
+        let snap_u = pc_snap(ctx.uses)
+        let snap_b = pc_snap(ctx.borrows)
+        let max_u = pc_snap_zeros(n)
+        let max_b = pc_snap_zeros(n)
         let mut a = 0
         while a < Array::length(arms) {
           let arm = Array::get(arms, a)
-          restore_prefix(ctx.uses, snap_u)
-          restore_prefix(ctx.borrows, snap_b)
+          pc_snap_restore(ctx.uses, snap_u, n)
+          pc_snap_restore(ctx.borrows, snap_b, n)
           let pnames: Array[String] = []
           pat_names(arm.0, pnames)
           let mut s = scope
@@ -2423,53 +2484,55 @@ export fn pc_count(ctx: PCtx, scope: Map[String, Int], expr: Expr) -> Int {
           }
           pc_count(ctx, s, arm.1)
           let mut id = 0
-          while id < Array::length(snap_u) {
-            let du = Array::get(ctx.uses, id) - Array::get(snap_u, id)
-            if du > Array::get(max_u, id) {
-              Array::set(max_u, id, du)
+          while id < n {
+            let du = Array::get(ctx.uses, id) - Array::get(pc_scratch, snap_u + id)
+            if du > Array::get(pc_scratch, max_u + id) {
+              Array::set(pc_scratch, max_u + id, du)
             }
-            let db = Array::get(ctx.borrows, id) - Array::get(snap_b, id)
-            if db > Array::get(max_b, id) {
-              Array::set(max_b, id, db)
+            let db = Array::get(ctx.borrows, id) - Array::get(pc_scratch, snap_b + id)
+            if db > Array::get(pc_scratch, max_b + id) {
+              Array::set(pc_scratch, max_b + id, db)
             }
             id = id + 1
           }
           a = a + 1
         }
-        restore_prefix(ctx.uses, snap_u)
-        restore_prefix(ctx.borrows, snap_b)
+        pc_snap_restore(ctx.uses, snap_u, n)
+        pc_snap_restore(ctx.borrows, snap_b, n)
         let mut id2 = 0
-        while id2 < Array::length(snap_u) {
-          Array::set(ctx.uses, id2, Array::get(snap_u, id2) + Array::get(max_u, id2))
-          Array::set(ctx.borrows, id2, Array::get(snap_b, id2) + Array::get(max_b, id2))
+        while id2 < n {
+          Array::set(ctx.uses, id2, Array::get(pc_scratch, snap_u + id2) + Array::get(pc_scratch, max_u + id2))
+          Array::set(ctx.borrows, id2, Array::get(pc_scratch, snap_b + id2) + Array::get(pc_scratch, max_b + id2))
           id2 = id2 + 1
         }
+        Array::truncate(pc_scratch, snap_u)
         0
       }
     },
     EHandle(hbody, arms) => {
-      let snap_u = copy_ints(ctx.uses)
-      let snap_b = copy_ints(ctx.borrows)
-      let max_u = zeros(Array::length(snap_u))
-      let max_b = zeros(Array::length(snap_b))
+      let n = Array::length(ctx.uses)
+      let snap_u = pc_snap(ctx.uses)
+      let snap_b = pc_snap(ctx.borrows)
+      let max_u = pc_snap_zeros(n)
+      let max_b = pc_snap_zeros(n)
       pc_count(ctx, scope, hbody)
       let mut id0 = 0
-      while id0 < Array::length(snap_u) {
-        let du = Array::get(ctx.uses, id0) - Array::get(snap_u, id0)
-        if du > Array::get(max_u, id0) {
-          Array::set(max_u, id0, du)
+      while id0 < n {
+        let du = Array::get(ctx.uses, id0) - Array::get(pc_scratch, snap_u + id0)
+        if du > Array::get(pc_scratch, max_u + id0) {
+          Array::set(pc_scratch, max_u + id0, du)
         }
-        let db = Array::get(ctx.borrows, id0) - Array::get(snap_b, id0)
-        if db > Array::get(max_b, id0) {
-          Array::set(max_b, id0, db)
+        let db = Array::get(ctx.borrows, id0) - Array::get(pc_scratch, snap_b + id0)
+        if db > Array::get(pc_scratch, max_b + id0) {
+          Array::set(pc_scratch, max_b + id0, db)
         }
         id0 = id0 + 1
       }
       let mut a = 0
       while a < Array::length(arms) {
         let arm = Array::get(arms, a)
-        restore_prefix(ctx.uses, snap_u)
-        restore_prefix(ctx.borrows, snap_b)
+        pc_snap_restore(ctx.uses, snap_u, n)
+        pc_snap_restore(ctx.borrows, snap_b, n)
         let pnames: Array[String] = []
         pat_names(arm.0, pnames)
         let mut s = scope
@@ -2482,27 +2545,28 @@ export fn pc_count(ctx: PCtx, scope: Map[String, Int], expr: Expr) -> Int {
         }
         pc_count(ctx, s, arm.1)
         let mut id = 0
-        while id < Array::length(snap_u) {
-          let du = Array::get(ctx.uses, id) - Array::get(snap_u, id)
-          if du > Array::get(max_u, id) {
-            Array::set(max_u, id, du)
+        while id < n {
+          let du = Array::get(ctx.uses, id) - Array::get(pc_scratch, snap_u + id)
+          if du > Array::get(pc_scratch, max_u + id) {
+            Array::set(pc_scratch, max_u + id, du)
           }
-          let db = Array::get(ctx.borrows, id) - Array::get(snap_b, id)
-          if db > Array::get(max_b, id) {
-            Array::set(max_b, id, db)
+          let db = Array::get(ctx.borrows, id) - Array::get(pc_scratch, snap_b + id)
+          if db > Array::get(pc_scratch, max_b + id) {
+            Array::set(pc_scratch, max_b + id, db)
           }
           id = id + 1
         }
         a = a + 1
       }
-      restore_prefix(ctx.uses, snap_u)
-      restore_prefix(ctx.borrows, snap_b)
+      pc_snap_restore(ctx.uses, snap_u, n)
+      pc_snap_restore(ctx.borrows, snap_b, n)
       let mut id2 = 0
-      while id2 < Array::length(snap_u) {
-        Array::set(ctx.uses, id2, Array::get(snap_u, id2) + Array::get(max_u, id2))
-        Array::set(ctx.borrows, id2, Array::get(snap_b, id2) + Array::get(max_b, id2))
+      while id2 < n {
+        Array::set(ctx.uses, id2, Array::get(pc_scratch, snap_u + id2) + Array::get(pc_scratch, max_u + id2))
+        Array::set(ctx.borrows, id2, Array::get(pc_scratch, snap_b + id2) + Array::get(pc_scratch, max_b + id2))
         id2 = id2 + 1
       }
+      Array::truncate(pc_scratch, snap_u)
       0
     },
     _ => 0

--- a/lib/@vibe/compiler/runtime/typecheck_fs.vibe
+++ b/lib/@vibe/compiler/runtime/typecheck_fs.vibe
@@ -7333,15 +7333,23 @@ fn checked_warning_stmts_lexed(input_path: String, source: String, tokens: Array
 /// appear in that same order, so nothing a later statement needs sits behind
 /// the cursor.
 fn unstable_import_offset(tokens: Array[Token], starts: Array[Int], pkg: String, cursor: Array[Int]) -> Int {
-  let want = String::concat("TIdent(", String::concat(pkg, ")"))
   let n = Array::length(starts)
   let mut i = Array::get(cursor, 0)
   while i + 1 < n {
-    if token_to_string(Array::get(tokens, i)) == "TImport" && token_to_string(Array::get(tokens, i + 1)) == want {
-      Array::set(cursor, 0, i + 1)
-      return Array::get(starts, i)
-    } else {
-      ()
+    // #2386: match the token constructors; rendering every token to a
+    // string and comparing the text allocated once per token of every
+    // file on the checker lane.
+    match Array::get(tokens, i) {
+      TImport => match Array::get(tokens, i + 1) {
+        TIdent(name) => if name == pkg {
+          Array::set(cursor, 0, i + 1)
+          return Array::get(starts, i)
+        } else {
+          ()
+        },
+        _ => ()
+      },
+      _ => ()
     }
     i = i + 1
   }
@@ -7502,20 +7510,16 @@ fn unstable_tokens_import_any(tokens: Array[Token], starts: Array[Int]) -> Bool 
   let mut i = 0
   let mut found = false
   while !found && i + 1 < n {
-    if token_to_string(Array::get(tokens, i)) == "TImport" {
-      let next = token_to_string(Array::get(tokens, i + 1))
-      if String::starts_with(next, "TIdent(") && String::ends_with(next, ")") {
-        let name = String::substring(next, 7, String::length(next) - 1)
-        if unstable_package_note(name) != "" {
+    match Array::get(tokens, i) {
+      TImport => match Array::get(tokens, i + 1) {
+        TIdent(name) => if unstable_package_note(name) != "" {
           found = true
         } else {
           ()
-        }
-      } else {
-        ()
-      }
-    } else {
-      ()
+        },
+        _ => ()
+      },
+      _ => ()
     }
     i = i + 1
   }

--- a/lib/@vibe/compiler/tests/lazy_mismatch_message_test.vibe
+++ b/lib/@vibe/compiler/tests/lazy_mismatch_message_test.vibe
@@ -1,0 +1,46 @@
+// #2386: `check_assignable_for` builds the mismatch message only when a
+// mismatch is reported, from a (head, subject) pair its callers hand over
+// instead of a string they concatenated first. The wording must not move:
+// the argument, binding and struct-field reports are pinned here as the
+// checker renders them. (The impl-target key case pins `impl_encode_name`'s
+// byte-code spelling: a StringBuilder rewrite of it was measured and dropped,
+// +1 MB cold / +2.4 MB warm of heap for no wall change.)
+import @vibe/compiler/core {
+  TypeExpr
+}
+
+import @vibe/compiler/checker {
+  check_program
+}
+
+import @vibe/compiler/syntax {
+  lex, parse_program
+}
+
+import @vibe/ast {
+  impl_target_key
+}
+
+fn first_check_error(source: String) -> String {
+  handle {
+    let _ = check_program(parse_program(lex(source)))
+    ""
+  } with { Exception::Throw(msg) => msg }
+}
+
+test "argument mismatch keeps its subject and wording" {
+  inspect(first_check_error("fn f(x: Int) -> Int {\n  x\n}\n\nfn g() -> Int {\n  f(\"s\")\n}\n"), content = "argument type mismatch for f: expected Int, got String")
+}
+
+test "binding mismatch keeps its subject and wording" {
+  inspect(first_check_error("fn g() -> Int {\n  let n: Int = \"s\"\n  n\n}\n"), content = "binding type mismatch for a local let: expected Int, got String [@fn=n]")
+}
+
+test "struct field mismatch keeps its subject and wording" {
+  inspect(first_check_error("struct P { x: Int }\n\nfn g() -> P {\n  P::{ x: \"s\" }\n}\n"), content = "struct field type mismatch for x: expected Int, got String")
+}
+
+test "impl target keys keep the byte-code spelling" {
+  inspect(impl_target_key(TyName("Foo")), content = "N70_111_111_Z")
+  inspect(impl_target_key(TyApp("Box", [TyName("Int")])), content = "A66_111_120_LN73_110_116_ZR")
+}

--- a/lib/@vibe/compiler/tests/perceus_scratch_snapshot_test.vibe
+++ b/lib/@vibe/compiler/tests/perceus_scratch_snapshot_test.vibe
@@ -1,0 +1,40 @@
+// #2386: the perceus planner's branch snapshots of the per-binding tables
+// (`uses` / `borrows` in the count pass, `remaining` in the emit pass) live
+// on one scratch stack instead of a fresh array per `if` / `match` /
+// `handle`. The plan must not change: nested constructs that consume an
+// outer binding on one path only are the shape that reads every snapshot
+// slot (the per-arm restore, the max/min merge across arms, and the swap
+// the `if` arms share), so their plan is pinned here as `vibe rc-plan`
+// prints it.
+import @vibe/compiler/runtime {
+  rc_plan_source
+}
+
+fn plan_of(source: String) -> String with Exception {
+  rc_plan_source(source, "")
+}
+
+fn one_line(s: String) -> String {
+  let out = StringBuilder::new()
+  let mut i = 0
+  while i < String::length(s) {
+    let c = String::char_code_at(s, i)
+    if c == '\n' {
+      StringBuilder::push(out, " ; ")
+    } else {
+      StringBuilder::push(out, String::substring(s, i, i + 1))
+    }
+    i = i + 1
+  }
+  StringBuilder::freeze(out)
+}
+
+test "an outer binding consumed in one arm of nested if / match keeps its plan" {
+  let src = "enum Node {\n  Leaf(Int);\n  Pair(Node, Node)\n}\n\nfn own(n: Node) -> Int {\n  match n {\n    Leaf(v) => v,\n    Pair(_, _) => 0\n  }\n}\n\nfn shape(n: Node, m: Node, flag: Bool) -> Int {\n  let k = Pair(n, m)\n  let r = if flag {\n    match k {\n      Pair(a, b) => if flag {\n        own(a)\n      } else {\n        own(b) + own(a)\n      },\n      Leaf(v) => v\n    }\n  } else {\n    own(k)\n  }\n  r + own(m)\n}\n"
+  inspect(one_line(plan_of(src)), content = "own n drop 1 ; shape m dup 1 ; shape a drop 1 ; shape b drop 1 ; shape k drop 1 ; shape m drop 1 ; Node::equals __shadow_1___b0 drop 1 ; Node::equals __b1 drop 1 ; Node::equals __shadow_0___a0 drop 1 ; Node::equals __a1 drop 1 ; Node::equals a drop 1 ; Node::equals b drop 1")
+}
+
+test "a handle whose body and arm consume different outer bindings keeps its plan" {
+  let src = "enum Node {\n  Leaf(Int);\n  Pair(Node, Node)\n}\n\nfn own(n: Node) -> Int {\n  match n {\n    Leaf(v) => v,\n    Pair(_, _) => 0\n  }\n}\n\nfn guarded(n: Node, m: Node) -> Int with Exception {\n  let k = Pair(n, m)\n  let r = handle {\n    own(k)\n  } with {\n    Exception::Throw(_) => own(m)\n  }\n  r + own(m)\n}\n"
+  inspect(one_line(plan_of(src)), content = "own n drop 1 ; guarded m dup 1 ; guarded k drop 1 ; guarded m drop 1 ; Node::equals __shadow_1___b0 drop 1 ; Node::equals __b1 drop 1 ; Node::equals __shadow_0___a0 drop 1 ; Node::equals __a1 drop 1 ; Node::equals a drop 1 ; Node::equals b drop 1")
+}


### PR DESCRIPTION
## What

Three slices of #2386 stacked on `beeab59`, each byte-identical to main on every corpus and measured on its own against the main it was written on. Each commit is one slice; the sections are in commit order.

### `3918955` — the checker builds a mismatch report's subject only when it is reported

Every caller of `check_assignable` (`checker/checker.vibe`) with a per-call subject concatenated the message first (`"argument type mismatch for " ++ label`) and handed it in, whether or not the types agreed: ~25 ms of `__rt_str_concat` under `unify_call_args` in a cold self-compile, for calls that almost always agree. `check_assignable_for` takes the head and the subject separately and joins them at the three report sites (and in `detect_narrowed_generic_mismatch`, which gets the same split); nine call sites pass the pair. The wording is unchanged.

A StringBuilder rewrite of `impl_encode_name` was part of this slice's first measurement and was dropped: it read +1.0 MB cold / +2.4 MB warm of heap for no wall change (a builder's buffer per short name costs more than the concat chain it replaced).

`lazy_mismatch_message_test.vibe` pins the argument, binding and struct-field reports as the checker renders them (and the impl-target key spelling, unchanged here); the same snapshots pass on main. Red: joining the pair in the other order renders "fargument type mismatch for :".

#### Measured (cand46)

Cache-isolated per the profiling skill, `codegen_lexer_test.vibe` over the full compiler closure, against a stage2 built from the tree of `823834c`, four interleaved pairs in alternating order (ABBA), run twice (the second on an idle machine):

| | `823834c` | `3918955` |
|---|---:|---:|
| `unify_call_args` cold inclusive | 0.03 s | 0.02 s |
| `__rt_str_concat` cold inclusive | 0.16 s | 0.15 s |
| cold wall, median of 4 (idle run) | 6.62 s | 6.64 s (noise; pairs −165, −150, +21, +126 ms) |
| warm wall, median of 4 (idle run) | 4.17 s | 4.24 s (noise) |
| heap_ptr cold / warm | 1,039,043,608 / 644,615,536 | 1,035,918,088 / 644,617,112 (−3.1 MB / +1.6 KB) |

The heap row is deterministic; the wall rows are inside the noise band, which is what ~25 ms buys on a 6.6 s compile. Byte-identical output on three closures and 22 rc fixtures.

### `e0226e2` — perceus branch snapshots of the count and emit tables live on one scratch stack

`pc_count` and `pc_emit` (`perceus/perceus.vibe`) copied their per-binding tables (`uses` and `borrows`, `remaining`) into fresh arrays for every `if`, `match` and `handle` they planned, plus a zero table per merge: ~49 ms of `__rt_arr_slice` in a cold self-compile, on both lanes, since the planner runs in codegen.

The snapshots now live on one scratch stack. A snapshot is the offset of its first slot (`pc_snap`, `pc_snap_slots`, `pc_snap_zeros`); the construct reads and writes its slots by offset, restores a prefix from them (`pc_snap_restore`) and truncates the stack back to its own first snapshot when it is done, so nested constructs stack and every slot a construct reads is below anything its children push. The per-arm restore, the max/min merges and the swap the `if` arms share are unchanged in what they read and write.

`perceus_scratch_snapshot_test.vibe` pins the rc-plan of an outer binding consumed on one path of nested `if` / `match` arms, and of a `handle` whose body and arm consume different outer bindings; the same plans come out of the array-copying planner. Red: a restore that reads one slot past its snapshot fails the nested-arms plan.

#### Measured (cand47)

Cache-isolated per the profiling skill, `codegen_lexer_test.vibe` over the full compiler closure, against a stage2 built from the tree of `9d14ff0` (the main this commit was written on), four interleaved pairs in alternating order (ABBA), idle machine:

| | `9d14ff0` | `e0226e2` |
|---|---:|---:|
| `copy_ints` cold inclusive | 0.03 s | 0 (gone) |
| `pc_snap` cold inclusive | 0 | 0.04 s |
| `__rt_arr_slice` cold inclusive | 0.08 s | 0.05 s |
| `pc_count` / `pc_emit` cold inclusive | 0.20 s / 0.12 s | 0.21 s / 0.14 s |
| cold wall, median of 4 | 6.98 s | 6.94 s (noise) |
| warm wall, median of 4 | 4.49 s | 4.49 s (noise) |
| heap_ptr cold / warm | 1,038,164,128 / 643,737,848 | 1,010,520,408 / 616,092,776 (−27.6 MB / −27.6 MB) |

The time moved from slicing into pushing (the same bytes are still copied per construct), so the wall rows do not move; what changes is where the bytes go: the stack is reused, so the planner no longer leaves a copy of its tables behind at every branch construct, and both lanes allocate 27.6 MB less (deterministic on the bump lane). Byte-identical output on three closures and 22 rc fixtures.

### `aef104a` — the unstable-import scans match token constructors instead of rendered tokens

`unstable_tokens_import_any` and `unstable_import_offset` (`runtime/typecheck_fs.vibe`) rendered every token of every file to its debug string (`token_to_string`) and compared the text to `"TImport"` / `"TIdent(pkg)"`: ~12 ms of `__rt_str_concat` in a cold self-compile on the checker lane, one allocation per token. Both scans match `TImport` followed by `TIdent(name)` on the tokens themselves; the verdicts and offsets are unchanged. `unstable_import_diagnostics_test.vibe`'s seven cases keep answering. Red: inverting the name match reports a physical import at line 0.

#### Measured (cand48)

Same protocol against the tree of `9d14ff0`:

| | `9d14ff0` | `aef104a` |
|---|---:|---:|
| `unstable_tokens_import_any` cold inclusive | 0.01 s | 0 |
| `token_to_string` cold inclusive | 0.01 s | 0 |
| cold wall, median of 4 | 6.69 s | 6.78 s (noise; pairs −136, +72, +151, −84 ms) |
| warm wall, median of 4 | 4.19 s | 4.31 s (noise) |
| heap_ptr cold / warm | 1,038,164,128 / 643,737,848 | 1,035,278,960 / 640,851,384 (−2.9 MB / −2.9 MB) |

The heap row is deterministic (one rendered string per token of every file, on both lanes); the wall rows are inside the noise band. Byte-identical output on three closures and 22 rc fixtures.

## Validation

Chain on `aef104a` (base `beeab59`; run in a staging worktree on the identical tree, tree hash `0b78e78` checked against the pushed head): bundle regen; stage2 == stage3; output equivalence; `test_cli_core.sh`; selfcompile KPI heap_ptr 967,237,496 bytes (against the shared default cache, so not comparable with the cache-isolated rows above); typing-env-reuse oracle; 233/233 affected unit-test files (import-graph selection over the changed files); `compiler_gate.sh` early / mid / late.

Each slice was also measured and byte-compared on its own before stacking (the rows above); the stack itself was chained once, on its head.

`vibe_fmt.sh --check` is a fixpoint on every changed file.

Refs #2386.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QKZdvBvHVUagwg6Yih8er8

---
_Generated by [Claude Code](https://claude.ai/code/session_01QKZdvBvHVUagwg6Yih8er8)_