### PR TITLE
normalize: the labeled-argument stage visits every module-owned statement, and a per-module run inlines its own wrappers only (#2563 review)

### DIFF
--- a/lib/@vibe/compiler/codegen/wasi/linked_compile.vibe
+++ b/lib/@vibe/compiler/codegen/wasi/linked_compile.vibe
@@ -3766,6 +3766,20 @@ fn oracle_is_interface_stmt(s: Stmt) -> Bool {
   }
 }
 
+/// The interface form of a context statement: a function whose return type
+/// is spelled loses its body (`EUnit`), the shape a `.vpkg` contract carries,
+/// so no body-reading collector (the trivial-wrapper inliner above all) can
+/// see through the interface. A function with no return annotation keeps its
+/// body: the contract would carry the checker's elaborated return type, which
+/// the pass reads off the body's tail expression (`fn_return_head_of`,
+/// `collect_fn_eq_return_shape`), and the oracle has no other spelling of it.
+fn oracle_interface_form(s: Stmt) -> Stmt {
+  match s {
+    SLet(exported, is_rec, name, ty, EFn(tps, bounds, params, Some(ret), eff, _)) => SLet(exported, is_rec, name, ty, EFn(tps, bounds, params, Some(ret), eff, EUnit)),
+    _ => s
+  }
+}
+
 /// Whether two renderings differ only at generated fresh-name counters
 /// (`__teq_l12_0` vs `__teq_l2_0`, `__me_ks22`, `_exn_payload100` vs
 /// `_exn_payload10`). Anything else is a real content difference.
