### PR TITLE
profile_compile: profile through the runner wrapper so V8's wasm inliner is on (#2386)

### DIFF
--- a/.claude/skills/compiler-perf-profiling/SKILL.md
+++ b/.claude/skills/compiler-perf-profiling/SKILL.md
@@ -76,12 +76,14 @@ Protocol for ANY before/after comparison on this lane:
 ```bash
 S2=<stage2.wasm>   # current stage2 (a scripts/generations.sh build artifact)
 VIBE_PREOPEN_DIR="$PWD" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
-  VIBE_NODE_EXTRA_FLAGS="--cpu-prof --cpu-prof-dir=/tmp --cpu-prof-name=compile.cpuprofile" \
+  VIBE_NODE_EXTRA_FLAGS="$(printf '%s\n' --cpu-prof --cpu-prof-dir=/tmp --cpu-prof-name=compile.cpuprofile)" \
   bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$S2" \
   lib/@vibe/compiler/tests/codegen_lexer_test.vibe /tmp/out.wasm __no_entry__
 ```
 
-**Go through the runner wrapper, never a bare `node --cpu-prof`.** The
+**Go through the runner wrapper, never a bare `node --cpu-prof`.**
+`VIBE_NODE_EXTRA_FLAGS` takes one flag per line (a value may contain
+spaces; the `printf` above puts each flag on its own line). The
 wrapper adds `--experimental-wasm-inlining` (V8 keeps its wasm-to-wasm
 inliner off for MVP modules unless asked; `vibe test` / `vibe run` and every
 gate run with it). A bare `node` profiles a compiler V8 never inlines, and

--- a/.claude/skills/compiler-perf-profiling/SKILL.md
+++ b/.claude/skills/compiler-perf-profiling/SKILL.md
@@ -76,10 +76,20 @@ Protocol for ANY before/after comparison on this lane:
 ```bash
 S2=<stage2.wasm>   # current stage2 (a scripts/generations.sh build artifact)
 VIBE_PREOPEN_DIR="$PWD" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
-  node --cpu-prof --cpu-prof-dir=/tmp --cpu-prof-name=compile.cpuprofile \
-  scripts/wasm_vibe_host_runner.js --invoke cli_main "$S2" \
+  VIBE_NODE_EXTRA_FLAGS="--cpu-prof --cpu-prof-dir=/tmp --cpu-prof-name=compile.cpuprofile" \
+  bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$S2" \
   lib/@vibe/compiler/tests/codegen_lexer_test.vibe /tmp/out.wasm __no_entry__
 ```
+
+**Go through the runner wrapper, never a bare `node --cpu-prof`.** The
+wrapper adds `--experimental-wasm-inlining` (V8 keeps its wasm-to-wasm
+inliner off for MVP modules unless asked; `vibe test` / `vibe run` and every
+gate run with it). A bare `node` profiles a compiler V8 never inlines, and
+the small runtime helpers then show up as calls: measured 2026-09-06 on one
+cold compile, `__rt_arr_get` 415 → 156 ms self, `__rt_eq` 291 → 114 ms,
+`__rt_arr_len` 148 → 0 ms, wall 7.14 → 6.55 s once the flag was on. The
+rows that survive inlining (`__rt_arr_push`, `__rt_str_eq`, `__rt_arr_new`)
+are the real intrinsic costs; the rest was the profile's artifact.
 
 Pick a heavyweight test that compiles the whole compiler closure
 (codegen_*_test / cli_test / selfhost_s5_*). Aggregating self time:

--- a/scripts/profile_compile.sh
+++ b/scripts/profile_compile.sh
@@ -50,10 +50,18 @@ echo "[profile-compile] input=$INPUT"
 echo "[profile-compile] out_dir=$OUT_DIR"
 
 start_ns=$(date +%s%N)
