### PR TITLE
Fail closed on an unclassified document (#2562)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -730,6 +730,10 @@ jobs:
         run: bash scripts/check_doc_path_citations_test.sh
       - name: doc path-citation lint
         run: bash scripts/check_doc_path_citations.sh
+      - name: doc classification lint self-test
+        run: bash scripts/check_doc_classification_test.sh
+      - name: doc classification lint
+        run: bash scripts/check_doc_classification.sh
       # The #1189 / ADR-0081 naming ratchet, reaching CI for the first time. It
       # is a release-check dep, but release-check has no CI job either, so its
       # one enforcement point was a local sign-off nobody re-runs on a green

--- a/Taskfile.pkl
+++ b/Taskfile.pkl
@@ -293,6 +293,29 @@ local testDocPathCitations = new Task {
   }
 }
 
+local testDocClassification = new Task {
+  name = "test-doc-classification"
+  description = "self-test for the doc audience-classification check (synthetic tree)"
+  cmd = "bash scripts/check_doc_classification_test.sh"
+  inputs {
+    "scripts/check_doc_classification.sh"
+    "scripts/check_doc_classification_test.sh"
+  }
+}
+
+local checkDocClassification = new Task {
+  name = "check-doc-classification"
+  description = "every document under docs/ is in exactly one audience class (#2562)"
+  cmd = "bash scripts/check_doc_classification.sh"
+  // docs/README.md carries the classification and docs/** is the corpus, so
+  // both are inputs: adding a document without a row has to re-ask the
+  // question rather than replay a cached "ok".
+  inputs {
+    "docs/**"
+    "scripts/check_doc_classification.sh"
+  }
+}
+
 local checkDocPathCitations = new Task {
   name = "check-doc-path-citations"
   description = "every backticked file path in docs/ resolves, or is recorded as debt"
@@ -1748,6 +1771,8 @@ local releaseCheck = new Task {
     testCheckTreesitterWasmCorpus
     checkDocPathCitations
     testDocPathCitations
+    checkDocClassification
+    testDocClassification
     testLintArchitecture
     testLintReviewRegressions
     testSessionStartGrep
@@ -1830,6 +1855,8 @@ tasks {
   lintArchitectureDebt
   checkDocPathCitations
   testDocPathCitations
+  checkDocClassification
+  testDocClassification
   testLintArchitecture
   lintReviewRegressions
   testLintReviewRegressions

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,14 +1,24 @@
 # docs/
 
 Audience index for [#2002](https://github.com/mizchi/vibe-lang/issues/2002).
-Paths are **current locations** at `7e3ca3ebc`. This file does not move anything;
-later PRs use it as the inventory.
+Paths are **current locations**. This file does not move anything; later PRs use
+it as the inventory.
+
+**Every document under `docs/` must appear in exactly one class table below**,
+and `scripts/check_doc_classification.sh` (`pkf run check-doc-classification`)
+enforces it: a new document in no table fails, a document in two tables fails,
+and a row pointing at a file that is no longer there fails. Add the row in the
+same change as the document.
 
 `docs/language-tour/` is not in the tree. Its content was folded into
 [cheatsheet.md](cheatsheet.md).
 
-Proposed later homes (`docs/user/…`, `docs/internal/…`, `docs/generated/`) are
-labels from #2002, not directories in this commit.
+The `Later home` column (`docs/user/…`, `docs/internal/…`, `docs/generated/`) is
+a **destination label, not a path that exists yet**; the moves are #2565, #2566
+and #2567. One exception is already real: `docs/internal/` exists and holds the
+two experiment records classified below, created ahead of the move. Do not add
+to it — a document goes where the tree puts things today, and moves happen in
+one pass so the link rewrites can be reviewed together.
 
 **Users:** [install](install.md) · [The Vibe Book](../book/README.md) ·
 [tutorial (pointer)](tutorial/README.md) ·
@@ -38,6 +48,7 @@ Install, learn, write, build, test, package, debug, deploy.
 | [cheatsheet.md](cheatsheet.md) | `user/reference/` | Language reference. Absorbed `language-tour/`. |
 | [cli-commands.md](cli-commands.md) | `user/reference/` | |
 | [editor-and-debugging.md](editor-and-debugging.md) | `user/reference/` | LSP, DAP, editor query CLI |
+| [source-range-contract.md](source-range-contract.md) | `user/reference/` | What a reported position MEANS (byte, ADR-0108). Written because [editor-and-debugging.md](editor-and-debugging.md) called byte offsets "char offsets"; enforced by `scripts/check_source_range_contract.sh` |
 | [guide/when-to-use-effects.md](guide/when-to-use-effects.md) | `user/guide/` | `guide/` is mixed; sibling is internal |
 | [vibe.md](vibe.md) | `user/reference/` | Implemented language design outside pure syntax |
 | [spec/syntax.md](spec/syntax.md) | `user/reference/` | Canonical implemented surface syntax. `spec/` is mixed |
@@ -125,8 +136,11 @@ the repo; not the user manual.
 | Current path | Later home | Notes |
 | --- | --- | --- |
 | [ast_binary_abi.md](ast_binary_abi.md) | `internal/compiler/` | |
+| [checked-body-transport.md](checked-body-transport.md) | `internal/compiler/` | Checked-implementation-body artifact + normalized typed-IR codec. Its "shadow-only" framing is superseded: #2505 promotes this lane, and the #1958 it cites is closed |
 | [checked-direct-expression-return-observation.md](checked-direct-expression-return-observation.md) | `internal/compiler/` | Checker observation note |
 | [tracing-design.md](tracing-design.md) | `internal/compiler/` | Proposed internal spans |
+| [internal/experimental-wasmfx-effect-backend.md](internal/experimental-wasmfx-effect-backend.md) | `internal/design/` | WasmFX feasibility probe. Tracked by #2221 |
+| [internal/experimental-wasmtime-guest-profiler.md](internal/experimental-wasmtime-guest-profiler.md) | `internal/design/` | Guest-profiler integration. Tracked by #2207 |
 | [vibec-component.md](vibec-component.md) | `internal/compiler/` | Compiler-core component split |
 | [wasm/gc-value-abi.md](wasm/gc-value-abi.md) | `internal/compiler/` | wasm-gc value ABI |
 | [wasm_threads_requirements.md](wasm_threads_requirements.md) | `internal/compiler/` | |
@@ -171,6 +185,7 @@ only while it is still cited.
 | [archive/moonbit-retirement.md](archive/moonbit-retirement.md) | Cited recovery record (`moonbit-host-final-2026-06-23`) |
 | [archive/mut-effect-plan.md](archive/mut-effect-plan.md) | |
 | [archive/report/](archive/report/) | Dated evaluations |
+| [archive/release-notes-0.3.0.md](archive/release-notes-0.3.0.md) | A release that was never cut (renumbered by ADR-0109). Kept as the record of 2026-06 to 2026-07-17; carries a status banner, so a delete candidate by the AGENTS.md rule |
 | [archive/review-by-x-markdown.md](archive/review-by-x-markdown.md) | |
 | [archive/spec/](archive/spec/) | Retired spec notes |
 | [archive/TODO.md](archive/TODO.md) | Moved from repo-root `TODO.md`. Delete candidate |
@@ -178,29 +193,12 @@ only while it is still cited.
 
 ## Inventory coverage
 
-Top-level names from `ls docs/` at the parent commit, excluding this router:
-
-`BENCHMARKS.md`, `adding-modules.md`, `adr.md`, `archive`, `ast_binary_abi.md`,
-`bootstrap.md`, `build-cache.md`, `builtin_contract_table.generated.md`,
-`capability-authorization-surface.md`, `cheatsheet.md`,
-`checked-direct-expression-return-observation.md`, `ci-speed.md`,
-`cli-commands.md`, `compiler-parallelism.md`, `concurrency.md`, `coverage.md`,
-`editor-and-debugging.md`, `effect-evidence-passing.md`,
-`effect-taxonomy-entry-policy.md`, `effect-taxonomy-review.md`,
-`effect-wit-mapping.md`, `effectset.md`, `error-effect-policy.md`,
-`exception-effect.md`, `guide`, `host-runtime-contract.md`,
-`http_server_contract.md`, `incremental-build.md`, `install.md`,
-`issue-triage.md`, `module-system-oracle.md`,
-`module-system-v2.md`, `mutability-control-review.md`,
-`naming-convention-migration.md`, `operation-gate.md`, `perceus-reuse.md`,
-`perf-snapshot-2026-08-07.md`, `pkfire-pkspec.md`, `pl-survey-2026-07.md`,
-`qualified-constructor-migration.md`, `region-mutable-state.md`,
-`registry-design.md`, `release-notes-0.1.0.md`, `release-roadmap.md`, `report`,
-`resource-kind-parameters.md`, `selfcompile-heap-policy.md`,
-`side-effect-consolidation.md`, `spec`, `tracing-design.md`, `tutorial`,
-`vibe.md`, `vibec-component.md`, `vibex-runtime-contract.md`,
-`wasip3-effect-alignment.md`, `wasm`, `wasm-opt-dogfood.md`,
-`wasm_threads_requirements.md`, `wit`, `zero-alloc-check.md`
+Answered by `scripts/check_doc_classification.sh`, not by a list kept here. A
+list of names copied from `ls docs/` is a **proxy** for "every document is
+classified", and it drifted within three weeks of being written: two documents
+were in no class table, one archived file was missing from the archive table,
+and `docs/internal/` had been created while the text above said it did not
+exist. The gate walks the tree instead, so this section cannot go stale.
 
 Mixed directories, children classified above:
 

--- a/scripts/check_doc_classification.sh
+++ b/scripts/check_doc_classification.sh
@@ -1,0 +1,210 @@
+#!/usr/bin/env bash
+# check_doc_classification.sh -- every document under docs/ has exactly one
+# audience class, and a new one fails closed (#2562, part of #2002).
+#
+# docs/README.md is the audience router: four classes (user, maintainer /
+# internal, generated, archive), one table row per document. It was written as
+# an inventory and it has no enforcement, so the only thing standing between the
+# classification and the tree is its own "Inventory coverage" section -- a list
+# of names copied by hand from `ls docs/` at one commit.
+#
+# That is a PROXY for "every document is classified", not the property. It
+# drifted within three weeks of being written: `checked-body-transport.md` and
+# `source-range-contract.md` were in no class table at all,
+# `archive/release-notes-0.3.0.md` was missing from the archive table, and
+# docs/internal/ had been created with two files in it while the router stated
+# ten lines from its top that `internal/` was "a label from #2002, not a
+# directory in this commit". Nothing was checking, so nothing said so.
+#
+# This gate answers the property instead. It enumerates the tree and asks, for
+# each file, which class claims it:
+#
+#   0 classes -> FAIL. Unclassified. The document exists and no reader knows
+#                who it is for.
+#   2 classes -> FAIL. Ambiguous ownership, which #2002's rule 4 forbids: a
+#                normative statement has one canonical home.
+#   a row matching nothing -> FAIL. A stale row is the same defect pointing the
+#                other way, and it is what a move without a link rewrite leaves
+#                behind.
+#
+# A row whose path is a DIRECTORY (`report/`, `wit/`, `archive/adr/`) covers
+# every file beneath it. The router marks `guide/`, `spec/` and `wasm/` as mixed
+# and classifies their children individually, so the scan descends rather than
+# matching a prefix and stopping.
+#
+# A row pointing outside docs/ (`../book/README.md`) is skipped: the corpus is
+# docs/, and book/ has its own gates (check_book_links.sh, vibe_md.sh,
+# check_tutorial_translation_parity.sh).
+#
+# THE GATE MUST NOT BE ABLE TO SEE ITSELF (AGENTS.md, twice-learned in #2138).
+# Two ways that could happen here, both closed:
+#
+#   1. docs/README.md is excluded from the corpus. It is the router -- it says
+#      so of itself, "This file is the audience router. It is not one of the
+#      four classes below." Scanning it would ask the router to classify
+#      itself, which it can always do by existing.
+#   2. The corpus comes from the filesystem, never from the router's own
+#      "Inventory coverage" list. Reading that list would make the document the
+#      evidence for a claim about the document -- the exact substitution this
+#      gate exists to remove. Once this gate runs, that section is redundant by
+#      construction.
+#
+# VIBE_DOC_CLASSIFICATION_ROOT points the scan at a different tree (the
+# pre-commit hook's staged snapshot). The scan walks the filesystem rather than
+# asking git, so it works in a `git checkout-index` export with no .git.
+#
+# Usage: bash scripts/check_doc_classification.sh [--list]
+#   --list  print every file and the class that claims it, and exit 0.
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$repo_root"
+
+list_mode=0
+[ "${1:-}" = "--list" ] && list_mode=1
+
+python3 - "${VIBE_DOC_CLASSIFICATION_ROOT:-$repo_root}" "$list_mode" <<'PY'
+import io, os, re, sys
+
+tree_root, list_mode = sys.argv[1], sys.argv[2] == "1"
+docs_dir = os.path.join(tree_root, "docs")
+router_rel = "docs/README.md"
+router_abs = os.path.join(tree_root, router_rel)
+
+if not os.path.isdir(docs_dir):
+    print(f"doc-classification: no docs/ under {tree_root}", file=sys.stderr)
+    sys.exit(2)
+if not os.path.exists(router_abs):
+    print(f"doc-classification: {router_rel} is missing -- it is the router "
+          "this gate reads the classification from", file=sys.stderr)
+    sys.exit(2)
+
+# --- the classification, read off the router's class tables -----------------
+#
+# A class is a `## <n>. <name>` heading. `###` sub-headings (Project,
+# Operations, Design, Compiler, Reports) partition a class for reading and do
+# not change it. Any other `## ` heading ends the class -- that is what keeps
+# "## Inventory coverage" from being read as a fifth class.
+#
+# Only the FIRST column of a row is the classification. The Notes column also
+# carries links (a directory row lists its children there), and counting those
+# would report a file as classified twice for being mentioned.
+
+CLASS_HEAD = re.compile(r"^## (\d)\. (.+?)\s*$")
+ROW_PATH = re.compile(r"^\| \[[^\]]*\]\(([^)]+)\)")
+
+cls = None
+entries = []  # (class, docs-relative path, router line number)
+for lineno, line in enumerate(
+    io.open(router_abs, encoding="utf-8").read().split("\n"), start=1
+):
+    head = CLASS_HEAD.match(line)
+    if head:
+        cls = f"{head.group(1)}. {head.group(2)}"
+        continue
+    if line.startswith("## "):
+        cls = None
+        continue
+    if cls is None or not line.startswith("| ["):
+        continue
+    row = ROW_PATH.match(line)
+    if row:
+        entries.append((cls, row.group(1), lineno))
+
+if not entries:
+    print(f"doc-classification: parsed no rows out of {router_rel}. The gate "
+          "would pass by seeing nothing, so it fails instead -- check that the "
+          "class headings still read `## 1. ...` and rows still start `| [`",
+          file=sys.stderr)
+    sys.exit(2)
+
+# `../book/README.md` and friends leave docs/; book/ is covered by its own gates.
+scoped = []
+for cls, target, lineno in entries:
+    if target.startswith("../"):
+        continue
+    scoped.append((cls, "docs/" + target.rstrip("/"), lineno))
+
+# --- the corpus, read off the filesystem -------------------------------------
+
+corpus = []
+for root, dirs, files in os.walk(docs_dir):
+    dirs[:] = sorted(d for d in dirs if d != ".git")
+    for name in sorted(files):
+        rel = os.path.relpath(os.path.join(root, name), tree_root)
+        if rel == router_rel:
+            continue  # the router is not one of its own four classes
+        corpus.append(rel)
+corpus.sort()
+
+if not corpus:
+    print("doc-classification: walked docs/ and found no files. The gate would "
+          "pass by seeing nothing, so it fails instead", file=sys.stderr)
+    sys.exit(2)
+
+
+def claims(path):
+    return sorted({c for c, t, _ in scoped if path == t or path.startswith(t + "/")})
+
+
+fails = 0
+
+if list_mode:
+    for path in corpus:
+        got = claims(path)
+        print(f"{path}\t{got[0] if len(got) == 1 else ','.join(got) or '(none)'}")
+    sys.exit(0)
+
+unclassified = [p for p in corpus if not claims(p)]
+ambiguous = [(p, claims(p)) for p in corpus if len(claims(p)) > 1]
+stale = [
+    (c, t, n)
+    for c, t, n in scoped
+    if not any(p == t or p.startswith(t + "/") for p in corpus)
+]
+
+for path in unclassified:
+    print(
+        f"doc-classification: FAIL: {path} is in no class table.\n"
+        f"    Add a row for it to {router_rel} under the class whose PRIMARY "
+        f"READER it is written for (#2002: classify by reader, not by the "
+        f"subsystem it mentions).",
+        file=sys.stderr,
+    )
+    fails += 1
+
+for path, got in ambiguous:
+    print(
+        f"doc-classification: FAIL: {path} is claimed by {len(got)} classes "
+        f"({', '.join(got)}).\n"
+        f"    A normative statement has one canonical home (#2002 rule 4). "
+        f"Delete the row in the class that is not its primary reader, or split "
+        f"the document.",
+        file=sys.stderr,
+    )
+    fails += 1
+
+for cls, target, lineno in stale:
+    print(
+        f"doc-classification: FAIL: {router_rel}:{lineno} classifies "
+        f"{target} under '{cls}', and nothing is there.\n"
+        f"    Repoint the row at where the file moved, or delete the row if the "
+        f"file is gone.",
+        file=sys.stderr,
+    )
+    fails += 1
+
+if fails:
+    print(
+        f"doc-classification: {fails} problem(s). "
+        f"Run with --list to see what claims each file.",
+        file=sys.stderr,
+    )
+    sys.exit(1)
+
+print(
+    f"doc-classification: ok ({len(corpus)} documents, "
+    f"{len(scoped)} rows, every document in exactly one class)"
+)
+PY

--- a/scripts/check_doc_classification_test.sh
+++ b/scripts/check_doc_classification_test.sh
@@ -1,0 +1,240 @@
+#!/usr/bin/env bash
+# check_doc_classification_test.sh -- red test for check_doc_classification.sh.
+#
+# Per AGENTS.md ("a passing gate means nothing until it is known to be able to
+# fail"): every case below MUTATES a synthetic tree and asserts the gate goes
+# red, with an unmutated tree as the control. The control runs FIRST, so a
+# mutation that silently changed nothing shows up as "the control and the
+# mutation agree" rather than as a pass.
+#
+# The tree is synthetic rather than the repository's own docs/, so the cases
+# stay fixed while docs/ changes. The gate's ability to fail on the REAL tree
+# was established separately: on the commit that introduced it, it reported all
+# five documents that had drifted out of docs/README.md.
+#
+# #2252: the gate's own environment variable is unset at the top and set
+# explicitly per case. Inheriting it from a shell (or from a session hook) is
+# how five self-tests were once quietly turned into no-ops.
+
+set -euo pipefail
+
+unset VIBE_DOC_CLASSIFICATION_ROOT
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+gate="$repo_root/scripts/check_doc_classification.sh"
+work="$(mktemp -d "${TMPDIR:-/tmp}/vibe_doc_classification_test.XXXXXX")"
+trap 'rm -rf "$work"' EXIT
+
+fails=0
+pass() { printf 'doc-classification-test: ok: %s\n' "$1"; }
+fail() { printf 'doc-classification-test: FAIL: %s\n' "$1" >&2; fails=1; }
+
+# Build a well-formed synthetic tree at $1.
+build_tree() {
+  root="$1"
+  rm -rf "$root"
+  mkdir -p "$root/docs/spec" "$root/docs/report" "$root/docs/archive"
+  printf '# install\n' > "$root/docs/install.md"
+  printf '# syntax\n' > "$root/docs/spec/syntax.md"
+  printf '# memory\n' > "$root/docs/spec/memory-contract.md"
+  printf '# bench a\n' > "$root/docs/report/bench-a.md"
+  printf '# bench b\n' > "$root/docs/report/bench-b.md"
+  printf '# old\n' > "$root/docs/archive/old.md"
+  cat > "$root/docs/README.md" <<'EOF'
+# docs/
+
+Router.
+
+## 1. User documentation
+
+| Current path | Later home | Notes |
+| --- | --- | --- |
+| [install.md](install.md) | `user/getting-started/` | |
+| [spec/syntax.md](spec/syntax.md) | `user/reference/` | |
+| [../book/](../book/README.md) | `user/book/` | outside docs/, skipped |
+
+## 2. Maintainer / internal
+
+### Design
+
+| Current path | Later home | Notes |
+| --- | --- | --- |
+| [spec/memory-contract.md](spec/memory-contract.md) | `internal/design/` | |
+
+### Reports
+
+| Current path | Later home | Notes |
+| --- | --- | --- |
+| [report/](report/) | `internal/reports/` | children: [bench-a.md](report/bench-a.md) |
+
+## 4. Archive
+
+| Current path | Notes |
+| --- | --- |
+| [archive/old.md](archive/old.md) | |
+
+## Inventory coverage
+
+`install.md`, `spec`, `report`, `archive`
+EOF
+}
+
+run_gate() { VIBE_DOC_CLASSIFICATION_ROOT="$1" bash "$gate" >"$2" 2>&1; }
+
+# --- control: the unmutated tree passes --------------------------------------
+#
+# First, and load-bearing. Every case below asserts a FAILURE; if the gate
+# rejected everything, they would all "pass" while proving nothing.
+
+t="$work/control"
+build_tree "$t"
+if run_gate "$t" "$work/control.out"; then
+  pass "control: a well-formed tree passes"
+else
+  fail "control: a well-formed tree was rejected -- every red case below is now meaningless"
+  cat "$work/control.out" >&2
+fi
+
+# The control also proves two positive behaviours that no red case can:
+#   - a file under a DIRECTORY row (report/bench-b.md, which the Notes column
+#     does not mention) is classified by the directory;
+#   - docs/README.md itself is not required to be classified.
+if grep -q "6 documents" "$work/control.out"; then
+  pass "control: the directory row covers a child the notes do not name, and the router is not in its own corpus"
+else
+  fail "control: expected 6 documents in the corpus, got: $(cat "$work/control.out")"
+fi
+
+# --- case 1: an unclassified document ----------------------------------------
+
+t="$work/unclassified"
+build_tree "$t"
+printf '# new\n' > "$t/docs/brand-new.md"
+if run_gate "$t" "$work/unclassified.out"; then
+  fail "case 1: an unclassified document passed"
+else
+  if grep -q "brand-new.md is in no class table" "$work/unclassified.out"; then
+    pass "case 1: an unclassified document fails, and the message names it"
+  else
+    fail "case 1: failed for the wrong reason: $(cat "$work/unclassified.out")"
+  fi
+fi
+
+# --- case 2: a document claimed by two classes -------------------------------
+
+t="$work/ambiguous"
+build_tree "$t"
+# Add install.md to the Archive table as well as the User table -- INSIDE the
+# table, not appended to the file. Appending puts the row after
+# "## Inventory coverage", where it is not a class row at all: the first
+# attempt at this case did exactly that, the gate stayed green, and the case
+# reported a failure it had not actually created. Verified below.
+awk '
+  { print }
+  /^\| \[archive\/old\.md\]\(archive\/old\.md\) \| \|$/ {
+    print "| [install.md](install.md) | duplicate of the user row |"
+  }
+' "$t/docs/README.md" > "$t/docs/README.new"
+mv "$t/docs/README.new" "$t/docs/README.md"
+# The mutation has to have landed inside the Archive table, i.e. before the
+# "## Inventory coverage" heading. A mutation that matched nothing would let
+# this case pass while proving nothing (AGENTS.md, gate discipline).
+if [ "$(awk '/^## Inventory coverage/ { exit } /^\| \[install\.md\]/ { n++ } END { print n+0 }' "$t/docs/README.md")" = "2" ]; then
+  pass "case 2 (mutation landed): install.md now has two rows above the coverage heading"
+else
+  fail "case 2: the mutation did not land -- the assertion below would prove nothing"
+fi
+if run_gate "$t" "$work/ambiguous.out"; then
+  fail "case 2: a document in two classes passed"
+else
+  if grep -q "install.md is claimed by 2 classes" "$work/ambiguous.out"; then
+    pass "case 2: two classes for one document fails"
+  else
+    fail "case 2: failed for the wrong reason: $(cat "$work/ambiguous.out")"
+  fi
+fi
+
+# --- case 3: a row that points at nothing ------------------------------------
+#
+# This is what a move without a link rewrite leaves behind, which is the defect
+# every later phase of #2002 can introduce.
+
+t="$work/stale"
+build_tree "$t"
+rm "$t/docs/install.md"
+if run_gate "$t" "$work/stale.out"; then
+  fail "case 3: a row pointing at a deleted file passed"
+else
+  if grep -q "classifies docs/install.md" "$work/stale.out"; then
+    pass "case 3: a stale row fails, and the message gives the router line"
+  else
+    fail "case 3: failed for the wrong reason: $(cat "$work/stale.out")"
+  fi
+fi
+
+# --- case 4: a router the parser cannot read ---------------------------------
+#
+# Silence is not safety. A router whose headings or rows changed shape parses to
+# zero rows, and "zero rows" would otherwise make every document unclassified
+# OR -- if the logic were inverted anywhere -- make the gate vacuously green.
+# It must refuse to answer instead.
+
+t="$work/unparseable"
+build_tree "$t"
+# Demote the class headings so no `## <n>. ` heading remains.
+sed 's/^## 1\./### 1./; s/^## 2\./### 2./; s/^## 4\./### 4./' \
+  "$t/docs/README.md" > "$t/docs/README.new"
+mv "$t/docs/README.new" "$t/docs/README.md"
+if run_gate "$t" "$work/unparseable.out"; then
+  fail "case 4: a router with no parseable class headings passed"
+else
+  if grep -q "parsed no rows" "$work/unparseable.out"; then
+    pass "case 4: an unparseable router refuses to answer instead of passing"
+  else
+    fail "case 4: failed for the wrong reason: $(cat "$work/unparseable.out")"
+  fi
+fi
+
+# --- case 5: an empty corpus -------------------------------------------------
+#
+# The other way to see nothing and call it ok.
+
+t="$work/empty"
+build_tree "$t"
+find "$t/docs" -type f ! -name README.md -exec rm {} +
+if run_gate "$t" "$work/empty.out"; then
+  fail "case 5: an empty docs/ passed"
+else
+  if grep -q "found no files" "$work/empty.out"; then
+    pass "case 5: an empty docs/ refuses to answer instead of passing"
+  else
+    fail "case 5: failed for the wrong reason: $(cat "$work/empty.out")"
+  fi
+fi
+
+# --- case 6: the "## Inventory coverage" section is not a fifth class --------
+#
+# It lists names in backticks. If the parser treated any `## ` heading as a
+# class, those names could classify documents -- and the gate would then be
+# reading the router's hand-maintained list, which is the proxy it exists to
+# replace.
+
+t="$work/coverage-not-a-class"
+build_tree "$t"
+printf '# new\n' > "$t/docs/brand-new.md"
+printf '\n| [brand-new.md](brand-new.md) | listed under coverage |\n' >> "$t/docs/README.md"
+if run_gate "$t" "$work/coverage.out"; then
+  fail "case 6: a row under '## Inventory coverage' classified a document"
+else
+  if grep -q "brand-new.md is in no class table" "$work/coverage.out"; then
+    pass "case 6: a row after a non-class heading does not classify"
+  else
+    fail "case 6: failed for the wrong reason: $(cat "$work/coverage.out")"
+  fi
+fi
+
+if [ "$fails" -ne 0 ]; then
+  echo "doc-classification-test: FAILED" >&2
+  exit 1
+fi
+echo "doc-classification-test: ok (control + 6 red cases)"


### PR DESCRIPTION
Closes #2562, the `blocker` of #2002. Every later phase of that epic moves files; without this a move can silently drop one.

## The defect

`docs/README.md` classifies every document by audience, and **nothing enforced it**. The only thing between the classification and the tree was its own "Inventory coverage" section — a list of names copied by hand from `ls docs/` at one commit. That is a **proxy** for "every document is classified", not the property, and it drifted within three weeks of being written.

## The gate

`scripts/check_doc_classification.sh` walks `docs/` and asks which class claims each file:

| result | verdict |
|---|---|
| 0 classes | FAIL — unclassified; the document exists and no reader knows who it is for |
| 2 classes | FAIL — #2002 rule 4: a normative statement has one canonical home |
| a row matching nothing | FAIL — a stale row, which is exactly what a move without a link rewrite leaves behind |

A directory row (`report/`, `wit/`, `archive/adr/`) covers its subtree, so the three mixed directories the router flags — `guide/`, `spec/`, `wasm/` — keep being classified per child rather than by prefix. Rows leaving `docs/` (`../book/README.md`) are skipped; `book/` has four gates of its own.

**It cannot see itself**, in the two ways it could have (AGENTS.md, twice-learned in #2138):

- `docs/README.md` is excluded from the corpus. It is the router and says so of itself — scanning it would ask the router to classify itself, which it can always do by existing.
- The corpus comes from the **filesystem**, never from the router's coverage list. Reading that list would make the document the evidence for a claim about the document — the substitution this gate exists to remove.

Both "seeing nothing" paths exit 2 rather than passing: a router that parses to zero rows, and an empty `docs/`.

## It was red on the tree it was written against

Which is the point — the drifts were the red test, and they are all now classified:

| path | was |
|---|---|
| `docs/checked-body-transport.md` | in no class table (cited by #2505 as the doc whose shadow-only framing must be rewritten) |
| `docs/source-range-contract.md` | in no class table (the byte-position contract `AGENTS.md` points at, enforced by `check_source_range_contract.sh`) |
| `docs/archive/release-notes-0.3.0.md` | missing from the archive table — **a fifth drift I had not found by hand** when filing #2562 |
| `docs/internal/experimental-wasmfx-effect-backend.md`<br>`docs/internal/experimental-wasmtime-guest-profiler.md` | in a directory the router said did not exist |

The last pair is the sharp one. `docs/README.md` stated ten lines from its top that `docs/internal/` was *"a label from #2002, not a directory in this commit"*, and it has existed since #2473 — part of the target structure built ahead of the move while the plan document denied it. That sentence is now true, and tells readers not to add to the directory before #2566 does the move with its link rewrites.

The coverage list is **replaced by the gate rather than corrected**: a list the gate re-derives on every run does not need maintaining, and keeping both keeps the proxy. The "Mixed directories" note beside it is real information and stays.

## Self-test

Control plus six red cases, each mutating a synthetic tree. The control runs **first** and asserts the corpus size, so a gate that rejected everything could not make the red cases vacuously pass. It also carries the two positive behaviours no red case can prove: a directory row covering a child the Notes column does not name, and the router not being required to classify itself.

Cases: unclassified file · one file in two classes · a row pointing at a deleted file · an unparseable router · an empty `docs/` · a row under `## Inventory coverage` **not** counting as a class (which is what stops the gate from reading the hand-maintained list through a parser bug).

**Case 2 caught its own first draft.** Appending the duplicate row put it after `## Inventory coverage`, where it is not a class row at all — the gate stayed green and the case would have reported a failure it never created. That is the exact "the mutation matched nothing" failure `AGENTS.md` records. It now inserts into the table with `awk` and **asserts the mutation landed** (two `install.md` rows above the coverage heading) before believing the result.

`#2252`: the gate's env var is `unset` at the top of the self-test and set per case, so an inherited value cannot turn cases into silent no-ops.

## Registration

`pkf run check-doc-classification` / `test-doc-classification`, both in the two aggregate lists that carry `checkDocPathCitations`, and both wired into CI's `structural-lint` job — `release-check` has no CI job of its own, which is how `lint-tracked-experiment-names` went unrun for weeks.

## Verification

- `check_gate_portability.sh` — ok (no ripgrep, no bare `sed -i`, no uninterpreted `\t`)
- `check_gate_self_tests.sh` — ok; the new gate has a self-test and is **not** in `gate_self_test_allowlist.txt`, and `gate_self_test_failing.txt` stays empty
- `check_doc_path_citations.sh` — ok (32 allowlisted, 0 new)
- `check_doc_commands.sh` — ok (594 references resolve; 593 before, +1 for the new task)
- `pkf run pre-commit` — passed

### One pre-existing failure, unrelated to this change

`scripts/check_task_inputs.sh` is **red on clean `origin/main`** — `bench-compile-hotspots` runs `scripts/profile_compile.sh`, which reaches the compiler, without `...compilerProbeInputs` or `cache = false`. Verified by stashing this branch's changes and re-running. It is a pkfire task wired into **no CI workflow**, so nothing has been running it — the same shape as #2538, and as the `lint-tracked-experiment-names` case `AGENTS.md` records. Reported separately rather than fixed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0194y71aVEMcwoem5oAxFJPX

---
_Generated by [Claude Code](https://claude.ai/code/session_0194y71aVEMcwoem5oAxFJPX)_