### PR TITLE
cache: source files are read once per process through a stat-validated text memo; cache rows fingerprint through the memo (#2386)

### DIFF
--- a/lib/@vibe/compiler/cache/cache_underlying.vibe
+++ b/lib/@vibe/compiler/cache/cache_underlying.vibe
@@ -185,8 +185,11 @@ let fingerprint_file_memo_index: MutMap[String, Int] = MutMap::new_string()
 /// file. One entry per path, replaced in place when the token changes, so
 /// the memo holds at most one text per file the process has read; a
 /// worker resets it per job (run_module_job_dir), as it does the
-/// fingerprint memo. Callers ask only about paths they have resolved to
-/// existing files, as they do before every stat_token today.
+/// fingerprint memo. A missing path fails at the stat the way it failed at
+/// the read it replaces: the node runner converts a stat failure into the
+/// same guest-visible host error as a read failure (a raw host exception
+/// used to escape there), and viberun answers token 0 and lets the read
+/// that follows raise.
 let source_text_memo: MutMap[String, (Int, String)] = MutMap::new_string()
 
 // #2386: how many host reads the memo has made (a miss, a changed token or

--- a/lib/@vibe/compiler/cache/cache_underlying.vibe
+++ b/lib/@vibe/compiler/cache/cache_underlying.vibe
@@ -165,6 +165,87 @@ let fingerprint_file_memo_fps = []
 /// file per lookup.
 let fingerprint_file_memo_index: MutMap[String, Int] = MutMap::new_string()
 
+/// #2386: process-wide memo of a source file's raw text, keyed by path and
+/// validated by Fs::stat_token on every hit, the way the fingerprint memo
+/// above validates its fingerprints (#1308). A cold compile of the
+/// compiler's own closure read each implementation file three to four
+/// times -- the contract desugar reads a package's members, the source walk
+/// reads each member again as a source, the package-deps check reads them
+/// once more, and the ingestion fingerprint reads every file to hash it:
+/// ~150 ms of host reads and utf8 decodes, and a fresh copy of every text
+/// per read. A repeat is now one stat_token probe and the text already in
+/// memory. The token is taken BEFORE the read (the caller's own token, or
+/// one this memo takes), so a file rewritten between the two is stored
+/// under the old token and re-read on the next ask; the other order would
+/// record the new token against the old text. The window that remains --
+/// an in-place rewrite of the same size inside one timestamp tick on the
+/// same inode -- is the one the persistent cache's source rows already
+/// trust the token over. A path whose token is the non-regular witness
+/// (-1, a symlink) is never memoized: that token cannot change with the
+/// file. One entry per path, replaced in place when the token changes, so
+/// the memo holds at most one text per file the process has read; a
+/// worker resets it per job (run_module_job_dir), as it does the
+/// fingerprint memo. Callers ask only about paths they have resolved to
+/// existing files, as they do before every stat_token today.
+let source_text_memo: MutMap[String, (Int, String)] = MutMap::new_string()
+
+// #2386: how many host reads the memo has made (a miss, a changed token or
+// an unmemoized path); the routing test reads it to prove a repeat took the
+// memo.
+let source_text_memo_reads: Array[Int] = [0]
+
+fn source_text_memo_read_counted(path: String) -> String with Fs {
+  Array::set(source_text_memo_reads, 0, Array::get(source_text_memo_reads, 0) + 1)
+  Fs::read_file(path)
+}
+
+export fn cache_source_text_memo_read_count() -> Int {
+  Array::get(source_text_memo_reads, 0)
+}
+
+/// The text of `path` as of `token`, its current Fs::stat_token taken by
+/// the caller before this ask. Answers from the memo when the stored token
+/// is `token`; otherwise reads the file and stores its text under `token`.
+export fn cache_read_source_with_token_fs(path: String, token: Int) -> String with Fs {
+  if token == -1 {
+    source_text_memo_read_counted(path)
+  } else {
+    let stored = match MutMap::get(source_text_memo, path) {
+      Some(entry) => {
+        let (stored_token, text) = entry
+        if stored_token == token {
+          Some(text)
+        } else {
+          None
+        }
+      },
+      None => None
+    }
+    match stored {
+      Some(text) => text,
+      None => {
+        let fresh = source_text_memo_read_counted(path)
+        MutMap::set(source_text_memo, path, (token, fresh))
+        fresh
+      }
+    }
+  }
+}
+
+/// The text of `path`: one stat_token probe, then the memo above.
+export fn cache_read_source_fs(path: String) -> String with Fs {
+  cache_read_source_with_token_fs(path, Fs::stat_token(path))
+}
+
+export fn cache_source_text_memo_reset() -> Unit {
+  let keys = MutMap::keys(source_text_memo)
+  let mut i = 0
+  while i < Array::length(keys) {
+    let _ = MutMap::delete(source_text_memo, Array::get(keys, i))
+    i = i + 1
+  }
+}
+
 /// #2386: per-run memo of compact_string_fingerprint over a module's SOURCE
 /// TEXT, keyed by path and verified by text equality. Four callers hashed
 /// the same text of every module once each per compile (the leaf
@@ -402,16 +483,17 @@ export fn cache_parse_ingestion_stamp_v1_text(text: String) -> Option[(String, S
   }
 }
 
-fn fingerprint_source(path: String) -> String with Fs {
-  let source = Fs::read_file(path)
+fn fingerprint_source(path: String, token: Int) -> String with Fs {
+  let source = cache_read_source_with_token_fs(path, token)
+  // Both telemetry pairs count the requests this filesystem boundary makes
+  // for a source's text and its fingerprint, and their consumers
+  // (scripts/edit_cycle_kpi.mjs, scripts/ingestion_stamp_oracle.mjs) check
+  // exactly that pairing. Since #2386 the text may come from the source-text
+  // memo above and the fingerprint from the per-compile memo below, each of
+  // which the compile already paid for once; the memos' own counters record
+  // that, not this boundary's contract.
   ingestion_telemetry_add(0, 1)
   ingestion_telemetry_add(1, String::length(source))
-  // The hash-call telemetry stays paired with the read: it counts the
-  // fingerprint requests this filesystem boundary makes, and its consumers
-  // (scripts/edit_cycle_kpi.mjs, scripts/ingestion_stamp_oracle.mjs) check
-  // exactly that pairing. Since #2386 the per-compile memo below may answer
-  // a request from a text the compile already hashed; that is the memo's
-  // own hash counter's business, not this boundary's contract.
   ingestion_telemetry_add(2, 1)
   ingestion_telemetry_add(3, String::length(source))
   compact_source_fingerprint_memo(path, source)
@@ -477,7 +559,7 @@ export fn cache_fingerprint_file_fs_with_ingestion_stamp(path: String, stamp_pat
         let fingerprint = match try_load_ingestion_stamp(stamp_path, token_text) {
           Some(hit) => hit,
           None => {
-            let fresh = fingerprint_source(path)
+            let fresh = fingerprint_source(path, token)
             publish_ingestion_stamp(stamp_path, token_text, fresh)
             fresh
           }
@@ -492,7 +574,7 @@ export fn cache_fingerprint_file_fs_with_ingestion_stamp(path: String, stamp_pat
   let fingerprint = match try_load_ingestion_stamp(stamp_path, token_text) {
     Some(hit) => hit,
     None => {
-      let fresh = fingerprint_source(path)
+      let fresh = fingerprint_source(path, token)
       publish_ingestion_stamp(stamp_path, token_text, fresh)
       fresh
     }
@@ -516,7 +598,7 @@ export fn cache_fingerprint_file_fs(path: String) -> String with Fs {
       if Array::get(fingerprint_file_memo_tokens, i) == token {
         return Array::get(fingerprint_file_memo_fps, i)
       } else {
-        let fingerprint = fingerprint_source(path)
+        let fingerprint = fingerprint_source(path, token)
         Array::set(fingerprint_file_memo_tokens, i, token)
         Array::set(fingerprint_file_memo_fps, i, fingerprint)
         return fingerprint
@@ -526,7 +608,7 @@ export fn cache_fingerprint_file_fs(path: String) -> String with Fs {
     }
     i = i + 1
   }
-  let fingerprint = fingerprint_source(path)
+  let fingerprint = fingerprint_source(path, token)
   Array::push(fingerprint_file_memo_paths, path)
   Array::push(fingerprint_file_memo_tokens, token)
   Array::push(fingerprint_file_memo_fps, fingerprint)
@@ -574,7 +656,7 @@ fn json_escape_string(value: String) -> String {
 
 /// schema v1 invariants: all counters are nonnegative; probes equal hits plus
 /// misses plus malformed; source/hash calls and input string_units rise only
-/// when this helper reads and hashes disk source. String units are language
+/// when this helper asks for a disk source's text and its fingerprint. String units are language
 /// String::length units, explicitly not raw bytes.
 export fn cache_ingestion_fingerprint_telemetry_json(nonce: String) -> String {
   let out = StringBuilder::new()

--- a/lib/@vibe/compiler/cache/index.vpkg
+++ b/lib/@vibe/compiler/cache/index.vpkg
@@ -87,6 +87,10 @@ fn compact_source_fingerprint_memo(path: String, source: String) -> String
 fn compact_source_fingerprint_memo_reset() -> Unit
 fn typing_module_fingerprint(source_fingerprint: String, dep_fps: Array[(String, String)], typing_semantics_seed: String) -> String
 fn compact_source_fingerprint_memo_hash_count() -> Int
+fn cache_read_source_fs(path: String) -> String with Fs
+fn cache_read_source_with_token_fs(path: String, token: Int) -> String with Fs
+fn cache_source_text_memo_reset() -> Unit
+fn cache_source_text_memo_read_count() -> Int
 fn cache_ingestion_compact_fingerprint_is_valid(fingerprint: String) -> Bool
 fn cache_ingestion_stamp_enabled() -> Bool
 fn cache_ingestion_stamp_v1_text(stat_token_text: String, fingerprint: String) -> String

--- a/lib/@vibe/compiler/cli_support.vibe
+++ b/lib/@vibe/compiler/cli_support.vibe
@@ -17,7 +17,7 @@ import @vibe/compiler/core {
 }
 
 import @vibe/compiler/cache {
-  set_persistent_cache_cfg_flags
+  cache_read_source_fs, set_persistent_cache_cfg_flags
 }
 
 import @vibe/parser {
@@ -420,7 +420,7 @@ export fn check_linked_file_source_groups(input_path: String) -> Array[(String, 
   // (`apply_vpkg_directory_shared_imports_fs`) can PREPEND import lines to an
   // ordinary `.vibe` file, which would shift every offset below and mislocate
   // the diagnostics this pre-parse exists to locate exactly.
-  let raw_entry_source = Fs::read_file(input_path)
+  let raw_entry_source = cache_read_source_fs(input_path)
   let entry_source = if is_contract_ext(input_path) {
     ingest_source_text_fs(input_path, raw_entry_source)
   } else {
@@ -602,7 +602,7 @@ export fn check_deprecated_warnings(input_path: String) -> Array[String] with Ex
 /// already accepted the file before this runs; this is a non-fatal `vibe check`
 /// hygiene report with an actionable removal.
 export fn check_redundant_import_warnings(input_path: String) -> Array[String] with Exception + Fs {
-  let source = Fs::read_file(input_path)
+  let source = cache_read_source_fs(input_path)
   check_redundant_import_warnings_from_source_groups(input_path, [
     ("entry", [(input_path, source)])
   ])
@@ -620,7 +620,7 @@ export fn check_redundant_import_warnings(input_path: String) -> Array[String] w
 fn owner_locating_source(path: String, source: String) -> Option[String] with Exception + Fs {
   if String::starts_with(source, vpkg_shared_import_marker) || String::starts_with(source, contract_facade_marker) {
     if Fs::exists(path) {
-      let physical = Fs::read_file(path)
+      let physical = cache_read_source_fs(path)
       if source == ingest_source_text_fs(path, physical) {
         Some(physical)
       } else {
@@ -662,7 +662,7 @@ fn checked_entry_source(input_path: String, source_groups: Array[(String, Array[
         // current bytes and require the complete synthetic snapshot to match;
         // a suffix comparison would accept a file whose leading bytes changed.
         if Fs::exists(input_path) {
-          let physical = Fs::read_file(input_path)
+          let physical = cache_read_source_fs(input_path)
           if source == ingest_source_text_fs(input_path, physical) {
             Some(physical)
           } else {
@@ -868,7 +868,7 @@ fn append_raw_vpkg_dep_sources(input_path: String, groups: Array[(String, Array[
     while mi < Array::length(members) {
       let (path, _source) = Array::get(members, mi)
       if path != input_path && String::ends_with(path, ".vpkg") && Fs::exists(path) {
-        Array::push(out, Fs::read_file(path))
+        Array::push(out, cache_read_source_fs(path))
       } else {
         ()
       }

--- a/lib/@vibe/compiler/loader/header_cache.vibe
+++ b/lib/@vibe/compiler/loader/header_cache.vibe
@@ -1,6 +1,7 @@
 //# Imports
 
 import @vibe/compiler/cache {
+  cache_read_source_with_token_fs,
   compact_source_fingerprint_memo,
   fingerprint_file_fs,
   normalize_persistent_cache_text,
@@ -300,15 +301,15 @@ fn resolved_export_names_fs(resolved: String) -> Array[String] with Exception + 
   match fresh {
     Some(names) => names,
     None => {
-      let computed = resolved_export_names_uncached_fs(resolved)
+      let computed = resolved_export_names_uncached_fs(resolved, token)
       MutMap::set(export_names_memo, resolved, (token, computed))
       computed
     }
   }
 }
 
-fn resolved_export_names_uncached_fs(resolved: String) -> Array[String] with Exception + Fs {
-  let source = Fs::read_file(resolved)
+fn resolved_export_names_uncached_fs(resolved: String, token: Int) -> Array[String] with Exception + Fs {
+  let source = cache_read_source_with_token_fs(resolved, token)
   if is_contract_ext(resolved) && !String::starts_with(source, contract_facade_marker) {
     let (_, pin_blanked) = extract_require_pins(source)
     let (cdecls, copaques, cextra) = parse_contract_program(lex(pin_blanked))

--- a/lib/@vibe/compiler/loader/index.vpkg
+++ b/lib/@vibe/compiler/loader/index.vpkg
@@ -112,6 +112,7 @@ fn fill_require_pins_fs_mode(source: String, repin: Bool) -> String with Excepti
 fn fill_require_pins_lenient(source: String) -> String with Fs
 fn publish_check_fs(prev_contract_path: String, next_contract_path: String, prev_version: String, next_version: String) -> Array[String] with Exception + Fs
 fn collect_all_sources_fs(entry_path: String) -> Array[(String, String)] with Exception + Fs
+fn build_persistent_sources_cache_text(entry_path: String, manifest_path: Option[String], sources: Array[(String, String)]) -> String with Exception + Fs
 fn collect_source_groups_fs(entry_path: String) -> Array[(String, Array[(String, String)])] with Exception + Fs
 fn collect_merged_stmts(sources: Array[(String, String)]) -> Array[Stmt] with Exception
 let vpkg_types_module_path_prefix: String

--- a/lib/@vibe/compiler/loader/loader.vibe
+++ b/lib/@vibe/compiler/loader/loader.vibe
@@ -232,7 +232,7 @@ fn exported_type_params_uncached_fs(path: String, dep_paths: Array[String], dep_
   // parsed as its new body under the old token, so the next ask re-reads it;
   // the other order would record the new token against the old parse.
   let token = Fs::stat_token(path)
-  let raw = Fs::read_file(path)
+  let raw = cache_read_source_with_token_fs(path, token)
   Array::push(exported_type_params_read_log, (path, token))
   Array::push(dep_paths, path)
   // Fingerprint the bytes that are parsed below. A second filesystem read
@@ -400,6 +400,8 @@ export ./manifest_sources.vibe {
 
 import @vibe/compiler/cache {
   build_source_groups_fingerprint_from_compact_fingerprints,
+  cache_read_source_fs,
+  cache_read_source_with_token_fs,
   compact_source_fingerprint_memo,
   compact_string_fingerprint,
   fingerprint_file_fs,
@@ -1168,10 +1170,11 @@ fn load_source_if_cached_file_spec_matches(path: String, stat_token_text: String
   } else {
     let has_stat_token = String::length(stat_token_text) > 0
     if has_stat_token {
-      if __to_string(Fs::stat_token(path)) == stat_token_text {
-        Some(Fs::read_file(path))
+      let token = Fs::stat_token(path)
+      if __to_string(token) == stat_token_text {
+        Some(cache_read_source_with_token_fs(path, token))
       } else if String::length(source_fingerprint) > 0 {
-        let source = Fs::read_file(path)
+        let source = cache_read_source_with_token_fs(path, token)
         if compact_source_fingerprint_memo(path, source) == source_fingerprint {
           Some(source)
         } else {
@@ -1181,7 +1184,7 @@ fn load_source_if_cached_file_spec_matches(path: String, stat_token_text: String
         None
       }
     } else if String::length(source_fingerprint) > 0 {
-      let source = Fs::read_file(path)
+      let source = cache_read_source_fs(path)
       if compact_source_fingerprint_memo(path, source) == source_fingerprint {
         Some(source)
       } else {
@@ -1513,7 +1516,7 @@ fn vpkg_directory_shared_import_prefix_fs(path: String) -> String with Exception
       if cached_hit != "" || String::starts_with(cached_prefix, "v3\n\n") {
         cached_hit
       } else {
-        let vpkg_raw = Fs::read_file(vpkg_path)
+        let vpkg_raw = cache_read_source_fs(vpkg_path)
         let (_, vpkg_pin_blanked) = extract_require_pins(vpkg_raw)
         let (vpkg_tokens, vpkg_starts, _ve) = lex_with_offsets(vpkg_pin_blanked)
         let (_, vpkg_opaques, vpkg_extra, vpkg_stmt_at, _vd) = parse_contract_program_spans(vpkg_tokens)
@@ -2368,7 +2371,7 @@ fn desugar_contract_source_fs(path: String, source: String) -> String with Excep
   while ri < Array::length(member_raws) {
     let raw = Array::get(member_raws, ri)
     let resolved = Array::get(member_paths, ri)
-    let resolved_content = Fs::read_file(resolved)
+    let resolved_content = cache_read_source_fs(resolved)
     StringBuilder::push(fresh_fp_sb, "|")
     StringBuilder::push(fresh_fp_sb, resolved)
     StringBuilder::push(fresh_fp_sb, ":")
@@ -2473,7 +2476,7 @@ fn desugar_contract_source_fs(path: String, source: String) -> String with Excep
 /// verification of an installed copy.
 export fn contract_package_hashes_fs(path: String) -> (String, String) with Exception + Fs {
   validate_index_layout_fs(path)
-  let raw = Fs::read_file(path)
+  let raw = cache_read_source_fs(path)
   let (_, blanked) = extract_require_pins(raw)
   let (decls, opaques, extra) = parse_contract_program(lex(blanked))
   let (impl_raws0, type_defs) = classify_contract_stmts(extra)
@@ -2527,7 +2530,7 @@ export fn contract_package_hashes_fs(path: String) -> (String, String) with Exce
       let iraw = Array::get(impl_raws, ri)
       let resolved = resolve_path_fs(dir, iraw)
       ensure_regular_source_fs(resolved)
-      let itext = Fs::read_file(resolved)
+      let itext = cache_read_source_fs(resolved)
       Array::push(sources, (iraw, itext))
       ri = ri + 1
     }
@@ -2918,7 +2921,7 @@ fn collect_package_hash_source_closure_fs(package_contract: String, package_dir:
   } else {
     path_set_add(visited, source_path)
     validate_index_layout_fs(source_path)
-    let source = Fs::read_file(source_path)
+    let source = cache_read_source_fs(source_path)
     Array::push(sources, (package_relative_hash_key(package_dir, source_path), source))
     let (deps, _, _) = load_or_parse_module_header_fs(source_path, source, 0)
     let mut i = 0
@@ -2958,7 +2961,7 @@ fn collect_sources_rec(path: String, sources: Array[(String, String)], visited: 
       throw("cannot resolve module: \{path} does not exist")
     } else ()
     validate_index_layout_fs(path)
-    let raw_source = Fs::read_file(path)
+    let raw_source = cache_read_source_fs(path)
     // #730 (D-2): require pin lines are a leading directive, extracted and
     // blanked (offset-preserving) before anything parses the source.
     let (pins, pin_blanked) = extract_require_pins(raw_source)
@@ -3367,7 +3370,7 @@ fn package_deps_missing(dir: String) -> Array[String] with Exception + Fs {
   if !Fs::exists(vpkg_path) {
     array_empty()
   } else {
-    let raw = Fs::read_file(vpkg_path)
+    let raw = cache_read_source_fs(vpkg_path)
     let name = extract_package_name(raw)
     if name == "" {
       array_empty()
@@ -3381,7 +3384,7 @@ fn package_deps_missing(dir: String) -> Array[String] with Exception + Fs {
       let mut i = 0
       while i < Array::length(impl_raws) {
         let resolved = resolve_path_fs(dir, Array::get(impl_raws, i))
-        Array::push(impl_sources, Fs::read_file(resolved))
+        Array::push(impl_sources, cache_read_source_fs(resolved))
         i = i + 1
       }
       let missing = deps_missing_for_imports(deps, impl_sources)

--- a/lib/@vibe/compiler/loader/loader.vibe
+++ b/lib/@vibe/compiler/loader/loader.vibe
@@ -1872,7 +1872,7 @@ export fn load_persistent_source_group_fingerprint_if_valid(entry_path: String) 
 /// ~3s (peak RSS 3.6GB measured) and memory.grow's ignored failure surfaced as
 /// a "memory access out of bounds" inside String::concat's memory.copy. Same
 /// fix and issue class as stable_cache_path's #366 note (lib/@vibe/cache).
-fn build_persistent_sources_cache_text(entry_path: String, manifest_path: Option[String], sources: Array[(String, String)]) -> String with Exception + Fs {
+export fn build_persistent_sources_cache_text(entry_path: String, manifest_path: Option[String], sources: Array[(String, String)]) -> String with Exception + Fs {
   let sb = StringBuilder::new()
   StringBuilder::push(sb, "version\t4\n")
   StringBuilder::push(sb, "resctx\t")
@@ -1907,7 +1907,7 @@ fn build_persistent_sources_cache_text(entry_path: String, manifest_path: Option
       StringBuilder::push(sb, "\t")
       StringBuilder::push(sb, __to_string(Fs::stat_token(path)))
       StringBuilder::push(sb, "\t")
-      StringBuilder::push(sb, compact_string_fingerprint(source))
+      StringBuilder::push(sb, compact_source_fingerprint_memo(path, source))
       StringBuilder::push(sb, "\n")
     }
     i = i + 1
@@ -1952,7 +1952,7 @@ fn build_persistent_source_groups_cache_text(entry_path: String, manifest_path: 
         StringBuilder::push(sb, "\t")
         StringBuilder::push(sb, __to_string(Fs::stat_token(path)))
         StringBuilder::push(sb, "\t")
-        StringBuilder::push(sb, compact_string_fingerprint(source))
+        StringBuilder::push(sb, compact_source_fingerprint_memo(path, source))
         StringBuilder::push(sb, "\n")
       }
       si = si + 1
@@ -2359,7 +2359,10 @@ fn desugar_contract_source_fs(path: String, source: String) -> String with Excep
   // actually read (same row format as the probe key) and publish the cache
   // entry under THAT key: in the no-race case the two keys are equal, and
   // under a mid-compile rewrite the entry lands under a key no stale probe
-  // can hit. Costs one extra rolling hash per member on cache MISSES only.
+  // can hit. The rebuilt row's fingerprint comes from the source-fingerprint
+  // memo, which verifies the text it answers for (#2386): a member whose body
+  // is the one the probe fingerprinted costs no second hash, and a rewritten
+  // body is hashed afresh.
   let fresh_fp_sb = StringBuilder::new()
   StringBuilder::push(fresh_fp_sb, contract_fp)
   let impl_units = array_empty()
@@ -2375,7 +2378,7 @@ fn desugar_contract_source_fs(path: String, source: String) -> String with Excep
     StringBuilder::push(fresh_fp_sb, "|")
     StringBuilder::push(fresh_fp_sb, resolved)
     StringBuilder::push(fresh_fp_sb, ":")
-    StringBuilder::push(fresh_fp_sb, compact_string_fingerprint(resolved_content))
+    StringBuilder::push(fresh_fp_sb, compact_source_fingerprint_memo(resolved, resolved_content))
     // #842: an impl raw may itself resolve to ANOTHER package's contract
     // (a cross-package `import ../pkg { ... }`, not just this package's own
     // sibling impl files) — route it through the same ingestion transform

--- a/lib/@vibe/compiler/loader/manifest_sources.vibe
+++ b/lib/@vibe/compiler/loader/manifest_sources.vibe
@@ -9,7 +9,11 @@ import @vibe/core {
 }
 
 import @vibe/compiler/cache {
-  compact_string_fingerprint, fingerprint_file_fs, normalize_persistent_cache_text, persistent_manifest_header_cache_path
+  cache_read_source_fs,
+  compact_string_fingerprint,
+  fingerprint_file_fs,
+  normalize_persistent_cache_text,
+  persistent_manifest_header_cache_path
 }
 
 import @vibe/compiler/core {
@@ -705,7 +709,7 @@ export fn load_manifest_full_sources(base_dir: String, rows: Array[(String, Stri
   while i < Array::length(rows) {
     let (_, rel_path) = Array::get(rows, i)
     let path = join_path(base_dir, rel_path)
-    Array::push(full_sources, (path, Fs::read_file(path)))
+    Array::push(full_sources, (path, cache_read_source_fs(path)))
     i = i + 1
   }
   full_sources
@@ -718,7 +722,7 @@ fn load_manifest_sources_by_path_index(base_dir: String, rows: Array[(String, St
     let (_, rel_path) = Array::get(rows, i)
     let path = join_path(base_dir, rel_path)
     if Map::has_key(needed_path_index, path) {
-      Array::push(sources, (path, Fs::read_file(path)))
+      Array::push(sources, (path, cache_read_source_fs(path)))
     }
     i = i + 1
   }
@@ -736,9 +740,9 @@ fn load_manifest_source_groups_by_path_index(base_dir: String, rows: Array[(Stri
     let path = join_path(base_dir, rel_path)
     if Map::has_key(needed_path_index, path) {
       if has_last_group && last_group_name == group_name {
-        Array::push(last_group_sources, (path, Fs::read_file(path)))
+        Array::push(last_group_sources, (path, cache_read_source_fs(path)))
       } else {
-        let ensured = ensure_grouped_source_bucket_seeded(groups, group_name, path, Fs::read_file(path))
+        let ensured = ensure_grouped_source_bucket_seeded(groups, group_name, path, cache_read_source_fs(path))
         last_group_name = group_name
         last_group_sources = ensured
         has_last_group = true
@@ -980,7 +984,7 @@ fn collect_needed_paths_from_manifest_headers(path: String, manifest_path_index:
     let deps = match manifest_header_deps_lookup(rows, current) {
       Some(found) => found,
       None => {
-        let source = Fs::read_file(current)
+        let source = cache_read_source_fs(current)
         if Map::has_key(manifest_path_index, current) {
           collect_manifest_header_deps_from_source_with_context(current, source, manifest_path_index)
         } else {
@@ -1019,7 +1023,7 @@ fn collect_needed_paths_and_manifest_headers(path: String, manifest_path_index: 
     }
     let current = Array::get(worklist, work_i)
     Array::push(visited, current)
-    let source = Fs::read_file(current)
+    let source = cache_read_source_fs(current)
     let deps = match manifest_header_deps_lookup(rows, current) {
       Some(found) => found,
       None => {
@@ -1062,7 +1066,7 @@ fn collect_needed_paths_from_manifest_scan(path: String, manifest_path_index: Ma
     }
     let current = Array::get(worklist, work_i)
     Array::push(visited, current)
-    let source = Fs::read_file(current)
+    let source = cache_read_source_fs(current)
     let deps = if Map::has_key(manifest_path_index, current) {
       collect_manifest_header_deps_from_source_with_context(current, source, manifest_path_index)
     } else {

--- a/lib/@vibe/compiler/runtime/typecheck_fs.vibe
+++ b/lib/@vibe/compiler/runtime/typecheck_fs.vibe
@@ -1,6 +1,8 @@
 //# Imports
 
 import @vibe/compiler/cache {
+  cache_read_source_fs,
+  cache_source_text_memo_reset,
   compact_source_fingerprint_memo,
   compact_source_fingerprint_memo_reset,
   compact_string_fingerprint,
@@ -2271,7 +2273,7 @@ fn load_planned_module_source(rdb: RippleDb, path: String) -> (RippleDb, Option[
     Some(source) => (rdb, Some(source)),
     None =>
     if is_vpkg_types_stub_path(path) && Fs::exists(path) {
-      let source = ingest_source_text_fs(path, Fs::read_file(path))
+      let source = ingest_source_text_fs(path, cache_read_source_fs(path))
       (ripple_set_source(rdb, path, source), Some(source))
     } else {
       (rdb, None)
@@ -5193,7 +5195,9 @@ fn parse_job_rows(job_text: String) -> (String, Array[String], Array[String]) wi
   // another with no walk around them, so it resets the memo per job: the
   // job's key is built through the memo like the walk's, and the memo holds
   // this job's source, not every source the worker has ever been handed.
+  // The source-text memo (#2386) is reset per job for the same reason.
   compact_source_fingerprint_memo_reset()
+  cache_source_text_memo_reset()
   let (path, deps, dep_fps) = parse_job_rows(Fs::read_file(job_dir_path(dir, "job.txt")))
   let source = Fs::read_file(job_dir_path(dir, "source.vibe"))
   let dep_envs = array_empty()
@@ -5801,7 +5805,7 @@ fn module_plan_data_fs(entry_path: String) -> (Array[String], Array[Int], Array[
     } else {
       ()
     }
-    let ingested = ingest_source_text_fs(p, Fs::read_file(p))
+    let ingested = ingest_source_text_fs(p, cache_read_source_fs(p))
     let (deps, _exports, _parse_count) = load_or_parse_module_header_fs(p, ingested, 0)
     Array::push(sources, ingested)
     Array::push(deps_of, deps)

--- a/lib/@vibe/compiler/tests/persistent_sources_cache_text_memo_test.vibe
+++ b/lib/@vibe/compiler/tests/persistent_sources_cache_text_memo_test.vibe
@@ -1,0 +1,34 @@
+import @vibe/compiler/loader {
+  build_persistent_sources_cache_text
+}
+
+import @vibe/compiler/cache {
+  cache_persistent_artifact_cache_path,
+  compact_source_fingerprint_memo_hash_count,
+  compact_source_fingerprint_memo_reset,
+  compact_string_fingerprint
+}
+
+// #2386: the persistent source-list and source-group cache texts fingerprint
+// every source row through the per-compile source-fingerprint memo, the same
+// memo the header pass and the ingestion fingerprint already filled for that
+// text, instead of hashing each source again on their own. The memo's hash
+// counter is the witness: a row's text is hashed once, and a second build of
+// the same rows hashes nothing.
+
+test "a source row's fingerprint comes from the memo, hashed once per text" {
+  let path = cache_persistent_artifact_cache_path("v1", "sources_cache_text_memo", "seed-a", "")
+  Fs::write_file(path, "let a = 1")
+  compact_source_fingerprint_memo_reset()
+  let c0 = compact_source_fingerprint_memo_hash_count()
+  let text = build_persistent_sources_cache_text(path, None, [
+    (path, "let a = 1")
+  ])
+  inspect(compact_source_fingerprint_memo_hash_count() - c0, content = "1")
+  let again = build_persistent_sources_cache_text(path, None, [
+    (path, "let a = 1")
+  ])
+  inspect(compact_source_fingerprint_memo_hash_count() - c0, content = "1")
+  inspect(again == text, content = "true")
+  inspect(String::ends_with(text, String::concat(compact_string_fingerprint("let a = 1"), "\n")), content = "true")
+}

--- a/lib/@vibe/compiler/tests/source_text_memo_test.vibe
+++ b/lib/@vibe/compiler/tests/source_text_memo_test.vibe
@@ -76,3 +76,17 @@ test "the ingestion fingerprint takes the memo and still counts its boundary rea
   inspect(json_field(telemetry, "source_read_calls"), content = "1")
   inspect(json_field(telemetry, "hash_calls"), content = "1")
 }
+
+test "a missing path fails at the memo's stat with a guest-visible error, as the read it replaces did" {
+  let path = cache_persistent_artifact_cache_path("v1", "source_text_memo", "seed-missing", "")
+  cache_source_text_memo_reset()
+  let outcome = handle {
+    let _ = cache_read_source_fs(path)
+    "no error"
+  } with { Exception::Throw(m) => if String::starts_with(m, "fs_stat_token failed for") || String::starts_with(m, "fs_read_file failed for") {
+    "host error"
+  } else {
+    m
+  } }
+  inspect(outcome, content = "host error")
+}

--- a/lib/@vibe/compiler/tests/source_text_memo_test.vibe
+++ b/lib/@vibe/compiler/tests/source_text_memo_test.vibe
@@ -1,0 +1,78 @@
+import @vibe/compiler/cache {
+  cache_fingerprint_file_fs,
+  cache_ingestion_fingerprint_telemetry_json,
+  cache_persistent_artifact_cache_path,
+  cache_read_source_fs,
+  cache_read_source_with_token_fs,
+  cache_set_ingestion_fingerprint_telemetry_enabled,
+  cache_source_text_memo_read_count,
+  cache_source_text_memo_reset
+}
+
+// #2386: the loader, the header pass and the ingestion fingerprint each read
+// a source file for themselves. They share one memo keyed by path and
+// validated by the file's stat token, so an unchanged file is read once per
+// process; the memo's read counter is the witness that a repeat took the
+// memo instead of the host.
+
+fn json_field(text: String, key: String) -> String {
+  let needle = String::concat("\"", String::concat(key, "\":"))
+  let at = String::index_of(text, needle)
+  if at < 0 {
+    ""
+  } else {
+    let start = at + String::length(needle)
+    let mut end = start
+    while end < String::length(text) && String::char_code_at(text, end) != 44 && String::char_code_at(text, end) != 125 {
+      end = end + 1
+    }
+    text[start: end]
+  }
+}
+
+test "a repeat ask for an unchanged file is answered without a host read" {
+  let path = cache_persistent_artifact_cache_path("v1", "source_text_memo", "seed-a", "")
+  Fs::write_file(path, "let a = 1")
+  cache_source_text_memo_reset()
+  let r0 = cache_source_text_memo_read_count()
+  let first = cache_read_source_fs(path)
+  let again = cache_read_source_fs(path)
+  inspect(first, content = "let a = 1")
+  inspect(again == first, content = "true")
+  inspect(cache_source_text_memo_read_count() - r0, content = "1")
+  let by_token = cache_read_source_with_token_fs(path, Fs::stat_token(path))
+  inspect(by_token == first, content = "true")
+  inspect(cache_source_text_memo_read_count() - r0, content = "1")
+}
+
+test "a rewritten file is read again, and a reset forgets it" {
+  let path = cache_persistent_artifact_cache_path("v1", "source_text_memo", "seed-b", "")
+  Fs::write_file(path, "let b = 1")
+  cache_source_text_memo_reset()
+  let r0 = cache_source_text_memo_read_count()
+  inspect(cache_read_source_fs(path), content = "let b = 1")
+  Fs::write_file(path, "let b = 12")
+  inspect(cache_read_source_fs(path), content = "let b = 12")
+  inspect(cache_source_text_memo_read_count() - r0, content = "2")
+  inspect(cache_read_source_fs(path), content = "let b = 12")
+  inspect(cache_source_text_memo_read_count() - r0, content = "2")
+  cache_source_text_memo_reset()
+  inspect(cache_read_source_fs(path), content = "let b = 12")
+  inspect(cache_source_text_memo_read_count() - r0, content = "3")
+}
+
+test "the ingestion fingerprint takes the memo and still counts its boundary read" {
+  let path = cache_persistent_artifact_cache_path("v1", "source_text_memo", "seed-c", "")
+  Fs::write_file(path, "let c = 1")
+  cache_source_text_memo_reset()
+  let _ = cache_read_source_fs(path)
+  let r0 = cache_source_text_memo_read_count()
+  cache_set_ingestion_fingerprint_telemetry_enabled(true)
+  let fp = cache_fingerprint_file_fs(path)
+  let telemetry = cache_ingestion_fingerprint_telemetry_json("memo")
+  cache_set_ingestion_fingerprint_telemetry_enabled(false)
+  inspect(cache_source_text_memo_read_count() - r0, content = "0")
+  inspect(String::length(fp) > 0, content = "true")
+  inspect(json_field(telemetry, "source_read_calls"), content = "1")
+  inspect(json_field(telemetry, "hash_calls"), content = "1")
+}

--- a/scripts/wasm_vibe_host_runner.js
+++ b/scripts/wasm_vibe_host_runner.js
@@ -2597,17 +2597,26 @@ async function main() {
       },
       fs_stat_token(pathTagged) {
         const filePath = decodeStringArg(instanceRef, pathTagged);
-        if (policyStatTokenConfig) {
-          return encodeHostInt(contentStatToken(filePath));
+        // A stat failure (a missing path, an unreadable directory) is a
+        // guest-visible host error, the same conversion fs_read_file makes:
+        // the compiler stats a source before reading it (#2386), so a path
+        // that used to fail at the read must fail the same way one call
+        // earlier, not escape the wasm boundary as a raw host exception.
+        try {
+          if (policyStatTokenConfig) {
+            return encodeHostInt(contentStatToken(filePath));
+          }
+          // Module/package loading reserves -1 as a stable non-regular-source
+          // witness. lstat is required here: stat would follow the link and make
+          // a symlink indistinguishable from its target.
+          if (fs.lstatSync(filePath).isSymbolicLink()) {
+            return encodeHostInt(-1n);
+          }
+          const { lower, upper } = buildFsMetadataHashParts(filePath);
+          return encodeHostInt(BigInt.asUintN(61, lower ^ upper));
+        } catch (e) {
+          throwVibeHostError(`fs_stat_token failed for '${filePath}': ${e.message}`);
         }
-        // Module/package loading reserves -1 as a stable non-regular-source
-        // witness. lstat is required here: stat would follow the link and make
-        // a symlink indistinguishable from its target.
-        if (fs.lstatSync(filePath).isSymbolicLink()) {
-          return encodeHostInt(-1n);
-        }
-        const { lower, upper } = buildFsMetadataHashParts(filePath);
-        return encodeHostInt(BigInt.asUintN(61, lower ^ upper));
       },
       fs_write_file(pathTagged, contentTagged) {
         const filePath = decodeStringArg(instanceRef, pathTagged);


### PR DESCRIPTION
## What

Two slices of #2386 on the filesystem lane, byte-identical to main on every corpus, plus the runner fix Codex's round-1 finding asked for: a source file is read from the host once per process, every later ask for the same file is a stat probe and the text already in memory, and the persistent source-cache rows take their fingerprints from the memo that already hashed the text.

### Source files are read once per process through a stat-validated text memo

A cold compile of the compiler's own closure read each implementation file three to four times: `desugar_contract_source_fs` reads a package's members, `collect_sources_rec` reads each member again as a source, `package_deps_missing` reads them once more, and the ingestion fingerprint (`fingerprint_source`) reads every file to hash it. Measured on the cold profile this commit was written against: 147 ms under `fs_read_file` (59 ms of `readFileSync` plus 42 ms of utf8 decoding in the host), and a fresh copy of every text per read.

`cache_underlying.vibe` now keeps one memo of a file's raw text, keyed by path and validated by `Fs::stat_token` on every hit, the way the #1308 fingerprint memo beside it validates its fingerprints. The token is taken before the read, so a file rewritten between the two lands under the old token and is re-read on the next ask (the other order would record the new token against the old text); the window that remains, an in-place same-size rewrite inside one timestamp tick on the same inode, is the one the persistent cache's source rows already trust the token over. The non-regular witness (-1, a symlink) is never memoized, since that token cannot change with the file. One entry per path, replaced in place, and a worker resets the memo per job as it does the fingerprint memo. `cache_read_source_with_token_fs` takes a token the caller already holds (the fingerprint memo, the header pass's export-list memo, the export-metadata walk, the cached-source probe); `cache_read_source_fs` takes its own.

The loader's, header pass's, manifest lane's, typing walk's and `vibe check`'s source reads go through it. Reads of persistent-cache files stay raw (each is read once), and so do the two reads whose failure a caller handles (`check_unstable_surface_warnings_*`).

`fingerprint_source` keeps both ingestion telemetry pairs counting the boundary's requests, so `source_read_calls == hash_calls` still holds for `scripts/edit_cycle_kpi.mjs` and `scripts/ingestion_stamp_oracle.mjs` (the oracle passes against a stage2 built from this tree: all of its observations, gate off and on, metadata-only, same-size, malformed and deleted, answer as asserted).

`source_text_memo_test.vibe` pins it: a repeat ask costs no host read (the memo's read counter is the witness), a rewritten file is read again and a reset forgets it, and the ingestion fingerprint takes the memo while still counting its boundary read. Red: a hit that ignores the token answers the old text of a rewritten file.

### Measured (cand53)

Cache-isolated per the profiling skill, `codegen_lexer_test.vibe` over the full compiler closure, against a stage2 built from the tree of `fc378db` (#2544's head, the commit this one was written on), idle machine, four interleaved pairs in alternating order (ABBA):

| | `fc378db` | cand53 |
|---|---:|---:|
| `fs_read_file` cold inclusive (host) | 0.15 s | 0.07 s |
| `readFileSync` cold inclusive (host) | 0.10 s | 0.06 s |
| `fs_stat_token` cold inclusive (host) | 0.05 s | 0.05 s |
| `cache_read_source_with_token_fs` cold inclusive | — | 0.05 s (the remaining reads) |
| `collect_source_groups_fs` cold inclusive | 1.04 s | 1.00 s |
| cold wall, median of 4 | 6.23 s | 6.14 s (−1.4%; pairs −127, −119, −54, +53 ms) |
| warm wall, median of 4 | 4.02 s | 3.95 s (−1.7%; every candidate run at or below every baseline run but one tie) |
| heap_ptr cold / warm | 863,464,488 / 550,483,088 | 850,994,008 / 545,102,344 (−12.5 MB / −5.4 MB) |

The heap rows are deterministic (one copy of each text per read that the memo now answers); the wall rows sit at the edge of the noise band, in the direction the profile rows predict. The stat probes did not grow because the callers that already hold a token pass it in. Byte-identical output on three closures and 22 rc fixtures.

### Codex round 1 (P1): a missing entry path fails at the stat the way it failed at the read

`vibe check does_not_exist.vibe` stats the entry before reading it now, and the node runner's `fs_stat_token` let the lstat failure escape the wasm boundary as a raw host exception (a stack dump) where `fs_read_file` converted the same failure into the guest-visible `error: fs_read_file failed for ...`. The runner makes the same conversion for a stat failure (`error: fs_stat_token failed for 'does_not_exist.vibe': ENOENT ...`, exit 1, reproduced before and after on the CLI core wasm); viberun already answered token 0 there and let the read that follows raise. The memo's doc comment states that contract instead of a caller precondition, and `source_text_memo_test.vibe` gains the case: asking the memo for a missing path is a handled `Exception` naming the failing host call. Red on the unconverted runner: the raw host exception takes the test process down.

### The persistent source-cache rows take their fingerprints from the source-fingerprint memo

`build_persistent_sources_cache_text`, `build_persistent_source_groups_cache_text` (`loader/loader.vibe`) and the contract desugar's rebuilt closure key each hashed every source's text again with `compact_string_fingerprint`, after the header pass and the ingestion fingerprint had already hashed the same text through the memo: 94 ms of `__rt_compact_fingerprint_hash` in a cold compile of the compiler's closure (32 + 32 + 30 ms), three of the four remaining direct hashes of whole sources. They ask `compact_source_fingerprint_memo` now, which verifies the text it answers for, so an unchanged text costs nothing and a rewritten member (the #1308 race the rebuilt key exists for) is hashed afresh.

`build_persistent_sources_cache_text` is exported so the routing can be pinned: `persistent_sources_cache_text_memo_test.vibe` asserts that a row's text is hashed once (the memo's counter is the witness), that a second build of the same rows hashes nothing, and that the row carries `compact_string_fingerprint` of the text. Red: hashing the row directly leaves the counter at 0.

#### Measured (cand54)

Same protocol, against a stage2 built from the tree of `1639687` (the first commit of this PR):

| | `1639687` | cand54 |
|---|---:|---:|
| `compact_string_fingerprint` cold inclusive | 0.16 s | 0.08 s |
| `__rt_compact_fingerprint_hash` cold inclusive | 0.16 s | 0.07 s |
| `build_persistent_sources_cache_text` / `..._source_groups_cache_text` cold inclusive | 0.04 s / 0.04 s | 0.01 s / 0.01 s |
| `collect_source_groups_fs` cold inclusive | 1.00 s | 0.91 s |
| cold wall, median of 4 | 6.22 s | 6.29 s (noise; pairs −33, −14, −53, +177 ms) |
| warm wall, median of 4 | 3.97 s | 4.02 s (noise) |
| heap_ptr cold / warm | 852,959,448 / 546,263,800 | 852,888,248 / 546,264,688 (−71 KB / +0.9 KB) |

The hashing rows are the evidence; ~90 ms is below this machine's wall noise. Byte-identical output on three closures and 22 rc fixtures.

## Validation

Chain on `1639687` (base `62086a5`; run in a staging worktree on the identical tree, tree hash `16bbb5b` checked against the pushed head): bundle regen; stage2 == stage3; output equivalence; `test_cli_core.sh`; selfcompile KPI heap_ptr 852,985,152 bytes (against the shared default cache, so not comparable with the cache-isolated rows above); typing-env-reuse oracle; 123/123 affected unit-test files (import-graph selection over the changed files); `compiler_gate.sh` early / mid / late; `scripts/ingestion_stamp_oracle.mjs` against a stage2 built from this tree.

Chain on `24c23a4` (the stack head: memo, runner fix, cache rows; same base and protocol, tree hash `b9e2bbf` checked against the pushed head): bundle regen; stage2 == stage3; output equivalence; `test_cli_core.sh`; selfcompile KPI heap_ptr 852,912,016 bytes; typing-env-reuse oracle; 124/124 affected unit-test files; `compiler_gate.sh` early / mid / late (its missing-import case runs on the converted runner).

`vibe_fmt.sh --check` is a fixpoint on every changed file.

Refs #2386.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QKZdvBvHVUagwg6Yih8er8

---
_Generated by [Claude Code](https://claude.ai/code/session_01QKZdvBvHVUagwg6Yih8er8)_