@@ -3972,7 +3986,7 @@ export fn prelude_pass_module_oracle_step(k: Int, a: Array[Stmt], c: Array[Stmt]
     let mut ps = 0
     while ps < Array::length(src) {
       if oracle_is_interface_stmt(Array::get(src, ps)) {
-        Array::push(dst, Array::get(src, ps))
+        Array::push(dst, oracle_interface_form(Array::get(src, ps)))
       } else {
         ()
       }

--- a/lib/@vibe/compiler/normalize/desugar_trait_dict.vibe
+++ b/lib/@vibe/compiler/normalize/desugar_trait_dict.vibe
@@ -19667,9 +19667,15 @@ export fn desugar_labeled_args(stmts: Array[Stmt]) -> Unit {
   // those tests. stmt_has_labeled_arg already gates each statement, so
   // dropping the early-out costs one scalar scan per statement in the case
   // where nothing needs relabelling.
+  // #2388: every module-owned statement, the functions
+  // `desugar_hoist_local_lambdas` appended after the context block included
+  // (a hoisted lambda's labeled call is reordered here or nowhere), never a
+  // context statement.
   let mut i = 0
-  while i < dtd_own_end(stmts) {
-    if stmt_has_labeled_arg(Array::get(stmts, i)) || (has_opt_tbl && stmt_calls_optional_fn(Array::get(stmts, i))) {
+  while i < Array::length(stmts) {
+    if !dtd_is_own_index(i) {
+      ()
+    } else if stmt_has_labeled_arg(Array::get(stmts, i)) || (has_opt_tbl && stmt_calls_optional_fn(Array::get(stmts, i))) {
       Array::set(stmts, i, relabel_stmt(Array::get(stmts, i), tbl))
     } else {
       ()
@@ -19703,13 +19709,17 @@ fn desugar_labeled_args_paired(stmts: Array[Stmt], roots: Array[BinderAuthorityN
     children: []
   }
   let mut i = 0
-  while i < dtd_own_end(stmts) {
-    let root = if i < Array::length(roots) {
-      Array::get(roots, i)
+  while i < Array::length(stmts) {
+    if dtd_is_own_index(i) {
+      let root = if i < Array::length(roots) {
+        Array::get(roots, i)
+      } else {
+        sentinel
+      }
+      Array::set(stmts, i, relabel_stmt_paired(Array::get(stmts, i), tbl, root, poisoned))
     } else {
-      sentinel
+      ()
     }
-    Array::set(stmts, i, relabel_stmt_paired(Array::get(stmts, i), tbl, root, poisoned))
     i = i + 1
   }
   optional_param_tbl_set(array_empty())
@@ -20059,10 +20069,16 @@ fn dtpw_expr_binds_name(expr: Expr, name: String) -> Bool {
 /// acceptable trade for guaranteed correctness, matching this file's
 /// established "bail out entirely when it can't be proven safe" pattern
 /// (see dlh_marker_only_called_directly's own doc comment).
+/// The trivial pass-through wrappers this run may inline. #2388: a
+/// per-module run reads the module's own definitions only -- a dependency
+/// interface carries signatures, not bodies, so a wrapper defined in another
+/// module is not inlinable there and must not be inlined here either; the
+/// shadowing scan below is bounded the same way for the same reason.
 fn dtpw_collect_wrappers(stmts: Array[Stmt]) -> Array[String] {
   let out = array_empty()
+  let own_end = dtd_own_end(stmts)
   let mut i = 0
-  while i < Array::length(stmts) {
+  while i < own_end {
     match Array::get(stmts, i) {
       SLet(_, _, name, _, EFn(_, _, params, _, _, body)) => if Array::length(params) == 1 {
         let (pname, _) = Array::get(params, 0)
@@ -20091,7 +20107,7 @@ fn dtpw_collect_wrappers(stmts: Array[Stmt]) -> Array[String] {
     let wn = Array::get(out, j)
     let mut shadowed = false
     let mut k = 0
-    while k < Array::length(stmts) && !shadowed {
+    while k < own_end && !shadowed {
       match Array::get(stmts, k) {
         SLet(_, _, _, _, sv) => if dtpw_expr_binds_name(sv, wn) {
           shadowed = true

--- a/lib/@vibe/compiler/tests/desugar_trait_dicts_module_test.vibe
+++ b/lib/@vibe/compiler/tests/desugar_trait_dicts_module_test.vibe
@@ -28,6 +28,18 @@ fn own_src() -> String {
   "struct Set[T] {\n  entries: Map[String, T]\n}\n\nexport fn contains[T: Hash](s: Set[T], value: T) -> Bool {\n  Map::has_key(s.entries, map_key_to_string(value))\n}\n\nstruct Pair {\n  p: (Int, String)\n}\n\nexport fn fail_own(msg: String) -> Int with Exception {\n  throw(msg)\n}\n"
 }
 
+// #2563 review: a dependency with a labeled-parameter function and a trivial
+// pass-through wrapper, and a module that calls both -- the wrapper directly,
+// the labeled function from a non-capturing effectful local lambda, which
+// `desugar_hoist_local_lambdas` promotes to a top-level function.
+fn dep2_src() -> String {
+  "export fn sub(x: Int, y: Int) -> Int {\n  x - y\n}\n\nexport fn apply(f: () -> Int) -> Int {\n  f()\n}\n"
+}
+
+fn own2_src() -> String {
+  "fn forty_two() -> Int {\n  42\n}\n\nexport fn via_apply() -> Int {\n  apply(forty_two)\n}\n\nexport fn use_local() -> Int with Log {\n  let f = (a: Int) -> Int with Log {\n    perform Log::Emit(\"x\")\n    let g = (b: Int, c?: Int) -> Int {\n      b\n    }\n    g(a)\n  }\n  f(2)\n}\n"
+}
+
 fn render_named(stmts: Array[Stmt], name: String) -> String {
   let mut out = ""
   let mut i = 0
@@ -115,4 +127,36 @@ test "generated local names restart at every declaration, so a module compiled a
   inspect(render_named(own, "fail_own"), content = "export let rec fail_own = (msg: String) -> Int with Exception { { let __exn_payload0 = msg; { Array::set(__exn_kind_cell, 0, \"String\"); { Array::set(__exn_kind_cell, 1, \"\"); throw(__exn_payload0) } } } }")
   inspect(render_named(synth, "Pair::equals") == whole_named("Pair::equals"), content = "true")
   inspect(render_named(own, "fail_own") == whole_named("fail_own"), content = "true")
+}
+
+fn whole2_named(name: String) -> String with Exception {
+  let stmts = parse_program(lex(String::concat(dep2_src(), own2_src())))
+  desugar_trait_dicts(stmts)
+  render_named(stmts, name)
+}
+
+test "a hoisted local lambda's labeled call is reordered in a per-module run" {
+  let ctx = parse_program(lex(dep2_src()))
+  let own = parse_program(lex(own2_src()))
+  let synth = desugar_trait_dicts_module(own, ctx, [], [])
+  // The hoisted function is appended after the context block, so it comes
+  // back with the synthesized set; the labeled-argument stage must still
+  // visit it -- the call to the dependency's `sub` binds by position after
+  // this pass, and a call left labeled here would bind `y = a` to `x`.
+  inspect(stmt_names(synth), content = "__hoisted_lam_0_f")
+  inspect(render_named(synth, "__hoisted_lam_0_f"), content = "let __hoisted_lam_0_f = (a: Int) -> Int with Log { { perform Log::Emit(\"x\"); { let g = (b: Int, c?: Option[Int]) -> Int { b }; g(a, None) } } }")
+  inspect(whole2_named("__hoisted_lam_0_f"), content = "let __hoisted_lam_0_f = (a: Int) -> Int with Log { { perform Log::Emit(\"x\"); { let g = (b: Int, c?: Option[Int]) -> Int { b }; g(a, None) } } }")
+  inspect(render_named(synth, "__hoisted_lam_0_f") == whole2_named("__hoisted_lam_0_f"), content = "true")
+  inspect(render_named(own, "use_local") == whole2_named("use_local"), content = "true")
+}
+
+test "a trivial wrapper defined in the dependency is not inlined by a per-module run" {
+  let ctx = parse_program(lex(dep2_src()))
+  let own = parse_program(lex(own2_src()))
+  let _ = desugar_trait_dicts_module(own, ctx, [], [])
+  // The whole-program run reads `apply`'s body and inlines the call; a
+  // dependency interface carries no body, so a per-module run cannot, and
+  // must not pretend to by reading the body it happens to be handed.
+  inspect(render_named(own, "via_apply"), content = "export let rec via_apply = () -> Int { apply(forty_two) }")
+  inspect(whole2_named("via_apply"), content = "export let rec via_apply = () -> Int { forty_two() }")
 }


### PR DESCRIPTION
## What

The two findings of the Codex review on #2563 (merged before this fix was pushed), both in the per-module entry of `desugar_trait_dicts`.

### P1: the labeled-argument stage visits every module-owned statement

`desugar_hoist_local_lambdas` appends the functions it promotes after the context block, and `desugar_labeled_args` stopped at `dtd_own_end`, the end of the original own region: a hoisted lambda's labeled or optional-argument call was left for codegen to bind positionally in a per-module run, where the whole-program run had rewritten it. The stage (and its binder-authority twin) now visits every index `dtd_is_own_index` admits, the own region and everything appended after the context, never a context statement.

### P2: a per-module run inlines its own wrappers only, and the oracle's interface has no bodies

`dtpw_collect_wrappers` read every statement, a context function's body included, so a per-module run inlined a call to a trivial wrapper defined in another module, a rewrite the real per-module compile cannot make because a `.vpkg` interface carries no body. The collector and its shadowing scan read the own region only. The oracle's interface form drops the body of every context function whose return type is spelled (`oracle_interface_form`); a function without a return annotation keeps its body, which stands in for the elaborated return type the contract would carry (`fn_return_head_of` and `collect_fn_eq_return_shape` read the tail expression for it).

### Test

`desugar_trait_dicts_module_test.vibe` gets a dependency that declares a trivial wrapper and a module whose effectful local lambda calls an optional-parameter lambda. The hoisted function comes back with `g(a, None)` in the module run as in the whole-program run (Red without the loop change: `g(a)`), and the module's `apply(forty_two)` stays a call where the whole-program run inlines `forty_two()` (Red without the collector bound: the module run inlined it too).

### Measured

On the compiler closure (`codegen_lexer_test.vibe`, 189 files) the oracle's keyed line is unchanged by the fix:

```
keyed missing=0 extra=0 copies=319 content=0 renames=1
```

No collector needed a context body, and the closure has no cross-module call of a trivial wrapper. The whole-program entry is untouched (every index is own there).

## Validation

Chain on `4151462` (this commit before its rebase; base `172a579`, tree `f4a2480`; the pushed head `df2fbc3` on `e2de697` differs from that tree only by `docs/issue-triage.md` from main): bundle regen; stage2 == stage3; output equivalence against a stage2 built from #2563's tree, byte-identical on three closures (`codegen_lexer_test`, `perceus_rc_test`, `checker_test`) and 22 rc fixtures; `test_cli_core.sh`; selfcompile KPI heap_ptr 841,728,464 bytes against 841,650,584 on #2563's tree (+78 KB, +0.01%); typing-env-reuse oracle; 246/246 affected unit-test files (import-graph selection over the changed files); `compiler_gate.sh` early / mid / late.

`vibe_fmt.sh --check` is a fixpoint on every changed file.

Refs #2388, #2386.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QKZdvBvHVUagwg6Yih8er8

---
_Generated by [Claude Code](https://claude.ai/code/session_01QKZdvBvHVUagwg6Yih8er8)_