### PR TITLE
Fix three gates that were red on main, and wire them into CI (#2577)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -734,6 +734,20 @@ jobs:
         run: bash scripts/check_doc_classification_test.sh
       - name: doc classification lint
         run: bash scripts/check_doc_classification.sh
+      - name: task-inputs gate self-test
+        run: bash scripts/check_task_inputs_test.sh
+      - name: task-inputs gate
+        run: bash scripts/check_task_inputs.sh
+      - name: doc-commands gate
+        run: bash scripts/check_doc_commands.sh
+      - name: portable-boundary gate self-test
+        run: bash scripts/check_portable_boundary_test.sh
+      - name: portable-boundary gate
+        run: bash scripts/check_portable_boundary.sh
+      - name: tracked-experiment-names lint self-test
+        run: bash scripts/lint_tracked_experiment_names_test.sh
+      - name: tracked-experiment-names lint
+        run: bash scripts/lint_tracked_experiment_names.sh
       # The #1189 / ADR-0081 naming ratchet, reaching CI for the first time. It
       # is a release-check dep, but release-check has no CI job either, so its
       # one enforcement point was a local sign-off nobody re-runs on a green

--- a/Taskfile.pkl
+++ b/Taskfile.pkl
@@ -440,6 +440,13 @@ local testLintTrackedExperimentNames =
 // same artifacts purely to diff them against the tracked copies.)
 local checkSelfhostPortableBoundary =
   scriptTask("check-portable-boundary", "scripts/check_portable_boundary.sh")
+// #2577: the gate had rotted to an `index.vibe` / `with { Error }` shape two
+// ADRs old and reported a missing boundary that was intact in the contract
+// beside it. The self-test pins that it can still fail -- and that a doc
+// comment naming a native entry point is not a leak, which is what the repair
+// had to distinguish.
+local testSelfhostPortableBoundary =
+  scriptTask("test-portable-boundary", "scripts/check_portable_boundary_test.sh")
 local checkHostRuntimeContract = new Task {
   name = "check-host-runtime-contract"
   description = "fail-closed conformance check for the documented vibe.* core host ABI"
@@ -1248,7 +1255,16 @@ local benchSelfhostCompileHotspots = new Task {
   name = "bench-compile-hotspots"
   cmd = "bash scripts/profile_compile.sh $@"
   acceptsArgs = true
-  inputs { ...vibeSources; ...scriptSources }
+  // `cache = false`, like every other measurement task that takes an argument
+  // (kpi-selfcompile, measure-fs-heap, kpi-edit-cycle). No input list can key
+  // this one correctly: the stage2 to profile arrives as an ARGUMENT, so two
+  // runs against different compilers would share a cache key and the second
+  // would replay the first's numbers -- the "which compiler answered" trap
+  // (AGENTS.md), in the one task whose entire output is a measurement. It ran
+  // with `inputs { ...vibeSources; ...scriptSources }`, which also omitted
+  // bootstrap/seed.json, and check_task_inputs.sh has been red on main since
+  // (#2577).
+  cache = false
 }
 
 local selfcompileKpi = new Task {
@@ -1874,6 +1890,7 @@ tasks {
   checkTreesitterWasmCorpus
   testCheckTreesitterWasmCorpus
   checkSelfhostPortableBoundary
+  testSelfhostPortableBoundary
   checkHostRuntimeContract
   checkVibeFmt
   checkTaskfileFmt

--- a/scripts/check_doc_commands.sh
+++ b/scripts/check_doc_commands.sh
@@ -82,7 +82,12 @@ tasks = set(re.findall(r'name\s*=\s*"(' + NAMECHARS + r')"', tf)) | set(re.finda
 SELF = os.path.normpath("scripts/check_doc_commands.sh")
 ENVPAT = re.compile(r'VIBE_[A-Z0-9_]+')
 read_env = set()
-for root in ("scripts", "lib", "tests", "eval", "install"):
+# `runtime` is here because the CLI RUNNER lives there. Leaving it out made
+# this gate's verdict depend on its environment (#2252): the only code read of
+# VIBE_BENCH_BACKEND is `runtime/vibe`, so the answer came from whether the
+# generated `cli_adapter_bundle.vibe` happened to be present -- green after
+# `ensure_generated.sh`, red in CI's structural-lint, same tree.
+for root in ("scripts", "lib", "tests", "eval", "install", "runtime"):
     for dp, _, fn in os.walk(root):
         for name in fn:
             # NOT .md (#2138 review). A document never READS a variable, it
@@ -100,10 +105,27 @@ for root in ("scripts", "lib", "tests", "eval", "install"):
             # its own regex literal. A gate must not be able to see itself.
             if os.path.normpath(os.path.join(dp, name)) == SELF:
                 continue
+            # Extension, OR a shebang. `runtime/vibe` is the CLI runner -- a
+            # tracked, load-bearing shell script with NO extension -- and it
+            # was invisible here. That made the gate's verdict depend on its
+            # ENVIRONMENT (#2252): the only code read of VIBE_BENCH_BACKEND is
+            # in that file, every other occurrence being a whole-line comment
+            # this scan correctly drops, so the answer came from whether the
+            # generated `cli_adapter_bundle.vibe` happened to exist. With
+            # `scripts/ensure_generated.sh` run it passed; in CI's
+            # structural-lint, which does not run it, the same tree failed.
+            # A shebang is the property ("this file is a script"); the
+            # extension was a proxy for it.
+            path = os.path.join(dp, name)
             if not name.endswith((".sh", ".mjs", ".js", ".vibe", ".vibex", ".pkl", ".ts", ".toml")):
-                continue
+                try:
+                    with open(path, "rb") as fh:
+                        if not fh.read(2) == b"#!":
+                            continue
+                except OSError:
+                    continue
             try:
-                body = open(os.path.join(dp, name), encoding="utf-8", errors="replace").read()
+                body = open(path, encoding="utf-8", errors="replace").read()
             except OSError:
                 continue
             # Drop WHOLE-LINE comments before harvesting names. A comment does

--- a/scripts/check_portable_boundary.sh
+++ b/scripts/check_portable_boundary.sh
@@ -17,11 +17,22 @@ require_line() {
   fi
 }
 
+# A doc comment naming a native entry point is a REFERENCE, not a leak: the
+# whole point of these files is to explain how they differ from the FS lane, so
+# `-- see compile_file_fs_mode's comment` is exactly the prose we want. The scan
+# strips `///` and `//` comment lines before matching. Code is what leaks
+# capability; prose about code does not.
+#
+# It strips whole comment LINES only, not trailing comments after code -- a
+# stripped tail would let `let x = 1 // perform Fs::read_file` hide a real call
+# on the same line if the two were ever reordered. A comment line is the one
+# shape that cannot execute.
 forbid_pattern() {
   local file="$1"
   local pattern="$2"
   local label="$3"
-  if grep -En "$pattern" "$ROOT_DIR/$file" >/tmp/vibe_portable_boundary_hits.$$; then
+  if grep -vE '^[[:space:]]*(///?|//#)' "$ROOT_DIR/$file" \
+    | grep -En "$pattern" >/tmp/vibe_portable_boundary_hits.$$; then
     cat /tmp/vibe_portable_boundary_hits.$$ >&2
     rm -f /tmp/vibe_portable_boundary_hits.$$
     fail "native capability leaked into portable boundary: $label ($file)"
@@ -31,25 +42,32 @@ forbid_pattern() {
 
 native_effect_pattern='with \{[^}]*(Fs|Process|Socket|Net)|perform (Fs|Process|Socket|Http)::|compile_file_fs|session-http|daemon'
 
+# The boundary is declared in the package CONTRACT (`index.vpkg`, ADR-0070),
+# not in an `index.vibe` facade -- and its effect row is spelled `with
+# Exception`, not `with { Error }` (ADR-0085). This gate asserted the older
+# form at the older path for long enough that both had gone: it reported
+# "missing expected pure boundary" for files that no longer exist, while every
+# boundary it names was intact in the contract beside them. Nothing caught it
+# because the gate runs in no CI job (#2577).
 require_line \
-  "lib/@vibe/compiler/entry/source_compile/index.vibe" \
-  '^export let compile_source: \(String\) -> Bytes with \{ Error \}' \
+  "lib/@vibe/compiler/entry/source_compile/index.vpkg" \
+  '^fn compile_source\(source: String\) -> Bytes with Exception$' \
   "compile_source stays in-memory"
 require_line \
-  "lib/@vibe/compiler/entry/source_compile/index.vibe" \
-  '^export let compile_source_wasi: \(String, String\) -> Bytes with \{ Error \}' \
+  "lib/@vibe/compiler/entry/source_compile/index.vpkg" \
+  '^fn compile_source_wasi\(source: String, entry_name: String\) -> Bytes with Exception$' \
   "compile_source_wasi stays in-memory"
 require_line \
-  "lib/@vibe/compiler/entry/source_compile/index.vibe" \
-  '^export let compile_source_wasi_mode: \(String, String, String\) -> Bytes with \{ Error \}' \
+  "lib/@vibe/compiler/entry/source_compile/index.vpkg" \
+  '^fn compile_source_wasi_mode\(source: String, entry_name: String, mode: String\) -> Bytes with Exception$' \
   "compile_source_wasi_mode stays in-memory"
 require_line \
   "lib/@vibe/compiler/entry/source_compile/wasi_only/preprocess_compile.vibe" \
-  '^export let compile_source_wasi_only: \(String, String\) -> Bytes with \{ Error \}' \
+  '^export fn compile_source_wasi_only\(source: String, entry_name: String\) -> Bytes with Exception' \
   "compile_source_wasi_only stays in-memory"
 require_line \
-  "lib/@vibe/compiler/entry/compiler/fs_compile/index.vibe" \
-  '^export let compile_with_closure_sources_wasi_mode_uncached: \(String, String, Array\[\(String, String\)\], String, String\) -> Bytes with \{ Error \}' \
+  "lib/@vibe/compiler/entry/compiler/fs_compile/index.vpkg" \
+  '^fn compile_with_closure_sources_wasi_mode_uncached\(main_source: String, main_path: String, sources: Array\[\(String, String\)\], entry_name: String, mode: String\) -> Bytes with Exception$' \
   "direct component closure compile stays in-memory"
 
 forbid_pattern \
@@ -57,7 +75,7 @@ forbid_pattern \
   "$native_effect_pattern" \
   "direct component entry"
 forbid_pattern \
-  "lib/@vibe/compiler/entry/source_compile/index.vibe" \
+  "lib/@vibe/compiler/entry/source_compile/source_compile.vibe" \
   "$native_effect_pattern" \
   "source compile API"
 forbid_pattern \

--- a/scripts/check_portable_boundary_test.sh
+++ b/scripts/check_portable_boundary_test.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+# check_portable_boundary_test.sh -- red test for check_portable_boundary.sh.
+#
+# Written when that gate was repaired (#2577). It had been asserting a
+# two-generations-old shape of the boundary -- `export let name: (...) -> Bytes
+# with { Error }` in an `index.vibe` facade -- after ADR-0070 moved the contract
+# to `index.vpkg` and ADR-0085 replaced `Error` with `Exception`. So it reported
+# "missing expected pure boundary" for files that no longer existed, while every
+# boundary it names was intact in the contract beside them. It runs in no CI
+# job, so nothing said so.
+#
+# Repairing a gate that has been dark is exactly when it needs a red test:
+# "it says ok now" is equally consistent with "it was fixed" and "it was
+# neutered". These four cases separate those, and the two mutation cases are
+# the ones the repair could plausibly have broken.
+#
+# The gate scans the repository from its own location rather than a tree it is
+# handed, so each case mutates a real file and restores it with `git checkout`.
+# The restore runs on EXIT, so an interrupted run does not leave the tree
+# modified.
+#
+# #2252: no environment is inherited -- this gate reads none, and the test sets
+# none.
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$repo_root"
+
+gate="scripts/check_portable_boundary.sh"
+impl="lib/@vibe/compiler/entry/source_compile/wasi_only/preprocess_compile.vibe"
+contract="lib/@vibe/compiler/entry/source_compile/index.vpkg"
+
+# Refuse to run against a dirty tree: the restore below would discard the
+# author's uncommitted work in these two files.
+if ! git diff --quiet -- "$impl" "$contract"; then
+  echo "portable-boundary-test: $impl or $contract has uncommitted changes." >&2
+  echo "  This test mutates and restores them with 'git checkout'. Commit or" >&2
+  echo "  stash first, so a restore cannot discard your work." >&2
+  exit 2
+fi
+
+restore() { git checkout -q -- "$impl" "$contract" 2>/dev/null || true; }
+trap restore EXIT
+
+fails=0
+pass() { printf 'portable-boundary-test: ok: %s\n' "$1"; }
+fail() { printf 'portable-boundary-test: FAIL: %s\n' "$1" >&2; fails=1; }
+
+# --- control, first: the unmutated tree passes -------------------------------
+#
+# Load-bearing. Three of the four cases assert a FAILURE, so a gate that
+# rejected everything would make them all "pass" while proving nothing.
+
+if bash "$gate" >/dev/null 2>&1; then
+  pass "control: the unmutated tree passes"
+else
+  fail "control: the unmutated tree is rejected -- the red cases below prove nothing"
+  bash "$gate" >&2 || true
+fi
+
+# --- case 1: a native capability in CODE is rejected -------------------------
+
+printf '\nlet _portable_boundary_probe = perform Fs::read_file("x")\n' >> "$impl"
+if bash "$gate" >/dev/null 2>&1; then
+  fail "case 1: a 'perform Fs::read_file' in code passed"
+else
+  pass "case 1: a native capability in code is rejected"
+fi
+restore
+
+# --- case 2: the same text in a COMMENT is accepted --------------------------
+#
+# The distinction the repair introduced, asserted rather than assumed. These
+# files exist to explain how they differ from the FS lane, so prose naming a
+# native entry point is the writing we want -- the gate was failing on
+# "-- see `compile_file_fs_mode`'s comment, #2391". Case 1 is what keeps this
+# from being a blanket exemption: strip comments, still catch code.
+
+printf '\n/// prose naming perform Fs::read_file and compile_file_fs_mode\n' >> "$impl"
+if bash "$gate" >/dev/null 2>&1; then
+  pass "case 2: the same names in a comment are accepted"
+else
+  fail "case 2: a doc comment naming a native entry point was rejected as a leak"
+fi
+restore
+
+# --- case 3: a boundary that gains an effect is rejected ---------------------
+#
+# The require_line half. `with Exception` becoming `with Fs` is the change this
+# gate exists to catch, and it is the half that had rotted: it was matching a
+# spelling no file in the tree had used for two ADRs.
+
+sed 's/^fn compile_source(source: String) -> Bytes with Exception$/fn compile_source(source: String) -> Bytes with Fs/' \
+  "$contract" > "$contract.probe"
+mv "$contract.probe" "$contract"
+if git diff --quiet -- "$contract"; then
+  fail "case 3: the mutation did not land -- the assertion below would prove nothing"
+else
+  if bash "$gate" >/dev/null 2>&1; then
+    fail "case 3: a boundary declaring 'with Fs' passed"
+  else
+    pass "case 3: a boundary that gains a native effect is rejected"
+  fi
+fi
+restore
+
+if [ "$fails" -ne 0 ]; then
+  echo "portable-boundary-test: FAILED" >&2
+  exit 1
+fi
+echo "portable-boundary-test: ok (control + 3 cases)"

--- a/scripts/gate_self_test_allowlist.txt
+++ b/scripts/gate_self_test_allowlist.txt
@@ -24,7 +24,6 @@ check_inline_builtin_capture.sh
 check_offbuild_typecheck.sh
 check_package_sibling_scope.sh
 check_playground_presets.sh
-check_portable_boundary.sh
 check_rc_default.sh
 check_tutorial_translation_parity.sh
 check_typecheck_fixtures.sh

--- a/scripts/tracked_experiment_name_allowlist.txt
+++ b/scripts/tracked_experiment_name_allowlist.txt
@@ -47,3 +47,4 @@ lib/@vibe/compiler/tests/cache_probe_test.vibe gate persistent-cache regression
 lib/@vibe/compiler/tests/cache_probe_type_db_fs_multi_dep_bench_test.vibe bench-fixture cache probe bench
 lib/@vibe/compiler/tests/checker_hotspot_probe_test.vibe gate checker hotspot regression
 lib/@vibe/compiler/tests/parser_hotspot_probe_test.vibe gate parser hotspot regression
+scripts/prefix_stability_probe.py manual-experiment #2388 codegen prefix-stability measurement; run by hand when the per-module body cache is worked on


### PR DESCRIPTION
Closes #2577. **Stacked on #2576** — that PR already edits `Taskfile.pkl` and `ci.yml`, and `docs/issue-triage.md`'s own rule says not to start a branch on a file an open PR occupies. Base retargets to `main` automatically when #2576 merges.

#2577 reported **one** unwired red gate. Working its third done-when item — *"audit whether any other pkfire-only gate has the same exposure"* — found **two more**, and one of them is the gate `AGENTS.md` already names as the cautionary example.

## 1. `check_task_inputs.sh`

`bench-compile-hotspots` reached the compiler with `inputs { ...vibeSources; ...scriptSources }`: no `bootstrap/seed.json`, no `cache = false`.

Fixed with **`cache = false`**, not the `...compilerProbeInputs` the gate's message suggests. No input list can key this task correctly: the stage2 to profile arrives as an **argument**, so two runs against different compilers share a cache key and the second replays the first's numbers — the "which compiler answered" trap, in the one task whose entire output is a measurement. Its three sibling measurement tasks that take arguments (`kpi-selfcompile`, `measure-fs-heap`, `kpi-edit-cycle`) all use `cache = false`; this was the outlier, and the gate accepts either.

## 2. `check_portable_boundary.sh` — newly found

It asserted a **two-generations-old** shape of the boundary:

```
export let compile_source: (String) -> Bytes with { Error }   # in entry/source_compile/index.vibe
```

ADR-0070 moved the contract to `index.vpkg`, and ADR-0085 replaced `Error` with `Exception`. So the gate reported *"missing expected pure boundary"* for **files that do not exist**, while every boundary it names was intact in the contract beside them:

```
fn compile_source(source: String) -> Bytes with Exception     # in entry/source_compile/index.vpkg
```

Repointing it revealed a second defect the first had been hiding: `forbid_pattern` matched `compile_file_fs_mode` inside a **doc comment** (`-- see \`compile_file_fs_mode\`'s comment, #2391`). These files exist to explain how they differ from the FS lane, so prose naming a native entry point is the writing we want. Comment **lines** are now stripped before matching — whole lines only, never a trailing comment after code, since a stripped tail could hide a real call sharing the line.

Repairing a gate that has been dark is exactly when *"it says ok now"* is equally consistent with **"it was fixed"** and **"it was neutered"**, so it gets the self-test it never had:

| case | expected |
|---|---|
| control, unmutated tree | passes (runs first — three cases assert failure, so a gate that rejected everything would make them vacuously pass) |
| `perform Fs::read_file` in **code** | rejected |
| the same names in a **comment** | accepted — this is what keeps the comment strip from being a blanket exemption |
| a boundary declaring `with Fs` | rejected |

Removed from `gate_self_test_allowlist.txt`; that ratchet allows removals.

## 3. `lint_tracked_experiment_names.sh` — newly found

`scripts/prefix_stability_probe.py` is a tracked probe with no allowlist entry — real, referenced by nothing, and measuring exactly the question #2388 is open about. Allowlisted as `manual-experiment` with that reason rather than deleted.

**This is the gate `AGENTS.md` cites**: *"`release-check` has no CI job, which is how `lint-tracked-experiment-names` went unrun for weeks."* It is still unrun, and it has been red.

## The wiring, which is the actual fix

All three, plus `check-doc-commands`, now run in CI's `structural-lint` job, each with its self-test where one exists. Three instances of one pattern — a gate that exists, is correct, and runs nowhere — is not three accidents.

## The audit, reported rather than acted on

**19 of 40 gate scripts have no path from any workflow** (traced transitively through `pkf run` tasks named in workflows, their aggregate members, `gates_shard.sh`, `compiler_gate.sh` and the four `tests/gates/*/run.sh` lanes). `release-check` appears in no workflow at all, which is the common cause.

Of the nine cheap ones I could measure directly, six were green, three were red — the three fixed here. The rest need a stage2 and cannot live in `structural-lint`; wiring those is a scheduling decision about which CI job pays for a compiler build, so it is left on #2577 with the data rather than guessed at here.

One methodological note, since it bit me mid-audit: my first pass classified the unwired gates as "needs a compiler" by grepping each script for `stage2|runtime/vibe|ensure_seed`. That matched `check_task_inputs.sh` and `check_doc_commands.sh`, both of which merely *talk about* the compiler and run in about a second. Measuring beat grepping — the same proxy-versus-property substitution these gates exist to stop.

## Verification

Every touched gate and self-test, run directly:

- gates: `check_gate_portability`, `check_gate_self_tests`, `check_task_inputs`, `check_portable_boundary`, `lint_tracked_experiment_names`, `check_doc_commands`, `check_doc_classification` — all green
- self-tests: `check_portable_boundary_test`, `check_doc_classification_test`, `check_task_inputs_test`, `lint_tracked_experiment_names_test` — all green
- `check_gate_self_tests.sh` still passes with one fewer exemption; `gate_self_test_failing.txt` stays empty
- `pkf run pre-commit` — passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0194y71aVEMcwoem5oAxFJPX

---
_Generated by [Claude Code](https://claude.ai/code/session_0194y71aVEMcwoem5oAxFJPX)_