### PR TITLE
docs/issue-triage: regenerate the applied state after #2579, and record two ways it rots

### DIFF
--- a/docs/issue-triage.md
+++ b/docs/issue-triage.md
@@ -1,7 +1,9 @@
 # Issue triage — deciding kind and priority mechanically
 
-Last updated: 2026-09-06 (applied state and lanes rewritten against the open
-set; the 2026-08-25 lists named merged PRs and closed issues).
+Last updated: 2026-09-08 (applied state rewritten against the open set after the
+#2579 merge; the 2026-09-06 edition had drifted five ways -- three new P1s
+missing, one epic's blocker landed, two issues in a state their own comments
+contradicted, and a closed issue still named in a lane).
 
 So that "what do I do next" does not have to be re-derived every time, **each
 label means exactly one thing**. Every issue is labelled independently on three
@@ -53,7 +55,7 @@ the same shelf as a real bug.
 An `epic` is an index, so it is never itself the thing to work on (look at its
 sub-issues).
 
-## Applied state as of 2026-09-06
+## Applied state as of 2026-09-08
 
 **Rewrite this section; never append to it.** It is a snapshot of the open set,
 and a snapshot that has drifted is worse than none — the 2026-08-25 edition sat
@@ -80,15 +82,21 @@ first, then take the leftover.
 | #2381 | `vibe symbols` silently ignores extra arguments, and has no batch mode |
 | #2378 | a library `fn` silently replaces a same-named builtin program-wide |
 
-### P1 — crashes, or cannot be written (5)
+### P1 — crashes, or cannot be written (8)
 
 | # | what |
 |---|---|
+| #2574 | calling a two-line helper from the module pruner's `ref.func` refusal path overflows the wasm stack |
+| #2573 | a compiler sibling missing from `compiler_sources_manifest.tsv` fails as `type_db: missing resolved dependency environment`, not as a manifest error |
+| #2570 | `+` over two `Trait::method(receiver)` results returning `Double` is typed `Int`, so a correct program is rejected |
 | #2535 | a module-level `let` initialized with two or more Bool literals (`[false, false]`) makes the next top-level item "unexpected token" |
 | #2527 | defining a `fn` named `id` or `call` that returns `Expr` makes an unrelated file fail with "cannot interpolate a value of type `Expr`" |
 | #2444 | `try { } with { }` says a handler arm must be fully qualified while the arm already is exactly that |
 | #2349 | `mapfile` (bash 4) keeps six gate scripts from running on macOS stock bash, so local sign-off is impossible there |
 | #2199 | OOB aborts name operation / index / length but carry no source provenance (rides #1987) |
+
+The first three arrived on 2026-09-06 and were missing from the previous
+edition of this table, which is the drift this section's own rule is about.
 
 ### P2 carrying `blocker` — the entrance to a subtree
 
@@ -107,8 +115,8 @@ first, then take the leftover.
 | #2492 | build-time configuration, `VIBE_*` → `#cfg` → #2497, #2498, #2499 |
 | #2493 | a compile-only artifact at or under 1.0 MB → #2500 (blocker), #2501 – #2506 |
 | #2494 | compiler memory, 128 MB per unit of work → #2509 (blocker), #2507, #2508, #2510 |
-| #2340 | SIMD-first data structures → #2347 (#2348 closed: both inline-wasm halves landed in #2399 / #2420) |
-| #2002 | documentation by audience → #2562 (blocker), #2564, #2565, #2566, #2567. Phases 0-1 already landed as `docs/README.md`; the gate is missing and the router has drifted three ways |
+| #2340 | SIMD-first data structures → #2347. #2348's two inline-wasm halves landed in #2399 / #2420; the issue itself carried a "Closing" comment for two days without the state change, applied 2026-09-08 |
+| #2002 | documentation by audience → #2564, #2565, #2566, #2567. **The blocker is gone**: #2562's fail-closed classification gate landed in #2576, so the four moves are unblocked and can run in order (delete, then user, then internal/generated, then split the mixed ones) |
 | #2001 | retire the scripts layer |
 
 ### Everything else
