### PR TITLE
normalize: a trait namespace operation's synthesized nodes carry a synthetic offset, not one derived from the trait's statement index (#2388 slice 2b)

### DIFF
--- a/lib/@vibe/compiler/normalize/desugar_trait_dict.vibe
+++ b/lib/@vibe/compiler/normalize/desugar_trait_dict.vibe
@@ -1024,8 +1024,22 @@ fn trait_operation_desugared_forwarding_bound(bounds: Array[(String, Array[Strin
   found
 }
 
+/// The offset every node of a synthesized `Trait::op` wrapper carries.
+/// Negative, so every offset-keyed table filters it out like the parser's
+/// own synthesized nodes, and distinct from the parser's -1 (interpolation,
+/// indexing, `assert`, and a call in a `fn` declaration's body), so a
+/// binding read from source can never pass for a generated one (#2357's
+/// masquerade checks). Before #2388 slice 2b the wrapper's nodes carried
+/// `2000000000 - i * 1000 - mi * 10`, which made a module's wrapper depend
+/// on the trait's statement index.
+fn trait_operation_synthetic_off() -> Int {
+  0 - 2
+}
+
+/// Whether a `Trait::op` binding's call node was synthesized by
+/// `derive_trait_namespace_operations` (see trait_operation_synthetic_off).
 fn trait_operation_has_generated_offset(offset: Int) -> Bool {
-  offset >= 1900000000
+  offset == trait_operation_synthetic_off()
 }
 
 fn trait_operation_type_option_equal(left: Option[TypeExpr], right: Option[TypeExpr]) -> Bool {
@@ -1436,7 +1450,15 @@ export fn derive_trait_namespace_operations(stmts: Array[Stmt]) -> Unit {
               hi = hi + 1
             }
             if dispatch != "" {
-              let synthetic_off = 2000000000 - i * 1000 - mi * 10
+              // The wrapper's nodes are synthesized, not read from a source
+              // position: they carry trait_operation_synthetic_off, which
+              // every offset-keyed table filters out (negative). #2388: a
+              // value derived from the trait's statement index made a
+              // module's wrapper depend on its position in the program (and
+              // on the lane: the checker derives per module, codegen on the
+              // merged program), and the checker lane's Double call row at
+              // that offset could alias a different merged wrapper's call.
+              let synthetic_off = trait_operation_synthetic_off()
               let extra_params = if uses_self {
                 [self_param]
               } else {
@@ -1455,7 +1477,7 @@ export fn derive_trait_namespace_operations(stmts: Array[Stmt]) -> Unit {
                 let param_ty = trait_operation_substitute_self(Array::get(raw_params, pi), dispatch)
                 let param_name = trait_operation_param_name(param_ty, pi, dispatch)
                 Array::push(value_params, (param_name, Some(param_ty)))
-                Array::push(call_args, EIdent(param_name, synthetic_off + pi + 1))
+                Array::push(call_args, EIdent(param_name, synthetic_off))
                 pi = pi + 1
               }
               let ret = trait_operation_substitute_self(raw_ret, dispatch)

--- a/lib/@vibe/compiler/tests/desugar_trait_dicts_module_test.vibe
+++ b/lib/@vibe/compiler/tests/desugar_trait_dicts_module_test.vibe
@@ -1,5 +1,5 @@
 import @vibe/compiler/core {
-  Stmt
+  Expr, Stmt
 }
 
 import @vibe/compiler/normalize {
@@ -159,4 +159,44 @@ test "a trivial wrapper defined in the dependency is not inlined by a per-module
   // must not pretend to by reading the body it happens to be handed.
   inspect(render_named(own, "via_apply"), content = "export let rec via_apply = () -> Int { apply(forty_two) }")
   inspect(whole2_named("via_apply"), content = "export let rec via_apply = () -> Int { forty_two() }")
+}
+
+/// The offset the printer does not show: the call node of a synthesized
+/// `Trait::op` wrapper's body.
+fn wrapper_call_off(stmts: Array[Stmt], name: String) -> Int {
+  let mut out = 0 - 99
+  let mut i = 0
+  while i < Array::length(stmts) {
+    match Array::get(stmts, i) {
+      SLet(_, _, n, _, EFn(_, _, _, _, _, body)) => if n == name {
+        out = match body {
+          ECall(_, _, off) => off,
+          _ => 0 - 98
+        }
+      } else {
+        ()
+      },
+      _ => ()
+    }
+    i = i + 1
+  }
+  out
+}
+
+test "a trait namespace operation carries the same synthetic offset whether its trait is compiled alone or after other files" {
+  // The module declaring `trait Hash` is compiled alone (its trait is
+  // statement 0) and as the tail of a program where three statements
+  // precede it. The wrapper's nodes are synthesized, not read from a
+  // source position, so both runs give them the wrapper's synthetic offset
+  // (-2: negative like the parser's own synthesized nodes, so it is in no
+  // offset-keyed table, and distinct from their -1, so a source binding can
+  // never pass for a generated one) rather than a value derived from the
+  // trait's statement index.
+  let own = parse_program(lex(dep_src()))
+  let ctx = parse_program(lex(own2_src()))
+  let _ = desugar_trait_dicts_module(own, ctx, [], [])
+  let whole = parse_program(lex(String::concat(own2_src(), dep_src())))
+  desugar_trait_dicts(whole)
+  inspect(wrapper_call_off(own, "Hash::hash_key"), content = "-2")
+  inspect(wrapper_call_off(whole, "Hash::hash_key"), content = "-2")
 }


### PR DESCRIPTION
## What

Slice 2b of the per-module `desugar_trait_dicts` on #2388: the last `renames` row of the oracle's keyed comparison. `derive_trait_namespace_operations` gave a `Trait::op` wrapper's call and argument nodes offsets computed from the trait's statement index (`2000000000 - i * 1000 - mi * 10 + k`). That index is the merged program's on the codegen lane and the module's own on the checker lane (which derives the same wrappers per module before `check_stmts`), so one wrapper carried two unrelated offsets, a module's wrapper depended on its position in the program, and the checker lane's Double call-result row at such an offset, rebased into the merge space, could land on a different merged wrapper's call node and change its f64/i64 lowering (`unique_typed_lowering_offsets_in_stmts` admits a row that names exactly one node).

### The wrapper's nodes carry a synthetic offset

The nodes now carry `trait_operation_synthetic_off`, -2: negative, so every offset-keyed table filters it out the way it filters the parser's own synthesized nodes (`off_marker` prints no marker; the typed-occurrence funnels, the Double / Int / Bool render channels and the typed-`==` rows all gate on `off >= 0`), and distinct from the parser's -1, which a call in a `fn` declaration's body carries, so a hand-written forwarding wrapper can never pass for a generated one. That last point is what `trait_operation_has_generated_offset` answers for #2357's conflict check; it asked for the old range and now asks for the sentinel, and the masquerade tests in `constructor_indexed_trait_dict_test.vibe` keep answering both ways (a `< 0` recognizer was tried first and let the source wrapper through, which is how the -1 came to light). A wrapper's nodes are therefore in no offset-keyed table on either lane: no synthesized node can claim a row.

### Test

`desugar_trait_dicts_module_test.vibe` compiles the module declaring `trait Hash` alone and as the tail of a three-statement program; the wrapper's call node reads -2 both ways. Red before: 2000000000 alone, 1999997000 after the other file.

### Measured

On the compiler closure (`codegen_lexer_test.vibe`, 189 files) the oracle's keyed line goes from #2563's `renames=1` to:

```
keyed missing=0 extra=0 copies=319 content=0 renames=0
```

The per-module run of the pass now produces every declaration of the whole-program run, keyed by name, with identical content; `copies=319` is the intended per-module helper duplication that the link-time dedup folds.

## Validation

Chain on `f67f6a5` (this commit before its rebase; base `4151462`, tree `e83d10a`; the pushed head `27ab910` on `ef52bd9` differs from that tree only by `docs/issue-triage.md` from main): bundle regen; stage2 == stage3; output equivalence against a stage2 built from #2571's tree, byte-identical on three closures (`codegen_lexer_test`, `perceus_rc_test`, `checker_test`), 22 rc fixtures, and a probe with Double-returning trait methods called through their namespace operations (the one offset-keyed channel a wrapper node could reach; same bytes, same run output on both compilers); `test_cli_core.sh`; selfcompile KPI heap_ptr 841,745,888 bytes against 841,728,464 on #2571's tree (+17 KB, +0.002%); typing-env-reuse oracle; 246/246 affected unit-test files (import-graph selection over the changed files); `compiler_gate.sh` early / mid / late.

`vibe_fmt.sh --check` is a fixpoint on every changed file.

Refs #2388, #2386.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QKZdvBvHVUagwg6Yih8er8

---
_Generated by [Claude Code](https://claude.ai/code/session_01QKZdvBvHVUagwg6Yih8er8)_