### PR TITLE
One spelling of the typing fingerprint, folded over the memoized source fingerprint (#2386)

### DIFF
--- a/lib/@vibe/compiler/_selfbuild_gate_block_a.vibe
+++ b/lib/@vibe/compiler/_selfbuild_gate_block_a.vibe
@@ -15,7 +15,8 @@ import @vibe/compiler/cache {
   persistent_dep_list_cache_path,
   persistent_leaf_fingerprint_cache_path,
   persistent_module_header_cache_path,
-  persistent_type_env_cache_path
+  persistent_type_env_cache_path,
+  typing_module_fingerprint
 }
 
 import @vibe/compiler/checker {
@@ -323,15 +324,11 @@ export fn selfbuild_probe_fn_count() -> Int with Exception {
   count
 }
 
+/// The typing walk's key for a module with these dependencies
+/// (typing_module_fingerprint, the one spelling of the formula) under the
+/// default typing-semantics seed.
 fn build_type_db_fingerprint(source: String, dep_fps: Array[(String, String)]) -> String {
-  let mut acc = compact_string_fingerprint(String::concat("typing-semantics:unchecked|source:", source))
-  let mut i = 0
-  while i < Array::length(dep_fps) {
-    let (dep_path, dep_fp) = Array::get(dep_fps, i)
-    acc = compact_string_fingerprint(String::concat(acc, String::concat("|", String::concat(dep_path, String::concat("=", dep_fp)))))
-    i = i + 1
-  }
-  acc
+  typing_module_fingerprint(compact_string_fingerprint(source), dep_fps, "unchecked")
 }
 
 fn probe_lex_source_by_path(path: String) -> Int with Exception {

--- a/lib/@vibe/compiler/cache/cache_underlying.vibe
+++ b/lib/@vibe/compiler/cache/cache_underlying.vibe
@@ -230,6 +230,30 @@ export fn compact_source_fingerprint_memo_reset() -> Unit {
   }
 }
 
+/// #2386: the typing fingerprint of one module -- the key its checked
+/// environment, dep list and typed-lowering offsets are published under.
+/// Folds the module's SOURCE FINGERPRINT behind the typing-semantics seed,
+/// then each dependency's `(path, fingerprint)` in declaration order (a
+/// sequence, not a set: permuting the dependencies changes the key).
+///
+/// The formula used to be spelled in seven places -- the typing walk, the
+/// cache CLI, two selfbuild probes and three tests that locate a module's
+/// cache entries -- and every one of them concatenated the WHOLE source text
+/// behind the prefix and hashed the copy, once per module, although the
+/// text's own fingerprint is memoized per compile
+/// (compact_source_fingerprint_memo). Folding that fingerprint instead
+/// hashes a short string; the source text is hashed once per compile.
+export fn typing_module_fingerprint(source_fingerprint: String, dep_fps: Array[(String, String)], typing_semantics_seed: String) -> String {
+  let mut acc = compact_string_fingerprint(String::concat("typing-semantics:", String::concat(typing_semantics_seed, String::concat("|source-fp:", source_fingerprint))))
+  let mut i = 0
+  while i < Array::length(dep_fps) {
+    let (dep_path, dep_fp) = Array::get(dep_fps, i)
+    acc = compact_string_fingerprint(String::concat(acc, String::concat("|", String::concat(dep_path, String::concat("=", dep_fp)))))
+    i = i + 1
+  }
+  acc
+}
+
 // #1379: opt-in, compiler-owned observations for the fingerprint helper.
 // They deliberately do not overlap runner-owned host_fs_scope: these counters
 // describe String work at this one cache boundary, not host-import raw bytes.

--- a/lib/@vibe/compiler/cache/index.vpkg
+++ b/lib/@vibe/compiler/cache/index.vpkg
@@ -85,6 +85,7 @@ fn cache_fingerprint_file_fs(path: String) -> String with Fs
 fn cache_fingerprint_file_fs_with_ingestion_stamp(path: String, stamp_path: String) -> String with Fs
 fn compact_source_fingerprint_memo(path: String, source: String) -> String
 fn compact_source_fingerprint_memo_reset() -> Unit
+fn typing_module_fingerprint(source_fingerprint: String, dep_fps: Array[(String, String)], typing_semantics_seed: String) -> String
 fn compact_source_fingerprint_memo_hash_count() -> Int
 fn cache_ingestion_compact_fingerprint_is_valid(fingerprint: String) -> Bool
 fn cache_ingestion_stamp_enabled() -> Bool

--- a/lib/@vibe/compiler/cache_probe_support.vibe
+++ b/lib/@vibe/compiler/cache_probe_support.vibe
@@ -5,7 +5,8 @@ import @vibe/compiler/cache {
   persistent_dep_list_cache_path,
   persistent_leaf_fingerprint_cache_path,
   persistent_module_header_cache_path,
-  persistent_type_env_cache_path
+  persistent_type_env_cache_path,
+  typing_module_fingerprint
 }
 
 import @vibe/core {
@@ -55,17 +56,11 @@ fn remove_file_if_exists(path: String) -> Unit with Fs {
   }
 }
 
+/// The typing walk's key for a module with these dependencies
+/// (typing_module_fingerprint, the one spelling of the formula) under the
+/// default typing-semantics seed.
 fn build_type_db_fingerprint(source: String, dep_fps: Array[(String, String)]) -> String {
-  let mut acc = compact_string_fingerprint(String::concat("typing-semantics:unchecked|source:", source))
-  let mut i = 0
-  while i < Array::length(dep_fps) {
-    let dep_pair = Array::get(dep_fps, i)
-    let dep_path = dep_pair.0
-    let dep_fp = dep_pair.1
-    acc = compact_string_fingerprint(String::concat(acc, String::concat("|", String::concat(dep_path, String::concat("=", dep_fp)))))
-    i = i + 1
-  }
-  acc
+  typing_module_fingerprint(compact_string_fingerprint(source), dep_fps, "unchecked")
 }
 
 export fn selfbuild_probe_type_db_cache_counts() -> Int with Exception {

--- a/lib/@vibe/compiler/entry/cli_cache/cli_cache.vibe
+++ b/lib/@vibe/compiler/entry/cli_cache/cli_cache.vibe
@@ -13,7 +13,7 @@ import @vibe/compiler/runtime {
 }
 
 import @vibe/compiler/cache {
-  compact_string_fingerprint, persistent_dep_list_cache_path, persistent_type_env_cache_path
+  compact_string_fingerprint, persistent_dep_list_cache_path, persistent_type_env_cache_path, typing_module_fingerprint
 }
 
 //# Functions
@@ -62,17 +62,11 @@ fn remove_file_if_exists(path: String) -> Unit with Fs {
   }
 }
 
+/// The typing walk's key for a module with these dependencies
+/// (typing_module_fingerprint, the one spelling of the formula) under the
+/// default typing-semantics seed.
 fn build_type_db_fingerprint(source: String, dep_fps: Array[(String, String)]) -> String {
-  let mut acc = compact_string_fingerprint(String::concat("typing-semantics:unchecked|source:", source))
-  let mut i = 0
-  while i < Array::length(dep_fps) {
-    let dep_pair = Array::get(dep_fps, i)
-    let dep_path = dep_pair.0
-    let dep_fp = dep_pair.1
-    acc = compact_string_fingerprint(String::concat(acc, String::concat("|", String::concat(dep_path, String::concat("=", dep_fp)))))
-    i = i + 1
-  }
-  acc
+  typing_module_fingerprint(compact_string_fingerprint(source), dep_fps, "unchecked")
 }
 
 export fn parse_batch_jobs_tsv(raw: String) -> Array[(String, String, String)] with Exception {

--- a/lib/@vibe/compiler/runtime/typecheck_fs.vibe
+++ b/lib/@vibe/compiler/runtime/typecheck_fs.vibe
@@ -10,7 +10,8 @@ import @vibe/compiler/cache {
   persistent_module_typed_lowering_offsets_cache_path,
   persistent_type_env_cache_path,
   persistent_typing_dependency_env_reuse_eligibility_path,
-  persistent_typing_dependency_env_reuse_sidecar_path
+  persistent_typing_dependency_env_reuse_sidecar_path,
+  typing_module_fingerprint
 }
 
 import @vibe/core {
@@ -2307,18 +2308,13 @@ export fn projected_import_env_for_test(source: String, path: String, deps: Arra
   build_import_env(parse_program_with_path(path, source), dir_of_path(path), dep_envs)
 }
 
-fn build_fingerprint(source: String, dep_fps: Array[(String, String)], semantics_seed: String) -> String {
-  let mut acc = compact_string_fingerprint(String::concat("typing-semantics:", String::concat(semantics_seed, String::concat("|source:", source))))
-  let mut i = 0
-  while i < Array::length(dep_fps) {
-    let dep_pair = Array::get(dep_fps, i)
-    let dep_path = dep_pair.0
-    let dep_fp = dep_pair.1
-    let next = String::concat(acc, String::concat("|", String::concat(dep_path, String::concat("=", dep_fp))))
-    acc = compact_string_fingerprint(next)
-    i = i + 1
-  }
-  acc
+/// The module's typing fingerprint (typing_module_fingerprint, the one
+/// spelling of the formula) over the per-compile memo of its source
+/// fingerprint: the leaf-fingerprint probe already asked the memo for this
+/// path and text, so the text is hashed once per compile, not once more
+/// behind a prefix here.
+fn build_fingerprint(path: String, source: String, dep_fps: Array[(String, String)], semantics_seed: String) -> String {
+  typing_module_fingerprint(compact_source_fingerprint_memo(path, source), dep_fps, semantics_seed)
 }
 
 fn copy_string_array(items: Array[String]) -> Array[String] {
@@ -4963,7 +4959,7 @@ fn check_module_impl(job: ModuleJob, observe_typing_artifact: Bool) -> ModuleOut
   // handed to it -- could publish a checked environment that the serial
   // driver would never look up, which would make a parallel pre-check pass
   // silently do nothing.
-  let fingerprint = build_fingerprint(job.source, job.dep_fps, typing_semantics_seed())
+  let fingerprint = build_fingerprint(job.path, job.source, job.dep_fps, typing_semantics_seed())
   if Array::length(unresolved_imports) > 0 {
     Diagnosed(job.path, for msg in unresolved_imports {
       String::concat(String::concat(job.path, ": "), msg)
@@ -5614,9 +5610,9 @@ fn commit_leaf_fingerprint_fs(rdb: RippleDb, env_cache: Array[(String, TypeEnv)]
       incremental_typecheck_telemetry_add(7, 1)
       (leaf_fingerprint, next_db, env_cache, next_dep_source_cache, parse_count)
     } else {
-      finish_typecheck_fs_impl(rdb, env_cache, dep_source_cache, parse_count, path, source, empty_stack(), empty_dep_fps(), build_fingerprint(source, empty_dep_fps(), typing_semantics_seed()))
+      finish_typecheck_fs_impl(rdb, env_cache, dep_source_cache, parse_count, path, source, empty_stack(), empty_dep_fps(), build_fingerprint(path, source, empty_dep_fps(), typing_semantics_seed()))
     },
-    None => finish_typecheck_fs_impl(rdb, env_cache, dep_source_cache, parse_count, path, source, empty_stack(), empty_dep_fps(), build_fingerprint(source, empty_dep_fps(), typing_semantics_seed()))
+    None => finish_typecheck_fs_impl(rdb, env_cache, dep_source_cache, parse_count, path, source, empty_stack(), empty_dep_fps(), build_fingerprint(path, source, empty_dep_fps(), typing_semantics_seed()))
   }
 }
 /// One module's step, once its dependency list is known and every dependency
@@ -5639,7 +5635,7 @@ fn commit_with_deps_fs(fps: Array[(String, String)], rdb: RippleDb, env_cache: A
     }
     i = i + 1
   }
-  let fingerprint = build_fingerprint(source, dep_fps, typing_semantics_seed())
+  let fingerprint = build_fingerprint(path, source, dep_fps, typing_semantics_seed())
   match ripple_get_fingerprint(rdb, path) {
     Some(cached_fp) =>
     if cached_fp == fingerprint {

--- a/lib/@vibe/compiler/runtime/typecheck_fs.vibe
+++ b/lib/@vibe/compiler/runtime/typecheck_fs.vibe
@@ -5188,6 +5188,12 @@ fn parse_job_rows(job_text: String) -> (String, Array[String], Array[String]) wi
     (path, deps, dep_fps)
   }
 } export fn run_module_job_dir(dir: String) -> Unit with Exception + Fs {
+  // The source-text fingerprint memo spans one compile (the serial walk
+  // resets it at its start). A worker process runs one module job after
+  // another with no walk around them, so it resets the memo per job: the
+  // job's key is built through the memo like the walk's, and the memo holds
+  // this job's source, not every source the worker has ever been handed.
+  compact_source_fingerprint_memo_reset()
   let (path, deps, dep_fps) = parse_job_rows(Fs::read_file(job_dir_path(dir, "job.txt")))
   let source = Fs::read_file(job_dir_path(dir, "source.vibe"))
   let dep_envs = array_empty()

--- a/lib/@vibe/compiler/tests/persistent_cache_test.vibe
+++ b/lib/@vibe/compiler/tests/persistent_cache_test.vibe
@@ -16,7 +16,8 @@ import @vibe/compiler/cache {
   persistent_source_list_cache_path,
   persistent_type_env_cache_path,
   persistent_typing_dependency_env_reuse_eligibility_path,
-  persistent_typing_dependency_env_reuse_sidecar_path
+  persistent_typing_dependency_env_reuse_sidecar_path,
+  typing_module_fingerprint
 }
 
 import @vibe/core {
@@ -143,15 +144,11 @@ fn remove_file_if_exists(path: String) -> Unit with Fs {
   }
 }
 
+/// The typing walk's key for a module with these dependencies
+/// (typing_module_fingerprint, the one spelling of the formula) under the
+/// default typing-semantics seed.
 fn build_type_db_fingerprint(source: String, dep_fps: Array[(String, String)]) -> String {
-  let mut acc = compact_string_fingerprint(String::concat("typing-semantics:unchecked|source:", source))
-  let mut i = 0
-  while i < Array::length(dep_fps) {
-    let (dep_path, dep_fp) = Array::get(dep_fps, i)
-    acc = compact_string_fingerprint(String::concat(acc, String::concat("|", String::concat(dep_path, String::concat("=", dep_fp)))))
-    i = i + 1
-  }
-  acc
+  typing_module_fingerprint(compact_string_fingerprint(source), dep_fps, "unchecked")
 }
 
 //# Misc

--- a/lib/@vibe/compiler/tests/type_db_cross_module_test.vibe
+++ b/lib/@vibe/compiler/tests/type_db_cross_module_test.vibe
@@ -61,7 +61,8 @@ import @vibe/compiler/cache {
   persistent_dep_list_cache_path,
   persistent_leaf_fingerprint_cache_path,
   persistent_module_header_cache_path,
-  persistent_type_env_cache_path
+  persistent_type_env_cache_path,
+  typing_module_fingerprint
 }
 
 //# Functions
@@ -85,15 +86,11 @@ fn string_to_bytes(s: String) -> Bytes {
   out
 }
 
+/// The typing walk's key for a module with these dependencies
+/// (typing_module_fingerprint, the one spelling of the formula) under the
+/// default typing-semantics seed.
 fn build_test_fingerprint(source: String, dep_fps: Array[(String, String)]) -> String {
-  let mut acc = compact_string_fingerprint(String::concat("typing-semantics:unchecked|source:", source))
-  let mut i = 0
-  while i < Array::length(dep_fps) {
-    let (dep_path, dep_fp) = Array::get(dep_fps, i)
-    acc = compact_string_fingerprint(String::concat(acc, String::concat("|", String::concat(dep_path, String::concat("=", dep_fp)))))
-    i = i + 1
-  }
-  acc
+  typing_module_fingerprint(compact_string_fingerprint(source), dep_fps, "unchecked")
 }
 
 fn checked_test_env(source: String) -> TypeEnv with Exception {

--- a/lib/@vibe/compiler/tests/type_db_vpkg_types_stub_test.vibe
+++ b/lib/@vibe/compiler/tests/type_db_vpkg_types_stub_test.vibe
@@ -9,7 +9,8 @@ import @vibe/compiler/cache {
   persistent_dep_list_cache_path,
   persistent_leaf_fingerprint_cache_path,
   persistent_module_header_cache_path,
-  persistent_type_env_cache_path
+  persistent_type_env_cache_path,
+  typing_module_fingerprint
 }
 
 import @vibe/compiler/core {
@@ -45,15 +46,11 @@ fn remove_file_if_exists(path: String) -> Unit with Fs {
   }
 }
 
+/// The typing walk's key for a module with these dependencies
+/// (typing_module_fingerprint, the one spelling of the formula) under the
+/// default typing-semantics seed.
 fn build_test_fingerprint(source: String, dep_fps: Array[(String, String)]) -> String {
-  let mut acc = compact_string_fingerprint(String::concat("typing-semantics:unchecked|source:", source))
-  let mut i = 0
-  while i < Array::length(dep_fps) {
-    let (dep_path, dep_fp) = Array::get(dep_fps, i)
-    acc = compact_string_fingerprint(String::concat(acc, String::concat("|", String::concat(dep_path, String::concat("=", dep_fp)))))
-    i = i + 1
-  }
-  acc
+  typing_module_fingerprint(compact_string_fingerprint(source), dep_fps, "unchecked")
 }
 
 fn remove_typecheck_fs_cache(path: String, source: String, fingerprint: String) -> Unit with Fs {

--- a/lib/@vibe/compiler/tests/typing_module_fingerprint_test.vibe
+++ b/lib/@vibe/compiler/tests/typing_module_fingerprint_test.vibe
@@ -1,0 +1,39 @@
+//# typing_module_fingerprint: the one spelling of a module's typing key (#2386)
+//
+// The typing walk, the cache CLI, the selfbuild probes and the tests that
+// locate a module's cache entries all call this function; the snapshots below
+// pin the value so a change to the formula is a visible diff here, and the
+// existing cache tests (persistent_cache_test, type_db_vpkg_types_stub_test)
+// pin that the typing walk publishes under the same key.
+
+import @vibe/compiler/cache {
+  compact_string_fingerprint, typing_module_fingerprint
+}
+
+fn no_deps() -> Array[(String, String)] {
+  let out: Array[(String, String)] = []
+  out
+}
+
+test "a module with no dependencies folds the seed and its source fingerprint" {
+  let fp = typing_module_fingerprint(compact_string_fingerprint("let x = 1\n"), no_deps(), "unchecked")
+  inspect(fp, content = "60:941290031:854514164")
+}
+
+test "the typing-semantics seed is part of the key" {
+  let src = compact_string_fingerprint("let x = 1\n")
+  inspect(typing_module_fingerprint(src, no_deps(), "checked") != typing_module_fingerprint(src, no_deps(), "unchecked"), content = "true")
+}
+
+test "dependencies fold in declaration order, path and fingerprint alike" {
+  let src = compact_string_fingerprint("import ./a.vibe { f }\n")
+  let a = ("./a.vibe", compact_string_fingerprint("export fn f() -> Int { 1 }\n"))
+  let b = ("./b.vibe", compact_string_fingerprint("export fn g() -> Int { 2 }\n"))
+  let a2 = ("./a.vibe", compact_string_fingerprint("export fn f() -> Int { 2 }\n"))
+  let ab = typing_module_fingerprint(src, [a, b], "unchecked")
+  let ba = typing_module_fingerprint(src, [b, a], "unchecked")
+  let ab2 = typing_module_fingerprint(src, [a2, b], "unchecked")
+  inspect(ab, content = "55:1502483249:280458484")
+  inspect(ab != ba, content = "true")
+  inspect(ab != ab2, content = "true")
+}


### PR DESCRIPTION
## What

One slice of #2386, on the typing walk (the cold, first-build lane; the warm lane pays the same hash once per module too).

### The typing fingerprint has one spelling, folded over the memoized source fingerprint

`build_fingerprint` (`runtime/typecheck_fs.vibe`) is the key a module's checked environment, dep list and typed-lowering offsets are published under. It concatenated the whole source text behind `typing-semantics:<seed>|source:` and hashed the copy, once per module: ~60 ms cold / ~30 ms warm of a compiler-closure compile in `__rt_compact_fingerprint_hash`, plus ~22 ms of `__rt_str_concat` and a full copy of every source, although the text's own fingerprint is memoized per compile (`compact_source_fingerprint_memo`, #2534) and already computed for the same path by the leaf-fingerprint probe.

The same formula was spelled in six more places, each of which has to agree with the walk byte for byte to find a module's cache entries: the cache CLI (`entry/cli_cache`), the selfbuild gate block, `cache_probe_support`, and three tests.

`typing_module_fingerprint(source_fingerprint, dep_fps, seed)` in `cache/cache_underlying.vibe` is now the one spelling. It folds the source fingerprint (a short string) behind the seed, then each dependency's `(path, fingerprint)` in declaration order, as before. The walk's `build_fingerprint` takes the path and folds the memoized source fingerprint; the six copies are one-line wrappers over the shared function.

**The key's value changes.** That is a persistent-cache key change, and it is safe for the same reason every compiler change is: the cache namespace (`persistent_cache_version_tag`) embeds the compiler-source fingerprint, so entries written by an earlier compiler were never visible to this one. The `<len>:<hash>:<hash>` shape the parallel-scheduler tests assert is unchanged.

`typing_module_fingerprint_test.vibe` pins the value with inspect snapshots (no dependencies; dependencies in declaration order, path and fingerprint alike; the seed). The agreement between the walk and the shared spelling is pinned by the existing cache tests: with the walk's seed mutated to `<seed>-mutated`, `persistent_cache_test` ("fresh db reuses persistent type env cache") and `type_db_cross_module_test` ("old and malformed fs cache and leaf entries cold-recheck as v9") fail, because the tests then look under a different key than the walk publishes.

### Measured (cand49)

Cache-isolated per the profiling skill, `codegen_lexer_test.vibe` over the full compiler closure, against a stage2 built from the tree of `beeab59` (the main this commit was written on), idle machine, four interleaved pairs in alternating order (ABBA):

| | `beeab59` | cand49 |
|---|---:|---:|
| `build_fingerprint` cold inclusive | 0.08 s | 0.01 s |
| `__rt_compact_fingerprint_hash` cold inclusive | 0.22 s | 0.15 s |
| `__rt_str_concat` cold inclusive | 0.18 s | 0.17 s |
| cold wall, median of 4 | 6.65 s | 6.45 s (−3.1%; every pair faster: −166, −395, −109, −15 ms) |
| warm wall, median of 4 | 4.20 s | 4.19 s (noise) |
| heap_ptr cold / warm | 999,725,176 / 643,737,656 | 967,802,176 / 627,884,672 (−31.9 MB / −15.9 MB) |

The heap rows are deterministic: the prefixed copy of every source is gone, and the cold lane built the key more often than the warm lane (its `build_fingerprint` hash row was twice the warm lane's, 60 ms against 30 ms, and its heap moves by twice as much). The cold wall moves by about what the hash and concat rows say; the warm lane's median is inside the noise band. Byte-identical output on three closures and 22 rc fixtures.

## Validation

Chain on `54ed41d` (base `82670c8`; run in a staging worktree on the identical tree, tree hash `fd06452` checked against the pushed head): bundle regen; stage2 == stage3; output equivalence; `test_cli_core.sh`; selfcompile KPI heap_ptr 935,249,520 bytes (the merged stack's chain read 967,237,496 on the same default cache); typing-env-reuse oracle; 122/122 affected unit-test files (import-graph selection over the changed files); `compiler_gate.sh` early / mid / late.

`vibe_fmt.sh --check` is a fixpoint on every changed file.

Refs #2386.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QKZdvBvHVUagwg6Yih8er8

---
_Generated by [Claude Code](https://claude.ai/code/session_01QKZdvBvHVUagwg6Yih8er8)_