### PR TITLE
Two #2386 slices: scratch-stack expression walkers, indexed string table

### DIFF
--- a/lib/@vibe/compiler/checker/checker_effects.vibe
+++ b/lib/@vibe/compiler/checker/checker_effects.vibe
@@ -23,6 +23,7 @@ import @vibe/compiler/core {
   exception_label_kind,
   exception_throw_label_for_kind,
   expr_children,
+  expr_children_into,
   find_typedef,
   has_standard_host_provider,
   is_entry_admitted_effect,
@@ -3119,12 +3120,7 @@ fn first_expr_offset(root: Expr) -> Int {
     } else {
       ()
     }
-    let children = expr_children(expr)
-    let mut i = 0
-    while i < Array::length(children) {
-      Array::push(stack, Array::get(children, i))
-      i = i + 1
-    }
+    expr_children_into(expr, stack)
   }
   first
 }

--- a/lib/@vibe/compiler/checker/checker_spawnable.vibe
+++ b/lib/@vibe/compiler/checker/checker_spawnable.vibe
@@ -1,7 +1,21 @@
 //# Imports
 
 import @vibe/compiler/core {
-  Expr, Pat, Subst, Type, TypeDef, TypeEnv, TypeExpr, env_lookup, env_mut_escape, expr_children, subst_apply, type_to_string
+  Expr,
+  Pat,
+  Subst,
+  Type,
+  TypeDef,
+  TypeEnv,
+  TypeExpr,
+  env_lookup,
+  env_mut_escape,
+  expr_child_at,
+  expr_children_pop,
+  expr_children_push,
+  expr_children_top,
+  subst_apply,
+  type_to_string
 }
 
 import @vibe/core {
@@ -190,8 +204,15 @@ fn sp_collect_free_vars_into(expr: Expr, bound: Array[String], out: Array[String
         Array::truncate(bound, mark)
       }
     },
-    _ => for child in expr_children(expr) {
-      sp_collect_free_vars_into(child, bound, out)
+    _ => {
+      let mark = expr_children_push(expr)
+      let end = expr_children_top()
+      let mut i = mark
+      while i < end {
+        sp_collect_free_vars_into(expr_child_at(i), bound, out)
+        i = i + 1
+      }
+      expr_children_pop(mark)
     }
   }
   ()
@@ -312,8 +333,15 @@ fn sp_collect_bare_callees(expr: Expr, bound: Array[String], out: Array[String])
         Array::truncate(bound, mark)
       }
     },
-    _ => for child in expr_children(expr) {
-      sp_collect_bare_callees(child, bound, out)
+    _ => {
+      let mark = expr_children_push(expr)
+      let end = expr_children_top()
+      let mut i = mark
+      while i < end {
+        sp_collect_bare_callees(expr_child_at(i), bound, out)
+        i = i + 1
+      }
+      expr_children_pop(mark)
     }
   }
   ()

