### PR TITLE
checker: the three effect-pass accumulators read children from the scratch stack (#2386)

### DIFF
--- a/lib/@vibe/compiler/checker/checker_effects.vibe
+++ b/lib/@vibe/compiler/checker/checker_effects.vibe
@@ -22,8 +22,12 @@ import @vibe/compiler/core {
   exception_kinds_compatible,
   exception_label_kind,
   exception_throw_label_for_kind,
+  expr_child_at,
   expr_children,
   expr_children_into,
+  expr_children_pop,
+  expr_children_push,
+  expr_children_top,
   find_typedef,
   has_standard_host_provider,
   is_entry_admitted_effect,
@@ -291,12 +295,14 @@ fn check_stdin_provider_direct_calls_expr_into(expr: Expr, out: Array[EffectErro
           ai = ai + 1
         }
       } else {
-        let children = expr_children(expr)
-        let mut i = 0
-        while i < Array::length(children) {
-          check_stdin_provider_direct_calls_expr_into(Array::get(children, i), out)
+        let mark = expr_children_push(expr)
+        let end = expr_children_top()
+        let mut i = mark
+        while i < end {
+          check_stdin_provider_direct_calls_expr_into(expr_child_at(i), out)
           i = i + 1
         }
+        expr_children_pop(mark)
       }
     },
     EIdent(name, _) => if is_stdin_provider_surface(name) {
@@ -305,12 +311,14 @@ fn check_stdin_provider_direct_calls_expr_into(expr: Expr, out: Array[EffectErro
       ()
     },
     _ => {
-      let children = expr_children(expr)
-      let mut i = 0
-      while i < Array::length(children) {
-        check_stdin_provider_direct_calls_expr_into(Array::get(children, i), out)
+      let mark = expr_children_push(expr)
+      let end = expr_children_top()
+      let mut i = mark
+      while i < end {
+        check_stdin_provider_direct_calls_expr_into(expr_child_at(i), out)
         i = i + 1
       }
+      expr_children_pop(mark)
     }
   }
 }
@@ -1939,12 +1947,14 @@ fn check_async_effects_expr_lo_into(expr: Expr, env: TypeEnv, in_async: Bool, lo
       check_async_effects_expr_lo_into(body, env, in_async, body_locals, out)
     },
     _ => {
-      let children = expr_children(expr)
-      let mut i = 0
-      while i < Array::length(children) {
-        check_async_effects_expr_lo_into(Array::get(children, i), env, in_async, locals, out)
+      let mark = expr_children_push(expr)
+      let end = expr_children_top()
+      let mut i = mark
+      while i < end {
+        check_async_effects_expr_lo_into(expr_child_at(i), env, in_async, locals, out)
         i = i + 1
       }
+      expr_children_pop(mark)
     }
   }
 }
@@ -5955,13 +5965,14 @@ fn check_mutability_expr_into(expr: Expr, mutable: Array[String], out: Array[Eff
     // New structural forms keep the same binding context; scoped forms above
     // intentionally remain explicit so their boundary semantics are visible.
     _ => {
-      let children = expr_children(expr)
-      let mut i = 0
-      while i < Array::length(children) {
-        check_mutability_expr_into(Array::get(children, i), mutable, out)
+      let mark = expr_children_push(expr)
+      let end = expr_children_top()
+      let mut i = mark
+      while i < end {
+        check_mutability_expr_into(expr_child_at(i), mutable, out)
         i = i + 1
       }
-      ()
+      expr_children_pop(mark)
     }
   }
 }


### PR DESCRIPTION
## What

One slice of #2386 on the checker lane, byte-identical to main on every corpus: the three effect-pass accumulators read their children from the shared scratch stack instead of building a list per node.

### The three effect-pass accumulators read children from the scratch stack

`check_stdin_provider_direct_calls_expr_into`, `check_async_effects_expr_lo_into` and `check_mutability_expr_into` (`checker/checker_effects.vibe`) still built a child list per expression node through `expr_children` after #2540 gave them their accumulators: on the current cold profile the two hot ones were 42 of the 51 ms under `expr_children`, one array per node of every body on the checker lane. They read their children from the scratch stack now (`expr_children_push` / `expr_child_at` / `expr_children_pop`, the #2543 shape), in the same order and with the same recursion, so every report keeps its position.

`effect_pass_accumulator_test.vibe` already pins each pass's reports in preorder through nested scopes, and `checker_async_effects_test.vibe` keeps answering. Red: a walk that stops one child short of the stack's top drops the last child's stdin-provider references (the three-report case reports none).

### Measured (cand57)

Cache-isolated per the profiling skill, `codegen_lexer_test.vibe` over the full compiler closure, against a stage2 built from the tree of `a5c3b00` (main), idle machine, four interleaved pairs in alternating order (ABBA):

| | `a5c3b00` | cand57 |
|---|---:|---:|
| `expr_children*` cold inclusive | 0.22 s | 0.18 s |
| `expr_children_into` cold inclusive | 0.12 s | 0.09 s |
| cold wall, median of 4 | 6.09 s | 6.14 s (noise; the last pair ran +0.4 s on both sides) |
| warm wall, median of 4 | 4.05 s | 4.09 s (noise; the warm lane does not run this code) |
| heap_ptr cold / warm | 846,539,248 / 539,393,560 | 829,452,224 / 539,388,888 (−17.1 MB / −4.7 KB) |

The cold heap row is deterministic (one child array per node of every body, checker lane only); the walls are inside the noise band. Byte-identical output on three closures and 22 rc fixtures.

## Validation

Chain on `9ee8b55` (base `a5c3b00`; run in a staging worktree on the identical tree, tree hash `c1bb9e7` checked against the pushed head): bundle regen; stage2 == stage3; output equivalence; `test_cli_core.sh`; selfcompile KPI heap_ptr 829,477,304 bytes (against the shared default cache, so not comparable with the cache-isolated rows above); typing-env-reuse oracle; 217/217 affected unit-test files (import-graph selection over the changed files); `compiler_gate.sh` early / mid / late.

`vibe_fmt.sh --check` is a fixpoint on every changed file.

Refs #2386.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QKZdvBvHVUagwg6Yih8er8

---
_Generated by [Claude Code](https://claude.ai/code/session_01QKZdvBvHVUagwg6Yih8er8)_