### PR TITLE
Settle the #1953 / #2498 conflict: `#cfg` takes the trace sinks, #1953 keeps configuration

### DIFF
--- a/docs/issue-triage.md
+++ b/docs/issue-triage.md
@@ -126,13 +126,17 @@ misdiagnosis and is closed), **#2219** (its "after the next bootstrap bump"
 precondition has fired — the committed seed emits the assert marker, so the
 legacy block recognizer can go).
 
-Two open issues **conflict** and want a decision before either is started:
-**#2498** puts the compiler's telemetry and trace sinks behind `#cfg(telemetry)`
-and is done when the signatures carrying them get shorter, while **#1953** puts
-the same sinks behind a `Log` effect whose handler is a parameter. Landing
-either first invalidates the other's plan. #1953's Config half — the
-one-element mutable configuration cells and their implicit setter order — does
-not overlap and stands on its own.
+Sequencing worth knowing: **#1953 comes after #2497 and #2498**, not beside
+them. The two issues used to conflict — both moved the compiler's trace and
+telemetry sinks, one behind `#cfg(telemetry)` and one behind a `Log` effect
+whose handler is a parameter, so landing either invalidated the other's plan.
+Settled 2026-09-06 in favour of `#cfg`: the sinks are #2498's, which absorbed
+the three sharper acceptance criteria, and #1953 is now the configuration half
+alone. That half gets *sharper* once the #2492 subtree lands, because what is
+left in the configuration cells is then exactly the per-compilation set #2497
+deliberately excludes from `#cfg` (`VIBE_CFG`, `VIBE_UNSTABLE`,
+`VIBE_INTERNAL_TRUSTED_SOURCE`) — two of which carry authority, so a `Config`
+row over them is a least-authority row in the literal sense.
 
 ## How to use sub-issues
 


### PR DESCRIPTION
Owner decision on the conflict #2560 surfaced. `#cfg(telemetry)` wins; #1953's `Log`-effect proposal for the same sinks is dropped.

Executed as a **fold plus a narrowing, not a close** — only the trace half was ever in conflict, and #1953's other half has a test that `#cfg` cannot express.

## What moved to #2498

Three of #1953's acceptance criteria were sharper than #2498's for the same subject, so they are now checklist items there rather than lost with the issue:

1. **A trace-disabled build retains no trace authority *or code* after DCE.** #2498 said "no telemetry encoder or sink parameters"; this is the stronger claim, and it is checked from a `VIBE_WASM_NAMES=1` build rather than by reading the source.
2. **Existing CLI and env behaviour preserved at the boundary** — a telemetry-enabled build answers the same `VIBE_*_OUT` / `_NONCE` reads in the same format, with the four oracles as the test *and* a required demonstration that they can still go red. This repository's gate discipline applied to gates this very change could silently neuter.
3. **Differential output, self-build fixpoint, and the heap/wall KPI pass.** Shortening hot signatures is exactly the change that can be correct and still move something else.

## What stayed on #1953

The one-element mutable configuration arrays, the implicit setter order across the typecheck and effect passes, and the criterion that carries the issue:

> Two concurrent or nested compiler invocations cannot observe each other's configuration.

`#cfg` is a build-time constant, so it cannot answer a question about two invocations of *the same build*. That is why this is a narrowing rather than a close.

#1953 is retitled to say so, and its body now records something it could not have known when filed: **the #2492 subtree makes it sharper, not redundant.** Once #2497 moves the compiler's own lane switches to build time and #2498 takes the sinks, what remains in the configuration cells is exactly the per-compilation set #2497 deliberately excludes from `#cfg` — `VIBE_CFG` (the compiled program's own cfg set), `VIBE_UNSTABLE` (the ADR-0068 authorization), `VIBE_INTERNAL_TRUSTED_SOURCE` (the self-build's `validate_user_source_stmts` bypass). Two of those carry **authority**, so a `Config` row over them is a least-authority row in the literal sense rather than by analogy to pillar 3. So #1953 sequences *after* #2497 and #2498 rather than racing them.

## The diff

`docs/issue-triage.md`: the "two open issues conflict and want a decision" paragraph becomes the sequencing note above. One file, prose only.

## Verification

- `scripts/check_doc_path_citations.sh` — ok (32 allowlisted, 0 new)
- `scripts/check_doc_commands.sh` — ok (593 references resolve)
- `pkf run pre-commit` — passed, review-regressions lint **ok** on its AST tier this time (the session hook now provides a working `vibe grep`, where the two earlier sweep PRs ran text-tier only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0194y71aVEMcwoem5oAxFJPX

---
_Generated by [Claude Code](https://claude.ai/code/session_0194y71aVEMcwoem5oAxFJPX)_