### PR TITLE
normalize: a per-module entry for desugar_trait_dicts (module + dependency interface → rewritten module + synthesized set), checked by the oracle (#2388)

### DIFF
--- a/lib/@vibe/compiler/codegen/wasi/linked_compile.vibe
+++ b/lib/@vibe/compiler/codegen/wasi/linked_compile.vibe
@@ -34,11 +34,16 @@ import @vibe/ast {
 }
 
 import @vibe/core {
-  array_empty
+  array_empty, struct MutMap
 }
 
 import @vibe/compiler/normalize {
-  desugar_inspect_calls, desugar_trait_dicts_with_typed_eq, lift_match_scrutinees, unbox_tuple_loop_params, uniquify_shadowed_bindings_fresh
+  desugar_inspect_calls,
+  desugar_trait_dicts_module,
+  desugar_trait_dicts_with_typed_eq,
+  lift_match_scrutinees,
+  unbox_tuple_loop_params,
+  uniquify_shadowed_bindings_fresh
 }
 
 import @vibe/compiler/perceus {
@@ -3739,6 +3744,179 @@ fn oracle_head(s: String) -> String {
   }
 }
 
+/// #2388: a module's dependency interface as the per-module pass sees it --
+/// what another file contributes without its bodies being compiled here: type,
+/// trait and suberror declarations, bounded-generic function definitions
+/// (their signature drives witness threading at a call site) and explicit
+/// `T::op` definitions (their presence suppresses a derive).
+fn oracle_is_interface_stmt(s: Stmt) -> Bool {
+  match s {
+    SEnum(_, _, _, _, _) => true,
+    SStruct(_, _, _, _, _, _) => true,
+    STypeAlias(_, _, _, _) => true,
+    SSuberror(_, _, _) => true,
+    STrait(_, _, _, _, _, _) => true,
+    SImpl(_, _, _, _) => true,
+    SLet(_, _, n, _, v) => if String::index_of(n, "::") >= 0 {
+      true
+    } else {
+      match v {
+        EFn(_, bounds, _, _, _, _) => Array::length(bounds) > 0,
+        _ => false
+      }
+    },
+    _ => false
+  }
+}
+
+/// Whether two renderings differ only at a generated fresh-name counter
+/// (`__teq_l12_0` vs `__teq_l2_0`, `__me_ks22`, `_exn_payload100` vs
+/// `_exn_payload10`): the first differing byte is a digit on both sides, or
+/// one side's digit run ended, right after a `__`- or `_exn_payload`-prefixed
+/// name. Anything else is a real content difference.
+fn oracle_rename_only(rw: String, rs: String) -> Bool {
+  let lim = if String::length(rw) < String::length(rs) {
+    String::length(rw)
+  } else {
+    String::length(rs)
+  }
+  let mut p = 0
+  while p < lim && String::char_code_at(rw, p) == String::char_code_at(rs, p) {
+    p = p + 1
+  }
+  if p == String::length(rw) && p == String::length(rs) {
+    true
+  } else {
+    let from = if p > 14 {
+      p - 14
+    } else {
+      0
+    }
+    let window = String::substring(rw, from, p)
+    let cw = if p < String::length(rw) {
+      String::char_code_at(rw, p)
+    } else {
+      0
+    }
+    let cs = if p < String::length(rs) {
+      String::char_code_at(rs, p)
+    } else {
+      0
+    }
+    let dw = cw >= 48 && cw <= 57
+    let dsd = cs >= 48 && cs <= 57
+    let prev_digit = p > 0 && String::char_code_at(rw, p - 1) >= 48 && String::char_code_at(rw, p - 1) <= 57
+    (dw || dsd) && (dw || prev_digit) && (dsd || prev_digit) && (String::index_of(window, "__") >= 0 || String::index_of(window, "_exn_payload") >= 0)
+  }
+}
+
+/// Compare the whole-program result `a` and the per-module result `trial` by
+/// declaration key rather than by position: per-module synthesis lands at each
+/// module's position and may repeat a helper per module, which a link-time
+/// dedup by name folds, so position and count are not the verdict. Keys that
+/// repeat within `a` are skipped (a repeated key cannot be matched). Returns
+/// `keyed missing=<in a only> extra=<in trial only> copies=<repeats in trial>
+/// content=<same key, different content, not a fresh-name rename>
+/// renames=<same key, fresh-name renames only>` plus the first missing key and
+/// the first content-differing key.
+fn oracle_keyed_line(a: Array[Stmt], trial: Array[Stmt], render: (Stmt) -> String) -> String {
+  let wmap: MutMap[String, Int] = MutMap::new_string()
+  let mut ki = 0
+  while ki < Array::length(a) {
+    let key = oracle_stmt_key(Array::get(a, ki))
+    if MutMap::has(wmap, key) {
+      MutMap::set(wmap, key, 0 - 1)
+    } else {
+      MutMap::set(wmap, key, ki)
+    }
+    ki = ki + 1
+  }
+  let seen: MutMap[String, Int] = MutMap::new_string()
+  let mut extra = 0
+  let mut copies = 0
+  let mut content = 0
+  let mut renames = 0
+  let mut first_content = ""
+  let mut ti = 0
+  while ti < Array::length(trial) {
+    let st = Array::get(trial, ti)
+    let key = oracle_stmt_key(st)
+    match MutMap::get(wmap, key) {
+      Some(widx) => {
+        if MutMap::has(seen, key) {
+          copies = copies + 1
+        } else {
+          MutMap::set(seen, key, 1)
+        }
+        if widx < 0 || Array::get(a, widx) == st {
+          ()
+        } else if oracle_rename_only(render(Array::get(a, widx)), render(st)) {
+          // Includes an identical rendering: the nodes then differ only in
+          // fields the printer does not show, i.e. synthetic offsets (the
+          // namespace operations derive theirs from the trait's statement
+          // index, which is module-local in a per-module run).
+          renames = renames + 1
+        } else {
+          content = content + 1
+          if content <= 3 {
+            let rw = render(Array::get(a, widx))
+            let rs = render(st)
+            let lim = if String::length(rw) < String::length(rs) {
+              String::length(rw)
+            } else {
+              String::length(rs)
+            }
+            let mut p = 0
+            while p < lim && String::char_code_at(rw, p) == String::char_code_at(rs, p) {
+              p = p + 1
+            }
+            let from = if p > 100 {
+              p - 100
+            } else {
+              0
+            }
+            let wto = if p + 100 < String::length(rw) {
+              p + 100
+            } else {
+              String::length(rw)
+            }
+            let sto = if p + 100 < String::length(rs) {
+              p + 100
+            } else {
+              String::length(rs)
+            }
+            first_content = String::concat(first_content, String::concat("\n    ", String::concat(key, String::concat(" at=", String::concat(Int::to_string(p), String::concat("\n    whole<", String::concat(String::substring(rw, from, wto), String::concat(">\n    split<", String::concat(String::substring(rs, from, sto), ">")))))))))
+          } else {
+            ()
+          }
+        }
+      },
+      None => {
+        extra = extra + 1
+      }
+    }
+    ti = ti + 1
+  }
+  let mut missing = 0
+  let mut first_missing = ""
+  ki = 0
+  while ki < Array::length(a) {
+    let key = oracle_stmt_key(Array::get(a, ki))
+    if MutMap::has(seen, key) {
+      ()
+    } else {
+      missing = missing + 1
+      if String::length(first_missing) == 0 {
+        first_missing = key
+      } else {
+        ()
+      }
+    }
+    ki = ki + 1
+  }
+  String::concat("  keyed missing=", String::concat(Int::to_string(missing), String::concat(" extra=", String::concat(Int::to_string(extra), String::concat(" copies=", String::concat(Int::to_string(copies), String::concat(" content=", String::concat(Int::to_string(content), String::concat(" renames=", String::concat(Int::to_string(renames), String::concat(" first_missing=", String::concat(first_missing, String::concat(" first_content=", String::concat(first_content, "\n"))))))))))))))
+}
+
 /// One step of the oracle: pass `k`. `a` is the whole-program state after
 /// passes 0..k-1 (advanced in place here by pass k); `c` is a FRESH merge of
 /// the same program with its per-statement file ids, brought to the same
@@ -3777,6 +3955,39 @@ export fn prelude_pass_module_oracle_step(k: Int, a: Array[Stmt], c: Array[Stmt]
     Array::push(part, Array::get(c, si))
     si = si + 1
   }
+  // The whole program goes first: for the per-module entry the context is
+  // the other files' POST-pass interface (a dependency is compiled before
+  // its dependents, so a dependent sees its threaded signatures), taken
+  // from `a` and limited to keys that existed before the pass (a
+  // synthesized statement belongs to its own module's output, not to a
+  // sibling's context).
+  oracle_apply_pass(k, a, entry_name, checker_eq_offsets, checker_eq_type_keys)
+  let pre_keys: MutMap[String, Int] = MutMap::new_string()
+  let mut pk = 0
+  while pk < Array::length(c) {
+    MutMap::set(pre_keys, oracle_stmt_key(Array::get(c, pk)), 1)
+    pk = pk + 1
+  }
+  // Each file's interface, taken BEFORE any module run: a module run rewrites
+  // its own part in place (a threaded signature is skipped by `build_gens` as
+  // already done), and a dependent must see the pre-pass, contract form.
+  let ifaces: Array[Array[Stmt]] = []
+  let mut pf = 0
+  while pf < file_count {
+    let src = Array::get(parts, pf)
+    let dst: Array[Stmt] = []
+    let mut ps = 0
+    while ps < Array::length(src) {
+      if oracle_is_interface_stmt(Array::get(src, ps)) {
+        Array::push(dst, Array::get(src, ps))
+      } else {
+        ()
+      }
+      ps = ps + 1
+    }
+    Array::push(ifaces, dst)
+    pf = pf + 1
+  }
   let trial: Array[Stmt] = []
   let trial_file: Array[Int] = []
   fi = 0
@@ -3787,7 +3998,49 @@ export fn prelude_pass_module_oracle_step(k: Int, a: Array[Stmt], c: Array[Stmt]
       ""
     }
     let part = Array::get(parts, fi)
-    oracle_apply_pass(k, part, part_entry, checker_eq_offsets, checker_eq_type_keys)
+    if k == 4 {
+      // The one pass with a per-module entry: the module's statements plus the
+      // other files' interface, synthesized program-level statements appended
+      // after the module's own.
+      let own_keys: MutMap[String, Int] = MutMap::new_string()
+      let mut ok = 0
+      while ok < Array::length(part) {
+        MutMap::set(own_keys, oracle_stmt_key(Array::get(part, ok)), 1)
+        ok = ok + 1
+      }
+      // The other files' PRE-pass interface: `build_gens` registers a bounded
+      // generic only from its unthreaded signature (a threaded one is
+      // skipped as already done), which is also the form a `.vpkg` contract
+      // carries.
+      let ctx: Array[Stmt] = []
+      let mut cj = 0
+      while cj < file_count {
+        if cj == fi {
+          ()
+        } else {
+          let other = Array::get(ifaces, cj)
+          let mut ci = 0
+          while ci < Array::length(other) {
+            let cs = Array::get(other, ci)
+            if MutMap::has(own_keys, oracle_stmt_key(cs)) {
+              ()
+            } else {
+              Array::push(ctx, cs)
+            }
+            ci = ci + 1
+          }
+        }
+        cj = cj + 1
+      }
+      let synthesized = desugar_trait_dicts_module(part, ctx, checker_eq_offsets, checker_eq_type_keys)
+      let mut sy = 0
+      while sy < Array::length(synthesized) {
+        Array::push(part, Array::get(synthesized, sy))
+        sy = sy + 1
+      }
+    } else {
+      oracle_apply_pass(k, part, part_entry, checker_eq_offsets, checker_eq_type_keys)
+    }
     let mut oi = 0
     while oi < Array::length(part) {
       Array::push(trial, Array::get(part, oi))
@@ -3796,7 +4049,6 @@ export fn prelude_pass_module_oracle_step(k: Int, a: Array[Stmt], c: Array[Stmt]
     }
     fi = fi + 1
   }
-  oracle_apply_pass(k, a, entry_name, checker_eq_offsets, checker_eq_type_keys)
   let nn = Array::length(a)
   let nt = Array::length(trial)
   let lim = if nn < nt {
@@ -3853,10 +4105,15 @@ export fn prelude_pass_module_oracle_step(k: Int, a: Array[Stmt], c: Array[Stmt]
     "differs"
   }
   let line = String::concat("PASS ", String::concat(oracle_pass_name(k), String::concat(" stmts=", String::concat(Int::to_string(nn), String::concat(" split=", String::concat(Int::to_string(nt), String::concat(" diff=", String::concat(Int::to_string(diffs), String::concat(" first=", String::concat(Int::to_string(first), String::concat(" file=", String::concat(Int::to_string(first_file), String::concat(" status=", String::concat(status, "\n"))))))))))))))
-  if diffs > 0 {
-    String::concat(line, String::concat("  whole: ", String::concat(first_whole, String::concat("\n  split: ", String::concat(first_split, "\n")))))
+  let line2 = if k == 4 {
+    String::concat(line, oracle_keyed_line(a, trial, render))
   } else {
     line
+  }
+  if diffs > 0 {
+    String::concat(line2, String::concat("  whole: ", String::concat(first_whole, String::concat("\n  split: ", String::concat(first_split, "\n")))))
+  } else {
+    line2
   }
 }
 

--- a/lib/@vibe/compiler/normalize/desugar_trait_dict.vibe
+++ b/lib/@vibe/compiler/normalize/desugar_trait_dict.vibe
@@ -1383,7 +1383,10 @@ fn trait_operation_param_name(ty: TypeExpr, index: Int, dispatch: String) -> Str
 /// Derive public `Trait::operation` wrappers without introducing bare names.
 export fn derive_trait_namespace_operations(stmts: Array[Stmt]) -> Unit {
   let additions = array_empty()
-  let original_len = Array::length(stmts)
+  // #2388: only the module's own traits get operations; the context (if any)
+  // sits after `original_len` and is carried through the reorder untouched.
+  let original_len = dtd_own_end(stmts)
+  let total = Array::length(stmts)
   let traits_raw = collect_namespace_traits(stmts)
   let supers_map = collect_trait_supers(stmts)
   let traits = flatten_traits(traits_raw, supers_map)
@@ -1516,9 +1519,20 @@ export fn derive_trait_namespace_operations(stmts: Array[Stmt]) -> Unit {
   } else {
     ()
   }
+  let mut ti = original_len
+  while ti < total {
+    Array::push(ordered, Array::get(stmts, ti))
+    ti = ti + 1
+  }
+  Array::set(dtd_own_growth, 0, Array::get(dtd_own_growth, 0) + Array::length(additions))
+  if Array::get(dtd_own_limit, 0) >= 0 {
+    Array::set(dtd_own_limit, 0, Array::get(dtd_own_limit, 0) + Array::length(additions))
+  } else {
+    ()
+  }
   let mut oi = 0
   while oi < Array::length(ordered) {
-    if oi < original_len {
+    if oi < total {
       Array::set(stmts, oi, Array::get(ordered, oi))
     } else {
       Array::push(stmts, Array::get(ordered, oi))
@@ -15499,6 +15513,7 @@ fn collect_decl_type_names(stmts: Array[Stmt]) -> Array[String] {
 
 export fn desugar_derives(stmts: Array[Stmt]) -> Unit {
   let gen = empty_stmt_list()
+  let own_end = dtd_own_end(stmts)
   let known_types = collect_decl_type_names(stmts)
   // #2136: the type variables a generated `Array[e]` helper has to bind. Filled
   // here because this is the first pass that generates one, and read again by
@@ -15511,7 +15526,7 @@ export fn desugar_derives(stmts: Array[Stmt]) -> Unit {
   let arr_elems = empty_type_exprs()
   let arr_keys = empty_str_array()
   let mut i = 0
-  while i < Array::length(stmts) {
+  while i < own_end {
     match Array::get(stmts, i) {
       SStruct(_, name, fields0, derives, _, decl_tparams) => {
         // #2141: the declaration's tparams scope its field types -- re-spell
@@ -15623,7 +15638,7 @@ export fn desugar_derives(stmts: Array[Stmt]) -> Unit {
   let elem_types = empty_type_exprs()
   let elem_keys = empty_str_array()
   let mut si = 0
-  while si < Array::length(stmts) {
+  while si < own_end {
     match Array::get(stmts, si) {
       // #2141: read the fields/payloads through the same decl-tparams
       // re-spelling the generator arms use, or this walk predicts an
@@ -16818,7 +16833,7 @@ fn dlh_hoist_stmt(stmt: Stmt, hoisted: Array[Stmt], ctr: Array[Int]) -> Stmt {
 export fn desugar_hoist_local_lambdas(stmts: Array[Stmt]) -> Unit {
   let hoisted = array_empty()
   let ctr = [0]
-  let n = Array::length(stmts)
+  let n = dtd_own_end(stmts)
   let mut i = 0
   while i < n {
     Array::set(stmts, i, dlh_hoist_stmt(Array::get(stmts, i), hoisted, ctr))
@@ -20187,6 +20202,59 @@ export fn desugar_trait_dicts(stmts: Array[Stmt]) -> Unit with Exception {
 /// before any rewrite reads it.
 let dtd_typed_eq_offs: Array[Int] = []
 
+/// #2388: the "declared here" boundary of a per-module run. The module entry
+/// (`desugar_trait_dicts_module`) lays the module's own statements first and
+/// its dependency interface after them, and records both lengths here, so the
+/// synthesis sites (derives, namespace operations, lambda hoisting, the rewrite
+/// loop, dict structs) work on the module's statements only and read the
+/// context for lookups. -1 (the whole-program entry) means everything is own.
+let dtd_own_limit: Array[Int] = [0 - 1]
+
+let dtd_ctx_len: Array[Int] = [0]
+
+/// Statements a stage inserted INSIDE the module's own region (the trait
+/// namespace operations land right after their trait, not at the end), so
+/// the module entry knows where its own region ends after the run.
+let dtd_own_growth: Array[Int] = [0]
+
+/// End (exclusive) of the module's own statements; the whole array when no
+/// module boundary is set.
+fn dtd_own_end(stmts: Array[Stmt]) -> Int {
+  let lim = Array::get(dtd_own_limit, 0)
+  if lim < 0 || lim > Array::length(stmts) {
+    Array::length(stmts)
+  } else {
+    lim
+  }
+}
+
+/// Whether index `i` is a module-owned statement: everything before the
+/// boundary, plus everything appended after the context block (the pass's
+/// own synthesized statements).
+fn dtd_is_own_index(i: Int) -> Bool {
+  let lim = Array::get(dtd_own_limit, 0)
+  lim < 0 || i < lim || i >= lim + Array::get(dtd_ctx_len, 0)
+}
+
+/// Whether `trait_name` is declared among the module's own statements.
+fn dtd_trait_declared_here(stmts: Array[Stmt], trait_name: String) -> Bool {
+  let own_end = dtd_own_end(stmts)
+  let mut i = 0
+  let mut found = false
+  while i < own_end && !found {
+    match Array::get(stmts, i) {
+      STrait(_, n, _, _, _, _) => if n == trait_name {
+        found = true
+      } else {
+        ()
+      },
+      _ => ()
+    }
+    i = i + 1
+  }
+  found
+}
+
 let dtd_typed_eq_keys: Array[String] = []
 
 fn dtd_typed_eq_key_for(boff: Int) -> String {
@@ -20314,6 +20382,62 @@ fn eq_ty_mentions_scope_formal(t: TypeExpr) -> Bool {
 }
 
 export fn desugar_trait_dicts_with_typed_eq(stmts: Array[Stmt], typed_eq_offsets: Array[Int], typed_eq_keys: Array[String]) -> Unit with Exception {
+  Array::set(dtd_own_limit, 0, 0 - 1)
+  Array::set(dtd_ctx_len, 0, 0)
+  dtd_run(stmts, typed_eq_offsets, typed_eq_keys)
+}
+
+/// #2388: the per-module entry. `own` is the module's statements, rewritten in
+/// place; `ctx` is its dependency interface -- the type / trait declarations,
+/// bounded-generic function definitions and explicit `T::op` definitions it
+/// can see through its imports, in their pre-pass (contract) form -- read for
+/// lookups and never emitted. Returns the statements the pass appended: the
+/// derived operations of the module's own types (`T::equals`, …) and the
+/// program-level helpers they and the module's `==` sites need
+/// (`__arr_equals__*`, `__map_equals__*`, the exn-kind cell). A caller links
+/// them once per name across modules; a `T::op` for a type this module
+/// declares is this module's definition. Only the trait namespace operations
+/// are placed inside `own` (right after their trait, as the whole-program
+/// entry does), which is why the entry tracks how much the own region grew.
+export fn desugar_trait_dicts_module(own: Array[Stmt], ctx: Array[Stmt], typed_eq_offsets: Array[Int], typed_eq_keys: Array[String]) -> Array[Stmt] with Exception {
+  let stmts: Array[Stmt] = []
+  let mut i = 0
+  while i < Array::length(own) {
+    Array::push(stmts, Array::get(own, i))
+    i = i + 1
+  }
+  let mut ci = 0
+  while ci < Array::length(ctx) {
+    Array::push(stmts, Array::get(ctx, ci))
+    ci = ci + 1
+  }
+  Array::set(dtd_own_limit, 0, Array::length(own))
+  Array::set(dtd_ctx_len, 0, Array::length(ctx))
+  Array::set(dtd_own_growth, 0, 0)
+  dtd_run(stmts, typed_eq_offsets, typed_eq_keys)
+  let own_n = Array::length(own)
+  let own_end = own_n + Array::get(dtd_own_growth, 0)
+  let mut wi = 0
+  while wi < own_end {
+    if wi < own_n {
+      Array::set(own, wi, Array::get(stmts, wi))
+    } else {
+      Array::push(own, Array::get(stmts, wi))
+    }
+    wi = wi + 1
+  }
+  let synthesized: Array[Stmt] = []
+  let mut si = own_end + Array::length(ctx)
+  while si < Array::length(stmts) {
+    Array::push(synthesized, Array::get(stmts, si))
+    si = si + 1
+  }
+  Array::set(dtd_own_limit, 0, 0 - 1)
+  Array::set(dtd_ctx_len, 0, 0)
+  synthesized
+}
+
+fn dtd_run(stmts: Array[Stmt], typed_eq_offsets: Array[Int], typed_eq_keys: Array[String]) -> Unit with Exception {
   // #2441: (re)populate the typed-`==` table for THIS program before any
   // rewrite can read it.
   Array::truncate(dtd_typed_eq_offs, 0)
@@ -20453,12 +20577,16 @@ export fn desugar_trait_dicts_with_typed_eq(stmts: Array[Stmt], typed_eq_offsets
   let mut i = 0
   while i < Array::length(stmts) {
     let stmt = Array::get(stmts, i)
-    match merged_source_boundary_local_names(stmt) {
-      Some(local_names) => {
-        user_assert_eq_set_merged_source(stmts, i + 1, local_names)
-        dtd_builtin_iterator_set_boundary(local_names)
-      },
-      None => Array::set(stmts, i, rewrite_stmt(stmt, gens, traits, struct_sets, fn_returns, toplevel_vars))
+    if !dtd_is_own_index(i) {
+      ()
+    } else {
+      match merged_source_boundary_local_names(stmt) {
+        Some(local_names) => {
+          user_assert_eq_set_merged_source(stmts, i + 1, local_names)
+          dtd_builtin_iterator_set_boundary(local_names)
+        },
+        None => Array::set(stmts, i, rewrite_stmt(stmt, gens, traits, struct_sets, fn_returns, toplevel_vars))
+      }
     }
     i = i + 1
   }
@@ -20485,7 +20613,7 @@ export fn desugar_trait_dicts_with_typed_eq(stmts: Array[Stmt], typed_eq_offsets
     let mut ti = 0
     while ti < Array::length(traits) {
       let (trait_name, sigs) = Array::get(traits, ti)
-      if struct_decl_exists(stmts, dict_struct_name(trait_name)) {
+      if struct_decl_exists(stmts, dict_struct_name(trait_name)) || !dtd_trait_declared_here(stmts, trait_name) {
         ()
       } else {
         // #2286: record the provenance at the ONE point a dict struct is

--- a/lib/@vibe/compiler/normalize/index.vpkg
+++ b/lib/@vibe/compiler/normalize/index.vpkg
@@ -90,6 +90,7 @@ fn validate_serializable_reexport_references(stmts: Array[Stmt]) -> Unit with Ex
 fn desugar_array_spread(stmts: Array[Stmt]) -> Unit
 fn desugar_trait_dicts(stmts: Array[Stmt]) -> Unit with Exception
 fn desugar_trait_dicts_with_typed_eq(stmts: Array[Stmt], typed_eq_offsets: Array[Int], typed_eq_keys: Array[String]) -> Unit with Exception
+fn desugar_trait_dicts_module(own: Array[Stmt], ctx: Array[Stmt], typed_eq_offsets: Array[Int], typed_eq_keys: Array[String]) -> Array[Stmt] with Exception
 fn synthesized_dict_field_trait(struct_name: String, field_name: String) -> String
 
 // --- unbox_tuple_loop.vibe (#1262)

--- a/lib/@vibe/compiler/tests/desugar_trait_dicts_module_test.vibe
+++ b/lib/@vibe/compiler/tests/desugar_trait_dicts_module_test.vibe
@@ -1,0 +1,106 @@
+import @vibe/compiler/core {
+  Stmt
+}
+
+import @vibe/compiler/normalize {
+  desugar_trait_dicts, desugar_trait_dicts_module
+}
+
+import @vibe/compiler/syntax {
+  lex, parse_program, print_stmt
+}
+
+// #2388: the per-module entry of the trait-dictionary pass. A dependency file
+// declares a trait, an impl and a bounded-generic function; the module file
+// declares a struct and a bounded-generic function that calls the
+// dependency's. Run whole-program (both files in one array) and per-module
+// (the module's statements plus the dependency's statements as a read-only
+// context), the module's function must come out the same -- the witness
+// threaded into the call -- and the context must not pick up definitions
+// that belong to its own module (its trait's namespace operation and dict
+// struct), while the program-level helpers land in the synthesized set.
+
+fn dep_src() -> String {
+  "export trait Hash {\n  hash_key(Self) -> String\n}\n\nimpl Hash for String {\n  hash_key(self) -> String {\n    self\n  }\n}\n\nexport fn map_key_to_string[K: Hash](key: K) -> String {\n  K::hash_key(key)\n}\n"
+}
+
+fn own_src() -> String {
+  "struct Set[T] {\n  entries: Map[String, T]\n}\n\nexport fn contains[T: Hash](s: Set[T], value: T) -> Bool {\n  Map::has_key(s.entries, map_key_to_string(value))\n}\n"
+}
+
+fn render_named(stmts: Array[Stmt], name: String) -> String {
+  let mut out = ""
+  let mut i = 0
+  while i < Array::length(stmts) {
+    match Array::get(stmts, i) {
+      SLet(_, _, n, _, _) => if n == name {
+        out = print_stmt(Array::get(stmts, i))
+      } else {
+        ()
+      },
+      _ => ()
+    }
+    i = i + 1
+  }
+  out
+}
+
+fn stmt_names(stmts: Array[Stmt]) -> String {
+  let mut out = ""
+  let mut i = 0
+  while i < Array::length(stmts) {
+    let n = match Array::get(stmts, i) {
+      SLet(_, _, n, _, _) => n,
+      SStruct(_, n, _, _, _, _) => String::concat("struct ", n),
+      STrait(_, n, _, _, _, _) => String::concat("trait ", n),
+      SImpl(_, _, n, _) => String::concat("impl ", n),
+      _ => "?"
+    }
+    out = String::concat(out, String::concat(if i == 0 {
+      ""
+    } else {
+      ", "
+    }, n))
+    i = i + 1
+  }
+  out
+}
+
+fn whole_contains() -> String with Exception {
+  let stmts = parse_program(lex(String::concat(dep_src(), own_src())))
+  desugar_trait_dicts(stmts)
+  render_named(stmts, "contains")
+}
+
+test "the module entry threads the witness into a call of the context's bounded generic" {
+  let ctx = parse_program(lex(dep_src()))
+  let own = parse_program(lex(own_src()))
+  let synth = desugar_trait_dicts_module(own, ctx, [], [])
+  inspect(render_named(own, "contains") == whole_contains(), content = "true")
+  inspect(render_named(own, "contains"), content = "export let rec contains = [T: Hash](__dict_Hash_T: HashDict[T], s: Set[T], value: T) -> Bool { Map::has_key(s.entries, map_key_to_string(__dict_Hash_T, value)) }")
+  // The context is read, never rewritten or extended: its trait gets no
+  // operation and no dict struct from this module's run. What the pass
+  // appends -- the module's own derived comparator and the program-level
+  // helper it needs -- comes back as the synthesized set.
+  inspect(stmt_names(ctx), content = "trait Hash, impl Hash, String::hash_key, map_key_to_string")
+  inspect(stmt_names(own), content = "struct Set, contains")
+  inspect(stmt_names(synth), content = "Set::equals, __map_equals__N6_String__N7___Vfp_T")
+}
+
+test "the whole-program entry is the module entry with no context and everything own" {
+  let stmts = parse_program(lex(String::concat(dep_src(), own_src())))
+  desugar_trait_dicts(stmts)
+  inspect(stmt_names(stmts), content = "trait Hash, impl Hash, String::hash_key, map_key_to_string, Hash::hash_key, struct Set, contains, Set::equals, __map_equals__N6_String__N7___Vfp_T, struct HashDict")
+}
+
+test "the dependency's own run places its trait operation inside the module and its dict struct in the synthesized set" {
+  let own = parse_program(lex(dep_src()))
+  let ctx = parse_program(lex(own_src()))
+  let synth = desugar_trait_dicts_module(own, ctx, [], [])
+  // The namespace operation is inserted after the trait's impls and the
+  // lets that follow them, growing the module's own region; the context's
+  // struct is not derived for here.
+  inspect(stmt_names(own), content = "trait Hash, impl Hash, String::hash_key, map_key_to_string, Hash::hash_key")
+  inspect(stmt_names(synth), content = "struct HashDict")
+  inspect(stmt_names(ctx), content = "struct Set, contains")
+}


### PR DESCRIPTION
## What

Slice 1 of the per-module `desugar_trait_dicts` on #2388, behaviour-preserving on the whole-program lane: a per-module entry for the pass, and the oracle (#2558) upgraded to run it and to compare by declaration.

### Why this shape

The measurement on #2388 (the two comments of 2026-09-06) showed that a file run alone through `desugar_trait_dicts_with_typed_eq` (a) misses instantiation comparators and witness threading because it cannot see its imports' type / trait declarations and bounded-generic signatures, (b) re-derives the comparators of every type it can see, and (c) differs from the whole program otherwise only in program-wide fresh-name counters. So the per-module input is the module plus its dependency **interface**, and the output is the rewritten module plus a **synthesized set** to link once per name.

### `desugar_trait_dicts_module(own, ctx, typed_eq_offsets, typed_eq_keys) -> Array[Stmt]` (`normalize/desugar_trait_dict.vibe`)

- `own`: the module's statements, rewritten in place. `ctx`: type / trait / suberror / alias declarations, bounded-generic function definitions and explicit `T::op` definitions of its imports, in their pre-pass (contract) form; read for lookups, never rewritten, never emitted.
- Returns what the pass appended: the derived operations of the module's own types (`T::equals`, …) and the program-level helpers they and the module's `==` sites need (`__arr_equals__*`, `__map_equals__*`, the exn-kind cell). Only the trait namespace operations are placed inside `own` (after their trait, as the whole-program entry does), so the entry tracks how much the own region grew.
- Inside the pass a "declared here" boundary (`dtd_own_limit` / `dtd_ctx_len`, `dtd_own_end` / `dtd_is_own_index`) gates the sites that synthesize or rewrite: `desugar_derives` (both scans), `derive_trait_namespace_operations` (scan and insertion, with the context carried through the reorder), `desugar_hoist_local_lambdas`, the `rewrite_stmt` loop, and the dict-struct synthesis (`dtd_trait_declared_here`). **The whole-program entry sets no boundary and is unchanged**: same statements, same order, byte-identical output (chain below).

### The oracle in module mode (`codegen/wasi/linked_compile.vibe`)

For the pass with a module entry the split side now runs `desugar_trait_dicts_module` per file with the other files' interface as context. Two things it had to get right, recorded in the code: the interfaces are snapshotted **before** any module run (a run threads its own signatures in place, and `build_gens` skips a threaded signature as already done — the dependent would then see a callee with no entry and leave the witness out), and the whole program runs first.

Because per-module synthesis lands at each module's position and may repeat a helper per module, position and count are not the verdict; `oracle_keyed_line` compares by declaration key: `keyed missing=<in whole only> extra=<in split only> copies=<repeats> content=<same key, different content> renames=<differs only at a fresh-name counter, or in fields the printer does not show: synthetic offsets>`.

Measured on the compiler closure (`codegen_lexer_test.vibe`, 189 files, 4584 statements):

```
PASS desugar_trait_dicts_with_typed_eq stmts=4699 split=4764 diff=4749 first=7 file=0 status=differs
  keyed missing=0 extra=0 copies=319 content=0 renames=270
```

Every declaration the whole program produces, the per-module runs produce with the same content; the 319 copies are the link-time dedup by name; the 270 renames are the program-wide counters (`eq_tuple_uid`, `_exn_payload<n>`, the loop indices) and the namespace operations' statement-index offsets — slice 2 seeds those per declaration. The positional line stays `differs` for this pass by construction.

### Test

`desugar_trait_dicts_module_test.vibe`, a two-file program (a trait, an impl and a `[K: Hash]` function; a struct and a `[T: Hash]` function calling it), from both sides: the module's function threads the witness into the call exactly as the whole-program entry renders it, the context is neither rewritten nor extended, the module's derived comparator and the helper it needs come back as the synthesized set; from the dependency's side, its trait operation is placed inside the module and its dict struct synthesized, while the dependent's struct is not derived for. `prelude_module_oracle_test.vibe` (all 17 passes `same` on its two-file program) keeps answering.

## Validation

Chain on `bd9f469` (base `a5fc6c2`; staging worktree on the identical tree, tree hash 8cb4189 checked against the pushed head): bundle regen; stage2 == stage3; output equivalence on three closures and the rc fixtures (`codegen_lexer_test`, `perceus_rc_test`, `checker_test` identical against a stage2 built from main's tree; 22/22 rc fixtures identical); `test_cli_core.sh`; selfcompile KPI heap_ptr 841,614,040 bytes (vs 839,714,528 for main's tree on the same lane, +1.9 MB: the two files grew by the entry and the oracle's keyed comparison and are part of the closure being compiled); typing-env-reuse oracle; 246/246 affected unit-test files; `compiler_gate.sh` early / mid / late.

`vibe_fmt.sh --check` is a fixpoint on every changed file.

Refs #2388, #2386.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QKZdvBvHVUagwg6Yih8er8

---
_Generated by [Claude Code](https://claude.ai/code/session_01QKZdvBvHVUagwg6Yih8er8)_