### PR TITLE
Issue sweep, round 2: two more closes, a precondition that has fired, and a conflict between two open issues

### DIFF
--- a/docs/issue-triage.md
+++ b/docs/issue-triage.md
@@ -107,8 +107,8 @@ first, then take the leftover.
 | #2492 | build-time configuration, `VIBE_*` → `#cfg` → #2497, #2498, #2499 |
 | #2493 | a compile-only artifact at or under 1.0 MB → #2500 (blocker), #2501 – #2506 |
 | #2494 | compiler memory, 128 MB per unit of work → #2509 (blocker), #2507, #2508, #2510 |
-| #2340 | SIMD-first data structures → #2347, #2348 |
-| #2002 | documentation by audience |
+| #2340 | SIMD-first data structures → #2347 (#2348 closed: both inline-wasm halves landed in #2399 / #2420) |
+| #2002 | documentation by audience — **no sub-issues**, so nothing here is startable; Phases 0-1 already landed as `docs/README.md` without being tracked |
 | #2001 | retire the scripts layer |
 
 ### Everything else
@@ -122,7 +122,17 @@ typed-lowering tables empty; both end at the same statement-merge shape, so do
 them together), **#2442** (bare-name builtin value forms, blocked only on
 teaching the lambda-site planner scope), **#2555** (delete the sidecar codec's
 hand-rolled renderer and unary counts — the bug they route around was a
-misdiagnosis and is closed).
+misdiagnosis and is closed), **#2219** (its "after the next bootstrap bump"
+precondition has fired — the committed seed emits the assert marker, so the
+legacy block recognizer can go).
+
+Two open issues **conflict** and want a decision before either is started:
+**#2498** puts the compiler's telemetry and trace sinks behind `#cfg(telemetry)`
+and is done when the signatures carrying them get shorter, while **#1953** puts
+the same sinks behind a `Log` effect whose handler is a parameter. Landing
+either first invalidates the other's plan. #1953's Config half — the
+one-element mutable configuration cells and their implicit setter order — does
+not overlap and stands on its own.
 
 ## How to use sub-issues
 


### PR DESCRIPTION
Follow-up to #2557. Same method — verify against the tree, not against a PR body — over the issues the first pass did not reach. Docs-only diff; the tracker work is listed below.

## The diff

`docs/issue-triage.md` kept true to the tracker, per the rule #2557 added ("if the tables disagree with `gh issue list --state open`, the tables are wrong"): #2340's row drops #2348, #2002 is annotated as an epic with no sub-issues, and the pick-up list gains #2219 plus the conflict below.

## Closed

**#2348 — inline wasm ergonomics.** Both halves are in the tree at `2397d56`. `call` between kernels landed in #2399 (`inline_wat.vibe` handles it, and `check_iw_callee_table` gives the *check* lane the same callee table codegen builds, so `vibe check` accepts what the build accepts); `Array[Int]` params landed in #2420 — the parser's own diagnostic now reads `must be typed Int, Bytes, or Array[Int]`. It shipped as the issue's *first* option, made safe by normalizing rather than by documenting the hazard: the assembler masks the tag off every `local.get` of such a param, so the kernel text names no lane, and the slot is read-only because writing it would hand RC's epilogue a value it did not allocate. The thread also contains a correction worth not re-deriving — the earlier "the layout is lane-dependent" measurement was taken through a build that did not mask the tag, and the layout is in fact identical on both lanes once it is off.

**#2146 — the `lane:stdlib` / `dx` / `refactoring` index.** Every issue it points at is closed: its 1 P0 (#2158), all 4 P1s (#2149, #2164, #2157, #2145), and four of its five ordered items — the fifth being #1849's seam, which #2557 closed as superseded by #2500 / #2501. Its two predecessor snapshots (#2129, #2131) were already closed as duplicates of it, so this retires the third. What was durable is in `scripts/`, not in the issue: the six gates it added still run, and `check-doc-commands` is now at 593 resolving references.

