### PR TITLE
#2002 gets a subtree: gate, delete, two moves, split

### DIFF
--- a/docs/issue-triage.md
+++ b/docs/issue-triage.md
@@ -108,7 +108,7 @@ first, then take the leftover.
 | #2493 | a compile-only artifact at or under 1.0 MB → #2500 (blocker), #2501 – #2506 |
 | #2494 | compiler memory, 128 MB per unit of work → #2509 (blocker), #2507, #2508, #2510 |
 | #2340 | SIMD-first data structures → #2347 (#2348 closed: both inline-wasm halves landed in #2399 / #2420) |
-| #2002 | documentation by audience — **no sub-issues**, so nothing here is startable; Phases 0-1 already landed as `docs/README.md` without being tracked |
+| #2002 | documentation by audience → #2562 (blocker), #2564, #2565, #2566, #2567. Phases 0-1 already landed as `docs/README.md`; the gate is missing and the router has drifted three ways |
 | #2001 | retire the scripts layer |
 
 ### Everything else


### PR DESCRIPTION
#2002 was labelled `epic` with **zero sub-issues**, so by `docs/issue-triage.md`'s own rule — *"an epic is an index, so it is never itself the thing to work on"* — nothing in it was startable. Five children filed, and #2002's body rewritten as an index that says where things stand.

Diff is one line of `docs/issue-triage.md` (the epics table row). The rest is on the tracker.

## The children, in the order they have to run

| # | what | why here |
|---|---|---|
| **#2562** | Fail closed on an unclassified document | **blocker** — every later phase moves files, and without this a move can silently drop one |
| #2564 | Delete the three delete candidates the router already names | cheapest phase; removes rather than moves, so it shrinks what the moves carry |
| #2565 | Move user documentation into `docs/user/` (15 files) | the half a reader benefits from |
| #2566 | Move maintainer docs into `docs/internal/`, machine-produced into `docs/generated/` (~60 files, five group-sized commits) | larger, lower risk |
| #2567 | Split the mixed-audience documents | last — the only phase that edits content rather than paths |

## Why the gate is the blocker, with evidence

Phase 0 and the router half of Phase 1 **had already landed** — as `docs/README.md`, without ever being tracked on the epic. Its sections are the four audience classes verbatim and every live document has a row. What was never built is the enforcement half, and measured on `ef512e7` the router has drifted three ways in under three weeks:

| path | state |
|---|---|
| `docs/checked-body-transport.md` | in **no class table at all** — cited by #2505 as the doc whose shadow-only wording must be rewritten |
| `docs/source-range-contract.md` | in **no class table at all** — the byte-position contract `AGENTS.md` points at, enforced by `scripts/check_source_range_contract.sh`, which names it in its own failure message |
| `docs/internal/` | not in the router at all — it exists and holds two files |

The last one is a document contradicting itself: ten lines from the top `docs/README.md` says *"Proposed later homes (`docs/user/…`, `docs/internal/…`, `docs/generated/`) are labels from #2002, not directories in this commit"*, and `docs/internal/` has existed since #2473. Part of the target structure got built ad hoc while the plan document says it does not exist.

Nothing noticed because the only thing between the classification and reality is the router's hand-copied "Inventory coverage" list — **a proxy for "every document is classified", not the property**. That is the exact shape `AGENTS.md` warns about, and the three drifts are a free red test: the gate must be red on today's tree before anything is fixed.

Two of the three are documents the compiler's own gates and issues depend on, so "unclassified" here is not cosmetic.

## What the sub-issues carry beyond the original plan

The body's eight planned sub-issues were written before any of this landed. These five are derived from the tree as it is now, and each names what actually breaks:

- The concrete gate surfaces every move must keep green — `check-doc-path-citations` (32 allowlisted, 0 new), `check-doc-commands` (**593** references resolving today, which is the tripwire), `check-book-links`, `vibe-md-tutorial`, `check-tutorial-translation-parity`.
- **`book/` probably should not move at all** (#2565): the router assigns it `user/book/`, but it is a top-level directory with four gates of its own, and "leave it and link to it" is likely the right answer — the point is that it gets decided rather than assumed.
- `builtin_contract_table.generated.md`'s deletion has a **precondition** the router states ("once a live builtin table exists"), so #2564 asks whether `check-cheatsheet-signatures` already is that table rather than deleting on a guess.
- #2567 leads with the sharpest real instance: `host-runtime-contract.md` and `wasm/host-runtime-contract.md` are two files with nearly the same name in **opposite** audience classes.
- Every sub-issue carries the same warning: **code examples in `docs/` are doctested, prose is not.** That asymmetry is why the deleted `docs/language-tour/` kept calling `String` a UTF-16 string after ADR-0098, and it is most dangerous during a phase that copies prose into new files.

## Verification

- `scripts/check_doc_path_citations.sh` — ok (32 allowlisted, 0 new)
- `scripts/check_doc_commands.sh` — ok (593 references resolve)
- `pkf run pre-commit` — passed, review-regressions lint ok on its AST tier
- The three drifts were measured by diffing `git ls-files docs/` against the router's coverage list and against its class tables, not read off the document

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0194y71aVEMcwoem5oAxFJPX

---
_Generated by [Claude Code](https://claude.ai/code/session_0194y71aVEMcwoem5oAxFJPX)_