### PR TITLE
Wire every remaining unwired gate into CI — and recover #2578, which merged into a dead branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -384,6 +384,75 @@ jobs:
           FREEZE_STAGE2="${gen}stage2.wasm" bash scripts/check_freeze_surface_test.sh
           FREEZE_STAGE2="${gen}stage2.wasm" bash scripts/check_freeze_surface.sh
 
+  compiler-contracts:
+    name: compiler-gate (contracts)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: ./.github/actions/setup-vibe
+        with:
+          node-version: 24
+          wasmtime: 'true'
+      - name: Generated compiler fingerprint
+        id: genfp
+        run: echo "fp=$(bash scripts/ensure_generated.sh --print-fingerprint)" >> "$GITHUB_OUTPUT"
+      - name: Restore cached stage2
+        id: stage2-cache
+        uses: actions/cache@v4
+        with:
+          path: _build/_ci_shard_gen
+          key: stage2-v2-${{ steps.genfp.outputs.fp }}-${{ hashFiles('scripts/generations.sh', 'scripts/wasm_vibe_host_runner.js') }}
+      - name: Install wasmtime (cold stage2 build only)
+        # Same reason as compiler-gate (docs): generations.sh's stage validation
+        # shells out to a wasmtime BINARY, and every compiler-touching PR moves
+        # the fingerprint in this cache key, so the cold path is the common one.
+        if: steps.stage2-cache.outputs.cache-hit != 'true'
+        env:
+          WASMTIME_VERSION: v47.0.2
+        run: |
+          set -euo pipefail
+          dir="wasmtime-${WASMTIME_VERSION}-x86_64-linux"
+          curl -sSL --fail --retry 5 --retry-delay 2 --retry-all-errors "https://github.com/bytecodealliance/wasmtime/releases/download/${WASMTIME_VERSION}/${dir}.tar.xz" | tar -xJ
+          echo "$PWD/$dir" >> "$GITHUB_PATH"
+      - name: Build stage2 on cache miss
+        if: steps.stage2-cache.outputs.cache-hit != 'true'
+        run: |
+          bash scripts/ensure_seed.sh
+          bash scripts/ensure_generated.sh
+          VIBE_PREBUILT_MODULE_SOURCE=lib/@vibe/compiler/_cli_adapter_module_source.vibe bash scripts/generations.sh build --out-dir _build/_ci_shard_gen
+      # Every gate below is handed the stage2 EXPLICITLY, by path. None of them
+      # discovers one for itself: left to their own devices they take the
+      # newest generation on disk, else the committed seed, and both answer
+      # confidently about a compiler that does not contain the change
+      # (AGENTS.md, "which compiler answered"). That is also why this job does
+      # not use the `ls -dt _build/selfhost/generations/*/ | head -1` idiom the
+      # older jobs share.
+      - name: Assert the stage2 exists
+        run: |
+          set -euo pipefail
+          test -s _build/_ci_shard_gen/stage2.wasm \
+            || { echo "::error::no stage2 to hand the contract gates"; exit 1; }
+      - name: RC-is-default gate
+        run: RC_DEFAULT_STAGE2="$PWD/_build/_ci_shard_gen/stage2.wasm" bash scripts/check_rc_default.sh
+      - name: Source-range contract gate
+        run: RANGE_STAGE2="$PWD/_build/_ci_shard_gen/stage2.wasm" bash scripts/check_source_range_contract.sh
+      - name: Cheatsheet-signatures gate
+        run: CHEATSHEET_SIG_STAGE2="$PWD/_build/_ci_shard_gen/stage2.wasm" bash scripts/check_cheatsheet_signatures.sh
+      - name: Package sibling-scope gate
+        run: SIBLING_SCOPE_STAGE2="$PWD/_build/_ci_shard_gen/stage2.wasm" bash scripts/check_package_sibling_scope.sh
+      - name: Declaration-scale gate
+        run: DECL_SCALE_STAGE2="$PWD/_build/_ci_shard_gen/stage2.wasm" bash scripts/check_declaration_scale.sh
+      - name: CLI line-termination gate
+        run: CLI_NL_STAGE2="$PWD/_build/_ci_shard_gen/stage2.wasm" bash scripts/check_cli_line_termination.sh
+      - name: Off-build typecheck gate
+        run: VIBE_OFFBUILD_STAGE2="$PWD/_build/_ci_shard_gen/stage2.wasm" bash scripts/check_offbuild_typecheck.sh
+      - name: Book skip-block gate
+        run: VIBE_SKIP_BLOCK_CLI_WASM="$PWD/_build/_ci_shard_gen/stage2.wasm" bash scripts/check_book_skip_blocks.sh
+      - name: Examples typecheck gate
+        run: EXAMPLES_STAGE2="$PWD/_build/_ci_shard_gen/stage2.wasm" bash scripts/check_examples_typecheck.sh
+      - name: Compile-only lanes gate
+        run: COMPILE_ONLY_STAGE2="$PWD/_build/_ci_shard_gen/stage2.wasm" bash scripts/check_compile_only_lanes.sh
+
   compiler-playground:
     name: compiler-gate (playground)
     runs-on: ubuntu-latest
@@ -748,6 +817,22 @@ jobs:
         run: bash scripts/lint_tracked_experiment_names_test.sh
       - name: tracked-experiment-names lint
         run: bash scripts/lint_tracked_experiment_names.sh
+      - name: gate-registry check self-test
+        run: bash scripts/check_gate_registry_test.sh
+      - name: gate-registry check
+        run: bash scripts/check_gate_registry.sh
+      - name: canonical-iterator-calls check self-test
+        run: bash scripts/check_canonical_iterator_calls_test.sh
+      - name: canonical-iterator-calls check
+        run: bash scripts/check_canonical_iterator_calls.sh
+      - name: lock-clean check self-test
+        run: bash scripts/check_lock_clean_test.sh
+      - name: lock-clean check
+        run: bash scripts/check_lock_clean.sh
+      - name: book-order check
+        run: bash scripts/check_book_order.sh
+      - name: inline-builtin-capture check
+        run: bash scripts/check_inline_builtin_capture.sh
       # The #1189 / ADR-0081 naming ratchet, reaching CI for the first time. It
       # is a release-check dep, but release-check has no CI job either, so its
       # one enforcement point was a local sign-off nobody re-runs on a green
@@ -1467,7 +1552,7 @@ jobs:
   # Aggregate required check (branch protection requires "ci-required").
   ci-required:
     name: ci-required
-    needs: [compiler-gate, compiler-gate-preflight, compiler-stage2-oracles, compiler-docs, compiler-playground, compiler-examples, review-regressions, compiler-gate-lanes, unit-tests, vibe-fmt-check, gc-gate, structural-lint]
+    needs: [compiler-gate, compiler-gate-preflight, compiler-stage2-oracles, compiler-docs, compiler-contracts, compiler-playground, compiler-examples, review-regressions, compiler-gate-lanes, unit-tests, vibe-fmt-check, gc-gate, structural-lint]
     if: always()
     runs-on: ubuntu-latest
     steps:
@@ -1487,6 +1572,10 @@ jobs:
           fi
           if [ "${{ needs.compiler-docs.result }}" != "success" ]; then
             echo "::error::compiler-docs did not succeed (${{ needs.compiler-docs.result }})"
+            exit 1
+          fi
+          if [ "${{ needs.compiler-contracts.result }}" != "success" ]; then
+            echo "::error::compiler-contracts did not succeed (${{ needs.compiler-contracts.result }})"
             exit 1
           fi
           if [ "${{ needs.compiler-playground.result }}" != "success" ]; then

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -396,6 +396,27 @@ jobs:
       - name: Generated compiler fingerprint
         id: genfp
         run: echo "fp=$(bash scripts/ensure_generated.sh --print-fingerprint)" >> "$GITHUB_OUTPUT"
+      # The generated artifacts are needed by the GATES, not just by the stage2
+      # build -- check_offbuild_typecheck typechecks every off-manifest source,
+      # and several import `compiler_sources_bundle.vibe` /
+      # `cli_adapter_bundle.vibe` or implement `cache/index.vpkg`'s
+      # `codegen_fingerprint` declaration. Producing them only inside the
+      # cache-miss build below meant a stage2 cache HIT left them absent and the
+      # gate reported 20 real contract violations against a half-built tree.
+      # Cached and ensured unconditionally, exactly as compiler-gate-lanes does.
+      - name: Cache generated compiler artifacts
+        uses: actions/cache@v4
+        with:
+          path: |
+            lib/@vibe/compiler/compiler_sources_bundle.vibe
+            lib/@vibe/compiler/cli_adapter_bundle.vibe
+            lib/@vibe/compiler/selfbuild_runtime_entry_bundle.vibe
+            lib/@vibe/compiler/_cli_adapter_module_source.vibe
+            lib/@vibe/compiler/cache/codegen_fingerprint.vibe
+            lib/@vibe/compiler/.generated.stamp
+          key: gen-v1-${{ steps.genfp.outputs.fp }}
+      - name: Ensure generated compiler artifacts
+        run: bash scripts/ensure_generated.sh
       - name: Restore cached stage2
         id: stage2-cache
         uses: actions/cache@v4
@@ -418,7 +439,6 @@ jobs:
         if: steps.stage2-cache.outputs.cache-hit != 'true'
         run: |
           bash scripts/ensure_seed.sh
-          bash scripts/ensure_generated.sh
           VIBE_PREBUILT_MODULE_SOURCE=lib/@vibe/compiler/_cli_adapter_module_source.vibe bash scripts/generations.sh build --out-dir _build/_ci_shard_gen
       # Every gate below is handed the stage2 EXPLICITLY, by path. None of them
       # discovers one for itself: left to their own devices they take the

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -423,18 +423,11 @@ jobs:
         with:
           path: _build/_ci_shard_gen
           key: stage2-v2-${{ steps.genfp.outputs.fp }}-${{ hashFiles('scripts/generations.sh', 'scripts/wasm_vibe_host_runner.js') }}
-      - name: Install wasmtime (cold stage2 build only)
-        # Same reason as compiler-gate (docs): generations.sh's stage validation
-        # shells out to a wasmtime BINARY, and every compiler-touching PR moves
-        # the fingerprint in this cache key, so the cold path is the common one.
-        if: steps.stage2-cache.outputs.cache-hit != 'true'
-        env:
-          WASMTIME_VERSION: v47.0.2
-        run: |
-          set -euo pipefail
-          dir="wasmtime-${WASMTIME_VERSION}-x86_64-linux"
-          curl -sSL --fail --retry 5 --retry-delay 2 --retry-all-errors "https://github.com/bytecodealliance/wasmtime/releases/download/${WASMTIME_VERSION}/${dir}.tar.xz" | tar -xJ
-          echo "$PWD/$dir" >> "$GITHUB_PATH"
+      # No second wasmtime install: setup-vibe above runs with wasmtime: 'true',
+      # which installs the same pinned 47.0.2 (scripts/install_wasmtime_release.sh)
+      # and puts $HOME/.wasmtime/bin on PATH. generations.sh's stage validation
+      # shells out to that binary and finds it. A duplicate release download
+      # would only add a transient-failure mode to a required job.
       - name: Build stage2 on cache miss
         if: steps.stage2-cache.outputs.cache-hit != 'true'
         run: |
@@ -468,8 +461,11 @@ jobs:
         run: VIBE_OFFBUILD_STAGE2="$PWD/_build/_ci_shard_gen/stage2.wasm" bash scripts/check_offbuild_typecheck.sh
       - name: Book skip-block gate
         run: VIBE_SKIP_BLOCK_CLI_WASM="$PWD/_build/_ci_shard_gen/stage2.wasm" bash scripts/check_book_skip_blocks.sh
-      - name: Examples typecheck gate
-        run: EXAMPLES_STAGE2="$PWD/_build/_ci_shard_gen/stage2.wasm" bash scripts/check_examples_typecheck.sh
+      # No examples typecheck here: check_examples_typecheck.sh was ALREADY
+      # wired, via `pkf run ci-check-examples-typecheck` in compiler-examples,
+      # against this same stage2 path. It was the one entry my by-hand audit
+      # got wrong -- the reachability trace missed the task indirection. Nine
+      # of the ten gates in this job were genuinely unrun; this one was not.
       - name: Compile-only lanes gate
         run: COMPILE_ONLY_STAGE2="$PWD/_build/_ci_shard_gen/stage2.wasm" bash scripts/check_compile_only_lanes.sh
 
@@ -837,8 +833,8 @@ jobs:
         run: bash scripts/lint_tracked_experiment_names_test.sh
       - name: tracked-experiment-names lint
         run: bash scripts/lint_tracked_experiment_names.sh
-      - name: gate-registry check self-test
-        run: bash scripts/check_gate_registry_test.sh
+      # The self-test already runs above as "compiler-gate registry self-test";
+      # only the production check was missing from CI.
       - name: gate-registry check
         run: bash scripts/check_gate_registry.sh
       - name: canonical-iterator-calls check self-test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -734,6 +734,20 @@ jobs:
         run: bash scripts/check_doc_classification_test.sh
       - name: doc classification lint
         run: bash scripts/check_doc_classification.sh
+      - name: task-inputs gate self-test
+        run: bash scripts/check_task_inputs_test.sh
+      - name: task-inputs gate
+        run: bash scripts/check_task_inputs.sh
+      - name: doc-commands gate
+        run: bash scripts/check_doc_commands.sh
+      - name: portable-boundary gate self-test
+        run: bash scripts/check_portable_boundary_test.sh
+      - name: portable-boundary gate
+        run: bash scripts/check_portable_boundary.sh
+      - name: tracked-experiment-names lint self-test
+        run: bash scripts/lint_tracked_experiment_names_test.sh
+      - name: tracked-experiment-names lint
+        run: bash scripts/lint_tracked_experiment_names.sh
       # The #1189 / ADR-0081 naming ratchet, reaching CI for the first time. It
       # is a release-check dep, but release-check has no CI job either, so its
       # one enforcement point was a local sign-off nobody re-runs on a green

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -393,6 +393,21 @@ jobs:
         with:
           node-version: 24
           wasmtime: 'true'
+      # The fingerprint step below is not seed-free: compute_fingerprint hashes
+      # bootstrap/seed/compiler.wasm and runs ensure_seed.sh unconditionally to
+      # get it, deliberately, so the value does not depend on whether the seed
+      # happened to be fetched yet. Without this cache that download runs on
+      # every clean runner -- including when the generated artifacts and stage2
+      # are both cache HITS and nothing else in the job needs the seed -- which
+      # puts a required job behind a release fetch it does not otherwise need.
+      # Same pair every other generation job uses.
+      - name: Cache seed artifact
+        uses: actions/cache@v4
+        with:
+          path: bootstrap/seed/compiler.wasm
+          key: seed-artifact-${{ hashFiles('bootstrap/seed.json') }}
+      - name: Ensure seed artifact
+        run: bash scripts/ensure_seed.sh
       - name: Generated compiler fingerprint
         id: genfp
         run: echo "fp=$(bash scripts/ensure_generated.sh --print-fingerprint)" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -424,10 +424,22 @@ jobs:
           path: _build/_ci_shard_gen
           key: stage2-v2-${{ steps.genfp.outputs.fp }}-${{ hashFiles('scripts/generations.sh', 'scripts/wasm_vibe_host_runner.js') }}
       # No second wasmtime install: setup-vibe above runs with wasmtime: 'true',
-      # which installs the same pinned 47.0.2 (scripts/install_wasmtime_release.sh)
-      # and puts $HOME/.wasmtime/bin on PATH. generations.sh's stage validation
-      # shells out to that binary and finds it. A duplicate release download
-      # would only add a transient-failure mode to a required job.
+      # which installs the same pinned 47.0.2 (scripts/install_wasmtime_release.sh
+      # -> $HOME/.wasmtime/bin) and appends exactly that directory to PATH,
+      # unconditionally. generations.sh's stage validation shells out to that
+      # binary and finds it. A duplicate download would not even hedge the
+      # transient-failure risk it looks like it hedges: setup-vibe's own
+      # installer curls the same GitHub release, so a second one doubles the
+      # exposure of a required job rather than covering it.
+      #
+      # Known limit, stated rather than left to look proven: this is the only
+      # wasmtime-using job that relies on setup-vibe alone (every other one
+      # still carries the redundant install), and the cold path only runs on a
+      # stage2 cache MISS. A ci.yml-only commit does not move the generated
+      # fingerprint in the cache key, so the run that introduced this did not
+      # exercise it. The guarantee above is by construction -- install dir ==
+      # PATH entry, PATH step unconditional -- not by a cold CI run; the next
+      # compiler-source change moves the fingerprint and exercises it for real.
       - name: Build stage2 on cache miss
         if: steps.stage2-cache.outputs.cache-hit != 'true'
         run: |

--- a/Taskfile.pkl
+++ b/Taskfile.pkl
@@ -440,6 +440,13 @@ local testLintTrackedExperimentNames =
 // same artifacts purely to diff them against the tracked copies.)
 local checkSelfhostPortableBoundary =
   scriptTask("check-portable-boundary", "scripts/check_portable_boundary.sh")