## Not closeable — actionable now

**#2219's precondition has fired.** It was written as *"after the next bootstrap bump: delete the legacy assert-abort block recognizer"*, and that bump landed in #2519. Verified three ways: `bootstrap/seed.json` pins `seed/cfg-spans-emission-2026-09-04`; the literal `assert failed: aborting` is present in `bootstrap/seed/compiler.wasm`; and an `assert_eq(1, 2)` failure run on the seed condenses with no trap echo. So reason 2's whole justification — "the committed seed predates the marker" — is gone. Title and body updated, because "After the next bootstrap bump:" reads as *not yet* to anyone scanning the list.

While checking it, one thing the issue does not mention: the two condensers it tells you to edit together are **not the same expression**. `scripts/vibe_test.sh:387` is `(ablk == 3 || pending_abort == 1)`; `runtime/vibe:816` is `(ablk == 3 || pending_abort == 1 || pre_abort == 1)`. Deleting `ablk` from both is not one edit repeated twice.

**#2002 is an epic with no sub-issues.** By the triage doc's own rule an epic is never the thing to work on — so nothing in it is startable, and it has been that way since 2026-08-16. Meanwhile its Phases 0 and 1 have largely landed *without* being tracked: `docs/README.md` is the audience router, and its sections are the four audience classes verbatim, with every live document classified. Commented with what exists, what is missing (the enforcement half — nothing rejects a new uncategorized top-level doc), and the one bounded next step (the three delete candidates the router already names; a fourth, `known-issues.md`, went in #2557).

## A conflict between two open issues, now recorded on both

**#2498 and #1953 propose different mechanisms for the same sinks, and neither mentioned the other.**

| | mechanism | "gone from the release build" means |
|---|---|---|
| #2498 | one `#cfg(telemetry)` over sixteen `VIBE_*_OUT` / `_NONCE` reads | the release stage2 has no telemetry encoder, and *the hot signatures that carried the sinks are shorter* |
| #1953 | a compiler-private `Log` effect with per-invocation handlers | trace-disabled builds retain no trace authority or code after DCE |

They pull the signatures in opposite directions: #2498 treats the threaded `Option[String]` sink as the defect, while #1953's fix *keeps* a parameter — the handler — and makes it explicit. Landing either first invalidates the other's plan. They are reconcilable in principle (a `Log` row that a `#cfg` build const-folds away is exactly `AGENTS.md` pillar 3's shape), but that is a third design nobody has written down. #1953's Config half — the one-element mutable configuration cells and their implicit setter order — does not overlap and stands on its own.

## Checked and left alone

#2454, #2373, #1848, #1943, #2472, #2497, #1962, #1963, #1460, #2102 — all verified genuinely open with distinct scopes. Two worth noting: #1848 still has exactly the 15 `array_contains_str` sites in `compile_expr_tail.vibe` it reported on 2026-08-24, so #2482 / #2536 addressed different scans; and #2454 is the correct home for the one #2451 "done when" row I described as superseded when closing it — cross-referenced there, since deleting those refinement arms is real work, just not behaviour-neutral.

Still not done, same reason as last time: re-parenting the orphan architecture issues (#1953, #1962, #1963, #1872 are all extracted from the closed #1496 / #1770 umbrellas and have no epic). That is a scoping decision, not a cleanup.

## Verification

- `scripts/check_doc_path_citations.sh` — ok (32 allowlisted, 0 new)
- `scripts/check_doc_commands.sh` — ok (593 references resolve)
- `pkf run pre-commit` — passed
- Every close verified against the tree at `2397d56`, and #2219's precondition verified against the pinned seed artifact rather than inferred from the bump landing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0194y71aVEMcwoem5oAxFJPX

---
_Generated by [Claude Code](https://claude.ai/code/session_0194y71aVEMcwoem5oAxFJPX)_