@@ -125,6 +133,21 @@ hand-rolled renderer and unary counts — the bug they route around was a
 misdiagnosis and is closed), **#2219** (its "after the next bootstrap bump"
 precondition has fired — the committed seed emits the assert marker, so the
 legacy block recognizer can go).
+
+**The gate-wiring pair, both from #2579 and both worth doing in order.** #2579
+wired all 19 previously-unreachable gate scripts into CI, so the count is zero
+today — by hand, and the hand audit got one of ten entries wrong. **#2580** is
+the mechanical replacement: a gate that fails when a `check_*` / `lint_*` script
+is reachable from no workflow, which is what keeps the count at zero.
+**#2581** is the other half of the same lesson: `check_portable_boundary.sh`
+answers a semantic question with a text scanner, and its review ran to 53
+findings — 52 fixed, one refused because measuring the emitted wasm showed the
+gate was right. Its three comments are the acceptance list for the AST version.
+
+**#1872 has no open parent.** Its parent #1770 closed, so the `effect Source`
+design is invisible from every open epic even though its remaining steps are
+written out. Either re-parent it or treat it as a standalone lane entry; do not
+assume it is covered because it has a phase number.
 
 Sequencing worth knowing: **#1953 comes after #2497 and #2498**, not beside
 them. The two issues used to conflict — both moved the compiler's trace and
@@ -176,8 +199,8 @@ serially. Running across lanes is free.**
 | **E. codegen / RC** | `codegen/**` | #2389, #1980, #1934 | |
 | **F. runtime / host** | `runtime/viberun`, abort provenance | #2199 (rides #1987), #2397 | |
 | **G. CLI / editor queries** | `lib/@vibe/cli/**`, `entry/cli_cache` | #2381 (P0), #2378 (P0), #1943, #2499 | |
-| **H. scripts / gates** | `scripts/**`, `tests/gates/**` | #2349 (P1), #2538, #2001 | |
-| **I. docs** | `docs/**`, `book/**` | #2002, #2146, #1346 | conflicts only on the cheatsheet |
+| **H. scripts / gates** | `scripts/**`, `tests/gates/**` | #2349 (P1), #2538, #2580, #2581, #2001 | #2580 before #2581: the reachability gate is cheap and keeps the wiring #2579 did from rotting, while #2581 needs a compiler-bearing job |
+| **I. docs** | `docs/**`, `book/**` | #2002 → #2564, #2565, #2566, #2567 (in that order), #1346 | conflicts only on the cheatsheet. #2146 closed 2026-09-06 |
 
 The #2386 perf subtree deliberately touches every lane — its slices land as many
 small independent PRs, which is why `git log` on a file is worth a look before