+# Through the runner wrapper, not a bare `node`: the wrapper adds the wasm
+# perf flags every other lane runs with (--experimental-wasm-inlining above
+# all -- V8 leaves its wasm-to-wasm inliner OFF for MVP modules unless asked).
+# Profiled without it, the small runtime helpers show up as calls V8 would
+# have inlined: measured 2026-09-06 on the same cold compile, __rt_arr_get
+# 415 -> 156 ms self, __rt_eq 291 -> 114 ms, __rt_arr_len 148 -> 0 ms,
+# wall 7.14 -> 6.55 s. Those rows were the profile's artifact, not the
+# compiler's cost.
 VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   VIBE_WASM_MEMORY_STATS=1 \
-  node --cpu-prof --cpu-prof-dir="$OUT_DIR" --cpu-prof-name="$PROFILE_NAME" \
-  scripts/wasm_vibe_host_runner.js --invoke cli_main "$STAGE2" \
+  VIBE_NODE_EXTRA_FLAGS="--cpu-prof --cpu-prof-dir=$OUT_DIR --cpu-prof-name=$PROFILE_NAME" \
+  bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$STAGE2" \
   "$INPUT" "$OUT_WASM" __no_entry__
 end_ns=$(date +%s%N)
 echo "[profile-compile] wall_ms=$(( (end_ns - start_ns) / 1000000 ))"

--- a/scripts/profile_compile.sh
+++ b/scripts/profile_compile.sh
@@ -58,9 +58,12 @@ start_ns=$(date +%s%N)
 # 415 -> 156 ms self, __rt_eq 291 -> 114 ms, __rt_arr_len 148 -> 0 ms,
 # wall 7.14 -> 6.55 s. Those rows were the profile's artifact, not the
 # compiler's cost.
+# One flag per line: the wrapper splits VIBE_NODE_EXTRA_FLAGS on newlines, so
+# an output directory with a space in its name stays one argument.
+extra_flags="$(printf '%s\n' --cpu-prof "--cpu-prof-dir=$OUT_DIR" "--cpu-prof-name=$PROFILE_NAME")"
 VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   VIBE_WASM_MEMORY_STATS=1 \
-  VIBE_NODE_EXTRA_FLAGS="--cpu-prof --cpu-prof-dir=$OUT_DIR --cpu-prof-name=$PROFILE_NAME" \
+  VIBE_NODE_EXTRA_FLAGS="$extra_flags" \
   bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$STAGE2" \
   "$INPUT" "$OUT_WASM" __no_entry__
 end_ns=$(date +%s%N)

--- a/scripts/run_wasm_vibe_host_runner.sh
+++ b/scripts/run_wasm_vibe_host_runner.sh
@@ -93,5 +93,17 @@ fi
 # caller knows its node accepts, such as --cpu-prof for scripts/profile_compile.sh,
 # which needs the perf flags above on the profiled process too -- a direct
 # `node --cpu-prof` skips them and profiles a compiler V8 never inlines.
-# shellcheck disable=SC2086
-exec node "${node_flags[@]}" ${VIBE_NODE_EXTRA_FLAGS:-} "$PROJECT_ROOT/scripts/wasm_vibe_host_runner.js" "$@"
+# One flag per LINE, so a value may contain spaces (`--cpu-prof-dir=/a dir`
+# stays one argument); a newline cannot be part of a flag.
+extra_flags=()
+if [ -n "${VIBE_NODE_EXTRA_FLAGS:-}" ]; then
+  while IFS= read -r vibe_extra_line || [ -n "$vibe_extra_line" ]; do
+    if [ -n "$vibe_extra_line" ]; then
+      extra_flags+=("$vibe_extra_line")
+    fi
+  done <<VIBE_EXTRA_EOF
+$VIBE_NODE_EXTRA_FLAGS
+VIBE_EXTRA_EOF
+fi
+
+exec node "${node_flags[@]}" ${extra_flags[@]+"${extra_flags[@]}"} "$PROJECT_ROOT/scripts/wasm_vibe_host_runner.js" "$@"

