### PR TITLE
core: the DCE collector's binder scan no longer allocates a closure per identifier (#2386)

### DIFF
--- a/lib/@vibe/compiler/core/dce.vibe
+++ b/lib/@vibe/compiler/core/dce.vibe
@@ -25,18 +25,24 @@ fn stmt_name(stmt: Stmt) -> Option[String] {
   }
 }
 
+/// #2386: a plain loop. This used to allocate a recursive closure (`let rec
+/// search`) per call, and add_ref calls it once per identifier of every
+/// definition: ~3.4 MB of closures per compiler-closure compile on either
+/// lane, for a scan over a stack that holds a handful of binders. (A hash
+/// set was measured for the stack and rejected: hashing the name costs more
+/// than comparing it against the few binders in scope.)
 fn dce_array_contains_str(arr: Array[String], s: String) -> Bool {
   let len = Array::length(arr)
-  let rec search: (Int) -> Bool = (i) -> {
-    if i >= len {
-      false
+  let mut i = 0
+  let mut found = false
+  while i < len && !found {
+    if Array::get(arr, i) == s {
+      found = true
+    } else {
+      i = i + 1
     }
-    else if Array::get(arr, i) == s {
-      true
-    }
-    else search(i + 1)
   }
-  search(0)
+  found
 }
 
 // #2386: `out` is deduped through ONE process-wide map stamped with a

--- a/lib/@vibe/compiler/tests/dce_bound_scope_test.vibe
+++ b/lib/@vibe/compiler/tests/dce_bound_scope_test.vibe
@@ -1,0 +1,62 @@
+//# The DCE collector's binder scope: a name is bound only while its scope is open (#2386)
+//
+// `collect_refs` keeps the binders in scope on a stack and asks a count map
+// whether an identifier names one of them. The snapshots pin the three
+// answers that matter: a reference under a shadowing `let` is the local's,
+// a reference after that scope ends is the global's again, and a match arm's
+// binder is popped with its arm.
+
+import @vibe/ast {
+  Expr, Pat
+}
+import @vibe/compiler/core {
+  Stmt, TypeExpr, dce_keep_flags
+}
+
+fn no_ty() -> Option[TypeExpr] {
+  None
+}
+
+fn render(flags: Array[Bool]) -> String {
+  let parts: Array[String] = []
+  let mut i = 0
+  while i < Array::length(flags) {
+    Array::push(parts, if Array::get(flags, i) {
+      "keep"
+    } else {
+      "drop"
+    })
+    i = i + 1
+  }
+  String::join(parts, ",")
+}
+
+fn program(main_body: Expr) -> Array[Stmt] {
+  [
+    SLet(false, false, "helper", no_ty(), EInt(1)),
+    SLet(false, false, "main", no_ty(), main_body)
+  ]
+}
+
+test "a reference under a shadowing let is the local's, not the global's" {
+  let body = ELet("helper", EInt(2), EIdent("helper", -1), -1)
+  inspect(render(dce_keep_flags(program(body), ["main"])), content = "drop,keep")
+}
+
+test "a reference after the shadowing scope ends is the global's again" {
+  let body = ESeq(ELet("helper", EInt(2), EIdent("helper", -1), -1), EIdent("helper", -1))
+  inspect(render(dce_keep_flags(program(body), ["main"])), content = "keep,keep")
+}
+
+test "a match arm's binder is popped with its arm" {
+  let body = EMatch(EInt(1), [
+    (PBind("helper"), EIdent("helper", -1)),
+    (PWild, EIdent("helper", -1))
+  ])
+  inspect(render(dce_keep_flags(program(body), ["main"])), content = "keep,keep")
+  let shadowed_only = EMatch(EInt(1), [
+    (PBind("helper"), EIdent("helper", -1)),
+    (PWild, EInt(0))
+  ])
+  inspect(render(dce_keep_flags(program(shadowed_only), ["main"])), content = "drop,keep")
+}


### PR DESCRIPTION
## What

One slice of #2386, on both lanes: the dead-code-elimination collector no longer scans the binders in scope for every identifier it meets.

### The DCE collector's binder scan no longer allocates a closure per identifier

`dce_array_contains_str` (`core/dce.vibe`), which `add_ref` asks once per identifier of every definition whether the name is a binder in scope, was written as a recursive closure (`let rec search`) allocated per call: ~3.4 MB of closures per compiler-closure compile on either lane, for a scan over a stack that holds a handful of binders. It is a plain loop now, answering as before.

A hash-set variant was measured first on the same corpus and rejected: with a count map maintained by the scope pushes and pops, `dce_keep_flags` read 0.12 s to 0.17 s cold and `dce_bound_has` alone 0.04 s, because hashing the name per identifier (a byte loop) costs more than comparing it against the few binders in scope with the native compare. The scan stays; only its allocation goes.

`dce_bound_scope_test.vibe` pins the scan's answers through `dce_keep_flags`: a reference under a shadowing `let` is the local's, a reference after that scope ends is the global's again, and a match arm's binder is popped with its arm (the same snapshots hold on the closure version). Red: a scan that stops one binder short answers keep for a global shadowed by the innermost let.

### Measured (cand52)

Cache-isolated per the profiling skill, `codegen_lexer_test.vibe` over the full compiler closure, against a stage2 built from the tree of `22b6a99` (#2543's head, the commit this one was written on), idle machine, four interleaved pairs in alternating order (ABBA):

| | `22b6a99` | cand52 |
|---|---:|---:|
| `add_ref` cold inclusive | 0.08 s | 0.06 s |
| `collect_refs_into` cold inclusive | 0.11 s | 0.09 s |
| `dce_keep_flags` cold inclusive | 0.12 s | 0.10 s |
| `evidence_dict_pass` cold inclusive | 0.30 s | 0.28 s |
| cold wall, median of 4 | 6.35 s | 6.39 s (noise) |
| warm wall, median of 4 | 4.13 s | 4.09 s (noise) |
| heap_ptr cold / warm | 870,233,288 / 557,253,368 | 863,464,488 / 550,483,088 (−6.8 MB / −6.8 MB) |

The heap rows are deterministic (one closure per identifier of every definition, on both lanes); the wall rows are inside the noise band. Byte-identical output on three closures and 22 rc fixtures.

## Validation

Chain on `fc378db` (base `145fa05`; run in a staging worktree on the identical tree, tree hash `4e89b75` checked against the pushed head): bundle regen; stage2 == stage3; output equivalence; `test_cli_core.sh`; selfcompile KPI heap_ptr 865,490,720 bytes (against the shared default cache, so not comparable with the cache-isolated rows above); typing-env-reuse oracle; 341/341 affected unit-test files (import-graph selection over the changed files); `compiler_gate.sh` early / mid / late.

`vibe_fmt.sh --check` is a fixpoint on every changed file.

Refs #2386.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QKZdvBvHVUagwg6Yih8er8

---
_Generated by [Claude Code](https://claude.ai/code/session_01QKZdvBvHVUagwg6Yih8er8)_