### PR TITLE
codegen: one pure-builtin allowlist, not two copies (#2373)

### DIFF
--- a/fixtures/async_future_boundary_resolved_test.vibe
+++ b/fixtures/async_future_boundary_resolved_test.vibe
@@ -1,8 +1,9 @@
 /// ADR-0089 Decision 2 (#1218): the Future cell primitives are inert
 /// callees for the evidence migration (`Future::pending`/`Future::ready`
 /// allocate the [state, payload] cell, `Future::resolve` is two stores;
-/// none can perform). Before they joined the pure-builtin allowlists
-/// (idp/edp_pure_builtin_names), this program was REJECTED outright: the
+/// none can perform). Before they joined the pure-builtin allowlist
+/// (idp_pure_builtin_names; #2373 folded the evidence pass's second copy of
+/// it into that one), this program was REJECTED outright: the
 /// entry boundary wraps the whole Async-row entry body in a
 /// `handle ... with Async`, and one opaque callee name sank the entire
 /// body to "not eligible for evidence-passing migration".

--- a/fixtures/effect_handle_call_evidence_pure_helper.vibe
+++ b/fixtures/effect_handle_call_evidence_pure_helper.vibe
@@ -2,7 +2,8 @@
 // user-defined PURE helper function (no `with` clause at all, so the
 // checker has already proven it performs no effect) that is neither a
 // needing function itself nor one of the hand-audited
-// `edp_pure_builtin_names`.
+// `idp_pure_builtin_names` (#2373 folded the evidence pass's second copy of
+// that list into the one the direct-perform pass reads).
 //
 // edp_has_unsafe_construct's ECall case used to unconditionally reject any
 // call whose callee wasn't "perform"/"resume", a hand-listed pure

--- a/fixtures/effect_suspend_bytes_index_of_bytes_test.vibe
+++ b/fixtures/effect_suspend_bytes_index_of_bytes_test.vibe
@@ -1,6 +1,6 @@
 // The `Bytes` search builtins (#2345) have to be on the hand-audited
-// pure-builtin allowlist (idp_pure_builtin_names / edp_pure_builtin_names,
-// codegen/common_base/inline_direct_perform.vibe) -- the same list
+// pure-builtin allowlist (idp_pure_builtin_names, the one list both passes
+// read since #2373 -- codegen/common_base/inline_direct_perform.vibe) -- the same list
 // `Array::concat` joined in #1536, and the one `String::index_of` has been on
 // all along.
 //

--- a/fixtures/gc_backend_effect_pure_builtin_index.vibe
+++ b/fixtures/gc_backend_effect_pure_builtin_index.vibe
@@ -1,6 +1,6 @@
 // ADR-0076 (#817) gc-backend follow-up: `edp_has_unsafe_construct`'s
-// pure-builtin allowlist (idp_pure_builtin_names/edp_pure_builtin_names,
-// codegen/common_base/inline_direct_perform.vibe) was missing `__index`
+// pure-builtin allowlist (idp_pure_builtin_names, the one list both passes
+// read since #2373 -- codegen/common_base/inline_direct_perform.vibe) was missing `__index`
 // (what `obj[i]` desugars to), `Array::get`/`Map::get`/`Bytes::get`, and
 // `Array::length`/`Map::size`/`Bytes::length` -- all seven individually
 // checker-verified pure (no possible perform, no function-typed param).

--- a/lib/@vibe/compiler/codegen/common_base/index.vpkg
+++ b/lib/@vibe/compiler/codegen/common_base/index.vpkg
@@ -279,6 +279,11 @@ fn lower_optional_performs(stmts: Array[Stmt], resolution: Array[(String, String
 // --- evidence_dict_pass
 fn evidence_dict_pass(stmts: Array[Stmt], entry_name: String) -> Array[String]
 fn edp_bind_census(stmts: Array[Stmt], names: Array[String]) -> Array[Bool]
+// #2373: the direct-perform and evidence passes read ONE pure-builtin
+// allowlist; this throws if a listed name is rejected by either predicate, or
+// if a non-member is accepted by one. Exported for
+// tests/pure_builtin_name_agreement_test.vibe.
+fn verify_pure_builtin_name_agreement() -> Unit with Exception
 
 // --- forin_discard_pass (#1916): wrap every discard-position `for` as
 // `ESeq(for .., EUnit)` so the linear ESeq lowering compiles it without the

--- a/lib/@vibe/compiler/codegen/common_base/inline_direct_perform.vibe
+++ b/lib/@vibe/compiler/codegen/common_base/inline_direct_perform.vibe
@@ -494,6 +494,13 @@ fn idp_call_is_unsafe(callee: Expr) -> Bool {
 /// perform in disguise), so only exact, individually-verified names belong
 /// here. Extending this list requires re-checking the new name's entry in
 /// those files, not just adding a plausible-looking string.
+///
+/// #2373: this is THE list -- both consumers read it. `idp_is_pure_builtin_
+/// call` (this pass, and `scps_named_call_ok`'s suspend-class lowering
+/// through it) and `edp_is_pure_builtin_call` (the evidence pass's safety
+/// scans) share one table; the evidence pass used to keep a second copy whose
+/// doc comment claimed to mirror this one and did not. The audit criterion is
+/// the same for both, so a name belongs to both or to neither.
 fn idp_pure_builtin_names() -> Array[String] {
   [
     "String::concat",
@@ -1146,7 +1153,7 @@ fn idp_bind_args(bind_names: Array[String], actual_args: Array[Expr], prepared_b
 /// effect_nested_handles.vibe for the regression lock. A call to a plain
 /// user-defined function the checker has ALREADY proven pure (empty
 /// declared row, `edp_pure_fn_names`) is ALSO safe now, not just the
-/// hand-audited `edp_pure_builtin_names` allowlist -- see fixtures/
+/// hand-audited `idp_pure_builtin_names` allowlist -- see fixtures/
 /// effect_handle_call_evidence_pure_helper.vibe. A bare `.field` READ
 /// (`EDot`, not a call through it) is ALSO safe now -- see fixtures/
 /// effect_handle_call_evidence_struct_field.vibe -- despite this pass
@@ -4859,7 +4866,7 @@ fn empty_str_array() -> Array[String] {
 /// clause cannot perform ANY effect, ever, so it cannot possibly hide a
 /// perform of `ename`, a call to a needing function, or anything else this
 /// pass would need to rewrite -- generalizing the old hand-audited
-/// `edp_pure_builtin_names` allowlist (kept as-is for the handful of
+/// `idp_pure_builtin_names` allowlist (kept as-is for the handful of
 /// builtins the checker doesn't track as ordinary functions) to every
 /// user-defined pure function too. Only the call's OWN ARGS still need
 /// checking (they're evaluated in the CALLER's context, where a perform of
@@ -5187,126 +5194,79 @@ fn edp_builtin_is_first_order(nm: String) -> Bool {
   }
 }
 
-/// Mirrors inline_direct_perform.vibe's idp_pure_builtin_names allowlist
-/// exactly (same hand-audited, individually-verified set -- see that file's
-/// doc comment for the auditing rule).
-fn edp_pure_builtin_names() -> Array[String] {
-  [
-    "String::concat",
-    "String::equals",
-    "String::length",
-    "String::substring",
-    "string_char_at",
-    "String::trim",
-    "String::split",
-    "String::contains",
-    "String::index_of",
-    // #2345: mirrors idp_pure_builtin_names' entry (same audit, see that
-    // list's comment).
-    "Bytes::index_of_bytes",
-    // #2345: mirrors idp_pure_builtin_names' entries (same audit).
-    "Bytes::index_of",
-    "Bytes::count",
-    "Bytes::last_index_of",
-    "Bytes::compare",
-    "String::to_lower",
-    "String::to_upper",
-    "String::ends_with",
-    "String::starts_with",
-    "String::char_code_at",
-    "String::last_index_of",
-    "String::from_char_code",
-    "String::join",
-    "Char::to_int",
-    "Char::from_int",
-    "Int::to_double",
-    "Int::to_float",
-    "Int::to_string",
-    "Double::to_int",
-    "Float::to_int",
-    "Double::to_string",
-    "Float::to_string",
-    "Double::abs",
-    "Double::floor",
-    "Double::ceil",
-    "Double::max",
-    "Double::min",
-    "Int::parse",
-    "Double::parse",
-    // Mirrors idp_pure_builtin_names' own additions (same doc comments,
-    // same audits) -- see that function's doc comment for the rationale,
-    // including 追記34 V2's `__to_string` (string-interp desugar output)
-    // and `not`.
-    "__index",
-    "Array::get",
-    "Map::get",
-    "Bytes::get",
-    "Array::length",
-    "Map::size",
-    "Bytes::length",
-    "__to_string",
-    "not",
-    // #1324: desugar_trait_dict's undeterminable-operand helpers -- mirrors
-    // idp_pure_builtin_names' entry (same audit, see that list's comment).
-    "__generic_add",
-    "__generic_rel_diff",
-    "str_lex_diff",
-    // #1374: the exception-kind side channel's write, emitted before every
-    // `throw` -- mirrors idp_pure_builtin_names' entry (same audit).
-    "Array::set",
-    // ADR-0089 D1 (#1218/#1312): the HOST sleeps. Not effect-free -- `sleep`
-    // carries the nominal Async row -- but what this list actually gates is
-    // "an opaque callee that cannot PERFORM a user effect and never invokes
-    // a function-typed argument", and both qualify (Int -> Unit host
-    // calls). Needed because the scoped sleep retarget deliberately leaves
-    // the raw builtin in top-level fn bodies when no entry boundary exists
-    // (Codex P1 on #1312): an Async-row fn like `fn delay() with Async
-    // { sleep(1) }` must classify as PERFORM-FREE (the stat_token
-    // precedent, edp_append_perform_free_row_fns) rather than sinking the
-    // whole effect's migration to ineligible on an unknown callee -- and
-    // the same call must pass scps_calls_ok when such a fn is driven from
-    // a suspend-class handle.
-    "sleep",
-    "sleep_blocking",
-    // ADR-0089 D2 (#1218): Future cell primitives -- mirrors
-    // idp_pure_builtin_names' entry (same audit, see that list's comment).
-    "Future::pending",
-    "Future::ready",
-    "Future::resolve",
-    // ADR-0089 step 4 (#1218): host-future surface + raw halves -- mirrors
-    // idp_pure_builtin_names' entry (same audit, see that list's comment).
-    "host_future_get",
-    "vibe_hf_get_raw",
-    "vibe_hf_wait_raw",
-    // ADR-0089 (c) (#1218): the NAMED sibling; its per-name raw halves are
-    // matched by prefix below (see idp_is_host_future_named_raw's comment).
-    "host_future_named",
-    // ADR-0089 Decision 3 (#1218): host-stream surface + shared raw read --
-    // mirrors idp_pure_builtin_names' entry (same audit, see that list's
-    // comment; the per-name `vibe_hs_get_raw$<name>` halves are matched by
-    // prefix below).
-    "host_stream_named",
-    "vibe_hs_close_raw",
-    "vibe_hs_read_raw",
-    "Stdin::read_via_stream",
-    "StdinStream::next",
-    "StdinStream::close",
-    "vibe_stdin_provider_acquire_raw",
-    "vibe_stdin_provider_read_raw",
-    "vibe_stdin_provider_close_raw"
-  ]
-}
-
-// #1875 R3: module-level memo (initialized once -- module_let_memo_test.vibe
+// #2373: this used to be a SECOND copy of the list, whose doc comment claimed
+// to mirror `idp_pure_builtin_names` "exactly" while three names
+// (`Array::concat`, `HostStream::next`, `HostStream::close`) were only in the
+// idp copy. The divergence was invisible because it ran in the harmless
+// direction -- edp's consumer has fallbacks (the registry first-order probe in
+// `edp_has_unsafe_construct`, the raw-half prefixes below) and idp's
+// (`scps_named_call_ok`, suspend-class lowering) has none -- so nothing failed
+// and nothing checked it either. A mirror gate would have enforced the copy;
+// there is no copy to enforce now, which is the same guarantee without a
+// script that can rot. The audit criterion is one criterion for both consumers
+// ("can neither perform a user effect nor invoke a function-typed argument"),
+// so a name belongs to both lists or to neither -- see
+// idp_pure_builtin_names' doc comment for what adding one requires.
+//
+// #1875 R3: the memo is idp's (initialized once -- module_let_memo_test.vibe
 // is the spec). edp_is_pure_builtin_call runs per CALL NODE inside every
 // safety scan and read query (RQOpaqueCall via edp_callee_is_resolvable,
 // edp_has_unsafe_construct_sc), so rebuilding the ~100-entry table per probe
 // was ~17MB of allocation for one analyzed effect's performing-fns fixpoint
 // alone.
-let edp_pure_builtin_names_table: Array[String] = edp_pure_builtin_names()
-
 fn edp_is_pure_builtin_call(nm: String) -> Bool {
-  idp_is_host_future_named_raw(nm) || idp_is_host_stream_named_raw(nm) || edp_str_array_contains(edp_pure_builtin_names_table, nm)
+  idp_is_host_future_named_raw(nm) || idp_is_host_stream_named_raw(nm) || edp_str_array_contains(idp_pure_builtin_names_table, nm)
+}
+
+/// #2373: the two consumers of the pure-builtin allowlist must not become two
+/// spellings of it again. `idp_is_pure_builtin_call` gates suspend-class
+/// lowering (`scps_named_call_ok`, which has no fallback: a name it does not
+/// recognize REFUSES the program naming the call) and `edp_is_pure_builtin_
+/// call` gates the evidence pass's safety scans (which do have fallbacks, so a
+/// name missing there only sinks eligibility silently). The failure directions
+/// are opposite, so neither list is the safe one to forget -- which is exactly
+/// how the second copy sat three names behind the first without anything
+/// failing. Both predicates now read one table; this asserts they answer
+/// alike, including the negative control that makes the assertion mean
+/// something (a predicate that returned `true` for everything would satisfy
+/// the positive half alone). Same shape as `is_borrow_ret_builtin`'s
+/// agreement test (#1979). Called from tests/pure_builtin_name_agreement_
+/// test.vibe.
+export fn verify_pure_builtin_name_agreement() -> Unit with Exception {
+  let names = idp_pure_builtin_names_table
+  if Array::length(names) == 0 {
+    throw("pure-builtin allowlist is empty: idp_pure_builtin_names_table has no entries, so every agreement check below is vacuous")
+  } else {
+    ()
+  }
+  let mut i = 0
+  while i < Array::length(names) {
+    let nm = Array::get(names, i)
+    if !idp_is_pure_builtin_call(nm) {
+      throw("pure-builtin allowlist drift: '\{nm}' is in idp_pure_builtin_names but idp_is_pure_builtin_call rejects it. The direct-perform pass and scps_named_call_ok read this predicate; a listed name it rejects refuses a program naming the call.")
+    } else {
+      ()
+    }
+    if !edp_is_pure_builtin_call(nm) {
+      throw("pure-builtin allowlist drift: '\{nm}' is in idp_pure_builtin_names but edp_is_pure_builtin_call rejects it. The evidence pass reads the SAME audited set -- if a second copy of the list was reintroduced, delete it and point edp_is_pure_builtin_call back at idp_pure_builtin_names_table.")
+    } else {
+      ()
+    }
+    i = i + 1
+  }
+  // Negative control: `Array::push` mutates and `println` writes, so neither
+  // is on the audited set. Without this, both loops above would pass for a
+  // predicate that answered `true` unconditionally.
+  if idp_is_pure_builtin_call("Array::push") || edp_is_pure_builtin_call("Array::push") {
+    throw("pure-builtin allowlist drift: 'Array::push' is not on the audited set but a predicate accepts it")
+  } else {
+    ()
+  }
+  if idp_is_pure_builtin_call("println") || edp_is_pure_builtin_call("println") {
+    throw("pure-builtin allowlist drift: 'println' is not on the audited set but a predicate accepts it")
+  } else {
+    ()
+  }
 }
 
 /// Every top-level function name whose declared effect row is

--- a/lib/@vibe/compiler/tests/pure_builtin_name_agreement_test.vibe
+++ b/lib/@vibe/compiler/tests/pure_builtin_name_agreement_test.vibe
@@ -1,0 +1,24 @@
+//# #2373: the pure-builtin allowlist had two copies. `edp_pure_builtin_names`
+//# claimed in its doc comment to mirror `idp_pure_builtin_names` "exactly" and
+//# was three names behind it (`Array::concat`, `HostStream::next`,
+//# `HostStream::close`). Nothing failed, because the copies drift in opposite
+//# directions and only one of them is load-bearing: the idp side gates
+//# suspend-class lowering (`scps_named_call_ok` REFUSES a program naming a
+//# callee it does not recognize) while the edp side has fallbacks, so a name
+//# missing there only sinks eligibility silently. Neither is the safe one to
+//# forget, which is why the divergence survived a doc comment asserting it
+//# could not exist.
+//#
+//# There is one table now. This pins that: both predicates answer alike for
+//# every listed name, and neither accepts a name that is not listed. The
+//# negative control is the half that makes the positive half mean anything --
+//# a predicate returning `true` unconditionally passes the loop and fails
+//# here. Same shape as borrow_returning_names_test.vibe's #1979 agreement
+//# test, whose two spellings failed the same way.
+import @vibe/compiler/codegen/common_base {
+  verify_pure_builtin_name_agreement
+}
+
+test "one pure-builtin allowlist: both predicates answer alike" {
+  verify_pure_builtin_name_agreement()
+}

--- a/tests/gates/mid/run.sh
+++ b/tests/gates/mid/run.sh
@@ -2235,7 +2235,8 @@ echo "[compiler-gate] evidence-dict pass let-bound perform ok"
 #       ordinary user-defined PURE helper function (no `with` clause, so
 #       the checker has already proven it performs no effect) that is
 #       neither a needing function itself nor a hand-listed
-#       `edp_pure_builtin_names` entry. edp_has_unsafe_construct now
+#       `idp_pure_builtin_names` entry (#2373: the evidence pass's own
+#       second copy of that list is gone). edp_has_unsafe_construct now
 #       recognizes a call to any function whose OWN declared effect row is
 #       checker-verified empty (edp_pure_fn_names) as safe, generalizing
 #       the old hand-audited builtin allowlist to every pure user-defined


### PR DESCRIPTION
Closes #2373.

## The divergence is still there

`edp_pure_builtin_names`' doc comment says it "mirrors `idp_pure_builtin_names` **exactly**". Measured on this tree, it does not — 72 names vs 69:

| missing from `edp` | why it never failed |
|---|---|
| `Array::concat` | `edp_has_unsafe_construct` reaches it through the registry first-order fallback (#2109) |
| `HostStream::next` | reached through the raw-half prefix predicates |
| `HostStream::close` | same |

The issue's framing is the important part: the two copies gate consumers whose **failure directions are opposite**. The idp side gates suspend-class lowering — `scps_named_call_ok` *refuses* a program naming a callee it does not recognize. The edp side has fallbacks, so a name missing there only sinks eligibility silently. Neither copy is the safe one to forget, which is exactly how the divergence outlived a comment asserting it could not exist.

## Delete the copy rather than gate it

`edp_is_pure_builtin_call` now reads `idp_pure_builtin_names_table`. The second list and its own module-level memo are gone (−115 lines of duplicated data).

This follows the repo's own #1979 consolidation in `core/builtin_registry.vibe` — *"there is one spelling of the names, not two that must be kept equal"* — and it is why this lands **without** a mirror gate. A script asserting two lists are equal is a proxy for the property; `AGENTS.md`'s gate discipline says to remove the structure that needs a proxy rather than to check the proxy. There is no second list for it to stand in for.

The three names becoming visible to the evidence pass is a widening in the direction its own fallbacks already reached them by. The audit criterion — *"can neither perform a user effect nor invoke a function-typed argument"* — is one criterion for both consumers, so a name belongs to both lists or to neither.

## What is pinned

`verify_pure_builtin_name_agreement` (exported, declared in `index.vpkg`) + `lib/@vibe/compiler/tests/pure_builtin_name_agreement_test.vibe`:

- every listed name is accepted by **both** predicates;
- `Array::push` and `println` by **neither** — the negative control is the half that makes the positive half mean anything, since a predicate answering `true` unconditionally passes the loop alone.

**Red-tested both ways**, with mutations that are type-correct so that only the assertion catches them:

| mutation | result |
|---|---|
| re-fork `edp_is_pure_builtin_call` onto a two-name table | FAIL |
| `fn edp_is_pure_builtin_call(nm) { String::length(nm) >= 0 }` | FAIL |
| restored | ok, 1 passed |

## Also

Repoints the four fixture comments and the `tests/gates/mid/run.sh` comment that named the now-deleted function.

## Verification

All against a stage2 built from this checkout (`_build/selfhost/generations/cfg-spans-emission-2026-09-04_cd9eb4f/stage2.wasm`), passed explicitly via `VIBE_TEST_CLI_WASM` / `VIBE_STAGE2_WASM` rather than letting the seed answer:

- `pure_builtin_name_agreement_test.vibe` — red → green as above
- `fixtures/effect_suspend_bytes_index_of_bytes_test.vibe` — 5 tests ok
- `fixtures/async_future_boundary_resolved_test.vibe` — compiles ok
- `scripts/vibe_fmt.sh --check` — clean on all three changed `lib/` files
- `scripts/compiler_gate.sh early mid late` — all lanes ok
- `pkf run pre-commit` — review-regressions lint, architecture-debt lint, doc-path citations all ok

## Not in scope

The issue's second, broader defect stands: *adding a builtin means editing several hand-maintained classification lists, and nothing points at the ones that were missed* (`builtin_is_non_allocating`, `scps_is_safe_mut_builtin`, `borrow_ret_builtin_name_table`, …). That is the registry-column or unclassified-name-ratchet work, a different change. This PR removes one whole list from that set and closes the mirror half; the census half is worth its own issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q9zbiDqkfF7xYQ3v8aCQ3b

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q9zbiDqkfF7xYQ3v8aCQ3b)_