### PR TITLE
gates: enforce that every gate is reachable from a workflow (#2580)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -856,6 +856,10 @@ jobs:
         run: bash scripts/check_portable_boundary_test.sh
       - name: portable-boundary gate
         run: bash scripts/check_portable_boundary.sh
+      - name: gate-wiring gate self-test
+        run: bash scripts/check_gate_wiring_test.sh
+      - name: gate-wiring gate
+        run: bash scripts/check_gate_wiring.sh
       - name: tracked-experiment-names lint self-test
         run: bash scripts/lint_tracked_experiment_names_test.sh
       - name: tracked-experiment-names lint

--- a/Taskfile.pkl
+++ b/Taskfile.pkl
@@ -431,8 +431,7 @@ local testCheckTreesitterWasmCorpus = new Task {
 // #2580: a gate that runs nowhere is indistinguishable from a passing one.
 // Three went dark before anything checked; this resolves reachability from the
 // workflows through pkf tasks and the script graph.
-local checkGateWiring =
-  scriptTask("check-gate-wiring", "scripts/check_gate_wiring.sh")
+local checkGateWiring = scriptTask("check-gate-wiring", "scripts/check_gate_wiring.sh")
 local testCheckGateWiring =
   scriptTask("test-check-gate-wiring", "scripts/check_gate_wiring_test.sh")
 local checkGatePortability =

--- a/Taskfile.pkl
+++ b/Taskfile.pkl
@@ -428,6 +428,13 @@ local testCheckTreesitterWasmCorpus = new Task {
   cmd = "bash scripts/check_treesitter_wasm_corpus_test.sh"
   inputs { ...compilerProbeInputs; ...scriptSources; ...treesitterCorpusInputs }
 }
+// #2580: a gate that runs nowhere is indistinguishable from a passing one.
+// Three went dark before anything checked; this resolves reachability from the
+// workflows through pkf tasks and the script graph.
+local checkGateWiring =
+  scriptTask("check-gate-wiring", "scripts/check_gate_wiring.sh")
+local testCheckGateWiring =
+  scriptTask("test-check-gate-wiring", "scripts/check_gate_wiring_test.sh")
 local checkGatePortability =
   scriptTask("check-gate-portability", "scripts/check_gate_portability.sh")
 local testCheckGatePortability =

--- a/scripts/check_gate_wiring.sh
+++ b/scripts/check_gate_wiring.sh
@@ -183,28 +183,37 @@ while pending_tasks:
             pending_tasks.append(local_to_task[local])
 
 # ---- walk the script graph, transitively, anywhere in the tree
+# A basename can name MORE THAN ONE file, and every one of them must be read.
+# `tests/gates/{bootstrap,early,mid,late}/run.sh` are four files with one
+# basename, and compiler_gate.sh invokes them as
+# `bash "$ROOT_DIR/tests/gates/$lane/run.sh"` -- a computed DIRECTORY with a
+# literal basename, which is the shape this scanner resolves. Keeping only the
+# first match made the answer depend on os.walk ORDER: it passed locally and
+# reported five gates dark in CI, because a different order read a different
+# `run.sh`. A gate that answers differently on two machines is worse than no
+# gate, so: all copies, sorted, every one read.
 by_basename = {}
-for dirpath, dirnames, filenames in os.walk("."):
-    dirnames[:] = [d for d in dirnames if d not in (".git", "node_modules", "_build", "target")]
-    for f in filenames:
+for dirpath, dirnames, filenames in sorted(os.walk(".")):
+    dirnames[:] = sorted(d for d in dirnames if d not in (".git", "node_modules", "_build", "target"))
+    for f in sorted(filenames):
         if f.endswith(".sh"):
-            by_basename.setdefault(f, os.path.join(dirpath, f).lstrip("./"))
+            by_basename.setdefault(f, []).append(os.path.join(dirpath, f).lstrip("./"))
 
 while pending_scripts:
     s = pending_scripts.pop()
     if s in reached_scripts:
         continue
     reached_scripts.add(s)
-    path = by_basename.get(s)
-    if not path or s in SKIP_AS_SOURCE:
+    if s in SKIP_AS_SOURCE:
         # #2138: this gate's own text, and its self-test's fixtures, are not
         # evidence of a wire. Reached (so it counts as wired), never read.
         continue
-    text = read(path)
-    check_resolvable(path, text)
-    for nxt in invoked_scripts(text):
-        if nxt != s:  # a script naming itself in its own message is not an edge
-            pending_scripts.append(nxt)
+    for path in by_basename.get(s, []):
+        text = read(path)
+        check_resolvable(path, text)
+        for nxt in invoked_scripts(text):
+            if nxt != s:  # a script naming itself in its own message is not an edge
+                pending_scripts.append(nxt)
 
 # ---- verdict
 dark = [g for g in corpus if g not in reached_scripts and g not in allow]

--- a/scripts/check_gate_wiring.sh
+++ b/scripts/check_gate_wiring.sh
@@ -1,0 +1,240 @@
+#!/usr/bin/env bash
+# Every gate must be REACHABLE from a workflow, or it is indistinguishable from
+# a passing one (#2580).
+#
+# That is not hypothetical. Three gates went dark, and none of the three was
+# found by a gate:
+#
+#   lint_tracked_experiment_names.sh  ran nowhere for weeks -- AGENTS.md records
+#                                     it ("release-check has no CI job")
+#   check_task_inputs.sh              red since #2473, unnoticed until #2577
+#   check_portable_boundary.sh        asserting a two-ADR-old shape, reporting
+#                                     "missing expected pure boundary" for files
+#                                     that no longer exist
+#
+# #2577 audited this BY HAND and #2579 wired the last of them. The audit is not
+# repeatable, so the next gate added with no workflow path is invisible again on
+# the day it lands. This makes the question answerable by a script.
+#
+# WHY THIS IS DECIDABLE, where "does this shell script reach the compiler" is
+# not: reachability here is a LEXICAL NAME GRAPH. A workflow names a task or a
+# script; a task names a script or other tasks; a script names other scripts.
+# AGENTS.md (#2248) is explicit that shell DATAFLOW does not converge for a
+# scanner -- this does not need dataflow. Two properties of the tree, both
+# measured, are what make the lexical read sound:
+#
+#   1. No `pkf run` anywhere takes a computed task name. All are literals.
+#   2. Script invocations vary the DIRECTORY (`"$SCRIPT_DIR/x.sh"`,
+#      `"$PROJECT_ROOT/scripts/x.sh"`) but never the BASENAME. So matching the
+#      basename in an invocation position resolves them all.
+#
+# Both are re-checked on every run: a computed task name or a computed basename
+# FAILS rather than being skipped, because silence and "unchecked" are
+# indistinguishable and that is the whole defect this gate exists for.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT="${VIBE_GATE_WIRING_ROOT:-$(dirname "$SCRIPT_DIR")}"
+cd "$ROOT"
+
+exec python3 - "$ROOT" <<'PYEOF'
+import os, re, sys
+
+root = sys.argv[1]
+os.chdir(root)
+
+SELF = "check_gate_wiring.sh"
+SELF_TEST = "check_gate_wiring_test.sh"
+ALLOWLIST = "scripts/gate_wiring_allowlist.txt"
+
+def read(p):
+    try:
+        with open(p, encoding="utf-8", errors="ignore") as f:
+            return f.read()
+    except OSError:
+        return ""
+
+def listdir(d):
+    try:
+        return sorted(os.listdir(d))
+    except OSError:
+        return []
+
+# ---- the corpus: EVERY gate script, this one included.
+#
+# A gate must not be able to see itself (#2138), and the precise reading matters
+# here. What must be excluded is this file's TEXT AS EVIDENCE: it names scripts
+# and task names in its own comments and regex literals, and its self-test
+# carries deliberate fixtures, so reading either as an edge would let it certify
+# a wire that does not exist. Excluding it from the CORPUS instead would be a
+# different thing entirely -- it would exempt this gate from the very property
+# it enforces, and it could then go dark exactly like the three that did.
+# So: in the corpus, out of the edge sources (see SKIP_AS_SOURCE below).
+gates = [f for f in listdir("scripts")
+         if re.match(r"^(check|lint)_.*\.sh$", f) and not f.endswith("_test.sh")]
+corpus = list(gates)
+SKIP_AS_SOURCE = {SELF, SELF_TEST}
+
+if not corpus:
+    print("[gate-wiring] FAIL: no gate scripts found under scripts/ -- the corpus went empty, "
+          "which is the shape that lets a checker pass while looking at nothing", file=sys.stderr)
+    sys.exit(1)
+
+# ---- allowlist: a gate that is genuinely local-only must SAY SO, in writing,
+# with a reason on the same line. Same shape as tracked_experiment_name_allowlist.txt.
+allow = {}
+for line in read(ALLOWLIST).splitlines():
+    line = line.strip()
+    if not line or line.startswith("#"):
+        continue
+    name, _, reason = line.partition(" ")
+    allow[name] = reason.strip()
+
+# ---- nodes we can walk into
+def strip_comments(text):
+    return "\n".join(l for l in text.splitlines() if not l.lstrip().startswith("#"))
+
+SH_INVOKE = re.compile(
+    r"""(?:^|[;&|(]|\bbash\b|\bsh\b|\bsource\b|\bexec\b|^\s*\.\s)"""
+    r"""[^\n;&|]*?([A-Za-z0-9_.-]+\.sh)\b""", re.M)
+ANY_SH = re.compile(r"\b([A-Za-z0-9_.-]+\.sh)\b")
+# Capture the whole token INCLUDING any quotes, then strip them. Excluding the
+# quote characters from the class instead makes `pkf run "$X"` match nothing at
+# all -- so the computed name it exists to catch would be skipped in silence,
+# which is exactly the failure being guarded against. (Caught by the self-test's
+# red 3 on the first draft.)
+PKF_RUN = re.compile(r"pkf\s+run\s+(\S+)")
+
+def _unquote(tok):
+    return tok.strip("\"'`")
+
+def invoked_scripts(text):
+    return set(SH_INVOKE.findall(strip_comments(text)))
+
+def named_tasks(text):
+    return {t for t in (_unquote(x) for x in PKF_RUN.findall(strip_comments(text)))
+            if t and "$" not in t and t != "--"}
+
+# ---- unresolvable references FAIL. Silence is "unchecked", not "safe".
+unresolvable = []
+def check_resolvable(rel, text):
+    body = strip_comments(text)
+    for m in PKF_RUN.finditer(body):
+        name = _unquote(m.group(1))
+        if "$" in name or name in ("--", ""):
+            unresolvable.append(f"{rel}: `pkf run {name}` names a computed task; this scanner "
+                                f"cannot resolve it, and skipping it would silently unreach every "
+                                f"gate behind it -- spell the task name literally")
+    # a computed BASENAME, e.g. `bash "$dir/$name.sh"`
+    for m in re.finditer(r"""\$\{?[A-Za-z_][A-Za-z0-9_]*\}?\.sh\b""", body):
+        unresolvable.append(f"{rel}: `{m.group(0)}` computes a script BASENAME; this scanner "
+                            f"resolves by basename, so spell it literally")
+
+# ---- Taskfile: task name -> body, and local binding -> task name
+taskfile = read("Taskfile.pkl")
+local_to_task = dict(re.findall(
+    r"local\s+(\w+)\s*=\s*new Task\s*\{\s*\n\s*name\s*=\s*\"([^\"]+)\"", taskfile))
+task_bodies = {}
+for m in re.finditer(r"local\s+(\w+)\s*=\s*new Task\s*\{(.*?)\n\}", taskfile, re.S):
+    local, body = m.group(1), m.group(2)
+    nm = re.search(r'name\s*=\s*"([^"]+)"', body)
+    if nm:
+        task_bodies[nm.group(1)] = body
+
+# ---- roots: the workflows
+workflows = [os.path.join(".github/workflows", f)
+             for f in listdir(".github/workflows") if f.endswith((".yml", ".yaml"))]
+if not workflows:
+    print("[gate-wiring] FAIL: no workflows found under .github/workflows -- with no roots "
+          "every gate would report as unreachable, which is a broken scan, not a finding",
+          file=sys.stderr)
+    sys.exit(1)
+
+reached_scripts = set()
+pending_scripts = []
+pending_tasks = []
+
+for wf in workflows:
+    text = read(wf)
+    check_resolvable(wf, text)
+    for s in invoked_scripts(text):
+        pending_scripts.append(s)
+    for t in named_tasks(text):
+        pending_tasks.append(t)
+
+# ---- walk the task graph
+seen_tasks = set()
+while pending_tasks:
+    t = pending_tasks.pop()
+    if t in seen_tasks:
+        continue
+    seen_tasks.add(t)
+    body = task_bodies.get(t)
+    if body is None:
+        # A workflow names a task the Taskfile does not define: that is a broken
+        # wire, and reporting it as "no gates behind it" would hide the break.
+        unresolvable.append(f".github/workflows: `pkf run {t}` names no task in Taskfile.pkl")
+        continue
+    check_resolvable(f"Taskfile.pkl task {t}", body)
+    for s in ANY_SH.findall(body):
+        pending_scripts.append(s)
+    for local in re.findall(r"\b(\w+)\b", body):
+        if local in local_to_task:
+            pending_tasks.append(local_to_task[local])
+
+# ---- walk the script graph, transitively, anywhere in the tree
+by_basename = {}
+for dirpath, dirnames, filenames in os.walk("."):
+    dirnames[:] = [d for d in dirnames if d not in (".git", "node_modules", "_build", "target")]
+    for f in filenames:
+        if f.endswith(".sh"):
+            by_basename.setdefault(f, os.path.join(dirpath, f).lstrip("./"))
+
+while pending_scripts:
+    s = pending_scripts.pop()
+    if s in reached_scripts:
+        continue
+    reached_scripts.add(s)
+    path = by_basename.get(s)
+    if not path or s in SKIP_AS_SOURCE:
+        # #2138: this gate's own text, and its self-test's fixtures, are not
+        # evidence of a wire. Reached (so it counts as wired), never read.
+        continue
+    text = read(path)
+    check_resolvable(path, text)
+    for nxt in invoked_scripts(text):
+        if nxt != s:  # a script naming itself in its own message is not an edge
+            pending_scripts.append(nxt)
+
+# ---- verdict
+dark = [g for g in corpus if g not in reached_scripts and g not in allow]
+stale_allow = [g for g in allow if g in reached_scripts]
+missing_allow = [g for g in allow if g not in gates]
+
+problems = []
+if unresolvable:
+    problems.append(("references this scanner cannot resolve (unresolved is UNCHECKED, "
+                     "not safe -- #2248)", sorted(set(unresolvable))))
+if dark:
+    problems.append(("gate scripts no workflow reaches -- they run nowhere, which is "
+                     "indistinguishable from passing",
+                     [f"  scripts/{g}" for g in dark]))
+if stale_allow:
+    problems.append(("allowlisted as local-only but now REACHED -- delete the row, or the "
+                     "allowlist becomes a place gates hide",
+                     [f"  {g}" for g in stale_allow]))
+if missing_allow:
+    problems.append(("allowlisted but no such gate script exists",
+                     [f"  {g}" for g in missing_allow]))
+
+if problems:
+    print("[gate-wiring] FAIL:", file=sys.stderr)
+    for title, lines in problems:
+        print(f"  {title}:", file=sys.stderr)
+        for l in lines:
+            print(f"  {l}" if not l.startswith("  ") else l, file=sys.stderr)
+    sys.exit(1)
+
+print(f"[gate-wiring] ok ({len(corpus)} gate script(s) reachable from "
+      f"{len(workflows)} workflow(s); {len(allow)} allowlisted local-only)")
+PYEOF

--- a/scripts/check_gate_wiring_test.sh
+++ b/scripts/check_gate_wiring_test.sh
@@ -118,6 +118,31 @@ grep -qF 'pkf run no-such-task' "$TMP_ROOT/.github/workflows/ci.yml" || fail "fi
 run && { cat "$TMP_ROOT/out" >&2; fail "a workflow naming an undefined task was accepted"; }
 ok "a workflow naming an undefined pkf task is rejected"
 
+# --- green/red 5: an AMBIGUOUS BASENAME must read EVERY file carrying it.
+# This is the shape `tests/gates/{bootstrap,early,mid,late}/run.sh` has, invoked
+# by compiler_gate.sh as `bash "$ROOT_DIR/tests/gates/$lane/run.sh"` -- computed
+# directory, literal basename. Keeping only the first match made the answer
+# depend on os.walk ORDER: the first draft passed locally and reported five
+# gates dark in CI. A gate that answers differently on two machines is worse
+# than no gate.
+reset_tree
+mkdir -p "$TMP_ROOT/lanes/a" "$TMP_ROOT/lanes/b"
+printf '#!/usr/bin/env bash\necho lane a, names no gate\n' > "$TMP_ROOT/lanes/a/run.sh"
+printf '#!/usr/bin/env bash\nbash scripts/check_only_in_lane_b.sh\n' > "$TMP_ROOT/lanes/b/run.sh"
+printf '#!/usr/bin/env bash\necho reached only through lane b\n' > "$TMP_ROOT/scripts/check_only_in_lane_b.sh"
+printf '      - run: bash "$ROOT/lanes/$lane/run.sh"\n' >> "$TMP_ROOT/.github/workflows/ci.yml"
+grep -qF 'lanes/$lane/run.sh' "$TMP_ROOT/.github/workflows/ci.yml" || fail "fixture 5 did not land"
+[ -f "$TMP_ROOT/lanes/a/run.sh" ] && [ -f "$TMP_ROOT/lanes/b/run.sh" ] || fail "fixture 5 lanes did not land"
+run || { cat "$TMP_ROOT/out" >&2; fail "a gate reached only through the SECOND file sharing a basename was reported dark"; }
+ok "an ambiguous basename reads every file carrying it, not whichever the walk hit first"
+
+# The same tree, five times, must give the same answer. Order-dependence is the
+# defect; one passing run does not rule it out.
+for _ in 1 2 3 4 5; do
+  run || { cat "$TMP_ROOT/out" >&2; fail "the ambiguous-basename tree answered differently between runs"; }
+done
+ok "the answer is stable across repeated runs"
+
 # --- red 4: a scan whose ROOTS vanish must fail, not report everything dark or
 # everything fine. An empty corpus is the shape that let five broken self-tests
 # sit green (#2252).

--- a/scripts/check_gate_wiring_test.sh
+++ b/scripts/check_gate_wiring_test.sh
@@ -1,0 +1,136 @@
+#!/usr/bin/env bash
+# Red/green for check_gate_wiring.sh. Every red case asserts the FIXTURE LANDED
+# before believing the verdict -- a mutation that matches nothing passes while
+# proving nothing, which is how #2248 shipped a check that could not fail.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+CHECK="$SCRIPT_DIR/check_gate_wiring.sh"
+TMP_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/vibe_gate_wiring_test.XXXXXX")"
+trap 'rm -rf "$TMP_ROOT"' EXIT
+
+fail() { echo "gate-wiring self-test: $1" >&2; exit 1; }
+ok() { echo "  ok  $1"; }
+run() { VIBE_GATE_WIRING_ROOT="$TMP_ROOT" bash "$CHECK" >"$TMP_ROOT/out" 2>&1; }
+
+# A minimal tree with every edge kind the real one uses: a workflow naming a
+# script directly, a workflow naming a pkf task, a task naming a script, and a
+# script naming another script.
+reset_tree() {
+  rm -rf "$TMP_ROOT/scripts" "$TMP_ROOT/.github" "$TMP_ROOT/Taskfile.pkl" "$TMP_ROOT/deep"
+  mkdir -p "$TMP_ROOT/scripts" "$TMP_ROOT/.github/workflows"
+  cat > "$TMP_ROOT/.github/workflows/ci.yml" <<'EOF'
+jobs:
+  lint:
+    steps:
+      - run: bash scripts/check_direct.sh
+      - run: pkf run some-task
+EOF
+  cat > "$TMP_ROOT/Taskfile.pkl" <<'EOF'
+local someTask = new Task {
+  name = "some-task"
+  cmd = "bash scripts/check_via_task.sh"
+}
+EOF
+  printf '#!/usr/bin/env bash\nbash "$SCRIPT_DIR/lint_transitive.sh"\n' > "$TMP_ROOT/scripts/check_direct.sh"
+  printf '#!/usr/bin/env bash\necho via-task\n' > "$TMP_ROOT/scripts/check_via_task.sh"
+  printf '#!/usr/bin/env bash\necho transitive\n' > "$TMP_ROOT/scripts/lint_transitive.sh"
+  rm -f "$TMP_ROOT/scripts/gate_wiring_allowlist.txt"
+}
+
+# --- green: all three reachable, including the transitive one and the one only
+# a task names. Without this the checker could pass by rejecting nothing.
+reset_tree
+run || { cat "$TMP_ROOT/out" >&2; fail "a fully wired tree was rejected"; }
+grep -qF "3 gate script(s) reachable" "$TMP_ROOT/out" || { cat "$TMP_ROOT/out" >&2; fail "the green run did not count all three"; }
+ok "a wired tree passes: direct, via a pkf task, and transitively through a script"
+
+# --- red 1: a gate no workflow reaches.
+reset_tree
+printf '#!/usr/bin/env bash\necho dark\n' > "$TMP_ROOT/scripts/check_dark.sh"
+[ -f "$TMP_ROOT/scripts/check_dark.sh" ] || fail "fixture 1 did not land"
+run && { cat "$TMP_ROOT/out" >&2; fail "a gate reachable from nothing was accepted"; }
+grep -qF "check_dark.sh" "$TMP_ROOT/out" || { cat "$TMP_ROOT/out" >&2; fail "the finding did not name the dark gate"; }
+ok "a gate no workflow reaches is rejected"
+
+# --- green 1b: the allowlist admits it, in writing, with a reason.
+printf 'check_dark.sh runs by hand only, on purpose\n' > "$TMP_ROOT/scripts/gate_wiring_allowlist.txt"
+run || { cat "$TMP_ROOT/out" >&2; fail "an allowlisted local-only gate was rejected"; }
+grep -qF "1 allowlisted" "$TMP_ROOT/out" || fail "the allowlisted count was not reported"
+ok "an allowlisted gate is accepted, and counted"
+
+# --- red 1c: an allowlist row that is now REACHED must fail, or the allowlist
+# becomes a place gates hide after someone wires them.
+reset_tree
+printf 'check_direct.sh stale row: this one IS wired\n' > "$TMP_ROOT/scripts/gate_wiring_allowlist.txt"
+run && { cat "$TMP_ROOT/out" >&2; fail "a stale allowlist row was accepted"; }
+grep -qF "check_direct.sh" "$TMP_ROOT/out" || fail "the stale-row finding did not name it"
+ok "an allowlist row for a gate that IS reached is rejected"
+
+# --- red 1d: an allowlist row naming no such script.
+reset_tree
+printf 'check_ghost.sh nothing by this name exists\n' > "$TMP_ROOT/scripts/gate_wiring_allowlist.txt"
+run && { cat "$TMP_ROOT/out" >&2; fail "an allowlist row for a nonexistent gate was accepted"; }
+ok "an allowlist row naming no gate is rejected"
+
+# --- red 2: unwiring a real invocation. This is the regression the three dark
+# gates actually were: the script still exists, nothing runs it.
+reset_tree
+grep -qF 'bash scripts/check_direct.sh' "$TMP_ROOT/.github/workflows/ci.yml" || fail "fixture 2 precondition missing"
+sed -i.bak '/check_direct\.sh/d' "$TMP_ROOT/.github/workflows/ci.yml"
+grep -qF 'check_direct.sh' "$TMP_ROOT/.github/workflows/ci.yml" && fail "fixture 2 did not land"
+run && { cat "$TMP_ROOT/out" >&2; fail "unwiring a gate from the workflow was accepted"; }
+grep -qF "check_direct.sh" "$TMP_ROOT/out" || fail "the unwired finding did not name it"
+ok "removing a workflow's invocation of a wired gate is rejected"
+
+# --- red 2b: unwiring the TASK also unreaches what only the task named.
+reset_tree
+sed -i.bak '/pkf run some-task/d' "$TMP_ROOT/.github/workflows/ci.yml"
+grep -qF 'pkf run some-task' "$TMP_ROOT/.github/workflows/ci.yml" && fail "fixture 2b did not land"
+run && { cat "$TMP_ROOT/out" >&2; fail "unwiring the task was accepted"; }
+grep -qF "check_via_task.sh" "$TMP_ROOT/out" || fail "the finding did not name the task-only gate"
+ok "removing the pkf task from the workflow unreaches the gate behind it"
+
+# --- red 3: a reference the scanner cannot resolve must FAIL, not be skipped.
+# Silence and "unchecked" are indistinguishable (#2248), which is the whole
+# defect this gate exists for.
+reset_tree
+printf '      - run: pkf run "$COMPUTED"\n' >> "$TMP_ROOT/.github/workflows/ci.yml"
+grep -qF 'pkf run "$COMPUTED"' "$TMP_ROOT/.github/workflows/ci.yml" || fail "fixture 3 did not land"
+run && { cat "$TMP_ROOT/out" >&2; fail "a computed task name was skipped silently"; }
+grep -qF "computed task" "$TMP_ROOT/out" || fail "the finding did not name the reason"
+ok "a computed pkf task name fails rather than being skipped"
+
+# --- red 3b: a computed script BASENAME. The scanner resolves by basename, so
+# this is the one shape that would silently unreach whatever it names.
+reset_tree
+printf 'bash "$dir/$name.sh"\n' >> "$TMP_ROOT/scripts/check_direct.sh"
+grep -qF '$name.sh' "$TMP_ROOT/scripts/check_direct.sh" || fail "fixture 3b did not land"
+run && { cat "$TMP_ROOT/out" >&2; fail "a computed script basename was skipped silently"; }
+grep -qF "computes a script BASENAME" "$TMP_ROOT/out" || fail "the finding did not name the reason"
+ok "a computed script basename fails rather than being skipped"
+
+# --- red 3c: a workflow naming a task the Taskfile does not define is a broken
+# wire; reporting it as "no gates behind it" would hide the break.
+reset_tree
+printf '      - run: pkf run no-such-task\n' >> "$TMP_ROOT/.github/workflows/ci.yml"
+grep -qF 'pkf run no-such-task' "$TMP_ROOT/.github/workflows/ci.yml" || fail "fixture 3c did not land"
+run && { cat "$TMP_ROOT/out" >&2; fail "a workflow naming an undefined task was accepted"; }
+ok "a workflow naming an undefined pkf task is rejected"
+
+# --- red 4: a scan whose ROOTS vanish must fail, not report everything dark or
+# everything fine. An empty corpus is the shape that let five broken self-tests
+# sit green (#2252).
+reset_tree
+rm -f "$TMP_ROOT/.github/workflows/ci.yml"
+run && { cat "$TMP_ROOT/out" >&2; fail "a tree with no workflows was accepted"; }
+grep -qF "no workflows found" "$TMP_ROOT/out" || fail "the empty-roots finding did not name the reason"
+ok "a tree with no workflows fails rather than passing vacuously"
+
+reset_tree
+rm -f "$TMP_ROOT"/scripts/check_*.sh "$TMP_ROOT"/scripts/lint_*.sh
+run && { cat "$TMP_ROOT/out" >&2; fail "an empty gate corpus was accepted"; }
+grep -qF "corpus went empty" "$TMP_ROOT/out" || fail "the empty-corpus finding did not name the reason"
+ok "an empty gate corpus fails rather than passing vacuously"
+
+echo "[gate-wiring-test] ok"

--- a/scripts/gate_wiring_allowlist.txt
+++ b/scripts/gate_wiring_allowlist.txt
@@ -1,0 +1,3 @@
+# Gates that deliberately run nowhere in CI. One per line: `<script.sh> <reason>`.
+# A row here is a written admission, not a default -- and it goes stale loudly:
+# a gate listed here that IS reached fails the check.


### PR DESCRIPTION
Closes #2580.

A gate that runs nowhere is indistinguishable from a passing one. Three went dark and **none of the three was found by a gate**:

| gate | how long it was dark |
|---|---|
| `lint_tracked_experiment_names.sh` | ran nowhere for weeks — `AGENTS.md` records it |
| `check_task_inputs.sh` | red since #2473, unnoticed until #2577 |
| `check_portable_boundary.sh` | asserting a two-ADR-old shape |

#2577 audited this **by hand** and #2579 wired the last of them. The audit is not repeatable, so the next gate added with no workflow path is invisible again on the day it lands. `check_gate_wiring.sh` makes it a question a script answers.

## Why this is decidable

Reachability here is a **lexical name graph** — a workflow names a task or a script, a task names a script or other tasks, a script names other scripts. #2248 is explicit that shell *dataflow* does not converge for a scanner; this needs none.

Two properties of the tree make the lexical read sound, and I **measured both before designing**, rather than assuming them:

1. **No `pkf run` anywhere takes a computed task name** — all literals.
2. Invocations vary the **directory** (`"$SCRIPT_DIR/x.sh"`, `"$PROJECT_ROOT/scripts/x.sh"`) but never the **basename** — so matching the basename in an invocation position resolves every one of them.

Both are re-checked on every run and **fail** when violated rather than being skipped: a computed task name, a computed basename, or a workflow naming a task the Taskfile does not define. Silence and "unchecked" are indistinguishable, which is the defect this gate exists for.

## Self-exclusion, read precisely (#2138)

What must be excluded is this gate's **text as evidence** — it names scripts and task names in its own comments and regex literals, and its self-test carries deliberate fixtures, so reading either as an edge would let it certify a wire that does not exist.

Excluding it from the **corpus** would be a different thing entirely: it would exempt this gate from the property it enforces, and it could then go dark exactly like the three that did. My first draft did that. So it is **in the corpus and out of the edge sources** — and, being in the corpus, it had to be wired into `ci.yml` beside the other structural lints before the gate would pass. It is.

## The allowlist

`scripts/gate_wiring_allowlist.txt` — a written admission with a reason per row, the shape `tracked_experiment_name_allowlist.txt` uses. It goes stale **loudly in both directions**: a row for a gate that *is* reached fails, and so does a row naming no gate. Currently empty.

## The self-test earned its keep immediately

Red case 3 caught a real bug in the first draft: the `pkf run` regex excluded the quote characters from its class, so `pkf run "$COMPUTED"` matched **nothing at all** — the computed name it exists to catch was skipped in silence, which is precisely the failure mode. Captured whole and unquoted now.

12 cases, each asserting the fixture landed before the verdict:

```
ok  a wired tree passes: direct, via a pkf task, and transitively through a script
ok  a gate no workflow reaches is rejected
ok  an allowlisted gate is accepted, and counted
ok  an allowlist row for a gate that IS reached is rejected
ok  an allowlist row naming no gate is rejected
ok  removing a workflow's invocation of a wired gate is rejected
ok  removing the pkf task from the workflow unreaches the gate behind it
ok  a computed pkf task name fails rather than being skipped
ok  a computed script basename fails rather than being skipped
ok  a workflow naming an undefined pkf task is rejected
ok  a tree with no workflows fails rather than passing vacuously
ok  an empty gate corpus fails rather than passing vacuously
```

## Measured on this tree

```
[gate-wiring] ok (41 gate script(s) reachable from 10 workflow(s); 0 allowlisted local-only)
```

That is #2579's "zero" now held by something repeatable.

`check-gate-portability`, `check-gate-registry`, `check-gate-self-tests`, `check-task-inputs`, `test_ci_compiler_gate_layout` and `pkf run pre-commit` all ok.

## Done-when, from the issue

- [x] Resolves reachability transitively through `pkf run` tasks, aggregate task members, and the script graph (`gates_shard.sh`, `compiler_gate.sh` and the `tests/gates/**` lanes are reached as ordinary script nodes — which is what caught `check_builtin_parity.sh`, reachable only via `tests/gates/bootstrap/preflight.sh`, in my prototype)
- [x] A script with no path fails, with an explicit allowlist requiring a written reason
- [x] It cannot see itself — text excluded as evidence, but **not** exempted from the check
- [x] Self-test asserting FAIL on a mutated tree, each red case verifying the mutation landed first

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q9zbiDqkfF7xYQ3v8aCQ3b

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q9zbiDqkfF7xYQ3v8aCQ3b)_