--- a/scripts/run_wasm_vibe_host_runner.sh
+++ b/scripts/run_wasm_vibe_host_runner.sh
@@ -89,4 +89,9 @@ if [ "$vibe_caller_set_stack" -eq 0 ] && [ "${VIBE_NODE_STACK_SIZE}" -gt 1200 ] 
   node_flags+=("--stack-size=${VIBE_NODE_STACK_SIZE}")
 fi
 
-exec node "${node_flags[@]}" "$PROJECT_ROOT/scripts/wasm_vibe_host_runner.js" "$@"
+# VIBE_NODE_EXTRA_FLAGS is appended verbatim (no probe, no cache): flags a
+# caller knows its node accepts, such as --cpu-prof for scripts/profile_compile.sh,
+# which needs the perf flags above on the profiled process too -- a direct
+# `node --cpu-prof` skips them and profiles a compiler V8 never inlines.
+# shellcheck disable=SC2086
+exec node "${node_flags[@]}" ${VIBE_NODE_EXTRA_FLAGS:-} "$PROJECT_ROOT/scripts/wasm_vibe_host_runner.js" "$@"


### PR DESCRIPTION
## What

A measurement fix, no compiler change: `scripts/profile_compile.sh` ran a bare `node --cpu-prof` without the `--experimental-wasm-inlining` flag that `scripts/run_wasm_vibe_host_runner.sh` adds for every real lane (`vibe test` / `vibe run` / the gates; V8 keeps its wasm-to-wasm inliner off for MVP modules unless asked, and node 22.22's default is `--no-experimental-wasm-inlining`). The profiled compiler was therefore one V8 never inlines, and the small runtime helpers showed up as calls.

Measured on the same cold compile of the compiler closure (`codegen_lexer_test.vibe`, stage2 of `e12d175`, cache-isolated), direct node vs. through the wrapper:

| self time | bare `node` | through the wrapper |
|---|---:|---:|
| `__rt_arr_get` | 415 ms | 156 ms |
| `__rt_eq` | 291 ms | 114 ms |
| `__rt_arr_len` | 148 ms | 0 ms (inlined away) |
| `__rt_arr_push` | 414 ms | 350 ms |
| `__rt_str_eq` | 323 ms | 261 ms |
| wall | 7.14 s | 6.55 s |

The rows that survive (`__rt_arr_push`, `__rt_str_eq`, `__rt_arr_new`) are the real intrinsic costs; the rest was the profile's artifact. Every cpu profile quoted on #2386 was taken this way; the wall and heap_ptr rows there went through the wrapper (`measure.sh`), so they stand. The #2386 status comment of 2026-09-06 carries the corrected reading.

### Changes

- `scripts/run_wasm_vibe_host_runner.sh`: `VIBE_NODE_EXTRA_FLAGS` is appended verbatim after the probed perf flags (no probe, no cache), one flag per line. A caller passing `--cpu-prof` knows its node accepts it, and the probe cache is keyed by the flag string, so routing per-run output paths through the probe would write one cache file per profile.
- `scripts/profile_compile.sh`: hands the cpu-prof flags through the wrapper instead of invoking node directly; the comment records the measurement.
- `.claude/skills/compiler-perf-profiling/SKILL.md`: the manual §1 command does the same, with the trap spelled out next to it.

### Codex round 1 (P2, fixed in 0e2dd3d)

The first version expanded the extra flags unquoted, so a `VIBE_PROFILE_OUT_DIR` with a space split `--cpu-prof-dir=<dir>` into two node arguments where the previous direct invocation had quoted it. The wrapper now reads the variable one flag per line into an array (`while IFS= read -r`) and appends the array; the two callers build the value with `printf '%s\n'`. Measured: a profile directory named `prof dir with space` gets its `compile.cpuprofile`, with the inlined rows.

Verified: `profile_compile.sh` from this tree on the same stage2 reports `__rt_arr_get` 178 ms / `__rt_eq` 115 ms / no `__rt_arr_len` row, and the memory-stats line is unchanged (heap_ptr 829,450,168 on the cold run). `check_gate_portability.sh` and `check_gate_self_tests.sh` ok.

Refs #2386.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QKZdvBvHVUagwg6Yih8er8