--- a/lib/@vibe/compiler/checker/checker_stmt.vibe
+++ b/lib/@vibe/compiler/checker/checker_stmt.vibe
@@ -43,7 +43,11 @@ import @vibe/compiler/core {
   env_type_defs,
   env_value_binding_with_origin,
   env_with_reexport_surface_blockers,
+  expr_child_at,
   expr_children,
+  expr_children_pop,
+  expr_children_push,
+  expr_children_top,
   find_enum_typedef,
   find_typedef,
   generalize,
@@ -4107,12 +4111,14 @@ fn tps_scan_expr(e: Expr, local_types: Array[String], where_label: String, ancho
     EFn(tparams, _, _, _, _, _) => tps_report(tparams, local_types, where_label, anchor, errors),
     _ => ()
   }
-  let kids = expr_children(e)
-  let mut i = 0
-  while i < Array::length(kids) {
-    tps_scan_expr(Array::get(kids, i), local_types, where_label, anchor, errors)
+  let mark = expr_children_push(e)
+  let end = expr_children_top()
+  let mut i = mark
+  while i < end {
+    tps_scan_expr(expr_child_at(i), local_types, where_label, anchor, errors)
     i = i + 1
   }
+  expr_children_pop(mark)
 }
 
 fn tps_decl_label(kind: String, name: String) -> String {
@@ -6359,12 +6365,14 @@ fn irc_collect_expr(e: Expr, out: Array[Int], want: Int, shims: Int) -> Unit {
     },
     _ => ()
   }
-  let kids = expr_children(e)
-  let mut i = 0
-  while i < Array::length(kids) {
-    irc_collect_expr(Array::get(kids, i), out, want, shims)
+  let mark = expr_children_push(e)
+  let end = expr_children_top()
+  let mut i = mark
+  while i < end {
+    irc_collect_expr(expr_child_at(i), out, want, shims)
     i = i + 1
   }
+  expr_children_pop(mark)
 }
 
 fn irc_collect_stmts(stmts: Array[Stmt], out: Array[Int], want: Int, shims: Int) -> Unit {

--- a/lib/@vibe/compiler/codegen/common_analysis/common_analysis.vibe
+++ b/lib/@vibe/compiler/codegen/common_analysis/common_analysis.vibe
@@ -13,7 +13,11 @@ import @vibe/compiler/core {
   builtin_value_form_arity,
   bytebuf_push,
   canonical_builtin_name,
+  expr_child_at,
   expr_children,
+  expr_children_pop,
+  expr_children_push,
+  expr_children_top,
   is_borrow_ret_builtin,
   is_exception_throw_operation,
   resolve_type_expr_core_shadowed,
@@ -572,12 +576,14 @@ fn count_typed_lowering_offsets_expr(e: Expr, counts: MutMap[Int, Int]) -> Unit 
     EDot(_, _, _, field_off) => count_one_offset(counts, field_off),
     _ => ()
   }
-  let kids = expr_children(e)
-  let mut i = 0
-  while i < Array::length(kids) {
-    count_typed_lowering_offsets_expr(Array::get(kids, i), counts)
+  let mark = expr_children_push(e)
+  let end = expr_children_top()
+  let mut i = mark
+  while i < end {
+    count_typed_lowering_offsets_expr(expr_child_at(i), counts)
     i = i + 1
   }
+  expr_children_pop(mark)
 }
 
 fn count_typed_lowering_offsets_stmts(stmts: Array[Stmt], counts: MutMap[Int, Int]) -> Unit {

--- a/lib/@vibe/compiler/codegen/common_base/common_base.vibe
+++ b/lib/@vibe/compiler/codegen/common_base/common_base.vibe
@@ -21,7 +21,7 @@ import @vibe/ast {
 }
 
 import @vibe/core {
-  array_empty
+  MutMap, array_empty
 }
 
 import @vibe/compiler/codegen/wasm_emit {
@@ -104,7 +104,75 @@ export struct FuncTable {
 export struct StrTable {
   strs: Array[String];
   offsets: Array[Int];
-  lengths: Array[Int]
+  lengths: Array[Int];
+  // #2386: string -> its FIRST slot in `strs`, built once per compile by
+  // str_table_new. str_table_index_of answers through it instead of scanning
+  // `strs` per string literal, map key and match-arm string (the scan was
+  // ~35 ms of a compiler-closure compile on either lane). A table built by
+  // str_table_lite leaves it empty and keeps the scan.
+  index: MutMap[String, Int]
+}
+
+/// A string table with its lookup index: `index` maps every string to the
+/// first slot that holds it, so a repeated string answers as the forward
+/// scan did. Build it ONCE per compile, after the last push to `strs`.
+export fn str_table_new(strs: Array[String], offsets: Array[Int], lengths: Array[Int]) -> StrTable {
+  let index = MutMap::with_capacity_string(Array::length(strs) * 2 + 16)
+  let mut i = 0
+  while i < Array::length(strs) {
+    let s = Array::get(strs, i)
+    if MutMap::has(index, s) {
+      ()
+    } else {
+      MutMap::set(index, s, i)
+    }
+    i = i + 1
+  }
+  StrTable::{
+    strs: strs,
+    offsets: offsets,
+    lengths: lengths,
+    index: index
+  }
+}
+
+/// A string table without an index: str_table_index_of scans `strs`. For
+/// the tables built per function (the gc lane) and the lite module path.
+export fn str_table_lite(strs: Array[String], offsets: Array[Int], lengths: Array[Int]) -> StrTable {
+  StrTable::{
+    strs: strs,
+    offsets: offsets,
+    lengths: lengths,
+    index: MutMap::new_string()
+  }
+}
+
+/// The slot of `s` in `st` -- the first one that holds it -- or a thrown
+/// "string not in table" (the message str_table_lookup throws).
+export fn str_table_index_of(st: StrTable, s: String) -> Int with Exception {
+  if MutMap::size(st.index) > 0 {
+    match MutMap::get(st.index, s) {
+      Some(i) => i,
+      None => throw(String::concat("string not in table: ", s))
+    }
+  } else {
+    let strs = st.strs
+    let len = Array::length(strs)
+    let mut i = 0
+    let mut found = -1
+    while i < len {
+      if String::equals(Array::get(strs, i), s) {
+        found = i
+        i = len
+      } else {
+        i = i + 1
+      }
+    }
+    if found < 0 {
+      throw(String::concat("string not in table: ", s))
+    }
+    found
+  }
 }
 
 export struct LambdaTable {

--- a/lib/@vibe/compiler/codegen/common_base/index.vpkg
+++ b/lib/@vibe/compiler/codegen/common_base/index.vpkg
@@ -153,6 +153,9 @@ fn ctor_sorted_index(names: Array[String]) -> (Array[String], Array[Int])
 fn source_declares_constructor(stmts: Array[Stmt], name: String) -> Bool
 fn append_hidden_attempt_constructors(names: Array[String], tags: Array[Int], field_counts: Array[Int], type_names: Array[String]) -> Unit
 fn ctor_table_index_of(ct: CtorTable, name: String) -> Int
+fn str_table_new(strs: Array[String], offsets: Array[Int], lengths: Array[Int]) -> StrTable
+fn str_table_lite(strs: Array[String], offsets: Array[Int], lengths: Array[Int]) -> StrTable
+fn str_table_index_of(st: StrTable, s: String) -> Int with Exception
 fn ctor_field_is_float(ctx: CompileCtx, ctor_idx: Int, field_idx: Int) -> Bool
 fn struct_field_candidates(ct: CtorTable, field: String) -> Array[(Int, Int)]
 fn struct_field_dispatch_cases(cands: Array[(Int, Int)]) -> Array[(Int, Int)]

--- a/lib/@vibe/compiler/codegen/expr/compile_call.vibe
+++ b/lib/@vibe/compiler/codegen/expr/compile_call.vibe
@@ -109,6 +109,7 @@ import @vibe/compiler/codegen/common_base {
   resolve_func,
   resolve_local,
   sized_bytes_new_expr,
+  str_table_index_of,
   struct_field_candidates,
   struct_field_dispatch_cases
 }
@@ -163,8 +164,7 @@ import @vibe/compiler/codegen/common_extractors {
   get_pint_value,
   get_pstring_value,
   get_ptuple_pats,
-  get_slet_export,
-  str_table_lookup
+  get_slet_export
 }
 
 import @vibe/compiler/codegen/wasm_emit {
@@ -3519,7 +3519,7 @@ fn compile_call_core(buf: Bytes, callee: Expr, args: Array[Expr], local_names: A
     }
     else if fname == "StringBuilder::freeze" {
       let nl = ce(buf, Array::get(args, 0), local_names, next_local, ctx, ld)
-      let empty_idx = str_table_lookup(ctx.str_table.strs, "")
+      let empty_idx = str_table_index_of(ctx.str_table, "")
       emit_str_ref(buf, Array::get(ctx.str_table.offsets, empty_idx), Array::get(ctx.str_table.lengths, empty_idx))
       let (join_idx, _, _) = resolve_func(ctx.func_table, "String::join")
       emit_call(buf, join_idx)

--- a/lib/@vibe/compiler/codegen/expr/compile_expr.vibe
+++ b/lib/@vibe/compiler/codegen/expr/compile_expr.vibe
@@ -84,7 +84,8 @@ import @vibe/compiler/codegen/common_base {
   is_pwild,
   is_slet,
   resolve_func,
-  resolve_local
+  resolve_local,
+  str_table_index_of
 }
 
 import @vibe/compiler/codegen/common_extractors {
@@ -135,8 +136,7 @@ import @vibe/compiler/codegen/common_extractors {
   get_pint_value,
   get_pstring_value,
   get_ptuple_pats,
-  get_slet_export,
-  str_table_lookup
+  get_slet_export
 }
 
 import @vibe/compiler/codegen/wasm_emit {
@@ -1010,7 +1010,7 @@ export fn compile_expr(buf: Bytes, expr: Expr, local_names: Array[String], next_
     }
   } else if __tag == 3 {
     let s = get_estring_value(expr)
-    let idx = str_table_lookup(ctx.str_table.strs, s)
+    let idx = str_table_index_of(ctx.str_table, s)
     emit_str_ref(buf, Array::get(ctx.str_table.offsets, idx), Array::get(ctx.str_table.lengths, idx))
     next_local
   } else if __tag == 4 {

--- a/lib/@vibe/compiler/codegen/expr/compile_expr_tail4.vibe
+++ b/lib/@vibe/compiler/codegen/expr/compile_expr_tail4.vibe
@@ -68,6 +68,7 @@ import @vibe/compiler/codegen/common_base {
   lookup_ctor,
   resolve_func,
   resolve_local,
+  str_table_index_of,
   struct_field_candidates,
   struct_field_dispatch_cases,
   struct_index_by_field_set,
@@ -122,8 +123,7 @@ import @vibe/compiler/codegen/common_extractors {
   get_pint_value,
   get_pstring_value,
   get_ptuple_pats,
-  get_slet_export,
-  str_table_lookup
+  get_slet_export
 }
 
 import @vibe/compiler/codegen/wasm_emit {
@@ -509,7 +509,7 @@ export fn compile_expr_tail4(buf: Bytes, expr: Expr, local_names: Array[String],
         let (key, val_expr) = Array::get(fields, mi)
         emit_local_get(buf, ptr_local)
         emit_i32_wrap_i64(buf)
-        let key_idx = str_table_lookup(ctx.str_table.strs, key)
+        let key_idx = str_table_index_of(ctx.str_table, key)
         if key_idx >= 0 {
           emit_str_ref(buf, Array::get(ctx.str_table.offsets, key_idx), Array::get(ctx.str_table.lengths, key_idx))
         } else {

--- a/lib/@vibe/compiler/codegen/expr/compile_match.vibe
+++ b/lib/@vibe/compiler/codegen/expr/compile_match.vibe
@@ -80,7 +80,8 @@ import @vibe/compiler/codegen/common_base {
   is_pwild,
   is_slet,
   resolve_func,
-  resolve_local
+  resolve_local,
+  str_table_index_of
 }
 
 import @vibe/compiler/codegen/common_extractors {
@@ -132,8 +133,7 @@ import @vibe/compiler/codegen/common_extractors {
   get_pint_value,
   get_pstring_value,
   get_ptuple_pats,
-  get_slet_export,
-  str_table_lookup
+  get_slet_export
 }
 
 import @vibe/compiler/codegen/wasm_emit {
@@ -1171,7 +1171,7 @@ export fn compile_match(buf: Bytes, expr: Expr, local_names: Array[String], next
           emit_i64_eq(buf)
         } else if is_pstring(sp) {
           let __sv = get_pstring_value(sp)
-          let __si = str_table_lookup(ctx.str_table.strs, __sv)
+          let __si = str_table_index_of(ctx.str_table, __sv)
           if __si >= 0 {
             let (__seq_fi, _, _) = resolve_func(ctx.func_table, "eq")
             load_field()
@@ -1412,7 +1412,7 @@ export fn compile_match(buf: Bytes, expr: Expr, local_names: Array[String], next
         } else {
           if is_pstring(__cond_p) {
             let sval = get_pstring_value(__cond_p)
-            let str_idx = str_table_lookup(ctx.str_table.strs, sval)
+            let str_idx = str_table_index_of(ctx.str_table, sval)
             if str_idx >= 0 {
               let (str_eq_fi, _, _) = resolve_func(ctx.func_table, "eq")
               emit_local_get(buf, scrut_local)
@@ -1537,7 +1537,7 @@ export fn compile_match(buf: Bytes, expr: Expr, local_names: Array[String], next
                   emit_i64_eq(buf)
                 },
                 PString(sv) => {
-                  let __si = str_table_lookup(ctx.str_table.strs, sv)
+                  let __si = str_table_index_of(ctx.str_table, sv)
                   if __si >= 0 {
                     let (__eqfi, _, _) = resolve_func(ctx.func_table, "eq")
                     emit_local_get(buf, scrut_local)

--- a/lib/@vibe/compiler/codegen/expr/compile_module_expr.vibe
+++ b/lib/@vibe/compiler/codegen/expr/compile_module_expr.vibe
@@ -9,7 +9,7 @@ import @vibe/compiler/core {
 }
 
 import @vibe/compiler/codegen/common_base {
-  CompileCtx, CtorTable, FuncTable, LambdaTable, StrTable, cov_disabled, linemap_disabled
+  CompileCtx, CtorTable, FuncTable, LambdaTable, cov_disabled, linemap_disabled, str_table_lite
 }
 
 import @vibe/compiler/codegen/wasm_emit {
@@ -174,11 +174,7 @@ export fn compile_module_expr_with_typed_offsets(stmts: Array[Stmt], checker_flo
       meta_i32: fresh_int_array(),
       meta_i64: fresh_int_array()
     }
-    let empty_str_table = StrTable::{
-      strs: fresh_string_array(),
-      offsets: fresh_int_array(),
-      lengths: fresh_int_array()
-    }
+    let empty_str_table = str_table_lite(fresh_string_array(), fresh_int_array(), fresh_int_array())
     let empty_ctor_table = CtorTable::{
       names: fresh_string_array(),
       tags: fresh_int_array(),

--- a/lib/@vibe/compiler/codegen/gc/backend_body.vibe
+++ b/lib/@vibe/compiler/codegen/gc/backend_body.vibe
@@ -40,7 +40,6 @@ import @vibe/compiler/codegen/common_base {
   CtorTable,
   FuncTable,
   LambdaTable,
-  StrTable,
   agg_info_of_type_expr,
   append_hidden_attempt_constructors,
   codegen_unresolved_name_prefix,
@@ -70,12 +69,13 @@ import @vibe/compiler/codegen/common_base {
   resolve_local,
   rewrite_self_tail_calls,
   source_declares_constructor,
+  str_table_lite,
   ty_head_names_formal,
   wrap_entry_exception_boundary
 }
 
 import @vibe/compiler/codegen/common_extractors {
-  array_contains_str, emit_assignop_op, emit_memory_copy, find_catchall_idx, str_table_lookup
+  array_contains_str, emit_assignop_op, emit_memory_copy, find_catchall_idx
 }
 
 import @vibe/compiler/codegen/wasm_emit {
@@ -2492,11 +2492,7 @@ fn compile_wasi_module_gc_impl(stmts: Array[Stmt], entry_name: String, generated
             names_sorted: array_empty(),
             names_sorted_pos: array_empty()
           }
-          let st = StrTable::{
-            strs: str_strs,
-            offsets: str_offsets,
-            lengths: str_lengths
-          }
+          let st = str_table_lite(str_strs, str_offsets, str_lengths)
           let ct = CtorTable::{
             names: ctor_names_list,
             tags: ctor_tags_list,
@@ -2604,11 +2600,7 @@ fn compile_wasi_module_gc_impl(stmts: Array[Stmt], entry_name: String, generated
         names_sorted: array_empty(),
         names_sorted_pos: array_empty()
       },
-      str_table: StrTable::{
-        strs: str_strs,
-        offsets: str_offsets,
-        lengths: str_lengths
-      },
+      str_table: str_table_lite(str_strs, str_offsets, str_lengths),
       lambda_table: lt_w,
       num_user_funcs: num_user_funcs,
       func_offset: func_offset,

--- a/lib/@vibe/compiler/codegen/gc/backend_call.vibe
+++ b/lib/@vibe/compiler/codegen/gc/backend_call.vibe
@@ -77,6 +77,7 @@ import @vibe/compiler/codegen/common_base {
   resolve_func,
   resolve_local,
   sized_bytes_new_expr,
+  str_table_index_of,
   struct_field_candidates,
   struct_field_dispatch_cases
 }
@@ -90,8 +91,7 @@ import @vibe/compiler/codegen/common_extractors {
   get_ecall_args,
   get_ecall_callee,
   get_eident_name,
-  get_estring_value,
-  str_table_lookup
+  get_estring_value
 }
 
 import @vibe/compiler/codegen/wasm_emit {
@@ -3467,7 +3467,7 @@ fn compile_call_gc(buf: Bytes, callee: Expr, args: Array[Expr], local_names: Arr
       }
       else if fname == "StringBuilder::freeze" {
         let nl = ce(buf, Array::get(args, 0), local_names, next_local, ld)
-        let empty_idx = str_table_lookup(ctx.str_table.strs, "")
+        let empty_idx = str_table_index_of(ctx.str_table, "")
         emit_str_ref(buf, Array::get(ctx.str_table.offsets, empty_idx), Array::get(ctx.str_table.lengths, empty_idx))
         let (join_idx, _, _) = resolve_func(ctx.func_table, "String::join")
         emit_call_resolved(buf, ctx, join_idx)
@@ -3480,7 +3480,7 @@ fn compile_call_gc(buf: Bytes, callee: Expr, args: Array[Expr], local_names: Arr
         let nl = ce(buf, Array::get(args, 0), local_names, next_local, ld)
         emit_call_resolved(buf, ctx, ts_idx)
         if fname == "println" {
-          let nl_idx = str_table_lookup(ctx.str_table.strs, "\n")
+          let nl_idx = str_table_index_of(ctx.str_table, "\n")
           emit_str_ref(buf, Array::get(ctx.str_table.offsets, nl_idx), Array::get(ctx.str_table.lengths, nl_idx))
           let (cat_idx, _, _) = resolve_func(ctx.func_table, "String::concat")
           emit_call_resolved(buf, ctx, cat_idx)

--- a/lib/@vibe/compiler/codegen/gc/backend_expr.vibe
+++ b/lib/@vibe/compiler/codegen/gc/backend_expr.vibe
@@ -63,6 +63,7 @@ import @vibe/compiler/codegen/common_base {
   gc_slot_map_set,
   resolve_func,
   resolve_local,
+  str_table_index_of,
   struct_field_candidates,
   struct_field_dispatch_cases,
   struct_index_by_field_set,
@@ -70,7 +71,7 @@ import @vibe/compiler/codegen/common_base {
 }
 
 import @vibe/compiler/codegen/common_extractors {
-  array_contains_int, array_contains_str, emit_assignop_op, emit_memory_copy, find_catchall_idx, str_table_lookup
+  array_contains_int, array_contains_str, emit_assignop_op, emit_memory_copy, find_catchall_idx
 }
 
 import @vibe/compiler/codegen/wasm_emit {
@@ -1341,7 +1342,7 @@ fn compile_expr_gc(buf: Bytes, expr: Expr, local_names: Array[String], next_loca
       next_local
     },
     EString(s) => {
-      let idx = str_table_lookup(ctx.str_table.strs, s)
+      let idx = str_table_index_of(ctx.str_table, s)
       emit_str_ref(buf, Array::get(ctx.str_table.offsets, idx), Array::get(ctx.str_table.lengths, idx))
       next_local
     },
@@ -1429,7 +1430,7 @@ fn compile_expr_gc(buf: Bytes, expr: Expr, local_names: Array[String], next_loca
           if const_i >= 0 {
             if Array::get(ctx.gc_const_kinds, const_i) == 1 {
               let cs = Array::get(ctx.gc_const_svals, const_i)
-              let csi = str_table_lookup(ctx.str_table.strs, cs)
+              let csi = str_table_index_of(ctx.str_table, cs)
               emit_str_ref(buf, Array::get(ctx.str_table.offsets, csi), Array::get(ctx.str_table.lengths, csi))
             } else {
               emit_i64_const(buf, Array::get(ctx.gc_const_ivals, const_i))
@@ -2604,7 +2605,7 @@ fn compile_expr_gc(buf: Bytes, expr: Expr, local_names: Array[String], next_loca
       let mut mi = 0
       while mi < mflen {
         let (mkey, mval) = Array::get(mfields, mi)
-        let mk_idx = str_table_lookup(ctx.str_table.strs, mkey)
+        let mk_idx = str_table_index_of(ctx.str_table, mkey)
         emit_local_get(buf, mptr)
         emit_i32_wrap_i64(buf)
         emit_str_ref(buf, Array::get(ctx.str_table.offsets, mk_idx), Array::get(ctx.str_table.lengths, mk_idx))

--- a/lib/@vibe/compiler/codegen/gc/backend_match.vibe
+++ b/lib/@vibe/compiler/codegen/gc/backend_match.vibe
@@ -45,11 +45,12 @@ import @vibe/compiler/codegen/common_base {
   gc_slot_log_reset_above,
   gc_slot_map_reset_above,
   resolve_func,
-  resolve_local
+  resolve_local,
+  str_table_index_of
 }
 
 import @vibe/compiler/codegen/common_extractors {
-  array_contains_str, emit_assignop_op, emit_memory_copy, find_catchall_idx, str_table_lookup
+  array_contains_str, emit_assignop_op, emit_memory_copy, find_catchall_idx
 }
 
 import @vibe/compiler/codegen/wasm_emit {
@@ -373,7 +374,7 @@ fn emit_gc_pat_test(buf: Bytes, local_names: Array[String], vloc: Int, pat: Pat,
       emit_i64_eq(buf)
     },
     PString(sval) => {
-      let str_idx = str_table_lookup(ctx.str_table.strs, sval)
+      let str_idx = str_table_index_of(ctx.str_table, sval)
       if str_idx >= 0 {
         let (streq_idx, _, _) = resolve_func(ctx.func_table, "String::equals")
         emit_local_get(buf, vloc)

--- a/lib/@vibe/compiler/codegen/wasi/linked_compile.vibe
+++ b/lib/@vibe/compiler/codegen/wasi/linked_compile.vibe
@@ -16,7 +16,10 @@ import @vibe/compiler/core {
   bytebuf_to_bytes,
   dce_stmts,
   exception_effect_labels_equal,
-  expr_children,
+  expr_child_at,
+  expr_children_pop,
+  expr_children_push,
+  expr_children_top,
   is_exception_effect_name,
   leb128_encode_s64,
   leb128_encode_u32,
@@ -889,13 +892,15 @@ fn lc_validate_stdin_provider_expr(expr: Expr) -> String {
       }
       err
     } else {
-      let children = expr_children(expr)
-      let mut i = 0
+      let mark = expr_children_push(expr)
+      let end = expr_children_top()
+      let mut i = mark
       let mut err = ""
-      while i < Array::length(children) && err == "" {
-        err = lc_validate_stdin_provider_expr(Array::get(children, i))
+      while i < end && err == "" {
+        err = lc_validate_stdin_provider_expr(expr_child_at(i))
         i = i + 1
       }
+      expr_children_pop(mark)
       err
     },
     EIdent(name, _) => if lc_is_stdin_provider_surface(name) {
@@ -904,13 +909,15 @@ fn lc_validate_stdin_provider_expr(expr: Expr) -> String {
       ""
     },
     _ => {
-      let children = expr_children(expr)
-      let mut i = 0
+      let mark = expr_children_push(expr)
+      let end = expr_children_top()
+      let mut i = mark
       let mut err = ""
-      while i < Array::length(children) && err == "" {
-        err = lc_validate_stdin_provider_expr(Array::get(children, i))
+      while i < end && err == "" {
+        err = lc_validate_stdin_provider_expr(expr_child_at(i))
         i = i + 1
       }
+      expr_children_pop(mark)
       err
     }
   }

--- a/lib/@vibe/compiler/codegen/wasi/linked_compile.vibe
+++ b/lib/@vibe/compiler/codegen/wasi/linked_compile.vibe
@@ -165,7 +165,6 @@ import @vibe/compiler/codegen/common_base {
   FuncTable,
   LambdaTable,
   LineMapState,
-  StrTable,
   agg_info_of_type_expr,
   append_hidden_attempt_constructors,
   await_poll_pass,
@@ -234,6 +233,8 @@ import @vibe/compiler/codegen/common_base {
   resolve_local,
   rewrite_self_tail_calls,
   source_declares_constructor,
+  str_table_index_of,
+  str_table_new,
   suspend_cps_pass,
   ty_head_names_formal,
   wrap_entry_exception_boundary
@@ -289,8 +290,7 @@ import @vibe/compiler/codegen/common_extractors {
   get_pint_value,
   get_pstring_value,
   get_ptuple_pats,
-  get_slet_export,
-  str_table_lookup
+  get_slet_export
 }
 
 import @vibe/compiler/codegen/expr {
@@ -5214,6 +5214,9 @@ export fn compile_wasi_module_linked_impl_with_typed_offsets(stmts: Array[Stmt],
     si = si + 1
   }
   let heap_start = ((str_pos + 7) / 8) * 8
+  // #2386: the string table and its index, built once here after the last
+  // push to str_strs and shared by every per-function CompileCtx below.
+  let str_table_shared = str_table_new(str_strs, str_offsets, str_lengths)
   let effect_names_list = lc_fresh_string_array()
   let effect_op_keys_list = lc_fresh_string_array()
   let effect_op_arities_list = array_empty()
@@ -7003,7 +7006,7 @@ export fn compile_wasi_module_linked_impl_with_typed_offsets(stmts: Array[Stmt],
   // operand guard needs one of these fragments; moving the PUSH instead
   // would reorder the builtins and shift every function index.
   let oob_fat_of: (String) -> Int = (frag) -> {
-    let fi = str_table_lookup(str_strs, frag)
+    let fi = str_table_index_of(str_table_shared, frag)
     (Array::get(str_offsets, fi)<<32)|Array::get(str_lengths, fi)
   }
   push_builtin(gen_str_concat_body(rc_shadow, str_operand_abort_idx, if rc_shadow {
@@ -7682,11 +7685,7 @@ export fn compile_wasi_module_linked_impl_with_typed_offsets(stmts: Array[Stmt],
             names_sorted: all_fn_names_sorted,
             names_sorted_pos: all_fn_names_sorted_pos
           },
-          str_table: StrTable::{
-            strs: str_strs,
-            offsets: str_offsets,
-            lengths: str_lengths
-          },
+          str_table: str_table_shared,
           lambda_table: lt_w,
           num_user_funcs: num_user_funcs,
           lambda_slot_base: lambda_slot_base,

--- a/lib/@vibe/compiler/core/expr_children.vibe
+++ b/lib/@vibe/compiler/core/expr_children.vibe
@@ -96,6 +96,49 @@ export fn expr_children(expr: Expr) -> Array[Expr] {
 
 fn expr_children_built(expr: Expr) -> Array[Expr] {
   let children = array_empty()
+  expr_children_into(expr, children)
+  children
+}
+
+/// #2386: the walkers' scratch stack. A walker that only VISITS children
+/// used to take `expr_children` -- a fresh array per interior node, filled
+/// by pushes -- and read it once: some 250 ms of `__rt_arr_new` /
+/// `__rt_arr_push` in a cold compiler-closure compile across a dozen
+/// walkers, on both lanes. Its children now go onto this one stack instead:
+/// `expr_children_push` appends them and answers the MARK of the first;
+/// they sit in `[mark, expr_children_top())`, read by `expr_child_at`, and
+/// `expr_children_pop(mark)` truncates back when the walker is done with
+/// them. Nested pushes (a walker recursing on a child, or calling another
+/// walker) land ABOVE the window and are popped before the walker reads its
+/// next slot, so the window stays valid; the discipline is LIFO, the same
+/// as the perceus planner's snapshot stack.
+let expr_child_scratch: Array[Expr] = []
+
+/// Push `expr`'s children onto the scratch stack; the mark of the first.
+export fn expr_children_push(expr: Expr) -> Int {
+  let mark = Array::length(expr_child_scratch)
+  expr_children_into(expr, expr_child_scratch)
+  mark
+}
+
+/// One past the last slot the latest push filled.
+export fn expr_children_top() -> Int {
+  Array::length(expr_child_scratch)
+}
+
+export fn expr_child_at(i: Int) -> Expr {
+  Array::get(expr_child_scratch, i)
+}
+
+/// Release every slot from `mark` up.
+export fn expr_children_pop(mark: Int) -> Unit {
+  Array::truncate(expr_child_scratch, mark)
+}
+
+/// Append `expr`'s immediate children to `out`, in the order
+/// `expr_children` lists them.
+export fn expr_children_into(expr: Expr, out: Array[Expr]) -> Unit {
+  let children = out
   match expr {
     ETuple(elems) => append_exprs(children, elems),
     EArray(elems) => append_exprs(children, elems),
@@ -153,7 +196,6 @@ fn expr_children_built(expr: Expr) -> Array[Expr] {
     EStringInterp(_) => (),
     EUnit => ()
   }
-  children
 }
 
 fn append_pair(dst: Array[Expr], first: Expr, second: Expr) -> Unit {

--- a/lib/@vibe/compiler/core/index.vpkg
+++ b/lib/@vibe/compiler/core/index.vpkg
@@ -121,6 +121,11 @@ type EnvValueBinding
 
 // --- expr_children
 fn expr_children(expr: Expr) -> Array[Expr]
+fn expr_children_into(expr: Expr, out: Array[Expr]) -> Unit
+fn expr_children_push(expr: Expr) -> Int
+fn expr_children_top() -> Int
+fn expr_child_at(i: Int) -> Expr
+fn expr_children_pop(mark: Int) -> Unit
 fn typed_lowering_arg_offset(expr: Expr) -> Int
 fn typed_lowering_float_key(expr: Expr) -> Int
 

--- a/lib/@vibe/compiler/normalize/desugar_trait_dict.vibe
+++ b/lib/@vibe/compiler/normalize/desugar_trait_dict.vibe
@@ -12,7 +12,11 @@ import @vibe/compiler/core {
   builtin_iterator_namespace_from_marker,
   builtin_iterator_namespace_markers,
   builtin_iterator_serialized_boundary_markers,
+  expr_child_at,
   expr_children,
+  expr_children_pop,
+  expr_children_push,
+  expr_children_top,
   is_exception_effect_name,
   is_exception_throw_operation,
   namespace_rename_original,
@@ -6385,12 +6389,14 @@ fn collect_push_elem_shapes(name: String, e: Expr, struct_sets: Array[(String, A
       collect_push_elem_shapes_in_arms(name, arms, struct_sets, var_types, fn_returns, out)
     },
     _ => {
-      let kids = expr_children(e)
-      let mut i = 0
-      while i < Array::length(kids) {
-        collect_push_elem_shapes(name, Array::get(kids, i), struct_sets, var_types, fn_returns, out)
+      let mark = expr_children_push(e)
+      let end = expr_children_top()
+      let mut i = mark
+      while i < end {
+        collect_push_elem_shapes(name, expr_child_at(i), struct_sets, var_types, fn_returns, out)
         i = i + 1
       }
+      expr_children_pop(mark)
     }
   }
 }
@@ -8149,17 +8155,19 @@ fn expr_uses_constructor_witness(expr: Expr, gens: Array[DictGen]) -> Bool {
     },
     _ => false
   }
-  let children = expr_children(expr)
-  let mut i = 0
+  let mark = expr_children_push(expr)
+  let end = expr_children_top()
+  let mut i = mark
   let mut found = here
-  while i < Array::length(children) {
-    if expr_uses_constructor_witness(Array::get(children, i), gens) {
+  while i < end {
+    if expr_uses_constructor_witness(expr_child_at(i), gens) {
       found = true
     } else {
       ()
     }
     i = i + 1
   }
+  expr_children_pop(mark)
   found
 }
 
@@ -9263,12 +9271,14 @@ fn collect_expr_binders(e: Expr, out: Array[String]) -> Unit {
     EHandle(_, arms) => collect_arm_binders(arms, out),
     _ => ()
   }
-  let kids = expr_children(e)
-  let mut i = 0
-  while i < Array::length(kids) {
-    collect_expr_binders(Array::get(kids, i), out)
+  let mark = expr_children_push(e)
+  let end = expr_children_top()
+  let mut i = mark
+  while i < end {
+    collect_expr_binders(expr_child_at(i), out)
     i = i + 1
   }
+  expr_children_pop(mark)
 }
 
 fn collect_local_binder_names(stmts: Array[Stmt]) -> Array[String] {
@@ -11552,12 +11562,14 @@ fn collect_expr_type_param_names(e: Expr, acc: Array[String]) -> Unit {
     EFn(tparams, _, _, _, _, _) => push_names_once(acc, tparams),
     _ => ()
   }
-  let kids = expr_children(e)
-  let mut i = 0
-  while i < Array::length(kids) {
-    collect_expr_type_param_names(Array::get(kids, i), acc)
+  let mark = expr_children_push(e)
+  let end = expr_children_top()
+  let mut i = mark
+  while i < end {
+    collect_expr_type_param_names(expr_child_at(i), acc)
     i = i + 1
   }
+  expr_children_pop(mark)
 }
 
 /// Fill `dtd_type_param_names` with every type-parameter name this program

--- a/lib/@vibe/compiler/normalize/unbox_tuple_loop.vibe
+++ b/lib/@vibe/compiler/normalize/unbox_tuple_loop.vibe
@@ -47,7 +47,7 @@
 //# Imports
 
 import @vibe/compiler/core {
-  Expr, Pat, Stmt, expr_children
+  Expr, Pat, Stmt, expr_child_at, expr_children_pop, expr_children_push, expr_children_top
 }
 
 import @vibe/core {
@@ -991,17 +991,19 @@ fn has_unbox_tuple_candidate_expr(e: Expr) -> Bool {
       has_unbox_tuple_candidate_expr(init) || has_unbox_tuple_candidate_expr(body)
     },
     _ => {
-      let kids = expr_children(e)
-      let mut i = 0
+      let mark = expr_children_push(e)
+      let end = expr_children_top()
+      let mut i = mark
       let mut hit = false
-      while i < Array::length(kids) && !hit {
-        if has_unbox_tuple_candidate_expr(Array::get(kids, i)) {
+      while i < end && !hit {
+        if has_unbox_tuple_candidate_expr(expr_child_at(i)) {
           hit = true
         } else {
           ()
         }
         i = i + 1
       }
+      expr_children_pop(mark)
       hit
     }
   }

--- a/lib/@vibe/compiler/perceus/perceus.vibe
+++ b/lib/@vibe/compiler/perceus/perceus.vibe
@@ -9,7 +9,19 @@ import @vibe/core {
 }
 
 import @vibe/compiler/core {
-  Expr, Pat, Stmt, TypeExpr, borrow_ret_builtin_names, bsearch_leftmost, expr_children, is_exception_throw_operation, sorted_names_of
+  Expr,
+  Pat,
+  Stmt,
+  TypeExpr,
+  borrow_ret_builtin_names,
+  bsearch_leftmost,
+  expr_child_at,
+  expr_children,
+  expr_children_pop,
+  expr_children_push,
+  expr_children_top,
+  is_exception_throw_operation,
+  sorted_names_of
 }
 
 //# Types
@@ -2965,13 +2977,15 @@ fn reuse_ident_occurrences(e: Expr, name: String) -> Int {
       0
     },
     _ => {
-      let kids = expr_children(e)
+      let mark = expr_children_push(e)
+      let end = expr_children_top()
       let mut acc = 0
-      let mut i = 0
-      while i < Array::length(kids) {
-        acc = acc + reuse_ident_occurrences(Array::get(kids, i), name)
+      let mut i = mark
+      while i < end {
+        acc = acc + reuse_ident_occurrences(expr_child_at(i), name)
         i = i + 1
       }
+      expr_children_pop(mark)
       acc
     }
   }
@@ -3082,20 +3096,24 @@ fn plan_reuse_pairs_walk(e: Expr, drop_names: Array[String], alias_names: Array[
         },
         _ => ()
       }
-      let kids = expr_children(e)
-      let mut i = 0
-      while i < Array::length(kids) {
-        plan_reuse_pairs_walk(Array::get(kids, i), drop_names, alias_names, actions, borrow_param_fns, borrow_param_masks)
+      let mark = expr_children_push(e)
+      let end = expr_children_top()
+      let mut i = mark
+      while i < end {
+        plan_reuse_pairs_walk(expr_child_at(i), drop_names, alias_names, actions, borrow_param_fns, borrow_param_masks)
         i = i + 1
       }
+      expr_children_pop(mark)
     },
     _ => {
-      let kids = expr_children(e)
-      let mut i = 0
-      while i < Array::length(kids) {
-        plan_reuse_pairs_walk(Array::get(kids, i), drop_names, alias_names, actions, borrow_param_fns, borrow_param_masks)
+      let mark = expr_children_push(e)
+      let end = expr_children_top()
+      let mut i = mark
+      while i < end {
+        plan_reuse_pairs_walk(expr_child_at(i), drop_names, alias_names, actions, borrow_param_fns, borrow_param_masks)
         i = i + 1
       }
+      expr_children_pop(mark)
     }
   }
 }

--- a/lib/@vibe/compiler/tests/expr_children_scratch_test.vibe
+++ b/lib/@vibe/compiler/tests/expr_children_scratch_test.vibe
@@ -1,0 +1,99 @@
+//# expr_children_push / expr_child_at / expr_children_pop: the walkers' scratch stack (#2386)
+//
+// A walker reads its children from the window `[mark, top)` the push
+// answers; nested pushes land above it and are popped before the walker
+// reads its next slot. The snapshots pin the visiting order (the same as
+// `expr_children`), the node counts through a nested walk, and that the
+// stack is balanced afterwards.
+
+import @vibe/ast {
+  Expr, Pat
+}
+import @vibe/compiler/core {
+  expr_child_at, expr_children, expr_children_into, expr_children_pop, expr_children_push, expr_children_top
+}
+
+fn count_nodes(e: Expr) -> Int {
+  let mark = expr_children_push(e)
+  let end = expr_children_top()
+  let mut total = 1
+  let mut i = mark
+  while i < end {
+    total = total + count_nodes(expr_child_at(i))
+    i = i + 1
+  }
+  expr_children_pop(mark)
+  total
+}
+
+/// Calls another walker on every child from INSIDE its own loop (a nested
+/// push over the window), then recurses: the sum of every subtree's size.
+fn nested_sizes(e: Expr) -> Int {
+  let mark = expr_children_push(e)
+  let end = expr_children_top()
+  let mut total = count_nodes(e)
+  let mut i = mark
+  while i < end {
+    let child = expr_child_at(i)
+    total = total + nested_sizes(child)
+    i = i + 1
+  }
+  expr_children_pop(mark)
+  total
+}
+
+fn ident_names(kids: Array[Expr]) -> String {
+  let names: Array[String] = []
+  let mut i = 0
+  while i < Array::length(kids) {
+    match Array::get(kids, i) {
+      EIdent(n, _) => Array::push(names, n),
+      _ => Array::push(names, "?")
+    }
+    i = i + 1
+  }
+  String::join(names, ",")
+}
+
+fn sample() -> Expr {
+  ECall(EIdent("f", 0), [EInt(1), ECall(EIdent("g", 1), [EInt(2), EInt(3)], 1)], 0)
+}
+
+test "a walker over the scratch stack counts every node and leaves the stack balanced" {
+  let before = expr_children_top()
+  inspect(count_nodes(sample()), content = "7")
+  inspect(expr_children_top() == before, content = "true")
+}
+
+test "a nested walker inside the loop does not disturb the outer window" {
+  let before = expr_children_top()
+  inspect(nested_sizes(sample()), content = "16")
+  inspect(expr_children_top() == before, content = "true")
+}
+
+test "expr_children_into lists the children in expr_children's order" {
+  let e = EIf(EIdent("c", 0), EIdent("t", 1), EIdent("e", 2))
+  let l = ELet("x", EIdent("v", 0), EIdent("b", 1), 0)
+  let m = EMatch(EIdent("s", 0), [
+    (PBind("p"), EIdent("a1", 1)),
+    (PWild, EIdent("a2", 2))
+  ])
+  let via_into: Array[Expr] = []
+  expr_children_into(e, via_into)
+  expr_children_into(l, via_into)
+  expr_children_into(m, via_into)
+  let via_list: Array[Expr] = []
+  let mut k = 0
+  let shapes = [e, l, m]
+  while k < Array::length(shapes) {
+    let kids = expr_children(Array::get(shapes, k))
+    let mut i = 0
+    while i < Array::length(kids) {
+      Array::push(via_list, Array::get(kids, i))
+      i = i + 1
+    }
+    k = k + 1
+  }
+  inspect(ident_names(via_into), content = "c,t,e,v,b,s,a1,a2")
+  inspect(ident_names(via_into) == ident_names(via_list), content = "true")
+}

--- a/lib/@vibe/compiler/tests/str_table_index_test.vibe
+++ b/lib/@vibe/compiler/tests/str_table_index_test.vibe
@@ -1,0 +1,46 @@
+//# str_table_index_of: the string table answers through its index (#2386)
+//
+// `str_table_new` builds the string -> first-slot index once; a table from
+// `str_table_lite` has no index and scans. Both answer the slot the forward
+// scan found (the FIRST of a repeated string) and throw the same message for
+// a string the table does not hold.
+
+import @vibe/compiler/codegen/common_base {
+  StrTable, str_table_index_of, str_table_lite, str_table_new
+}
+
+fn probe(st: StrTable, s: String) -> String {
+  handle {
+    __to_string(str_table_index_of(st, s))
+  } with { Exception::Throw(m) => String::concat("throw: ", m) }
+}
+
+fn strs() -> Array[String] {
+  ["", "a", "b", "a", "c"]
+}
+
+fn offsets() -> Array[Int] {
+  [64, 64, 65, 66, 67]
+}
+
+fn lengths() -> Array[Int] {
+  [0, 1, 1, 1, 1]
+}
+
+fn probes(st: StrTable) -> String {
+  String::join([
+    probe(st, ""),
+    probe(st, "a"),
+    probe(st, "b"),
+    probe(st, "c"),
+    probe(st, "zz")
+  ], " ")
+}
+
+test "the indexed table answers the first slot of a repeated string and throws for a missing one" {
+  inspect(probes(str_table_new(strs(), offsets(), lengths())), content = "0 1 2 4 throw: string not in table: zz")
+}
+
+test "a table without an index scans and answers the same" {
+  inspect(probes(str_table_lite(strs(), offsets(), lengths())), content = "0 1 2 4 throw: string not in table: zz")
+}


### PR DESCRIPTION
## What

Two slices of #2386 stacked on `567dd7b`, both byte-identical to main on every corpus and each measured against the tree it was written on. Each commit is one slice; the sections are in commit order.

### `9393b5d` — expression walkers read children from a scratch stack

`expr_children` (`core/expr_children.vibe`) answers a node's immediate children as an array: a fresh one per interior node, filled by pushes. Twelve walkers took it and read it once, on both lanes: the checker's render-argument collector and type-param scan, the trait-dict desugar's binder, type-param and push-shape collectors and its constructor-witness scan, the perceus reuse planner and its identifier count, the typed-lowering offset census, the stdin-provider validator, the unbox-tuple candidate scan, the spawnable checker's free-variable and bare-callee collectors, and the effect pass's first-offset walk. Measured on the tree of `beeab59`, that was ~245 ms of `expr_children` inclusive in a cold compiler-closure compile (~117 ms warm), nearly all of it `__rt_arr_new` / `__rt_arr_push`.

`expr_children_into(expr, out)` appends the children to a caller-owned array, and a scratch stack in `expr_children.vibe` carries them for the walkers: `expr_children_push(e)` appends `e`'s children and answers the mark of the first; the walker reads `[mark, expr_children_top())` through `expr_child_at`; `expr_children_pop(mark)` releases them. Nested pushes (the walker recursing on a child, or calling another walker from inside its loop) land above the window and are popped before the next slot is read, so the discipline is LIFO, the same as the perceus planner's snapshot stack (#2541). Children are visited in `expr_children`'s order, so every walker answers as before; `first_expr_offset` keeps its explicit stack and appends through `expr_children_into`. `expr_children` itself stays for the readers that keep the list.

`expr_children_scratch_test.vibe` pins a node count through the stack, a nested walk from inside the loop, that the stack is balanced afterwards, and that `expr_children_into` lists children in `expr_children`'s order. Red: a push that answers one past the first child counts 5 nodes of 7.

### Measured (cand50)

Cache-isolated per the profiling skill, `codegen_lexer_test.vibe` over the full compiler closure, against a stage2 built from the tree of `54ed41d` (#2542's head, the commit this one is stacked on), four interleaved pairs in alternating order (ABBA):

| | `54ed41d` | cand50 |
|---|---:|---:|
| `expr_children*` cold inclusive | 0.29 s | 0.19 s (the readers that keep the list, plus the stack's own frames) |
| `__rt_arr_push` cold inclusive | 0.55 s | 0.39 s |
| `__rt_arr_new` cold inclusive | 0.27 s | 0.22 s |
| cold wall, median of 4 | 6.51 s | 6.47 s (noise) |
| warm wall, median of 4 | 4.17 s | 4.09 s (−1.9%; pairs −346, +11, −56, −49 ms) |
| heap_ptr cold / warm | 934,142,208 / 597,352,856 | 870,002,576 / 557,020,568 (−64.1 MB / −40.3 MB) |

The heap rows are deterministic: one array per interior node per walk is gone, on both lanes. The wall rows are at the edge of the noise band (one pair of the four overlapped a commit hook on this machine). Byte-identical output on three closures and 22 rc fixtures.

### `22b6a99` — the string table answers lookups through an index built once per compile

`str_table_lookup` (`common_extractors`) scanned the whole string table, the program's literals, map keys and interpolation parts plus the seeded runtime fragments, once per string literal, map key and match-arm string it compiled, comparing strings as it went: ~35 ms of `String::equals` in a compiler-closure compile on either lane, all of it under `compile_expr` and `compile_match`.

`StrTable` carries `index`, string to first slot. `str_table_new` builds it once, after the linked lane's last push to the table, and every per-function `CompileCtx` shares the one table (the OOB-fragment constants read it too). `str_table_index_of(st, s)` answers through the index and throws the same "string not in table" for a string the table does not hold; a table from `str_table_lite` (the gc lane's per-function tables, the lite module path) has no index and keeps the scan. A repeated string answers its first slot, as the scan did. The thirteen call sites that passed `ctx.str_table.strs` pass the table now. `str_table_lookup` itself stays exported for the raw-array readers.

`str_table_index_test.vibe` pins both tables on a table with a repeated string: the empty string at slot 0, the first of the repeats, a missing string's message. Red: an index that keeps the last slot answers 3 for `"a"`.

### Measured (cand51)

Cache-isolated per the profiling skill, `codegen_lexer_test.vibe` over the full compiler closure, against a stage2 built from the tree of the commit this one is stacked on (cand50), idle machine, four interleaved pairs in alternating order (ABBA):

| | cand50 | cand51 |
|---|---:|---:|
| `str_table_lookup` / `str_table_index_of` cold inclusive | 0.04 s / — | 0 / 0.00 s |
| `compile_expr` cold inclusive | 0.62 s | 0.57 s |
| `compile_match` cold inclusive | 0.33 s | 0.29 s |
| cold wall, median of 4 | 6.60 s | 6.47 s (−2.0%; pairs −210, +79, −172, −135 ms) |
| warm wall, median of 4 | 4.12 s | 4.11 s (noise) |
| heap_ptr cold / warm | 870,002,576 / 557,020,568 | 870,241,080 / 557,257,952 (+238 KB: the index) |

Byte-identical output on three closures and 22 rc fixtures.

## Validation

Chain on `9393b5d` (cand50 alone, base `567dd7b`; staging worktree on the identical tree, tree hash `0dc30db`): bundle regen; stage2 == stage3; output equivalence; `test_cli_core.sh`; selfcompile KPI heap_ptr 871,408,824 bytes (against the shared default cache); typing-env-reuse oracle; 339/339 affected unit-test files; `compiler_gate.sh` early / mid / late.

Chain on `22b6a99` (the stack head, tree hash `036c38c` checked against the pushed head): bundle regen; stage2 == stage3; output equivalence; `test_cli_core.sh`; selfcompile KPI heap_ptr 872,279,416 bytes; typing-env-reuse oracle; 340/340 affected unit-test files; `compiler_gate.sh` early / mid / late.

`vibe_fmt.sh --check` is a fixpoint on every changed file.

Refs #2386.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QKZdvBvHVUagwg6Yih8er8

---
_Generated by [Claude Code](https://claude.ai/code/session_01QKZdvBvHVUagwg6Yih8er8)_