### PR TITLE
normalize: fresh names per declaration, and the dependency interface is every top-level definition (#2388 slice 2)

### DIFF
--- a/lib/@vibe/compiler/codegen/wasi/linked_compile.vibe
+++ b/lib/@vibe/compiler/codegen/wasi/linked_compile.vibe
@@ -3745,10 +3745,13 @@ fn oracle_head(s: String) -> String {
 }
 
 /// #2388: a module's dependency interface as the per-module pass sees it --
-/// what another file contributes without its bodies being compiled here: type,
-/// trait and suberror declarations, bounded-generic function definitions
-/// (their signature drives witness threading at a call site) and explicit
-/// `T::op` definitions (their presence suppresses a derive).
+/// what another file contributes without its bodies being compiled here:
+/// type, trait, suberror and impl declarations, and every top-level
+/// definition (a function's signature drives witness threading at a call
+/// site and the exception kind of a throw whose payload it returns; an
+/// explicit `T::op` suppresses a derive). Bodies ride along unread: the
+/// module entry never rewrites or emits a context statement, which is the
+/// bodyless form a `.vpkg` contract carries.
 fn oracle_is_interface_stmt(s: Stmt) -> Bool {
   match s {
     SEnum(_, _, _, _, _) => true,
@@ -3757,57 +3760,47 @@ fn oracle_is_interface_stmt(s: Stmt) -> Bool {
     SSuberror(_, _, _) => true,
     STrait(_, _, _, _, _, _) => true,
     SImpl(_, _, _, _) => true,
-    SLet(_, _, n, _, v) => if String::index_of(n, "::") >= 0 {
-      true
-    } else {
-      match v {
-        EFn(_, bounds, _, _, _, _) => Array::length(bounds) > 0,
-        _ => false
-      }
-    },
+    SLet(_, _, _, _, _) => true,
+    SLetMut(_, _, _) => true,
     _ => false
   }
 }
 
-/// Whether two renderings differ only at a generated fresh-name counter
+/// Whether two renderings differ only at generated fresh-name counters
 /// (`__teq_l12_0` vs `__teq_l2_0`, `__me_ks22`, `_exn_payload100` vs
-/// `_exn_payload10`): the first differing byte is a digit on both sides, or
-/// one side's digit run ended, right after a `__`- or `_exn_payload`-prefixed
-/// name. Anything else is a real content difference.
+/// `_exn_payload10`). Anything else is a real content difference.
 fn oracle_rename_only(rw: String, rs: String) -> Bool {
-  let lim = if String::length(rw) < String::length(rs) {
-    String::length(rw)
-  } else {
-    String::length(rs)
-  }
-  let mut p = 0
-  while p < lim && String::char_code_at(rw, p) == String::char_code_at(rs, p) {
-    p = p + 1
-  }
-  if p == String::length(rw) && p == String::length(rs) {
-    true
-  } else {
-    let from = if p > 14 {
-      p - 14
+  oracle_strip_counters(rw) == oracle_strip_counters(rs)
+}
+
+/// The rendering with every generated counter removed: a digit run right
+/// after `__teq_l` / `__teq_r` / `__me_` / `__ae_` / `__be_` / `_exn_payload`
+/// (the names the pass mints from program-wide counters). Comparing the
+/// stripped renderings sees a real difference AFTER a renamed binder, which
+/// a first-difference test does not.
+fn oracle_strip_counters(s: String) -> String {
+  let out = StringBuilder::new()
+  let n = String::length(s)
+  let mut i = 0
+  while i < n {
+    StringBuilder::push(out, String::substring(s, i, i + 1))
+    i = i + 1
+    // After the '_' that ends one of the prefixes, skip a digit run.
+    let tail_from = if i > 12 {
+      i - 12
     } else {
       0
     }
-    let window = String::substring(rw, from, p)
-    let cw = if p < String::length(rw) {
-      String::char_code_at(rw, p)
+    let tail = String::substring(s, tail_from, i)
+    if String::ends_with(tail, "__teq_l") || String::ends_with(tail, "__teq_r") || String::ends_with(tail, "__me_k") || String::ends_with(tail, "__me_ks") || String::ends_with(tail, "__me_i") || String::ends_with(tail, "__me_ok") || String::ends_with(tail, "__ae_i") || String::ends_with(tail, "__ae_ok") || String::ends_with(tail, "__be_i") || String::ends_with(tail, "__be_ok") || String::ends_with(tail, "_exn_payload") {
+      while i < n && String::char_code_at(s, i) >= 48 && String::char_code_at(s, i) <= 57 {
+        i = i + 1
+      }
     } else {
-      0
+      ()
     }
-    let cs = if p < String::length(rs) {
-      String::char_code_at(rs, p)
-    } else {
-      0
-    }
-    let dw = cw >= 48 && cw <= 57
-    let dsd = cs >= 48 && cs <= 57
-    let prev_digit = p > 0 && String::char_code_at(rw, p - 1) >= 48 && String::char_code_at(rw, p - 1) <= 57
-    (dw || dsd) && (dw || prev_digit) && (dsd || prev_digit) && (String::index_of(window, "__") >= 0 || String::index_of(window, "_exn_payload") >= 0)
   }
+  StringBuilder::freeze(out)
 }
 
 /// Compare the whole-program result `a` and the per-module result `trial` by

--- a/lib/@vibe/compiler/normalize/desugar_trait_dict.vibe
+++ b/lib/@vibe/compiler/normalize/desugar_trait_dict.vibe
@@ -738,7 +738,7 @@ fn annotate_params_from_sig(params: Array[(String, Option[TypeExpr])], ptypes: A
 fn inject_method_generics_reporting_change(stmts: Array[Stmt], impl_map: Array[(String, String)], gen_table: Array[(String, Array[(String, Array[String], Array[(String, Array[String])])])], traits: Array[(String, Array[(String, Array[TypeExpr], TypeExpr)])]) -> Bool {
   let mut changed = false
   let mut i = 0
-  while i < Array::length(stmts) {
+  while i < dtd_own_end(stmts) {
     match Array::get(stmts, i) {
       SLet(exp, isrec, qname, ann, body) => match body {
         EFn(tparams, bounds, params, ret, eff, fbody) => if Array::length(tparams) == 0 {
@@ -11942,6 +11942,7 @@ fn emit_recorded_arr_equals(stmts: Array[Stmt]) -> Unit {
     if top_level_fn_exists(stmts, arr_equals_name(et)) {
       ()
     } else {
+      dtd_fresh_reset_for_decl()
       Array::push(stmts, gen_arr_equals_fn(et, known_types))
     }
     i = i + 1
@@ -11965,6 +11966,18 @@ let dtd_eq_tuple_uid = [0]
 
 fn eq_tuple_uid_reset() -> Unit {
   Array::set(dtd_eq_tuple_uid, 0, 0)
+}
+
+/// #2388: fresh names are minted per declaration, not per program. The tuple
+/// / map comparator binders (`__teq_l<n>_<k>`, `__me_ks<n>`) and the throw
+/// payload lets (`__exn_payload<n>`) are local to the statement or helper
+/// they appear in, so their counters restart at every top-level statement
+/// the rewrite loop visits and at every generated helper: a module's output
+/// then does not depend on what was compiled before it, and a per-module run
+/// mints the same names as the whole-program run (the oracle's `renames`).
+fn dtd_fresh_reset_for_decl() -> Unit {
+  eq_tuple_uid_reset()
+  Array::set(dtd_exn_kind_state, 2, 0)
 }
 
 fn eq_tuple_uid_next() -> Int {
@@ -12030,6 +12043,7 @@ fn emit_recorded_map_equals(stmts: Array[Stmt]) -> Unit {
         if top_level_fn_exists(stmts, map_equals_name(k_ty, v_ty)) {
           ()
         } else {
+          dtd_fresh_reset_for_decl()
           Array::push(stmts, gen_map_equals_fn(k_ty, v_ty, known_types))
         }
       } else {
@@ -14106,6 +14120,7 @@ fn emit_recorded_generic_eq(stmts: Array[Stmt]) -> Unit {
             } else {
               ()
             }
+            dtd_fresh_reset_for_decl()
             Array::push(stmts, gen_specialized_eq_fn(head, args, decl.1, decl.2, known))
             Array::truncate(dtd_eq_specialization_stack, 0)
           } else {
@@ -14127,6 +14142,7 @@ fn emit_recorded_generic_eq(stmts: Array[Stmt]) -> Unit {
             } else {
               ()
             }
+            dtd_fresh_reset_for_decl()
             Array::push(stmts, gen_specialized_enum_eq_fn(head, args, edecl.1, edecl.2, known))
             Array::truncate(dtd_eq_specialization_stack, 0)
           } else {
@@ -15536,6 +15552,7 @@ export fn desugar_derives(stmts: Array[Stmt]) -> Unit {
         // stable Map-key string is its structural representation (#638), so
         // generate `to_string` for Show OR Hash.
         if (str_array_contains(derives, "Show") || str_array_contains(derives, "Hash")) && !top_level_fn_exists(stmts, qualified_name(name, "to_string")) {
+          dtd_fresh_reset_for_decl()
           Array::push(gen, gen_show_fn(name, fields, known_types))
           derived_renderer_record(name)
         } else {
@@ -15545,6 +15562,7 @@ export fn desugar_derives(stmts: Array[Stmt]) -> Unit {
         // the recursive `to_string`), so the method-bearing `Hash` witness at a
         // `get_by(m, T::{..})` call site resolves to a stable structural key.
         if str_array_contains(derives, "Hash") && !top_level_fn_exists(stmts, qualified_name(name, "hash_key")) {
+          dtd_fresh_reset_for_decl()
           Array::push(gen, gen_hash_key_fn(name))
         } else {
           ()
@@ -15560,11 +15578,13 @@ export fn desugar_derives(stmts: Array[Stmt]) -> Unit {
           ()
         }
         if str_array_contains(derives, "Ord") && !top_level_fn_exists(stmts, qualified_name(name, "compare")) {
+          dtd_fresh_reset_for_decl()
           Array::push(gen, gen_compare_fn(name, fields))
         } else {
           ()
         }
         if str_array_contains(derives, "Default") && !top_level_fn_exists(stmts, qualified_name(name, "default")) {
+          dtd_fresh_reset_for_decl()
           Array::push(gen, gen_default_fn(name, fields, known_types))
         } else {
           ()
@@ -15574,6 +15594,7 @@ export fn desugar_derives(stmts: Array[Stmt]) -> Unit {
         // sensible default for any struct, and a struct never relied on the old
         // pointer-identity `==` (which was silently always-false).
         if !top_level_fn_exists(stmts, qualified_name(name, "equals")) {
+          dtd_fresh_reset_for_decl()
           Array::push(gen, gen_eq_fn(name, fields, known_types))
         } else {
           ()
@@ -15583,12 +15604,14 @@ export fn desugar_derives(stmts: Array[Stmt]) -> Unit {
         // #2141: same re-spelling as the SStruct arm, for payload types.
         let variants = subst_variant_formals(variants0, decl_tparams)
         if (str_array_contains(derives, "Show") || str_array_contains(derives, "Hash")) && !top_level_fn_exists(stmts, qualified_name(ename, "to_string")) {
+          dtd_fresh_reset_for_decl()
           Array::push(gen, gen_enum_show_fn(ename, variants, known_types))
           derived_renderer_record(ename)
         } else {
           ()
         }
         if str_array_contains(derives, "Hash") && !top_level_fn_exists(stmts, qualified_name(ename, "hash_key")) {
+          dtd_fresh_reset_for_decl()
           Array::push(gen, gen_hash_key_fn(ename))
         } else {
           ()
@@ -15608,11 +15631,13 @@ export fn desugar_derives(stmts: Array[Stmt]) -> Unit {
           ()
         }
         if str_array_contains(derives, "Ord") && !top_level_fn_exists(stmts, qualified_name(ename, "compare")) {
+          dtd_fresh_reset_for_decl()
           Array::push(gen, gen_enum_compare_fn(ename, variants, known_types))
         } else {
           ()
         }
         if str_array_contains(derives, "Default") && !top_level_fn_exists(stmts, qualified_name(ename, "default")) {
+          dtd_fresh_reset_for_decl()
           Array::push(gen, gen_enum_default_fn(ename, variants, known_types))
         } else {
           ()
@@ -15620,6 +15645,7 @@ export fn desugar_derives(stmts: Array[Stmt]) -> Unit {
         // Generate `E::equals` for every enum (same rationale as structs), so
         // the `==` dispatch resolves enum operands too.
         if !top_level_fn_exists(stmts, qualified_name(ename, "equals")) {
+          dtd_fresh_reset_for_decl()
           Array::push(gen, gen_enum_eq_fn(ename, variants, known_types))
         } else {
           ()
@@ -15686,6 +15712,7 @@ export fn desugar_derives(stmts: Array[Stmt]) -> Unit {
   while ei < Array::length(elem_types) {
     let et = Array::get(elem_types, ei)
     if !top_level_fn_exists(stmts, arr_equals_name(et)) {
+      dtd_fresh_reset_for_decl()
       Array::push(gen, gen_arr_equals_fn(et, known_types))
     } else {
       ()
@@ -15704,6 +15731,7 @@ export fn desugar_derives(stmts: Array[Stmt]) -> Unit {
   while ei2 < Array::length(arr_elems) {
     let et2 = Array::get(arr_elems, ei2)
     if !top_level_fn_exists(stmts, arr_to_string_name(et2)) {
+      dtd_fresh_reset_for_decl()
       Array::push(gen, gen_arr_to_string_fn(et2, known_types))
     } else {
       ()
@@ -19640,7 +19668,7 @@ export fn desugar_labeled_args(stmts: Array[Stmt]) -> Unit {
   // dropping the early-out costs one scalar scan per statement in the case
   // where nothing needs relabelling.
   let mut i = 0
-  while i < Array::length(stmts) {
+  while i < dtd_own_end(stmts) {
     if stmt_has_labeled_arg(Array::get(stmts, i)) || (has_opt_tbl && stmt_calls_optional_fn(Array::get(stmts, i))) {
       Array::set(stmts, i, relabel_stmt(Array::get(stmts, i), tbl))
     } else {
@@ -19675,7 +19703,7 @@ fn desugar_labeled_args_paired(stmts: Array[Stmt], roots: Array[BinderAuthorityN
     children: []
   }
   let mut i = 0
-  while i < Array::length(stmts) {
+  while i < dtd_own_end(stmts) {
     let root = if i < Array::length(roots) {
       Array::get(roots, i)
     } else {
@@ -19857,7 +19885,8 @@ fn das_stmt(stmt: Stmt) -> Stmt {
 
 /// In-place lowering of array-literal spreads across the whole program (#790).
 export fn desugar_array_spread(stmts: Array[Stmt]) -> Unit {
-  let n = Array::length(stmts)
+  // #2388: a per-module run rewrites the module's own statements only.
+  let n = dtd_own_end(stmts)
   let mut i = 0
   while i < n {
     Array::set(stmts, i, das_stmt(Array::get(stmts, i)))
@@ -20174,8 +20203,9 @@ fn dtpw_inline_trivial_wrappers(stmts: Array[Stmt]) -> Unit {
   if Array::length(wrappers) == 0 {
     ()
   } else {
+    let own_end = dtd_own_end(stmts)
     let mut i = 0
-    while i < Array::length(stmts) {
+    while i < own_end {
       match Array::get(stmts, i) {
         SLet(exported, is_rec, name, ty, expr) => Array::set(stmts, i, SLet(exported, is_rec, name, ty, dtpw_inline_expr(expr, wrappers))),
         _ => ()
@@ -20580,6 +20610,7 @@ fn dtd_run(stmts: Array[Stmt], typed_eq_offsets: Array[Int], typed_eq_keys: Arra
     if !dtd_is_own_index(i) {
       ()
     } else {
+      dtd_fresh_reset_for_decl()
       match merged_source_boundary_local_names(stmt) {
         Some(local_names) => {
           user_assert_eq_set_merged_source(stmts, i + 1, local_names)

--- a/lib/@vibe/compiler/tests/desugar_trait_dicts_module_test.vibe
+++ b/lib/@vibe/compiler/tests/desugar_trait_dicts_module_test.vibe
@@ -21,11 +21,11 @@ import @vibe/compiler/syntax {
 // struct), while the program-level helpers land in the synthesized set.
 
 fn dep_src() -> String {
-  "export trait Hash {\n  hash_key(Self) -> String\n}\n\nimpl Hash for String {\n  hash_key(self) -> String {\n    self\n  }\n}\n\nexport fn map_key_to_string[K: Hash](key: K) -> String {\n  K::hash_key(key)\n}\n"
+  "export trait Hash {\n  hash_key(Self) -> String\n}\n\nimpl Hash for String {\n  hash_key(self) -> String {\n    self\n  }\n}\n\nexport fn map_key_to_string[K: Hash](key: K) -> String {\n  K::hash_key(key)\n}\n\nstruct Key {\n  k: (Int, String)\n}\n\nexport fn fail_dep(msg: String) -> Int with Exception {\n  throw(msg)\n}\n"
 }
 
 fn own_src() -> String {
-  "struct Set[T] {\n  entries: Map[String, T]\n}\n\nexport fn contains[T: Hash](s: Set[T], value: T) -> Bool {\n  Map::has_key(s.entries, map_key_to_string(value))\n}\n"
+  "struct Set[T] {\n  entries: Map[String, T]\n}\n\nexport fn contains[T: Hash](s: Set[T], value: T) -> Bool {\n  Map::has_key(s.entries, map_key_to_string(value))\n}\n\nstruct Pair {\n  p: (Int, String)\n}\n\nexport fn fail_own(msg: String) -> Int with Exception {\n  throw(msg)\n}\n"
 }
 
 fn render_named(stmts: Array[Stmt], name: String) -> String {
@@ -66,31 +66,31 @@ fn stmt_names(stmts: Array[Stmt]) -> String {
   out
 }
 
-fn whole_contains() -> String with Exception {
+fn whole_named(name: String) -> String with Exception {
   let stmts = parse_program(lex(String::concat(dep_src(), own_src())))
   desugar_trait_dicts(stmts)
-  render_named(stmts, "contains")
+  render_named(stmts, name)
 }
 
 test "the module entry threads the witness into a call of the context's bounded generic" {
   let ctx = parse_program(lex(dep_src()))
   let own = parse_program(lex(own_src()))
   let synth = desugar_trait_dicts_module(own, ctx, [], [])
-  inspect(render_named(own, "contains") == whole_contains(), content = "true")
+  inspect(render_named(own, "contains") == whole_named("contains"), content = "true")
   inspect(render_named(own, "contains"), content = "export let rec contains = [T: Hash](__dict_Hash_T: HashDict[T], s: Set[T], value: T) -> Bool { Map::has_key(s.entries, map_key_to_string(__dict_Hash_T, value)) }")
   // The context is read, never rewritten or extended: its trait gets no
   // operation and no dict struct from this module's run. What the pass
   // appends -- the module's own derived comparator and the program-level
   // helper it needs -- comes back as the synthesized set.
-  inspect(stmt_names(ctx), content = "trait Hash, impl Hash, String::hash_key, map_key_to_string")
-  inspect(stmt_names(own), content = "struct Set, contains")
-  inspect(stmt_names(synth), content = "Set::equals, __map_equals__N6_String__N7___Vfp_T")
+  inspect(stmt_names(ctx), content = "trait Hash, impl Hash, String::hash_key, map_key_to_string, struct Key, fail_dep")
+  inspect(stmt_names(own), content = "struct Set, contains, struct Pair, fail_own")
+  inspect(stmt_names(synth), content = "Set::equals, Pair::equals, __map_equals__N6_String__N7___Vfp_T, __exn_kind_cell")
 }
 
 test "the whole-program entry is the module entry with no context and everything own" {
   let stmts = parse_program(lex(String::concat(dep_src(), own_src())))
   desugar_trait_dicts(stmts)
-  inspect(stmt_names(stmts), content = "trait Hash, impl Hash, String::hash_key, map_key_to_string, Hash::hash_key, struct Set, contains, Set::equals, __map_equals__N6_String__N7___Vfp_T, struct HashDict")
+  inspect(stmt_names(stmts), content = "trait Hash, impl Hash, String::hash_key, map_key_to_string, Hash::hash_key, struct Key, fail_dep, struct Set, contains, struct Pair, fail_own, Key::equals, Set::equals, Pair::equals, __map_equals__N6_String__N7___Vfp_T, __exn_kind_cell, struct HashDict")
 }
 
 test "the dependency's own run places its trait operation inside the module and its dict struct in the synthesized set" {
@@ -98,9 +98,21 @@ test "the dependency's own run places its trait operation inside the module and 
   let ctx = parse_program(lex(own_src()))
   let synth = desugar_trait_dicts_module(own, ctx, [], [])
   // The namespace operation is inserted after the trait's impls and the
-  // lets that follow them, growing the module's own region; the context's
-  // struct is not derived for here.
-  inspect(stmt_names(own), content = "trait Hash, impl Hash, String::hash_key, map_key_to_string, Hash::hash_key")
-  inspect(stmt_names(synth), content = "struct HashDict")
-  inspect(stmt_names(ctx), content = "struct Set, contains")
+  // lets that immediately follow them, growing the module's own region; the
+  // context's structs are not derived for here.
+  inspect(stmt_names(own), content = "trait Hash, impl Hash, String::hash_key, map_key_to_string, Hash::hash_key, struct Key, fail_dep")
+  inspect(stmt_names(synth), content = "Key::equals, __exn_kind_cell, struct HashDict")
+  inspect(stmt_names(ctx), content = "struct Set, contains, struct Pair, fail_own")
+}
+
+test "generated local names restart at every declaration, so a module compiled after the dependency gets the names it gets alone" {
+  let ctx = parse_program(lex(dep_src()))
+  let own = parse_program(lex(own_src()))
+  let synth = desugar_trait_dicts_module(own, ctx, [], [])
+  // Whole-program, the dependency's `Key::equals` and `fail_dep` would have
+  // consumed the tuple-binder and payload counters first.
+  inspect(render_named(synth, "Pair::equals"), content = "let Pair::equals = (a: Pair, b: Pair) -> Bool { (match a.p { (__teq_l0_0, __teq_l0_1) => match b.p { (__teq_r0_0, __teq_r0_1) => (((__teq_l0_0 + 0) == (__teq_r0_0 + 0)) && ((__teq_l0_1 == __teq_r0_1) && true)) } } && true) }")
+  inspect(render_named(own, "fail_own"), content = "export let rec fail_own = (msg: String) -> Int with Exception { { let __exn_payload0 = msg; { Array::set(__exn_kind_cell, 0, \"String\"); { Array::set(__exn_kind_cell, 1, \"\"); throw(__exn_payload0) } } } }")
+  inspect(render_named(synth, "Pair::equals") == whole_named("Pair::equals"), content = "true")
+  inspect(render_named(own, "fail_own") == whole_named("fail_own"), content = "true")
 }


### PR DESCRIPTION
## What

Slice 2 of the per-module `desugar_trait_dicts` on #2388: the per-module run now mints the same generated names as the whole-program run, and the dependency interface it reads is every top-level definition of the dependency. Measured by the oracle's keyed comparison on the compiler closure, the `renames` row goes from 270 (#2559) to 1.

### Fresh names per declaration (`normalize/desugar_trait_dict.vibe`)

Three counters ran program-wide: `eq_tuple_uid` (the `__teq_l<n>_<k>` binders of a tuple comparison and the `__me_*<n>` locals of a map-equals helper) and the throw payload lets (`__exn_payload<n>`). The names a statement got therefore depended on everything compiled before it, which is exactly what a per-module run cannot see. All three are local to the statement or helper they appear in, so `dtd_fresh_reset_for_decl` restarts them at every top-level statement the rewrite loop visits and before every generated helper. A module's output no longer depends on its position in the program, and the per-module run mints the same names as the whole-program run.

This changes the whole-program pass's output: generated **local** names only, no other node. See the equivalence row below for what that means in the emitted wasm.

### The dependency interface is every top-level definition

#2559 carried type / trait / suberror declarations, bounded generic definitions and `T::op` definitions. The counter renames hid a real difference behind them: `throw(unexpected_token(...))` records the payload's exception kind from the callee's return type (`collect_fn_returns`), and with the callee defined in another file the kind was `""` instead of `"String"`. The interface is now every top-level definition of the dependency (`oracle_is_interface_stmt`), the bodyless view a `.vpkg` contract carries. The early stages that rewrite statements in place (`desugar_array_spread`, the wrapper inliner, `desugar_labeled_args`, the method-generics injection) are gated to the module's own region like the later ones: a context statement is read, never rewritten (an unguarded one trapped out of bounds in `das_expr` the moment the interface grew).

### The oracle compares whole renderings with the counters stripped

The rename classifier used to stop at the first differing byte, which is how the exception-kind difference stayed hidden behind a renamed binder. `oracle_rename_only` now compares the two renderings with every generated counter stripped (`oracle_strip_counters`), so a difference after a renamed binder is a content difference.

Measured on the compiler closure (`codegen_lexer_test.vibe`, 189 files), through a temporary driver of `prelude_pass_module_oracle_step`:

```
keyed missing=0 extra=0 copies=319 content=0 renames=1
```

The one rename left is the trait namespace operations' synthetic offsets (`synthetic_off`), which come from the trait's statement index (module-local in a per-module run) and which the printer does not show; that is the next slice.

### Test

`desugar_trait_dicts_module_test.vibe` gives both files a struct with a tuple field and a throwing function. The module's derived comparator binds `__teq_l0_*` and its throw binds `__exn_payload0` whether the module is compiled alone or after the dependency, and both renderings equal the whole-program ones. Red with the reset removed: the module-alone and whole-program renderings differ (`__teq_l1_*`, `__exn_payload1`). `prelude_module_oracle_test.vibe` keeps answering.

## Validation

Chain on `172a579` (base `31520de`; run in a staging worktree on the identical tree, tree hash `61cf752` checked against the pushed head): bundle regen; stage2 == stage3; output equivalence against a stage2 built from main's tree, byte-identical on three closures (`codegen_lexer_test`, `perceus_rc_test`, `checker_test`) and 22 rc fixtures, so the renamed binders are wasm locals and no emitted byte moves; `test_cli_core.sh`; selfcompile KPI heap_ptr 841,650,584 bytes against 841,614,040 on main's tree (+36 KB, +0.004%); typing-env-reuse oracle; 246/246 affected unit-test files (import-graph selection over the changed files); `compiler_gate.sh` early / mid / late.

`vibe_fmt.sh --check` is a fixpoint on every changed file.

Refs #2388, #2386.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QKZdvBvHVUagwg6Yih8er8

---
_Generated by [Claude Code](https://claude.ai/code/session_01QKZdvBvHVUagwg6Yih8er8)_