@@ -198,6 +221,17 @@ a list conflicts with the neighbouring lane.
   the issues still open, and one (#2437) whose scope had been rewritten three
   times in comments while the body still described the original ask. A merged
   PR does not close an issue; a person does.
+- **The state and the comments can disagree in both directions, so check both.**
+  Two cases on 2026-09-08: #2348 carried a "Closing" comment for two days with
+  the state never applied, and #2581 was closed by a merge although nothing about
+  it was done.
+- **Never write `#NNNN` after a closing verb you are negating.** #2581 was closed
+  by a commit body reading *"This does not close #2581."* — GitHub's parser sees
+  `close #2581` and does not see the `not`. The keywords are `close` / `closes` /
+  `closed` / `fix*` / `resolve*`, anywhere in a commit body on the default branch.
+  Spell it `does not close issue 2581`, with no `#`, when saying so. This
+  repository writes commit bodies that explain what a change deliberately does
+  NOT do, so the hazard is structural here rather than incidental.
 - **Restate a body when its comments have overtaken it.** A reader who has to
   reconstruct the current ask from a comment thread pays that cost every time.
   The body holds where things stand; the thread holds how it got there.


### PR DESCRIPTION
`docs/issue-triage.md` says of its own applied-state section: *"Rewrite this section; never append to it. It is a snapshot of the open set, and a snapshot that has drifted is worse than none."* It had drifted five ways, so this rewrites it against the open set as of 2026-09-08.

The GitHub-side cleanup that goes with it is already applied (issue state and labels are not in the diff): **87 open issues before, 85 after.**

## What had drifted

| # | drift | verified how |
|---|---|---|
| P1 table | listed **5** where there are **8** — #2574, #2573, #2570 were filed 2026-09-06 and never added | `list_issues --label P1 --state open` |
| #2002 | named #2562 as the subtree's blocker; it merged in #2576, so the four document moves are unblocked | #2562 is closed, `closed_by_pull_requests` → #2576 |
| #2348 | listed as closed, and was **open** — its own 2026-09-06 comment ends "Closing" and the state change never applied | both halves confirmed in the tree before closing (below) |
| #2146 | named in the docs lane; closed 2026-09-06 | `issue_read` |
| #2577 / #2580 / #2581 | #2577 was done and open; the two follow-ups #2579 produced were in no lane | three done-when items verified in the tree (below) |

The open-PR table (#2522) and the P0 table (#2523, #2475, #2381, #2378) were both still accurate and are unchanged.

## Issue-state changes, each verified in the tree first

**#2348 closed.** Its comment cited two landing points; both are there on `cd9eb4f`:

```console
$ grep -n 'must be typed Int, Bytes, or Array\[Int\]' lib/@vibe/parser/parser_expr.vibe
911:      throw("inline wasm fn '\{name}': param '\{pn}' must be typed Int, Bytes, or Array[Int] ...

$ grep -n 'check_iw_callee_table' lib/@vibe/compiler/runtime/typecheck_fs.vibe
6339:fn check_iw_callee_table(...)
```

**#2577 closed.** All three "Done when" items:

```console
$ grep -n cache Taskfile.pkl   # bench-compile-hotspots, line 1255ff
  cache = false
$ bash scripts/check_task_inputs.sh
check-task-inputs: ok (18 compiler-touching tasks ... all key on compiler sources)
$ grep -n check_task_inputs .github/workflows/ci.yml
850:        run: bash scripts/check_task_inputs_test.sh
852:        run: bash scripts/check_task_inputs.sh
```

Plus the third item, the audit: #2579 wired all 19 previously-unreachable gate scripts, so the count is zero.

**#2581 reopened.** It was closed at the moment #2579 merged, by a commit body that says the opposite:

```
This does not close #2581. The scan is no longer guessing at syntax, but it is
```

GitHub's parser reads `close #2581` and does not read the `not`. Nothing about that state was intended, and substantively nothing in the issue is done — #2579 kept the gate a text scanner and its review went from 4 findings to 53.

**Labels.** Three issues carried no kind axis, which the doc's own rule makes part of filing: #2221 (`experimental` only → `+enhancement +P2`), #1987 (`P2` only → `+enhancement +runtime +dx`), #1872 (`P2` + lane only → `+enhancement +refactoring`).

## Two new entries under "Limits of this classification"

Both are from this pass rather than restated advice:

- **The state and the comments disagree in both directions, so check both.** #2348 carried a closing comment with no close; #2581 was closed with nothing done.
- **Never write `#NNNN` after a closing verb you are negating.** This repository writes commit bodies that explain what a change deliberately does *not* do, so `does not close #2581` is a shape it will produce again. Spell it `does not close issue 2581`, with no `#`.

## Also recorded

#1872's parent (#1770) is closed, so the `effect Source` design is reachable from no open epic despite having its remaining steps written out. Noted in "Everything else" rather than silently re-parented.

## Verification

`check-doc-path-citations`, `check-doc-commands` and `doc-classification` all green; `pkf run pre-commit` passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0194y71aVEMcwoem5oAxFJPX

---
_Generated by [Claude Code](https://claude.ai/code/session_0194y71aVEMcwoem5oAxFJPX)_