### PR TITLE
gates: no bash 4 `mapfile`, and a rule so it cannot come back (#2349)

### DIFF
--- a/scripts/cache_clean.sh
+++ b/scripts/cache_clean.sh
@@ -31,7 +31,12 @@ done
 
 # Collect the persistent-cache files (NUL-safe; nothing else under _build is
 # touched, so generation builds / fixtures are preserved).
-mapfile -d '' -t files < <(find _build -maxdepth 1 -type f -name 'vibe_*' -print0 2>/dev/null || true)
+# bash 3.2 (macOS stock) has no `mapfile` (#2349). `read -d ''` is the
+# NUL-delimited equivalent and is a bash 3 builtin.
+files=()
+while IFS= read -r -d '' f || [ -n "$f" ]; do
+  files+=("$f")
+done < <(find _build -maxdepth 1 -type f -name 'vibe_*' -print0 2>/dev/null || true)
 
 count=${#files[@]}
 if [ "$count" -eq 0 ]; then

--- a/scripts/check_freeze_surface.sh
+++ b/scripts/check_freeze_surface.sh
@@ -165,9 +165,19 @@ for name in sorted(negated - frozen):
     print("N " + name)
 PYEOF
 
-mapfile -t syms < <(awk '$1=="F"{print $2}' "$freeze_lists")
-mapfile -t negated < <(awk '$1=="N"{print $2}' "$freeze_lists")
-mapfile -t conflicts < <(awk '$1=="C"{print $2}' "$freeze_lists")
+# bash 3.2 (macOS stock) has no `mapfile` (#2349).
+syms=()
+while IFS= read -r line || [ -n "$line" ]; do
+  syms+=("$line")
+done < <(awk '$1=="F"{print $2}' "$freeze_lists")
+negated=()
+while IFS= read -r line || [ -n "$line" ]; do
+  negated+=("$line")
+done < <(awk '$1=="N"{print $2}' "$freeze_lists")
+conflicts=()
+while IFS= read -r line || [ -n "$line" ]; do
+  conflicts+=("$line")
+done < <(awk '$1=="C"{print $2}' "$freeze_lists")
 
 if [ "${#conflicts[@]}" -gt 0 ]; then
   echo "check-freeze-surface: FAIL: $DOC says two different things about ${#conflicts[@]} name(s):" >&2
@@ -303,7 +313,12 @@ if [ "${#missing[@]}" -gt 0 ]; then
 fi
 
 # The index document: every name it presents as a builtin must be one.
-mapfile -t index_syms < <(FREEZE_CHEATSHEET="$CHEATSHEET" python3 - <<'PYEOF'
+# bash 3.2 (macOS stock) has no `mapfile` (#2349).
+index_syms=()
+while IFS= read -r line || [ -n "$line" ]; do
+  index_syms+=("$line")
+done < <(FREEZE_CHEATSHEET="$CHEATSHEET" python3 - <<'PYEOF'
+
 import os, re, sys
 
 doc = open(os.environ["FREEZE_CHEATSHEET"], encoding="utf-8").read()

--- a/scripts/check_gate_portability.sh
+++ b/scripts/check_gate_portability.sh
@@ -17,7 +17,13 @@
 #      quoting: `grep -qE $'^x:finding\t'`. `\d` is the same trap (grep has no
 #      `\d`; `\s`, `\w` and `\b` are real GNU extensions and stay allowed).
 #
-# Both are lexical, so both are decidable from the text.
+#   3. `mapfile` is a bash 4 builtin and macOS ships bash 3.2, so a script
+#      using it aborts before it can validate anything. Eleven uses across six
+#      scripts had accumulated under this gate (#2349) -- including both
+#      formatter entry points, so `pkf run fmt` and `bash scripts/
+#      check_vibe_fmt.sh` did not run on a supported contributor platform.
+#
+# All are lexical, so all are decidable from the text.
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
@@ -79,6 +85,26 @@ findings="$(
       next
     }
 
+    # 4. `mapfile` (and its `readarray` synonym) is a bash 4 builtin. macOS
+    #    ships bash 3.2, so a script using it aborts before it can validate
+    #    anything -- this failure mode taken to the limit: not "a gate that
+    #    fails for an unrelated reason" but a gate that cannot start at all.
+    #    Eleven uses across six scripts had accumulated under a gate whose whole
+    #    job is this class, including check_vibe_fmt.sh and vibe_fmt_apply.sh,
+    #    so the documented local sign-off commands did not run on a supported
+    #    contributor platform (#2349).
+    #
+    #    Only a real invocation counts: the word must start a command, so a
+    #    mention inside a comment or a message string passes.
+    #
+    #    NOTE for anyone editing this awk program: it is one single-quoted
+    #    shell string, so an apostrophe anywhere in here -- including in a
+    #    comment -- closes it and the shell then parses awk syntax as its own.
+    /(^|[;&|(]|[[:space:]]then|[[:space:]]do|[[:space:]]else)[[:space:]]*(mapfile|readarray)([[:space:]]|$)/ {
+      printf "  %s:%d: mapfile/readarray is a bash 4 builtin; macOS ships bash 3.2 -- fill the array with a `while IFS= read -r ...` loop over a process substitution instead (`read -r -d` for NUL-delimited input)\n", rel, FNR
+      next
+    }
+
     # 3. `sed -i` with no suffix. GNU takes an optional one, BSD/macOS REQUIRES
     #    one, so the bare form aborts there. Lexical, and a real instance:
     #    check_book_console_test.sh -- a release-check dependency -- used it,
@@ -118,4 +144,4 @@ if [ -n "$findings" ]; then
   exit 1
 fi
 
-echo "[gate-portability] ok (no ripgrep dependency; no bare sed -i; no uninterpreted \\t in grep patterns)"
+echo "[gate-portability] ok (no ripgrep dependency; no bash 4 mapfile; no bare sed -i; no uninterpreted \\t in grep patterns)"

--- a/scripts/check_gate_portability.sh
+++ b/scripts/check_gate_portability.sh
@@ -94,13 +94,22 @@ findings="$(
     #    so the documented local sign-off commands did not run on a supported
     #    contributor platform (#2349).
     #
-    #    Only a real invocation counts: the word must start a command, so a
-    #    mention inside a comment or a message string passes.
+    #    Matched as a WORD anywhere on the line, not in command position.
+    #    A command-position rule was the first draft and it was too narrow in
+    #    a way that is easy to reach by accident (Codex on #2588): `if mapfile
+    #    -t xs < f; then`, `command mapfile ...`, `! mapfile ...` and
+    #    `FOO=bar mapfile ...` all run the builtin and all sailed past it.
+    #    Enumerating reserved words, negation, assignment prefixes and the
+    #    command/builtin wrappers is the losing side of that game, so this
+    #    fails CLOSED instead -- the same shape the `rg` rule above uses, for
+    #    the same reason. Whole-line comments are already dropped further up;
+    #    a mention in a message string is a finding, and the fix is to reword
+    #    the message.
     #
     #    NOTE for anyone editing this awk program: it is one single-quoted
     #    shell string, so an apostrophe anywhere in here -- including in a
     #    comment -- closes it and the shell then parses awk syntax as its own.
-    /(^|[;&|(]|[[:space:]]then|[[:space:]]do|[[:space:]]else)[[:space:]]*(mapfile|readarray)([[:space:]]|$)/ {
+    /(^|[^A-Za-z0-9_.\/-])(mapfile|readarray)([^A-Za-z0-9_.\/-]|$)/ {
       printf "  %s:%d: mapfile/readarray is a bash 4 builtin; macOS ships bash 3.2 -- fill the array with a `while IFS= read -r ...` loop over a process substitution instead (`read -r -d` for NUL-delimited input)\n", rel, FNR
       next
     }

--- a/scripts/check_gate_portability_test.sh
+++ b/scripts/check_gate_portability_test.sh
@@ -99,20 +99,36 @@ grep -qF 'mapfile -d' "$TMP_ROOT/scripts/clean.sh" || fail "fixture 1e2 did not 
 run && { cat "$TMP_ROOT/out" >&2; fail "a NUL-delimited mapfile call was accepted"; }
 ok "the NUL-delimited mapfile spelling is rejected"
 
+# --- red 1f: PREFIXED invocations. A command-position rule was the first
+# draft, and `if mapfile ...`, `command mapfile ...`, `! mapfile ...` and
+# `FOO=bar mapfile ...` all ran the builtin and all sailed past it (Codex on
+# #2588). Each is asserted on its own so a rule that fixes one and misses
+# another cannot pass.
+for prefixed in \
+  'if mapfile -t xs < input; then echo hi; fi' \
+  'command mapfile -t ys < input' \
+  '! mapfile -t zs < input' \
+  'FOO=bar mapfile -t ws < input'; do
+  reset_tree
+  printf '%s\n' "$prefixed" >> "$TMP_ROOT/scripts/clean.sh"
+  grep -qF "$prefixed" "$TMP_ROOT/scripts/clean.sh" || fail "fixture 1f did not land: $prefixed"
+  run && { cat "$TMP_ROOT/out" >&2; fail "a prefixed mapfile call was accepted: $prefixed"; }
+done
+ok "prefixed mapfile calls (if / command / ! / VAR=) are rejected"
+
 # --- green guard for 1d: the REPLACEMENT must pass, or the rule could be
-# satisfied by rejecting every array fill; and a mention of the word in a
-# comment or a message is not a call.
+# satisfied by rejecting every array fill; and a whole-line comment mentioning
+# the builtin is not a call -- the six converted scripts each carry one.
 reset_tree
 cat >> "$TMP_ROOT/scripts/clean.sh" <<'EOF'
 files=()
 while IFS= read -r line || [ -n "$line" ]; do
   files+=("$line")
 done < <(git ls-files)
-# mapfile is a bash 4 builtin, which is why this loop exists
-echo "use a read loop instead of mapfile"
+# bash 3.2 has no mapfile, which is why this loop exists
 EOF
 run || { cat "$TMP_ROOT/out" >&2; fail "the portable read-loop replacement was rejected"; }
-ok "the read-loop replacement passes, and mapfile in a comment or a string is not a call"
+ok "the read-loop replacement passes, and mapfile in a whole-line comment is not a call"
 
 # --- red 2: ripgrep behind a pipe.
 reset_tree

--- a/scripts/check_gate_portability_test.sh
+++ b/scripts/check_gate_portability_test.sh
@@ -75,6 +75,45 @@ printf '%s\n' 'sed "s/a/b/" "$1" > "$1.tmp" && mv "$1.tmp" "$1"' >> "$TMP_ROOT/s
 run || { cat "$TMP_ROOT/out" >&2; fail "a portable sed spelling was rejected"; }
 ok "sed -i.bak and a temp-file edit still pass"
 
+# --- red 1d: `mapfile` (bash 4). macOS ships bash 3.2, so the script aborts
+# before it validates anything -- a gate that cannot start. Eleven uses across
+# six scripts, including both formatter entry points, had accumulated under
+# this gate before it had a rule for them (#2349).
+reset_tree
+printf '%s\n' 'mapfile -t files < <(git ls-files)' >> "$TMP_ROOT/scripts/clean.sh"
+grep -qF 'mapfile -t files' "$TMP_ROOT/scripts/clean.sh" || fail "fixture 1d did not land"
+run && { cat "$TMP_ROOT/out" >&2; fail "a mapfile call was accepted"; }
+grep -qF 'bash 4 builtin' "$TMP_ROOT/out" || { cat "$TMP_ROOT/out" >&2; fail "mapfile finding did not name the reason"; }
+ok "a mapfile call is rejected"
+
+# --- red 1e: the `readarray` synonym, and the NUL-delimited spelling.
+reset_tree
+printf '%s\n' 'readarray -t files < <(git ls-files)' >> "$TMP_ROOT/scripts/clean.sh"
+grep -qF 'readarray -t files' "$TMP_ROOT/scripts/clean.sh" || fail "fixture 1e did not land"
+run && { cat "$TMP_ROOT/out" >&2; fail "a readarray call was accepted"; }
+ok "the readarray synonym is rejected"
+
+reset_tree
+printf '%s\n' 'mapfile -d "" -t files < <(find . -print0)' >> "$TMP_ROOT/scripts/clean.sh"
+grep -qF 'mapfile -d' "$TMP_ROOT/scripts/clean.sh" || fail "fixture 1e2 did not land"
+run && { cat "$TMP_ROOT/out" >&2; fail "a NUL-delimited mapfile call was accepted"; }
+ok "the NUL-delimited mapfile spelling is rejected"
+
+# --- green guard for 1d: the REPLACEMENT must pass, or the rule could be
+# satisfied by rejecting every array fill; and a mention of the word in a
+# comment or a message is not a call.
+reset_tree
+cat >> "$TMP_ROOT/scripts/clean.sh" <<'EOF'
+files=()
+while IFS= read -r line || [ -n "$line" ]; do
+  files+=("$line")
+done < <(git ls-files)
+# mapfile is a bash 4 builtin, which is why this loop exists
+echo "use a read loop instead of mapfile"
+EOF
+run || { cat "$TMP_ROOT/out" >&2; fail "the portable read-loop replacement was rejected"; }
+ok "the read-loop replacement passes, and mapfile in a comment or a string is not a call"
+
 # --- red 2: ripgrep behind a pipe.
 reset_tree
 printf '%s\n' 'printf x | rg -v y' >> "$TMP_ROOT/scripts/clean.sh"

--- a/scripts/check_vibe_fmt.sh
+++ b/scripts/check_vibe_fmt.sh
@@ -44,7 +44,11 @@ is_allowed() {
   ' "$ALLOWLIST_FILE"
 }
 
-mapfile -t files < <(git ls-files "$SCAN_ROOT/*.vibe" "$SCAN_ROOT/*.vpkg" | sort)
+# bash 3.2 (macOS stock) has no `mapfile` (#2349).
+files=()
+while IFS= read -r line || [ -n "$line" ]; do
+  files+=("$line")
+done < <(git ls-files "$SCAN_ROOT/*.vibe" "$SCAN_ROOT/*.vpkg" | sort)
 
 if [ "${#files[@]}" -eq 0 ]; then
   echo "vibe-fmt lint: no tracked .vibe/.vpkg files under $SCAN_ROOT" >&2

--- a/scripts/coverage_wasm_std.sh
+++ b/scripts/coverage_wasm_std.sh
@@ -40,7 +40,11 @@ for name in "${legacy_vars[@]}"; do
 done
 
 cd "$PROJECT_ROOT"
-mapfile -t tests < <(find lib/@vibe/builtin -name '*_test.vibe' | sort)
+# bash 3.2 (macOS stock) has no `mapfile` (#2349).
+tests=()
+while IFS= read -r line || [ -n "$line" ]; do
+  tests+=("$line")
+done < <(find lib/@vibe/builtin -name '*_test.vibe' | sort)
 # `|| true` used to swallow BOTH of grep's non-zero statuses, and they mean
 # opposite things: 1 is "no line matched" (legitimate -- the empty-selection
 # check below reports it), 2 is "this pattern is not valid ERE", which must
@@ -48,7 +52,7 @@ mapfile -t tests < <(find lib/@vibe/builtin -name '*_test.vibe' | sort)
 # not ripgrep's dialect -- see docs/coverage.md.
 select_tests() { # <label> <grep-args...>
   local label="$1"; shift
-  local out status=0
+  local out status=0 line
   out="$(printf '%s\n' "${tests[@]}" | "$@")" || status=$?
   if [ "$status" -gt 1 ]; then
     echo "[wasm std coverage] $label is not a valid POSIX extended regex (grep exit $status)" >&2
@@ -56,7 +60,12 @@ select_tests() { # <label> <grep-args...>
     echo "[wasm std coverage]   \\d, (?i) and other PCRE/Rust-regex constructs are rejected." >&2
     exit 2
   fi
-  mapfile -t tests < <(printf '%s' "$out" | grep -v '^$' || true)
+  # bash 3.2 has no `mapfile` (#2349). `while ... done < <(...)` runs in THIS
+  # shell -- a pipeline would not, and `tests` is the caller's array.
+  tests=()
+  while IFS= read -r line || [ -n "$line" ]; do
+    tests+=("$line")
+  done < <(printf '%s' "$out" | grep -v '^$' || true)
 }
 if [ -n "$FILTER" ]; then
   select_tests VIBE_WASM_STD_COVERAGE_FILTER grep -E "$FILTER"

--- a/scripts/lint_method_style_naming.sh
+++ b/scripts/lint_method_style_naming.sh
@@ -56,7 +56,11 @@ is_allowed() {
   ' "$ALLOWLIST_FILE"
 }
 
-mapfile -t vpkgs < <(git ls-files 'lib/@vibe/*/index.vpkg' 'lib/@vibex/*/index.vpkg' \
+# bash 3.2 (macOS stock) has no `mapfile` (#2349).
+vpkgs=()
+while IFS= read -r line || [ -n "$line" ]; do
+  vpkgs+=("$line")
+done < <(git ls-files 'lib/@vibe/*/index.vpkg' 'lib/@vibex/*/index.vpkg' \
   | grep -v '^lib/@vibe/compiler/' | grep -v '^lib/@vibe/cli/' | sort)
 
 if [ "${#vpkgs[@]}" -eq 0 ]; then
@@ -82,14 +86,22 @@ for vpkg in "${vpkgs[@]}"; do
   #    the 49 violations this lint reported were that. `Byte`, `Parser`,
   #    `StringView` and the rest of prelude's types are genuinely its own and
   #    stay in scope, as does @vibe/wit_runtime's own `export enum Result`.
-  mapfile -t types < <(grep -oE '^(export )?(opaque )?(type|struct|enum) [A-Z][A-Za-z0-9_]*' "$vpkg" \
+  # bash 3.2 has no `mapfile` (#2349). The reset matters here: this runs once
+  # per vpkg and the loop appends, where `mapfile` overwrote.
+  types=()
+  while IFS= read -r line || [ -n "$line" ]; do
+    types+=("$line")
+  done < <(grep -oE '^(export )?(opaque )?(type|struct|enum) [A-Z][A-Za-z0-9_]*' "$vpkg" \
     | sed -E 's/^(export )?(opaque )?(type|struct|enum) //' \
     | grep -vxE 'Int|Float|Double|Bool|String|Char|Unit|Bytes|Array|Option')
   [ "${#types[@]}" -eq 0 ] && continue
   type_alt="$(IFS='|'; echo "${types[*]}")"
 
   # 2. Type::method names already declared in this package's contract
-  mapfile -t qualified < <(grep -oE "^fn (${type_alt})::[a-zA-Z_][a-zA-Z0-9_]*" "$vpkg" \
+  qualified=()
+  while IFS= read -r line || [ -n "$line" ]; do
+    qualified+=("$line")
+  done < <(grep -oE "^fn (${type_alt})::[a-zA-Z_][a-zA-Z0-9_]*" "$vpkg" \
     | sed -E 's/^fn //')
 
   # 3. bare recv-shaped fns: `fn name(recv: OwnType[...]?, ...)`

--- a/scripts/vibe_fmt_apply.sh
+++ b/scripts/vibe_fmt_apply.sh
@@ -36,7 +36,13 @@ is_excluded() {
   ' "$ALLOWLIST_FILE"
 }
 
-mapfile -t files < <(git ls-files "$SCAN_ROOT/*.vibe" "$SCAN_ROOT/*.vpkg" | sort)
+# bash 3.2 (macOS stock) has no `mapfile` (#2349): read the list instead. The
+# `|| [ -n "$line" ]` tail keeps a final line that carries no newline, which is
+# the one behaviour `mapfile` has and a bare `read` loop does not.
+files=()
+while IFS= read -r line || [ -n "$line" ]; do
+  files+=("$line")
+done < <(git ls-files "$SCAN_ROOT/*.vibe" "$SCAN_ROOT/*.vpkg" | sort)
 
 to_format=()
 skipped=0


### PR DESCRIPTION
Closes #2349.

## The defect

`mapfile` is a bash 4 builtin; macOS ships bash 3.2. Every script using it aborts at **exit 127** before validating anything. Eleven uses across six scripts — including **both formatter entry points** — meant `pkf run fmt`, `bash scripts/check_vibe_fmt.sh` and `pkf run release-check` did not run on a supported contributor platform.

| script | uses |
|---|---:|
| `scripts/check_freeze_surface.sh` | 4 |
| `scripts/lint_method_style_naming.sh` | 3 |
| `scripts/coverage_wasm_std.sh` | 2 (one inside a function) |
| `scripts/vibe_fmt_apply.sh` | 1 |
| `scripts/check_vibe_fmt.sh` | 1 |
| `scripts/cache_clean.sh` | 1 (NUL-delimited) |

## The conversion

Each becomes `arr=(); while IFS= read -r line || [ -n "$line" ]; do arr+=("$line"); done < <(...)`, and the NUL one `read -r -d ''`. Three details that are **not** cosmetic:

- the `|| [ -n "$line" ]` tail keeps a final line carrying no newline — behaviour `mapfile` has and a bare `read` loop does not;
- `while … done < <(…)` runs in the **current shell**, which matters in `coverage_wasm_std.sh`'s `select_tests`, where the array belongs to the caller — a pipeline would have filled a subshell copy;
- the explicit `arr=()` reset matters in `lint_method_style_naming.sh`, where the fill runs once per vpkg inside a loop and `mapfile` overwrote where `+=` appends.

## The rule that stops it recurring

`check_gate_portability.sh` already rejects `rg`, bare `sed -i`, and `\t` in a grep pattern. It had nothing for bash 4 builtins — which is how eleven uses accumulated *under a gate whose whole job is this class*. A gate that cannot **start** on a supported platform is that failure mode at its limit.

**The rule fails closed** — a word match anywhere on a line that is not a whole-line comment, the same shape the `rg` rule above it has always used. My first draft matched only command position, and [Codex caught](https://github.com/mizchi/vibe-lang/pull/2588#discussion_r3972368451) that `if mapfile …`, `command mapfile …`, `! mapfile …` and `FOO=bar mapfile …` all run the builtin and all sailed past it — measured, the gate reported that tree clean. Enumerating reserved words, negation, assignment prefixes and the `command`/`builtin` wrappers is the losing side of that game; the cost of failing closed is that a mention in a message string is a finding, and rewording a message is the cheap direction.

That gate is one single-quoted shell string, so an apostrophe anywhere inside it — **including in a comment** — closes it and hands the awk source to the shell to parse. My first draft did exactly that (`this gate's own failure mode`) and died with a shell syntax error. The new comment says so, next to the code, since the next editor cannot see it from outside.

Self-test cases added: `mapfile`, the `readarray` synonym, the NUL-delimited spelling, **one per prefix** (asserted individually, so a rule that fixes one and misses another cannot pass), and a green guard asserting the **replacement loop passes** and that a whole-line comment mentioning the builtin is not a call — which is what the six converted scripts rely on. Without that guard the rule could be satisfied by rejecting every array fill.

## Verified, not argued

This box has bash 5.2 and no 3.2, so `BASH_ENV` sources `enable -n mapfile; enable -n readarray` into **each script's own shell** — removing the builtin exactly as 3.2 lacks it. (An earlier attempt disabled it in the *parent* shell and proved nothing: a new `bash` re-enables its builtins. The control below is what caught that.)

| run | result |
|---|---|
| control | `mapfile: command not found` |
| `lint_method_style_naming.sh` **(old)** | **exit 127**, `mapfile: command not found` line 59 |
| `lint_method_style_naming.sh` (new) | exit 0, output **identical** to old |
| `check_freeze_surface.sh` (new) | exit 0, output **identical** to old |
| `check_vibe_fmt.sh` (new) | exit 0, 1127 files, 0 violations |
| `vibe_fmt_apply.sh` (new) | exit 0, 1127 files, **0 rewritten, 0 lib diffs** |
| `cache_clean.sh` (new) | exit 0, reclaimed 3999 files |
| `coverage_wasm_std.sh` (new) | exit 0, zero `command not found` |

**Linux behaviour unchanged**: three scripts were run before and after and produce byte-identical output and exit codes. The NUL loop was compared against `mapfile -d ''` on names containing a **space** and a **tab**, and on an empty directory — identical both ways.

**Red-tested twice**: with the rule disabled, the self-test fails with `a mapfile call was accepted`; restored, all 18 cases pass and the real tree is clean.

## Scope note

The issue's Done-when asks that the six scripts run under bash 3.2. I verified the *specific* blocker (`mapfile`) is gone and swept the six for other bash-4-only constructs (`declare -A`, `${x^^}`, `${x,,}`, `&>>`, `coproc`) — none. `${!name:-}` in `coverage_wasm_std.sh` is indirect expansion, bash 2+. I could not run a real 3.2 interpreter here, so that sweep is by construct, not by execution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q9zbiDqkfF7xYQ3v8aCQ3b