### PR TITLE
cli: compile-only artifact drops the gc, instrumentation and shadow lanes by reachability (#2497)

### DIFF
--- a/Taskfile.pkl
+++ b/Taskfile.pkl
@@ -638,7 +638,9 @@ local testCheckCompileOnlyLanes = new Task {
     ...compilerProbeInputs
     ...scriptSources
   }
-  deps { selfhostGeneration }
+  // After the gate, not beside it: the self-test reads the named artifact the
+  // gate builds, and sibling dependencies run concurrently.
+  deps { checkCompileOnlyLanes }
 }
 local checkDocCommands = new Task {
   name = "check-doc-commands"

--- a/Taskfile.pkl
+++ b/Taskfile.pkl
@@ -614,6 +614,31 @@ local checkRcDefault = new Task {
   }
   deps { selfhostGeneration }
 }
+// #2497: the compile-only artifact (scripts/build_compile_only.sh) has exactly
+// the lanes it claims, asked of the wasm: no gc-backend / instrumentation /
+// rc-shadow function bodies (read from the name section), and every switch
+// that would select one is refused by name rather than compiled on another
+// lane. Builds the artifact with names from the HEAD generation's stage2.
+local checkCompileOnlyLanes = new Task {
+  name = "check-compile-only-lanes"
+  description = "the compile-only artifact contains no dropped-lane bodies and refuses their switches by name"
+  cmd = "bash scripts/check_compile_only_lanes.sh"
+  inputs {
+    ...compilerProbeInputs
+    ...scriptSources
+  }
+  deps { selfhostGeneration }
+}
+local testCheckCompileOnlyLanes = new Task {
+  name = "test-check-compile-only-lanes"
+  description = "check-compile-only-lanes fails on a stripped, a leaking, and a full-CLI artifact"
+  cmd = "bash scripts/check_compile_only_lanes_test.sh"
+  inputs {
+    ...compilerProbeInputs
+    ...scriptSources
+  }
+  deps { selfhostGeneration }
+}
 local checkDocCommands = new Task {
   name = "check-doc-commands"
   description = "commands shown in docs name tasks, scripts and env vars that exist"
@@ -1745,6 +1770,8 @@ local releaseCheck = new Task {
     checkPackageSiblingScope
     checkDocCommands
     checkRcDefault
+    checkCompileOnlyLanes
+    testCheckCompileOnlyLanes
     checkTaskInputs
     testCheckTaskInputs
     doctestGated
@@ -1842,6 +1869,8 @@ tasks {
   checkPackageSiblingScope
   checkDocCommands
   checkRcDefault
+  checkCompileOnlyLanes
+  testCheckCompileOnlyLanes
   checkTaskInputs
   testCheckTaskInputs
   testGenerateSelfhostBundle

--- a/Taskfile.pkl
+++ b/Taskfile.pkl
@@ -621,7 +621,8 @@ local checkRcDefault = new Task {
 // lane. Builds the artifact with names from the HEAD generation's stage2.
 local checkCompileOnlyLanes = new Task {
   name = "check-compile-only-lanes"
-  description = "the compile-only artifact contains no dropped-lane bodies and refuses their switches by name"
+  description =
+    "the compile-only artifact contains no dropped-lane bodies and refuses their switches by name"
   cmd = "bash scripts/check_compile_only_lanes.sh"
   inputs {
     ...compilerProbeInputs

--- a/docs/bootstrap.md
+++ b/docs/bootstrap.md
@@ -395,6 +395,7 @@ compiler wasm を作る canonical な入口は 1 つ:
 | artifact | builder | 出力先 | 役割 |
 |---|---|---|---|
 | stage2 | `scripts/generations.sh build` | `_build/selfhost/generations/<ts>/stage2.wasm` | pinned seed から self-reproduce した candidate。bootstrap bump / release の元。 |
+| compile-only | `scripts/build_compile_only.sh` | `_build/compile_only/vibe_compile_only.wasm` | The same env-mode CLI as stage2, DCE-rooted at `main_compile_only` (cli_adapter.vibe): only the two production allocator lanes; the gc backend, the coverage / trace / break instrumentation, rc-shadow and the cache / telemetry twins are absent from the wasm, and their switches are refused by name (#2497, gate `scripts/check_compile_only_lanes.sh`). Invoke it as `cli_main_compile_only`. |
 
 配布物 (release asset の `vibe-compiler-<tag>.wasm`) は adopt された seed
 (= 過去の stage2) そのもので、`scripts/build_release_assets.sh` /

--- a/lib/@vibe/compiler/cli_adapter.vibe
+++ b/lib/@vibe/compiler/cli_adapter.vibe
@@ -634,33 +634,6 @@ fn apply_cfg_env(source: String, cfg_csv: String) -> String {
   }
 }
 
-fn compile_source_for_rc_flag(source: String, entry_name: String, rc_flag: String, trusted_generated: Bool) -> Bytes with Exception {
-  // ADR-0055 #493 cutover: the Perceus RC codegen (memory-reclaiming linear
-  // backend) is the DEFAULT; set VIBE_RC=0 to opt back into the legacy bump
-  // path. The compiler self-build, bootstrap, and bump-baseline gates pin
-  // VIBE_RC=0 (see scripts/*.sh) so they stay byte-identical on bump.
-  if rc_flag == "shadow" {
-    // #715 recurrence guard: RC codegen + shadow-liveness traps (debug builds).
-    if trusted_generated {
-      compile_generated_source_wasi_only_rc_shadow(source, entry_name)
-    } else {
-      compile_source_wasi_only_rc_shadow(source, entry_name)
-    }
-  } else if rc_flag != "0" {
-    if trusted_generated {
-      compile_generated_source_wasi_only_rc(source, entry_name)
-    } else {
-      compile_source_wasi_only_rc(source, entry_name)
-    }
-  } else {
-    if trusted_generated {
-      compile_generated_source_wasi_only(source, entry_name)
-    } else {
-      compile_source_wasi_only(source, entry_name)
-    }
-  }
-}
-
 /// Remove a ` [@off=...]` side-channel marker WITHOUT resolving it. The marker
 /// is internal transport for a source offset (#1514); a lane that does not know
 /// which source text the offset indexes (the FS-compile lane compiles MERGED
@@ -862,7 +835,12 @@ fn configure_typing_dependency_env_reuse_policy() -> Unit with Exception + Env {
   }
 }
 
-export fn cli_main() -> Int with Exception + Fs + Env + Stdin + Stdout {
+/// The env-mode CLI body, parameterized by its lane tables (#2497). `cli_main`
+/// installs the full tables; `cli_main_compile_only` the production ones. The
+/// tables are the ONLY difference between the two artifacts, so every other
+/// switch (command selectors, VIBE_CFG, VIBE_UNSTABLE, the trusted-source
+/// boundary) behaves identically on both.
+fn cli_main_with_lanes(fs_lanes: (FsLane, String, String) -> (Bytes, String) with Exception + Fs + Env, ss_lanes: (SsLane, String, String, Bool) -> Bytes with Exception) -> Int with Exception + Fs + Env + Stdin + Stdout {
   // Reset the process-wide TDRE8 cell before every invocation. Only the
   // check-only branch may enable it after strict policy validation below;
   // build/codegen lanes stay conservative, and a prior check in a long-lived
@@ -1419,86 +1397,24 @@ export fn cli_main() -> Int with Exception + Fs + Env + Stdin + Stdout {
       // the unit-test batch runs many compiles in one daemon.
       unstable_closure_reset()
       let artifact_input_trace_nonce = Env::get("VIBE_ARTIFACT_INPUT_TRACE_NONCE")
-      // debugger trace (DAP P1 groundwork): `vibe run --trace` sets VIBE_DEBUG=1
-      // so the user file (and its imports) is compiled with function-call
-      // execution-trace instrumentation; running the produced wasm fills the
-      // in-memory trace log that the runner dumps via VIBE_TRACE_OUT.
-      // The special compile MODES (coverage / debugger break / trace) are
-      // checked first; they are mutually exclusive instrumentation builds and
-      // are unaffected by the RC cutover. The normal compile then defaults to
-      // the Perceus RC backend (#493 cutover, #705 parity) unless VIBE_RC=0
-      // selects the legacy bump path (which carries the #634 testmeta variant).
-      let fs_backend = Env::get("VIBE_BACKEND")
-      let fs_coverage_selected = Env::get("VIBE_COVERAGE") == "1"
-      let fs_debug_break_selected = !fs_coverage_selected && Env::get("VIBE_DEBUG_BREAK") == "1"
-      let fs_debug_trace_selected = !fs_coverage_selected && !fs_debug_break_selected && Env::get("VIBE_DEBUG") == "1"
-      // Instrumentation selectors have higher precedence than VIBE_BACKEND.
+      let fs_lane = fs_lane_request(mark_memory, artifact_input_trace_out, artifact_input_trace_nonce, artifact_input_trace_checked_error_row_mode, artifact_input_trace_diagnostics_mode, artifact_input_trace_dep_order_seed)
       // Record the lane that will actually produce `bytes`; raw Env presence
       // is not an artifact property when selectors are combined.
-      let fs_gc_selected = !fs_coverage_selected && !fs_debug_break_selected && !fs_debug_trace_selected && fs_backend == "gc"
-      let (bytes, artifact_input_trace) = if fs_coverage_selected {
-        (compile_file_fs_mode_coverage(input_path, entry_name), "")
-      } else if fs_gc_selected {
-        (compile_file_fs_mode_gc(input_path, entry_name), "")
-      } else if fs_debug_break_selected {
-        // debugger breakpoint (DAP P1): `vibe run --break` sets VIBE_DEBUG_BREAK=1
-        // so the user file is compiled with `vibe::dbg_break` host-hook calls at
-        // each user function entry; the runner pauses on the named breakpoints.
-        (compile_file_fs_mode_break(input_path, entry_name), "")
-      } else if fs_debug_trace_selected {
-        (compile_file_fs_mode_trace(input_path, entry_name), "")
-      } else if Env::get("VIBE_RC") == "shadow" {
-        // #715/#768: shadow-liveness double-free traps for import-resolving
-        // builds (previously only the single-source path honored "shadow";
-        // this path silently compiled plain RC).
-        (compile_file_fs_mode_rc_shadow(input_path, entry_name), "")
-      } else if Env::get("VIBE_RC") != "0" {
-        // ADR-0055 #493 cutover DEFAULT: RC reclaims memory each iteration; the
-        // legacy bump path leaks until exit. Opt back into bump with VIBE_RC=0.
-        // #1553: under VIBE_PROFILE_MEMORY_MARKS=1 take the heap-marked twin
-        // (same pipeline, named memory mark per phase); production runs keep
-        // the exact unmarked lane.
-        if mark_memory {
-          (compile_file_fs_mode_rc_heap_marked(input_path, entry_name), "")
-        } else {
-          // #2388 step 3: opt-in cross-compile codegen body cache. "verify"
-          // double-compiles and byte-compares (trust building); "on" replays
-          // persisted bodies. Env is read here, keeping file_compile Env-free
-          // (#634). Any other value keeps the exact production lane.
-          let body_cache_mode = Env::get("VIBE_CODEGEN_BODY_CACHE")
-          if body_cache_mode == "verify" || body_cache_mode == "on" {
-            (compile_file_fs_mode_rc_body_cached(input_path, entry_name, body_cache_mode), "")
-          } else {
-            (compile_file_fs_mode_rc(input_path, entry_name), "")
-          }
-        }
-      } else {
-        // Legacy bump path (VIBE_RC=0). #634 (ADR-0026): only when `vibe test`
-        // requests the pure-test cache verdict (VIBE_TESTMETA_OUT set) do we
-        // route through the variant that ALSO emits the `.testmeta` sidecar
-        // (riding the merged stmts this compile already builds — no extra
-        // parse). Env is read here (this layer has it), keeping the file_compile
-        // layer Env-free.
-        let testmeta_out = Env::get("VIBE_TESTMETA_OUT")
-        if artifact_input_trace_out != "" {
-          compile_file_fs_mode_cached_artifact_input_trace(input_path, entry_name, "no-dce", artifact_input_trace_nonce, artifact_input_trace_checked_error_row_mode, artifact_input_trace_diagnostics_mode, artifact_input_trace_dep_order_seed)
-        } else if testmeta_out != "" {
-          (compile_file_fs_mode_testmeta(input_path, entry_name, "no-dce", testmeta_out), "")
-        } else if mark_memory {
-          // #1553: bump attribution twin. As with its RC sibling, this is
-          // selected only for explicit heap observation; ordinary VIBE_RC=0
-          // compiles retain the Env-free production helper above.
-          (compile_file_fs_mode_bump_heap_marked(input_path, entry_name), "")
-        } else {
-          (compile_file_fs_mode(input_path, entry_name, "no-dce"), "")
-        }
+      let fs_coverage_selected = match fs_lane {
+        FsLaneCoverage => true,
+        _ => false
       }
+      let fs_gc_selected = match fs_lane {
+        FsLaneGc => true,
+        _ => false
+      }
+      let (bytes, artifact_input_trace) = fs_lanes(fs_lane, input_path, entry_name)
       // Binary-size (#1100): release executables ship without the name
       // section / module-linking exports. Instrumented builds (coverage /
       // trace / break / rc-shadow) are debug artifacts whose tooling reads
       // both, so they stay untouched; so do `__no_entry__` test/bench builds
       // (gated inside strip_executable_wasm_env).
-      let fs_instrumented = fs_coverage_selected || fs_gc_selected || fs_debug_break_selected || fs_debug_trace_selected || Env::get("VIBE_RC") == "shadow"
+      let fs_instrumented = fs_lane_is_instrumented(fs_lane)
       let core_bytes = if fs_instrumented {
         bytes
       } else {
@@ -2005,14 +1921,11 @@ export fn cli_main() -> Int with Exception + Fs + Env + Stdin + Stdout {
     profile_memory_mark(mark_memory)
     0
   } else {
-    // ADR-0055 #493 cutover toggle. This comment used to say "Env::get returns
-    // "" when unset, so default stays the bump path" -- that is BACKWARDS after
-    // the cutover, and it sat three lines above the code that decides:
-    // compile_source_for_rc_flag takes the RC path on `rc_flag != "0"`, so
-    // UNSET selects RC and only an explicit VIBE_RC=0 selects the legacy bump
-    // path. Measured on the same input through the seed: unset and VIBE_RC=1
-    // both produce 2,814,912 bytes, VIBE_RC=0 produces 1,969,067.
-    // The FS_COMPILE branch above states it correctly.
+    // ADR-0055 #493 cutover toggle: `ss_lane_request` takes the RC path on
+    // `rc_flag != "0"`, so UNSET selects RC and only an explicit VIBE_RC=0
+    // selects the legacy bump path. Measured on the same input through the
+    // seed: unset and VIBE_RC=1 both produce 2,814,912 bytes, VIBE_RC=0
+    // produces 1,969,067.
     // #1514: bound OUTSIDE the handle so the `Throw` arm -- a sibling scope, not
     // the handled body -- can name it when resolving a diagnostic's offset.
     let source_cfg = apply_cfg_env(source, Env::get("VIBE_CFG"))
@@ -2022,33 +1935,15 @@ export fn cli_main() -> Int with Exception + Fs + Env + Stdin + Stdout {
       // statements. Trust is out-of-band: ordinary source bytes can never
       // opt themselves into this lane.
       let trusted_generated = Env::get("VIBE_INTERNAL_TRUSTED_SOURCE") == "1"
-      // #cov: function-level coverage build (same source pipeline, instrumented
-      // codegen). Running the produced wasm records which compiler functions ran.
-      let bytes = if Env::get("VIBE_COVERAGE") == "1" {
-        if trusted_generated {
-          compile_generated_source_wasi_only_coverage(source_cfg, entry_name)
-        } else {
-          compile_source_wasi_only_coverage(source_cfg, entry_name)
-        }
-      } else if Env::get("VIBE_BACKEND") == "gc" {
-        // wasm-gc backend lane (parity checks / #415). Direct source compile
-        // only; FS-import mode and the special instrumentation modes stay
-        // linear-backend-only.
-        if trusted_generated {
-          compile_generated_source_gc_only(source_cfg, entry_name)
-        } else {
-          compile_source_gc_only(source_cfg, entry_name)
-        }
-      } else {
-        compile_source_for_rc_flag(source_cfg, entry_name, rc_flag, trusted_generated)
-      }
+      let ss_lane = ss_lane_request(rc_flag)
+      let bytes = ss_lanes(ss_lane, source_cfg, entry_name, trusted_generated)
       profile_memory_mark(mark_memory)
       // Binary-size (#1100): same release strip as the FS-compile lane above.
       // This single-source lane builds the compiler's own stage wasm
       // (generations.sh), so the dist CLI sheds its name section and the
       // 700+ `*_exp_lib__*` module-linking exports here. gc / coverage /
       // rc-shadow lanes stay untouched (parity and debug tooling).
-      let ss_instrumented = Env::get("VIBE_COVERAGE") == "1" || Env::get("VIBE_BACKEND") == "gc" || rc_flag == "shadow"
+      let ss_instrumented = ss_lane_is_instrumented(ss_lane)
       let ss_out_bytes = if ss_instrumented {
         bytes
       } else {
@@ -2100,5 +1995,310 @@ export fn main() -> Unit with Exception + Fs + Env + Stdin + Stdout + Process {
     vibe_process_exit_raw(code)
   } else {
     ()
+  }
+}
+
+/// The full env-mode CLI: every lane table entry.
+export fn cli_main() -> Int with Exception + Fs + Env + Stdin + Stdout {
+  cli_main_with_lanes(fs_lane_compile_full, ss_lane_compile_full)
+}
+
+/// #2497: the compile-only artifact's entry. Same CLI, production lane tables
+/// only; a request for any other lane is refused by name. Built by
+/// scripts/build_compile_only.sh from the module source that
+/// scripts/generate_bundle.sh emits rooted at `main_compile_only`, so the gc
+/// backend, the instrumentation compiles and the rc-shadow lane are not merely
+/// unreachable at run time but absent from the wasm (pinned by
+/// scripts/check_compile_only_lanes.sh). Declared in this file for the same
+/// reason `main` is: only the entry file's own exports keep their public
+/// names through the flatten.
+export fn cli_main_compile_only() -> Int with Exception + Fs + Env + Stdin + Stdout {
+  cli_main_with_lanes(fs_lane_compile_production, ss_lane_compile_production)
+}
+
+export fn main_compile_only() -> Unit with Exception + Fs + Env + Stdin + Stdout + Process {
+  let code = cli_main_compile_only()
+  if code != 0 {
+    vibe_process_exit_raw(code)
+  } else {
+    ()
+  }
+}
+
+// The lane tables sit AFTER the CLI body on purpose: scripts/check_selector_precedence.sh
+// derives the adapter's selector precedence from the SOURCE ORDER of
+// `Env::get("VIBE_*") == ..` tests, and the lane requests re-read switches
+// (VIBE_COVERAGE, VIBE_DEBUG_BREAK, VIBE_DEBUG, VIBE_BACKEND) that
+// `cli_main_with_lanes` already tests earlier, in the order the launcher
+// embeds. Defined before it, these reads would move those selectors to the
+// front of the derived order and desynchronize every launcher arm's clears.
+
+/// #2497: which compile the env-mode request asked for on the FS lane, read
+/// from the environment once, in the same precedence the arms had when they
+/// were inline: the instrumentation modes (coverage / break / trace) first,
+/// then the gc backend, then the allocator lanes. The TABLE that turns a lane
+/// into a compile is a parameter of `cli_main_with_lanes`. The full CLI
+/// installs `fs_lane_compile_full`; the compile-only artifact
+/// (`main_compile_only`, scripts/build_compile_only.sh) installs
+/// `fs_lane_compile_production`, which knows the two allocator lanes and
+/// refuses every other request by the switch that asked for it. Nothing else
+/// names the instrumentation, gc and shadow compiles, so the module-source
+/// DCE rooted at `main_compile_only` leaves their bodies out of that artifact
+/// (pillar 3: a capability fixed at build time drives DCE); a refused request
+/// is a diagnostic, never a silent fall-through to a lane it did not ask for.
+enum FsLane {
+  FsLaneCoverage;
+  FsLaneGc;
+  FsLaneBreak;
+  FsLaneTrace;
+  FsLaneRcShadow;
+  FsLaneRcHeapMarked;
+  FsLaneRcBodyCached(String);
+  FsLaneRc;
+  FsLaneBumpArtifactInputTrace(String, String, String, String);
+  FsLaneBumpTestmeta(String);
+  FsLaneBumpHeapMarked;
+  FsLaneBump
+}
+
+/// The switch that selected the lane, as the user spelled it -- the diagnostic
+/// for a refused lane names the edit that fixes it.
+fn fs_lane_switch(lane: FsLane) -> String {
+  match lane {
+    FsLaneCoverage => "VIBE_COVERAGE=1",
+    FsLaneGc => "VIBE_BACKEND=gc",
+    FsLaneBreak => "VIBE_DEBUG_BREAK=1",
+    FsLaneTrace => "VIBE_DEBUG=1",
+    FsLaneRcShadow => "VIBE_RC=shadow",
+    FsLaneRcHeapMarked => "VIBE_PROFILE_MEMORY_MARKS=1",
+    FsLaneRcBodyCached(mode) => String::concat("VIBE_CODEGEN_BODY_CACHE=", mode),
+    FsLaneRc => "the RC lane",
+    FsLaneBumpArtifactInputTrace(_, _, _, _) => "VIBE_ARTIFACT_INPUT_TRACE_OUT",
+    FsLaneBumpTestmeta(_) => "VIBE_TESTMETA_OUT",
+    FsLaneBumpHeapMarked => "VIBE_PROFILE_MEMORY_MARKS=1",
+    FsLaneBump => "the bump lane (VIBE_RC=0)"
+  }
+}
+
+/// Instrumented builds (coverage / trace / break / gc / rc-shadow) are debug
+/// artifacts whose tooling reads the name section and the module-linking
+/// exports, so the release strip leaves them untouched.
+fn fs_lane_is_instrumented(lane: FsLane) -> Bool {
+  match lane {
+    FsLaneCoverage => true,
+    FsLaneGc => true,
+    FsLaneBreak => true,
+    FsLaneTrace => true,
+    FsLaneRcShadow => true,
+    _ => false
+  }
+}
+
+fn fs_lane_request(mark_memory: Bool, artifact_input_trace_out: String, artifact_input_trace_nonce: String, artifact_input_trace_checked_error_row_mode: String, artifact_input_trace_diagnostics_mode: String, artifact_input_trace_dep_order_seed: String) -> FsLane with Env {
+  // The special compile MODES (coverage / debugger break / trace) are checked
+  // first; they are mutually exclusive instrumentation builds and are
+  // unaffected by the RC cutover. Instrumentation selectors have higher
+  // precedence than VIBE_BACKEND. The normal compile then defaults to the
+  // Perceus RC backend (#493 cutover, #705 parity) unless VIBE_RC=0 selects
+  // the legacy bump path (which carries the #634 testmeta variant).
+  let coverage_selected = Env::get("VIBE_COVERAGE") == "1"
+  let debug_break_selected = !coverage_selected && Env::get("VIBE_DEBUG_BREAK") == "1"
+  let debug_trace_selected = !coverage_selected && !debug_break_selected && Env::get("VIBE_DEBUG") == "1"
+  let gc_selected = !coverage_selected && !debug_break_selected && !debug_trace_selected && Env::get("VIBE_BACKEND") == "gc"
+  if coverage_selected {
+    FsLaneCoverage
+  } else if gc_selected {
+    FsLaneGc
+  } else if debug_break_selected {
+    // debugger breakpoint (DAP P1): `vibe run --break` sets VIBE_DEBUG_BREAK=1
+    // so the user file is compiled with `vibe::dbg_break` host-hook calls at
+    // each user function entry; the runner pauses on the named breakpoints.
+    FsLaneBreak
+  } else if debug_trace_selected {
+    // debugger trace (DAP P1 groundwork): `vibe run --trace` sets VIBE_DEBUG=1
+    // so the user file (and its imports) is compiled with function-call
+    // execution-trace instrumentation; running the produced wasm fills the
+    // in-memory trace log that the runner dumps via VIBE_TRACE_OUT.
+    FsLaneTrace
+  } else if Env::get("VIBE_RC") == "shadow" {
+    // #715/#768: shadow-liveness double-free traps for import-resolving
+    // builds (previously only the single-source path honored "shadow";
+    // this path silently compiled plain RC).
+    FsLaneRcShadow
+  } else if Env::get("VIBE_RC") != "0" {
+    // ADR-0055 #493 cutover DEFAULT: RC reclaims memory each iteration; the
+    // legacy bump path leaks until exit. Opt back into bump with VIBE_RC=0.
+    // #1553: under VIBE_PROFILE_MEMORY_MARKS=1 take the heap-marked twin
+    // (same pipeline, named memory mark per phase); production runs keep
+    // the exact unmarked lane.
+    if mark_memory {
+      FsLaneRcHeapMarked
+    } else {
+      // #2388 step 3: opt-in cross-compile codegen body cache. "verify"
+      // double-compiles and byte-compares (trust building); "on" replays
+      // persisted bodies. Env is read here, keeping file_compile Env-free
+      // (#634). Any other value keeps the exact production lane.
+      let body_cache_mode = Env::get("VIBE_CODEGEN_BODY_CACHE")
+      if body_cache_mode == "verify" || body_cache_mode == "on" {
+        FsLaneRcBodyCached(body_cache_mode)
+      } else {
+        FsLaneRc
+      }
+    }
+  } else {
+    // Legacy bump path (VIBE_RC=0). #634 (ADR-0026): only when `vibe test`
+    // requests the pure-test cache verdict (VIBE_TESTMETA_OUT set) do we
+    // route through the variant that ALSO emits the `.testmeta` sidecar
+    // (riding the merged stmts this compile already builds -- no extra
+    // parse). Env is read here (this layer has it), keeping the file_compile
+    // layer Env-free.
+    let testmeta_out = Env::get("VIBE_TESTMETA_OUT")
+    if artifact_input_trace_out != "" {
+      FsLaneBumpArtifactInputTrace(artifact_input_trace_nonce, artifact_input_trace_checked_error_row_mode, artifact_input_trace_diagnostics_mode, artifact_input_trace_dep_order_seed)
+    } else if testmeta_out != "" {
+      FsLaneBumpTestmeta(testmeta_out)
+    } else if mark_memory {
+      // #1553: bump attribution twin. As with its RC sibling, this is
+      // selected only for explicit heap observation; ordinary VIBE_RC=0
+      // compiles retain the Env-free production helper above.
+      FsLaneBumpHeapMarked
+    } else {
+      FsLaneBump
+    }
+  }
+}
+
+/// Every FS lane the full CLI serves. Returns the compiled bytes and the
+/// artifact-input trace (empty for every lane but the trace twin).
+fn fs_lane_compile_full(lane: FsLane, input_path: String, entry_name: String) -> (Bytes, String) with Exception + Fs + Env {
+  match lane {
+    FsLaneCoverage => (compile_file_fs_mode_coverage(input_path, entry_name), ""),
+    FsLaneGc => (compile_file_fs_mode_gc(input_path, entry_name), ""),
+    FsLaneBreak => (compile_file_fs_mode_break(input_path, entry_name), ""),
+    FsLaneTrace => (compile_file_fs_mode_trace(input_path, entry_name), ""),
+    FsLaneRcShadow => (compile_file_fs_mode_rc_shadow(input_path, entry_name), ""),
+    FsLaneRcHeapMarked => (compile_file_fs_mode_rc_heap_marked(input_path, entry_name), ""),
+    FsLaneRcBodyCached(mode) => (compile_file_fs_mode_rc_body_cached(input_path, entry_name, mode), ""),
+    FsLaneRc => (compile_file_fs_mode_rc(input_path, entry_name), ""),
+    FsLaneBumpArtifactInputTrace(nonce, checked_error_row_mode, diagnostics_mode, dep_order_seed) => compile_file_fs_mode_cached_artifact_input_trace(input_path, entry_name, "no-dce", nonce, checked_error_row_mode, diagnostics_mode, dep_order_seed),
+    FsLaneBumpTestmeta(testmeta_out) => (compile_file_fs_mode_testmeta(input_path, entry_name, "no-dce", testmeta_out), ""),
+    FsLaneBumpHeapMarked => (compile_file_fs_mode_bump_heap_marked(input_path, entry_name), ""),
+    FsLaneBump => (compile_file_fs_mode(input_path, entry_name, "no-dce"), "")
+  }
+}
+
+/// The compile-only artifact's FS lanes: the two allocator lanes, exactly as
+/// the full CLI compiles them. Every other switch is refused by name.
+fn fs_lane_compile_production(lane: FsLane, input_path: String, entry_name: String) -> (Bytes, String) with Exception + Fs + Env {
+  match lane {
+    FsLaneRc => (compile_file_fs_mode_rc(input_path, entry_name), ""),
+    FsLaneBump => (compile_file_fs_mode(input_path, entry_name, "no-dce"), ""),
+    _ => throw(lane_not_in_this_build(fs_lane_switch(lane)))
+  }
+}
+
+fn lane_not_in_this_build(switch: String) -> String {
+  String::concat("this compiler is the compile-only build and has no lane for ", String::concat(switch, "; unset it, or run the same command with the full CLI build (stage2.wasm from scripts/generations.sh)"))
+}
+
+/// The single-source lane's request (the flat self-build path), same shape.
+enum SsLane {
+  SsLaneCoverage;
+  SsLaneGc;
+  SsLaneRcShadow;
+  SsLaneRc;
+  SsLaneBump
+}
+
+fn ss_lane_switch(lane: SsLane) -> String {
+  match lane {
+    SsLaneCoverage => "VIBE_COVERAGE=1",
+    SsLaneGc => "VIBE_BACKEND=gc",
+    SsLaneRcShadow => "VIBE_RC=shadow",
+    SsLaneRc => "the RC lane",
+    SsLaneBump => "the bump lane (VIBE_RC=0)"
+  }
+}
+
+fn ss_lane_is_instrumented(lane: SsLane) -> Bool {
+  match lane {
+    SsLaneCoverage => true,
+    SsLaneGc => true,
+    SsLaneRcShadow => true,
+    _ => false
+  }
+}
+
+fn ss_lane_request(rc_flag: String) -> SsLane with Env {
+  // ADR-0055 #493 cutover: the Perceus RC codegen (memory-reclaiming linear
+  // backend) is the DEFAULT; set VIBE_RC=0 to opt back into the legacy bump
+  // path. The compiler self-build, bootstrap, and bump-baseline gates pin
+  // VIBE_RC=0 (see scripts/*.sh) so they stay byte-identical on bump.
+  if Env::get("VIBE_COVERAGE") == "1" {
+    // #cov: function-level coverage build (same source pipeline, instrumented
+    // codegen). Running the produced wasm records which compiler functions ran.
+    SsLaneCoverage
+  } else if Env::get("VIBE_BACKEND") == "gc" {
+    // wasm-gc backend lane (parity checks / #415). Direct source compile
+    // only; FS-import mode and the special instrumentation modes stay
+    // linear-backend-only.
+    SsLaneGc
+  } else if rc_flag == "shadow" {
+    // #715 recurrence guard: RC codegen + shadow-liveness traps (debug builds).
+    SsLaneRcShadow
+  } else if rc_flag != "0" {
+    SsLaneRc
+  } else {
+    SsLaneBump
+  }
+}
+
+/// `trusted_generated`: compiler-generated flat/module source carries reserved
+/// provenance statements. Trust is out-of-band (VIBE_INTERNAL_TRUSTED_SOURCE):
+/// ordinary source bytes can never opt themselves into that lane, and it stays
+/// a per-compilation input on every artifact (#2497).
+fn ss_lane_compile_full(lane: SsLane, source: String, entry_name: String, trusted_generated: Bool) -> Bytes with Exception {
+  match lane {
+    SsLaneCoverage => if trusted_generated {
+      compile_generated_source_wasi_only_coverage(source, entry_name)
+    } else {
+      compile_source_wasi_only_coverage(source, entry_name)
+    },
+    SsLaneGc => if trusted_generated {
+      compile_generated_source_gc_only(source, entry_name)
+    } else {
+      compile_source_gc_only(source, entry_name)
+    },
+    SsLaneRcShadow => if trusted_generated {
+      compile_generated_source_wasi_only_rc_shadow(source, entry_name)
+    } else {
+      compile_source_wasi_only_rc_shadow(source, entry_name)
+    },
+    SsLaneRc => if trusted_generated {
+      compile_generated_source_wasi_only_rc(source, entry_name)
+    } else {
+      compile_source_wasi_only_rc(source, entry_name)
+    },
+    SsLaneBump => if trusted_generated {
+      compile_generated_source_wasi_only(source, entry_name)
+    } else {
+      compile_source_wasi_only(source, entry_name)
+    }
+  }
+}
+
+fn ss_lane_compile_production(lane: SsLane, source: String, entry_name: String, trusted_generated: Bool) -> Bytes with Exception {
+  match lane {
+    SsLaneRc => if trusted_generated {
+      compile_generated_source_wasi_only_rc(source, entry_name)
+    } else {
+      compile_source_wasi_only_rc(source, entry_name)
+    },
+    SsLaneBump => if trusted_generated {
+      compile_generated_source_wasi_only(source, entry_name)
+    } else {
+      compile_source_wasi_only(source, entry_name)
+    },
+    _ => throw(lane_not_in_this_build(ss_lane_switch(lane)))
   }
 }

--- a/lib/@vibe/compiler/index.vpkg
+++ b/lib/@vibe/compiler/index.vpkg
@@ -477,6 +477,11 @@ fn profile_plan_main() -> Int with Exception + Fs + Env
 // cli_adapter.vibe, not a dead/duplicate standalone entry file.
 fn main() -> Unit with Exception + Fs + Env + Stdin + Stdout + Process
 
+// #2497: the compile-only artifact's entry pair (scripts/build_compile_only.sh).
+// Same CLI body as `cli_main`, production lane tables only.
+fn cli_main_compile_only() -> Int with Exception + Fs + Env + Stdin + Stdout
+fn main_compile_only() -> Unit with Exception + Fs + Env + Stdin + Stdout + Process
+
 // lsp_server.vibe moved to lib/@vibe/lsp/ (@vibe/lsp package) -- cli_adapter.vibe
 // now consumes it as an external dependency (`import @vibe/lsp { ... }`), not
 // a same-directory impl file, so it is no longer part of THIS package's own

--- a/scripts/build_compile_only.sh
+++ b/scripts/build_compile_only.sh
@@ -46,17 +46,39 @@ COMPILER="$(resolve_stage2 build-compile-only "$COMPILER_OVERRIDE")" || exit 1
 
 WORK="$(dirname "$OUT")"
 mkdir -p "$WORK"
-MODULE_SOURCE="$WORK/cli_compile_only_module_source.vibe"
+# Every side file is keyed on the output's basename, so two builds into one
+# directory (the gate's named artifact next to the plain one) never share a
+# path.
+STEM="$WORK/$(basename "$OUT" .wasm)"
+MODULE_SOURCE="$STEM.module_source.vibe"
+
+# The adapter dispatches on VIBE_* selectors in source order, so an inherited
+# selector (`VIBE_CHECK_ONLY=1` exported by the caller) would hijack this
+# compile: cli_main would take that branch and write `ok` where the wasm goes.
+# Clear every selector the launcher knows before setting the ones this build
+# needs. The list is read from runtime/vibe, the copy that
+# scripts/check_selector_precedence.sh keeps in sync with cli_adapter.vibe.
+selector_clear_args() {
+  local order s out=""
+  order="$(sed -n '/^VIBE_SELECTOR_ORDER="/,/"$/p' "$ROOT_DIR/runtime/vibe" | tr -d '"' | sed 's/^VIBE_SELECTOR_ORDER=//')"
+  [ -n "$order" ] || { echo "build_compile_only: runtime/vibe has no VIBE_SELECTOR_ORDER" >&2; return 1; }
+  for s in $order; do out="$out -u $s"; done
+  printf '%s' "$out"
+}
+CLEAR_ARGS="$(selector_clear_args)" || exit 1
 
 # The bundles and the merge-flatten tool are keyed by ensure_generated's
 # fingerprint; this brings them up to date (a no-op when they already are).
-bash "$ROOT_DIR/scripts/ensure_generated.sh" >&2
+# Under the cleared selector set too: the generator drives the seed's cli_main
+# for its merge and emit passes, and an inherited selector would hijack those
+# the same way it would hijack the compile below.
+env $CLEAR_ARGS bash "$ROOT_DIR/scripts/ensure_generated.sh" >&2
 
 # The generator rewrites its default outputs in lib/; point them at scratch
 # copies so this build touches nothing but its own directory, and ask only
 # for the compile-only emission (no adapter module source, hence no seed
 # validation compile).
-BUNDLE_TMP="$(mktemp -d "$WORK/.bundle.XXXXXX")"
+BUNDLE_TMP="$(mktemp -d "$STEM.bundle.XXXXXX")"
 trap 'rm -rf "$BUNDLE_TMP"' EXIT
 rm -f "$MODULE_SOURCE"
 VIBE_BUNDLE_OUT="$BUNDLE_TMP/compiler_sources_bundle.vibe" \
@@ -64,9 +86,9 @@ VIBE_ADAPTER_BUNDLE_OUT="$BUNDLE_TMP/cli_adapter_bundle.vibe" \
 VIBE_RUNTIME_ENTRY_BUNDLE_OUT="$BUNDLE_TMP/selfbuild_runtime_entry_bundle.vibe" \
 VIBE_ADAPTER_MODULE_SOURCE_OUT="" \
 VIBE_COMPILE_ONLY_MODULE_SOURCE_OUT="$MODULE_SOURCE" \
-  bash "$ROOT_DIR/scripts/generate_bundle.sh" >"$WORK/generate_bundle.log" 2>&1 || {
+  env $CLEAR_ARGS bash "$ROOT_DIR/scripts/generate_bundle.sh" >"$STEM.generate_bundle.log" 2>&1 || {
     echo "build_compile_only: compile-only module source emission failed:" >&2
-    tail -40 "$WORK/generate_bundle.log" >&2
+    tail -40 "$STEM.generate_bundle.log" >&2
     exit 1
   }
 [ -s "$MODULE_SOURCE" ] || { echo "build_compile_only: module source not produced: $MODULE_SOURCE" >&2; exit 1; }
@@ -78,6 +100,7 @@ VIBE_COMPILE_ONLY_MODULE_SOURCE_OUT="$MODULE_SOURCE" \
 rm -f "$OUT" "$OUT.diag"
 if ! (
   cd "$ROOT_DIR" &&
+    env $CLEAR_ARGS \
     VIBE_RC=0 \
     VIBE_INTERNAL_TRUSTED_SOURCE=1 \
     VIBE_PREOPEN_DIR="$ROOT_DIR" \
@@ -88,12 +111,18 @@ if ! (
     VIBE_NODE_WASM_FLAGS="${VIBE_NODE_WASM_FLAGS:---experimental-wasm-exnref --stack-size=${VIBE_GENERATION_NODE_STACK_SIZE:-131072}}" \
     VIBE_WASM_NAMES="$([ "$NAMES" = 1 ] && echo 1 || echo 0)" \
     bash "$ROOT_DIR/scripts/run_wasm_vibe_host_runner.sh" --invoke cli_main \
-      "$COMPILER" "$MODULE_SOURCE" "$OUT" cli_main_compile_only >"$WORK/compile.log" 2>&1
+      "$COMPILER" "$MODULE_SOURCE" "$OUT" cli_main_compile_only >"$STEM.compile.log" 2>&1
 ); then
   echo "build_compile_only: compile failed:" >&2
   cat "$OUT.diag" 2>/dev/null >&2 || true
-  tail -40 "$WORK/compile.log" >&2
+  tail -40 "$STEM.compile.log" >&2
   exit 1
 fi
 [ -s "$OUT" ] || { echo "build_compile_only: no output: $OUT" >&2; cat "$OUT.diag" 2>/dev/null >&2 || true; exit 1; }
+# A non-empty file is not a compiler: a hijacked verb writes text there. The
+# output must start with the wasm magic.
+if [ "$(head -c 4 "$OUT" | od -An -tx1 | tr -d ' \n')" != "0061736d" ]; then
+  echo "build_compile_only: $OUT is not a wasm module (first bytes: $(head -c 16 "$OUT" | od -An -c | tr -s ' '))" >&2
+  exit 1
+fi
 echo "compile-only artifact: $OUT ($(wc -c <"$OUT") bytes)"

--- a/scripts/build_compile_only.sh
+++ b/scripts/build_compile_only.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+# build_compile_only.sh -- the compile-only compiler artifact (#2497).
+#
+# The same env-mode CLI as stage2, DCE-rooted at `main_compile_only`
+# (lib/@vibe/compiler/cli_adapter.vibe) instead of `main`. Its lane tables
+# name only the two production allocator lanes (RC, and bump under VIBE_RC=0),
+# so the gc backend, the coverage / trace / break instrumentation compiles,
+# the rc-shadow lane and the body-cache / heap-marked / testmeta twins are
+# unreachable at module-source emission and absent from the wasm -- not merely
+# skipped at run time. A request for one of them (VIBE_BACKEND=gc,
+# VIBE_DEBUG_BREAK=1, VIBE_RC=shadow, ...) is refused by name; it never falls
+# through to a lane it did not ask for. scripts/check_compile_only_lanes.sh
+# pins both halves.
+#
+# Steps: ensure the generated bundles are current, emit the compile-only module
+# source from the exact merged program (scripts/generate_bundle.sh,
+# VIBE_COMPILE_ONLY_MODULE_SOURCE_OUT), compile it with stage2.
+#
+# Usage:
+#   bash scripts/build_compile_only.sh [--out FILE] [--names] [--compiler stage2.wasm]
+#     --out FILE      default _build/compile_only/vibe_compile_only.wasm
+#     --names         keep the name section (VIBE_WASM_NAMES=1), for attribution
+#                     and for check_compile_only_lanes.sh
+#     --compiler W    the compiler that compiles the flat source; default: the
+#                     generation for HEAD (scripts/resolve_stage2.sh), override
+#                     also via COMPILE_ONLY_COMPILER
+# Prints `compile-only artifact: <path> (<bytes> bytes)` on success.
+set -euo pipefail
+ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT_DIR"
+. "$ROOT_DIR/scripts/resolve_stage2.sh"
+
+OUT="$ROOT_DIR/_build/compile_only/vibe_compile_only.wasm"
+NAMES=0
+COMPILER_OVERRIDE="${COMPILE_ONLY_COMPILER:-}"
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --out) OUT="$2"; shift 2 ;;
+    --names) NAMES=1; shift ;;
+    --compiler) COMPILER_OVERRIDE="$2"; shift 2 ;;
+    -h|--help) sed -n '2,30p' "$0"; exit 0 ;;
+    *) echo "build_compile_only: unknown argument: $1" >&2; exit 2 ;;
+  esac
+done
+COMPILER="$(resolve_stage2 build-compile-only "$COMPILER_OVERRIDE")" || exit 1
+
+WORK="$(dirname "$OUT")"
+mkdir -p "$WORK"
+MODULE_SOURCE="$WORK/cli_compile_only_module_source.vibe"
+
+# The bundles and the merge-flatten tool are keyed by ensure_generated's
+# fingerprint; this brings them up to date (a no-op when they already are).
+bash "$ROOT_DIR/scripts/ensure_generated.sh" >&2
+
+# The generator rewrites its default outputs in lib/; point them at scratch
+# copies so this build touches nothing but its own directory, and ask only
+# for the compile-only emission (no adapter module source, hence no seed
+# validation compile).
+BUNDLE_TMP="$(mktemp -d "$WORK/.bundle.XXXXXX")"
+trap 'rm -rf "$BUNDLE_TMP"' EXIT
+rm -f "$MODULE_SOURCE"
+VIBE_BUNDLE_OUT="$BUNDLE_TMP/compiler_sources_bundle.vibe" \
+VIBE_ADAPTER_BUNDLE_OUT="$BUNDLE_TMP/cli_adapter_bundle.vibe" \
+VIBE_RUNTIME_ENTRY_BUNDLE_OUT="$BUNDLE_TMP/selfbuild_runtime_entry_bundle.vibe" \
+VIBE_ADAPTER_MODULE_SOURCE_OUT="" \
+VIBE_COMPILE_ONLY_MODULE_SOURCE_OUT="$MODULE_SOURCE" \
+  bash "$ROOT_DIR/scripts/generate_bundle.sh" >"$WORK/generate_bundle.log" 2>&1 || {
+    echo "build_compile_only: compile-only module source emission failed:" >&2
+    tail -40 "$WORK/generate_bundle.log" >&2
+    exit 1
+  }
+[ -s "$MODULE_SOURCE" ] || { echo "build_compile_only: module source not produced: $MODULE_SOURCE" >&2; exit 1; }
+
+# Same compile as a stage hop (scripts/generations.sh run_cli_compile): the
+# compiler self-build is pinned to the bump lane, flat generated source is
+# the trusted-source lane, and the persistent artifact cache stays out of a
+# build whose output is compared by bytes.
+rm -f "$OUT" "$OUT.diag"
+if ! (
+  cd "$ROOT_DIR" &&
+    VIBE_RC=0 \
+    VIBE_INTERNAL_TRUSTED_SOURCE=1 \
+    VIBE_PREOPEN_DIR="$ROOT_DIR" \
+    VIBE_IMPORT_ABI="${VIBE_IMPORT_ABI:-raw}" \
+    VIBE_WASM_PRE_GROW_PAGES="${VIBE_GENERATION_WASM_PRE_GROW_PAGES:-0}" \
+    VIBE_DISABLE_PERSISTENT_ARTIFACT_CACHE="${VIBE_GENERATION_DISABLE_PERSISTENT_ARTIFACT_CACHE:-1}" \
+    VIBE_SKIP_RUN_INIT="${VIBE_GENERATION_SKIP_RUN_INIT:-1}" \
+    VIBE_NODE_WASM_FLAGS="${VIBE_NODE_WASM_FLAGS:---experimental-wasm-exnref --stack-size=${VIBE_GENERATION_NODE_STACK_SIZE:-131072}}" \
+    VIBE_WASM_NAMES="$([ "$NAMES" = 1 ] && echo 1 || echo 0)" \
+    bash "$ROOT_DIR/scripts/run_wasm_vibe_host_runner.sh" --invoke cli_main \
+      "$COMPILER" "$MODULE_SOURCE" "$OUT" cli_main_compile_only >"$WORK/compile.log" 2>&1
+); then
+  echo "build_compile_only: compile failed:" >&2
+  cat "$OUT.diag" 2>/dev/null >&2 || true
+  tail -40 "$WORK/compile.log" >&2
+  exit 1
+fi
+[ -s "$OUT" ] || { echo "build_compile_only: no output: $OUT" >&2; cat "$OUT.diag" 2>/dev/null >&2 || true; exit 1; }
+echo "compile-only artifact: $OUT ($(wc -c <"$OUT") bytes)"

--- a/scripts/check_compile_only_lanes.sh
+++ b/scripts/check_compile_only_lanes.sh
@@ -95,9 +95,18 @@ if [ -z "$ARTIFACT" ]; then
 fi
 [ -s "$ARTIFACT" ] || fail "artifact not found: $ARTIFACT"
 
-WORK="$ROOT_DIR/_build/_compile_only_lanes"
-rm -rf "$WORK"; mkdir -p "$WORK"
+# Private scratch: the gate and its self-test may run side by side.
+WORK="$(mktemp -d "${TMPDIR:-/tmp}/compile_only_lanes.XXXXXX")"
 trap 'rm -rf "$WORK"' EXIT
+# Clear every CLI selector the launcher knows before each probe compile, so an
+# inherited one (`VIBE_CHECK_ONLY=1` in the caller's environment) cannot turn
+# the compile into another verb. Same source as scripts/build_compile_only.sh:
+# runtime/vibe's VIBE_SELECTOR_ORDER, kept in sync with cli_adapter.vibe by
+# scripts/check_selector_precedence.sh.
+SELECTOR_ORDER="$(sed -n '/^VIBE_SELECTOR_ORDER="/,/"$/p' "$ROOT_DIR/runtime/vibe" | tr -d '"' | sed 's/^VIBE_SELECTOR_ORDER=//')"
+[ -n "$SELECTOR_ORDER" ] || fail "runtime/vibe has no VIBE_SELECTOR_ORDER"
+CLEAR_ARGS=""
+for s in $SELECTOR_ORDER; do CLEAR_ARGS="$CLEAR_ARGS -u $s"; done
 # Allocating, so the RC and bump lanes have something to differ on.
 cat > "$WORK/probe.vibe" <<'VIBE'
 fn main() -> Int {
@@ -112,7 +121,7 @@ compile_probe() { # <label> <env assignments...>; sets PROBE_OUT / PROBE_DIAG
   PROBE_OUT="$WORK/$label.wasm"
   PROBE_DIAG=""
   rm -f "$PROBE_OUT" "$PROBE_OUT.diag"
-  env "$@" VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
+  env $CLEAR_ARGS -u VIBE_RC -u VIBE_CODEGEN_BODY_CACHE "$@" VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
     bash scripts/run_wasm_vibe_host_runner.sh --invoke "$ENTRY" "$ARTIFACT" \
     "$WORK/probe.vibe" "$PROBE_OUT" main >"$WORK/$label.log" 2>&1 || true
   if [ -f "$PROBE_OUT.diag" ]; then
@@ -121,11 +130,11 @@ compile_probe() { # <label> <env assignments...>; sets PROBE_OUT / PROBE_DIAG
   return 0
 }
 
-# 2. refusal, one switch at a time, each on top of an otherwise clean env
-# (`env -u` so a caller's exported VIBE_RC / VIBE_BACKEND cannot leak in).
+# 2. refusal, one switch at a time, each on top of the cleared env above (so
+# a caller's exported VIBE_RC / VIBE_BACKEND cannot leak in either).
 refuse() { # <switch NAME=VALUE>
   local switch="$1"
-  compile_probe "refuse_${switch%%=*}" -u VIBE_RC -u VIBE_BACKEND -u VIBE_DEBUG -u VIBE_DEBUG_BREAK -u VIBE_COVERAGE -u VIBE_CODEGEN_BODY_CACHE "$switch"
+  compile_probe "refuse_${switch%%=*}" "$switch"
   if [ -s "$PROBE_OUT" ]; then
     fail "$switch was ACCEPTED by $ARTIFACT (invoke $ENTRY): it compiled the probe instead of refusing the lane"
   fi
@@ -141,10 +150,10 @@ echo "compile-only-lanes: refusal ok (6 switches refused by name)"
 
 # 3. acceptance: the default (RC) lane and the bump lane compile; they differ;
 # the default output runs.
-compile_probe default -u VIBE_RC -u VIBE_BACKEND -u VIBE_DEBUG -u VIBE_DEBUG_BREAK -u VIBE_COVERAGE -u VIBE_CODEGEN_BODY_CACHE
+compile_probe default
 [ -s "$PROBE_OUT" ] || fail "the default lane did not compile the probe: ${PROBE_DIAG:-<no diag>}"
 DEFAULT_OUT="$PROBE_OUT"
-compile_probe bump -u VIBE_BACKEND -u VIBE_DEBUG -u VIBE_DEBUG_BREAK -u VIBE_COVERAGE -u VIBE_CODEGEN_BODY_CACHE VIBE_RC=0
+compile_probe bump VIBE_RC=0
 [ -s "$PROBE_OUT" ] || fail "the bump lane (VIBE_RC=0) did not compile the probe: ${PROBE_DIAG:-<no diag>}"
 cmp -s "$DEFAULT_OUT" "$PROBE_OUT" && fail "the default and VIBE_RC=0 outputs are identical, so the probe cannot tell the two lanes apart"
 got="$(bash scripts/run_wasm_vibe_host_runner.sh "$DEFAULT_OUT" 2>/dev/null | tail -1 | tr -d '[:space:]')"

--- a/scripts/check_compile_only_lanes.sh
+++ b/scripts/check_compile_only_lanes.sh
@@ -1,0 +1,156 @@
+#!/usr/bin/env bash
+# The compile-only artifact (#2497) has exactly the lanes it claims, asked of
+# the WASM rather than of the source.
+#
+# scripts/build_compile_only.sh roots the module-source DCE at
+# `main_compile_only`, whose lane tables name only the production compiles.
+# Two things must then hold, and each is checked where it can be seen:
+#
+#   1. ABSENCE. The wasm defines no function from the gc backend
+#      (codegen/gc, entry/source_compile/gc_only), no instrumentation compile
+#      (coverage / trace / break), no rc-shadow, body-cache, heap-marked,
+#      testmeta or artifact-input-trace twin. Read from the name section, so
+#      the artifact is built with VIBE_WASM_NAMES=1 -- and a wasm whose
+#      functions are mostly UNNAMED fails here: a scanner that cannot see is
+#      unchecked, not safe.
+#   2. REFUSAL. Each switch that selects a dropped lane (VIBE_BACKEND=gc,
+#      VIBE_DEBUG_BREAK=1, VIBE_DEBUG=1, VIBE_RC=shadow, VIBE_COVERAGE=1,
+#      VIBE_CODEGEN_BODY_CACHE=on) produces no wasm and a diagnostic that names
+#      the switch. Silently compiling on another lane is the failure this
+#      guards against (policy: never silently wrong).
+#   3. ACCEPTANCE. The two production lanes still compile, and the default
+#      lane's output runs.
+#
+# Usage:
+#   bash scripts/check_compile_only_lanes.sh
+#       builds the named artifact with scripts/build_compile_only.sh (compiler:
+#       COMPILE_ONLY_STAGE2 override, else the generation for HEAD) and runs 1-3
+#   bash scripts/check_compile_only_lanes.sh --artifact W --entry NAME
+#       runs 1-3 against an existing wasm, invoked through NAME
+#   bash scripts/check_compile_only_lanes.sh --scan-only W
+#       runs check 1 alone against W (the self-test's mutation probe)
+set -euo pipefail
+ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT_DIR"
+
+ARTIFACT=""
+ENTRY="cli_main_compile_only"
+SCAN_ONLY=""
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --artifact) ARTIFACT="$2"; shift 2 ;;
+    --entry) ENTRY="$2"; shift 2 ;;
+    --scan-only) SCAN_ONLY="$2"; shift 2 ;;
+    *) echo "check-compile-only-lanes: unknown argument: $1" >&2; exit 2 ;;
+  esac
+done
+
+fail() { echo "compile-only-lanes: FAIL: $*" >&2; exit 1; }
+
+# Function-name fragments of the dropped lanes. Each is a source-level name
+# (the flatten keeps it as a prefix of the mangled wasm name) or a module path
+# fragment (`<file>_vibe` suffixes carry the module). Measured on the CLI
+# stage2 they match 190 functions / 158 KB; on the compile-only artifact, 0.
+ABSENT_PATTERNS='codegen_gc_backend|source_compile_gc_only|compile_file_fs_mode_gc|compile_file_fs_mode_break|compile_file_fs_mode_trace|compile_file_fs_mode_coverage|compile_file_fs_mode_rc_shadow|compile_file_fs_mode_rc_body_cached|compile_file_fs_mode_testmeta|heap_marked|artifact_input_trace|sources_coverage_impl|sources_trace_impl|sources_break_impl|rc_shadow_impl|gc_only_impl|wasi_only_coverage|wasi_only_rc_shadow'
+
+scan_names() { # <wasm>
+  local wasm="$1" listing
+  listing="$(mktemp "${TMPDIR:-/tmp}/compile_only_names.XXXXXX")"
+  node scripts/wasm_func_sizes.mjs "$wasm" --top 1000000 >"$listing" 2>/dev/null \
+    || { rm -f "$listing"; fail "could not read $wasm (scripts/wasm_func_sizes.mjs)"; }
+  local summary total named
+  summary="$(grep -E '^-- code section:' "$listing" || true)"
+  total="$(printf '%s\n' "$summary" | sed -n 's/.* across \([0-9]*\) functions.*/\1/p')"
+  named="$(printf '%s\n' "$summary" | sed -n 's/.*(\([0-9]*\) named).*/\1/p')"
+  [ -n "$total" ] && [ -n "$named" ] || { rm -f "$listing"; fail "no code-section summary for $wasm"; }
+  # The strip drops the name section; a stripped artifact must be reported as
+  # unreadable, never as clean. 90% is far below any named build (measured
+  # 5617/6003 = 93.6%; the unnamed rest are runtime and generated helpers) and
+  # far above a stripped one (0).
+  if [ "$total" -eq 0 ] || [ $((named * 100 / total)) -lt 90 ]; then
+    rm -f "$listing"
+    fail "$wasm names only $named of $total functions; build it with VIBE_WASM_NAMES=1 (scripts/build_compile_only.sh --names) so the lane check can see"
+  fi
+  local hits
+  hits="$(grep -E '^ *[0-9]+ #' "$listing" | awk '{print $1, $NF}' | grep -E "$ABSENT_PATTERNS" || true)"
+  rm -f "$listing"
+  if [ -n "$hits" ]; then
+    echo "compile-only-lanes: FAIL: $wasm still defines functions of a dropped lane:" >&2
+    printf '%s\n' "$hits" | sort -rn | head -40 >&2
+    exit 1
+  fi
+  echo "compile-only-lanes: absence ok ($named of $total functions named, none from a dropped lane)"
+}
+
+if [ -n "$SCAN_ONLY" ]; then
+  scan_names "$SCAN_ONLY"
+  exit 0
+fi
+
+if [ -z "$ARTIFACT" ]; then
+  ARTIFACT="$ROOT_DIR/_build/compile_only/vibe_compile_only.names.wasm"
+  COMPILE_ONLY_COMPILER="${COMPILE_ONLY_STAGE2:-}" \
+    bash scripts/build_compile_only.sh --names --out "$ARTIFACT" >&2 \
+    || fail "scripts/build_compile_only.sh failed"
+fi
+[ -s "$ARTIFACT" ] || fail "artifact not found: $ARTIFACT"
+
+WORK="$ROOT_DIR/_build/_compile_only_lanes"
+rm -rf "$WORK"; mkdir -p "$WORK"
+trap 'rm -rf "$WORK"' EXIT
+# Allocating, so the RC and bump lanes have something to differ on.
+cat > "$WORK/probe.vibe" <<'VIBE'
+fn main() -> Int {
+  let xs = [1, 2, 3]
+  let ys = [Array::length(xs), 4]
+  Array::length(ys) + Array::length(xs) + 37
+}
+VIBE
+
+compile_probe() { # <label> <env assignments...>; sets PROBE_OUT / PROBE_DIAG
+  local label="$1"; shift
+  PROBE_OUT="$WORK/$label.wasm"
+  PROBE_DIAG=""
+  rm -f "$PROBE_OUT" "$PROBE_OUT.diag"
+  env "$@" VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
+    bash scripts/run_wasm_vibe_host_runner.sh --invoke "$ENTRY" "$ARTIFACT" \
+    "$WORK/probe.vibe" "$PROBE_OUT" main >"$WORK/$label.log" 2>&1 || true
+  if [ -f "$PROBE_OUT.diag" ]; then
+    PROBE_DIAG="$(cat "$PROBE_OUT.diag")"
+  fi
+  return 0
+}
+
+# 2. refusal, one switch at a time, each on top of an otherwise clean env
+# (`env -u` so a caller's exported VIBE_RC / VIBE_BACKEND cannot leak in).
+refuse() { # <switch NAME=VALUE>
+  local switch="$1"
+  compile_probe "refuse_${switch%%=*}" -u VIBE_RC -u VIBE_BACKEND -u VIBE_DEBUG -u VIBE_DEBUG_BREAK -u VIBE_COVERAGE -u VIBE_CODEGEN_BODY_CACHE "$switch"
+  if [ -s "$PROBE_OUT" ]; then
+    fail "$switch was ACCEPTED by $ARTIFACT (invoke $ENTRY): it compiled the probe instead of refusing the lane"
+  fi
+  case "$PROBE_DIAG" in
+    *"has no lane for $switch"*) ;;
+    *) fail "$switch produced no wasm but the diagnostic does not name it: '${PROBE_DIAG:-<none>}'" ;;
+  esac
+}
+for sw in VIBE_BACKEND=gc VIBE_DEBUG_BREAK=1 VIBE_DEBUG=1 VIBE_RC=shadow VIBE_COVERAGE=1 VIBE_CODEGEN_BODY_CACHE=on; do
+  refuse "$sw"
+done
+echo "compile-only-lanes: refusal ok (6 switches refused by name)"
+
+# 3. acceptance: the default (RC) lane and the bump lane compile; they differ;
+# the default output runs.
+compile_probe default -u VIBE_RC -u VIBE_BACKEND -u VIBE_DEBUG -u VIBE_DEBUG_BREAK -u VIBE_COVERAGE -u VIBE_CODEGEN_BODY_CACHE
+[ -s "$PROBE_OUT" ] || fail "the default lane did not compile the probe: ${PROBE_DIAG:-<no diag>}"
+DEFAULT_OUT="$PROBE_OUT"
+compile_probe bump -u VIBE_BACKEND -u VIBE_DEBUG -u VIBE_DEBUG_BREAK -u VIBE_COVERAGE -u VIBE_CODEGEN_BODY_CACHE VIBE_RC=0
+[ -s "$PROBE_OUT" ] || fail "the bump lane (VIBE_RC=0) did not compile the probe: ${PROBE_DIAG:-<no diag>}"
+cmp -s "$DEFAULT_OUT" "$PROBE_OUT" && fail "the default and VIBE_RC=0 outputs are identical, so the probe cannot tell the two lanes apart"
+got="$(bash scripts/run_wasm_vibe_host_runner.sh "$DEFAULT_OUT" 2>/dev/null | tail -1 | tr -d '[:space:]')"
+[ "$got" = "42" ] || fail "the default lane's output printed '$got', expected 42"
+echo "compile-only-lanes: acceptance ok (RC and bump lanes compile, default runs)"
+
+# 1. absence, last: it needs the name section and says so when it is missing.
+scan_names "$ARTIFACT"
+echo "compile-only-lanes: ok ($ARTIFACT, $(wc -c <"$ARTIFACT") bytes with names)"

--- a/scripts/check_compile_only_lanes_test.sh
+++ b/scripts/check_compile_only_lanes_test.sh
@@ -14,7 +14,10 @@
 #
 # Fixture: the named compile-only artifact the gate builds
 # (_build/compile_only/vibe_compile_only.names.wasm); built here when absent.
-# COMPILE_ONLY_STAGE2 overrides the compiler, as for the gate.
+# In release-check this task depends on check-compile-only-lanes, so the gate
+# has finished writing it before this reads it; the gate's own scratch is a
+# private mktemp directory, so the two never share a path even when run side
+# by side. COMPILE_ONLY_STAGE2 overrides the compiler, as for the gate.
 set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
 cd "$ROOT_DIR"
@@ -93,7 +96,8 @@ LEAK_SRC="$TMP/leak.vibe"
   printf '  acc\n}\n'
 } > "$LEAK_SRC"
 LEAK="$TMP/leak.wasm"
-env -u VIBE_RC -u VIBE_BACKEND VIBE_WASM_NAMES=1 VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
+env $(sed -n '/^VIBE_SELECTOR_ORDER="/,/"$/p' "$ROOT_DIR/runtime/vibe" | tr -d '"' | sed 's/^VIBE_SELECTOR_ORDER=//' | sed 's/\(VIBE_[A-Z_]*\)/-u \1/g') \
+  -u VIBE_RC VIBE_WASM_NAMES=1 VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$STAGE2" "$LEAK_SRC" "$LEAK" main >"$TMP/leak.build.log" 2>&1 || true
 [ -s "$LEAK" ] || { echo "check_compile_only_lanes_test: FAIL (leak): probe did not compile" >&2; cat "$LEAK.diag" 2>/dev/null >&2; exit 1; }
 node scripts/wasm_func_sizes.mjs "$LEAK" --top 1000000 | grep -q 'compile_file_fs_mode_gc' \

--- a/scripts/check_compile_only_lanes_test.sh
+++ b/scripts/check_compile_only_lanes_test.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+# Self-test for scripts/check_compile_only_lanes.sh (#2248 rule: a gate must
+# prove it can fail). Each case mutates a REAL input and asserts the gate fails
+# with the message for that mutation; the control run must pass.
+#
+#   1. blind      -- the named artifact with its name section stripped: the
+#                    scan must refuse to certify what it cannot see.
+#   2. leak       -- a named wasm that defines a function of a dropped lane
+#                    (a probe program spelling `compile_file_fs_mode_gc`):
+#                    the absence check must name it.
+#   3. accepted   -- the full CLI stage2, invoked as `cli_main`: it serves
+#                    VIBE_BACKEND=gc, so the refusal check must fail.
+#   4. control    -- the real compile-only artifact passes.
+#
+# Fixture: the named compile-only artifact the gate builds
+# (_build/compile_only/vibe_compile_only.names.wasm); built here when absent.
+# COMPILE_ONLY_STAGE2 overrides the compiler, as for the gate.
+set -euo pipefail
+ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT_DIR"
+. "$ROOT_DIR/scripts/resolve_stage2.sh"
+GATE="scripts/check_compile_only_lanes.sh"
+STAGE2="$(resolve_stage2 compile-only-lanes-test "${COMPILE_ONLY_STAGE2:-}")" || exit 1
+ART="$ROOT_DIR/_build/compile_only/vibe_compile_only.names.wasm"
+if [ ! -s "$ART" ]; then
+  bash scripts/build_compile_only.sh --names --out "$ART" --compiler "$STAGE2" >&2
+fi
+TMP="$(mktemp -d "${TMPDIR:-/tmp}/compile_only_lanes_test.XXXXXX")"
+trap 'rm -rf "$TMP"' EXIT
+
+expect_fail() { # <case> <needle> <gate args...>
+  local label="$1" needle="$2"; shift 2
+  local log="$TMP/$label.log" rc=0
+  bash "$GATE" "$@" >"$log" 2>&1 || rc=$?
+  if [ "$rc" -eq 0 ]; then
+    echo "check_compile_only_lanes_test: FAIL ($label): the gate passed on a mutated input" >&2
+    cat "$log" >&2
+    exit 1
+  fi
+  if ! grep -qF -- "$needle" "$log"; then
+    echo "check_compile_only_lanes_test: FAIL ($label): the gate failed, but not with '$needle':" >&2
+    cat "$log" >&2
+    exit 1
+  fi
+  echo "check_compile_only_lanes_test: ok ($label): failed as expected"
+}
+
+# 1. blind: drop the "name" custom section. The mutation must have hit -- a
+# copy identical to the artifact proves nothing.
+STRIPPED="$TMP/stripped.wasm"
+python3 - "$ART" "$STRIPPED" <<'PY'
+import sys
+src, dst = sys.argv[1:]
+b = open(src, "rb").read()
+def uleb(p):
+    r = s = 0
+    while True:
+        x = b[p]; p += 1
+        r |= (x & 0x7f) << s; s += 7
+        if not x & 0x80:
+            return r, p
+out = bytearray(b[:8]); p = 8; dropped = 0
+while p < len(b):
+    sid = b[p]; size, q = uleb(p + 1); end = q + size
+    if sid == 0:
+        nlen, r = uleb(q)
+        if b[r:r + nlen] == b"name":
+            dropped += 1; p = end; continue
+    out += b[p:end]; p = end
+assert dropped == 1, dropped
+open(dst, "wb").write(out)
+PY
+cmp -s "$ART" "$STRIPPED" && { echo "check_compile_only_lanes_test: FAIL (blind): strip did not change the artifact" >&2; exit 1; }
+expect_fail blind "names only" --scan-only "$STRIPPED"
+
+# 2. leak: a named user build whose function names include a dropped lane's.
+# Enough functions that the runtime's unnamed helpers stay under the 10% the
+# scan tolerates; the mutation is verified by reading the names back first.
+LEAK_SRC="$TMP/leak.vibe"
+{
+  echo 'fn compile_file_fs_mode_gc() -> Int { 1 }'
+  i=0
+  while [ "$i" -lt 60 ]; do
+    echo "fn helper_$i(x: Int) -> Int { x + $i }"
+    i=$((i + 1))
+  done
+  printf 'fn main() -> Int {\n  let mut acc = compile_file_fs_mode_gc()\n'
+  i=0
+  while [ "$i" -lt 60 ]; do
+    echo "  acc = helper_$i(acc)"
+    i=$((i + 1))
+  done
+  printf '  acc\n}\n'
+} > "$LEAK_SRC"
+LEAK="$TMP/leak.wasm"
+env -u VIBE_RC -u VIBE_BACKEND VIBE_WASM_NAMES=1 VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
+  bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$STAGE2" "$LEAK_SRC" "$LEAK" main >"$TMP/leak.build.log" 2>&1 || true
+[ -s "$LEAK" ] || { echo "check_compile_only_lanes_test: FAIL (leak): probe did not compile" >&2; cat "$LEAK.diag" 2>/dev/null >&2; exit 1; }
+node scripts/wasm_func_sizes.mjs "$LEAK" --top 1000000 | grep -q 'compile_file_fs_mode_gc' \
+  || { echo "check_compile_only_lanes_test: FAIL (leak): the probe's name section lacks compile_file_fs_mode_gc, so the mutation did not hit" >&2; exit 1; }
+expect_fail leak "still defines functions of a dropped lane" --scan-only "$LEAK"
+
+# 3. accepted: the full CLI serves the gc lane, so the refusal check fails on
+# the first switch.
+expect_fail accepted "VIBE_BACKEND=gc was ACCEPTED" --artifact "$STAGE2" --entry cli_main
+
+# 4. control.
+if ! bash "$GATE" --artifact "$ART" --entry cli_main_compile_only >"$TMP/control.log" 2>&1; then
+  echo "check_compile_only_lanes_test: FAIL (control): the gate rejects the real compile-only artifact" >&2
+  cat "$TMP/control.log" >&2
+  exit 1
+fi
+echo "check_compile_only_lanes_test: ok (control)"
+echo "check_compile_only_lanes_test: all cases ok"

--- a/scripts/generate_bundle.sh
+++ b/scripts/generate_bundle.sh
@@ -1162,6 +1162,29 @@ if [ -n "$ADAPTER_MODULE_SOURCE_OUT" ]; then
   cp "$ADAPTER_MODULE_SOURCE_FILE" "$ADAPTER_MODULE_SOURCE_OUT_TMP"
   mv "$ADAPTER_MODULE_SOURCE_OUT_TMP" "$ADAPTER_MODULE_SOURCE_OUT"
 fi
+# #2497: the compile-only artifact is the SAME merged program DCE-rooted at
+# `main_compile_only` (cli_adapter.vibe) instead of `main`. Its lane tables
+# name only the production compiles, so the gc backend, the instrumentation
+# compiles and the rc-shadow lane fall out of the reachability walk here, at
+# emission -- the wasm never contains them (scripts/check_compile_only_lanes.sh
+# is the proof). Opt-in and NOT one of the five ensured artifacts: only
+# scripts/build_compile_only.sh asks for it, so the ordinary generation pays
+# nothing. No seed validation compile either -- the consumer compiles it
+# immediately, which is the same check.
+COMPILE_ONLY_MODULE_SOURCE_OUT="${VIBE_COMPILE_ONLY_MODULE_SOURCE_OUT:-}"
+if [ -n "$COMPILE_ONLY_MODULE_SOURCE_OUT" ]; then
+  trace_begin "compile-only module source"; _t="$TRACE_TOKEN"
+  mkdir -p "$(dirname "$COMPILE_ONLY_MODULE_SOURCE_OUT")" "$PROJECT_ROOT/_build"
+  COMPILE_ONLY_MODULE_SOURCE_TMP="$(mktemp "$PROJECT_ROOT/_build/cli_compile_only_module_source.XXXXXX")"
+  run_host_vibe_cmd emit-module-source "$ADAPTER_MERGED_SOURCE_FILE" "$COMPILE_ONLY_MODULE_SOURCE_TMP" "main_compile_only" >/dev/null
+  if [ ! -s "$COMPILE_ONLY_MODULE_SOURCE_TMP" ]; then
+    echo "generate_bundle: compile-only module source (root main_compile_only) was not produced" >&2
+    cat "$COMPILE_ONLY_MODULE_SOURCE_TMP.diag" >&2 2>/dev/null || true
+    exit 1
+  fi
+  mv "$COMPILE_ONLY_MODULE_SOURCE_TMP" "$COMPILE_ONLY_MODULE_SOURCE_OUT"
+  trace_end "$_t" 0
+fi
 trace_begin "adapter bundle (pass 2)"; _t="$TRACE_TOKEN"
 write_adapter_bundle "$ADAPTER_MERGED_SOURCE_FILE" "$ADAPTER_MODULE_SOURCE_FILE"
 trace_end "$_t" 0


### PR DESCRIPTION
Part of #2497 (unit 1: the first lane cut, measured).

## What changes

- **`cli_adapter.vibe`**: the env-mode CLI body becomes `cli_main_with_lanes(fs_lanes, ss_lanes)`. The FS-lane and single-source-lane selectors read the environment once into a lane request (`FsLane` / `SsLane`, same precedence as the inline arms had) and hand it to a lane table. `cli_main` installs the full tables; the new `cli_main_compile_only` / `main_compile_only` install the production tables, which know the two allocator lanes (RC, and bump under `VIBE_RC=0`) and refuse every other switch **by name**:
  ```
  this compiler is the compile-only build and has no lane for VIBE_BACKEND=gc; unset it, or run the same command with the full CLI build (stage2.wasm from scripts/generations.sh)
  ```
  A refused request is a diagnostic, never a silent fall-through to another lane.
- **`scripts/generate_bundle.sh`**: opt-in `VIBE_COMPILE_ONLY_MODULE_SOURCE_OUT` emits the same merged program DCE-rooted at `main_compile_only`. Not one of the five ensured artifacts; the ordinary generation pays nothing.
- **`scripts/build_compile_only.sh`**: emits that source and compiles it with stage2 (`--names` keeps the name section).
- **`scripts/check_compile_only_lanes.sh`** + self-test, wired into `release-check` after `selfhostGeneration`: absence (from the name section; a stripped artifact is reported as unreadable, not clean), refusal of six switches by name, acceptance of the two production lanes with the default output running. The self-test fails the gate on a stripped artifact, on a named wasm that defines a dropped lane's name, and on the full CLI stage2 (which accepts `VIBE_BACKEND=gc`).
- `index.vpkg` declares the two new entries; `docs/bootstrap.md` gets the artifact row.

## Measured (CLI stage2 vs compile-only, both from these sources, `VIBE_WASM_NAMES=1`, code section)

| | CLI stage2 | compile-only |
|---|---:|---:|
| code section | 2,744,372 B / 6,300 fns | 2,575,630 B / 6,003 fns (−168,742 B, −6.1 %) |
| `codegen/gc` + `source_compile/gc_only` | 140,004 B / 164 fns | 0 |
| heap-marked / testmeta / artifact-input-trace twins | 4,242 B | 0 |
| `compile_file_fs_mode_{gc,break,trace,coverage,rc_shadow,rc_body_cached,testmeta}`, `*_{coverage,trace,break,rc_shadow,gc_only}_impl` | present | 0 |
| debug-break / trace names | 6,902 B | 2,669 B |
| `cli_main`, `main`, `profile_plan_main` | present | 0 |

What stays: the flag-guarded arms **inside** `compile_wasi_module_linked_impl` (rc-shadow `emit_shadow_*`, `emit_dbg_line_stmt`, coverage driver helpers, `codegen_body_cache_*`), which top-level reachability cannot see. Those are the next unit (either constant-folding the lane booleans at the wrapper, or `#cfg` once the seed can carry it, see below).

Behaviour on the artifact: default and `VIBE_RC=0` compile and the output runs (`42`); `VIBE_BACKEND=gc`, `VIBE_DEBUG_BREAK=1`, `VIBE_DEBUG=1`, `VIBE_RC=shadow`, `VIBE_COVERAGE=1`, `VIBE_CODEGEN_BODY_CACHE=on` each produce no wasm and the diagnostic above. `VIBE_CFG`, `VIBE_UNSTABLE` and `VIBE_INTERNAL_TRUSTED_SOURCE` are untouched (per-compilation on every artifact, as the issue requires).

## Why reachability instead of `#cfg` on the lane statements

`#cfg` has only positive flags. A lane under `#cfg(lane)` with its refusing stub under `#cfg(lane_absent)` leaves every reader that parses compiler sources with no flag set (`vibe check`, the LSP, the two tests that import `cli_adapter`) with an unknown name. A `#cfg(not(flag))` form fixes that but needs a seed bump before compiler sources may use it, and the release for the currently pinned seed (`seed/cfg-spans-emission-2026-09-04`) is not published yet, so a second bump would stack on an unpublished one. Rooting the module-source DCE at a second entry needs neither and reaches the artifact the issue describes; the allocator question (whether the compile-only build should ship RC, bump or both) is left open and both lanes are kept.

## Verification

- `generations.sh build --stage3`: stage3 == stage2 (fixpoint) from these sources.
- `check_compile_only_lanes.sh` and its self-test pass against that stage2; `check_gate_self_tests.sh`, `check_selector_precedence.sh` (+ test), `check_task_inputs.sh`, `check_gate_portability.sh`, `check_doc_commands.sh`, `check_vibe_fmt.sh`, `precommit.sh` all ok.
- `vpkg_scan_test.vibe` and `module_loader_collect_sources_test.vibe` (the tests importing `cli_adapter`) pass on that stage2.
- The lane tables sit after the CLI body on purpose: `check_selector_precedence.sh` derives the launcher's selector order from source order, and defined earlier the re-read switches moved to the front of it.
- `scripts/generate_bundle_test.sh` fails in this container on `main` too (its synthetic project has no `scripts/run_wasm_vibe_host_runner.sh` for the merge-tool bootstrap); unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0135RDJv1VCvuJqYKF88kGhU

---
_Generated by [Claude Code](https://claude.ai/code/session_0135RDJv1VCvuJqYKF88kGhU)_