+// #2577: the gate had rotted to an `index.vibe` / `with { Error }` shape two
+// ADRs old and reported a missing boundary that was intact in the contract
+// beside it. The self-test pins that it can still fail -- and that a doc
+// comment naming a native entry point is not a leak, which is what the repair
+// had to distinguish.
+local testSelfhostPortableBoundary =
+  scriptTask("test-portable-boundary", "scripts/check_portable_boundary_test.sh")
 local checkHostRuntimeContract = new Task {
   name = "check-host-runtime-contract"
   description = "fail-closed conformance check for the documented vibe.* core host ABI"
@@ -1248,7 +1255,16 @@ local benchSelfhostCompileHotspots = new Task {
   name = "bench-compile-hotspots"
   cmd = "bash scripts/profile_compile.sh $@"
   acceptsArgs = true
-  inputs { ...vibeSources; ...scriptSources }
+  // `cache = false`, like every other measurement task that takes an argument
+  // (kpi-selfcompile, measure-fs-heap, kpi-edit-cycle). No input list can key
+  // this one correctly: the stage2 to profile arrives as an ARGUMENT, so two
+  // runs against different compilers would share a cache key and the second
+  // would replay the first's numbers -- the "which compiler answered" trap
+  // (AGENTS.md), in the one task whose entire output is a measurement. It ran
+  // with `inputs { ...vibeSources; ...scriptSources }`, which also omitted
+  // bootstrap/seed.json, and check_task_inputs.sh has been red on main since
+  // (#2577).
+  cache = false
 }
 
 local selfcompileKpi = new Task {
@@ -1874,6 +1890,7 @@ tasks {
   checkTreesitterWasmCorpus
   testCheckTreesitterWasmCorpus
   checkSelfhostPortableBoundary
+  testSelfhostPortableBoundary
   checkHostRuntimeContract
   checkVibeFmt
   checkTaskfileFmt

--- a/scripts/check_doc_commands.sh
+++ b/scripts/check_doc_commands.sh
@@ -82,7 +82,12 @@ tasks = set(re.findall(r'name\s*=\s*"(' + NAMECHARS + r')"', tf)) | set(re.finda
 SELF = os.path.normpath("scripts/check_doc_commands.sh")
 ENVPAT = re.compile(r'VIBE_[A-Z0-9_]+')
 read_env = set()
-for root in ("scripts", "lib", "tests", "eval", "install"):
+# `runtime` is here because the CLI RUNNER lives there. Leaving it out made
+# this gate's verdict depend on its environment (#2252): the only code read of
+# VIBE_BENCH_BACKEND is `runtime/vibe`, so the answer came from whether the
+# generated `cli_adapter_bundle.vibe` happened to be present -- green after
+# `ensure_generated.sh`, red in CI's structural-lint, same tree.
+for root in ("scripts", "lib", "tests", "eval", "install", "runtime"):
     for dp, _, fn in os.walk(root):
         for name in fn:
             # NOT .md (#2138 review). A document never READS a variable, it
@@ -100,10 +105,27 @@ for root in ("scripts", "lib", "tests", "eval", "install"):
             # its own regex literal. A gate must not be able to see itself.
             if os.path.normpath(os.path.join(dp, name)) == SELF:
                 continue
+            # Extension, OR a shebang. `runtime/vibe` is the CLI runner -- a
+            # tracked, load-bearing shell script with NO extension -- and it
+            # was invisible here. That made the gate's verdict depend on its
+            # ENVIRONMENT (#2252): the only code read of VIBE_BENCH_BACKEND is
+            # in that file, every other occurrence being a whole-line comment
+            # this scan correctly drops, so the answer came from whether the
+            # generated `cli_adapter_bundle.vibe` happened to exist. With
+            # `scripts/ensure_generated.sh` run it passed; in CI's
+            # structural-lint, which does not run it, the same tree failed.
+            # A shebang is the property ("this file is a script"); the
+            # extension was a proxy for it.
+            path = os.path.join(dp, name)
             if not name.endswith((".sh", ".mjs", ".js", ".vibe", ".vibex", ".pkl", ".ts", ".toml")):
-                continue
+                try:
+                    with open(path, "rb") as fh:
+                        if not fh.read(2) == b"#!":
+                            continue
+                except OSError:
+                    continue
             try:
-                body = open(os.path.join(dp, name), encoding="utf-8", errors="replace").read()
+                body = open(path, encoding="utf-8", errors="replace").read()
             except OSError:
                 continue
             # Drop WHOLE-LINE comments before harvesting names. A comment does

--- a/scripts/check_portable_boundary.sh
+++ b/scripts/check_portable_boundary.sh
@@ -86,6 +86,36 @@ forbid_foreign_effect_rows() { # <file> <label>
   fi
 }
 
+# The effect row is not the only way to reach a capability. `allows` grants
+# capability AUTHORITY in the signature, separately from the row (ADR-0075/0084,
+# #1961), and the granted operation is then called plainly -- not through
+# `perform`:
+#
+#   fn main() -> String with () allows Fs::read_file { Fs::read_file("x") }
+#
+# so it matched neither the row allow-list nor `perform (Fs|...)::`, and the
+# gate exited 0. Measured on preprocess_compile.vibe before this check.
+#
+# Neither pure boundary uses `allows` at all, so the allowed set here is empty:
+# any capability authority is a leak by definition on a boundary whose contract
+# is "stays in-memory". A capability name is CamelCase, which is what separates
+# a real clause from English prose ("allows them to ..."); comment lines are
+# stripped first regardless.
+forbid_capability_authority() { # <file> <label>
+  local file="$1" label="$2"
+  if grep -vE '^[[:space:]]*(///?|//#)' "$ROOT_DIR/$file" \
+    | grep -nE '\ballows +[A-Z]' >/tmp/vibe_portable_authority_hits.$$; then
+    echo "selfhost-portable-boundary: capability authority granted in $label ($file)" >&2
+    sed 's/^/  /' /tmp/vibe_portable_authority_hits.$$ >&2
+    rm -f /tmp/vibe_portable_authority_hits.$$
+    echo '  An `allows` clause hands this boundary host authority, which is' >&2
+    echo "  what it must not have. Move the capability to a caller that is" >&2
+    echo "  allowed to hold it and pass the result in." >&2
+    exit 1
+  fi
+  rm -f /tmp/vibe_portable_authority_hits.$$
+}
+
 # The boundary is declared in the package CONTRACT (`index.vpkg`, ADR-0070),
 # not in an `index.vibe` facade -- and its effect row is spelled `with
 # Exception`, not `with { Error }` (ADR-0085). This gate asserted the older
@@ -137,6 +167,13 @@ forbid_foreign_effect_rows \
   "lib/@vibe/compiler/entry/source_compile/source_compile.vibe" \
   "source compile API"
 forbid_foreign_effect_rows \
+  "lib/@vibe/compiler/entry/source_compile/wasi_only/preprocess_compile.vibe" \
+  "wasi source compile API"
+
+forbid_capability_authority \
+  "lib/@vibe/compiler/entry/source_compile/source_compile.vibe" \
+  "source compile API"
+forbid_capability_authority \
   "lib/@vibe/compiler/entry/source_compile/wasi_only/preprocess_compile.vibe" \
   "wasi source compile API"
 

--- a/scripts/check_portable_boundary.sh
+++ b/scripts/check_portable_boundary.sh
@@ -52,10 +52,14 @@ strip_handler_arm_heads() {
       if (c ~ /[A-Za-z_]/ && (i == 1 || substr(s, i - 1, 1) !~ /[A-Za-z0-9_]/)) {
         j = i
         while (j <= n && substr(s, j, 1) ~ /[A-Za-z0-9_]/) { j++ }
-        if (substr(s, j, 2) == "::") {
-          k = j + 2
+        jj = j
+        while (jj <= n && substr(s, jj, 1) == " ") { jj++ }
+        if (substr(s, jj, 2) == "::") {
+          k = jj + 2
+          while (k <= n && substr(s, k, 1) == " ") { k++ }
+          ks = k
           while (k <= n && substr(s, k, 1) ~ /[A-Za-z0-9_]/) { k++ }
-          if (k > j + 2) {
+          if (k > ks) {
             m = k
             while (m <= n && substr(s, m, 1) == " ") { m++ }
             if (substr(s, m, 1) == "(") {
@@ -93,15 +97,17 @@ forbid_pattern() {
   # It used to drop only whole comment LINES, so an inert diagnostic such as
   # "do not generate perform Fs::read_file here" was reported as a leak, which
   # is a required gate rejecting an ordinary message.
-  # Checked on BOTH views. The line-preserving one gives line numbers for the
-  # report; the flattened one catches a separator that spans lines, which a
-  # line-oriented grep cannot see (`perform` and `Fs::ReadFile` on two lines
-  # compiles). Either matching is a failure -- reporting is best-effort, the
-  # verdict is not.
+  # The VERDICT comes from the flattened view alone; the line-preserving one is
+  # read only to cite a line. Both used to decide, and that was wrong in one
+  # direction: the flattened text is the line text with newlines turned into
+  # spaces, so anything a line-oriented grep can match it matches too -- but
+  # not the reverse. A handler arm head written across lines is stripped in the
+  # flat view and not in the per-line one, and the per-line leftovers were
+  # rejecting a pure helper. One authoritative view, one answer.
   boundary_scan_lines "$file" | strip_handler_arm_heads | grep -En "$pattern" >/tmp/vibe_portable_boundary_hits.$$ || true
   flat_hit=0
   if boundary_scan_text "$file" | strip_handler_arm_heads | grep -Eq "$pattern"; then flat_hit=1; fi
-  if [ -s /tmp/vibe_portable_boundary_hits.$$ ] || [ "$flat_hit" -eq 1 ]; then
+  if [ "$flat_hit" -eq 1 ]; then
     if [ -s /tmp/vibe_portable_boundary_hits.$$ ]; then
       cat /tmp/vibe_portable_boundary_hits.$$ >&2
     else
@@ -116,8 +122,19 @@ forbid_pattern() {
 # Separators are `[[:space:]]+`, not one literal space. `perform  Fs::ReadFile`
 # with two spaces, or a tab or newline after `perform`, all compile and all
 # bypassed a pattern that matched exactly one space.
-native_effect_pattern='with[[:space:]]*\{[^}]*(Fs|Process|Socket|Net)|perform[[:space:]]+(Fs|Process|Socket|Http)::|\b(compile_file_fs|session-http|daemon)\b'
+native_effect_pattern='with[[:space:]]*\{[^}]*(Fs|Process|Socket|Net)|perform[[:space:]]+(Fs|Process|Socket|Http)[[:space:]]*::|\b(compile_file_fs|daemon)\b'
 
+# `session-http` was dropped from the lane list. Strings and comments are
+# removed before this runs, so in the remaining text that spelling can only be
+# the subtraction `session - http` -- it is not one vibe identifier, and a
+# helper returning it was rejected as a lane leak. A pattern that can only ever
+# match something else is not a weaker check, it is a wrong one.
+#
+# Whitespace is allowed around `::`. The lexer permits it, so `Console ::
+# write_stream(...)` is the same call, and requiring adjacency left the entry
+# file -- where this pattern is the only check for a plain capability call --
+# open to it.
+#
 # The three lane names are anchored to token boundaries. Unanchored, `daemon`
 # matched inside `daemonless_probe` and `compile_file_fs` inside
 # `compile_file_fsx_probe`, so an ordinary helper whose name merely CONTAINS a
@@ -738,7 +755,7 @@ require_line \
 # IO and says so, carrying `with Exception + Fs` / `with Fs`. Its contract is
 # exactly that row, so a call inside it is declared and the others are not. It
 # makes exactly one capability call today, `Fs::stat_token`.
-entry_native_pattern="$native_effect_pattern"'|(Console|Env|Process|Socket|Http|Net)::'
+entry_native_pattern="$native_effect_pattern"'|(Console|Env|Process|Socket|Http|Net)[[:space:]]*::'
 forbid_pattern \
   "lib/@vibe/compiler/cli_direct_component_entry.vibe" \
   "$entry_native_pattern" \

--- a/scripts/check_portable_boundary.sh
+++ b/scripts/check_portable_boundary.sh
@@ -789,7 +789,40 @@ require_line \
 # IO and says so, carrying `with Exception + Fs` / `with Fs`. Its contract is
 # exactly that row, so a call inside it is declared and the others are not. It
 # makes exactly one capability call today, `Fs::stat_token`.
-entry_native_pattern="$native_effect_pattern"'|(Console|Env|Process|Socket|Http|Net)[[:space:]]*::'
+# The capability names are READ FROM THE COMPILER, not restated here. The
+# hand-written list said Console|Env|Process|Socket|Http|Net, and the real one
+# (capability_effect_name_list in lib/@vibe/parser/parser_base.vibe) has ten:
+# it also has Stdin, Stdout, Stderr and Profiler, which the entry file could
+# therefore use unseen, and it does NOT have Net. Enumerating a list that lives
+# somewhere else is the structure that produces that drift; reading it removes
+# the class rather than the four names.
+#
+# `Fs` is dropped from the derived list for this file alone: this entry does
+# file IO and declares it (`with Exception + Fs`), so banning it would be the
+# false positive the row allow-list was switched off to avoid.
+#
+# Fails closed. If the list cannot be read -- the file moved, the shape
+# changed -- the gate stops rather than checking against nothing, because an
+# empty alternation would match nothing and print ok.
+# Every stage is guarded with `|| true` so the reader cannot die under `set -e`
+# before the check below runs. Exiting 1 with no message would be fail-closed
+# and SILENT, and silence is indistinguishable from unchecked -- the message is
+# the part that tells the next person what to repair.
+entry_capabilities="$(
+  { awk '/^let capability_effect_name_list/,/^\]/' \
+      "$ROOT_DIR/lib/@vibe/parser/parser_base.vibe" 2>/dev/null || true; } \
+  | { grep -oE '"[A-Za-z_][A-Za-z0-9_]*"' || true; } | tr -d '"' \
+  | { grep -vx Fs || true; } | paste -sd'|' -
+)"
+entry_capability_count="$(printf '%s' "$entry_capabilities" | tr '|' '\n' | { grep -c . || true; })"
+if [ "$entry_capability_count" -lt 5 ]; then
+  echo "selfhost-portable-boundary: cannot read capability_effect_name_list from" >&2
+  echo "  lib/@vibe/parser/parser_base.vibe -- the gate would check the entry file" >&2
+  echo "  against an empty capability list and pass everything. Fix the reader in" >&2
+  echo "  scripts/check_portable_boundary.sh rather than removing this guard." >&2
+  exit 1
+fi
+entry_native_pattern="$native_effect_pattern|($entry_capabilities)[[:space:]]*::"
 forbid_pattern \
   "lib/@vibe/compiler/cli_direct_component_entry.vibe" \
   "$entry_native_pattern" \

--- a/scripts/check_portable_boundary.sh
+++ b/scripts/check_portable_boundary.sh
@@ -76,19 +76,26 @@ PORTABLE_ALLOWED_EFFECTS='Exception|Async'
 #     Fs { ... }
 forbid_foreign_effect_rows() { # <file> <label>
   local file="$1" label="$2" bad
-  # An effect item may carry type arguments -- `parse_effect_item`
-  # (lib/@vibe/parser/parser_base.vibe) accepts `Exception[String] + Fs`, and it
-  # compiles. Matching bare identifiers stopped at the `[`, recorded the allowed
-  # `Exception`, and never saw the `Fs`. The argument is dropped BEFORE the row
-  # is split on `+`, so an argument that itself contains `+` cannot fragment
-  # into pieces that match nothing and read as leaks.
+  # This deliberately does NOT model the row grammar. Six review rounds went
+  # into a regex that tried to, and each round found another form it did not
+  # know: a row split after `+`, an item with type arguments
+  # (`Exception[String] + Fs`), a qualified item (`Exception::Throw + Fs`).
+  # Every patch was correct and none of them made the next one less likely,
+  # because enumerating a grammar in a regex is the proxy -- the property is
+  # "no capability name appears in this boundary's effect row".
+  #
+  # So: take the whole span from `with` to the start of the body, drop type
+  # arguments and the `::op` suffix of a qualified item, and check EVERY
+  # capability name in it. Separators are irrelevant -- `+`, newlines, or a
+  # syntax `parse_effect_item` grows next week -- because nothing about the
+  # row's shape is assumed. A name is either allow-listed or it is a leak.
   bad="$(sed 's://.*::' "$ROOT_DIR/$file" \
     | tr '\n' ' ' \
-    | grep -oE 'with +[A-Z][A-Za-z0-9_]*(\[[^]]*\])?( *\+ *[A-Z][A-Za-z0-9_]*(\[[^]]*\])?)*' \
+    | grep -oE 'with +[^{;]*' \
     | sed 's/^with  *//' \
     | sed 's/\[[^]]*\]//g' \
-    | tr '+' '\n' \
-    | sed 's/^[[:space:]]*//; s/[[:space:]]*$//' \
+    | sed 's/::[A-Za-z0-9_]*//g' \
+    | grep -oE '[A-Z][A-Za-z0-9_]*' \
     | grep -vE "^($PORTABLE_ALLOWED_EFFECTS)$" \
     | sort -u)" || true
   if [ -n "$bad" ]; then
@@ -199,17 +206,23 @@ forbid_pattern \
 # at lines 304/322, so an allow-list there would fail the gate on correct code.
 # It keeps forbid_pattern above, which bans the direct `perform Fs::` and the
 # FS compile lane rather than the row.
-forbid_foreign_effect_rows \
+# Authority first, then the row. The row span now runs from `with` to the body,
+# so it also covers the capability named in an `allows` clause -- harmless as
+# defence in depth, but it would report the generic "non-portable effect row"
+# for a declaration whose actual problem is an authority grant. The specific
+# diagnostic has to win, and the self-test asserts the message names `allows`,
+# which is what caught this ordering.
+forbid_capability_authority \
   "lib/@vibe/compiler/entry/source_compile/source_compile.vibe" \
   "source compile API"
-forbid_foreign_effect_rows \
+forbid_capability_authority \
   "lib/@vibe/compiler/entry/source_compile/wasi_only/preprocess_compile.vibe" \
   "wasi source compile API"
 
-forbid_capability_authority \
+forbid_foreign_effect_rows \
   "lib/@vibe/compiler/entry/source_compile/source_compile.vibe" \
   "source compile API"
-forbid_capability_authority \
+forbid_foreign_effect_rows \
   "lib/@vibe/compiler/entry/source_compile/wasi_only/preprocess_compile.vibe" \
   "wasi source compile API"
 

--- a/scripts/check_portable_boundary.sh
+++ b/scripts/check_portable_boundary.sh
@@ -197,7 +197,15 @@ boundary_scan_lines() { # <file>
             # effect really called `where` is rejected either way -- it is
             # simply not `Exception` or `Async`. The suffix keeps the name
             # readable in the diagnostic instead of dropping it.
-            if (nm == "fn" || nm == "let" || nm == "type" || nm == "with" \
+            # `r#fn` is the ONE raw spelling that is still the keyword:
+            # lex_ident returns TFn for it (lexer.vibe, #1280 -- a binding
+            # named fn cannot be smuggled back in through r#). Suffixing it
+            # like the others cost the `fn ` reset, so a preceding type alias
+            # kept decl = "type" and the functions native row was suppressed.
+            # It is emitted as the keyword because that is what it IS.
+            if (nm == "fn") {
+              out = out "fn"
+            } else if (nm == "let" || nm == "type" || nm == "with" \
                 || nm == "where" || nm == "allows" || nm == "perform") {
               out = out nm "_"
             } else {

--- a/scripts/check_portable_boundary.sh
+++ b/scripts/check_portable_boundary.sh
@@ -64,6 +64,30 @@ native_effect_pattern='with \{[^}]*(Fs|Process|Socket|Net)|perform (Fs|Process|S
 # this list is a deliberate act; that is the property being enforced.
 PORTABLE_ALLOWED_EFFECTS='Exception|Async'
 
+# The normalized view both boundary scanners read: string literals removed,
+# comments removed to end of line, newlines flattened.
+#
+# ONE function on purpose. The row scan and the authority scan ask the same
+# question of the same files, and when they each did their own normalization
+# they drifted: a fix for a capability split across lines went into one and not
+# the other, and the gap it left was a real bypass.
+#
+# Strings go first. A comment may contain a quote, but stripping it only eats
+# the rest of a line that is already a comment; stripping comments first would
+# truncate a string containing `//` (a URL). Neither scanned file has either
+# today -- this is about which order stays correct when one appears.
+#
+# Why strings must be removed at all: the row scan reads the whole span from
+# `with` to the body, so an inert message like "compile with Fs when requested"
+# was captured and reported as `effect: Fs`. A required gate that fails on
+# correct code is one that gets disabled (#2252), so a false positive here is
+# not the safe direction -- it is a different way to lose the gate.
+boundary_scan_text() { # <file>
+  sed 's/"[^"]*"//g' "$ROOT_DIR/$1" \
+    | sed 's://.*::' \
+    | tr '\n' ' '
+}
+
 # Reject any effect row on a pure boundary that names something outside the
 # allow-list. Comment lines are stripped first, as in forbid_pattern.
 #
@@ -89,8 +113,7 @@ forbid_foreign_effect_rows() { # <file> <label>
   # capability name in it. Separators are irrelevant -- `+`, newlines, or a
   # syntax `parse_effect_item` grows next week -- because nothing about the
   # row's shape is assumed. A name is either allow-listed or it is a leak.
-  bad="$(sed 's://.*::' "$ROOT_DIR/$file" \
-    | tr '\n' ' ' \
+  bad="$(boundary_scan_text "$file" \
     | grep -oE 'with +[^{;]*' \
     | sed 's/^with  *//' \
     | sed 's/\[[^]]*\]//g' \
@@ -141,8 +164,7 @@ forbid_foreign_effect_rows() { # <file> <label>
 # (`expected an effect name in the effect row after 'with'`).
 forbid_capability_authority() { # <file> <label>
   local file="$1" label="$2"
-  if sed 's://.*::' "$ROOT_DIR/$file" \
-    | tr '\n' ' ' \
+  if boundary_scan_text "$file" \
     | grep -oE '\ballows +[A-Z][A-Za-z0-9_:]*' >/tmp/vibe_portable_authority_hits.$$; then
     echo "selfhost-portable-boundary: capability authority granted in $label ($file)" >&2
     sed 's/^/  granted: /' /tmp/vibe_portable_authority_hits.$$ >&2

--- a/scripts/check_portable_boundary.sh
+++ b/scripts/check_portable_boundary.sh
@@ -101,13 +101,33 @@ forbid_foreign_effect_rows() { # <file> <label>
 # is "stays in-memory". A capability name is CamelCase, which is what separates
 # a real clause from English prose ("allows them to ..."); comment lines are
 # stripped first regardless.
+#
+# The capability need not be adjacent to the keyword. Both of these compile
+# (measured on a stage2 built from this checkout, `vibe test`):
+#
+#   fn probe() -> String with Exception allows
+#     Fs::read_file { ... }              # newline
+#   fn probe() -> String with Exception allows // note
+#     Fs::read_file { ... }              # trailing comment, then newline
+#
+# so requiring adjacency on one line missed both. Comments are removed to end
+# of line and the file is flattened to a single line before matching, which
+# makes the check insensitive to whitespace and to anything commented out
+# between the keyword and the capability. `/* ... */` needs no handling: vibe
+# has no block comments, and that spelling does not parse at all
+# (`expected an effect name in the effect row after 'with'`).
 forbid_capability_authority() { # <file> <label>
   local file="$1" label="$2"
-  if grep -vE '^[[:space:]]*(///?|//#)' "$ROOT_DIR/$file" \
-    | grep -nE '\ballows +[A-Z]' >/tmp/vibe_portable_authority_hits.$$; then
+  if sed 's://.*::' "$ROOT_DIR/$file" \
+    | tr '\n' ' ' \
+    | grep -oE '\ballows +[A-Z][A-Za-z0-9_:]*' >/tmp/vibe_portable_authority_hits.$$; then
     echo "selfhost-portable-boundary: capability authority granted in $label ($file)" >&2
-    sed 's/^/  /' /tmp/vibe_portable_authority_hits.$$ >&2
+    sed 's/^/  granted: /' /tmp/vibe_portable_authority_hits.$$ >&2
     rm -f /tmp/vibe_portable_authority_hits.$$
+    # Matching happens on the flattened file, so the match itself carries no
+    # position. Point at every line holding the keyword, which is where the
+    # edit goes.
+    grep -nE '\ballows\b' "$ROOT_DIR/$file" | sed 's/^/  at /' >&2 || true
     echo '  An `allows` clause hands this boundary host authority, which is' >&2
     echo "  what it must not have. Move the capability to a caller that is" >&2
     echo "  allowed to hold it and pass the result in." >&2

--- a/scripts/check_portable_boundary.sh
+++ b/scripts/check_portable_boundary.sh
@@ -614,6 +614,26 @@ boundary_effect_rows() { # reads normalized text on stdin
     #
     # Counting rows against a fixed threshold instead got the last of those
     # wrong: two rows does not mean one of them is the declarations.
+    #
+    # `type` is the ONLY suppressed keyword, and `let` deliberately is not.
+    # Round 52 asked for `let stored = (p: String) -> Int with Fs {
+    # Fs::stat_token(p) }` to be skipped too, on the argument that storing an
+    # effectful function is pure -- the distinction already made for aliases
+    # and for returned closure types. That is right about the type system and
+    # wrong about this gate: the subject here is the emitted wasm, so the
+    # question is what each shape IMPORTS. Measured, each as a whole program
+    # whose closure is never called, grepping the module for `fs_stat_token`:
+    #
+    #   type Cb = (String) -> Int with Fs                              absent
+    #   fn make(g: (String) -> Int with Fs) -> (String) -> Int ... {g} absent
+    #   let stored: (String) -> Int with Fs = g     (annotation only)  absent
+    #   let stored = (p: String) -> Int with Fs { Fs::stat_token(p) }  PRESENT
+    #
+    # The first three are type positions with no code behind them. A closure
+    # LITERAL is a body that gets emitted, and its host import lands in the
+    # module whether or not anything invokes it -- so "any caller must declare
+    # its own row" is true and not sufficient. Pinned by the last two cases in
+    # scripts/check_portable_boundary_test.sh.
     if (decl != "type") {
       # Which layer, if any, is the declarations own? Rows are absorbed by the
       # returned function types first, so the declaration owns the LAST row

--- a/scripts/check_portable_boundary.sh
+++ b/scripts/check_portable_boundary.sh
@@ -182,6 +182,17 @@ boundary_scan_lines() { # <file>
           prev = (i > 1) ? substr(line, i - 1, 1) : " "
           if (prev !~ /[A-Za-z0-9_]/) { i += 2; continue }
         }
+        # `perform?` is a DIFFERENT token from `perform` (ADR-0088; the parser
+        # builds EIdent("perform?") at parser_expr_primary.vibe:803), but it
+        # invokes the same capability, so it is the same thing to this gate.
+        # The native-call pattern spelled only `perform`, so `perform?
+        # Fs::read_file(path)` passed the required check outright. Normalizing
+        # the suffix here, rather than adding `\\??` to one regex, is what
+        # keeps the next consumer of this text from having to know that two
+        # spellings exist -- the same reason the raw-identifier prefix is
+        # dropped above.
+        if (c == "?" && i > 7 && substr(line, i - 7, 7) == "perform" \
+            && substr(line, i - 8, 1) !~ /[A-Za-z0-9_]/) { i++; continue }
         if (c == "\"") { sp++; mode[sp] = "str"; i++; continue }
         if (c == "#" && substr(line, i + 1, 1) == "|") { break }   # raw string to EOL
         if (c == "/" && substr(line, i + 1, 1) == "/") { break }   # comment to EOL

--- a/scripts/check_portable_boundary.sh
+++ b/scripts/check_portable_boundary.sh
@@ -47,17 +47,44 @@ native_effect_pattern='with \{[^}]*(Fs|Process|Socket|Net)|perform (Fs|Process|S
 # construct from an effect row. An effect ROW is unbraced and `+`-separated:
 # `with Fs`, `with Exception + Fs`, `with Exception + Fs + Env`. Nothing
 # matched that, so a boundary implementation could declare `with Fs` outright
-# and this gate printed `ok` -- measured, not inferred: appending
-# `export fn probe_native() -> Unit with Fs` to preprocess_compile.vibe passed.
+# and this gate printed `ok` -- measured, not inferred.
 #
-# Scoped to the two source_compile boundaries deliberately. Their contract is
-# "stays in-memory", so a native row there is the leak. The third scanned file,
-# cli_direct_component_entry.vibe, is the entry that DOES file IO and carries
-# `with Exception + Fs` / `with Fs` legitimately; banning the row there would
-# fail the gate on correct code. It keeps the pattern above, which forbids the
-# direct `perform Fs::` and the FS compile lane rather than the row.
-native_effect_row='with +([A-Za-z_][A-Za-z0-9_]* *\+ *)*(Fs|Process|Socket|Net|Http)\b'
-pure_boundary_pattern="$native_effect_pattern|$native_effect_row"
+# The row check below is an ALLOW-LIST, and that is the point. A deny-list of
+# capability names is a proxy for "is this effect native", and it failed twice
+# in a row: first it knew only the braced spelling (`with Fs` passed), then,
+# rewritten as `Fs|Process|Socket|Net|Http`, it still passed `with Env` and
+# `with Console` -- both capability builtins (AGENTS.md). Each fix closed the
+# hole someone happened to look at. Enumerating what these boundaries MAY carry
+# cannot silently miss a capability that does not exist yet: a new effect is
+# rejected until someone decides it belongs, which is the safe direction.
+#
+# Exception is what the contract requires. Async is admitted because it is
+# already used here (2 rows in preprocess_compile.vibe) and grants no host
+# access by itself -- it is a scheduling effect, not a capability. Adding to
+# this list is a deliberate act; that is the property being enforced.
+PORTABLE_ALLOWED_EFFECTS='Exception|Async'
+
+# Reject any effect row on a pure boundary that names something outside the
+# allow-list. Comment lines are stripped first, as in forbid_pattern.
+forbid_foreign_effect_rows() { # <file> <label>
+  local file="$1" label="$2" bad
+  bad="$(grep -vE '^[[:space:]]*(///?|//#)' "$ROOT_DIR/$file" \
+    | grep -oE 'with +[A-Z][A-Za-z0-9_]*( *\+ *[A-Z][A-Za-z0-9_]*)*' \
+    | sed 's/^with  *//' \
+    | tr '+' '\n' \
+    | sed 's/^[[:space:]]*//; s/[[:space:]]*$//' \
+    | grep -vE "^($PORTABLE_ALLOWED_EFFECTS)$" \
+    | sort -u)" || true
+  if [ -n "$bad" ]; then
+    echo "selfhost-portable-boundary: non-portable effect row in $label ($file)" >&2
+    echo "$bad" | sed 's/^/  effect: /' >&2
+    echo "  This boundary must stay in-memory. Drop the effect, or move the" >&2
+    echo "  work behind a caller that already carries it. If the effect is" >&2
+    echo "  genuinely portable, add it to PORTABLE_ALLOWED_EFFECTS with a" >&2
+    echo "  reason -- deliberately, not to make this message go away." >&2
+    exit 1
+  fi
+}
 
 # The boundary is declared in the package CONTRACT (`index.vpkg`, ADR-0070),
 # not in an `index.vibe` facade -- and its effect row is spelled `with
@@ -93,11 +120,24 @@ forbid_pattern \
   "direct component entry"
 forbid_pattern \
   "lib/@vibe/compiler/entry/source_compile/source_compile.vibe" \
-  "$pure_boundary_pattern" \
+  "$native_effect_pattern" \
   "source compile API"
 forbid_pattern \
   "lib/@vibe/compiler/entry/source_compile/wasi_only/preprocess_compile.vibe" \
-  "$pure_boundary_pattern" \
+  "$native_effect_pattern" \
+  "wasi source compile API"
+
+# The row allow-list, on the two boundaries whose contract is "stays
+# in-memory". Not applied to cli_direct_component_entry.vibe: that is the entry
+# that DOES file IO and carries `with Exception + Fs` / `with Fs` legitimately
+# at lines 304/322, so an allow-list there would fail the gate on correct code.
+# It keeps forbid_pattern above, which bans the direct `perform Fs::` and the
+# FS compile lane rather than the row.
+forbid_foreign_effect_rows \
+  "lib/@vibe/compiler/entry/source_compile/source_compile.vibe" \
+  "source compile API"
+forbid_foreign_effect_rows \
+  "lib/@vibe/compiler/entry/source_compile/wasi_only/preprocess_compile.vibe" \
   "wasi source compile API"
 
 echo "selfhost portable boundary: ok"

--- a/scripts/check_portable_boundary.sh
+++ b/scripts/check_portable_boundary.sh
@@ -36,16 +36,30 @@ forbid_pattern() {
   # It used to drop only whole comment LINES, so an inert diagnostic such as
   # "do not generate perform Fs::read_file here" was reported as a leak, which
   # is a required gate rejecting an ordinary message.
-  if boundary_scan_lines "$file" \
-    | grep -En "$pattern" >/tmp/vibe_portable_boundary_hits.$$; then
-    cat /tmp/vibe_portable_boundary_hits.$$ >&2
+  # Checked on BOTH views. The line-preserving one gives line numbers for the
+  # report; the flattened one catches a separator that spans lines, which a
+  # line-oriented grep cannot see (`perform` and `Fs::ReadFile` on two lines
+  # compiles). Either matching is a failure -- reporting is best-effort, the
+  # verdict is not.
+  boundary_scan_lines "$file" | grep -En "$pattern" >/tmp/vibe_portable_boundary_hits.$$ || true
+  flat_hit=0
+  if boundary_scan_text "$file" | grep -Eq "$pattern"; then flat_hit=1; fi
+  if [ -s /tmp/vibe_portable_boundary_hits.$$ ] || [ "$flat_hit" -eq 1 ]; then
+    if [ -s /tmp/vibe_portable_boundary_hits.$$ ]; then
+      cat /tmp/vibe_portable_boundary_hits.$$ >&2
+    else
+      echo "  (match spans lines; no single line to cite)" >&2
+    fi
     rm -f /tmp/vibe_portable_boundary_hits.$$
     fail "native capability leaked into portable boundary: $label ($file)"
   fi
   rm -f /tmp/vibe_portable_boundary_hits.$$
 }
 
-native_effect_pattern='with \{[^}]*(Fs|Process|Socket|Net)|perform (Fs|Process|Socket|Http)::|compile_file_fs|session-http|daemon'
+# Separators are `[[:space:]]+`, not one literal space. `perform  Fs::ReadFile`
+# with two spaces, or a tab or newline after `perform`, all compile and all
+# bypassed a pattern that matched exactly one space.
+native_effect_pattern='with[[:space:]]*\{[^}]*(Fs|Process|Socket|Net)|perform[[:space:]]+(Fs|Process|Socket|Http)::|compile_file_fs|session-http|daemon'
 
 # The `with \{...\}` alternative above matches the HANDLER syntax
 # (`try ... with { Exception::Throw(e) => ... }`), which is a different

--- a/scripts/check_portable_boundary.sh
+++ b/scripts/check_portable_boundary.sh
@@ -168,6 +168,20 @@ boundary_scan_lines() { # <file>
             continue
           }
         }
+        # A RAW IDENTIFIER is the same name. `lex_ident` in
+        # lib/@vibe/parser/lexer.vibe turns `r#Exception` into
+        # TIdent("Exception") -- the exact token the plain spelling gives -- so
+        # the two are one name to the compiler and must be one name here.
+        # Splitting the source text instead produced `r` AND `Exception`, which
+        # rejected a portable boundary as `effect: r`, and in the other
+        # direction `perform r#Fs::ReadFile(p)` matched no native pattern at
+        # all and passed. Dropping the prefix once, in the lexical pass, is
+        # what makes every check downstream see what the compiler sees.
+        # `r` must be the whole identifier, as in the raw-string branch above.
+        if (c == "r" && substr(line, i + 1, 1) == "#" && substr(line, i + 2, 1) ~ /[A-Za-z0-9_]/) {
+          prev = (i > 1) ? substr(line, i - 1, 1) : " "
+          if (prev !~ /[A-Za-z0-9_]/) { i += 2; continue }
+        }
         if (c == "\"") { sp++; mode[sp] = "str"; i++; continue }
         if (c == "#" && substr(line, i + 1, 1) == "|") { break }   # raw string to EOL
         if (c == "/" && substr(line, i + 1, 1) == "/") { break }   # comment to EOL

--- a/scripts/check_portable_boundary.sh
+++ b/scripts/check_portable_boundary.sh
@@ -265,17 +265,23 @@ boundary_scan_text() { # <file>
 # one of them is recoverable.
 boundary_effect_rows() { # reads normalized text on stdin
   awk '{
-    s = $0; n = length(s); depth = 0; brace = 0; arrows = 0; rown = 0; i = 1
+    s = $0; n = length(s); depth = 0; brack = 0; brace = 0; arrows = 0; rown = 0; i = 1
     while (i <= n) {
       c = substr(s, i, 1)
       if (c == "(") { depth++; i++; continue }
       if (c == ")") { if (depth > 0) depth--; i++; continue }
-      if (depth == 0 && brace == 0 && substr(s, i, 3) == "fn ") {
+      # Brackets nest like parens. `-> Array[() -> Unit] with Fs` has an arrow
+      # INSIDE the type argument; counting it made arrows 2 against 1 row, so
+      # the row was written off as the returned closures and a native boundary
+      # passed. A type argument is not a return-type layer.
+      if (c == "[") { brack++; i++; continue }
+      if (c == "]") { if (brack > 0) brack--; i++; continue }
+      if (depth == 0 && brack == 0 && brace == 0 && substr(s, i, 3) == "fn ") {
         prev = (i > 1) ? substr(s, i - 1, 1) : " "
         if (prev !~ /[A-Za-z0-9_]/) { arrows = 0; rown = 0 }
         i += 3; continue
       }
-      if (c == "-" && substr(s, i + 1, 1) == ">" && depth == 0 && brace == 0) {
+      if (c == "-" && substr(s, i + 1, 1) == ">" && depth == 0 && brack == 0 && brace == 0) {
         arrows++; i++; continue
       }
       if (c == "{") {
@@ -283,8 +289,8 @@ boundary_effect_rows() { # reads normalized text on stdin
         brace++; i++; continue
       }
       if (c == "}") { if (brace > 0) brace--; i++; continue }
-      if (c == ";" && depth == 0 && brace == 0) { flush(); arrows = 0; rown = 0; i++; continue }
-      if (depth == 0 && brace == 0 && substr(s, i, 5) == "with ") {
+      if (c == ";" && depth == 0 && brack == 0 && brace == 0) { flush(); arrows = 0; rown = 0; i++; continue }
+      if (depth == 0 && brack == 0 && brace == 0 && substr(s, i, 5) == "with ") {
         prev = (i > 1) ? substr(s, i - 1, 1) : " "
         if (prev ~ /[A-Za-z0-9_]/) { i++; continue }
         j = i + 5; row = ""; d2 = 0

--- a/scripts/check_portable_boundary.sh
+++ b/scripts/check_portable_boundary.sh
@@ -126,9 +126,14 @@ PORTABLE_ALLOWED_EFFECTS='Exception|Async'
 # matters: the grammar attempts kept missing forms nobody had enumerated, while
 # string nesting is closed by construction here.
 boundary_scan_lines() { # <file>
-  awk '{
+  awk 'BEGIN { sp = 0; mode[0] = "code"; bdepth[0] = 0 }
+  {
     line = $0; n = length(line); out = ""
-    sp = 0; mode[0] = "code"; bdepth[0] = 0
+    # State is initialized ONCE, not per line: a string literal may span
+    # physical lines (measured -- it compiles), so resetting to code mode at
+    # each record scanned the continuation as executable and reported inert
+    # text as a leak. Comments and raw strings still end at EOL, which the
+    # `break` below gives for free without carrying any state.
     i = 1
     while (i <= n) {
       c = substr(line, i, 1)

--- a/scripts/check_portable_boundary.sh
+++ b/scripts/check_portable_boundary.sh
@@ -180,7 +180,31 @@ boundary_scan_lines() { # <file>
         # `r` must be the whole identifier, as in the raw-string branch above.
         if (c == "r" && substr(line, i + 1, 1) == "#" && substr(line, i + 2, 1) ~ /[A-Za-z0-9_]/) {
           prev = (i > 1) ? substr(line, i - 1, 1) : " "
-          if (prev !~ /[A-Za-z0-9_]/) { i += 2; continue }
+          if (prev !~ /[A-Za-z0-9_]/) {
+            j = i + 2; nm = ""
+            while (j <= n && substr(line, j, 1) ~ /[A-Za-z0-9_]/) { nm = nm substr(line, j, 1); j++ }
+            # The WHOLE POINT of `r#` is that the name is a name and not the
+            # keyword it is spelled like, so emitting it bare hands the
+            # scanner its own syntax: `with Exception + r#where + Fs` became
+            # `... where ...`, the row stopped at the contract terminator, and
+            # the native Fs after it was never read. An underscore is appended
+            # to exactly the keywords the passes below react to. Every one of
+            # them requires a following space, so the suffix defeats the match
+            # while leaving an ordinary identifier behind.
+            #
+            # Nothing is lost by not restoring the true name: none of these
+            # keywords is an allow-listed effect or a native capability, so an
+            # effect really called `where` is rejected either way -- it is
+            # simply not `Exception` or `Async`. The suffix keeps the name
+            # readable in the diagnostic instead of dropping it.
+            if (nm == "fn" || nm == "let" || nm == "type" || nm == "with" \
+                || nm == "where" || nm == "allows" || nm == "perform") {
+              out = out nm "_"
+            } else {
+              out = out nm
+            }
+            i = j; continue
+          }
         }
         # `perform?` is a DIFFERENT token from `perform` (ADR-0088; the parser
         # builds EIdent("perform?") at parser_expr_primary.vibe:803), but it

--- a/scripts/check_portable_boundary.sh
+++ b/scripts/check_portable_boundary.sh
@@ -39,9 +39,50 @@ require_line() {
 # result cannot be a pattern -- and the arm BODY is left untouched, so a real
 # capability call inside one is still a leak.
 strip_handler_arm_heads() {
-  sed -E \
-    -e 's/[A-Za-z_][A-Za-z0-9_]*::[A-Za-z0-9_]*[[:space:]]*\([^)]*\)[[:space:]]*=>/ /g' \
-    -e 's/[A-Za-z_][A-Za-z0-9_]*::[A-Za-z0-9_]*[[:space:]]*=>/ /g'
+  # The argument list is BALANCED, not `[^)]*`. `Fs::ReadFile((_path)) =>` is a
+  # legal grouping -- parse_handle_arm delegates to the recursive pattern
+  # parser -- and a regex that stopped at the first `)` left the head in place,
+  # so a pure helper was rejected again. Parentheses are counted here rather
+  # than approximated, which holds at any depth instead of one more than the
+  # last counterexample.
+  awk '{
+    s = $0; n = length(s); out = ""; i = 1
+    while (i <= n) {
+      c = substr(s, i, 1)
+      if (c ~ /[A-Za-z_]/ && (i == 1 || substr(s, i - 1, 1) !~ /[A-Za-z0-9_]/)) {
+        j = i
+        while (j <= n && substr(s, j, 1) ~ /[A-Za-z0-9_]/) { j++ }
+        if (substr(s, j, 2) == "::") {
+          k = j + 2
+          while (k <= n && substr(s, k, 1) ~ /[A-Za-z0-9_]/) { k++ }
+          if (k > j + 2) {
+            m = k
+            while (m <= n && substr(s, m, 1) == " ") { m++ }
+            if (substr(s, m, 1) == "(") {
+              d = 0
+              while (m <= n) {
+                cc = substr(s, m, 1)
+                if (cc == "(") { d++ }
+                else if (cc == ")") { d--; if (d == 0) { m++; break } }
+                m++
+              }
+            }
+            while (m <= n && substr(s, m, 1) == " ") { m++ }
+            if (substr(s, m, 2) == "=>") {
+              # A handler arm head: the operation is DISCHARGED here, not
+              # called. Blank the head and leave the arrow, so the arm body
+              # after it is still scanned.
+              out = out " "
+              i = m; continue
+            }
+          }
+        }
+        out = out substr(s, i, j - i); i = j; continue
+      }
+      out = out c; i++
+    }
+    print out
+  }'
 }
 forbid_pattern() {
   local file="$1"

--- a/scripts/check_portable_boundary.sh
+++ b/scripts/check_portable_boundary.sh
@@ -59,8 +59,16 @@ forbid_pattern() {
 # Separators are `[[:space:]]+`, not one literal space. `perform  Fs::ReadFile`
 # with two spaces, or a tab or newline after `perform`, all compile and all
 # bypassed a pattern that matched exactly one space.
-native_effect_pattern='with[[:space:]]*\{[^}]*(Fs|Process|Socket|Net)|perform[[:space:]]+(Fs|Process|Socket|Http)::|compile_file_fs|session-http|daemon'
+native_effect_pattern='with[[:space:]]*\{[^}]*(Fs|Process|Socket|Net)|perform[[:space:]]+(Fs|Process|Socket|Http)::|\b(compile_file_fs|session-http|daemon)\b'
 
+# The three lane names are anchored to token boundaries. Unanchored, `daemon`
+# matched inside `daemonless_probe` and `compile_file_fs` inside
+# `compile_file_fsx_probe`, so an ordinary helper whose name merely CONTAINS a
+# forbidden lane failed the required job on correct code. A lane is a name, not
+# a substring. `\b` is a GNU extension that check_gate_portability admits, and
+# it is the boundary that matters here: `my_daemon_helper` keeps building
+# because an underscore is a word character.
+#
 # The `with \{...\}` alternative above matches the HANDLER syntax
 # (`try ... with { Exception::Throw(e) => ... }`), which is a different
 # construct from an effect row. An effect ROW is unbraced and `+`-separated:

--- a/scripts/check_portable_boundary.sh
+++ b/scripts/check_portable_boundary.sh
@@ -648,8 +648,9 @@ boundary_effect_rows() { # reads normalized text on stdin
 #
 #   fn probe() -> String with Exception +
 #     Fs { ... }
-forbid_foreign_effect_rows() { # <file> <label>
+forbid_foreign_effect_rows() { # <file> <label> [allow-list]
   local file="$1" label="$2" bad
+  local allowed="${3:-$PORTABLE_ALLOWED_EFFECTS}"
   # This deliberately does NOT model the row grammar. Six review rounds went
   # into a regex that tried to, and each round found another form it did not
   # know: a row split after `+`, an item with type arguments
@@ -682,7 +683,7 @@ forbid_foreign_effect_rows() { # <file> <label>
     | sed 's/\[[^]]*\]//g' \
     | sed -E 's/[[:space:]]*::[[:space:]]*[A-Za-z0-9_]*//g' \
     | grep -oE '[A-Za-z_][A-Za-z0-9_]*' \
-    | grep -vE "^($PORTABLE_ALLOWED_EFFECTS)$" \
+    | grep -vE "^($allowed)$" \
     | sort -u)" || true
   if [ -n "$bad" ]; then
     echo "selfhost-portable-boundary: non-portable effect row in $label ($file)" >&2
@@ -862,6 +863,27 @@ forbid_capability_authority \
 forbid_capability_authority \
   "lib/@vibe/compiler/entry/source_compile/wasi_only/preprocess_compile.vibe" \
   "wasi source compile API"
+
+# The entry file gets the row check too, with ITS contract as the allow-list.
+#
+# It was exempt because it legitimately carries `with Exception + Fs` / `with
+# Fs`, and a shared allow-list would have failed the gate on correct code. That
+# was the right call about the shared list and the wrong call about the check:
+# an allow-list of what this boundary IS entitled to costs nothing and closes
+# the one class no call pattern can -- an UNQUALIFIED capability builtin.
+# `println` has no namespace token to match, so no regex over the call reaches
+# it, but the checker requires `with Stdout` on the declaration, and the row is
+# a name the scanner can read. Measured: `fn f() -> Unit with Stdout {
+# println("leaked") }` passed every call pattern and is caught here.
+#
+# The three effects are what the file declares today: Exception, Fs (both
+# measured from its own rows), and Async for consistency with the shared list.
+# Widening this is a deliberate act, exactly like adding to
+# PORTABLE_ALLOWED_EFFECTS.
+forbid_foreign_effect_rows \
+  "lib/@vibe/compiler/cli_direct_component_entry.vibe" \
+  "direct component entry" \
+  "$PORTABLE_ALLOWED_EFFECTS|Fs"
 
 forbid_foreign_effect_rows \
   "lib/@vibe/compiler/entry/source_compile/source_compile.vibe" \

--- a/scripts/check_portable_boundary.sh
+++ b/scripts/check_portable_boundary.sh
@@ -105,6 +105,22 @@ PORTABLE_ALLOWED_EFFECTS='Exception|Async'
 #
 # Order: quoted strings, then raw strings, then comments. A `//` inside a raw
 # string is removed with the raw string rather than mistaken for a comment.
+# KNOWN LIMIT, recorded rather than chased: a string literal nested inside an
+# interpolation -- `"\{String::concat("perform Fs::read_file", " is inert")}"` --
+# is not stripped. The quotes pair sequentially, so the inner text survives into
+# the scanned stream and forbid_pattern reports it as a leak.
+#
+# Not fixed here, deliberately. Stripping that correctly means tracking
+# interpolation nesting, which is lexing vibe, and this file has already been
+# through five rounds of "the scanner does not see what the lexer sees" -- each
+# fix correct, each followed by another form. #2581 is where that ends, by
+# asking the compiler; a sixth regex would only move the boundary again.
+#
+# Accepting it is defensible because it is strictly NARROWER than what this gate
+# did before: pre-PR it stripped whole comment lines only, so ANY string
+# containing `perform Fs::` was a false positive. Now only a nested one is.
+# Neither scanned file contains such a string today.
+#
 # Line-preserving form, so a report can still cite a line number.
 boundary_scan_lines() { # <file>
   sed -E 's/"([^"\\]|\\.)*"//g' "$ROOT_DIR/$1" \

--- a/scripts/check_portable_boundary.sh
+++ b/scripts/check_portable_boundary.sh
@@ -228,18 +228,45 @@ boundary_scan_text() { # <file>
 # Consequence worth stating: an effect row on a nested function or lambda,
 # being inside a body, is not scanned. That is a miss rather than a false
 # positive -- the safe direction of the two -- and neither boundary has one.
+#
+# AMBIGUITY IS SKIPPED, NOT GUESSED. A return type may itself be a function
+# type, and then the row belongs to the RETURNED value, not to the declaration:
+#
+#   fn make() -> (String) -> Unit with Log::Emit    # make is PURE
+#
+# (pinned by fixtures/typecheck/closure_row_return_position.vibe). That `with`
+# is at parenthesis depth 0 like any other, so the scan reported `Log` and
+# rejected a legitimate helper.
+#
+# Telling those apart is a question about the TYPE grammar -- arrow
+# associativity -- not about lexical structure, and grammar is what this scan
+# stopped modelling at review round 7 after six straight misses. So when more
+# than one `->` appears at depth 0 before the `with`, the row is left
+# unclassified rather than attributed to the declaration.
+#
+# That is deliberately a MISS: a boundary returning an effectful closure is not
+# checked. The trade is explicit -- a miss is recorded in #2581, which will
+# answer this from the AST; a false positive fails CI on correct code and gets
+# the gate deleted (#2252). Between guessing wrong in the two directions, only
+# one of them is recoverable.
 boundary_effect_rows() { # reads normalized text on stdin
   awk '{
-    s = $0; n = length(s); depth = 0; brace = 0; i = 1
+    s = $0; n = length(s); depth = 0; brace = 0; arrows = 0; i = 1
     while (i <= n) {
       c = substr(s, i, 1)
       if (c == "(") { depth++; i++; continue }
       if (c == ")") { if (depth > 0) depth--; i++; continue }
-      if (c == "{") { brace++; i++; continue }
+      if (c == "-" && substr(s, i + 1, 1) == ">" && depth == 0 && brace == 0) {
+        arrows++; i++; continue
+      }
+      if (c == "{") { if (brace == 0) { arrows = 0 }; brace++; i++; continue }
       if (c == "}") { if (brace > 0) brace--; i++; continue }
       if (depth == 0 && brace == 0 && substr(s, i, 5) == "with ") {
         prev = (i > 1) ? substr(s, i - 1, 1) : " "
         if (prev ~ /[A-Za-z0-9_]/) { i++; continue }
+        # more than one depth-0 arrow: the row may belong to a returned
+        # function type, so leave it unclassified rather than guess
+        if (arrows > 1) { i++; continue }
         j = i + 5; row = ""; d2 = 0
         while (j <= n) {
           cc = substr(s, j, 1)

--- a/scripts/check_portable_boundary.sh
+++ b/scripts/check_portable_boundary.sh
@@ -76,10 +76,17 @@ PORTABLE_ALLOWED_EFFECTS='Exception|Async'
 #     Fs { ... }
 forbid_foreign_effect_rows() { # <file> <label>
   local file="$1" label="$2" bad
+  # An effect item may carry type arguments -- `parse_effect_item`
+  # (lib/@vibe/parser/parser_base.vibe) accepts `Exception[String] + Fs`, and it
+  # compiles. Matching bare identifiers stopped at the `[`, recorded the allowed
+  # `Exception`, and never saw the `Fs`. The argument is dropped BEFORE the row
+  # is split on `+`, so an argument that itself contains `+` cannot fragment
+  # into pieces that match nothing and read as leaks.
   bad="$(sed 's://.*::' "$ROOT_DIR/$file" \
     | tr '\n' ' ' \
-    | grep -oE 'with +[A-Z][A-Za-z0-9_]*( *\+ *[A-Z][A-Za-z0-9_]*)*' \
+    | grep -oE 'with +[A-Z][A-Za-z0-9_]*(\[[^]]*\])?( *\+ *[A-Z][A-Za-z0-9_]*(\[[^]]*\])?)*' \
     | sed 's/^with  *//' \
+    | sed 's/\[[^]]*\]//g' \
     | tr '+' '\n' \
     | sed 's/^[[:space:]]*//; s/[[:space:]]*$//' \
     | grep -vE "^($PORTABLE_ALLOWED_EFFECTS)$" \

--- a/scripts/check_portable_boundary.sh
+++ b/scripts/check_portable_boundary.sh
@@ -265,7 +265,7 @@ boundary_scan_text() { # <file>
 # one of them is recoverable.
 boundary_effect_rows() { # reads normalized text on stdin
   awk '{
-    s = $0; n = length(s); depth = 0; brack = 0; brace = 0; arrows = 0; rown = 0; i = 1
+    s = $0; n = length(s); depth = 0; brack = 0; brace = 0; arrows = 0; rown = 0; decl = ""; i = 1
     while (i <= n) {
       c = substr(s, i, 1)
       if (c == "(") { depth++; i++; continue }
@@ -278,18 +278,43 @@ boundary_effect_rows() { # reads normalized text on stdin
       if (c == "]") { if (brack > 0) brack--; i++; continue }
       if (depth == 0 && brack == 0 && brace == 0 && substr(s, i, 3) == "fn ") {
         prev = (i > 1) ? substr(s, i - 1, 1) : " "
-        if (prev !~ /[A-Za-z0-9_]/) { arrows = 0; rown = 0 }
+        if (prev !~ /[A-Za-z0-9_]/) { arrows = 0; rown = 0; decl = "fn" }
         i += 3; continue
+      }
+      # Which KIND of declaration a row was collected under.
+      #
+      # `type ReviewCallback = () -> Unit with ReviewAsk` is one arrow and one
+      # row, the shape that means "the row is the declarations own" -- so the
+      # alias was reported as a non-portable boundary and failed the required
+      # job on correct code. The row belongs to the aliased function TYPE.
+      # Naming a type performs nothing; the boundary is what a caller can
+      # reach, and that is the same reason the lone row of a RETURNED closure
+      # is skipped.
+      #
+      # `let ` resets alongside it, and must: without it an alias would
+      # suppress the row of the next declaration when that one is a bodyless
+      # `export let`, turning a false positive into a miss one declaration
+      # later. A declaration with no keyword at all keeps being checked --
+      # this suppresses `type` and nothing else.
+      if (depth == 0 && brack == 0 && brace == 0 && substr(s, i, 5) == "type ") {
+        prev = (i > 1) ? substr(s, i - 1, 1) : " "
+        if (prev == " ") { arrows = 0; rown = 0; decl = "type" }
+        i += 5; continue
+      }
+      if (depth == 0 && brack == 0 && brace == 0 && substr(s, i, 4) == "let ") {
+        prev = (i > 1) ? substr(s, i - 1, 1) : " "
+        if (prev == " ") { arrows = 0; rown = 0; decl = "let" }
+        i += 4; continue
       }
       if (c == "-" && substr(s, i + 1, 1) == ">" && depth == 0 && brack == 0 && brace == 0) {
         arrows++; i++; continue
       }
       if (c == "{") {
-        if (brace == 0) { flush(); arrows = 0; rown = 0 }
+        if (brace == 0) { flush(); arrows = 0; rown = 0; decl = "" }
         brace++; i++; continue
       }
       if (c == "}") { if (brace > 0) brace--; i++; continue }
-      if (c == ";" && depth == 0 && brack == 0 && brace == 0) { flush(); arrows = 0; rown = 0; i++; continue }
+      if (c == ";" && depth == 0 && brack == 0 && brace == 0) { flush(); arrows = 0; rown = 0; decl = ""; i++; continue }
       if (depth == 0 && brack == 0 && brace == 0 && substr(s, i, 5) == "with ") {
         prev = (i > 1) ? substr(s, i - 1, 1) : " "
         if (prev ~ /[A-Za-z0-9_]/) { i++; continue }
@@ -305,6 +330,16 @@ boundary_effect_rows() { # reads normalized text on stdin
           # collecting them as one made the count 1, which took the
           # single-row skip path and let Fs through
           else if (d2 == 0 && substr(s, j, 5) == "with " && substr(row, length(row), 1) ~ /[ ]/) { break }
+          # A new declaration ends the row as surely as a body does. The
+          # normalized text has no line breaks, so `type Cb = () -> Unit with
+          # ReviewAsk` followed by `export fn f() -> Unit with Fs {` ran the
+          # row scan straight through the `fn `, which is where the reset
+          # lives -- the next declaration was then read as part of the alias
+          # and its native row went unreported. No effect item contains these
+          # keywords, so breaking on them costs nothing.
+          else if (d2 == 0 && substr(s, j, 3) == "fn " && substr(row, length(row), 1) ~ /[ ]/) { break }
+          else if (d2 == 0 && substr(s, j, 5) == "type " && substr(row, length(row), 1) ~ /[ ]/) { break }
+          else if (d2 == 0 && substr(s, j, 4) == "let " && substr(row, length(row), 1) ~ /[ ]/) { break }
           row = row cc; j++
         }
         rowbuf[++rown] = row
@@ -340,7 +375,7 @@ boundary_effect_rows() { # reads normalized text on stdin
     #
     # Counting rows against a fixed threshold instead got the last of those
     # wrong: two rows does not mean one of them is the declarations.
-    if (rown >= arrows && rown >= 1) {
+    if (decl != "type" && rown >= arrows && rown >= 1) {
       print rowbuf[rown]
     }
     rown = 0

--- a/scripts/check_portable_boundary.sh
+++ b/scripts/check_portable_boundary.sh
@@ -66,9 +66,18 @@ PORTABLE_ALLOWED_EFFECTS='Exception|Async'
 
 # Reject any effect row on a pure boundary that names something outside the
 # allow-list. Comment lines are stripped first, as in forbid_pattern.
+#
+# Comments are dropped to end of line and the file flattened to one line before
+# matching, for the same reason as forbid_capability_authority below: a row may
+# be split after `+`. Measured -- this compiles, and a line-by-line scan matched
+# `with Exception`, accepted it, and never associated the `Fs`:
+#
+#   fn probe() -> String with Exception +
+#     Fs { ... }
 forbid_foreign_effect_rows() { # <file> <label>
   local file="$1" label="$2" bad
-  bad="$(grep -vE '^[[:space:]]*(///?|//#)' "$ROOT_DIR/$file" \
+  bad="$(sed 's://.*::' "$ROOT_DIR/$file" \
+    | tr '\n' ' ' \
     | grep -oE 'with +[A-Z][A-Za-z0-9_]*( *\+ *[A-Z][A-Za-z0-9_]*)*' \
     | sed 's/^with  *//' \
     | tr '+' '\n' \

--- a/scripts/check_portable_boundary.sh
+++ b/scripts/check_portable_boundary.sh
@@ -256,6 +256,16 @@ boundary_effect_rows() { # reads normalized text on stdin
       c = substr(s, i, 1)
       if (c == "(") { depth++; i++; continue }
       if (c == ")") { if (depth > 0) depth--; i++; continue }
+      if (depth == 0 && brace == 0 && substr(s, i, 3) == "fn ") {
+        # Anchor the arrow count to THIS declaration. Resetting only on `{`
+        # meant a bodyless declaration carrying an arrow -- `type Cb = (Int) ->
+        # Int` -- left the count at 1, so the arrow of the NEXT function made 2
+        # and its row was skipped as ambiguous. An unrelated type alias
+        # silently disabled the check for the declaration after it.
+        prev = (i > 1) ? substr(s, i - 1, 1) : " "
+        if (prev !~ /[A-Za-z0-9_]/) { arrows = 0 }
+        i += 3; continue
+      }
       if (c == "-" && substr(s, i + 1, 1) == ">" && depth == 0 && brace == 0) {
         arrows++; i++; continue
       }
@@ -273,6 +283,9 @@ boundary_effect_rows() { # reads normalized text on stdin
           if (cc == "(") { d2++ }
           else if (cc == ")") { if (d2 > 0) { d2-- } else { break } }
           else if (d2 == 0 && (cc == "{" || cc == ";")) { break }
+          # a `where` contract follows the row and is not part of it:
+          # `fn f(x: Int) -> Int with Exception where { requires: x >= 0 }`
+          else if (d2 == 0 && substr(s, j, 6) == "where " && substr(row, length(row), 1) ~ /[ \t]/) { break }
           row = row cc; j++
         }
         print row

--- a/scripts/check_portable_boundary.sh
+++ b/scripts/check_portable_boundary.sh
@@ -322,9 +322,19 @@ boundary_effect_rows() { # reads normalized text on stdin
     # with Fs` -- the earlier ones bind to the inner function types and the LAST
     # one is f own row, so that one is checked. Skipping all of them, as this
     # did before, let a boundary carry Fs unnoticed.
-    if (arrows <= 1) {
-      for (k = 1; k <= rown; k++) { print rowbuf[k] }
-    } else if (rown >= 2) {
+    # Each arrow layer AFTER the declarations own can carry one row, so the
+    # returned function types hold at most (arrows - 1) of them. The
+    # declaration owns a row only when there are more rows than layers to
+    # absorb them, and then it is the last.
+    #
+    #   -> Unit with Fs                                arrows 1, rows 1 -> own
+    #   -> (String) -> Unit with Log                   arrows 2, rows 1 -> none
+    #   -> (String) -> Unit with Exception with Fs     arrows 2, rows 2 -> own
+    #   -> () -> () -> Unit with Exception with Ask    arrows 3, rows 2 -> none
+    #
+    # Counting rows against a fixed threshold instead got the last of those
+    # wrong: two rows does not mean one of them is the declarations.
+    if (rown >= arrows && rown >= 1) {
       print rowbuf[rown]
     }
     rown = 0

--- a/scripts/check_portable_boundary.sh
+++ b/scripts/check_portable_boundary.sh
@@ -443,10 +443,17 @@ boundary_effect_rows() { # reads normalized text on stdin
       # and must stay opaque, so they clear the flag -- an `impl Eq for Int`
       # with no block at all would otherwise hand its transparency to whatever
       # brace came next.
-      if (depth == 0 && brack == 0 && brace == 0 && implb >= 0 && substr(s, i, 5) == "impl ") {
+      # `impl` may be followed by a space OR by `[` -- `impl[T] Tr[T] for S[T]`
+      # is the generic form and the lexer emits TImpl then TLBracket, with no
+      # space required. Matching the literal `impl ` left that block opaque, so
+      # a method inside it could carry `with Fs` unseen. A keyword ends where
+      # the identifier characters end, not where a space happens to be.
+      if (depth == 0 && brack == 0 && brace == 0 && implb >= 0 \
+          && substr(s, i, 4) == "impl" \
+          && (substr(s, i + 4, 1) == " " || substr(s, i + 4, 1) == "[")) {
         prev = (i > 1) ? substr(s, i - 1, 1) : " "
         if (prev !~ /[A-Za-z0-9_.]/) { impending = 1 }
-        i += 5; continue
+        i += 4; continue
       }
       if (depth == 0 && brack == 0 && brace == 0 \
           && (substr(s, i, 7) == "struct " || substr(s, i, 5) == "enum " \

--- a/scripts/check_portable_boundary.sh
+++ b/scripts/check_portable_boundary.sh
@@ -136,6 +136,18 @@ boundary_scan_lines() { # <file>
         if (c == "\"") { sp++; mode[sp] = "str"; i++; continue }
         if (c == "#" && substr(line, i + 1, 1) == "|") { break }   # raw string to EOL
         if (c == "/" && substr(line, i + 1, 1) == "/") { break }   # comment to EOL
+        if (c == "\047") {
+          # A char literal is inert, and a brace inside one would otherwise be
+          # counted as a real brace -- which skips every declaration after it,
+          # since they all then look nested. \047 is the quote character:
+          # writing it literally would end the single-quoted awk program.
+          # Consumed ONLY when the shape actually matches, so a stray quote is
+          # left alone rather than eating the code after it.
+          if (substr(line, i + 1, 1) == "\\") {
+            if (substr(line, i + 3, 1) == "\047") { out = out " "; i += 4; continue }
+          } else if (substr(line, i + 2, 1) == "\047") { out = out " "; i += 3; continue }
+          out = out c; i++; continue
+        }
         if (c == "{") { bdepth[sp]++; out = out c; i++; continue }
         if (c == "}") {
           if (bdepth[sp] > 0) { bdepth[sp]--; out = out c }

--- a/scripts/check_portable_boundary.sh
+++ b/scripts/check_portable_boundary.sh
@@ -42,6 +42,23 @@ forbid_pattern() {
 
 native_effect_pattern='with \{[^}]*(Fs|Process|Socket|Net)|perform (Fs|Process|Socket|Http)::|compile_file_fs|session-http|daemon'
 
+# The `with \{...\}` alternative above matches the HANDLER syntax
+# (`try ... with { Exception::Throw(e) => ... }`), which is a different
+# construct from an effect row. An effect ROW is unbraced and `+`-separated:
+# `with Fs`, `with Exception + Fs`, `with Exception + Fs + Env`. Nothing
+# matched that, so a boundary implementation could declare `with Fs` outright
+# and this gate printed `ok` -- measured, not inferred: appending
+# `export fn probe_native() -> Unit with Fs` to preprocess_compile.vibe passed.
+#
+# Scoped to the two source_compile boundaries deliberately. Their contract is
+# "stays in-memory", so a native row there is the leak. The third scanned file,
+# cli_direct_component_entry.vibe, is the entry that DOES file IO and carries
+# `with Exception + Fs` / `with Fs` legitimately; banning the row there would
+# fail the gate on correct code. It keeps the pattern above, which forbids the
+# direct `perform Fs::` and the FS compile lane rather than the row.
+native_effect_row='with +([A-Za-z_][A-Za-z0-9_]* *\+ *)*(Fs|Process|Socket|Net|Http)\b'
+pure_boundary_pattern="$native_effect_pattern|$native_effect_row"
+
 # The boundary is declared in the package CONTRACT (`index.vpkg`, ADR-0070),
 # not in an `index.vibe` facade -- and its effect row is spelled `with
 # Exception`, not `with { Error }` (ADR-0085). This gate asserted the older
@@ -76,11 +93,11 @@ forbid_pattern \
   "direct component entry"
 forbid_pattern \
   "lib/@vibe/compiler/entry/source_compile/source_compile.vibe" \
-  "$native_effect_pattern" \
+  "$pure_boundary_pattern" \
   "source compile API"
 forbid_pattern \
   "lib/@vibe/compiler/entry/source_compile/wasi_only/preprocess_compile.vibe" \
-  "$native_effect_pattern" \
+  "$pure_boundary_pattern" \
   "wasi source compile API"
 
 echo "selfhost portable boundary: ok"

--- a/scripts/check_portable_boundary.sh
+++ b/scripts/check_portable_boundary.sh
@@ -27,6 +27,22 @@ require_line() {
 # stripped tail would let `let x = 1 // perform Fs::read_file` hide a real call
 # on the same line if the two were ever reordered. A comment line is the one
 # shape that cannot execute.
+# The head of a handler arm NAMES an operation being discharged; it is not a
+# call of it. `handle { f() } with { Fs::ReadFile(_p) => resume("ok") }` is a
+# pure helper taking an Fs-effectful callback and handling it locally, and
+# nothing escapes -- yet the `with \{...\}` alternative saw `Fs` inside the
+# braces and the capability-namespace alternative added for the entry file saw
+# `Console::` in an arm head. Both rejected correct code.
+#
+# An arm head is decidable without parsing: a qualified name whose argument
+# list is immediately followed by `=>`. Nothing else puts `=>` there -- a call
+# result cannot be a pattern -- and the arm BODY is left untouched, so a real
+# capability call inside one is still a leak.
+strip_handler_arm_heads() {
+  sed -E \
+    -e 's/[A-Za-z_][A-Za-z0-9_]*::[A-Za-z0-9_]*[[:space:]]*\([^)]*\)[[:space:]]*=>/ /g' \
+    -e 's/[A-Za-z_][A-Za-z0-9_]*::[A-Za-z0-9_]*[[:space:]]*=>/ /g'
+}
 forbid_pattern() {
   local file="$1"
   local pattern="$2"
@@ -41,9 +57,9 @@ forbid_pattern() {
   # line-oriented grep cannot see (`perform` and `Fs::ReadFile` on two lines
   # compiles). Either matching is a failure -- reporting is best-effort, the
   # verdict is not.
-  boundary_scan_lines "$file" | grep -En "$pattern" >/tmp/vibe_portable_boundary_hits.$$ || true
+  boundary_scan_lines "$file" | strip_handler_arm_heads | grep -En "$pattern" >/tmp/vibe_portable_boundary_hits.$$ || true
   flat_hit=0
-  if boundary_scan_text "$file" | grep -Eq "$pattern"; then flat_hit=1; fi
+  if boundary_scan_text "$file" | strip_handler_arm_heads | grep -Eq "$pattern"; then flat_hit=1; fi
   if [ -s /tmp/vibe_portable_boundary_hits.$$ ] || [ "$flat_hit" -eq 1 ]; then
     if [ -s /tmp/vibe_portable_boundary_hits.$$ ]; then
       cat /tmp/vibe_portable_boundary_hits.$$ >&2
@@ -330,7 +346,7 @@ boundary_scan_text() { # <file>
 # one of them is recoverable.
 boundary_effect_rows() { # reads normalized text on stdin
   awk '{
-    s = $0; n = length(s); depth = 0; brack = 0; brace = 0; arrows = 0; rown = 0; authn = 0; decl = ""; i = 1
+    s = $0; n = length(s); depth = 0; brack = 0; brace = 0; implb = 0; impending = 0; arrows = 0; rown = 0; authn = 0; decl = ""; i = 1
     while (i <= n) {
       c = substr(s, i, 1)
       if (c == "(") { depth++; i++; continue }
@@ -341,9 +357,30 @@ boundary_effect_rows() { # reads normalized text on stdin
       # passed. A type argument is not a return-type layer.
       if (c == "[") { brack++; i++; continue }
       if (c == "]") { if (brack > 0) brack--; i++; continue }
+      # An `impl` block holds DECLARATIONS, not statements. Its methods sit one
+      # brace deep, so the brace == 0 guard below skipped every one of them and
+      # a method could carry `with Fs` unseen. The block is made transparent
+      # instead: its `{` does not open a body.
+      #
+      # `struct` / `enum` / `effect` bodies are NOT declarations in this sense
+      # and must stay opaque, so they clear the flag -- an `impl Eq for Int`
+      # with no block at all would otherwise hand its transparency to whatever
+      # brace came next.
+      if (depth == 0 && brack == 0 && brace == 0 && implb >= 0 && substr(s, i, 5) == "impl ") {
+        prev = (i > 1) ? substr(s, i - 1, 1) : " "
+        if (prev !~ /[A-Za-z0-9_.]/) { impending = 1 }
+        i += 5; continue
+      }
+      if (depth == 0 && brack == 0 && brace == 0 \
+          && (substr(s, i, 7) == "struct " || substr(s, i, 5) == "enum " \
+              || substr(s, i, 7) == "effect ")) {
+        prev = (i > 1) ? substr(s, i - 1, 1) : " "
+        if (prev !~ /[A-Za-z0-9_.]/) { impending = 0 }
+        i++; continue
+      }
       if (depth == 0 && brack == 0 && brace == 0 && substr(s, i, 3) == "fn ") {
         prev = (i > 1) ? substr(s, i - 1, 1) : " "
-        if (prev !~ /[A-Za-z0-9_]/) { arrows = 0; rown = 0; authn = 0; decl = "fn" }
+        if (prev !~ /[A-Za-z0-9_]/) { arrows = 0; rown = 0; authn = 0; decl = "fn"; impending = 0 }
         i += 3; continue
       }
       # Which KIND of declaration a row was collected under.
@@ -368,12 +405,12 @@ boundary_effect_rows() { # reads normalized text on stdin
       # declaration.
       if (depth == 0 && brack == 0 && brace == 0 && substr(s, i, 5) == "type ") {
         prev = (i > 1) ? substr(s, i - 1, 1) : " "
-        if (prev !~ /[A-Za-z0-9_.]/) { arrows = 0; rown = 0; authn = 0; decl = "type" }
+        if (prev !~ /[A-Za-z0-9_.]/) { arrows = 0; rown = 0; authn = 0; decl = "type"; impending = 0 }
         i += 5; continue
       }
       if (depth == 0 && brack == 0 && brace == 0 && substr(s, i, 4) == "let ") {
         prev = (i > 1) ? substr(s, i - 1, 1) : " "
-        if (prev !~ /[A-Za-z0-9_.]/) { arrows = 0; rown = 0; authn = 0; decl = "let" }
+        if (prev !~ /[A-Za-z0-9_.]/) { arrows = 0; rown = 0; authn = 0; decl = "let"; impending = 0 }
         i += 4; continue
       }
       if (c == "-" && substr(s, i + 1, 1) == ">" && depth == 0 && brack == 0 && brace == 0) {
@@ -381,9 +418,14 @@ boundary_effect_rows() { # reads normalized text on stdin
       }
       if (c == "{") {
         if (brace == 0) { flush(); arrows = 0; rown = 0; authn = 0; decl = "" }
+        if (brace == 0 && impending) { implb++; impending = 0; i++; continue }
         brace++; i++; continue
       }
-      if (c == "}") { if (brace > 0) brace--; i++; continue }
+      if (c == "}") {
+        if (brace > 0) { brace-- }
+        else if (implb > 0) { flush(); arrows = 0; rown = 0; authn = 0; decl = ""; implb-- }
+        i++; continue
+      }
       if (c == ";" && depth == 0 && brack == 0 && brace == 0) { flush(); arrows = 0; rown = 0; authn = 0; decl = ""; i++; continue }
       # `=` ends the TYPE of a binding and starts its value. Without this,
       # `export let f: (Int) -> Unit with Exception = (x) -> { () }` ran the

--- a/scripts/check_portable_boundary.sh
+++ b/scripts/check_portable_boundary.sh
@@ -637,9 +637,20 @@ require_line \
   '^fn compile_with_closure_sources_wasi_mode_uncached\(main_source: String, main_path: String, sources: Array\[\(String, String\)\], entry_name: String, mode: String\) -> Bytes with Exception$' \
   "direct component closure compile stays in-memory"
 
+# The entry file gets one MORE alternative than the other two. Its row
+# allow-list is deliberately off (see below), so a capability call there is not
+# caught by the row -- and only `perform` spellings were banned, which left a
+# plain `Console::write_stream(...)` free. That is a capability builtin, called
+# as an ordinary function (ADR-0084), so no `perform` appears anywhere.
+#
+# `Fs::` is NOT in this list, on purpose: this entry is the one that does file
+# IO and says so, carrying `with Exception + Fs` / `with Fs`. Its contract is
+# exactly that row, so a call inside it is declared and the others are not. It
+# makes exactly one capability call today, `Fs::stat_token`.
+entry_native_pattern="$native_effect_pattern"'|(Console|Env|Process|Socket|Http|Net)::'
 forbid_pattern \
   "lib/@vibe/compiler/cli_direct_component_entry.vibe" \
-  "$native_effect_pattern" \
+  "$entry_native_pattern" \
   "direct component entry"
 forbid_pattern \
   "lib/@vibe/compiler/entry/source_compile/source_compile.vibe" \
@@ -662,6 +673,14 @@ forbid_pattern \
 # for a declaration whose actual problem is an authority grant. The specific
 # diagnostic has to win, and the self-test asserts the message names `allows`,
 # which is what caught this ordering.
+# The entry file too. Its row allow-list is off, but an `allows` clause is
+# authority rather than an effect, and this boundary is not entitled to any:
+# it has none today, and one appearing is a leak whatever its row says. Only
+# `perform` spellings were banned here, so `allows Console::write_stream`
+# passed the required gate outright.
+forbid_capability_authority \
+  "lib/@vibe/compiler/cli_direct_component_entry.vibe" \
+  "direct component entry"
 forbid_capability_authority \
   "lib/@vibe/compiler/entry/source_compile/source_compile.vibe" \
   "source compile API"

--- a/scripts/check_portable_boundary.sh
+++ b/scripts/check_portable_boundary.sh
@@ -652,7 +652,15 @@ forbid_foreign_effect_rows() { # <file> <label>
   # "no capability name appears in this boundary's effect row".
   #
   # So: take the whole span from `with` to the start of the body, drop type
-  # arguments and the `::op` suffix of a qualified item, and check EVERY
+  # arguments and the `::op` suffix of a qualified item -- whitespace around
+  # the `::` included, because parse_effect_item consumes the token regardless
+  # of spacing (parser_base.vibe), so `with Exception :: Throw` is the same row
+  # as `with Exception::Throw`. Stripping only the adjacent form left `Throw`
+  # to reach the allow-list as an effect of its own, and the row was rejected.
+  # This is the second place the same spacing assumption was wrong; the direct
+  # call pattern was the first.
+  #
+  # ...and check EVERY
   # capability name in it. Separators are irrelevant -- `+`, newlines, or a
   # syntax `parse_effect_item` grows next week -- because nothing about the
   # row's shape is assumed. A name is either allow-listed or it is a leak.
@@ -665,7 +673,7 @@ forbid_foreign_effect_rows() { # <file> <label>
     | boundary_effect_rows \
     | sed -n 's/^row://p' \
     | sed 's/\[[^]]*\]//g' \
-    | sed 's/::[A-Za-z0-9_]*//g' \
+    | sed -E 's/[[:space:]]*::[[:space:]]*[A-Za-z0-9_]*//g' \
     | grep -oE '[A-Za-z_][A-Za-z0-9_]*' \
     | grep -vE "^($PORTABLE_ALLOWED_EFFECTS)$" \
     | sort -u)" || true

--- a/scripts/check_portable_boundary.sh
+++ b/scripts/check_portable_boundary.sh
@@ -406,7 +406,13 @@ boundary_effect_rows() { # reads normalized text on stdin
           if (substr(s, j, 1) ~ /[A-Z]/) {
             name = ""
             while (j <= n && substr(s, j, 1) ~ /[A-Za-z0-9_:]/) { name = name substr(s, j, 1); j++ }
-            authbuf[++authn] = name
+            # Remember WHICH row this clause follows. An `allows` belongs to
+            # the same function-type layer as the row it trails, so comparing
+            # independent counts got `-> () -> Unit with Exception with ()
+            # allows Fs::read_file` wrong: two arrows, two rows, one clause,
+            # and the clause is the outer declarations along with the second
+            # row. authn >= arrows was false and the authority went unreported.
+            authbuf[++authn] = name; authrow[authn] = rown
             i = j; continue
           }
           i += 7; continue
@@ -475,15 +481,24 @@ boundary_effect_rows() { # reads normalized text on stdin
     # Counting rows against a fixed threshold instead got the last of those
     # wrong: two rows does not mean one of them is the declarations.
     if (decl != "type") {
-      if (rown >= arrows && rown >= 1) { print "row:" rowbuf[rown] }
-      # Authority binds to an arrow layer exactly as a row does. `fn make() ->
-      # () -> Unit with () allows Fs::read_file` grants the authority to the
-      # RETURNED function type, not to make, which performs nothing; emitting
-      # every clause rejected that pure helper. The clause the declaration owns
-      # is the last, and only when there are more clauses than layers to absorb
-      # them -- the same arithmetic as the row above, and with one arrow there
-      # is only one function type at depth 0 for a clause to attach to.
-      if (authn >= arrows && authn >= 1) { print "auth:" authbuf[authn] }
+      # Which layer, if any, is the declarations own? Rows are absorbed by the
+      # returned function types first, so the declaration owns the LAST row
+      # only when there are at least as many rows as arrow layers. With no row
+      # at all it still owns the signature when there is a single layer -- an
+      # `allows` can trail a bare return type.
+      own = -1
+      if (rown >= arrows && rown >= 1) { print "row:" rowbuf[rown]; own = rown }
+      else if (rown == 0 && arrows <= 1) { own = 0 }
+      # Authority rides the row it trails, so the declarations clause is the
+      # one recorded against the declarations own layer. Emitting every clause
+      # rejected a pure helper that merely hands out an authorised closure;
+      # counting clauses against arrows instead missed the case where the
+      # closure took the first row and the declaration kept the second.
+      if (own >= 0) {
+        for (k = 1; k <= authn; k++) {
+          if (authrow[k] == own) { print "auth:" authbuf[k] }
+        }
+      }
     }
     rown = 0; authn = 0
   }'

--- a/scripts/check_portable_boundary.sh
+++ b/scripts/check_portable_boundary.sh
@@ -17,11 +17,22 @@ require_line() {
   fi
 }
 
+# A doc comment naming a native entry point is a REFERENCE, not a leak: the
+# whole point of these files is to explain how they differ from the FS lane, so
+# `-- see compile_file_fs_mode's comment` is exactly the prose we want. The scan
+# strips `///` and `//` comment lines before matching. Code is what leaks
+# capability; prose about code does not.
+#
+# It strips whole comment LINES only, not trailing comments after code -- a
+# stripped tail would let `let x = 1 // perform Fs::read_file` hide a real call
+# on the same line if the two were ever reordered. A comment line is the one
+# shape that cannot execute.
 forbid_pattern() {
   local file="$1"
   local pattern="$2"
   local label="$3"
-  if grep -En "$pattern" "$ROOT_DIR/$file" >/tmp/vibe_portable_boundary_hits.$$; then
+  if grep -vE '^[[:space:]]*(///?|//#)' "$ROOT_DIR/$file" \
+    | grep -En "$pattern" >/tmp/vibe_portable_boundary_hits.$$; then
     cat /tmp/vibe_portable_boundary_hits.$$ >&2
     rm -f /tmp/vibe_portable_boundary_hits.$$
     fail "native capability leaked into portable boundary: $label ($file)"
@@ -31,25 +42,32 @@ forbid_pattern() {
 
 native_effect_pattern='with \{[^}]*(Fs|Process|Socket|Net)|perform (Fs|Process|Socket|Http)::|compile_file_fs|session-http|daemon'
 
+# The boundary is declared in the package CONTRACT (`index.vpkg`, ADR-0070),
+# not in an `index.vibe` facade -- and its effect row is spelled `with
+# Exception`, not `with { Error }` (ADR-0085). This gate asserted the older
+# form at the older path for long enough that both had gone: it reported
+# "missing expected pure boundary" for files that no longer exist, while every
+# boundary it names was intact in the contract beside them. Nothing caught it
+# because the gate runs in no CI job (#2577).
 require_line \
-  "lib/@vibe/compiler/entry/source_compile/index.vibe" \
-  '^export let compile_source: \(String\) -> Bytes with \{ Error \}' \
+  "lib/@vibe/compiler/entry/source_compile/index.vpkg" \
+  '^fn compile_source\(source: String\) -> Bytes with Exception$' \
   "compile_source stays in-memory"
 require_line \
-  "lib/@vibe/compiler/entry/source_compile/index.vibe" \
-  '^export let compile_source_wasi: \(String, String\) -> Bytes with \{ Error \}' \
+  "lib/@vibe/compiler/entry/source_compile/index.vpkg" \
+  '^fn compile_source_wasi\(source: String, entry_name: String\) -> Bytes with Exception$' \
   "compile_source_wasi stays in-memory"
 require_line \
-  "lib/@vibe/compiler/entry/source_compile/index.vibe" \
-  '^export let compile_source_wasi_mode: \(String, String, String\) -> Bytes with \{ Error \}' \
+  "lib/@vibe/compiler/entry/source_compile/index.vpkg" \
+  '^fn compile_source_wasi_mode\(source: String, entry_name: String, mode: String\) -> Bytes with Exception$' \
   "compile_source_wasi_mode stays in-memory"
 require_line \
   "lib/@vibe/compiler/entry/source_compile/wasi_only/preprocess_compile.vibe" \
-  '^export let compile_source_wasi_only: \(String, String\) -> Bytes with \{ Error \}' \
+  '^export fn compile_source_wasi_only\(source: String, entry_name: String\) -> Bytes with Exception' \
   "compile_source_wasi_only stays in-memory"
 require_line \
-  "lib/@vibe/compiler/entry/compiler/fs_compile/index.vibe" \
-  '^export let compile_with_closure_sources_wasi_mode_uncached: \(String, String, Array\[\(String, String\)\], String, String\) -> Bytes with \{ Error \}' \
+  "lib/@vibe/compiler/entry/compiler/fs_compile/index.vpkg" \
+  '^fn compile_with_closure_sources_wasi_mode_uncached\(main_source: String, main_path: String, sources: Array\[\(String, String\)\], entry_name: String, mode: String\) -> Bytes with Exception$' \
   "direct component closure compile stays in-memory"
 
 forbid_pattern \
@@ -57,7 +75,7 @@ forbid_pattern \
   "$native_effect_pattern" \
   "direct component entry"
 forbid_pattern \
-  "lib/@vibe/compiler/entry/source_compile/index.vibe" \
+  "lib/@vibe/compiler/entry/source_compile/source_compile.vibe" \
   "$native_effect_pattern" \
   "source compile API"
 forbid_pattern \

--- a/scripts/check_portable_boundary.sh
+++ b/scripts/check_portable_boundary.sh
@@ -86,10 +86,25 @@ PORTABLE_ALLOWED_EFFECTS='Exception|Async'
 # ended the literal at the backslash-escaped quote inside
 # `"prefix \"with Fs\" suffix"` and left the inert text exposed, failing the
 # gate on a perfectly ordinary diagnostic string.
+#
+# Every string form the lexer knows has to go, not just the double-quoted one:
+# `#|` opens a RAW string that runs to end of line, and leaving it in made
+# `#|compile with Fs when requested` report `effect: Fs`, `effect: when`,
+# `effect: requested` -- a required gate rejecting an ordinary message.
+#
+# Whitespace is normalized for the same reason. The lexer treats a tab as
+# whitespace (lib/@vibe/parser/lexer.vibe), so `with<TAB>Fs` is a legal row;
+# matching the literal text "with " missed it entirely. Tabs, newlines and
+# carriage returns all become spaces here, once, so nothing downstream has to
+# remember that a separator might not be a space.
+#
+# Order: quoted strings, then raw strings, then comments. A `//` inside a raw
+# string is removed with the raw string rather than mistaken for a comment.
 boundary_scan_text() { # <file>
   sed -E 's/"([^"\\]|\\.)*"//g' "$ROOT_DIR/$1" \
+    | sed 's/#|.*$//' \
     | sed 's://.*::' \
-    | tr '\n' ' '
+    | tr '\n\t\r' '   '
 }
 
 # Every DECLARATION's own effect row, one per line.

--- a/scripts/check_portable_boundary.sh
+++ b/scripts/check_portable_boundary.sh
@@ -31,7 +31,12 @@ forbid_pattern() {
   local file="$1"
   local pattern="$2"
   local label="$3"
-  if grep -vE '^[[:space:]]*(///?|//#)' "$ROOT_DIR/$file" \
+  # Reads the same normalized view as the row and authority scans -- strings
+  # and comments removed, lines preserved so the report keeps its line numbers.
+  # It used to drop only whole comment LINES, so an inert diagnostic such as
+  # "do not generate perform Fs::read_file here" was reported as a leak, which
+  # is a required gate rejecting an ordinary message.
+  if boundary_scan_lines "$file" \
     | grep -En "$pattern" >/tmp/vibe_portable_boundary_hits.$$; then
     cat /tmp/vibe_portable_boundary_hits.$$ >&2
     rm -f /tmp/vibe_portable_boundary_hits.$$
@@ -100,11 +105,15 @@ PORTABLE_ALLOWED_EFFECTS='Exception|Async'
 #
 # Order: quoted strings, then raw strings, then comments. A `//` inside a raw
 # string is removed with the raw string rather than mistaken for a comment.
-boundary_scan_text() { # <file>
+# Line-preserving form, so a report can still cite a line number.
+boundary_scan_lines() { # <file>
   sed -E 's/"([^"\\]|\\.)*"//g' "$ROOT_DIR/$1" \
     | sed 's/#|.*$//' \
-    | sed 's://.*::' \
-    | tr '\n\t\r' '   '
+    | sed 's://.*::'
+}
+
+boundary_scan_text() { # <file>
+  boundary_scan_lines "$1" | tr '\n\t\r' '   '
 }
 
 # Every DECLARATION's own effect row, one per line.
@@ -123,14 +132,27 @@ boundary_scan_text() { # <file>
 # construction, whatever shape they take. Everything up to the body brace is
 # then the row, so separators, type arguments and qualified items still need no
 # special handling.
+#
+# BRACE depth matters as well as paren depth. `handle { ... } with ReviewAsk
+# { ... }` discharges an effect locally and is not a signature, but its `with`
+# is at paren depth 0, so it was read as a declaration row and reported
+# `effect: ReviewAsk` -- rejecting a helper that is pure precisely BECAUSE it
+# handles the effect. A declaration's row sits before the body brace (brace
+# depth 0); a handler clause is inside a body (depth >= 1).
+#
+# Consequence worth stating: an effect row on a nested function or lambda,
+# being inside a body, is not scanned. That is a miss rather than a false
+# positive -- the safe direction of the two -- and neither boundary has one.
 boundary_effect_rows() { # reads normalized text on stdin
   awk '{
-    s = $0; n = length(s); depth = 0; i = 1
+    s = $0; n = length(s); depth = 0; brace = 0; i = 1
     while (i <= n) {
       c = substr(s, i, 1)
       if (c == "(") { depth++; i++; continue }
       if (c == ")") { if (depth > 0) depth--; i++; continue }
-      if (depth == 0 && substr(s, i, 5) == "with ") {
+      if (c == "{") { brace++; i++; continue }
+      if (c == "}") { if (brace > 0) brace--; i++; continue }
+      if (depth == 0 && brace == 0 && substr(s, i, 5) == "with ") {
         prev = (i > 1) ? substr(s, i - 1, 1) : " "
         if (prev ~ /[A-Za-z0-9_]/) { i++; continue }
         j = i + 5; row = ""; d2 = 0

--- a/scripts/check_portable_boundary.sh
+++ b/scripts/check_portable_boundary.sh
@@ -561,7 +561,16 @@ boundary_effect_rows() { # reads normalized text on stdin
           if (cc == "(") { d2++ }
           else if (cc == ")") { if (d2 > 0) { d2-- } else { break } }
           else if (d2 == 0 && (cc == "{" || cc == ";")) { break }
-          else if (d2 == 0 && substr(s, j, 6) == "where " ) { break }
+          # ...and `where` must start at a TOKEN boundary, the same test the
+          # `fn` / `type` / `let` breaks below already make. Unanchored, it
+          # matched inside an effect NAME: `with Asyncwhere + Fs` broke at
+          # character 6, kept the row as `Async` -- allow-listed -- and dropped
+          # `+ Fs` entirely. Measured on c89c47367 with a boundary that calls
+          # `Fs::stat_token`: the gate printed `ok`, EXIT=0. A silent miss, and
+          # the cheapest possible one to introduce: any effect whose name ends
+          # in `where` hides everything after it in the row.
+          else if (d2 == 0 && substr(s, j, 6) == "where " \
+                   && substr(row, length(row), 1) ~ /[ ]/) { break }
           # a following `with` starts a NEW row rather than continuing this
           # one: `-> (String) -> Unit with Exception with Fs` is two rows, and
           # collecting them as one made the count 1, which took the
@@ -668,6 +677,84 @@ boundary_effect_rows() { # reads normalized text on stdin
 #
 #   fn probe() -> String with Exception +
 #     Fs { ... }
+# `effectset Name = { A, B }` (ADR-0071) declares a SET of effects, and a
+# declaration then says `with Name`. Tokenizing the row yields the ALIAS, so a
+# portable boundary using one was rejected as `effect: PortableEffects` even
+# though every member is allow-listed.
+#
+# Adding the alias to PORTABLE_ALLOWED_EFFECTS would be the wrong fix and an
+# actively dangerous one: the allow-list would then admit the NAME, and a later
+# edit adding `Fs` to that set would pass unseen. So the members are read from
+# the declaration itself -- the same move as deriving the capability list from
+# `capability_effect_name_list` instead of restating it. What the gate checks
+# stays "no capability name appears in this row", with the alias resolved to
+# what it actually stands for.
+#
+# Only an UNQUALIFIED effectset declared in the scanned file itself is
+# expanded. An imported one, and the qualified `effectset Effect::Name = ...`
+# form, are not visible here and stay unexpanded -- which means they are
+# reported, which is the safe direction. Do not "fix" that by allow-listing the
+# name; move the declaration into the file, or spell the row out.
+boundary_effectset_defs() { # <file> -- emits `NAME MEMBER`, one pair per line
+  boundary_scan_text "$1" \
+    | grep -oE 'effectset[[:space:]]+[A-Za-z_][A-Za-z0-9_]*[[:space:]]*=[[:space:]]*\{[^{}]*\}' \
+    | awk '{
+        s = $0
+        sub(/^effectset[[:space:]]+/, "", s)
+        eq = index(s, "=")
+        if (eq == 0) { next }
+        name = substr(s, 1, eq - 1)
+        gsub(/[[:space:]]/, "", name)
+        ob = index(s, "{"); cb = index(s, "}")
+        if (ob == 0 || cb <= ob) { next }
+        body = substr(s, ob + 1, cb - ob - 1)
+        n = split(body, parts, ",")
+        for (i = 1; i <= n; i++) {
+          m = parts[i]
+          gsub(/[[:space:]]/, "", m)
+          gsub(/\[[^]]*\]/, "", m)
+          sub(/::.*$/, "", m)
+          if (m != "") { print name " " m }
+        }
+      }' || true
+}
+
+boundary_expand_effectsets() { # <file> -- expands aliases in the tokens on stdin
+  local defs
+  defs="$(boundary_effectset_defs "$1")" || true
+  awk -v defs="$defs" '
+    BEGIN {
+      n = split(defs, lines, "\n")
+      for (i = 1; i <= n; i++) {
+        if (lines[i] == "") { continue }
+        split(lines[i], kv, " ")
+        members[kv[1]] = members[kv[1]] " " kv[2]
+      }
+    }
+    {
+      # Transitive: `effectset A = { B }` over `effectset B = { Exception }`
+      # has to reach Exception. Bounded, because a scanner must terminate on
+      # input it did not validate -- a cyclic set is not legal vibe, and after
+      # the bound its alias is still in the stream, so it is REPORTED rather
+      # than silently dropped.
+      out = $0
+      for (round = 0; round < 8; round++) {
+        changed = 0; nxt = ""
+        k = split(out, toks, " ")
+        for (j = 1; j <= k; j++) {
+          t = toks[j]
+          if (t == "") { continue }
+          if (t in members) { nxt = nxt members[t]; changed = 1 }
+          else { nxt = nxt " " t }
+        }
+        out = nxt
+        if (changed == 0) { break }
+      }
+      k = split(out, toks, " ")
+      for (j = 1; j <= k; j++) { if (toks[j] != "") { print toks[j] } }
+    }'
+}
+
 forbid_foreign_effect_rows() { # <file> <label> [allow-list]
   local file="$1" label="$2" bad
   local allowed="${3:-$PORTABLE_ALLOWED_EFFECTS}"
@@ -703,6 +790,7 @@ forbid_foreign_effect_rows() { # <file> <label> [allow-list]
     | sed 's/\[[^]]*\]//g' \
     | sed -E 's/[[:space:]]*::[[:space:]]*[A-Za-z0-9_]*//g' \
     | grep -oE '[A-Za-z_][A-Za-z0-9_]*' \
+    | boundary_expand_effectsets "$file" \
     | grep -vE "^($allowed)$" \
     | sort -u)" || true
   if [ -n "$bad" ]; then

--- a/scripts/check_portable_boundary.sh
+++ b/scripts/check_portable_boundary.sh
@@ -82,10 +82,57 @@ PORTABLE_ALLOWED_EFFECTS='Exception|Async'
 # was captured and reported as `effect: Fs`. A required gate that fails on
 # correct code is one that gets disabled (#2252), so a false positive here is
 # not the safe direction -- it is a different way to lose the gate.
+# The string pattern is escape-aware: `"([^"\\]|\\.)*"`. A plain `"[^"]*"`
+# ended the literal at the backslash-escaped quote inside
+# `"prefix \"with Fs\" suffix"` and left the inert text exposed, failing the
+# gate on a perfectly ordinary diagnostic string.
 boundary_scan_text() { # <file>
-  sed 's/"[^"]*"//g' "$ROOT_DIR/$1" \
+  sed -E 's/"([^"\\]|\\.)*"//g' "$ROOT_DIR/$1" \
     | sed 's://.*::' \
     | tr '\n' ' '
+}
+
+# Every DECLARATION's own effect row, one per line.
+#
+# "The text from `with` to the next `{`" was wrong, and wrong in the expensive
+# direction: a parameter carries its own row, so
+#
+#   fn probe(f: () -> Unit with Exception) -> Unit with Exception { f() }
+#
+# started at the PARAMETER's `with`, swallowed `) -> Unit`, and reported
+# `effect: Unit` -- rejecting a legitimate higher-order helper. A required gate
+# that blocks correct code is one that gets removed (#2252).
+#
+# The outer row is the one at parenthesis depth 0. That is a lexical property,
+# not a guess at the grammar: parameter rows are inside `(...)` by
+# construction, whatever shape they take. Everything up to the body brace is
+# then the row, so separators, type arguments and qualified items still need no
+# special handling.
+boundary_effect_rows() { # reads normalized text on stdin
+  awk '{
+    s = $0; n = length(s); depth = 0; i = 1
+    while (i <= n) {
+      c = substr(s, i, 1)
+      if (c == "(") { depth++; i++; continue }
+      if (c == ")") { if (depth > 0) depth--; i++; continue }
+      if (depth == 0 && substr(s, i, 5) == "with ") {
+        prev = (i > 1) ? substr(s, i - 1, 1) : " "
+        if (prev ~ /[A-Za-z0-9_]/) { i++; continue }
+        j = i + 5; row = ""; d2 = 0
+        while (j <= n) {
+          cc = substr(s, j, 1)
+          if (cc == "(") { d2++ }
+          else if (cc == ")") { if (d2 > 0) { d2-- } else { break } }
+          else if (d2 == 0 && (cc == "{" || cc == ";")) { break }
+          row = row cc; j++
+        }
+        print row
+        i = j
+        continue
+      }
+      i++
+    }
+  }'
 }
 
 # Reject any effect row on a pure boundary that names something outside the
@@ -113,12 +160,16 @@ forbid_foreign_effect_rows() { # <file> <label>
   # capability name in it. Separators are irrelevant -- `+`, newlines, or a
   # syntax `parse_effect_item` grows next week -- because nothing about the
   # row's shape is assumed. A name is either allow-listed or it is a leak.
+  # Tokens are matched in EITHER case. An effect-row variable is lowercase
+  # (`fn probe[e](f: () -> Unit with e) -> Unit with e`), and such a boundary
+  # runs whatever effect its caller instantiates -- including Fs. Only matching
+  # capitalized names silently dropped it. Unresolved is not portable, so the
+  # allow-list rejects it like any other name it does not know.
   bad="$(boundary_scan_text "$file" \
-    | grep -oE 'with +[^{;]*' \
-    | sed 's/^with  *//' \
+    | boundary_effect_rows \
     | sed 's/\[[^]]*\]//g' \
     | sed 's/::[A-Za-z0-9_]*//g' \
-    | grep -oE '[A-Z][A-Za-z0-9_]*' \
+    | grep -oE '[A-Za-z_][A-Za-z0-9_]*' \
     | grep -vE "^($PORTABLE_ALLOWED_EFFECTS)$" \
     | sort -u)" || true
   if [ -n "$bad" ]; then

--- a/scripts/check_portable_boundary.sh
+++ b/scripts/check_portable_boundary.sh
@@ -315,6 +315,20 @@ boundary_effect_rows() { # reads normalized text on stdin
       }
       if (c == "}") { if (brace > 0) brace--; i++; continue }
       if (c == ";" && depth == 0 && brack == 0 && brace == 0) { flush(); arrows = 0; rown = 0; decl = ""; i++; continue }
+      # `=` ends the TYPE of a binding and starts its value. Without this,
+      # `export let f: (Int) -> Unit with Exception = (x) -> { () }` ran the
+      # row on to the initializer body and reported `effect: x` on a portable
+      # file. The initializer arrow also inflated the layer count, so simply
+      # stopping the row there would have skipped the declaration instead;
+      # flushing at `=` reports the row and leaves the value to be scanned as
+      # what it is. `decl` is NOT cleared -- `type Cb = () -> Unit with R` has
+      # its row AFTER the `=`, and clearing it would re-open the alias false
+      # positive one character later. A comparison operator is not a binding.
+      if (c == "=" && depth == 0 && brack == 0 && brace == 0 \
+          && substr(s, i + 1, 1) != "=" \
+          && ((i > 1) ? substr(s, i - 1, 1) : " ") !~ /[=<>!+\-*\/%]/) {
+        flush(); arrows = 0; rown = 0; i++; continue
+      }
       if (depth == 0 && brack == 0 && brace == 0 && substr(s, i, 5) == "with ") {
         prev = (i > 1) ? substr(s, i - 1, 1) : " "
         if (prev ~ /[A-Za-z0-9_]/) { i++; continue }
@@ -337,6 +351,7 @@ boundary_effect_rows() { # reads normalized text on stdin
           # lives -- the next declaration was then read as part of the alias
           # and its native row went unreported. No effect item contains these
           # keywords, so breaking on them costs nothing.
+          else if (d2 == 0 && cc == "=" && substr(s, j + 1, 1) != "=" && substr(s, j - 1, 1) !~ /[=<>!+\-*\/%]/) { break }
           else if (d2 == 0 && substr(s, j, 3) == "fn " && substr(row, length(row), 1) ~ /[ ]/) { break }
           else if (d2 == 0 && substr(s, j, 5) == "type " && substr(row, length(row), 1) ~ /[ ]/) { break }
           else if (d2 == 0 && substr(s, j, 4) == "let " && substr(row, length(row), 1) ~ /[ ]/) { break }

--- a/scripts/check_portable_boundary.sh
+++ b/scripts/check_portable_boundary.sh
@@ -265,49 +265,69 @@ boundary_scan_text() { # <file>
 # one of them is recoverable.
 boundary_effect_rows() { # reads normalized text on stdin
   awk '{
-    s = $0; n = length(s); depth = 0; brace = 0; arrows = 0; i = 1
+    s = $0; n = length(s); depth = 0; brace = 0; arrows = 0; rown = 0; i = 1
     while (i <= n) {
       c = substr(s, i, 1)
       if (c == "(") { depth++; i++; continue }
       if (c == ")") { if (depth > 0) depth--; i++; continue }
       if (depth == 0 && brace == 0 && substr(s, i, 3) == "fn ") {
-        # Anchor the arrow count to THIS declaration. Resetting only on `{`
-        # meant a bodyless declaration carrying an arrow -- `type Cb = (Int) ->
-        # Int` -- left the count at 1, so the arrow of the NEXT function made 2
-        # and its row was skipped as ambiguous. An unrelated type alias
-        # silently disabled the check for the declaration after it.
         prev = (i > 1) ? substr(s, i - 1, 1) : " "
-        if (prev !~ /[A-Za-z0-9_]/) { arrows = 0 }
+        if (prev !~ /[A-Za-z0-9_]/) { arrows = 0; rown = 0 }
         i += 3; continue
       }
       if (c == "-" && substr(s, i + 1, 1) == ">" && depth == 0 && brace == 0) {
         arrows++; i++; continue
       }
-      if (c == "{") { if (brace == 0) { arrows = 0 }; brace++; i++; continue }
+      if (c == "{") {
+        if (brace == 0) { flush(); arrows = 0; rown = 0 }
+        brace++; i++; continue
+      }
       if (c == "}") { if (brace > 0) brace--; i++; continue }
+      if (c == ";" && depth == 0 && brace == 0) { flush(); arrows = 0; rown = 0; i++; continue }
       if (depth == 0 && brace == 0 && substr(s, i, 5) == "with ") {
         prev = (i > 1) ? substr(s, i - 1, 1) : " "
         if (prev ~ /[A-Za-z0-9_]/) { i++; continue }
-        # more than one depth-0 arrow: the row may belong to a returned
-        # function type, so leave it unclassified rather than guess
-        if (arrows > 1) { i++; continue }
         j = i + 5; row = ""; d2 = 0
         while (j <= n) {
           cc = substr(s, j, 1)
           if (cc == "(") { d2++ }
           else if (cc == ")") { if (d2 > 0) { d2-- } else { break } }
           else if (d2 == 0 && (cc == "{" || cc == ";")) { break }
-          # a `where` contract follows the row and is not part of it:
-          # `fn f(x: Int) -> Int with Exception where { requires: x >= 0 }`
-          else if (d2 == 0 && substr(s, j, 6) == "where " && substr(row, length(row), 1) ~ /[ \t]/) { break }
+          else if (d2 == 0 && substr(s, j, 6) == "where " ) { break }
+          # a following `with` starts a NEW row rather than continuing this
+          # one: `-> (String) -> Unit with Exception with Fs` is two rows, and
+          # collecting them as one made the count 1, which took the
+          # single-row skip path and let Fs through
+          else if (d2 == 0 && substr(s, j, 5) == "with " && substr(row, length(row), 1) ~ /[ ]/) { break }
           row = row cc; j++
         }
-        print row
+        rowbuf[++rown] = row
         i = j
         continue
       }
       i++
     }
+    flush()
+  }
+  function flush(  k) {
+    # Which of the rows collected for this declaration are the DECLARATIONS own?
+    #
+    # One depth-0 arrow: the signature is `fn f(...) -> T with R`, so every row
+    # found belongs to f.
+    #
+    # More than one: the return type is itself a function type, and a row may
+    # belong to it instead. With exactly one row -- `fn make() -> (String) ->
+    # Unit with Log::Emit` -- it is the returned closures and f is pure, so it
+    # is skipped. With two or more -- `fn f() -> (String) -> Unit with Exception
+    # with Fs` -- the earlier ones bind to the inner function types and the LAST
+    # one is f own row, so that one is checked. Skipping all of them, as this
+    # did before, let a boundary carry Fs unnoticed.
+    if (arrows <= 1) {
+      for (k = 1; k <= rown; k++) { print rowbuf[k] }
+    } else if (rown >= 2) {
+      print rowbuf[rown]
+    }
+    rown = 0
   }'
 }
 

--- a/scripts/check_portable_boundary.sh
+++ b/scripts/check_portable_boundary.sh
@@ -122,8 +122,27 @@ forbid_pattern() {
 # Separators are `[[:space:]]+`, not one literal space. `perform  Fs::ReadFile`
 # with two spaces, or a tab or newline after `perform`, all compile and all
 # bypassed a pattern that matched exactly one space.
-native_effect_pattern='with[[:space:]]*\{[^}]*(Fs|Process|Socket|Net)|perform[[:space:]]+(Fs|Process|Socket|Http)[[:space:]]*::|\b(compile_file_fs|daemon)\b'
+native_effect_pattern='with[[:space:]]*\{[^}]*(Fs|Process|Socket|Net)|perform[[:space:]]+(Fs|Process|Socket|Http)[[:space:]]*::|\bcompile_file_fs\b'
 
+# `daemon` was dropped for the same reason as `session-http` below, one round
+# later and one level up. Anchoring it to token boundaries (round 40) stopped
+# it matching INSIDE a name, but an exact identifier is still not a reference:
+# `fn f(daemon: Int) -> Int { daemon }` is an ordinary parameter, and matching
+# the token rejected it -- an ordinary local name blocking a required job.
+#
+# What settles it is that `daemon` names nothing in this tree. Every occurrence
+# under lib/ is inside a comment, and comments are removed before this pattern
+# runs, so the alternative could only ever match a name someone chose. That is
+# the same wrong check as `session-http`, not a weaker one.
+#
+# `compile_file_fs` STAYS, and stays unqualified, because it is the opposite
+# case: a real exported function (entry/compiler/file_compile, fs_compile), so
+# a bare occurrence in a boundary file is a real reference -- including in an
+# `import { compile_file_fs }` list, which has neither `(` nor `::` after it.
+# Requiring a call shape here would have traded a false positive nobody will
+# write (a parameter named compile_file_fs) for a miss that is exactly how the
+# lane would be reached.
+#
 # `session-http` was dropped from the lane list. Strings and comments are
 # removed before this runs, so in the remaining text that spelling can only be
 # the subtraction `session - http` -- it is not one vibe identifier, and a

--- a/scripts/check_portable_boundary.sh
+++ b/scripts/check_portable_boundary.sh
@@ -279,7 +279,7 @@ boundary_scan_text() { # <file>
 # one of them is recoverable.
 boundary_effect_rows() { # reads normalized text on stdin
   awk '{
-    s = $0; n = length(s); depth = 0; brack = 0; brace = 0; arrows = 0; rown = 0; decl = ""; i = 1
+    s = $0; n = length(s); depth = 0; brack = 0; brace = 0; arrows = 0; rown = 0; authn = 0; decl = ""; i = 1
     while (i <= n) {
       c = substr(s, i, 1)
       if (c == "(") { depth++; i++; continue }
@@ -292,7 +292,7 @@ boundary_effect_rows() { # reads normalized text on stdin
       if (c == "]") { if (brack > 0) brack--; i++; continue }
       if (depth == 0 && brack == 0 && brace == 0 && substr(s, i, 3) == "fn ") {
         prev = (i > 1) ? substr(s, i - 1, 1) : " "
-        if (prev !~ /[A-Za-z0-9_]/) { arrows = 0; rown = 0; decl = "fn" }
+        if (prev !~ /[A-Za-z0-9_]/) { arrows = 0; rown = 0; authn = 0; decl = "fn" }
         i += 3; continue
       }
       # Which KIND of declaration a row was collected under.
@@ -312,23 +312,23 @@ boundary_effect_rows() { # reads normalized text on stdin
       # this suppresses `type` and nothing else.
       if (depth == 0 && brack == 0 && brace == 0 && substr(s, i, 5) == "type ") {
         prev = (i > 1) ? substr(s, i - 1, 1) : " "
-        if (prev == " ") { arrows = 0; rown = 0; decl = "type" }
+        if (prev == " ") { arrows = 0; rown = 0; authn = 0; decl = "type" }
         i += 5; continue
       }
       if (depth == 0 && brack == 0 && brace == 0 && substr(s, i, 4) == "let ") {
         prev = (i > 1) ? substr(s, i - 1, 1) : " "
-        if (prev == " ") { arrows = 0; rown = 0; decl = "let" }
+        if (prev == " ") { arrows = 0; rown = 0; authn = 0; decl = "let" }
         i += 4; continue
       }
       if (c == "-" && substr(s, i + 1, 1) == ">" && depth == 0 && brack == 0 && brace == 0) {
         arrows++; i++; continue
       }
       if (c == "{") {
-        if (brace == 0) { flush(); arrows = 0; rown = 0; decl = "" }
+        if (brace == 0) { flush(); arrows = 0; rown = 0; authn = 0; decl = "" }
         brace++; i++; continue
       }
       if (c == "}") { if (brace > 0) brace--; i++; continue }
-      if (c == ";" && depth == 0 && brack == 0 && brace == 0) { flush(); arrows = 0; rown = 0; decl = ""; i++; continue }
+      if (c == ";" && depth == 0 && brack == 0 && brace == 0) { flush(); arrows = 0; rown = 0; authn = 0; decl = ""; i++; continue }
       # `=` ends the TYPE of a binding and starts its value. Without this,
       # `export let f: (Int) -> Unit with Exception = (x) -> { () }` ran the
       # row on to the initializer body and reported `effect: x` on a portable
@@ -341,7 +341,28 @@ boundary_effect_rows() { # reads normalized text on stdin
       if (c == "=" && depth == 0 && brack == 0 && brace == 0 \
           && substr(s, i + 1, 1) != "=" \
           && ((i > 1) ? substr(s, i - 1, 1) : " ") !~ /[=<>!+\-*\/%]/) {
-        flush(); arrows = 0; rown = 0; i++; continue
+        flush(); arrows = 0; rown = 0; authn = 0; i++; continue
+      }
+      # An `allows` clause grants host authority (ADR-0088). It is collected
+      # HERE, in the one pass that knows which declaration it belongs to,
+      # rather than by a separate whole-file grep -- that grep had no notion of
+      # declarations, so it rejected `type Cb = () -> Unit with R allows Fs`,
+      # authority that belongs to the aliased function type exactly as the row
+      # does. A capability name is CamelCase; the uppercase test is what keeps
+      # the English verb in prose from reading as a grant.
+      if (depth == 0 && brack == 0 && brace == 0 && substr(s, i, 7) == "allows ") {
+        prev = (i > 1) ? substr(s, i - 1, 1) : " "
+        if (prev !~ /[A-Za-z0-9_]/) {
+          j = i + 7
+          while (j <= n && substr(s, j, 1) == " ") { j++ }
+          if (substr(s, j, 1) ~ /[A-Z]/) {
+            name = ""
+            while (j <= n && substr(s, j, 1) ~ /[A-Za-z0-9_:]/) { name = name substr(s, j, 1); j++ }
+            authbuf[++authn] = name
+            i = j; continue
+          }
+          i += 7; continue
+        }
       }
       if (depth == 0 && brack == 0 && brace == 0 && substr(s, i, 5) == "with ") {
         prev = (i > 1) ? substr(s, i - 1, 1) : " "
@@ -366,6 +387,7 @@ boundary_effect_rows() { # reads normalized text on stdin
           # and its native row went unreported. No effect item contains these
           # keywords, so breaking on them costs nothing.
           else if (d2 == 0 && cc == "=" && substr(s, j + 1, 1) != "=" && substr(s, j - 1, 1) !~ /[=<>!+\-*\/%]/) { break }
+          else if (d2 == 0 && substr(s, j, 7) == "allows " && substr(row, length(row), 1) ~ /[ ]/) { break }
           else if (d2 == 0 && substr(s, j, 3) == "fn " && substr(row, length(row), 1) ~ /[ ]/) { break }
           else if (d2 == 0 && substr(s, j, 5) == "type " && substr(row, length(row), 1) ~ /[ ]/) { break }
           else if (d2 == 0 && substr(s, j, 4) == "let " && substr(row, length(row), 1) ~ /[ ]/) { break }
@@ -404,10 +426,11 @@ boundary_effect_rows() { # reads normalized text on stdin
     #
     # Counting rows against a fixed threshold instead got the last of those
     # wrong: two rows does not mean one of them is the declarations.
-    if (decl != "type" && rown >= arrows && rown >= 1) {
-      print rowbuf[rown]
+    if (decl != "type") {
+      if (rown >= arrows && rown >= 1) { print "row:" rowbuf[rown] }
+      for (k = 1; k <= authn; k++) { print "auth:" authbuf[k] }
     }
-    rown = 0
+    rown = 0; authn = 0
   }'
 }
 
@@ -443,6 +466,7 @@ forbid_foreign_effect_rows() { # <file> <label>
   # allow-list rejects it like any other name it does not know.
   bad="$(boundary_scan_text "$file" \
     | boundary_effect_rows \
+    | sed -n 's/^row://p' \
     | sed 's/\[[^]]*\]//g' \
     | sed 's/::[A-Za-z0-9_]*//g' \
     | grep -oE '[A-Za-z_][A-Za-z0-9_]*' \
@@ -491,8 +515,15 @@ forbid_foreign_effect_rows() { # <file> <label>
 # (`expected an effect name in the effect row after 'with'`).
 forbid_capability_authority() { # <file> <label>
   local file="$1" label="$2"
+  # Declaration-aware, not a whole-file grep: boundary_effect_rows is the one
+  # pass that knows which declaration a clause belongs to, and it tags what it
+  # emits. The grep it replaced rejected an `allows` on a type alias, where the
+  # authority belongs to the aliased function type -- the same reasoning that
+  # already skips an alias's effect row.
   if boundary_scan_text "$file" \
-    | grep -oE '\ballows +[A-Z][A-Za-z0-9_:]*' >/tmp/vibe_portable_authority_hits.$$; then
+    | boundary_effect_rows \
+    | sed -n 's/^auth:/allows /p' >/tmp/vibe_portable_authority_hits.$$
+    [ -s /tmp/vibe_portable_authority_hits.$$ ]; then
     echo "selfhost-portable-boundary: capability authority granted in $label ($file)" >&2
     sed 's/^/  granted: /' /tmp/vibe_portable_authority_hits.$$ >&2
     rm -f /tmp/vibe_portable_authority_hits.$$

--- a/scripts/check_portable_boundary.sh
+++ b/scripts/check_portable_boundary.sh
@@ -138,6 +138,22 @@ boundary_scan_lines() { # <file>
     while (i <= n) {
       c = substr(line, i, 1)
       if (mode[sp] == "code") {
+        if (c == "r" && substr(line, i + 1, 1) == "\"") {
+          # Raw quoted string. lib/@vibe/parser/lexer.vibe scans to the next
+          # quote with NO escape processing, so `r"trailing\"` ENDS at that
+          # quote. Treating it as an ordinary string consumed the backslash and
+          # quote together, stayed in string mode, and discarded every
+          # declaration after it. `r` must be the whole identifier, matching the
+          # lexer, so `var"` is not one.
+          prev = (i > 1) ? substr(line, i - 1, 1) : " "
+          if (prev !~ /[A-Za-z0-9_]/) {
+            j = i + 2
+            while (j <= n && substr(line, j, 1) != "\"") { j++ }
+            out = out " "
+            if (j <= n) { i = j + 1 } else { sp++; mode[sp] = "raw"; i = j }
+            continue
+          }
+        }
         if (c == "\"") { sp++; mode[sp] = "str"; i++; continue }
         if (c == "#" && substr(line, i + 1, 1) == "|") { break }   # raw string to EOL
         if (c == "/" && substr(line, i + 1, 1) == "/") { break }   # comment to EOL
@@ -161,6 +177,11 @@ boundary_scan_lines() { # <file>
           i++; continue
         }
         out = out c; i++; continue
+      }
+      # a raw string carries to the next quote, across lines, with no escapes
+      if (mode[sp] == "raw") {
+        if (c == "\"") { sp--; }
+        i++; continue
       }
       # inside a string literal: the text is inert, the interpolations are not
       if (c == "\\") {

--- a/scripts/check_portable_boundary.sh
+++ b/scripts/check_portable_boundary.sh
@@ -105,27 +105,58 @@ PORTABLE_ALLOWED_EFFECTS='Exception|Async'
 #
 # Order: quoted strings, then raw strings, then comments. A `//` inside a raw
 # string is removed with the raw string rather than mistaken for a comment.
-# KNOWN LIMIT, recorded rather than chased: a string literal nested inside an
-# interpolation -- `"\{String::concat("perform Fs::read_file", " is inert")}"` --
-# is not stripped. The quotes pair sequentially, so the inner text survives into
-# the scanned stream and forbid_pattern reports it as a leak.
+# Drop what does not execute, keep what does. Line-preserving, so a report can
+# still cite a line number.
 #
-# Not fixed here, deliberately. Stripping that correctly means tracking
-# interpolation nesting, which is lexing vibe, and this file has already been
-# through five rounds of "the scanner does not see what the lexer sees" -- each
-# fix correct, each followed by another form. #2581 is where that ends, by
-# asking the compiler; a sixth regex would only move the boundary again.
+# This replaced three `sed` passes, and the reason is a hole they created rather
+# than a form they missed. `"\{perform Fs::ReadFile(path)}"` is an interpolation:
+# the body between `\{` and `}` is CODE and runs. Removing the whole quoted
+# token discarded it, so a real capability call inside one became invisible --
+# and on cli_direct_component_entry.vibe, which is deliberately outside the
+# effect-row allow-list, forbid_pattern is the only thing watching for exactly
+# that. The regex made this gate weaker than it was before the change.
 #
-# Accepting it is defensible because it is strictly NARROWER than what this gate
-# did before: pre-PR it stripped whole comment lines only, so ANY string
-# containing `perform Fs::` was a false positive. Now only a nested one is.
-# Neither scanned file contains such a string today.
+# One pass with an explicit mode stack handles it, and closes the neighbouring
+# case for free: a string nested INSIDE an interpolation
+# (`"\{String::concat("perform Fs::read_file", " is inert")}"`) has its literal
+# text dropped while its own interpolations are kept.
 #
-# Line-preserving form, so a report can still cite a line number.
+# This is a scanner for one lexical construct with a decidable structure, not
+# another attempt to model the effect-row grammar in a pattern. The distinction
+# matters: the grammar attempts kept missing forms nobody had enumerated, while
+# string nesting is closed by construction here.
 boundary_scan_lines() { # <file>
-  sed -E 's/"([^"\\]|\\.)*"//g' "$ROOT_DIR/$1" \
-    | sed 's/#|.*$//' \
-    | sed 's://.*::'
+  awk '{
+    line = $0; n = length(line); out = ""
+    sp = 0; mode[0] = "code"; bdepth[0] = 0
+    i = 1
+    while (i <= n) {
+      c = substr(line, i, 1)
+      if (mode[sp] == "code") {
+        if (c == "\"") { sp++; mode[sp] = "str"; i++; continue }
+        if (c == "#" && substr(line, i + 1, 1) == "|") { break }   # raw string to EOL
+        if (c == "/" && substr(line, i + 1, 1) == "/") { break }   # comment to EOL
+        if (c == "{") { bdepth[sp]++; out = out c; i++; continue }
+        if (c == "}") {
+          if (bdepth[sp] > 0) { bdepth[sp]--; out = out c }
+          else if (sp > 0) { sp--; out = out " " }                 # end of interpolation
+          else { out = out c }
+          i++; continue
+        }
+        out = out c; i++; continue
+      }
+      # inside a string literal: the text is inert, the interpolations are not
+      if (c == "\\") {
+        if (substr(line, i + 1, 1) == "{") {
+          sp++; mode[sp] = "code"; bdepth[sp] = 0; out = out " "; i += 2; continue
+        }
+        i += 2; continue
+      }
+      if (c == "\"") { if (sp > 0) sp--; i++; continue }
+      i++
+    }
+    print out
+  }' "$ROOT_DIR/$1"
 }
 
 boundary_scan_text() { # <file>

--- a/scripts/check_portable_boundary.sh
+++ b/scripts/check_portable_boundary.sh
@@ -353,14 +353,19 @@ boundary_effect_rows() { # reads normalized text on stdin
       # `export let`, turning a false positive into a miss one declaration
       # later. A declaration with no keyword at all keeps being checked --
       # this suppresses `type` and nothing else.
+      # A declaration keyword starts at any token boundary, not only after a
+      # space: `;type Cb = () -> Unit with R` is legal, and requiring a space
+      # missed it, so the aliases row was attributed to the boundary. The dot
+      # stays excluded so a field access spelled `x.type` is not read as a
+      # declaration.
       if (depth == 0 && brack == 0 && brace == 0 && substr(s, i, 5) == "type ") {
         prev = (i > 1) ? substr(s, i - 1, 1) : " "
-        if (prev == " ") { arrows = 0; rown = 0; authn = 0; decl = "type" }
+        if (prev !~ /[A-Za-z0-9_.]/) { arrows = 0; rown = 0; authn = 0; decl = "type" }
         i += 5; continue
       }
       if (depth == 0 && brack == 0 && brace == 0 && substr(s, i, 4) == "let ") {
         prev = (i > 1) ? substr(s, i - 1, 1) : " "
-        if (prev == " ") { arrows = 0; rown = 0; authn = 0; decl = "let" }
+        if (prev !~ /[A-Za-z0-9_.]/) { arrows = 0; rown = 0; authn = 0; decl = "let" }
         i += 4; continue
       }
       if (c == "-" && substr(s, i + 1, 1) == ">" && depth == 0 && brack == 0 && brace == 0) {
@@ -471,7 +476,14 @@ boundary_effect_rows() { # reads normalized text on stdin
     # wrong: two rows does not mean one of them is the declarations.
     if (decl != "type") {
       if (rown >= arrows && rown >= 1) { print "row:" rowbuf[rown] }
-      for (k = 1; k <= authn; k++) { print "auth:" authbuf[k] }
+      # Authority binds to an arrow layer exactly as a row does. `fn make() ->
+      # () -> Unit with () allows Fs::read_file` grants the authority to the
+      # RETURNED function type, not to make, which performs nothing; emitting
+      # every clause rejected that pure helper. The clause the declaration owns
+      # is the last, and only when there are more clauses than layers to absorb
+      # them -- the same arithmetic as the row above, and with one arrow there
+      # is only one function type at depth 0 for a clause to attach to.
+      if (authn >= arrows && authn >= 1) { print "auth:" authbuf[authn] }
     }
     rown = 0; authn = 0
   }'

--- a/scripts/check_portable_boundary_test.sh
+++ b/scripts/check_portable_boundary_test.sh
@@ -30,17 +30,21 @@ cd "$repo_root"
 gate="scripts/check_portable_boundary.sh"
 impl="lib/@vibe/compiler/entry/source_compile/wasi_only/preprocess_compile.vibe"
 contract="lib/@vibe/compiler/entry/source_compile/index.vpkg"
+# The entry file is scanned too, and is deliberately outside the effect-row
+# allow-list -- forbid_pattern is its only protection, which is what the
+# native-call cases at the end exercise.
+entry="lib/@vibe/compiler/cli_direct_component_entry.vibe"
 
 # Refuse to run against a dirty tree: the restore below would discard the
-# author's uncommitted work in these two files.
-if ! git diff --quiet -- "$impl" "$contract"; then
-  echo "portable-boundary-test: $impl or $contract has uncommitted changes." >&2
+# author's uncommitted work in these files.
+if ! git diff --quiet -- "$impl" "$contract" "$entry"; then
+  echo "portable-boundary-test: $impl, $contract or $entry has uncommitted changes." >&2
   echo "  This test mutates and restores them with 'git checkout'. Commit or" >&2
   echo "  stash first, so a restore cannot discard your work." >&2
   exit 2
 fi
 
-restore() { git checkout -q -- "$impl" "$contract" 2>/dev/null || true; }
+restore() { git checkout -q -- "$impl" "$contract" "$entry" 2>/dev/null || true; }
 trap restore EXIT
 
 fails=0
@@ -793,8 +797,55 @@ else
 fi
 restore
 
+# --- cases 48-50: whitespace in a native call -------------------------------
+#
+# `perform  Fs::ReadFile` (two spaces), a tab, and a newline separator all
+# compile, and all bypassed a pattern matching exactly one literal space. The
+# newline case additionally needs the FLATTENED view: a line-oriented grep
+# cannot see a match that spans lines, so forbid_pattern now checks both.
+#
+# These run against the entry file rather than "$impl": cli_direct_component_entry
+# is deliberately outside the effect-row allow-list, so forbid_pattern is its
+# ONLY protection, which is what makes this class of miss matter there.
+printf '\nexport fn probe_sp2(p: String) -> String with Fs {\n  perform  Fs::ReadFile(p)\n}\n' >> "$entry"
+if grep -qF 'perform  Fs::ReadFile(p)' "$entry"; then
+  if bash "$gate" >/dev/null 2>&1; then
+    fail "case: a native call with two spaces passed the gate"
+  else
+    pass "case: repeated whitespace in a native call is still a leak"
+  fi
+else
+  fail "case: the two-space mutation did not land -- the assertion proves nothing"
+fi
+restore
+
+printf '\nexport fn probe_spnl(p: String) -> String with Fs {\n  perform\n    Fs::ReadFile(p)\n}\n' >> "$entry"
+if grep -qE '^  perform$' "$entry"; then
+  if bash "$gate" >/dev/null 2>&1; then
+    fail "case: a native call split across lines passed the gate"
+  else
+    pass "case: a native call split across lines is still a leak"
+  fi
+else
+  fail "case: the newline mutation did not land -- the assertion proves nothing"
+fi
+restore
+
+# And the converse, so widening the separator does not start flagging prose.
+printf '\nexport fn probe_sp_str() -> String with Exception {\n  "do not perform  Fs::ReadFile here"\n}\n' >> "$entry"
+if grep -qF 'do not perform  Fs::ReadFile here' "$entry"; then
+  if bash "$gate" >/dev/null 2>&1; then
+    pass "case: the same text inside a string is still not a leak"
+  else
+    fail "case: an inert string with a spaced native call failed the gate"
+  fi
+else
+  fail "case: the string mutation did not land -- the assertion above proves nothing"
+fi
+restore
+
 if [ "$fails" -ne 0 ]; then
   echo "portable-boundary-test: FAILED" >&2
   exit 1
 fi
-echo "portable-boundary-test: ok (control + 47 cases)"
+echo "portable-boundary-test: ok (control + 50 cases)"

--- a/scripts/check_portable_boundary_test.sh
+++ b/scripts/check_portable_boundary_test.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+# check_portable_boundary_test.sh -- red test for check_portable_boundary.sh.
+#
+# Written when that gate was repaired (#2577). It had been asserting a
+# two-generations-old shape of the boundary -- `export let name: (...) -> Bytes
+# with { Error }` in an `index.vibe` facade -- after ADR-0070 moved the contract
+# to `index.vpkg` and ADR-0085 replaced `Error` with `Exception`. So it reported
+# "missing expected pure boundary" for files that no longer existed, while every
+# boundary it names was intact in the contract beside them. It runs in no CI
+# job, so nothing said so.
+#
+# Repairing a gate that has been dark is exactly when it needs a red test:
+# "it says ok now" is equally consistent with "it was fixed" and "it was
+# neutered". These four cases separate those, and the two mutation cases are
+# the ones the repair could plausibly have broken.
+#
+# The gate scans the repository from its own location rather than a tree it is
+# handed, so each case mutates a real file and restores it with `git checkout`.
+# The restore runs on EXIT, so an interrupted run does not leave the tree
+# modified.
+#
+# #2252: no environment is inherited -- this gate reads none, and the test sets
+# none.
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$repo_root"
+
+gate="scripts/check_portable_boundary.sh"
+impl="lib/@vibe/compiler/entry/source_compile/wasi_only/preprocess_compile.vibe"
+contract="lib/@vibe/compiler/entry/source_compile/index.vpkg"
+
+# Refuse to run against a dirty tree: the restore below would discard the
+# author's uncommitted work in these two files.
+if ! git diff --quiet -- "$impl" "$contract"; then
+  echo "portable-boundary-test: $impl or $contract has uncommitted changes." >&2
+  echo "  This test mutates and restores them with 'git checkout'. Commit or" >&2
+  echo "  stash first, so a restore cannot discard your work." >&2
+  exit 2
+fi
+
+restore() { git checkout -q -- "$impl" "$contract" 2>/dev/null || true; }
+trap restore EXIT
+
+fails=0
+pass() { printf 'portable-boundary-test: ok: %s\n' "$1"; }
+fail() { printf 'portable-boundary-test: FAIL: %s\n' "$1" >&2; fails=1; }
+
+# --- control, first: the unmutated tree passes -------------------------------
+#
+# Load-bearing. Three of the four cases assert a FAILURE, so a gate that
+# rejected everything would make them all "pass" while proving nothing.
+
+if bash "$gate" >/dev/null 2>&1; then
+  pass "control: the unmutated tree passes"
+else
+  fail "control: the unmutated tree is rejected -- the red cases below prove nothing"
+  bash "$gate" >&2 || true
+fi
+
+# --- case 1: a native capability in CODE is rejected -------------------------
+
+printf '\nlet _portable_boundary_probe = perform Fs::read_file("x")\n' >> "$impl"
+if bash "$gate" >/dev/null 2>&1; then
+  fail "case 1: a 'perform Fs::read_file' in code passed"
+else
+  pass "case 1: a native capability in code is rejected"
+fi
+restore
+
+# --- case 2: the same text in a COMMENT is accepted --------------------------
+#
+# The distinction the repair introduced, asserted rather than assumed. These
+# files exist to explain how they differ from the FS lane, so prose naming a
+# native entry point is the writing we want -- the gate was failing on
+# "-- see `compile_file_fs_mode`'s comment, #2391". Case 1 is what keeps this
+# from being a blanket exemption: strip comments, still catch code.
+
+printf '\n/// prose naming perform Fs::read_file and compile_file_fs_mode\n' >> "$impl"
+if bash "$gate" >/dev/null 2>&1; then
+  pass "case 2: the same names in a comment are accepted"
+else
+  fail "case 2: a doc comment naming a native entry point was rejected as a leak"
+fi
+restore
+
+# --- case 3: a boundary that gains an effect is rejected ---------------------
+#
+# The require_line half. `with Exception` becoming `with Fs` is the change this
+# gate exists to catch, and it is the half that had rotted: it was matching a
+# spelling no file in the tree had used for two ADRs.
+
+sed 's/^fn compile_source(source: String) -> Bytes with Exception$/fn compile_source(source: String) -> Bytes with Fs/' \
+  "$contract" > "$contract.probe"
+mv "$contract.probe" "$contract"
+if git diff --quiet -- "$contract"; then
+  fail "case 3: the mutation did not land -- the assertion below would prove nothing"
+else
+  if bash "$gate" >/dev/null 2>&1; then
+    fail "case 3: a boundary declaring 'with Fs' passed"
+  else
+    pass "case 3: a boundary that gains a native effect is rejected"
+  fi
+fi
+restore
+
+if [ "$fails" -ne 0 ]; then
+  echo "portable-boundary-test: FAILED" >&2
+  exit 1
+fi
+echo "portable-boundary-test: ok (control + 3 cases)"

--- a/scripts/check_portable_boundary_test.sh
+++ b/scripts/check_portable_boundary_test.sh
@@ -197,8 +197,56 @@ else
 fi
 restore
 
+# --- cases 11-12: capability authority via `allows` -------------------------
+#
+# `allows` grants authority in the signature, separately from the effect row,
+# and the operation is then called plainly rather than through `perform`. So it
+# matched neither the row allow-list nor `perform (Fs|...)::`: measured, the
+# gate exited 0 on a boundary that read a file.
+for grant in 'Fs::read_file' 'Console::write_stream'; do
+  printf '\nexport fn probe_allows() -> String with Exception allows %s {\n  ""\n}\n' "$grant" >> "$impl"
+  if grep -qF "allows $grant {" "$impl"; then
+    # Capture the diagnostic, not just the exit status. Checking only the
+    # status let a broken message through once already: a backtick inside a
+    # double-quoted echo ran `allows` as a command, so the gate printed
+    # "allows: command not found" and "An  clause ...", and this case stayed
+    # green. AGENTS.md requires the message name the edit that fixes it, so an
+    # unreadable one is a defect the self-test has to be able to see.
+    out="$(bash "$gate" 2>&1)" && rc=0 || rc=$?
+    if [ "$rc" -eq 0 ]; then
+      fail "case: a boundary granted 'allows $grant' passed the gate"
+    elif printf '%s' "$out" | grep -q 'command not found'; then
+      fail "case: the gate's own diagnostic is broken: $out"
+    elif printf '%s' "$out" | grep -qF 'allows'; then
+      pass "case: capability authority 'allows $grant' is rejected, with a readable message"
+    else
+      fail "case: rejected, but the message never says what was wrong: $out"
+    fi
+  else
+    fail "case: the 'allows $grant' mutation did not land -- the assertion proves nothing"
+  fi
+  restore
+done
+
+# --- case 13: English prose containing "allows" is still accepted -----------
+#
+# The clause is told from prose by the CamelCase capability name. Without this,
+# the obvious fix (matching the bare word `allows`) would reject every comment
+# that uses the English verb -- and the tree has several.
+printf '\n/// This entry point allows them to compile without touching the host.\n' >> "$impl"
+if grep -qF 'allows them to compile' "$impl"; then
+  if bash "$gate" >/dev/null 2>&1; then
+    pass "case: prose using the word 'allows' is accepted"
+  else
+    fail "case: an English 'allows' in a comment was read as a capability grant"
+  fi
+else
+  fail "case: the prose mutation did not land -- the assertion above proves nothing"
+fi
+restore
+
 if [ "$fails" -ne 0 ]; then
   echo "portable-boundary-test: FAILED" >&2
   exit 1
 fi
-echo "portable-boundary-test: ok (control + 10 cases)"
+echo "portable-boundary-test: ok (control + 13 cases)"

--- a/scripts/check_portable_boundary_test.sh
+++ b/scripts/check_portable_boundary_test.sh
@@ -2100,8 +2100,62 @@ else
 fi
 restore
 
+# --- cases 127-128: a closure LITERAL under `let` is code, not a type --------
+#
+# Round 52 asked for the row of `let stored = (p: String) -> Int with Fs {
+# Fs::stat_token(p) }` to be suppressed, on the argument that storing an
+# effectful function is pure, the same distinction already made for function
+# type aliases (case: `type Cb = ...`) and returned closure types. The premise
+# is right about the type system and wrong about this gate, and MEASUREMENT is
+# what settles it -- the subject here is the emitted wasm host imports, so the
+# question is what each shape imports, not what it evaluates.
+#
+# Compiled all four, each a whole program whose closure is NEVER CALLED, and
+# grepped the module for the `fs_stat_token` host import:
+#
+#   type Cb = (String) -> Int with Fs                                  absent
+#   fn make(g: (String) -> Int with Fs) -> (String) -> Int with Fs {g} absent
+#   let stored: (String) -> Int with Fs = g        (annotation only)   absent
+#   let stored = (p: String) -> Int with Fs { Fs::stat_token(p) }      PRESENT
+#
+# The first three are type positions with no code behind them. The fourth is a
+# closure literal -- a body that gets emitted, and its import lands in the
+# module whether or not anything invokes it. "Any function that invokes it must
+# declare its own row" is true and not sufficient: nothing invokes this one and
+# the boundary imports the filesystem anyway.
+#
+# So the row stays reported, and these cases pin it. If a later round makes
+# `let` suppress its value row like `type` does, case 127 fails -- and that is
+# the finding, not the fix.
+printf '\nexport let stored = (p: String) -> Int with Fs { Fs::stat_token(p) }\n' >> "$impl"
+if grep -qF -- 'export let stored = (p: String) -> Int with Fs {' "$impl"; then
+  if bash "$gate" >/dev/null 2>&1; then
+    fail "case: a stored closure literal acquired Fs without being reported"
+  else
+    pass "case: a closure literal under 'let' is reported like any other body"
+  fi
+else
+  fail "case: the stored-closure mutation did not land -- it proves nothing"
+fi
+restore
+
+# The control for it: the same binding with a row the allow-list admits must
+# still build. Without this the case above would also pass on a gate that
+# rejected every `let`.
+printf '\nexport let stored = (p: String) -> Int with Exception { String::length(p) }\n' >> "$impl"
+if grep -qF -- 'export let stored = (p: String) -> Int with Exception {' "$impl"; then
+  if bash "$gate" >/dev/null 2>&1; then
+    pass "case: a stored closure with an allowed row still builds"
+  else
+    fail "case: an allowed row on a stored closure was rejected"
+  fi
+else
+  fail "case: the allowed-row mutation did not land -- it proves nothing"
+fi
+restore
+
 if [ "$fails" -ne 0 ]; then
   echo "portable-boundary-test: FAILED" >&2
   exit 1
 fi
-echo "portable-boundary-test: ok (control + 126 cases)"
+echo "portable-boundary-test: ok (control + 128 cases)"

--- a/scripts/check_portable_boundary_test.sh
+++ b/scripts/check_portable_boundary_test.sh
@@ -1926,8 +1926,54 @@ else
 fi
 restore
 
+# --- cases 113-115: `impl` may be followed by `[` ---------------------------
+#
+# Round 49, and the third spacing variant in three rounds. `impl[T] Tr[T] for
+# S[T]` is the generic form: the lexer emits TImpl then TLBracket, with no
+# space required. Matching the literal `impl ` left that block opaque, so a
+# method inside it could carry `with Fs` unseen -- measured, the gate printed
+# ok. A keyword ends where the identifier characters end, not where a space
+# happens to be.
+printf '\nexport trait ProbeG[T] {\n  read_it(Self, String) -> Int\n}\n\nexport struct ProbeGS[T] {\n  x: T\n}\n\nimpl[T] ProbeG[T] for ProbeGS[T] {\n  read_it(self, p) -> Int with Fs {\n    Fs::stat_token(p)\n  }\n}\n' >> "$impl"
+if grep -qF -- 'impl[T] ProbeG[T] for ProbeGS[T] {' "$impl"; then
+  if bash "$gate" >/dev/null 2>&1; then
+    fail "case: a generic impl block stayed opaque and hid a native row"
+  else
+    pass "case: a generic impl[T] block is transparent like a plain one"
+  fi
+else
+  fail "case: the generic-impl mutation did not land -- it proves nothing"
+fi
+restore
+
+printf '\nexport trait ProbeG2[T] {\n  read_it(Self, String) -> Int\n}\n\nexport struct ProbeGS2[T] {\n  x: T\n}\n\nimpl[T] ProbeG2[T] for ProbeGS2[T] {\n  read_it(self, p) -> Int with Async {\n    0\n  }\n}\n' >> "$impl"
+if grep -qF -- 'impl[T] ProbeG2[T] for ProbeGS2[T] {' "$impl"; then
+  if bash "$gate" >/dev/null 2>&1; then
+    pass "case: an allowed row in a generic impl block is accepted"
+  else
+    fail "case: an allowed row in a generic impl block was rejected"
+  fi
+else
+  fail "case: the generic-impl-allowed mutation did not land -- it proves nothing"
+fi
+restore
+
+# Dropping the trailing space cannot make the keyword match a longer name:
+# `implicit_probe` starts with `impl` and is an ordinary function.
+printf '\nfn implicit_probe() -> Bool {\n  false\n}\n' >> "$impl"
+if grep -qF -- 'fn implicit_probe() -> Bool {' "$impl"; then
+  if bash "$gate" >/dev/null 2>&1; then
+    pass "case: a name merely starting with impl is not an impl block"
+  else
+    fail "case: implicit_probe was read as an impl block"
+  fi
+else
+  fail "case: the implicit-name mutation did not land -- it proves nothing"
+fi
+restore
+
 if [ "$fails" -ne 0 ]; then
   echo "portable-boundary-test: FAILED" >&2
   exit 1
 fi
-echo "portable-boundary-test: ok (control + 112 cases)"
+echo "portable-boundary-test: ok (control + 115 cases)"

--- a/scripts/check_portable_boundary_test.sh
+++ b/scripts/check_portable_boundary_test.sh
@@ -1283,8 +1283,48 @@ else
 fi
 restore
 
+# --- cases 75-76: a raw keyword must not become scanner syntax --------------
+#
+# Round 34, and this one was made by round 31: stripping `r#` handed the
+# scanner its own syntax. `r#where` is an identifier -- being an identifier is
+# the whole point of the `r#` spelling -- but emitted bare it read as the
+# contract keyword, so `with Exception + r#where + Fs` stopped at it and the
+# native Fs after it was never seen. Measured: ACCEPT.
+#
+# An underscore is now appended to exactly the keywords the passes below react
+# to. All of them require a following space, so the suffix defeats the match
+# and leaves an ordinary identifier. Nothing is lost by not restoring the true
+# name: no keyword is an allow-listed effect or a native capability, so an
+# effect genuinely called `where` is rejected either way -- it is simply not
+# `Exception` or `Async`.
+printf '\neffect r#where {\n  Tick() -> Unit\n}\n\nexport fn probe_raw_kw() -> Unit with Exception + r#where + Fs {\n  ()\n}\n' >> "$impl"
+if grep -qF -- 'with Exception + r#where + Fs {' "$impl"; then
+  if bash "$gate" >/dev/null 2>&1; then
+    fail "case: a raw keyword truncated the row and hid the native effect"
+  else
+    pass "case: a raw keyword does not terminate the effect row"
+  fi
+else
+  fail "case: the raw-keyword mutation did not land -- the assertion proves nothing"
+fi
+restore
+
+# Without the native effect: the raw keyword is itself an unresolved name, and
+# unresolved is not portable -- the same rule as the row variable in case 25.
+printf '\neffect r#where {\n  Tick() -> Unit\n}\n\nexport fn probe_raw_kw_only() -> Unit with Exception + r#where {\n  ()\n}\n' >> "$impl"
+if grep -qF -- 'with Exception + r#where {' "$impl"; then
+  if bash "$gate" >/dev/null 2>&1; then
+    fail "case: an effect named by a raw keyword passed the allow-list"
+  else
+    pass "case: an effect named by a raw keyword is not allow-listed"
+  fi
+else
+  fail "case: the raw-keyword-only mutation did not land -- it proves nothing"
+fi
+restore
+
 if [ "$fails" -ne 0 ]; then
   echo "portable-boundary-test: FAILED" >&2
   exit 1
 fi
-echo "portable-boundary-test: ok (control + 74 cases)"
+echo "portable-boundary-test: ok (control + 76 cases)"

--- a/scripts/check_portable_boundary_test.sh
+++ b/scripts/check_portable_boundary_test.sh
@@ -2043,8 +2043,65 @@ else
 fi
 rm -f "$gate_tmp"
 
+# --- cases 122-125: the entry file gets the row check, with its contract -----
+#
+# Round 51, and the class I told the reviewer one round earlier was impossible
+# here. That was true of the CALL and I stopped there: `println` has no
+# namespace token, so no regex over the call reaches it. But the checker
+# REQUIRES `with Stdout` on the declaration -- measured, `fn f() -> Unit {
+# println("x") }` is rejected with "missing { Stdout }" -- and a row is a name
+# the scanner can already read. The handle was one layer over from where I was
+# looking.
+#
+# So the entry file gets the row check too, with an allow-list of what it IS
+# entitled to (Exception, Fs, Async). It was exempt because a SHARED allow-list
+# would have failed it on its own legitimate `with Exception + Fs`; that was
+# right about the shared list and wrong about the check.
+printf '\nfn probe_println_row() -> Unit with Stdout {\n  println("leaked")\n}\n' >> "$entry"
+if grep -qF -- 'println("leaked")' "$entry"; then
+  if bash "$gate" >/dev/null 2>&1; then
+    fail "case: an unqualified capability builtin passed the entry gate"
+  else
+    pass "case: an unqualified builtin is caught by its declared row"
+  fi
+else
+  fail "case: the println mutation did not land -- it proves nothing"
+fi
+restore
+
+# The three effects it actually declares must keep building. This is the
+# direction that kept the row check off this file for so long, so all three
+# are pinned rather than sampled.
+for row in 'Fs' 'Exception' 'Exception + Fs'; do
+  printf '\nfn probe_entry_contract(p: String) -> Int with %s {\n  Fs::stat_token(p)\n}\n' "$row" >> "$entry"
+  if grep -qF "with $row {" "$entry"; then
+    if bash "$gate" >/dev/null 2>&1; then
+      pass "case: the entry file may declare 'with $row'"
+    else
+      fail "case: the entry file own contract 'with $row' was rejected"
+    fi
+  else
+    fail "case: the '$row' mutation did not land -- the assertion proves nothing"
+  fi
+  restore
+done
+
+# And a capability it is NOT entitled to is now caught by the row, whatever the
+# call looks like -- no namespace token needed.
+printf '\nfn probe_entry_stdin_row() -> Unit with Stdin {\n  ()\n}\n' >> "$entry"
+if grep -qF -- 'fn probe_entry_stdin_row() -> Unit with Stdin {' "$entry"; then
+  if bash "$gate" >/dev/null 2>&1; then
+    fail "case: an excluded capability row passed the entry gate"
+  else
+    pass "case: an excluded capability is caught by the row alone"
+  fi
+else
+  fail "case: the Stdin-row mutation did not land -- it proves nothing"
+fi
+restore
+
 if [ "$fails" -ne 0 ]; then
   echo "portable-boundary-test: FAILED" >&2
   exit 1
 fi
-echo "portable-boundary-test: ok (control + 121 cases)"
+echo "portable-boundary-test: ok (control + 126 cases)"

--- a/scripts/check_portable_boundary_test.sh
+++ b/scripts/check_portable_boundary_test.sh
@@ -1131,8 +1131,107 @@ else
 fi
 restore
 
+# --- cases 67-70: authority belongs to a declaration too --------------------
+#
+# Round 32. The `allows` check was a whole-file grep with no notion of
+# declarations, so `type Cb = () -> Unit with Log::Emit allows Fs::read_file`
+# was rejected -- authority that belongs to the aliased function type, exactly
+# as its effect row does. `allows` in type position is legal and the parser has
+# its own test for it (lib/@vibe/compiler/tests/parser_test.vibe, "#1345:
+# `allows` works in type position too").
+#
+# The fix moved the collection into boundary_effect_rows, the one pass that
+# knows which declaration a clause belongs to; the two checks now read the same
+# tagged stream. Cases 11-15 still hold -- they are on `fn` declarations, which
+# is the point.
+printf '\ntype AllowsAlias = () -> Unit with Log::Emit allows Fs::read_file\n' >> "$impl"
+if grep -qF -- 'type AllowsAlias = () -> Unit with Log::Emit allows Fs::read_file' "$impl"; then
+  if bash "$gate" >/dev/null 2>&1; then
+    pass "case: an allows clause on a type alias is not the boundary authority"
+  else
+    fail "case: a legal allows clause in type position failed the gate"
+  fi
+else
+  fail "case: the alias-allows mutation did not land -- it proves nothing"
+fi
+restore
+
+# The miss that suppression could open, pinned in the same commit: an alias
+# must not swallow the authority of the declaration after it.
+printf '\ntype AllowsAlias2 = () -> Unit with Log::Emit allows Fs::read_file\n\nexport fn probe_after_allows_alias() -> String with Exception allows Console::write_stream {\n  ""\n}\n' >> "$impl"
+if grep -qF -- 'allows Console::write_stream {' "$impl"; then
+  if bash "$gate" >/dev/null 2>&1; then
+    fail "case: an alias swallowed the next declaration authority clause"
+  else
+    pass "case: a declaration after an allows alias keeps its own authority"
+  fi
+else
+  fail "case: the alias-then-authority mutation did not land -- it proves nothing"
+fi
+restore
+
+# A BINDING is a boundary declaration, so its authority is still reported --
+# the same split as case 62 draws for rows.
+printf '\nexport let probe_bind_allows: (Int) -> Unit with Exception allows Fs::read_file = (x) -> {\n  ()\n}\n' >> "$impl"
+if grep -qF -- 'export let probe_bind_allows: (Int) -> Unit with Exception allows Fs::read_file = (x) -> {' "$impl"; then
+  if bash "$gate" >/dev/null 2>&1; then
+    fail "case: authority on a function binding went unreported"
+  else
+    pass "case: a function binding authority clause is still the boundary own"
+  fi
+else
+  fail "case: the binding-allows mutation did not land -- it proves nothing"
+fi
+restore
+
+# --- case 70: THE COST OF CASE 67, pinned so it is visible ------------------
+#
+# `type Cb = () -> Unit with () allows Fs` is now accepted. Same trade as cases
+# 43 and 60: an alias is not itself a boundary, and no text scan can tell
+# whether the boundary ever hands one out. #2581 answers it from the AST.
+#
+# When #2581 lands this flips to a rejection. UPDATE THE CASE, do not revert --
+# accepting the alias is what keeps legal code building.
+printf '\ntype AllowsAlias3 = () -> Unit with () allows Fs\n' >> "$impl"
+if grep -qF -- 'type AllowsAlias3 = () -> Unit with () allows Fs' "$impl"; then
+  if bash "$gate" >/dev/null 2>&1; then
+    pass "case: KNOWN MISS -- authority named only by an alias (#2581)"
+  else
+    fail "case: the alias authority miss closed; flip this case to a rejection"
+  fi
+else
+  fail "case: the alias-authority-miss mutation did not land -- it proves nothing"
+fi
+restore
+
+# --- case 71: authority is diagnosed AS authority ---------------------------
+#
+# Round 32, found by red-testing rather than by review: dropping the `allows`
+# row terminator changed no verdict, so nothing failed -- the clause was simply
+# swallowed into the effect row and rejected there instead, as
+# `effect: allows` alongside `effect: Fs`. Same exit code, useless message: it
+# names an effect that does not exist and no edit that fixes it, which is the
+# defect AGENTS.md's actionable-diagnostic rule is about. Cases 11-12 could not
+# see it because they assert only that the text `allows` appears somewhere.
+#
+# So this pins the CLAUSE being diagnosed as a clause.
+printf '\nexport fn probe_auth_msg() -> String with Exception allows Fs::read_file {\n  ""\n}\n' >> "$impl"
+if grep -qF -- 'allows Fs::read_file {' "$impl"; then
+  out="$(bash "$gate" 2>&1)" && rc=0 || rc=$?
+  if [ "$rc" -eq 0 ]; then
+    fail "case: an authority clause passed the gate"
+  elif printf '%s' "$out" | grep -qF 'granted: allows Fs::read_file'; then
+    pass "case: an authority clause is diagnosed as authority, not as an effect"
+  else
+    fail "case: rejected, but not as an authority grant: $out"
+  fi
+else
+  fail "case: the authority-message mutation did not land -- it proves nothing"
+fi
+restore
+
 if [ "$fails" -ne 0 ]; then
   echo "portable-boundary-test: FAILED" >&2
   exit 1
 fi
-echo "portable-boundary-test: ok (control + 66 cases)"
+echo "portable-boundary-test: ok (control + 71 cases)"

--- a/scripts/check_portable_boundary_test.sh
+++ b/scripts/check_portable_boundary_test.sh
@@ -419,8 +419,59 @@ else
 fi
 restore
 
+# --- case 25: an effect-row variable ----------------------------------------
+#
+# `fn probe[e](f: () -> Unit with e) -> Unit with e` runs whatever effect its
+# caller instantiates, Fs included, while naming no capability at all. Matching
+# only capitalized names dropped it silently. Unresolved is not portable, so
+# the allow-list rejects it like any other name it does not know.
+printf '\nexport fn probe_rv[e](f: () -> Unit with e) -> Unit with e {\n  f()\n}\n' >> "$impl"
+if grep -qF -- '-> Unit with e {' "$impl"; then
+  if bash "$gate" >/dev/null 2>&1; then
+    fail "case: an effect-row variable passed the gate"
+  else
+    pass "case: an unresolved effect-row variable is rejected"
+  fi
+else
+  fail "case: the row-variable mutation did not land -- the assertion proves nothing"
+fi
+restore
+
+# --- case 26: a parameter carries its own row -------------------------------
+#
+# THE false positive. "From `with` to the next `{`" started at the PARAMETER's
+# row, swallowed `) -> Unit`, and reported `effect: Unit` on a legitimate
+# higher-order helper. The outer row is the one at parenthesis depth 0.
+printf '\nexport fn probe_cb(f: () -> Unit with Exception) -> Unit with Exception {\n  f()\n}\n' >> "$impl"
+if grep -qF '(f: () -> Unit with Exception)' "$impl"; then
+  if bash "$gate" >/dev/null 2>&1; then
+    pass "case: a parameter's own effect row is not read as the declaration's"
+  else
+    fail "case: a higher-order helper with an effectful callback was rejected"
+  fi
+else
+  fail "case: the callback mutation did not land -- the assertion above proves nothing"
+fi
+restore
+
+# --- case 27: an escaped quote inside a string ------------------------------
+#
+# `"[^"]*"` ended the literal at the backslash-escaped quote and left the inert
+# text exposed, so an ordinary diagnostic string failed the gate.
+printf '\nexport fn probe_eq() -> String with Exception {\n  "prefix \\"with Fs\\" suffix"\n}\n' >> "$impl"
+if grep -qF 'prefix \"with Fs\" suffix' "$impl"; then
+  if bash "$gate" >/dev/null 2>&1; then
+    pass "case: an escaped quote inside a string does not expose its text"
+  else
+    fail "case: a string containing an escaped quote failed the gate"
+  fi
+else
+  fail "case: the escaped-quote mutation did not land -- the assertion above proves nothing"
+fi
+restore
+
 if [ "$fails" -ne 0 ]; then
   echo "portable-boundary-test: FAILED" >&2
   exit 1
 fi
-echo "portable-boundary-test: ok (control + 24 cases)"
+echo "portable-boundary-test: ok (control + 27 cases)"

--- a/scripts/check_portable_boundary_test.sh
+++ b/scripts/check_portable_boundary_test.sh
@@ -310,8 +310,39 @@ else
 fi
 restore
 
+# --- cases 18-19: an effect item with type arguments ------------------------
+#
+# `parse_effect_item` accepts a generic item, and `with Exception[String] + Fs`
+# compiles -- verified with `vibe test`. Matching bare identifiers stopped at
+# the `[`, recorded the allowed `Exception`, and never saw the `Fs`. Both
+# directions again: the generic form must not hide a capability, and must not
+# start rejecting an allowed row either.
+printf '\nexport fn probe_gen() -> Unit with Exception[String] + Fs {\n  ()\n}\n' >> "$impl"
+if grep -qF 'with Exception[String] + Fs' "$impl"; then
+  if bash "$gate" >/dev/null 2>&1; then
+    fail "case: a generic effect item hid the capability after it"
+  else
+    pass "case: a capability after a generic effect item is rejected"
+  fi
+else
+  fail "case: the generic-item mutation did not land -- the assertion proves nothing"
+fi
+restore
+
+printf '\nexport fn probe_gen_ok() -> Unit with Exception[String] + Async {\n  ()\n}\n' >> "$impl"
+if grep -qF 'with Exception[String] + Async' "$impl"; then
+  if bash "$gate" >/dev/null 2>&1; then
+    pass "case: a generic item in an otherwise allowed row is accepted"
+  else
+    fail "case: 'with Exception[String] + Async' was rejected -- the type argument leaked into the name"
+  fi
+else
+  fail "case: the generic-item mutation did not land -- the assertion proves nothing"
+fi
+restore
+
 if [ "$fails" -ne 0 ]; then
   echo "portable-boundary-test: FAILED" >&2
   exit 1
 fi
-echo "portable-boundary-test: ok (control + 17 cases)"
+echo "portable-boundary-test: ok (control + 19 cases)"

--- a/scripts/check_portable_boundary_test.sh
+++ b/scripts/check_portable_boundary_test.sh
@@ -341,8 +341,40 @@ else
 fi
 restore
 
+# --- cases 20-21: a qualified effect item -----------------------------------
+#
+# `parse_effect_item` accepts `Ident::Ident`, and `with Exception::Throw + Fs`
+# compiles. This was the sixth form the old grammar-matching regex did not
+# know, and the reason the scan stopped modelling the grammar: it now reads the
+# whole span between `with` and the body and checks every capability name in
+# it, so separators and item shapes do not matter. The allowed-qualified case
+# is what proves the `::op` suffix is dropped rather than read as a name.
+printf '\nexport fn probe_qual() -> Unit with Exception::Throw + Fs {\n  ()\n}\n' >> "$impl"
+if grep -qF 'with Exception::Throw + Fs' "$impl"; then
+  if bash "$gate" >/dev/null 2>&1; then
+    fail "case: a qualified effect item hid the capability after it"
+  else
+    pass "case: a capability after a qualified effect item is rejected"
+  fi
+else
+  fail "case: the qualified-item mutation did not land -- the assertion proves nothing"
+fi
+restore
+
+printf '\nexport fn probe_qual_ok() -> Unit with Exception::Throw {\n  ()\n}\n' >> "$impl"
+if grep -qF 'with Exception::Throw {' "$impl"; then
+  if bash "$gate" >/dev/null 2>&1; then
+    pass "case: a qualified allowed item is accepted"
+  else
+    fail "case: 'with Exception::Throw' was rejected -- the operation name was read as an effect"
+  fi
+else
+  fail "case: the qualified-item mutation did not land -- the assertion proves nothing"
+fi
+restore
+
 if [ "$fails" -ne 0 ]; then
   echo "portable-boundary-test: FAILED" >&2
   exit 1
 fi
-echo "portable-boundary-test: ok (control + 19 cases)"
+echo "portable-boundary-test: ok (control + 21 cases)"

--- a/scripts/check_portable_boundary_test.sh
+++ b/scripts/check_portable_boundary_test.sh
@@ -1601,8 +1601,127 @@ else
 fi
 restore
 
+# --- cases 94-95: a handler arm head names an operation, it does not call it -
+#
+# Round 42, a false positive. `handle { f() } with { Fs::ReadFile(_p) =>
+# resume("ok") }` is a pure helper taking an Fs-effectful callback and
+# discharging it locally -- nothing escapes -- yet the `with \{...\}`
+# alternative saw `Fs` between the braces and rejected it. The spelling is
+# pinned in lib/@vibe/fs/index_import_test.vibe.
+#
+# Measuring the neighbour found the SAME defect in the capability-namespace
+# alternative added for the entry file one round earlier: a `Console::Write`
+# arm head there was read as a call. Both are fixed by exempting the arm HEAD,
+# which is decidable without parsing -- a qualified name whose argument list is
+# immediately followed by `=>`.
+printf '\nfn probe_handled_fs(f: () -> String with Fs) -> String with Exception {\n  handle {\n    f()\n  } with { Fs::ReadFile(_path) => resume("ok"); Fs::WriteFile(_p, _c) => resume(0); Fs::Exists(_p) => resume(true); Fs::Mkdir(_p) => resume(0) }\n}\n' >> "$impl"
+if grep -qF -- 'Fs::ReadFile(_path) => resume("ok")' "$impl"; then
+  if bash "$gate" >/dev/null 2>&1; then
+    pass "case: an effect discharged by a local handler is not a leak"
+  else
+    fail "case: a helper handling Fs locally was rejected"
+  fi
+else
+  fail "case: the handled-effect mutation did not land -- it proves nothing"
+fi
+restore
+
+printf '\nfn probe_handled_console(f: () -> Unit with Console) -> Unit {\n  handle {\n    f()\n  } with { Console::Write(_s) => resume(()) }\n}\n' >> "$entry"
+if grep -qF -- 'Console::Write(_s) => resume(())' "$entry"; then
+  if bash "$gate" >/dev/null 2>&1; then
+    pass "case: a handler arm head in the entry file is not a capability call"
+  else
+    fail "case: a Console arm head in the entry file was read as a call"
+  fi
+else
+  fail "case: the entry handler mutation did not land -- it proves nothing"
+fi
+restore
+
+# --- case 96: the arm BODY is not exempt ------------------------------------
+#
+# The exemption is the head only. A real capability call inside an arm body is
+# still a leak, and without this the fix could have been "stop scanning
+# handlers".
+printf '\nfn probe_arm_body(f: () -> Unit with Console) -> Unit {\n  handle {\n    f()\n  } with { Console::Write(_s) => {\n    Console::write_stream("leaked")\n    resume(())\n  } }\n}\n' >> "$entry"
+if grep -qF -- 'Console::write_stream("leaked")' "$entry"; then
+  if bash "$gate" >/dev/null 2>&1; then
+    fail "case: a capability call inside a handler arm body passed the gate"
+  else
+    pass "case: a handler arm body is still scanned"
+  fi
+else
+  fail "case: the arm-body mutation did not land -- it proves nothing"
+fi
+restore
+
+# --- cases 97-99: an impl block holds declarations --------------------------
+#
+# Round 41, a P1 miss. An impl method sits one brace deep, and the row scan
+# guards everything on brace == 0, so a method could carry `with Fs` unseen --
+# measured, the gate printed ok. The block is transparent now: its `{` does not
+# open a body.
+#
+# `struct` / `enum` / `effect` bodies are NOT declarations in that sense and
+# stay opaque. Case 99 is why they have to clear the flag: a block-less `impl
+# Eq for Int` would otherwise hand its transparency to whatever brace came
+# next, and the native row after it would be read at the wrong depth.
+printf '\nexport trait ProbeReader {\n  read_it(Self, String) -> Int\n}\n\nexport struct ProbeR {\n  x: Int\n}\n\nimpl ProbeReader for ProbeR {\n  read_it(self, p) -> Int with Fs {\n    Fs::stat_token(p)\n  }\n}\n' >> "$impl"
+if grep -qF -- 'read_it(self, p) -> Int with Fs {' "$impl"; then
+  if bash "$gate" >/dev/null 2>&1; then
+    fail "case: an impl method carrying a native row passed the gate"
+  else
+    pass "case: an impl method row is checked like any other declaration"
+  fi
+else
+  fail "case: the impl mutation did not land -- the assertion proves nothing"
+fi
+restore
+
+printf '\nexport trait ProbeReader2 {\n  read_it(Self, String) -> Int\n}\n\nexport struct ProbeR2 {\n  x: Int\n}\n\nimpl ProbeReader2 for ProbeR2 {\n  read_it(self, p) -> Int with Async {\n    0\n  }\n}\n' >> "$impl"
+if grep -qF -- 'read_it(self, p) -> Int with Async {' "$impl"; then
+  if bash "$gate" >/dev/null 2>&1; then
+    pass "case: an impl method with an allowed row is accepted"
+  else
+    fail "case: an impl method with an allowed row was rejected"
+  fi
+else
+  fail "case: the impl-allowed mutation did not land -- it proves nothing"
+fi
+restore
+
+# The probe carries the row in a struct FIELD, not in a following function,
+# and that is the whole point. Written as a following function it rejected
+# either way -- the verdict came from the function, not from the struct -- so
+# removing the clear changed nothing and the case proved nothing. A struct body
+# is opaque, so a field row is invisible; the control below is the same struct
+# with no impl before it, and the two must agree.
+printf '\nexport trait ProbeMarker\n\nimpl ProbeMarker for Int\n\nexport struct HolderS {\n  f: () -> Unit with Fs\n}\n' >> "$impl"
+if grep -qF -- 'export struct HolderS {' "$impl"; then
+  if bash "$gate" >/dev/null 2>&1; then
+    pass "case: a block-less impl does not make the next brace transparent"
+  else
+    fail "case: a block-less impl leaked transparency into a struct body"
+  fi
+else
+  fail "case: the block-less impl mutation did not land -- it proves nothing"
+fi
+restore
+
+printf '\nexport struct HolderS2 {\n  f: () -> Unit with Fs\n}\n' >> "$impl"
+if grep -qF -- 'export struct HolderS2 {' "$impl"; then
+  if bash "$gate" >/dev/null 2>&1; then
+    pass "case: a struct field row is invisible, impl or no impl"
+  else
+    fail "case: a struct field row was read as the boundary own"
+  fi
+else
+  fail "case: the struct-control mutation did not land -- it proves nothing"
+fi
+restore
+
 if [ "$fails" -ne 0 ]; then
   echo "portable-boundary-test: FAILED" >&2
   exit 1
 fi
-echo "portable-boundary-test: ok (control + 93 cases)"
+echo "portable-boundary-test: ok (control + 100 cases)"

--- a/scripts/check_portable_boundary_test.sh
+++ b/scripts/check_portable_boundary_test.sh
@@ -1083,8 +1083,56 @@ else
 fi
 restore
 
+# --- cases 64-66: a raw identifier is the same name -------------------------
+#
+# Round 31. `lex_ident` (lib/@vibe/parser/lexer.vibe) turns `r#Exception` into
+# TIdent("Exception") -- the exact token the plain spelling produces -- so the
+# two ARE one name. Splitting the source text instead produced `r` and
+# `Exception` as separate tokens and rejected a portable boundary as
+# `effect: r`.
+#
+# The prefix is dropped once, in the lexical pass, so the fix is not confined
+# to the direction that was reported: measured before it, `perform
+# r#Fs::ReadFile(path)` in the entry file matched no native pattern and passed
+# the gate outright (case 66). One spelling, one answer, every check.
+printf '\nexport fn probe_raw_allowed() -> Unit with r#Exception {\n  ()\n}\n' >> "$impl"
+if grep -qF -- '-> Unit with r#Exception {' "$impl"; then
+  if bash "$gate" >/dev/null 2>&1; then
+    pass "case: a raw identifier spelling of an allowed effect is accepted"
+  else
+    fail "case: a raw identifier was split, most likely rejected as effect: r"
+  fi
+else
+  fail "case: the raw-identifier mutation did not land -- it proves nothing"
+fi
+restore
+
+printf '\nexport fn probe_raw_native() -> Unit with r#Fs {\n  ()\n}\n' >> "$impl"
+if grep -qF -- '-> Unit with r#Fs {' "$impl"; then
+  if bash "$gate" >/dev/null 2>&1; then
+    fail "case: a native effect spelled raw passed the allow-list"
+  else
+    pass "case: a raw identifier does not hide a native effect"
+  fi
+else
+  fail "case: the raw-native mutation did not land -- the assertion proves nothing"
+fi
+restore
+
+printf '\nfn probe_raw_call() -> Unit {\n  perform r#Fs::ReadFile(path)\n}\n' >> "$entry"
+if grep -qF -- 'perform r#Fs::ReadFile(path)' "$entry"; then
+  if bash "$gate" >/dev/null 2>&1; then
+    fail "case: a native call spelled raw evaded the native-pattern scan"
+  else
+    pass "case: a raw identifier does not hide a native call either"
+  fi
+else
+  fail "case: the raw-call mutation did not land -- the assertion proves nothing"
+fi
+restore
+
 if [ "$fails" -ne 0 ]; then
   echo "portable-boundary-test: FAILED" >&2
   exit 1
 fi
-echo "portable-boundary-test: ok (control + 63 cases)"
+echo "portable-boundary-test: ok (control + 66 cases)"

--- a/scripts/check_portable_boundary_test.sh
+++ b/scripts/check_portable_boundary_test.sh
@@ -731,8 +731,70 @@ else
 fi
 restore
 
+# --- cases 44-45: arrow count belongs to ONE declaration --------------------
+#
+# The ambiguity guard reset only on `{`, so a bodyless declaration carrying an
+# arrow (`type Cb = (Int) -> Int`) left the count at 1; the next function's own
+# arrow made 2 and its row was skipped. An unrelated type alias silently
+# disabled the check for the declaration after it. The count is anchored to
+# `fn` now. Both directions, since the anchor could equally over-reset.
+printf '\ntype Cb = (Int) -> Int\n\nexport fn rn_native() -> Unit with Fs {\n  ()\n}\n' >> "$impl"
+if grep -qF -- 'type Cb = (Int) -> Int' "$impl"; then
+  if bash "$gate" >/dev/null 2>&1; then
+    fail "case: a type alias with an arrow disabled the check for the next declaration"
+  else
+    pass "case: an arrow in a bodyless declaration does not leak into the next"
+  fi
+else
+  fail "case: the alias mutation did not land -- the assertion proves nothing"
+fi
+restore
+
+printf '\ntype Cb2 = (Int) -> Int\n\nexport fn rn_pure() -> Unit with Exception {\n  ()\n}\n' >> "$impl"
+if grep -qF -- 'type Cb2 = (Int) -> Int' "$impl"; then
+  if bash "$gate" >/dev/null 2>&1; then
+    pass "case: an allowed row after a bodyless arrow declaration is still accepted"
+  else
+    fail "case: the arrow anchor made an allowed row reject"
+  fi
+else
+  fail "case: the alias mutation did not land -- the assertion proves nothing"
+fi
+restore
+
+# --- cases 46-47: a `where` contract follows the row ------------------------
+#
+# `fn f(x: Int) -> Int with Exception where { requires: x >= 0 }` -- the row
+# ends at `where`, not at the contract's brace. Including it reported
+# `effect: where` and rejected a legitimate design-by-contract declaration.
+printf '\nexport fn checked(x: Int) -> Int with Exception where { requires: x >= 0 } {\n  x\n}\n' >> "$impl"
+if grep -qF 'with Exception where { requires:' "$impl"; then
+  if bash "$gate" >/dev/null 2>&1; then
+    pass "case: a where contract is not part of the effect row"
+  else
+    fail "case: a declaration with a where contract was rejected"
+  fi
+else
+  fail "case: the where mutation did not land -- the assertion above proves nothing"
+fi
+restore
+
+# The row before a `where` must still be checked, or stopping early becomes a
+# way to hide one.
+printf '\nexport fn checked_bad(x: Int) -> Int with Fs where { requires: x >= 0 } {\n  x\n}\n' >> "$impl"
+if grep -qF 'with Fs where { requires:' "$impl"; then
+  if bash "$gate" >/dev/null 2>&1; then
+    fail "case: a native row before a where contract was skipped"
+  else
+    pass "case: the row before a where contract is still checked"
+  fi
+else
+  fail "case: the where mutation did not land -- the assertion proves nothing"
+fi
+restore
+
 if [ "$fails" -ne 0 ]; then
   echo "portable-boundary-test: FAILED" >&2
   exit 1
 fi
-echo "portable-boundary-test: ok (control + 43 cases)"
+echo "portable-boundary-test: ok (control + 47 cases)"

--- a/scripts/check_portable_boundary_test.sh
+++ b/scripts/check_portable_boundary_test.sh
@@ -1838,8 +1838,49 @@ else
 fi
 restore
 
+# --- cases 108-109: the `daemon` lane named nothing --------------------------
+#
+# Round 47. Round 40 anchored the lane names to token boundaries, which stopped
+# `daemon` matching INSIDE `daemonless_probe` -- necessary, and not sufficient.
+# An exact identifier is still not a reference: `fn f(daemon: Int) -> Int {
+# daemon }` is an ordinary parameter, and matching the token rejected it.
+#
+# What settles it is that `daemon` names NOTHING in this tree: every occurrence
+# under lib/ is inside a comment, and comments are removed before the pattern
+# runs, so the alternative could only ever match a name someone chose. Same
+# wrong check as `session-http` in case 105, one round later and one level up.
+printf '\nfn probe_param_daemon(daemon: Int) -> Int {\n  daemon\n}\n' >> "$impl"
+if grep -qF -- 'fn probe_param_daemon(daemon: Int) -> Int {' "$impl"; then
+  if bash "$gate" >/dev/null 2>&1; then
+    pass "case: an ordinary parameter named daemon is not a lane reference"
+  else
+    fail "case: a local named daemon was rejected as a native lane"
+  fi
+else
+  fail "case: the daemon-parameter mutation did not land -- it proves nothing"
+fi
+restore
+
+# `compile_file_fs` is the OPPOSITE case and stays unqualified: it is a real
+# exported function (entry/compiler/file_compile, fs_compile), so a bare
+# occurrence in a boundary file is a real reference -- including inside an
+# `import { compile_file_fs }` list, which has neither `(` nor `::` after it.
+# This pins the bare form, so a later "require a call shape" cannot pass by
+# only keeping case 93 (the call) green.
+printf '\nfn probe_lane_value() -> Bool {\n  let f = compile_file_fs\n  false\n}\n' >> "$impl"
+if grep -qF -- 'let f = compile_file_fs' "$impl"; then
+  if bash "$gate" >/dev/null 2>&1; then
+    fail "case: a bare reference to the compile_file_fs lane passed the gate"
+  else
+    pass "case: a bare reference to a real lane is still a reference"
+  fi
+else
+  fail "case: the lane-value mutation did not land -- it proves nothing"
+fi
+restore
+
 if [ "$fails" -ne 0 ]; then
   echo "portable-boundary-test: FAILED" >&2
   exit 1
 fi
-echo "portable-boundary-test: ok (control + 107 cases)"
+echo "portable-boundary-test: ok (control + 109 cases)"

--- a/scripts/check_portable_boundary_test.sh
+++ b/scripts/check_portable_boundary_test.sh
@@ -1426,8 +1426,47 @@ else
 fi
 restore
 
+# --- cases 83-84: authority rides the row it trails -------------------------
+#
+# Round 38, and the other half of round 37: comparing independent counts
+# (authn >= arrows) was still wrong. `fn f() -> () -> Unit with Exception with
+# () allows Fs::read_file` has two arrows, two rows and one clause -- the
+# returned closure takes the first row, the declaration keeps the second AND
+# the authority trailing it -- so one clause against two arrows read as "the
+# closures", and the filesystem authority went unreported. Measured: ACCEPT.
+#
+# Each clause is now recorded against the row it follows, and the declaration
+# reports the clause on the layer it actually owns. Counting was the proxy;
+# the association is the property.
+printf '\nexport fn probe_auth_layer() -> () -> Unit with Exception with () allows Fs::read_file {\n  () -> {\n    ()\n  }\n}\n' >> "$impl"
+if grep -qF -- 'with Exception with () allows Fs::read_file {' "$impl"; then
+  if bash "$gate" >/dev/null 2>&1; then
+    fail "case: authority on the declaration own row layer went unreported"
+  else
+    pass "case: authority trailing the declaration own row is reported"
+  fi
+else
+  fail "case: the authority-layer mutation did not land -- it proves nothing"
+fi
+restore
+
+# Round 37 must survive it: the SAME arrow count with the clause on the
+# closure's layer stays accepted. These two differ only in which row the
+# clause trails, which is exactly what the counting rule could not see.
+printf '\nexport fn probe_auth_layer_closure() -> () -> Unit with () allows Fs::read_file {\n  () -> {\n    ()\n  }\n}\n' >> "$impl"
+if grep -qF -- '-> () -> Unit with () allows Fs::read_file {' "$impl"; then
+  if bash "$gate" >/dev/null 2>&1; then
+    pass "case: authority on a returned closure layer is still not the declaration own"
+  else
+    fail "case: a pure helper returning an authorised closure was rejected again"
+  fi
+else
+  fail "case: the closure-authority mutation did not land -- it proves nothing"
+fi
+restore
+
 if [ "$fails" -ne 0 ]; then
   echo "portable-boundary-test: FAILED" >&2
   exit 1
 fi
-echo "portable-boundary-test: ok (control + 82 cases)"
+echo "portable-boundary-test: ok (control + 84 cases)"

--- a/scripts/check_portable_boundary_test.sh
+++ b/scripts/check_portable_boundary_test.sh
@@ -1359,8 +1359,75 @@ else
 fi
 restore
 
+# --- cases 79-80: a declaration keyword follows any token boundary ----------
+#
+# Round 36. The `type` and `let` handlers required a preceding SPACE, chosen
+# over the `fn ` handler's looser test so that a field access spelled `x.type`
+# could not be read as a declaration. A semicolon is a legal separator, so
+# `;type Cb = () -> Unit with ReviewAsk` was not recognised as an alias and its
+# row was charged to the boundary -- measured, rejected as `effect: ReviewAsk`.
+# The dot alone is excluded now.
+printf '\n;type SemiAlias = () -> Unit with ReviewAsk\n' >> "$impl"
+if grep -qF -- ';type SemiAlias = () -> Unit with ReviewAsk' "$impl"; then
+  if bash "$gate" >/dev/null 2>&1; then
+    pass "case: an alias after a top-level semicolon is still an alias"
+  else
+    fail "case: an alias introduced after a semicolon was charged to the boundary"
+  fi
+else
+  fail "case: the semicolon-alias mutation did not land -- it proves nothing"
+fi
+restore
+
+printf '\n;type SemiAlias2 = () -> Unit with ReviewAsk\n\nexport fn probe_after_semi_alias() -> Unit with Fs {\n  ()\n}\n' >> "$impl"
+if grep -qF -- 'export fn probe_after_semi_alias() -> Unit with Fs {' "$impl"; then
+  if bash "$gate" >/dev/null 2>&1; then
+    fail "case: the alias after a semicolon swallowed the next declaration row"
+  else
+    pass "case: a declaration after a semicolon alias keeps its own row"
+  fi
+else
+  fail "case: the semicolon-alias-then-native mutation did not land -- it proves nothing"
+fi
+restore
+
+# --- cases 81-82: authority binds to an arrow layer, like a row -------------
+#
+# Round 37, and the other half of round 32: authority was collected per
+# declaration but emitted regardless of the return-type arrows, so a pure
+# helper that hands OUT an authorised closure was rejected as though it held
+# the authority itself. `parse_type_impl` attaches the clause to the returned
+# TyFn; the arithmetic is now the same as the row above (authn >= arrows).
+printf '\nexport fn probe_returns_authorised() -> () -> Unit with () allows Fs::read_file {\n  () -> {\n    ()\n  }\n}\n' >> "$impl"
+if grep -qF -- '-> () -> Unit with () allows Fs::read_file {' "$impl"; then
+  if bash "$gate" >/dev/null 2>&1; then
+    pass "case: authority on a returned closure type is not the declaration own"
+  else
+    fail "case: a pure helper returning an authorised closure was rejected"
+  fi
+else
+  fail "case: the returned-authority mutation did not land -- it proves nothing"
+fi
+restore
+
+# The direction that must not regress with it: a HIGHER-ORDER declaration that
+# really does hold the authority is still reported. The parameter's arrow is
+# inside parentheses, so it is not a return-type layer and cannot absorb the
+# clause.
+printf '\nexport fn probe_ho_authority(g: () -> Unit) -> Unit with Exception allows Fs::read_file {\n  ()\n}\n' >> "$impl"
+if grep -qF -- 'export fn probe_ho_authority(g: () -> Unit) -> Unit with Exception allows Fs::read_file {' "$impl"; then
+  if bash "$gate" >/dev/null 2>&1; then
+    fail "case: a higher-order declaration hid its own authority clause"
+  else
+    pass "case: a parameter arrow does not absorb the declaration authority"
+  fi
+else
+  fail "case: the higher-order-authority mutation did not land -- it proves nothing"
+fi
+restore
+
 if [ "$fails" -ne 0 ]; then
   echo "portable-boundary-test: FAILED" >&2
   exit 1
 fi
-echo "portable-boundary-test: ok (control + 78 cases)"
+echo "portable-boundary-test: ok (control + 82 cases)"

--- a/scripts/check_portable_boundary_test.sh
+++ b/scripts/check_portable_boundary_test.sh
@@ -517,8 +517,57 @@ else
 fi
 restore
 
+# --- cases 31-32: forbid_pattern reads the same normalized view -------------
+#
+# forbid_pattern dropped only whole comment LINES, so an inert diagnostic
+# containing `perform Fs::read_file` was reported as a leak. Case 1 already
+# covers a comment; this covers a STRING, and the pair with case 32 is what
+# keeps the fix from becoming a way to hide the real call.
+printf '\nexport fn probe_pstr() -> String with Exception {\n  "do not generate perform Fs::read_file here"\n}\n' >> "$impl"
+if grep -qF 'do not generate perform Fs::read_file here' "$impl"; then
+  if bash "$gate" >/dev/null 2>&1; then
+    pass "case: 'perform Fs::' inside a string literal is not a leak"
+  else
+    fail "case: an inert string containing 'perform Fs::' failed the gate"
+  fi
+else
+  fail "case: the string mutation did not land -- the assertion above proves nothing"
+fi
+restore
+
+printf '\nexport fn probe_pcall() -> Unit with Exception {\n  perform Fs::read_file("x")\n}\n' >> "$impl"
+if grep -qF 'perform Fs::read_file("x")' "$impl"; then
+  if bash "$gate" >/dev/null 2>&1; then
+    fail "case: a real 'perform Fs::' call was hidden by the string strip"
+  else
+    pass "case: a real 'perform Fs::' call is still a leak"
+  fi
+else
+  fail "case: the call mutation did not land -- the assertion proves nothing"
+fi
+restore
+
+# --- case 33: a handler clause is not a declaration row ---------------------
+#
+# `handle { ... } with ReviewAsk { ... }` discharges an effect locally. Its
+# `with` is at paren depth 0, so it was read as a signature and reported
+# `effect: ReviewAsk` -- rejecting a helper that is pure BECAUSE it handles the
+# effect. A declaration's row sits before the body brace; a handler is inside
+# one, so brace depth tells them apart.
+printf '\nexport fn probe_handle() -> Unit with Exception {\n  handle {\n    ()\n  } with ReviewAsk {\n    ReviewAsk::Ask(_k) => ()\n  }\n}\n' >> "$impl"
+if grep -qF '} with ReviewAsk {' "$impl"; then
+  if bash "$gate" >/dev/null 2>&1; then
+    pass "case: a handler clause is not read as a declaration effect row"
+  else
+    fail "case: a locally handled effect was reported as non-portable"
+  fi
+else
+  fail "case: the handler mutation did not land -- the assertion above proves nothing"
+fi
+restore
+
 if [ "$fails" -ne 0 ]; then
   echo "portable-boundary-test: FAILED" >&2
   exit 1
 fi
-echo "portable-boundary-test: ok (control + 30 cases)"
+echo "portable-boundary-test: ok (control + 33 cases)"

--- a/scripts/check_portable_boundary_test.sh
+++ b/scripts/check_portable_boundary_test.sh
@@ -922,8 +922,44 @@ else
 fi
 restore
 
+# --- cases 55-56: a type argument is not a return-type layer ----------------
+#
+# Round 27. The arrow layers of case 53 are counted by scanning for `->` at
+# parenthesis depth 0 -- but brackets were not tracked, so the arrow inside
+# `Array[() -> Unit]` counted as a layer of its own. `-> Array[() -> Unit] with
+# Fs` then read as arrows 2 against rows 1, which is the "returned closure owns
+# it" shape, and the declaration's native row went unchecked.
+#
+# A type ARGUMENT is not a layer: nothing is returned through it that could own
+# a row. Brackets now nest like parens, so the arrow inside them is invisible
+# to the count and the row is the declaration's.
+printf '\nexport fn probe_brk_native() -> Array[() -> Unit] with Fs {\n  []\n}\n' >> "$impl"
+if grep -qF -- '-> Array[() -> Unit] with Fs {' "$impl"; then
+  if bash "$gate" >/dev/null 2>&1; then
+    fail "case: an arrow inside a type argument hid the declaration native row"
+  else
+    pass "case: an arrow inside a type argument is not a return-type layer"
+  fi
+else
+  fail "case: the bracket mutation did not land -- the assertion proves nothing"
+fi
+restore
+
+# The converse at the same shape, so the fix is not "brackets mean reject".
+printf '\nexport fn probe_brk_ok() -> Array[() -> Unit] with Async {\n  []\n}\n' >> "$impl"
+if grep -qF -- '-> Array[() -> Unit] with Async {' "$impl"; then
+  if bash "$gate" >/dev/null 2>&1; then
+    pass "case: an allowed row on a bracketed return type is accepted"
+  else
+    fail "case: an allowed row on a bracketed return type was rejected"
+  fi
+else
+  fail "case: the bracket mutation did not land -- the assertion proves nothing"
+fi
+restore
+
 if [ "$fails" -ne 0 ]; then
   echo "portable-boundary-test: FAILED" >&2
   exit 1
 fi
-echo "portable-boundary-test: ok (control + 54 cases)"
+echo "portable-boundary-test: ok (control + 56 cases)"

--- a/scripts/check_portable_boundary_test.sh
+++ b/scripts/check_portable_boundary_test.sh
@@ -597,8 +597,40 @@ else
 fi
 restore
 
+# --- cases 36-37: a char literal is inert -----------------------------------
+#
+# A brace inside a char literal was counted as a real brace, so every
+# declaration AFTER it looked nested and had its effect row skipped. One
+# `'{'` anywhere in the file silently disabled the rest of the scan -- the
+# worst kind of miss, since it is unbounded and invisible.
+printf '\nfn brace_literal_probe() -> Char {\n  %s{%s\n}\n\nexport fn probe_after_char() -> Unit with Fs {\n  ()\n}\n' "'" "'" >> "$impl"
+if grep -qF "export fn probe_after_char() -> Unit with Fs {" "$impl"; then
+  if bash "$gate" >/dev/null 2>&1; then
+    fail "case: a brace in a char literal disabled the scan for everything after it"
+  else
+    pass "case: a char literal does not corrupt the brace depth"
+  fi
+else
+  fail "case: the char-literal mutation did not land -- the assertion proves nothing"
+fi
+restore
+
+# The converse: consuming a char literal must not eat the code after it, or the
+# same declaration would go unscanned for the opposite reason.
+printf '\nfn quote_char_probe() -> Char {\n  %s\\\\%s%s\n}\n\nexport fn probe_after_quote() -> Unit with Exception {\n  ()\n}\n' "'" "n" "'" >> "$impl"
+if grep -qF "export fn probe_after_quote() -> Unit with Exception {" "$impl"; then
+  if bash "$gate" >/dev/null 2>&1; then
+    pass "case: an escaped char literal is consumed without eating what follows"
+  else
+    fail "case: an escaped char literal broke the scan of the next declaration"
+  fi
+else
+  fail "case: the escaped-char mutation did not land -- the assertion proves nothing"
+fi
+restore
+
 if [ "$fails" -ne 0 ]; then
   echo "portable-boundary-test: FAILED" >&2
   exit 1
 fi
-echo "portable-boundary-test: ok (control + 35 cases)"
+echo "portable-boundary-test: ok (control + 37 cases)"

--- a/scripts/check_portable_boundary_test.sh
+++ b/scripts/check_portable_boundary_test.sh
@@ -566,8 +566,39 @@ else
 fi
 restore
 
+# --- cases 34-35: an interpolation body executes ----------------------------
+#
+# `"\{ ... }"` is not inert: the body between `\{` and `}` is code and runs.
+# Stripping the whole quoted token discarded it, so a real capability call
+# inside one became invisible -- a hole the pre-PR gate did not have, since it
+# stripped no strings at all. The pair keeps both directions honest: the
+# executable body is scanned, the inert text around it is not.
+printf '\nexport fn probe_interp_exec() -> String with Exception {\n  "\\{perform Fs::read_file("x")}"\n}\n' >> "$impl"
+if grep -qF 'perform Fs::read_file' "$impl"; then
+  if bash "$gate" >/dev/null 2>&1; then
+    fail "case: a capability call inside an interpolation body was invisible"
+  else
+    pass "case: an interpolation body is scanned, not discarded with the string"
+  fi
+else
+  fail "case: the interpolation mutation did not land -- the assertion proves nothing"
+fi
+restore
+
+printf '\nexport fn probe_interp_inert() -> String with Exception {\n  "\\{String::concat("perform Fs::read_file", " is inert")}"\n}\n' >> "$impl"
+if grep -qF 'is inert' "$impl"; then
+  if bash "$gate" >/dev/null 2>&1; then
+    pass "case: a string nested inside an interpolation is still inert"
+  else
+    fail "case: an inert literal nested in an interpolation failed the gate"
+  fi
+else
+  fail "case: the nested-literal mutation did not land -- the assertion proves nothing"
+fi
+restore
+
 if [ "$fails" -ne 0 ]; then
   echo "portable-boundary-test: FAILED" >&2
   exit 1
 fi
-echo "portable-boundary-test: ok (control + 33 cases)"
+echo "portable-boundary-test: ok (control + 35 cases)"

--- a/scripts/check_portable_boundary_test.sh
+++ b/scripts/check_portable_boundary_test.sh
@@ -629,8 +629,39 @@ else
 fi
 restore
 
+# --- cases 38-39: a string literal may span physical lines ------------------
+#
+# Measured: a multi-line string compiles. Resetting lexical state at each awk
+# record scanned the continuation as executable code and reported inert text as
+# a leak. State is carried across records now -- and the second case is what
+# keeps that from becoming a way to swallow the rest of the file: a real effect
+# row AFTER a multi-line string must still be caught.
+printf '\nexport fn probe_ml() -> String with Exception {\n  "line one\n  perform Fs::read_file continues here"\n}\n' >> "$impl"
+if grep -qF 'continues here' "$impl"; then
+  if bash "$gate" >/dev/null 2>&1; then
+    pass "case: a multi-line string continuation is inert"
+  else
+    fail "case: the continuation of a multi-line string was scanned as code"
+  fi
+else
+  fail "case: the multi-line mutation did not land -- the assertion above proves nothing"
+fi
+restore
+
+printf '\nexport fn probe_ml2() -> String with Exception {\n  "line one\n  ends here"\n}\n\nexport fn probe_after_ml() -> Unit with Fs {\n  ()\n}\n' >> "$impl"
+if grep -qF 'export fn probe_after_ml() -> Unit with Fs {' "$impl"; then
+  if bash "$gate" >/dev/null 2>&1; then
+    fail "case: a multi-line string swallowed everything after it"
+  else
+    pass "case: a declaration after a multi-line string is still scanned"
+  fi
+else
+  fail "case: the after-multiline mutation did not land -- the assertion proves nothing"
+fi
+restore
+
 if [ "$fails" -ne 0 ]; then
   echo "portable-boundary-test: FAILED" >&2
   exit 1
 fi
-echo "portable-boundary-test: ok (control + 37 cases)"
+echo "portable-boundary-test: ok (control + 39 cases)"

--- a/scripts/check_portable_boundary_test.sh
+++ b/scripts/check_portable_boundary_test.sh
@@ -45,7 +45,12 @@ if ! git diff --quiet -- "$impl" "$contract" "$entry"; then
 fi
 
 restore() { git checkout -q -- "$impl" "$contract" "$entry" 2>/dev/null || true; }
-trap restore EXIT
+# The EXIT trap also sweeps the gate copies a case may leave behind. `set -e`
+# can end the run between writing one and removing it, and a stray
+# `scripts/.portable_boundary_*.sh` is then an untracked file that other gates
+# scan -- a failure with nothing to do with what broke.
+cleanup() { restore; rm -f scripts/.portable_boundary_*probe*.sh; }
+trap cleanup EXIT
 
 fails=0
 pass() { printf 'portable-boundary-test: ok: %s\n' "$1"; }
@@ -2154,8 +2159,107 @@ else
 fi
 restore
 
+# --- cases 129-132: an `effectset` alias resolves to its members -------------
+#
+# Round 53. `effectset PortableEffects = { Exception, Async }` (ADR-0071) plus
+# `with PortableEffects` was rejected as `effect: PortableEffects` -- a false
+# positive on a boundary whose every member is allow-listed.
+#
+# The tempting fix is to add the alias to PORTABLE_ALLOWED_EFFECTS, and it is
+# the dangerous one: the list would then admit the NAME, so a later edit adding
+# `Fs` to that set passes unseen. The members are read from the declaration
+# instead. Cases 130 and 131 are that danger, pinned in both the direct and the
+# transitive shape; 132 is the fail-closed direction for an alias the scanned
+# file cannot see.
+for probe in \
+  'effectset PortableEffects = { Exception, Async };PortableEffects;accept' \
+  'effectset SneakyEffects = { Exception, Fs };SneakyEffects;reject' \
+  'effectset Inner = { Fs } effectset Outer = { Inner, Async };Outer;reject' \
+  ';ImportedElsewhere;reject'
+do
+  decls="${probe%%;*}"; rest="${probe#*;}"
+  row="${rest%%;*}"; want="${rest##*;}"
+  printf '\n%s\n\nexport fn probe_set(x: Int) -> Int with %s {\n  x + 1\n}\n' "$decls" "$row" >> "$impl"
+  if grep -qF "with $row {" "$impl"; then
+    if bash "$gate" >/dev/null 2>&1; then
+      if [ "$want" = "accept" ]; then
+        pass "case: an effectset of allowed members is expanded, not rejected"
+      else
+        fail "case: '$row' hid a capability behind an effectset alias"
+      fi
+    else
+      if [ "$want" = "reject" ]; then
+        pass "case: '$row' is reported rather than taken at its name"
+      else
+        fail "case: a portable effectset alias was rejected"
+      fi
+    fi
+  else
+    fail "case: the '$row' mutation did not land -- it proves nothing"
+  fi
+  restore
+done
+
+# --- case 133: `where` must start at a token boundary ------------------------
+#
+# Found while measuring round 53, and worse than the finding that led to it.
+# The `where` break in the row scanner was unanchored, so it matched INSIDE an
+# effect name: `with Asyncwhere + Fs` broke at character 6, kept the row as
+# `Async` -- which is allow-listed -- and dropped `+ Fs` entirely. Measured on
+# c89c47367, with a boundary body that calls `Fs::stat_token`: the gate printed
+# `ok`, EXIT=0. A silent miss, and the cheapest kind to introduce, since any
+# effect whose name ends in `where` hides the rest of its own row.
+#
+# The three sibling breaks (`fn ` / `type ` / `let `) already made the token
+# test; `where` was the one that did not. Cases 46-47 above keep the real
+# contract form working.
+printf '\neffect Asyncwhere {\n  Ping() -> Unit\n}\n\nexport fn probe_hidden(x: Int) -> Int with Asyncwhere + Fs {\n  Fs::stat_token("x") + x\n}\n' >> "$impl"
+if grep -qF 'with Asyncwhere + Fs {' "$impl"; then
+  if bash "$gate" >/dev/null 2>&1; then
+    fail "case: an effect name ending in 'where' hid the rest of the row"
+  else
+    pass "case: 'where' inside an effect name does not end the row"
+  fi
+else
+  fail "case: the Asyncwhere mutation did not land -- it proves nothing"
+fi
+restore
+
+# --- case 134: expansion happens BEFORE the allow-list ----------------------
+#
+# Cases 130-131 above pass on a gate with no expansion at all -- there the
+# alias is rejected under its own name, for the wrong reason. So they do not
+# actually prove the dangerous fix was avoided. This one does: it allow-lists
+# the alias NAME, exactly what round 53 warned against, and asserts `Fs` is
+# still reported. That can only hold if the members are resolved first.
+#
+# The gate is copied INSIDE scripts/ rather than to a temp dir: ROOT_DIR comes
+# from BASH_SOURCE, so a copy under /tmp resolves the repository wrongly and
+# fails for a reason that has nothing to do with the property (that mistake
+# made an earlier probe "pass" while proving nothing).
+probe_gate="scripts/.portable_boundary_allowlist_probe.$$.sh"
+sed "s/^PORTABLE_ALLOWED_EFFECTS='Exception|Async'\$/PORTABLE_ALLOWED_EFFECTS='Exception|Async|SneakyEffects'/" \
+  "$gate" > "$probe_gate"
+if grep -qF "PORTABLE_ALLOWED_EFFECTS='Exception|Async|SneakyEffects'" "$probe_gate"; then
+  printf '\neffectset SneakyEffects = { Exception, Fs }\n\nexport fn probe_set(x: Int) -> Int with SneakyEffects {\n  x + 1\n}\n' >> "$impl"
+  # Capture, then grep. Piping the gate straight into grep looks equivalent
+  # and is not: this harness runs under `set -o pipefail`, so the gate's own
+  # exit 1 -- the whole point of the case -- makes the pipeline non-zero even
+  # when grep matches, and the case reports the property ABSENT while it holds.
+  probe_out="$(bash "$probe_gate" 2>&1 || true)"
+  if printf '%s\n' "$probe_out" | grep -qE '^  effect: Fs$'; then
+    pass "case: an allow-listed alias still reports the Fs inside it"
+  else
+    fail "case: allow-listing the alias name hid a capability member"
+  fi
+  restore
+else
+  fail "case: the allow-list mutation did not land -- it proves nothing"
+fi
+rm -f "$probe_gate"
+
 if [ "$fails" -ne 0 ]; then
   echo "portable-boundary-test: FAILED" >&2
   exit 1
 fi
-echo "portable-boundary-test: ok (control + 128 cases)"
+echo "portable-boundary-test: ok (control + 134 cases)"

--- a/scripts/check_portable_boundary_test.sh
+++ b/scripts/check_portable_boundary_test.sh
@@ -142,8 +142,63 @@ else
 fi
 restore
 
+# --- cases 6-8: the allow-list rejects every non-portable capability --------
+#
+# `Fs` alone (case 4) is satisfied by a deny-list, which is what this gate had
+# twice -- and both times it passed a capability nobody had thought to name.
+# `Env` and `Console` are capability builtins (AGENTS.md) and both passed the
+# Fs|Process|Socket|Net|Http matcher. `Nonsense` stands for the capability that
+# does not exist yet: an allow-list must reject it without being taught to.
+for eff in Env Console Nonsense; do
+  printf '\nexport fn probe_%s() -> Unit with %s {\n  ()\n}\n' "$eff" "$eff" >> "$impl"
+  if grep -qE "^export fn probe_$eff\(\) -> Unit with $eff \{$" "$impl"; then
+    if bash "$gate" >/dev/null 2>&1; then
+      fail "case: an implementation declaring 'with $eff' passed the gate"
+    else
+      pass "case: 'with $eff' is rejected by the allow-list"
+    fi
+  else
+    fail "case: the 'with $eff' mutation did not land -- the assertion proves nothing"
+  fi
+  restore
+done
+
+# --- case 9: an allowed effect in a COMPOUND row is still accepted -----------
+#
+# The row splitter has to handle `A + B`, not just a bare effect. If it did not,
+# every compound row would read as one unknown name and the gate would reject
+# code it must accept -- a gate that fails closed on correct input gets
+# disabled, which is the outcome #2252 describes.
+printf '\nexport fn probe_compound() -> Unit with Exception + Async {\n  ()\n}\n' >> "$impl"
+if grep -qE '^export fn probe_compound\(\) -> Unit with Exception \+ Async \{$' "$impl"; then
+  if bash "$gate" >/dev/null 2>&1; then
+    pass "case: a compound row of allowed effects is accepted"
+  else
+    fail "case: 'with Exception + Async' was rejected -- the row splitter is wrong"
+  fi
+else
+  fail "case: the compound-row mutation did not land -- the assertion proves nothing"
+fi
+restore
+
+# --- case 10: a native capability hidden in a compound row is caught ---------
+#
+# The converse of case 9, and the shape a real leak takes: the forbidden effect
+# is not the first name in the row.
+printf '\nexport fn probe_mixed() -> Unit with Exception + Fs {\n  ()\n}\n' >> "$impl"
+if grep -qE '^export fn probe_mixed\(\) -> Unit with Exception \+ Fs \{$' "$impl"; then
+  if bash "$gate" >/dev/null 2>&1; then
+    fail "case: 'with Exception + Fs' passed -- only the first effect is checked"
+  else
+    pass "case: a native effect later in a compound row is rejected"
+  fi
+else
+  fail "case: the mixed-row mutation did not land -- the assertion proves nothing"
+fi
+restore
+
 if [ "$fails" -ne 0 ]; then
   echo "portable-boundary-test: FAILED" >&2
   exit 1
 fi
-echo "portable-boundary-test: ok (control + 5 cases)"
+echo "portable-boundary-test: ok (control + 10 cases)"

--- a/scripts/check_portable_boundary_test.sh
+++ b/scripts/check_portable_boundary_test.sh
@@ -1030,8 +1030,61 @@ else
 fi
 restore
 
+# --- cases 61-63: a binding's initializer is not part of its row ------------
+#
+# Round 29, another false positive. `export let f: (Int) -> Unit with Exception
+# = (x) -> { () }` ran the row scan past the type and into the value, so the
+# lambda's parameter was reported as `effect: x` on a portable file.
+#
+# `=` ends the type and starts the value. Stopping the row there is not enough
+# on its own: the initializer's arrow would still count as a return-type layer
+# and push rows below arrows, skipping the declaration instead of reporting
+# it. So `=` FLUSHES -- the row is attributed, then the value is scanned as
+# what it is. `decl` survives the flush, because a type alias keeps its row
+# after the `=`.
+printf '\nexport let probe_bind_ok: (Int) -> Unit with Exception = (x) -> {\n  ()\n}\n' >> "$impl"
+if grep -qF -- 'export let probe_bind_ok: (Int) -> Unit with Exception = (x) -> {' "$impl"; then
+  if bash "$gate" >/dev/null 2>&1; then
+    pass "case: a binding initializer is not read as part of the effect row"
+  else
+    fail "case: a portable function binding was rejected, most likely as effect: x"
+  fi
+else
+  fail "case: the binding mutation did not land -- the assertion proves nothing"
+fi
+restore
+
+# The direction that matters more: flushing at `=` must not cost the row. A
+# binding IS a boundary declaration -- unlike a type alias, it is a value a
+# caller can reach -- so its native row is still reported.
+printf '\nexport let probe_bind_native: (Int) -> Unit with Fs = (x) -> {\n  ()\n}\n' >> "$impl"
+if grep -qF -- 'export let probe_bind_native: (Int) -> Unit with Fs = (x) -> {' "$impl"; then
+  if bash "$gate" >/dev/null 2>&1; then
+    fail "case: a native row on a function binding went unreported"
+  else
+    pass "case: a function binding native row is still the boundary own"
+  fi
+else
+  fail "case: the native-binding mutation did not land -- it proves nothing"
+fi
+restore
+
+# And the declaration after a binding is still its own, the same property
+# case 58 pins for an alias.
+printf '\nexport let probe_bind_then: (Int) -> Unit with Exception = (x) -> {\n  ()\n}\n\nexport fn probe_after_bind() -> Unit with Fs {\n  ()\n}\n' >> "$impl"
+if grep -qF -- 'export fn probe_after_bind() -> Unit with Fs {' "$impl"; then
+  if bash "$gate" >/dev/null 2>&1; then
+    fail "case: a binding swallowed the next declaration native row"
+  else
+    pass "case: a declaration after a binding keeps its own row"
+  fi
+else
+  fail "case: the binding-then-native mutation did not land -- it proves nothing"
+fi
+restore
+
 if [ "$fails" -ne 0 ]; then
   echo "portable-boundary-test: FAILED" >&2
   exit 1
 fi
-echo "portable-boundary-test: ok (control + 60 cases)"
+echo "portable-boundary-test: ok (control + 63 cases)"

--- a/scripts/check_portable_boundary_test.sh
+++ b/scripts/check_portable_boundary_test.sh
@@ -470,8 +470,55 @@ else
 fi
 restore
 
+# --- case 28: a raw string is a string too ----------------------------------
+#
+# `#|` opens a RAW string running to end of line. Normalization removed only
+# double-quoted literals, so `#|compile with Fs when requested` was reported as
+# `effect: Fs`, `effect: when`, `effect: requested` -- a required gate
+# rejecting an ordinary message.
+printf '\nexport fn probe_raw() -> String with Exception {\n  #|compile with Fs when requested\n}\n' >> "$impl"
+if grep -qF '#|compile with Fs when requested' "$impl"; then
+  if bash "$gate" >/dev/null 2>&1; then
+    pass "case: a raw string is not read as an effect row"
+  else
+    fail "case: a '#|' raw string mentioning 'with Fs' failed the gate"
+  fi
+else
+  fail "case: the raw-string mutation did not land -- the assertion above proves nothing"
+fi
+restore
+
+# --- cases 29-30: a tab is whitespace ---------------------------------------
+#
+# The lexer treats a tab as whitespace, so `with<TAB>Fs` is a legal row.
+# Matching the literal text "with " missed it and the gate exited 0. The same
+# hid a tab-separated `allows` clause, so both keywords are pinned.
+printf '\nexport fn probe_tab() -> Unit with\tFs {\n  ()\n}\n' >> "$impl"
+if grep -qF $'with\tFs' "$impl"; then
+  if bash "$gate" >/dev/null 2>&1; then
+    fail "case: a tab-separated effect row passed the gate"
+  else
+    pass "case: a tab after 'with' is still an effect row"
+  fi
+else
+  fail "case: the tab mutation did not land -- the assertion proves nothing"
+fi
+restore
+
+printf '\nexport fn probe_tab_allows() -> String with Exception allows\tFs::read_file {\n  ""\n}\n' >> "$impl"
+if grep -qF $'allows\tFs::read_file' "$impl"; then
+  if bash "$gate" >/dev/null 2>&1; then
+    fail "case: a tab-separated 'allows' clause passed the gate"
+  else
+    pass "case: a tab after 'allows' is still a capability grant"
+  fi
+else
+  fail "case: the tab-allows mutation did not land -- the assertion proves nothing"
+fi
+restore
+
 if [ "$fails" -ne 0 ]; then
   echo "portable-boundary-test: FAILED" >&2
   exit 1
 fi
-echo "portable-boundary-test: ok (control + 27 cases)"
+echo "portable-boundary-test: ok (control + 30 cases)"

--- a/scripts/check_portable_boundary_test.sh
+++ b/scripts/check_portable_boundary_test.sh
@@ -373,8 +373,54 @@ else
 fi
 restore
 
+# --- cases 22-24: string literals are not effect rows -----------------------
+#
+# The converse direction, and the one that actually loses a gate: reading the
+# whole span from `with` to the body captured an inert message such as
+# "compile with Fs when requested" and reported `effect: Fs` on correct code.
+# A required gate that fails on code that is fine gets disabled (#2252), so a
+# false positive is not the safe side of this check -- it is a second way to
+# lose it. Same for a string that happens to contain the word `allows`.
+printf '\nexport fn probe_msg() -> String with Exception {\n  "compile with Fs when requested"\n}\n' >> "$impl"
+if grep -qF 'compile with Fs when requested' "$impl"; then
+  if bash "$gate" >/dev/null 2>&1; then
+    pass "case: a string literal naming an effect is not read as a row"
+  else
+    fail "case: an inert string mentioning 'with Fs' failed the gate"
+  fi
+else
+  fail "case: the string mutation did not land -- the assertion above proves nothing"
+fi
+restore
+
+printf '\nexport fn probe_msg2() -> String with Exception {\n  "this allows Fs::read_file to run"\n}\n' >> "$impl"
+if grep -qF 'this allows Fs::read_file to run' "$impl"; then
+  if bash "$gate" >/dev/null 2>&1; then
+    pass "case: a string literal naming an allows clause is not read as a grant"
+  else
+    fail "case: an inert string mentioning 'allows' failed the gate"
+  fi
+else
+  fail "case: the string mutation did not land -- the assertion above proves nothing"
+fi
+restore
+
+# Stripping strings must not become a way to HIDE a real row: a declaration
+# that genuinely carries `with Fs` is still caught when a string sits beside it.
+printf '\nexport fn probe_both() -> String with Fs {\n  "a harmless with Exception message"\n}\n' >> "$impl"
+if grep -qF 'export fn probe_both() -> String with Fs {' "$impl"; then
+  if bash "$gate" >/dev/null 2>&1; then
+    fail "case: a real 'with Fs' was hidden by the string strip"
+  else
+    pass "case: a real row is still caught when a string sits beside it"
+  fi
+else
+  fail "case: the mixed mutation did not land -- the assertion proves nothing"
+fi
+restore
+
 if [ "$fails" -ne 0 ]; then
   echo "portable-boundary-test: FAILED" >&2
   exit 1
 fi
-echo "portable-boundary-test: ok (control + 21 cases)"
+echo "portable-boundary-test: ok (control + 24 cases)"

--- a/scripts/check_portable_boundary_test.sh
+++ b/scripts/check_portable_boundary_test.sh
@@ -716,7 +716,11 @@ restore
 # --- case 43: THE COST OF CASE 42, pinned so it is visible ------------------
 #
 # Skipping the ambiguous multi-arrow shape means a boundary that returns an
-# Fs-carrying closure is NOT checked. This case asserts that miss deliberately.
+# Fs-carrying closure is NOT checked, WHEN that is the only row in the
+# signature. If the signature carries a second row, the last one is the
+# declarations own and IS checked (cases 51-52) -- that narrowing came from
+# review round 25, where skipping every row let a real leak through.
+# This case asserts the remaining miss deliberately.
 # It is not an endorsement: telling it from case 42 needs the type grammar, and
 # grammar is what this scan stopped modelling. #2581 answers it from the AST.
 #
@@ -844,8 +848,42 @@ else
 fi
 restore
 
+# --- cases 51-52: a multi-arrow signature may still carry its OWN row -------
+#
+# The ambiguity skip added at review round 21 dropped EVERY row in a
+# multi-arrow signature. But `fn f() -> (String) -> Unit with Exception with Fs`
+# has two: the first binds to the returned function type, the LAST is f own row.
+# Skipping both let a boundary carry Fs unnoticed -- a miss in exactly what this
+# gate is for, introduced by the guard meant to prevent a false positive.
+#
+# The rule now: one row in a multi-arrow signature is the closures (skip, case
+# 42); two or more means the last is the declarations (check).
+printf '\nexport fn probe_two_rows() -> (String) -> Unit with Exception with Fs {\n  (s) -> {\n    ()\n  }\n}\n' >> "$impl"
+if grep -qF 'with Exception with Fs {' "$impl"; then
+  if bash "$gate" >/dev/null 2>&1; then
+    fail "case: a multi-arrow signature hid the function own native row"
+  else
+    pass "case: the last row of a multi-arrow signature is the declaration own"
+  fi
+else
+  fail "case: the two-row mutation did not land -- the assertion proves nothing"
+fi
+restore
+
+printf '\nexport fn probe_two_ok() -> (String) -> Unit with Exception with Async {\n  (s) -> {\n    ()\n  }\n}\n' >> "$impl"
+if grep -qF 'with Exception with Async {' "$impl"; then
+  if bash "$gate" >/dev/null 2>&1; then
+    pass "case: a multi-arrow signature whose own row is allowed is accepted"
+  else
+    fail "case: an allowed last row in a multi-arrow signature was rejected"
+  fi
+else
+  fail "case: the two-row mutation did not land -- the assertion proves nothing"
+fi
+restore
+
 if [ "$fails" -ne 0 ]; then
   echo "portable-boundary-test: FAILED" >&2
   exit 1
 fi
-echo "portable-boundary-test: ok (control + 50 cases)"
+echo "portable-boundary-test: ok (control + 52 cases)"

--- a/scripts/check_portable_boundary_test.sh
+++ b/scripts/check_portable_boundary_test.sh
@@ -660,8 +660,39 @@ else
 fi
 restore
 
+# --- cases 40-41: a raw quoted string has no escapes ------------------------
+#
+# `r"..."` scans to the next quote with NO escape processing
+# (lib/@vibe/parser/lexer.vibe), so `r"trailing\"` ENDS at that quote. Treating
+# it as an ordinary string consumed the backslash and quote together, stayed in
+# string mode, and discarded every declaration after it -- the unbounded shape
+# of miss again, from a different construct.
+printf '\nexport fn raw_probe() -> String with Exception {\n  r"trailing\\\\"\n}\n\nexport fn native_after_raw() -> Unit with Fs {\n  ()\n}\n' >> "$impl"
+if grep -qF 'export fn native_after_raw() -> Unit with Fs {' "$impl"; then
+  if bash "$gate" >/dev/null 2>&1; then
+    fail "case: a raw string ending in a backslash disabled the scan after it"
+  else
+    pass "case: a raw quoted string ends at its quote, not at an escape"
+  fi
+else
+  fail "case: the raw-string mutation did not land -- the assertion proves nothing"
+fi
+restore
+
+printf '\nexport fn raw_inert() -> String with Exception {\n  r"perform Fs::read_file is inert"\n}\n' >> "$impl"
+if grep -qF 'r"perform Fs::read_file is inert"' "$impl"; then
+  if bash "$gate" >/dev/null 2>&1; then
+    pass "case: raw string content is inert"
+  else
+    fail "case: the content of a raw string was scanned as code"
+  fi
+else
+  fail "case: the raw-inert mutation did not land -- the assertion above proves nothing"
+fi
+restore
+
 if [ "$fails" -ne 0 ]; then
   echo "portable-boundary-test: FAILED" >&2
   exit 1
 fi
-echo "portable-boundary-test: ok (control + 39 cases)"
+echo "portable-boundary-test: ok (control + 41 cases)"

--- a/scripts/check_portable_boundary_test.sh
+++ b/scripts/check_portable_boundary_test.sh
@@ -1323,8 +1323,44 @@ else
 fi
 restore
 
+# --- cases 77-78: `r#fn` is still the keyword -------------------------------
+#
+# Round 35, and round 34 made it: the underscore that stops a raw keyword from
+# becoming syntax was applied to `fn` as well, but `r#fn` is the ONE raw
+# spelling that IS the keyword. lex_ident returns TFn for it
+# (lib/@vibe/parser/lexer.vibe, #1280 -- a binding named fn cannot be smuggled
+# back in through r#). Suffixed to `fn_`, it stopped being the reset, so a
+# preceding `type` alias kept decl = "type" and the following function's
+# native row was suppressed. Measured: ACCEPT.
+#
+# The lesson is round 34's inverted: normalizing raw source needs the LEXER's
+# rule for each name, not a rule about raw identifiers in general.
+printf '\ntype LeadAlias = Int\n\nr#fn probe_raw_fn() -> Unit with Fs {\n  ()\n}\n' >> "$impl"
+if grep -qF -- 'r#fn probe_raw_fn() -> Unit with Fs {' "$impl"; then
+  if bash "$gate" >/dev/null 2>&1; then
+    fail "case: r#fn stopped being a declaration and the native row was skipped"
+  else
+    pass "case: r#fn is the function keyword, so the declaration is checked"
+  fi
+else
+  fail "case: the r#fn mutation did not land -- the assertion proves nothing"
+fi
+restore
+
+printf '\ntype LeadAlias2 = Int\n\nr#fn probe_raw_fn_ok() -> Unit with Async {\n  ()\n}\n' >> "$impl"
+if grep -qF -- 'r#fn probe_raw_fn_ok() -> Unit with Async {' "$impl"; then
+  if bash "$gate" >/dev/null 2>&1; then
+    pass "case: an allowed row on an r#fn declaration is accepted"
+  else
+    fail "case: an allowed row on an r#fn declaration was rejected"
+  fi
+else
+  fail "case: the r#fn-allowed mutation did not land -- it proves nothing"
+fi
+restore
+
 if [ "$fails" -ne 0 ]; then
   echo "portable-boundary-test: FAILED" >&2
   exit 1
 fi
-echo "portable-boundary-test: ok (control + 76 cases)"
+echo "portable-boundary-test: ok (control + 78 cases)"

--- a/scripts/check_portable_boundary_test.sh
+++ b/scripts/check_portable_boundary_test.sh
@@ -691,8 +691,48 @@ else
 fi
 restore
 
+# --- case 42: a returned function type carries its own row ------------------
+#
+# `fn make() -> (String) -> Unit with Log::Emit` is PURE: the row belongs to
+# the returned closure (fixtures/typecheck/closure_row_return_position.vibe).
+# That `with` is at parenthesis depth 0 like any other, so it was reported as
+# the declaration's row and a legitimate helper was rejected.
+printf '\nexport fn make_logger() -> (String) -> Unit with Log::Emit {\n  (s) -> {\n    ()\n  }\n}\n' >> "$impl"
+if grep -qF -- '-> (String) -> Unit with Log::Emit {' "$impl"; then
+  if bash "$gate" >/dev/null 2>&1; then
+    pass "case: a returned function type's row is not the declaration's"
+  else
+    fail "case: a pure helper returning an effectful closure was rejected"
+  fi
+else
+  fail "case: the closure-return mutation did not land -- the assertion proves nothing"
+fi
+restore
+
+# --- case 43: THE COST OF CASE 42, pinned so it is visible ------------------
+#
+# Skipping the ambiguous multi-arrow shape means a boundary that returns an
+# Fs-carrying closure is NOT checked. This case asserts that miss deliberately.
+# It is not an endorsement: telling it from case 42 needs the type grammar, and
+# grammar is what this scan stopped modelling. #2581 answers it from the AST.
+#
+# If a future change makes this REJECT, that is an improvement -- update this
+# case rather than reverting the change. The point is that the gap is written
+# down as a test, not left to be rediscovered.
+printf '\nexport fn make_reader() -> (String) -> Unit with Fs {\n  (s) -> {\n    ()\n  }\n}\n' >> "$impl"
+if grep -qF -- '-> (String) -> Unit with Fs {' "$impl"; then
+  if bash "$gate" >/dev/null 2>&1; then
+    pass "case: KNOWN MISS -- a returned Fs-carrying closure is not checked (#2581)"
+  else
+    fail "case: unexpected -- if this now rejects, update the case, do not revert"
+  fi
+else
+  fail "case: the known-miss mutation did not land -- the assertion proves nothing"
+fi
+restore
+
 if [ "$fails" -ne 0 ]; then
   echo "portable-boundary-test: FAILED" >&2
   exit 1
 fi
-echo "portable-boundary-test: ok (control + 41 cases)"
+echo "portable-boundary-test: ok (control + 43 cases)"

--- a/scripts/check_portable_boundary_test.sh
+++ b/scripts/check_portable_boundary_test.sh
@@ -1465,8 +1465,105 @@ else
 fi
 restore
 
+# --- cases 85-89: the entry file had only the `perform` ban ------------------
+#
+# Round 39, a P1 miss. `cli_direct_component_entry.vibe` is the one scanned
+# file whose row allow-list is deliberately OFF -- it does file IO and says so,
+# carrying `with Exception + Fs` -- so forbid_pattern was its only protection,
+# and that banned `perform` spellings alone. A capability builtin is called as
+# an ORDINARY FUNCTION (ADR-0084), so no `perform` appears:
+#
+#   fn f() -> Unit with () allows Console::write_stream {
+#     Console::write_stream("boundary leaked")
+#   }
+#
+# passed the required gate outright. Measured, and the shape is the one
+# lib/@vibe/compiler/tests/checker_entry_effect_test.vibe accepts.
+#
+# Both halves are closed: the authority check now runs on this file too (it has
+# no `allows` clause today, so any is a leak), and the call pattern gains the
+# capability namespaces this boundary is not entitled to.
+printf '\nfn probe_entry_console() -> Unit with () allows Console::write_stream {\n  Console::write_stream("boundary leaked")\n}\n' >> "$entry"
+if grep -qF -- 'Console::write_stream("boundary leaked")' "$entry"; then
+  if bash "$gate" >/dev/null 2>&1; then
+    fail "case: the entry file acquired console authority and passed the gate"
+  else
+    pass "case: console authority in the direct component entry is rejected"
+  fi
+else
+  fail "case: the entry-console mutation did not land -- it proves nothing"
+fi
+restore
+
+# The two halves separately, so neither is carried by the other.
+#
+# The authority probe grants `Fs::stat_token`, NOT Console, and that choice is
+# the whole point: `Fs::` is deliberately outside the call pattern (case 88),
+# so this is the only shape the authority check can be seen alone in. Written
+# with Console it passed for the wrong reason -- the call pattern matched the
+# capability name inside the clause -- and removing the authority check changed
+# nothing, which is a green case proving nothing (the round-32 mistake).
+#
+# It is also the right rule and not just a convenient probe: this entry may
+# CALL Fs under its declared `with Fs` row, and may not GRANT Fs authority
+# outward. Performing under a declared row and handing the capability to a
+# caller are different things.
+printf '\nfn probe_entry_auth_only(p: String) -> Int with () allows Fs::stat_token {\n  Fs::stat_token(p)\n}\n' >> "$entry"
+if grep -qF -- 'allows Fs::stat_token {' "$entry"; then
+  if bash "$gate" >/dev/null 2>&1; then
+    fail "case: an allows clause in the entry file passed the gate"
+  else
+    pass "case: an authority clause in the entry file is rejected on its own"
+  fi
+else
+  fail "case: the entry-authority mutation did not land -- it proves nothing"
+fi
+restore
+
+printf '\nfn probe_entry_call_only() -> Unit with Console {\n  Console::write_stream("leaked")\n}\n' >> "$entry"
+if grep -qF -- 'Console::write_stream("leaked")' "$entry"; then
+  if bash "$gate" >/dev/null 2>&1; then
+    fail "case: a plain capability call in the entry file passed the gate"
+  else
+    pass "case: a plain capability call in the entry file is rejected on its own"
+  fi
+else
+  fail "case: the entry-call mutation did not land -- it proves nothing"
+fi
+restore
+
+# --- cases 88-89: what the entry file IS entitled to -------------------------
+#
+# `Fs::` is deliberately absent from that list. This entry does file IO and
+# declares it, so a call inside its own contract must keep building -- it makes
+# exactly one today, `Fs::stat_token`. A ban that also caught this would be the
+# false positive the row allow-list was switched off to avoid.
+printf '\nfn probe_entry_fs(p: String) -> Int with Fs {\n  Fs::stat_token(p)\n}\n' >> "$entry"
+if grep -qF -- 'fn probe_entry_fs(p: String) -> Int with Fs {' "$entry"; then
+  if bash "$gate" >/dev/null 2>&1; then
+    pass "case: the entry file own declared Fs contract still builds"
+  else
+    fail "case: the entry file declared Fs call was rejected"
+  fi
+else
+  fail "case: the entry-fs mutation did not land -- it proves nothing"
+fi
+restore
+
+printf '\nfn probe_entry_str() -> String {\n  "do not call Console::write_stream here"\n}\n' >> "$entry"
+if grep -qF -- 'do not call Console::write_stream here' "$entry"; then
+  if bash "$gate" >/dev/null 2>&1; then
+    pass "case: a capability name inside a string is still inert in the entry file"
+  else
+    fail "case: a string naming a capability was read as a call"
+  fi
+else
+  fail "case: the entry-string mutation did not land -- it proves nothing"
+fi
+restore
+
 if [ "$fails" -ne 0 ]; then
   echo "portable-boundary-test: FAILED" >&2
   exit 1
 fi
-echo "portable-boundary-test: ok (control + 84 cases)"
+echo "portable-boundary-test: ok (control + 89 cases)"

--- a/scripts/check_portable_boundary_test.sh
+++ b/scripts/check_portable_boundary_test.sh
@@ -958,8 +958,80 @@ else
 fi
 restore
 
+# --- cases 57-60: a row belongs to a declaration KIND -----------------------
+#
+# Round 28, and a false positive: `type ReviewCallback = () -> Unit with
+# ReviewAsk` is one arrow and one row, which is the "the row is the
+# declaration's own" shape, so a harmless alias failed the required job on
+# correct code. Naming a type performs nothing -- the row belongs to the
+# aliased function type, the same reason the lone row of a returned closure is
+# skipped (case 42).
+printf '\ntype ReviewCallback = () -> Unit with ReviewAsk\n' >> "$impl"
+if grep -qF -- 'type ReviewCallback = () -> Unit with ReviewAsk' "$impl"; then
+  if bash "$gate" >/dev/null 2>&1; then
+    pass "case: an effectful type alias is not a boundary row"
+  else
+    fail "case: a type alias naming an effect failed the gate"
+  fi
+else
+  fail "case: the alias mutation did not land -- the assertion proves nothing"
+fi
+restore
+
+# The miss that suppressing `type` opened, and which the fix above had to close
+# in the same commit. Measured: with only the flush guard, this went from
+# REJECT to ACCEPT. The normalized text has no line breaks, so the alias's row
+# scan ran straight through the following `fn ` -- which is where the reset
+# lives -- and the whole native declaration was read as part of the alias. A
+# declaration keyword now ends a row.
+printf '\ntype ReviewCallback2 = () -> Unit with ReviewAsk\n\nexport fn probe_after_alias() -> Unit with Fs {\n  ()\n}\n' >> "$impl"
+if grep -qF -- 'export fn probe_after_alias() -> Unit with Fs {' "$impl"; then
+  if bash "$gate" >/dev/null 2>&1; then
+    fail "case: an effectful alias swallowed the next declaration native row"
+  else
+    pass "case: a declaration keyword ends the preceding row"
+  fi
+else
+  fail "case: the alias-then-native mutation did not land -- it proves nothing"
+fi
+restore
+
+printf '\ntype ReviewCallback3 = () -> Unit with ReviewAsk\n\nexport fn probe_after_alias_ok() -> Unit with Async {\n  ()\n}\n' >> "$impl"
+if grep -qF -- 'export fn probe_after_alias_ok() -> Unit with Async {' "$impl"; then
+  if bash "$gate" >/dev/null 2>&1; then
+    pass "case: an allowed declaration after an effectful alias is accepted"
+  else
+    fail "case: an allowed declaration after an effectful alias was rejected"
+  fi
+else
+  fail "case: the alias-then-allowed mutation did not land -- it proves nothing"
+fi
+restore
+
+# --- case 60: THE COST OF CASE 57, pinned so it is visible -------------------
+#
+# `type FsCallback = () -> Unit with Fs` is now accepted. That is the price of
+# case 57 and it is the same trade as case 43: a type that names a native
+# effect is not itself a boundary, and no text scan can tell whether the
+# boundary ever hands one out. #2581 answers it from the AST, where the alias
+# can be followed to the declaration that uses it.
+#
+# When #2581 lands this case flips to a rejection. UPDATE THE CASE, do not
+# revert the fix -- accepting the alias is what keeps correct code building.
+printf '\ntype FsCallback = () -> Unit with Fs\n' >> "$impl"
+if grep -qF -- 'type FsCallback = () -> Unit with Fs' "$impl"; then
+  if bash "$gate" >/dev/null 2>&1; then
+    pass "case: KNOWN MISS -- a native effect named only by an alias (#2581)"
+  else
+    fail "case: the alias miss closed; flip this case to a rejection"
+  fi
+else
+  fail "case: the alias-miss mutation did not land -- the assertion proves nothing"
+fi
+restore
+
 if [ "$fails" -ne 0 ]; then
   echo "portable-boundary-test: FAILED" >&2
   exit 1
 fi
-echo "portable-boundary-test: ok (control + 56 cases)"
+echo "portable-boundary-test: ok (control + 60 cases)"

--- a/scripts/check_portable_boundary_test.sh
+++ b/scripts/check_portable_boundary_test.sh
@@ -1720,8 +1720,45 @@ else
 fi
 restore
 
+# --- cases 101-102: a handler pattern nests -----------------------------
+#
+# Round 43. The arm-head exemption matched the argument list with `[^)]*`,
+# which stops at the FIRST `)`. `Fs::ReadFile((_path)) =>` is a legal grouping
+# -- parse_handle_arm delegates to the recursive pattern parser -- so the head
+# survived the strip and the pure helper was rejected again.
+#
+# Parentheses are counted now instead of approximated, so the answer does not
+# depend on the depth. The probe uses TWO levels deliberately: a fix that only
+# allowed one more level than the reported counterexample would pass a
+# one-level case and fail here.
+printf '\nfn probe_nested_arm(f: () -> String with Fs) -> String with Exception {\n  handle {\n    f()\n  } with { Fs::ReadFile(((_p))) => resume("ok"); Fs::WriteFile(_a, _b) => resume(0); Fs::Exists(_p) => resume(true); Fs::Mkdir(_p) => resume(0) }\n}\n' >> "$impl"
+if grep -qF -- 'Fs::ReadFile(((_p))) => resume("ok")' "$impl"; then
+  if bash "$gate" >/dev/null 2>&1; then
+    pass "case: a nested handler pattern is still an arm head"
+  else
+    fail "case: a nested handler pattern was read as a capability call"
+  fi
+else
+  fail "case: the nested-pattern mutation did not land -- it proves nothing"
+fi
+restore
+
+# And the body after a nested head is still scanned -- the strip must consume
+# the head only, however deep its pattern goes.
+printf '\nfn probe_nested_arm_body(f: () -> Unit with Console) -> Unit {\n  handle {\n    f()\n  } with { Console::Write((_s)) => {\n    Console::write_stream("leaked")\n    resume(())\n  } }\n}\n' >> "$entry"
+if grep -qF -- 'Console::write_stream("leaked")' "$entry"; then
+  if bash "$gate" >/dev/null 2>&1; then
+    fail "case: a call after a nested arm head passed the gate"
+  else
+    pass "case: the body after a nested arm head is still scanned"
+  fi
+else
+  fail "case: the nested-arm-body mutation did not land -- it proves nothing"
+fi
+restore
+
 if [ "$fails" -ne 0 ]; then
   echo "portable-boundary-test: FAILED" >&2
   exit 1
 fi
-echo "portable-boundary-test: ok (control + 100 cases)"
+echo "portable-boundary-test: ok (control + 102 cases)"

--- a/scripts/check_portable_boundary_test.sh
+++ b/scripts/check_portable_boundary_test.sh
@@ -1757,8 +1757,89 @@ else
 fi
 restore
 
+# --- cases 103-107: one authoritative view, one lane list, spaced `::` ------
+#
+# Round 44-46, three findings on one head.
+#
+# 103. The arm-head strip runs per RECORD, so an arm written across lines was
+# stripped in the flattened view and not in the line-preserving one -- and both
+# views used to decide the verdict, so the per-line leftovers rejected a pure
+# helper. The flattened text is the line text with newlines turned into
+# spaces, so it matches everything a line-oriented grep can and more: the
+# verdict now comes from it alone, and the line view is read only to cite a
+# line. Case 104 is the reason both existed -- a separator that spans lines.
+printf '\nfn probe_split_arm(f: () -> Unit with Console) -> Unit {\n  handle {\n    f()\n  } with { Console::Write(\n    _s\n  ) => resume(()) }\n}\n' >> "$entry"
+if grep -qF -- 'with { Console::Write(' "$entry"; then
+  if bash "$gate" >/dev/null 2>&1; then
+    pass "case: a handler arm head written across lines is still an arm head"
+  else
+    fail "case: an arm head split across lines was read as a capability call"
+  fi
+else
+  fail "case: the split-arm mutation did not land -- it proves nothing"
+fi
+restore
+
+printf '\nfn probe_split_perform(p: String) -> Bool {\n  let _ = perform\n    Fs::ReadFile(p)\n  false\n}\n' >> "$impl"
+if grep -qF -- 'let _ = perform' "$impl"; then
+  if bash "$gate" >/dev/null 2>&1; then
+    fail "case: a native call split across lines passed after the view change"
+  else
+    pass "case: the flattened view still catches a separator spanning lines"
+  fi
+else
+  fail "case: the split-perform mutation did not land -- it proves nothing"
+fi
+restore
+
+# 105. `session-http` was dropped from the lane list. Strings and comments are
+# removed before the pattern runs, so in what remains that spelling can only be
+# the subtraction `session - http` -- it is not one vibe identifier. A pattern
+# that can only ever match something else is not a weaker check, it is a wrong
+# one, and it rejected a helper returning that expression.
+printf '\nfn probe_lane_sub(session: Int, http: Int) -> Int {\n  session-http\n}\n' >> "$impl"
+if grep -qF -- 'session-http' "$impl"; then
+  if bash "$gate" >/dev/null 2>&1; then
+    pass "case: a subtraction is not the session-http lane"
+  else
+    fail "case: session - http was rejected as a native lane"
+  fi
+else
+  fail "case: the lane-subtraction mutation did not land -- it proves nothing"
+fi
+restore
+
+# 106-107. The lexer allows whitespace around `::`, so `Console :: write_stream`
+# is the same call -- and in the entry file this pattern is the ONLY check for
+# a plain capability call. Requiring adjacency left it open. The arm-head strip
+# had to learn the same spacing, or fixing the pattern would have broken the
+# handler again.
+printf '\nfn probe_spaced_call() -> Unit with Console {\n  Console :: write_stream("leaked")\n}\n' >> "$entry"
+if grep -qF -- 'Console :: write_stream("leaked")' "$entry"; then
+  if bash "$gate" >/dev/null 2>&1; then
+    fail "case: a spaced :: capability call passed the entry gate"
+  else
+    pass "case: whitespace around :: does not hide a capability call"
+  fi
+else
+  fail "case: the spaced-call mutation did not land -- it proves nothing"
+fi
+restore
+
+printf '\nfn probe_spaced_arm(f: () -> Unit with Console) -> Unit {\n  handle {\n    f()\n  } with { Console :: Write(_s) => resume(()) }\n}\n' >> "$entry"
+if grep -qF -- 'Console :: Write(_s) => resume(())' "$entry"; then
+  if bash "$gate" >/dev/null 2>&1; then
+    pass "case: a spaced :: arm head is still an arm head"
+  else
+    fail "case: a spaced :: arm head was read as a capability call"
+  fi
+else
+  fail "case: the spaced-arm mutation did not land -- it proves nothing"
+fi
+restore
+
 if [ "$fails" -ne 0 ]; then
   echo "portable-boundary-test: FAILED" >&2
   exit 1
 fi
-echo "portable-boundary-test: ok (control + 102 cases)"
+echo "portable-boundary-test: ok (control + 107 cases)"

--- a/scripts/check_portable_boundary_test.sh
+++ b/scripts/check_portable_boundary_test.sh
@@ -882,8 +882,48 @@ else
 fi
 restore
 
+# --- cases 53-54: rows are matched against arrow LAYERS, not counted --------
+#
+# Round 25 used "two or more rows means the last is the declarations". Round 26
+# found the counterexample: `-> () -> () -> Unit with Exception with ReviewAsk`
+# has two rows and BOTH belong to the nested closures, so that rule rejected a
+# pure helper.
+#
+# The invariant instead: each arrow layer after the declarations own can carry
+# one row, so the returned function types absorb at most (arrows - 1). The
+# declaration owns a row only when rows >= arrows, and then it is the last.
+#
+#   arrows 1, rows 1 -> own      arrows 2, rows 1 -> none
+#   arrows 2, rows 2 -> own      arrows 3, rows 2 -> none
+#   arrows 3, rows 3 -> own
+printf '\nexport fn probe_nested_pure() -> () -> () -> Unit with Exception with ReviewAsk {\n  () -> {\n    () -> {\n      ()\n    }\n  }\n}\n' >> "$impl"
+if grep -qF 'with Exception with ReviewAsk {' "$impl"; then
+  if bash "$gate" >/dev/null 2>&1; then
+    pass "case: two rows absorbed by two closure layers leave the declaration pure"
+  else
+    fail "case: a pure helper returning nested effectful closures was rejected"
+  fi
+else
+  fail "case: the nested mutation did not land -- the assertion above proves nothing"
+fi
+restore
+
+# And the converse at the same arrow depth, so the invariant is not just
+# "three arrows means never check".
+printf '\nexport fn probe_nested_own() -> () -> () -> Unit with Exception with Async with Fs {\n  () -> {\n    () -> {\n      ()\n    }\n  }\n}\n' >> "$impl"
+if grep -qF 'with Exception with Async with Fs {' "$impl"; then
+  if bash "$gate" >/dev/null 2>&1; then
+    fail "case: a third row at three arrows is the declaration own and was skipped"
+  else
+    pass "case: rows beyond the closure layers are the declaration own"
+  fi
+else
+  fail "case: the nested-own mutation did not land -- the assertion proves nothing"
+fi
+restore
+
 if [ "$fails" -ne 0 ]; then
   echo "portable-boundary-test: FAILED" >&2
   exit 1
 fi
-echo "portable-boundary-test: ok (control + 52 cases)"
+echo "portable-boundary-test: ok (control + 54 cases)"

--- a/scripts/check_portable_boundary_test.sh
+++ b/scripts/check_portable_boundary_test.sh
@@ -1230,8 +1230,61 @@ else
 fi
 restore
 
+# --- cases 72-74: `perform?` invokes the same capability --------------------
+#
+# Round 33, a MISS and the sharpest one in this review: the native-call pattern
+# spelled only `perform`, so `perform? Fs::read_file(path)` in the entry file
+# passed the required gate outright. `perform?` is a different TOKEN (ADR-0088;
+# the parser builds EIdent("perform?") at parser_expr_primary.vibe:803, and
+# lib/@vibe/compiler/tests/perform_question_lowering_test.vibe pins its
+# lowering) but it reaches the same capability, which is the only thing this
+# gate is asking about.
+#
+# The suffix is normalized in the lexical pass rather than by adding `\??` to
+# one regex, so the next reader of this text does not have to know that two
+# spellings exist -- the same reason the raw-identifier prefix is dropped.
+printf '\nfn probe_perform_q(path: String) -> Int with () allows Fs::read_file? {\n  let _ = perform? Fs::read_file(path)\n  0\n}\n' >> "$entry"
+if grep -qF -- 'perform? Fs::read_file(path)' "$entry"; then
+  if bash "$gate" >/dev/null 2>&1; then
+    fail "case: an optional perform of a native capability passed the gate"
+  else
+    pass "case: perform? reaches the same capability and is rejected"
+  fi
+else
+  fail "case: the perform? mutation did not land -- the assertion proves nothing"
+fi
+restore
+
+# The normalization is lexical, so it must not reach inside a string. Same
+# pairing as case 32 for the plain spelling.
+printf '\nfn probe_perform_q_str() -> String {\n  "do not generate perform? Fs::read_file here"\n}\n' >> "$entry"
+if grep -qF -- 'do not generate perform? Fs::read_file here' "$entry"; then
+  if bash "$gate" >/dev/null 2>&1; then
+    pass "case: perform? inside a string literal is still inert"
+  else
+    fail "case: a string mentioning perform? was read as a native call"
+  fi
+else
+  fail "case: the perform?-in-string mutation did not land -- it proves nothing"
+fi
+restore
+
+# And a `?` that is NOT the perform suffix keeps its meaning: an optional
+# parameter is ordinary code, not a capability call.
+printf '\nfn probe_opt_param(x?: Int) -> Int {\n  0\n}\n' >> "$entry"
+if grep -qF -- 'fn probe_opt_param(x?: Int) -> Int {' "$entry"; then
+  if bash "$gate" >/dev/null 2>&1; then
+    pass "case: an optional parameter is not touched by the perform? rule"
+  else
+    fail "case: an optional parameter was rejected"
+  fi
+else
+  fail "case: the optional-parameter mutation did not land -- it proves nothing"
+fi
+restore
+
 if [ "$fails" -ne 0 ]; then
   echo "portable-boundary-test: FAILED" >&2
   exit 1
 fi
-echo "portable-boundary-test: ok (control + 71 cases)"
+echo "portable-boundary-test: ok (control + 74 cases)"

--- a/scripts/check_portable_boundary_test.sh
+++ b/scripts/check_portable_boundary_test.sh
@@ -1879,8 +1879,55 @@ else
 fi
 restore
 
+# --- cases 110-112: a qualified row item may be spaced ----------------------
+#
+# Round 48, and the second place the same spacing assumption was wrong -- the
+# direct-call pattern was the first, one round earlier. `parse_effect_item`
+# consumes the `::` token regardless of source spacing (parser_base.vibe), so
+# `with Exception :: Throw` is the same row as `with Exception::Throw`.
+# Stripping only the ADJACENT `::op` left `Throw` to reach the allow-list as an
+# effect of its own, and the row was rejected: `effect: Throw` on a portable
+# boundary.
+printf '\nexport fn probe_spaced_qualified() -> Unit with Exception :: Throw {\n  ()\n}\n' >> "$impl"
+if grep -qF -- 'with Exception :: Throw {' "$impl"; then
+  if bash "$gate" >/dev/null 2>&1; then
+    pass "case: a spaced qualified row item is the same item"
+  else
+    fail "case: a spaced qualified row was rejected, most likely as effect: Throw"
+  fi
+else
+  fail "case: the spaced-qualified mutation did not land -- it proves nothing"
+fi
+restore
+
+# The strip must not become a way to hide the CAPABILITY either: only the
+# `::op` suffix goes, never the head.
+printf '\nexport fn probe_spaced_qualified_native() -> Unit with Fs :: ReadFile {\n  ()\n}\n' >> "$impl"
+if grep -qF -- 'with Fs :: ReadFile {' "$impl"; then
+  if bash "$gate" >/dev/null 2>&1; then
+    fail "case: a spaced qualified NATIVE row passed the allow-list"
+  else
+    pass "case: spacing does not hide the capability in a qualified row"
+  fi
+else
+  fail "case: the spaced-native mutation did not land -- it proves nothing"
+fi
+restore
+
+printf '\nexport fn probe_spaced_compound() -> Unit with Exception :: Throw + Fs {\n  ()\n}\n' >> "$impl"
+if grep -qF -- 'with Exception :: Throw + Fs {' "$impl"; then
+  if bash "$gate" >/dev/null 2>&1; then
+    fail "case: a native item beside a spaced qualified item was missed"
+  else
+    pass "case: the rest of a compound row survives the spaced strip"
+  fi
+else
+  fail "case: the spaced-compound mutation did not land -- it proves nothing"
+fi
+restore
+
 if [ "$fails" -ne 0 ]; then
   echo "portable-boundary-test: FAILED" >&2
   exit 1
 fi
-echo "portable-boundary-test: ok (control + 109 cases)"
+echo "portable-boundary-test: ok (control + 112 cases)"

--- a/scripts/check_portable_boundary_test.sh
+++ b/scripts/check_portable_boundary_test.sh
@@ -1562,8 +1562,47 @@ else
 fi
 restore
 
+# --- cases 90-93: a forbidden lane is a name, not a substring ---------------
+#
+# Round 40, a false positive. The three lane names in native_effect_pattern
+# were unanchored, so `daemon` matched inside `daemonless_probe` and
+# `compile_file_fs` inside `compile_file_fsx_probe`: an ordinary helper whose
+# name merely CONTAINS a forbidden lane failed the required job on correct
+# code. They are anchored to token boundaries now.
+#
+# `my_daemon_helper` is the case that says why the anchor is the right shape
+# rather than a longer list of exceptions -- an underscore is a word
+# character, so the name simply has no boundary there.
+for name in daemonless_probe my_daemon_helper compile_file_fsx_probe; do
+  printf '\nfn %s() -> Bool {\n  false\n}\n' "$name" >> "$impl"
+  if grep -qF "fn $name() -> Bool {" "$impl"; then
+    if bash "$gate" >/dev/null 2>&1; then
+      pass "case: a helper named $name is not a forbidden lane"
+    else
+      fail "case: $name was rejected because its name contains a lane"
+    fi
+  else
+    fail "case: the $name mutation did not land -- the assertion proves nothing"
+  fi
+  restore
+done
+
+# The direction the anchor must not cost: the lanes themselves are still
+# forbidden. Without this the fix could have been "delete the alternative".
+printf '\nfn probe_real_lane(p: String) -> Bool {\n  let _ = compile_file_fs(p)\n  false\n}\n' >> "$impl"
+if grep -qF -- 'let _ = compile_file_fs(p)' "$impl"; then
+  if bash "$gate" >/dev/null 2>&1; then
+    fail "case: the compile_file_fs lane passed after anchoring"
+  else
+    pass "case: the compile_file_fs lane is still forbidden"
+  fi
+else
+  fail "case: the lane mutation did not land -- the assertion proves nothing"
+fi
+restore
+
 if [ "$fails" -ne 0 ]; then
   echo "portable-boundary-test: FAILED" >&2
   exit 1
 fi
-echo "portable-boundary-test: ok (control + 89 cases)"
+echo "portable-boundary-test: ok (control + 93 cases)"

--- a/scripts/check_portable_boundary_test.sh
+++ b/scripts/check_portable_boundary_test.sh
@@ -105,8 +105,45 @@ else
 fi
 restore
 
+# --- case 4: an IMPLEMENTATION that declares a native effect row ------------
+#
+# The forbid_pattern half, which case 3 does NOT reach: case 3 edits the
+# contract line, so require_line fails first and the gate's rejection says
+# nothing about whether forbid_pattern recognizes the row syntax. It did not.
+# Measured before the fix: appending this exact declaration left the gate
+# printing `ok`, because native_effect_pattern only knew the braced
+# `with { ... }` spelling -- which is the HANDLER syntax, not an effect row.
+printf '\nexport fn probe_native() -> Unit with Fs {\n  ()\n}\n' >> "$impl"
+if grep -qE '^export fn probe_native\(\) -> Unit with Fs \{$' "$impl"; then
+  if bash "$gate" >/dev/null 2>&1; then
+    fail "case 4: an implementation declaring 'with Fs' passed the gate"
+  else
+    pass "case 4: a native effect row in an implementation is rejected"
+  fi
+else
+  fail "case 4: the mutation did not land -- the assertion below would prove nothing"
+fi
+restore
+
+# --- case 5: a non-native effect row is still accepted -----------------------
+#
+# Case 4 alone is also satisfied by a matcher that rejects every `with` row, so
+# this pins the other side: `with Exception` is what these boundaries are
+# REQUIRED to carry, and must not start reading as a leak.
+printf '\nexport fn probe_pure() -> Unit with Exception {\n  ()\n}\n' >> "$impl"
+if grep -qE '^export fn probe_pure\(\) -> Unit with Exception \{$' "$impl"; then
+  if bash "$gate" >/dev/null 2>&1; then
+    pass "case 5: a non-native effect row is accepted"
+  else
+    fail "case 5: 'with Exception' was rejected as a native leak"
+  fi
+else
+  fail "case 5: the mutation did not land -- the assertion above would prove nothing"
+fi
+restore
+
 if [ "$fails" -ne 0 ]; then
   echo "portable-boundary-test: FAILED" >&2
   exit 1
 fi
-echo "portable-boundary-test: ok (control + 3 cases)"
+echo "portable-boundary-test: ok (control + 5 cases)"

--- a/scripts/check_portable_boundary_test.sh
+++ b/scripts/check_portable_boundary_test.sh
@@ -245,8 +245,41 @@ else
 fi
 restore
 
+# --- cases 14-15: the capability need not be adjacent to `allows` -----------
+#
+# Both of these COMPILE -- verified with `vibe test` on a stage2 built from this
+# checkout, not assumed -- and both slipped past the first version of the check,
+# which required the capability to follow the keyword on the same line.
+#
+# (`allows /* c */ Fs::read_file` needs no case: vibe has no block comments, so
+# it does not parse -- "expected an effect name in the effect row after 'with'".
+# A case for it would assert a rejection the language already guarantees.)
+printf '\nexport fn probe_nl() -> String with Exception allows\n  Fs::read_file {\n  ""\n}\n' >> "$impl"
+if grep -qE 'allows$' "$impl"; then
+  if bash "$gate" >/dev/null 2>&1; then
+    fail "case: 'allows' with the capability on the NEXT LINE passed the gate"
+  else
+    pass "case: a capability on the next line is still rejected"
+  fi
+else
+  fail "case: the newline mutation did not land -- the assertion proves nothing"
+fi
+restore
+
+printf '\nexport fn probe_tc() -> String with Exception allows // note\n  Fs::read_file {\n  ""\n}\n' >> "$impl"
+if grep -qF 'allows // note' "$impl"; then
+  if bash "$gate" >/dev/null 2>&1; then
+    fail "case: 'allows' followed by a trailing comment passed the gate"
+  else
+    pass "case: a comment between the keyword and the capability is stripped"
+  fi
+else
+  fail "case: the trailing-comment mutation did not land -- the assertion proves nothing"
+fi
+restore
+
 if [ "$fails" -ne 0 ]; then
   echo "portable-boundary-test: FAILED" >&2
   exit 1
 fi
-echo "portable-boundary-test: ok (control + 13 cases)"
+echo "portable-boundary-test: ok (control + 15 cases)"

--- a/scripts/check_portable_boundary_test.sh
+++ b/scripts/check_portable_boundary_test.sh
@@ -278,8 +278,40 @@ else
 fi
 restore
 
+# --- cases 16-17: an effect row split across lines --------------------------
+#
+# A row may be broken after `+`, and it compiles -- verified with `vibe test`.
+# A line-by-line scan matched `with Exception`, accepted it, and never
+# associated the `Fs` on the next line. Both directions are pinned: the split
+# row must still be REJECTED when it names a capability, and still ACCEPTED
+# when it does not, since flattening must not make the scanner blind or
+# trigger-happy.
+printf '\nexport fn probe_split() -> String with Exception +\n  Fs {\n  ""\n}\n' >> "$impl"
+if grep -qE 'with Exception \+$' "$impl"; then
+  if bash "$gate" >/dev/null 2>&1; then
+    fail "case: a row split after '+' hid a native effect from the gate"
+  else
+    pass "case: a native effect on the next line of a split row is rejected"
+  fi
+else
+  fail "case: the split-row mutation did not land -- the assertion proves nothing"
+fi
+restore
+
+printf '\nexport fn probe_split_ok() -> String with Exception +\n  Async {\n  ""\n}\n' >> "$impl"
+if grep -qE 'with Exception \+$' "$impl"; then
+  if bash "$gate" >/dev/null 2>&1; then
+    pass "case: a split row of allowed effects is accepted"
+  else
+    fail "case: 'with Exception +\\n Async' was rejected -- flattening broke acceptance"
+  fi
+else
+  fail "case: the split-row mutation did not land -- the assertion proves nothing"
+fi
+restore
+
 if [ "$fails" -ne 0 ]; then
   echo "portable-boundary-test: FAILED" >&2
   exit 1
 fi
-echo "portable-boundary-test: ok (control + 15 cases)"
+echo "portable-boundary-test: ok (control + 17 cases)"

--- a/scripts/check_portable_boundary_test.sh
+++ b/scripts/check_portable_boundary_test.sh
@@ -1972,8 +1972,79 @@ else
 fi
 restore
 
+# --- cases 116-118: the capability list is read, not restated ---------------
+#
+# Round 50. The entry file's namespace list was written by hand as
+# Console|Env|Process|Socket|Http|Net. The real list --
+# capability_effect_name_list in lib/@vibe/parser/parser_base.vibe -- has TEN
+# names: it also has Stdin, Stdout, Stderr and Profiler, which this boundary
+# could therefore use unseen, and it does NOT have Net. Measured: `fn f() ->
+# Int with Stdin { Stdin::read_char() }` compiles and the gate printed ok.
+#
+# The gate derives the list from that file now. Enumerating a list that lives
+# somewhere else is the structure that produces the drift, so this removes the
+# class rather than the four names -- a capability added to the compiler is
+# covered here without anyone remembering to come back.
+for cap in Stdin Stdout Stderr Profiler; do
+  printf '\nfn probe_cap_%s() -> Unit with %s {\n  %s::write_all("x")\n}\n' "$cap" "$cap" "$cap" >> "$entry"
+  if grep -qF "fn probe_cap_$cap() -> Unit with $cap {" "$entry"; then
+    if bash "$gate" >/dev/null 2>&1; then
+      fail "case: the entry file used $cap and passed the gate"
+    else
+      pass "case: $cap is a capability the entry file may not use"
+    fi
+  else
+    fail "case: the $cap mutation did not land -- the assertion proves nothing"
+  fi
+  restore
+done
+
+# The derived list must not swallow the file's own declared contract.
+printf '\nfn probe_declared_fs(p: String) -> Int with Fs {\n  Fs::stat_token(p)\n}\n' >> "$entry"
+if grep -qF -- 'fn probe_declared_fs(p: String) -> Int with Fs {' "$entry"; then
+  if bash "$gate" >/dev/null 2>&1; then
+    pass "case: Fs is dropped from the derived list, as the contract requires"
+  else
+    fail "case: the derived list banned the entry file own declared Fs call"
+  fi
+else
+  fail "case: the declared-Fs mutation did not land -- it proves nothing"
+fi
+restore
+
+# And the reader must FAIL CLOSED, LOUDLY. An empty alternation would match
+# nothing and the gate would print ok on everything, which is the worst
+# outcome a derived list can have.
+#
+# The first version of this guard never fired: `set -e` killed the script on
+# the reader's own pipeline first, so the gate exited 1 with NO message.
+# Fail-closed and silent is not good enough -- silence is indistinguishable
+# from unchecked, and the message is the part that says what to repair. Every
+# stage of the reader is guarded so the check itself is what stops the run.
+#
+# The mutation renames the array in the gate's own copy, which is the shape
+# change the guard exists for: the file is still readable, so nothing errors.
+# The copy has to live beside the gate: it derives ROOT_DIR from BASH_SOURCE,
+# so a copy in /tmp resolves every repository path against /tmp and fails for
+# an unrelated reason -- which is how the first draft of this case "passed".
+gate_tmp="scripts/.portable_boundary_reader_probe.$$.sh"
+sed 's/capability_effect_name_list/capability_effect_name_list_RENAMED/' "$gate" > "$gate_tmp"
+if ! grep -q 'capability_effect_name_list_RENAMED' "$gate_tmp"; then
+  fail "case: the capability-reader mutation did not land -- it proves nothing"
+else
+  out="$(bash "$gate_tmp" 2>&1)" && rc=0 || rc=$?
+  if [ "$rc" -eq 0 ]; then
+    fail "case: an unreadable capability list still passed the gate"
+  elif printf '%s' "$out" | grep -qF 'cannot read capability_effect_name_list'; then
+    pass "case: an unreadable capability list fails closed, and says so"
+  else
+    fail "case: it failed closed but silently, which reads as unchecked: $out"
+  fi
+fi
+rm -f "$gate_tmp"
+
 if [ "$fails" -ne 0 ]; then
   echo "portable-boundary-test: FAILED" >&2
   exit 1
 fi
-echo "portable-boundary-test: ok (control + 115 cases)"
+echo "portable-boundary-test: ok (control + 121 cases)"

--- a/scripts/gate_self_test_allowlist.txt
+++ b/scripts/gate_self_test_allowlist.txt
@@ -24,7 +24,6 @@ check_inline_builtin_capture.sh
 check_offbuild_typecheck.sh
 check_package_sibling_scope.sh
 check_playground_presets.sh
-check_portable_boundary.sh
 check_rc_default.sh
 check_tutorial_translation_parity.sh
 check_typecheck_fixtures.sh

--- a/scripts/tracked_experiment_name_allowlist.txt
+++ b/scripts/tracked_experiment_name_allowlist.txt
@@ -47,3 +47,4 @@ lib/@vibe/compiler/tests/cache_probe_test.vibe gate persistent-cache regression
 lib/@vibe/compiler/tests/cache_probe_type_db_fs_multi_dep_bench_test.vibe bench-fixture cache probe bench
 lib/@vibe/compiler/tests/checker_hotspot_probe_test.vibe gate checker hotspot regression
 lib/@vibe/compiler/tests/parser_hotspot_probe_test.vibe gate parser hotspot regression
+scripts/prefix_stability_probe.py manual-experiment #2388 codegen prefix-stability measurement; run by hand when the per-module body cache is worked on


### PR DESCRIPTION
Retargeted to `main`. **This now also carries #2578's content**, which never reached main.

## First: #2578 is orphaned, and this PR is the recovery

#2578 was stacked on #2576 and its base was `claude/doc-classification-gate-8eytq3`. #2576 merged to `main` at `8ec22b6` **first**; #2578 then merged into that same branch at `f444e01` — after it had already served its purpose. So its commits sit on a branch nothing merges from:

```console
$ git merge-base --is-ancestor c35ea3b origin/main   # #2578's head
  NO -- orphaned
$ git show origin/main:scripts/check_portable_boundary.sh | grep -c index.vpkg
0
$ git show origin/main:scripts/check_doc_commands.sh | grep -c '"runtime"'
0
```

None of it is in main: the three red-gate fixes, the `check_doc_commands` environment fix, and the first four CI wirings. This branch already contained them (I merged `wire-unrun-gates` in at `b48b908`), so retargeting to `main` recovers all of it in one PR. #2578 can be closed as superseded by this one.

That is a stacked-PR hazard worth naming: merging a stacked PR into its base **after** that base has landed puts the work somewhere no one will merge from, and nothing reports it.

## What this PR now contains

### Three gates that were red on main (was #2578)

| gate | defect |
|---|---|
| `check_task_inputs.sh` | `bench-compile-hotspots` reached the compiler with no `bootstrap/seed.json` and no `cache = false`. Fixed with `cache = false` — the stage2 to profile arrives as an **argument**, so no input list can key it, and its three sibling measurement tasks all do the same |
| `check_portable_boundary.sh` | asserted a **two-ADR-old** shape (`export let … with { Error }` in an `index.vibe` facade) after ADR-0070 moved the contract to `index.vpkg` and ADR-0085 replaced `Error` with `Exception`. It reported "missing expected pure boundary" for files that do not exist, while every boundary it names was intact beside them. Repointing revealed a second defect it had been hiding: `forbid_pattern` matched a native entry point inside a **doc comment**. Comment lines are stripped now — whole lines only, never a trailing comment after code. Gained the self-test it never had (control first, then code-rejected / comment-accepted / `with Fs`-rejected) and came off `gate_self_test_allowlist.txt` |
| `lint_tracked_experiment_names.sh` | `scripts/prefix_stability_probe.py` had no allowlist entry. **This is the gate `AGENTS.md` names** as the example of one that went unrun — still unrun, and red |

### `check_doc_commands` depended on build artifacts (was #2578)

Found by wiring it into CI: green locally, red in CI, same tree.

```
check-doc-commands: FAIL: AGENTS.md:674: `VIBE_BENCH_BACKEND` -- nothing in the tree reads this
```

True for what the gate could see, false about the tree. The only code read is `runtime/vibe:2606`; every occurrence in a scanned file is a whole-line comment it correctly drops. `runtime` was not a walk root, and `runtime/vibe` has **no extension**, so the answer came from whether the *generated* `cli_adapter_bundle.vibe` happened to exist. Both fixed; measured that **each alone is insufficient**. A shebang is the property; the extension list was a proxy for it.

### The remaining gates (this PR's original subject)

Five need no compiler → `structural-lint`. Nine do → a new `compiler-gate (contracts)` job on the same cached stage2 the docs and playground jobs use, added to `ci-required`.

**Nine, not ten — the by-hand audit got one entry wrong.** Codex caught it: `check_examples_typecheck.sh` was already wired, via `pkf run ci-check-examples-typecheck` in the pre-existing `compiler-examples` job, against this same `_build/_ci_shard_gen/stage2.wasm`. My reachability trace missed the task indirection. I re-checked all ten against `origin/main`'s workflow and Taskfile rather than fix only the one reported:

```
check_rc_default                 direct-in-wf=0  via-task: none
check_source_range_contract      direct-in-wf=0  via-task: none
check_cheatsheet_signatures      direct-in-wf=0  via-task: none
check_package_sibling_scope      direct-in-wf=0  via-task: none
check_declaration_scale          direct-in-wf=0  via-task: none
check_cli_line_termination       direct-in-wf=0  via-task: none
check_offbuild_typecheck         direct-in-wf=0  via-task: none
check_book_skip_blocks           direct-in-wf=0  via-task: none
check_examples_typecheck         direct-in-wf=0  via-task: ci-check-examples-typecheck   <-- already wired
check_compile_only_lanes         direct-in-wf=0  via-task: none
```

Exactly one. The other nine were genuinely unrun. That a hand audit made this mistake is the argument for #2580, which asks for a gate that answers this question mechanically.

**Every one of those nine already accepted an explicit stage2 override** — the `AGENTS.md` rule honoured by their authors and then never exercised, because nothing ran them. The job hands each the artifact **by path** and asserts it exists, deliberately avoiding the `ls -dt _build/selfhost/generations/*/ | head -1` idiom the older jobs share.

All verified **GREEN against a stage2 built from this checkout**, not the seed — for gates that assert properties of the current compiler sources, that distinction is the whole point:

```
rc_default GREEN            offbuild_typecheck  GREEN
source_range_contract GREEN book_skip_blocks    GREEN
cheatsheet_signatures GREEN compile_only_lanes  GREEN
package_sibling_scope GREEN
declaration_scale GREEN
cli_line_termination GREEN
```

After this, **"19 of 40 gate scripts have no path from any workflow" is zero** — the one remaining name on that list, `check_examples_typecheck.sh`, was never unwired to begin with.

## Rebased onto #2569, and why that needed re-validating

#2569 merged while this PR was green, and it is not an inert base bump. It added two **absence** assertions to `scripts/check_compile_only_lanes.sh`:

```diff
-ABSENT_PATTERNS='codegen_gc_backend|...'
+ABSENT_PATTERNS='emit_shadow_mark_freed|emit_str_operand_guard|codegen_gc_backend|...'
```

Those hold only if the compile-only artifact was built by a compiler containing #2569's const-bool fold — and this PR's contracts job is what hands that build its stage2. So the new job and the new assertion had never been exercised together: my green predates the merge, #2569's green predates the job. Re-measured on the merged tree, cold, with a stage2 built from it:

```
compile-only-lanes: refusal ok (6 switches refused by name)
compile-only-lanes: acceptance ok (RC and bump lanes compile, default runs)
compile-only-lanes: absence ok (5603 of 5985 functions named, none from a dropped lane)
compile-only-lanes: ok
```

## Two other Codex findings, both real

- **A second wasmtime install.** `setup-vibe` already runs with `wasmtime: 'true'`, installing the same pinned 47.0.2 via `scripts/install_wasmtime_release.sh` and putting `$HOME/.wasmtime/bin` on PATH. The duplicate release download added a transient-failure mode to a job that is now *required*. Removed. The same duplication exists in four pre-existing jobs — same fix, but widening this PR to them is a separate change.
- **The gate-registry self-test ran twice.** The pre-existing `compiler-gate registry self-test` step already invokes it; only the production `check_gate_registry.sh` was missing, so only that is added.

## Verification

- All touched gates and self-tests run green directly.
- `check_doc_commands` red-tested by renaming a documented variable to an unread one — the *first* attempt appended a new line to `AGENTS.md` and the gate stayed green, because the mutation was not in a shape the scan reads. The landing mutation edits an existing reference in place.
- `test_ci_compiler_gate_layout.sh` passes with the new job; `check_gate_portability.sh` clean; `gate_self_test_failing.txt` still empty.
- `ci.yml` parses after the three step removals.
- `pkf run pre-commit` passed on every commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0194y71aVEMcwoem5oAxFJPX