### PR TITLE
sidecar codec v8: decimal counts and a digest, not unary and duplication (#2555)

### DIFF
--- a/lib/@vibe/compiler/runtime/index.vpkg
+++ b/lib/@vibe/compiler/runtime/index.vpkg
@@ -138,6 +138,14 @@ fn module_typed_eq_rows_for_path(path: String) -> Option[(Array[Int], Array[Stri
 fn publish_module_typed_lowering_offsets(path: String, fingerprint: String, offsets: Option[Array[Int]], eq_offs: Array[Int], eq_keys: Array[String]) -> Unit
 fn rebind_module_typed_lowering_offsets(path: String, fingerprint: String) -> Bool
 
+// #2555: the typed-lowering sidecar CODEC, exported so its corruption-rejection
+// contract can be asserted directly instead of through the shape that happens
+// to encode it. Compiler-internal framing only -- the envelope's layout stays
+// private to typecheck_fs.vibe; these two are the encode and decode ends of it.
+// Consumed by tests/typed_lowering_sidecar_codec_test.vibe.
+fn module_typed_lowering_text(offsets: Array[Int], eq_offs: Array[Int], eq_keys: Array[String]) -> String
+fn parse_module_typed_lowering_offsets_text(text: String) -> Option[(Array[Int], Array[Int], Array[String])]
+
 // #2449: the per-file rebase and the tag decoder for the typed-lowering
 // tables, shared by BOTH merges (the grouped file merge and the
 // inline-source merge) so a tag cannot be understood by only one of them.

--- a/lib/@vibe/compiler/runtime/typecheck_fs.vibe
+++ b/lib/@vibe/compiler/runtime/typecheck_fs.vibe
@@ -352,83 +352,68 @@ export fn module_typed_eq_rows_for_path(path: String) -> Option[(Array[Int], Arr
   found
 }
 
-/// #2427-safe decimal renderer for the eq rows below: the v6 envelope's
-/// documented constraint is "no new `__to_string` integer-rendering call
-/// sites in this codec", so the eq rows spell their offsets digit by digit
-/// through char codes instead.
-fn module_typed_lowering_render_nat(v: Int) -> String {
-  if v <= 0 {
-    "0"
-  } else {
-    let digits = array_empty()
-    let mut rest = v
-    while rest > 0 {
-      Array::push(digits, String::from_char_code(48 + (rest - rest / 10 * 10)))
-      rest = rest / 10
-    }
-    let out = StringBuilder::new()
-    let mut i = Array::length(digits) - 1
-    while i >= 0 {
-      StringBuilder::push(out, Array::get(digits, i))
-      i = i - 1
-    }
-    StringBuilder::freeze(out)
-  }
+/// v8 (#2555). The envelope carries, in order: the version header, one
+/// DECIMAL offset per line, a decimal `count`, one `eqrow` per typed-`==`
+/// site, a decimal `eqcount`, a `digest` over the body, and an end marker.
+/// The strict decoder requires every one of them.
+///
+/// What each piece defends against:
+///
+///   end marker  -- a truncated file loses it and decodes as a miss.
+///   counts      -- a deleted or inserted row no longer matches the declared
+///                  size.
+///   digest      -- any character-level change inside an otherwise well-formed
+///                  file. `compact_string_fingerprint` over the body lines
+///                  joined in emission order, so a reordering is caught too.
+///   digit parse -- a row that is not all digits poisons the whole parse.
+///
+/// A torn write is NOT among them, because it cannot happen: both hosts
+/// implement `Fs::write_file` as a temp file plus `rename` (scripts/
+/// wasm_vibe_host_runner.js's `atomicWriteFileSync`, runtime/viberun/src/
+/// main.rs -- "rename() is atomic on POSIX"), so a reader sees the previous
+/// complete file or the new complete file, never a prefix. The digest is what
+/// covers the case the counts and the end marker cannot: a character-level
+/// change in a file that is otherwise intact, which for THIS file would change
+/// what a compile emits (#2425, #2449) rather than merely losing a cache hit.
+///
+/// One line of digest is both cheaper and stronger than the per-row
+/// duplication it replaces: cheaper because the rows are not doubled, which
+/// matters at the ~800 sidecars a cold compile writes (#2546), and stronger
+/// because duplication cannot see a change that hits both copies, nor a
+/// reordering.
+fn module_typed_lowering_body_digest(body: Array[String]) -> String {
+  compact_string_fingerprint(String::join(body, "\n"))
 }
 
-fn module_typed_lowering_text(offsets: Array[Int], eq_offs: Array[Int], eq_keys: Array[String]) -> String {
+export fn module_typed_lowering_text(offsets: Array[Int], eq_offs: Array[Int], eq_keys: Array[String]) -> String {
   let parts = array_empty()
-  // v5 (#2425 review rounds 3+5+6): a torn write survives as a PREFIX of
-  // the intended file, so the envelope closes with an explicit end marker
-  // the strict decoder requires -- truncation loses the marker and decodes
-  // as a miss -- every row is duplicated so a digit-level corruption breaks
-  // the duplicate equality, and a unary count line binds the row-set size
-  // so deleting or inserting a whole row fails too. The earlier v2
-  // shape declared a count and checksum instead; rendering those Int call
-  // results through __to_string trips a latent bundle-lane float-offset
-  // misclassification in the compiler's own build (probed to the call-site
-  // offset, not the values -- see the issue linked from PR #2425), so the
-  // envelope deliberately adds no new integer-rendering call sites.
-  Array::push(parts, "module_typed_lowering_offsets\tv7")
-  let count_marks = array_empty()
+  // The lines the digest covers: the offset rows and the eq rows, in emission
+  // order. The header, the counts, the digest line itself and the end marker
+  // are not in it -- they are checked directly.
+  let body = array_empty()
+  Array::push(parts, "module_typed_lowering_offsets\tv8")
   let n = Array::length(offsets)
   let mut i = 0
   while i < n {
-    // Each row carries the SAME rendered value twice (#2425 round 5): a
-    // digit-level corruption inside an otherwise-intact file breaks the
-    // duplicate equality and decodes as a miss, without introducing any new
-    // integer-rendering call site (one __to_string, reused -- see the
-    // header note on why a rendered checksum is off the table).
     let row_text = __to_string(Array::get(offsets, i))
-    Array::push(parts, String::concat(row_text, String::concat("\t", row_text)))
-    Array::push(count_marks, "#")
+    Array::push(parts, row_text)
+    Array::push(body, row_text)
     i = i + 1
   }
-  // The count line binds the ROW SET's size in UNARY (#2425 round 6): one
-  // '#' per row, so deleting or inserting a whole duplicated row breaks the
-  // count without rendering any integer through __to_string (the #2427
-  // constraint). Reordering rows is semantically inert -- the table is a
-  // SET of offsets -- so size plus per-row duplicate equality plus the end
-  // marker covers every corruption that could change what a compile emits.
-  Array::push(parts, String::concat("module_typed_lowering_offsets\tcount\t", String::join(count_marks, "")))
-  // #2441 (v7): the typed-`==` rows, same envelope discipline -- each row
-  // renders its (offset, TypeExpr key) pair TWICE and a separate unary
-  // count binds the eq-row set's size. Offsets render through the
-  // char-code renderer above (the #2427 constraint); keys are
-  // impl_target_key strings, whose charset (digits, '_', structure
-  // letters) can never contain a tab or newline.
-  let eq_count_marks = array_empty()
+  Array::push(parts, String::concat("module_typed_lowering_offsets\tcount\t", __to_string(n)))
+  // #2441: the typed-`==` rows. Keys are impl_target_key strings, whose
+  // charset (digits, `_`, structure letters) can never contain a tab or a
+  // newline, so the cell split is unambiguous.
   let eq_n = Array::length(eq_offs)
   let mut ei = 0
   while ei < eq_n {
-    let eoff_text = module_typed_lowering_render_nat(Array::get(eq_offs, ei))
-    let ekey_text = Array::get(eq_keys, ei)
-    let half = String::concat(eoff_text, String::concat("\t", ekey_text))
-    Array::push(parts, String::concat("module_typed_lowering_offsets\teqrow\t", String::concat(half, String::concat("\t", half))))
-    Array::push(eq_count_marks, "#")
+    let eq_row = String::concat("module_typed_lowering_offsets\teqrow\t", String::concat(__to_string(Array::get(eq_offs, ei)), String::concat("\t", Array::get(eq_keys, ei))))
+    Array::push(parts, eq_row)
+    Array::push(body, eq_row)
     ei = ei + 1
   }
-  Array::push(parts, String::concat("module_typed_lowering_offsets\teqcount\t", String::join(eq_count_marks, "")))
+  Array::push(parts, String::concat("module_typed_lowering_offsets\teqcount\t", __to_string(eq_n)))
+  Array::push(parts, String::concat("module_typed_lowering_offsets\tdigest\t", module_typed_lowering_body_digest(body)))
   Array::push(parts, "module_typed_lowering_offsets\tend")
   String::concat(String::join(parts, "\n"), "\n")
 }
@@ -459,26 +444,38 @@ fn module_typed_lowering_parse_nat(line: String) -> Option[Int] {
   }
 }
 
-/// Strict v5 decode: the header line, duplicated digit-only rows, exactly
-/// one unary count line whose length equals the row count, and the closing
-/// end marker must all be present, or the answer is `None` -- an ordinary
-/// cold-cache miss that re-checks the module. A truncated file loses the
-/// end marker, a corrupted row fails the digit parse or the duplicate
-/// equality (a random digit change cannot hit both copies identically), a
-/// deleted or inserted row fails the count, and a v1..v4 or foreign header
-/// fails outright; none of them can change what a compile emits.
-fn parse_module_typed_lowering_offsets_text(text: String) -> Option[(Array[Int], Array[Int], Array[String])] {
+/// Strict v8 decode: the exact version header, digit-only offset rows, one
+/// decimal `count` matching the row set, the `eqrow` lines, one decimal
+/// `eqcount` matching them, one `digest` matching the body, and the closing end
+/// marker -- all of them, or the answer is `None`, an ordinary cold-cache miss
+/// that re-checks the module.
+///
+/// So: a truncated file loses the end marker; a corrupted row fails the digit
+/// parse or the digest; a deleted, inserted or reordered row fails the count or
+/// the digest; a v1..v7 or foreign header fails outright. None of them can
+/// change what a compile emits, which is the property the whole envelope
+/// exists for (#2425, #2449).
+///
+/// A v7 file on disk decodes as a miss, which is the correct and cheap
+/// outcome: the module is re-checked and rewritten in v8. The persistent
+/// cache's namespace already embeds a hash of the compiler SOURCES, so a v7
+/// sidecar and a v8 decoder do not in practice meet; the header check is the
+/// belt to that braces.
+export fn parse_module_typed_lowering_offsets_text(text: String) -> Option[(Array[Int], Array[Int], Array[String])] {
   let lines = String::split(normalize_persistent_cache_text(text), "\n")
-  if Array::length(lines) == 0 || Array::get(lines, 0) != "module_typed_lowering_offsets\tv7" {
+  if Array::length(lines) == 0 || Array::get(lines, 0) != "module_typed_lowering_offsets\tv8" {
     None
   } else {
     let out: Array[Int] = []
     let eq_offs: Array[Int] = []
     let eq_keys: Array[String] = []
+    let body: Array[String] = []
     let mut ok = true
     let mut saw_end = false
     let mut declared_count = 0 - 1
     let mut declared_eq_count = 0 - 1
+    let mut declared_digest = ""
+    let mut saw_digest = false
     let mut i = 1
     while i < Array::length(lines) && ok {
       let line = Array::get(lines, i)
@@ -490,17 +487,18 @@ fn parse_module_typed_lowering_offsets_text(text: String) -> Option[(Array[Int],
       } else if line == "module_typed_lowering_offsets\tend" {
         saw_end = true
       } else if String::starts_with(line, "module_typed_lowering_offsets\teqrow\t") {
-        // #2441 (v7): `eqrow<TAB>off<TAB>key<TAB>off<TAB>key`, both halves
-        // identical -- a digit- or letter-level corruption breaks the
-        // duplicate equality, exactly like the Int rows above.
+        // `eqrow<TAB>off<TAB>key`. The key charset cannot contain a tab, so
+        // exactly four cells and a non-empty key is the whole shape check; the
+        // digest covers character-level damage inside either cell.
         let cells = String::split(line, "\t")
-        if Array::length(cells) != 6 || Array::get(cells, 2) != Array::get(cells, 4) || Array::get(cells, 3) != Array::get(cells, 5) || String::length(Array::get(cells, 3)) == 0 {
+        if Array::length(cells) != 4 || String::length(Array::get(cells, 3)) == 0 {
           ok = false
         } else {
           match module_typed_lowering_parse_nat(Array::get(cells, 2)) {
             Some(value) => {
               Array::push(eq_offs, value)
               Array::push(eq_keys, Array::get(cells, 3))
+              Array::push(body, line)
             },
             None => ok = false
           }
@@ -509,21 +507,9 @@ fn parse_module_typed_lowering_offsets_text(text: String) -> Option[(Array[Int],
         if declared_eq_count >= 0 {
           ok = false
         } else {
-          let unary_start = String::length("module_typed_lowering_offsets\teqcount\t")
-          let line_len = String::length(line)
-          let mut mark = unary_start
-          let mut marks_ok = true
-          while mark < line_len && marks_ok {
-            if String::char_code_at(line, mark) == 35 {
-              mark = mark + 1
-            } else {
-              marks_ok = false
-            }
-          }
-          if marks_ok {
-            declared_eq_count = line_len - unary_start
-          } else {
-            ok = false
+          match module_typed_lowering_parse_nat(String::substring(line, String::length("module_typed_lowering_offsets\teqcount\t"), String::length(line))) {
+            Some(value) => declared_eq_count = value,
+            None => ok = false
           }
         }
       } else if String::starts_with(line, "module_typed_lowering_offsets\tcount\t") {
@@ -531,37 +517,36 @@ fn parse_module_typed_lowering_offsets_text(text: String) -> Option[(Array[Int],
           // A second count line is not a prefix of any valid write.
           ok = false
         } else {
-          let unary_start = String::length("module_typed_lowering_offsets\tcount\t")
-          let line_len = String::length(line)
-          let mut mark = unary_start
-          let mut marks_ok = true
-          while mark < line_len && marks_ok {
-            if String::char_code_at(line, mark) == 35 {
-              mark = mark + 1
-            } else {
-              marks_ok = false
-            }
+          match module_typed_lowering_parse_nat(String::substring(line, String::length("module_typed_lowering_offsets\tcount\t"), String::length(line))) {
+            Some(value) => declared_count = value,
+            None => ok = false
           }
-          if marks_ok {
-            declared_count = line_len - unary_start
-          } else {
+        }
+      } else if String::starts_with(line, "module_typed_lowering_offsets\tdigest\t") {
+        if saw_digest {
+          ok = false
+        } else {
+          saw_digest = true
+          declared_digest = String::substring(line, String::length("module_typed_lowering_offsets\tdigest\t"), String::length(line))
+          if String::length(declared_digest) == 0 {
             ok = false
+          } else {
+            ()
           }
         }
       } else {
-        let cells = String::split(line, "\t")
-        if Array::length(cells) != 2 || Array::get(cells, 0) != Array::get(cells, 1) {
-          ok = false
-        } else {
-          match module_typed_lowering_parse_nat(Array::get(cells, 0)) {
-            Some(value) => Array::push(out, value),
-            None => ok = false
-          }
+        // A plain offset row: all digits, nothing else.
+        match module_typed_lowering_parse_nat(line) {
+          Some(value) => {
+            Array::push(out, value)
+            Array::push(body, line)
+          },
+          None => ok = false
         }
       }
       i = i + 1
     }
-    if ok && saw_end && declared_count == Array::length(out) && declared_eq_count == Array::length(eq_offs) {
+    if ok && saw_end && saw_digest && declared_count == Array::length(out) && declared_eq_count == Array::length(eq_offs) && declared_digest == module_typed_lowering_body_digest(body) {
       Some((out, eq_offs, eq_keys))
     } else {
       None

--- a/lib/@vibe/compiler/tests/typed_lowering_sidecar_codec_test.vibe
+++ b/lib/@vibe/compiler/tests/typed_lowering_sidecar_codec_test.vibe
@@ -1,0 +1,188 @@
+//# #2555: the typed-lowering sidecar codec's corruption contract, asserted
+//# DIRECTLY instead of through the shape that happened to encode it.
+//#
+//# The v5-v7 envelope wrote every row twice and spelled both counts in unary.
+//# Neither was chosen on its merits: PR #2425 round 3 asked for "a declared
+//# count/checksum", v2 shipped exactly that, and it was pulled again for a
+//# constraint that turned out to be a misdiagnosis. v8 restores the count and
+//# adds a digest, and this file pins what that has to keep buying.
+//#
+//# The property is one-directional and that is the point: a corrupted sidecar
+//# must decode as `None`, an ordinary cache MISS that re-checks the module.
+//# It must never decode as a DIFFERENT table, because the offsets decide what
+//# a compile emits (#2425, #2449) -- a wrong table is the silent-wrong failure,
+//# a miss is just slower.
+import @vibe/core {
+  array_empty
+}
+
+import @vibe/compiler/runtime {
+  module_typed_lowering_text, parse_module_typed_lowering_offsets_text
+}
+
+fn sample_text() -> String {
+  module_typed_lowering_text([8, 24, 6263971], [40, 128], ["I", "S"])
+}
+
+/// Decodes back to exactly what was encoded?
+fn round_trips(text: String) -> Bool {
+  match parse_module_typed_lowering_offsets_text(text) {
+    Some((offs, eq_offs, eq_keys)) => Array::length(offs) == 3 && Array::get(offs, 0) == 8 && Array::get(offs, 1) == 24 && Array::get(offs, 2) == 6263971 && Array::length(eq_offs) == 2 && Array::get(eq_offs, 0) == 40 && Array::get(eq_offs, 1) == 128 && Array::length(eq_keys) == 2 && Array::get(eq_keys, 0) == "I" && Array::get(eq_keys, 1) == "S",
+    None => false
+  }
+}
+
+fn rejected(text: String) -> Bool {
+  match parse_module_typed_lowering_offsets_text(text) {
+    Some(_) => false,
+    None => true
+  }
+}
+
+/// Drop the first line whose content is exactly `victim`.
+fn drop_line(text: String, victim: String) -> String {
+  edit_line(text, victim, "", true)
+}
+
+/// Replace the first line whose content is exactly `victim`, IN PLACE.
+///
+/// In place is the whole point. Appending the replacement to the end of the
+/// file instead would put it after the end marker, where the decoder rejects it
+/// for being trailing content -- so the test would pass while the mechanism it
+/// names went unexercised. Measured: with the digest check removed from the
+/// decoder, an append-style "changed offset digit" case still passed.
+fn replace_line(text: String, victim: String, replacement: String) -> String {
+  edit_line(text, victim, replacement, false)
+}
+
+fn edit_line(text: String, victim: String, replacement: String, drop: Bool) -> String {
+  let lines = String::split(text, "\n")
+  let kept = array_empty()
+  let mut edited = false
+  let mut i = 0
+  while i < Array::length(lines) {
+    let line = Array::get(lines, i)
+    if !edited && line == victim {
+      edited = true
+      if drop {
+        ()
+      } else {
+        Array::push(kept, replacement)
+      }
+    } else {
+      Array::push(kept, line)
+    }
+    i = i + 1
+  }
+  String::join(kept, "\n")
+}
+
+/// Insert `line` immediately before the end marker, i.e. inside the envelope.
+fn insert_before_end(text: String, line: String) -> String {
+  replace_line(text, "module_typed_lowering_offsets\tend", String::concat(line, "\nmodule_typed_lowering_offsets\tend"))
+}
+
+test "a well-formed envelope round-trips" {
+  inspect(round_trips(sample_text()), "true")
+}
+
+// Every mutation below must be REJECTED. Each one is a real way a sidecar can
+// come back wrong, and each is caught by a different piece of the envelope --
+// stated next to it, so a future change that removes a piece fails the case
+// that names it rather than silently widening what is accepted.
+
+test "a dropped offset row is rejected (the count)" {
+  inspect(rejected(drop_line(sample_text(), "24")), "true")
+}
+
+test "a dropped eq row is rejected (the eqcount)" {
+  inspect(rejected(drop_line(sample_text(), "module_typed_lowering_offsets\teqrow\t40\tI")), "true")
+}
+
+test "a changed offset digit is rejected (the digest)" {
+  // In place, so the count still matches and the end marker is still there:
+  // this is exactly the case the per-row duplication used to catch and the
+  // counts cannot. Removing the digest check from the decoder makes THIS test
+  // fail, which is how it was shown to be load-bearing.
+  inspect(rejected(replace_line(sample_text(), "24", "25")), "true")
+}
+
+test "a changed eq key is rejected (the digest)" {
+  inspect(rejected(replace_line(sample_text(), "module_typed_lowering_offsets\teqrow\t40\tI", "module_typed_lowering_offsets\teqrow\t40\tZ")), "true")
+}
+
+test "truncation before the end marker is rejected (the end marker)" {
+  inspect(rejected(drop_line(sample_text(), "module_typed_lowering_offsets\tend")), "true")
+}
+
+test "content after the end marker is rejected" {
+  // The only case that SHOULD be an append.
+  inspect(rejected(String::concat(sample_text(), "8\n")), "true")
+}
+
+test "a missing digest line is rejected" {
+  let lines = String::split(sample_text(), "\n")
+  let kept = array_empty()
+  let mut i = 0
+  while i < Array::length(lines) {
+    let line = Array::get(lines, i)
+    if String::starts_with(line, "module_typed_lowering_offsets\tdigest\t") {
+      ()
+    } else {
+      Array::push(kept, line)
+    }
+    i = i + 1
+  }
+  inspect(rejected(String::join(kept, "\n")), "true")
+}
+
+test "a wrong digest is rejected" {
+  let lines = String::split(sample_text(), "\n")
+  let kept = array_empty()
+  let mut i = 0
+  while i < Array::length(lines) {
+    let line = Array::get(lines, i)
+    if String::starts_with(line, "module_typed_lowering_offsets\tdigest\t") {
+      Array::push(kept, "module_typed_lowering_offsets\tdigest\tdeadbeef")
+    } else {
+      Array::push(kept, line)
+    }
+    i = i + 1
+  }
+  inspect(rejected(String::join(kept, "\n")), "true")
+}
+
+test "a wrong count is rejected" {
+  inspect(rejected(replace_line(sample_text(), "module_typed_lowering_offsets\tcount\t3", "module_typed_lowering_offsets\tcount\t2")), "true")
+}
+
+test "a second count line is rejected" {
+  // Inside the envelope, so it is the duplicate-count rule that rejects it and
+  // not the trailing-content rule.
+  inspect(rejected(insert_before_end(sample_text(), "module_typed_lowering_offsets\tcount\t3")), "true")
+}
+
+test "a foreign or older header is rejected" {
+  let body = drop_line(sample_text(), "module_typed_lowering_offsets\tv8")
+  inspect(rejected(String::concat("module_typed_lowering_offsets\tv7\n", body)), "true")
+  inspect(rejected(String::concat("something_else\tv8\n", body)), "true")
+  inspect(rejected(""), "true")
+}
+
+test "a non-digit offset row is rejected (the digit parse)" {
+  inspect(rejected(replace_line(sample_text(), "24", "2x")), "true")
+}
+
+// The empty table is a real case -- most modules have no typed-lowering rows
+// at all -- and it must round-trip rather than being mistaken for a miss.
+test "the empty table round-trips as an empty table, not a miss" {
+  let empty = module_typed_lowering_text([], [], [])
+  match parse_module_typed_lowering_offsets_text(empty) {
+    Some((offs, eq_offs, eq_keys)) => {
+      inspect(Array::length(offs), "0")
+      inspect(Array::length(eq_offs), "0")
+      inspect(Array::length(eq_keys), "0")
+    },
+    None => assert(false)
+  }
+}

--- a/tests/gates/late/run.sh
+++ b/tests/gates/late/run.sh
@@ -9257,11 +9257,11 @@ if ! VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh \
 fi
 # Torn/corrupted sidecars must decode as MISSES, not as partial answers
 # (#2425 review round 3): truncate every offsets sidecar in the warm cache to
-# its header line plus at most one row, then compile again. The v5 envelope's
+# its header line plus at most one row, then compile again. The envelope's
 # required end marker rejects the truncation, the affected modules re-check,
 # and the output stays byte-identical; a decoder that accepted the torn file
 # would drop classifications and change the bytes. (Digit-level corruption is
-# rejected by the duplicated-row equality -- rounds 3+5 on the PR.)
+# rejected by the v8 digest -- see the next mutation.)
 found_sidecar=0
 while IFS= read -r sc_file; do
   found_sidecar=1
@@ -9286,26 +9286,35 @@ if ! cmp -s "$ffsdir/cold.wasm" "$ffsdir/torn.wasm"; then
 fi
 # Digit-level corruption inside an INTACT sidecar must also decode as a miss
 # (#2425 review round 5): the torn compile above re-warmed the cache, so flip
-# one digit of the first offset row's first copy in every sidecar (same
-# length -- the end marker survives) and compile again. The duplicated-row
-# equality rejects the row, the module re-checks, and the bytes stay
-# identical; the v3 decoder accepted this and the emitted bytes CHANGED
-# (red-proven on the PR).
+# one digit of the first offset row in every sidecar (same length, so the
+# count, the end marker and every other line survive) and compile again. Only
+# the v8 digest can see this one -- the counts still match and the envelope is
+# still well formed -- so it is the case that proves the digest is
+# load-bearing. The module re-checks and the bytes stay identical; the v3
+# decoder accepted this and the emitted bytes CHANGED (red-proven on #2425).
+#
+# #2555: a v8 row is ONE bare decimal per line. It was `off<TAB>off` while the
+# envelope duplicated every row, and this recipe matched on that -- when the
+# duplication went away the mutation silently matched nothing, which the
+# "probe went stale" check below caught.
 flipped_rows=0
 while IFS= read -r sc_file; do
+  before_first=$(awk -F'\t' 'NF == 1 && $1 ~ /^[0-9]+$/ { print $1; exit }' "$sc_file")
   awk -F'\t' 'BEGIN { OFS = "\t"; done = 0 }
-    done == 0 && NF == 2 && $1 ~ /^[0-9]+$/ {
+    done == 0 && NF == 1 && $1 ~ /^[0-9]+$/ {
       first = substr($1, 1, 1)
       $1 = (first != "9" ? "9" : "1") substr($1, 2)
       done = 1
     }
     { print }' "$sc_file" > "$sc_file.flip" && mv "$sc_file.flip" "$sc_file"
-  file_mismatches=$(awk -F'\t' 'NF == 2 && $1 ~ /^[0-9]+$/ && $2 ~ /^[0-9]+$/ && $1 != $2 { n += 1 } END { print n + 0 }' "$sc_file")
-  flipped_rows=$((flipped_rows + file_mismatches))
+  after_first=$(awk -F'\t' 'NF == 1 && $1 ~ /^[0-9]+$/ { print $1; exit }' "$sc_file")
+  if [ -n "$before_first" ] && [ "$before_first" != "$after_first" ]; then
+    flipped_rows=$((flipped_rows + 1))
+  fi
 done < <(grep -rl "^module_typed_lowering_offsets" "$ffsdir/cache" 2>/dev/null)
 # The mutation must actually HIT (gate discipline: a red test that matched
-# nothing proves nothing) -- the lane test's own modules carry offset rows,
-# so at least one sidecar must now hold a mismatched duplicate pair.
+# nothing proves nothing) -- the lane test's own modules carry offset rows, so
+# at least one sidecar's first row must now read differently than it did.
 if [ "$flipped_rows" = "0" ]; then
   echo "[compiler-gate] FAIL: digit-flip mutation matched no sidecar row (#2391) -- the probe went stale" >&2
   exit 1
@@ -9325,15 +9334,14 @@ if ! cmp -s "$ffsdir/cold.wasm" "$ffsdir/flipped.wasm"; then
 fi
 # Whole-row deletion inside an intact sidecar must also decode as a miss
 # (#2425 review round 6): the flipped compile re-warmed the cache, so delete
-# the first duplicated row from every sidecar (header, remaining pairs,
-# count line, and end marker all survive) and compile again. The unary
-# count line no longer matches the row set, the module re-checks, and the
-# bytes stay identical.
+# the first offset row from every sidecar (header, remaining rows, count line,
+# and end marker all survive) and compile again. The declared count no longer
+# matches the row set, the module re-checks, and the bytes stay identical.
 deleted_rows=0
 while IFS= read -r sc_file; do
-  before_rows=$(awk -F'\t' 'NF == 2 && $1 ~ /^[0-9]+$/ && $1 == $2 { n += 1 } END { print n + 0 }' "$sc_file")
+  before_rows=$(awk -F'\t' 'NF == 1 && $1 ~ /^[0-9]+$/ { n += 1 } END { print n + 0 }' "$sc_file")
   awk -F'\t' 'BEGIN { done = 0 }
-    done == 0 && NF == 2 && $1 ~ /^[0-9]+$/ && $1 == $2 { done = 1; next }
+    done == 0 && NF == 1 && $1 ~ /^[0-9]+$/ { done = 1; next }
     { print }' "$sc_file" > "$sc_file.del" && mv "$sc_file.del" "$sc_file"
   if [ "$before_rows" -gt 0 ]; then
     deleted_rows=$((deleted_rows + 1))
@@ -9392,7 +9400,7 @@ fi
 # discipline: assert the probe hit, not just that the answer looked right).
 string_rows=0
 while IFS= read -r sc_file; do
-  file_rows=$(awk -F'\t' 'NF == 2 && $1 ~ /^[0-9]+$/ && $1 == $2 { if ($1 % 4 == 1 || $1 % 4 == 2) n += 1 } END { print n + 0 }' "$sc_file")
+  file_rows=$(awk -F'\t' 'NF == 1 && $1 ~ /^[0-9]+$/ { if ($1 % 4 == 1 || $1 % 4 == 2) n += 1 } END { print n + 0 }' "$sc_file")
   string_rows=$((string_rows + file_rows))
 done < <(grep -rl "^module_typed_lowering_offsets" "$sbdir/cache" 2>/dev/null)
 if [ "$string_rows" = "0" ]; then


### PR DESCRIPTION
Closes #2555.

## The constraint is not real

`runtime/typecheck_fs.vibe` carried three pieces of complexity existing only to satisfy *"no new `__to_string` integer-rendering call sites in this codec"*, recorded against #2427: a hand-rolled digit-by-digit renderer, a **unary** `count` (one `#` per row), and a **unary** `eqcount` plus every row written **twice**.

None of it was chosen on its merits. PR #2425 round 3 asked for exactly *"a declared count/checksum"*; v2 shipped that and was pulled for the constraint. The duplication and the unary counts are the substitutes it forced.

Two independent, measured reasons the constraint is gone:

1. **#2427 was a misdiagnosis.** The trap was the runtime string-pointer heuristic in `__to_string`'s generic arm, which cannot fire below `n >= 2^37`. The largest offset across the **2,063 sidecars on disk** in this checkout is **6,263,971** — four orders of magnitude under it. #2424 removed the dependence generally; #2586 (just merged) closed the remaining shapes.
2. **The codec never honoured it anyway.** The plain rows have rendered through `__to_string` all along, at what is now line 393.

## The duplication, decided on its merits

The issue asked me not to sweep this away with the rest. The threat it defends against — a torn write leaving a prefix — **cannot happen**. Both hosts write via temp file + `rename`: `atomicWriteFileSync` in `scripts/wasm_vibe_host_runner.js`, and `runtime/viberun/src/main.rs`, whose own comment reads *"file + rename so a concurrent reader never sees a truncated file … rename() is atomic on POSIX"*. A reader sees the previous complete file or the new one, never a prefix.

So: **decimal counts, rows written once, and one `digest` line** (`compact_string_fingerprint` over the body in emission order).

That is strictly **cheaper** than duplication — one line instead of doubling every row, which matters at the ~800 sidecars a cold compile writes (#2546) — and strictly **stronger**: duplication cannot see a change that hits both copies, nor a reordering. It is also what round 3 originally asked for, now that the thing that blocked it is gone.

A real sidecar, before and after:

```
 module_typed_lowering_offsets	v7          module_typed_lowering_offsets	v8
 1155	1155                                 1155
 module_typed_lowering_offsets	count	##   module_typed_lowering_offsets	count	2
 …eqrow	40	I	40	I                      …eqrow	40	I
 module_typed_lowering_offsets	eqcount	##  module_typed_lowering_offsets	eqcount	1
                                             module_typed_lowering_offsets	digest	193:602232687:1603511863
 module_typed_lowering_offsets	end          module_typed_lowering_offsets	end
```

`render_nat` and every `#2427` reference are gone.

## The gate caught its own staleness

Gate 125's and gate 126's `awk` mutation recipes matched `off<TAB>off`; a v8 row is one bare decimal. The issue flagged these as the thing needing deliberate re-derivation, and **gate 125 failed loudly rather than mutating nothing**:

```
[compiler-gate] FAIL: digit-flip mutation matched no sidecar row (#2391) -- the probe went stale
```

That is #2248's rule working. All three recipes are re-derived and the comments that described the old shape updated.

## The test, and the flaw it caught in itself

`lib/@vibe/compiler/tests/typed_lowering_sidecar_codec_test.vibe` — 14 tests asserting the corruption contract **directly** rather than through the shape that happened to encode it: dropped row, dropped eq row, changed offset digit, changed eq key, truncation, trailing content, missing digest, wrong digest, wrong count, second count line, older/foreign header, non-digit row — each must decode as `None` — plus the round-trip and the empty table.

Mutations are applied **in place**, and that mattered. My first version appended the mutated row, which landed *after* the end marker and was rejected as trailing content — so *"a changed offset digit is rejected (the digest)"* **passed with the digest check removed from the decoder**. The test named one mechanism and exercised another until fixed.

## Verification

Stage2 built from this checkout, passed explicitly:

| check | result |
|---|---|
| digest check deleted from the decoder | *"a changed offset digit is rejected (the digest)"* **FAILS** |
| restored | 14 tests pass |
| **end to end**: flip one digit inside a real sidecar's eq row — count, eqcount and end marker all still valid, so **only the digest can catch it** | rejected → re-check → emitted wasm **byte-identical** to the cold compile |
| cold == warm on 3 real module closures, isolated `VIBE_BUILD_CACHE_DIR`, each writing a sidecar | identical |
| `compiler_gate.sh early mid late` | all lanes ok, incl. gates 125/126 with re-derived mutations |
| `vibe_fmt.sh --check` | clean on all three changed `lib/` files |

## Done-when, from the issue

- [x] No `#2427` reference remains in `runtime/typecheck_fs.vibe` (grep: 0)
- [x] The eq rows and both count lines render through `__to_string`
- [x] Envelope version bumped, gate expectations re-derived deliberately, cold-vs-warm re-proved on real module closures
- [x] A red test confirms the codec still rejects a mutated sidecar — asserted directly, and shown to fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q9zbiDqkfF7xYQ3v8aCQ3b

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q9zbiDqkfF7xYQ3v8aCQ3b)_