### PR TITLE
gate-wiring: fix five ways it could certify a wire that does not exist (#2591 review)

### DIFF
--- a/Taskfile.pkl
+++ b/Taskfile.pkl
@@ -1785,6 +1785,8 @@ local releaseCheck = new Task {
     // failing on the tree with no one to see it. Same failure mode the
     // `testWasmValidateParity` comment below describes.
     lintTrackedExperimentNames
+    checkGateWiring
+    testCheckGateWiring
     checkGatePortability
     testCheckGatePortability
     checkTreesitterArtifacts
@@ -1889,6 +1891,8 @@ tasks {
   testReviewLintVibex
   lintTrackedExperimentNames
   testLintTrackedExperimentNames
+  checkGateWiring
+  testCheckGateWiring
   checkGatePortability
   testCheckGatePortability
   checkTreesitterArtifacts

--- a/book/en/12_tests.vibe.md
+++ b/book/en/12_tests.vibe.md
@@ -45,13 +45,15 @@ $ vibe test demo_test.vibe
 FAIL demo_test.vibe
        failing test: double works
        assert_eq failed
+         at off=62
          expected: 43
          actual:   42
 [vibe-test] 0 passed, 1 failed (1 files, 1 tests)
 ```
 
-The report does not yet carry a line number, so two asserts with the
-same expected value in one test are indistinguishable (#2202).
+`at off=62` is the assert's own position, so two asserts with the same
+expected value in one test are told apart (#2202). It is a BYTE offset,
+not a line number -- every position in vibe is a byte offset (ADR-0108).
 
 `assert_eq(actual, expected)` works for any type that can be compared,
 and compares strings by content — so you can assert directly on a

--- a/book/ja/12_tests.vibe.md
+++ b/book/ja/12_tests.vibe.md
@@ -44,13 +44,15 @@ $ vibe test demo_test.vibe
 FAIL demo_test.vibe
        failing test: double works
        assert_eq failed
+         at off=62
          expected: 43
          actual:   42
 [vibe-test] 0 passed, 1 failed (1 files, 1 tests)
 ```
 
-レポートにはまだ行番号が付かないので、同じ期待値の assert が1つの
-テストに2つあると区別できません (#2202)。
+`at off=62` は assert 自身の位置なので、同じ期待値の assert が1つの
+テストに2つあっても区別できます (#2202)。これは行番号ではなく
+**バイトオフセット**です — vibe の位置はすべてバイト単位 (ADR-0108)。
 
 `assert_eq(actual, expected)` は比較可能な任意の型で使え、文字列は内容で
 比較します — なので連結の結果や関数の戻り値に対して、何も変換せずそのまま

--- a/scripts/check_gate_wiring.sh
+++ b/scripts/check_gate_wiring.sh
@@ -60,6 +60,14 @@ def listdir(d):
     except OSError:
         return []
 
+# SCOPE, stated so it is a boundary and not an oversight: `scripts/check_*.sh`
+# and `scripts/lint_*.sh`, which is what #2580 defines. The repo also has 27
+# `*_gate.sh` scripts (compiler_gate.sh, minify_gate.sh, the
+# test_*_component_gate.sh family) that this does NOT cover, so an unwired one
+# there is still invisible. Raised by Codex on #2591 and carried to its own
+# issue rather than widened here: several would need investigation or an
+# allowlist row each, which is a different change from installing the check.
+
 # ---- the corpus: EVERY gate script, this one included.
 #
 # A gate must not be able to see itself (#2138), and the precise reading matters
@@ -73,7 +81,16 @@ def listdir(d):
 gates = [f for f in listdir("scripts")
          if re.match(r"^(check|lint)_.*\.sh$", f) and not f.endswith("_test.sh")]
 corpus = list(gates)
-SKIP_AS_SOURCE = {SELF, SELF_TEST}
+
+# EVERY gate self-test is excluded as an edge source, not just this one's
+# (Codex P1 on #2591). A self-test names its production gate because it RUNS it
+# against mutation fixtures -- that is a red/green harness, not evidence the
+# gate runs against the checkout. Left in, removing `check_portable_boundary.sh`
+# from the workflow would leave `check_portable_boundary_test.sh` still naming
+# it, and the gate would report it reached: precisely the dark-gate case this
+# exists to catch, certified by the thing that proves nothing about CI.
+SKIP_AS_SOURCE = {f for f in listdir("scripts") if f.endswith("_test.sh")}
+SKIP_AS_SOURCE.add(SELF)
 
 if not corpus:
     print("[gate-wiring] FAIL: no gate scripts found under scripts/ -- the corpus went empty, "
@@ -83,20 +100,58 @@ if not corpus:
 # ---- allowlist: a gate that is genuinely local-only must SAY SO, in writing,
 # with a reason on the same line. Same shape as tracked_experiment_name_allowlist.txt.
 allow = {}
+no_reason = []
 for line in read(ALLOWLIST).splitlines():
     line = line.strip()
     if not line or line.startswith("#"):
         continue
     name, _, reason = line.partition(" ")
-    allow[name] = reason.strip()
+    reason = reason.strip()
+    if not reason:
+        # The row is meant to be a written admission. Accepting a bare filename
+        # would let a gate leave enforcement with no justification at all
+        # (Codex P2 on #2591).
+        no_reason.append(name)
+    allow[name] = reason
 
 # ---- nodes we can walk into
 def strip_comments(text):
     return "\n".join(l for l in text.splitlines() if not l.lstrip().startswith("#"))
 
+# An edge needs an actual RUNNER before the path. The first draft also accepted
+# start-of-line followed by arbitrary text, so any non-comment line mentioning a
+# basename counted -- `echo "run bash scripts/check_dark.sh"` in a reachable
+# wrapper certified a wire that does not exist (Codex P1 on #2591). A runner
+# word, optional flags/env/quotes, an optional computed or literal directory,
+# then the basename.
 SH_INVOKE = re.compile(
-    r"""(?:^|[;&|(]|\bbash\b|\bsh\b|\bsource\b|\bexec\b|^\s*\.\s)"""
+    r"""(?:\bbash\b|\bsh\b|\bsource\b|\bexec\b|(?:^|[;&|(])\s*\.)"""
     r"""[^\n;&|]*?([A-Za-z0-9_.-]+\.sh)\b""", re.M)
+
+# ...and a line whose command EMITS text is not running anything. This is what
+# separates `bash scripts/x.sh` from `echo "... bash scripts/x.sh"`.
+EMITS = re.compile(r"^\s*(echo|printf|cat|:|#)\b")
+
+# A DYNAMIC invocation: a runner applied to a whole path this scanner cannot
+# read, e.g. compiler_gate.sh's `script="$(gate_lane_script "$lane")"` followed
+# by `bash "$script"`. Resolving that needs shell dataflow, which #2248 says
+# does not converge for a scanner -- and the rule there is to remove the
+# structure that needs it, not to chase it.
+#
+# So the structure removed is the SILENCE: such a line must be accompanied by a
+# `# gate-wiring: reaches <path>` directive in the same file, declaring what it
+# runs. The declaration is lexical, reviewable next to the code, and CHECKED --
+# a path that does not exist fails. Without one the line fails outright, because
+# skipping it would silently unreach everything behind the dispatcher.
+# Only a dynamic RUN counts, not a dynamic `source`. Sourcing brings a
+# library's functions into scope -- `source "$GATES_LIB"` in each lane
+# entrypoint -- and a library is not a gate; whatever it would run is written in
+# its own file, which is reached on its own terms. Demanding a directive for
+# every dynamic source would make the rule noisy without closing anything.
+DYNAMIC_INVOKE = re.compile(
+    r"""^\s*(?:\bbash\b|\bsh\b|\bexec\b)\s+"?\$\{?[A-Za-z_][A-Za-z0-9_]*\}?"?\s*$""",
+    re.M)
+REACHES = re.compile(r"^\s*#\s*gate-wiring:\s*reaches\s+(\S+)\s*$", re.M)
 ANY_SH = re.compile(r"\b([A-Za-z0-9_.-]+\.sh)\b")
 # Capture the whole token INCLUDING any quotes, then strip them. Excluding the
 # quote characters from the class instead makes `pkf run "$X"` match nothing at
@@ -109,7 +164,12 @@ def _unquote(tok):
     return tok.strip("\"'`")
 
 def invoked_scripts(text):
-    return set(SH_INVOKE.findall(strip_comments(text)))
+    out = set()
+    for line in strip_comments(text).splitlines():
+        if EMITS.match(line):
+            continue
+        out |= set(SH_INVOKE.findall(line))
+    return out
 
 def named_tasks(text):
     return {t for t in (_unquote(x) for x in PKF_RUN.findall(strip_comments(text)))
@@ -117,8 +177,23 @@ def named_tasks(text):
 
 # ---- unresolvable references FAIL. Silence is "unchecked", not "safe".
 unresolvable = []
+declared_edges = []
+
 def check_resolvable(rel, text):
     body = strip_comments(text)
+    # Directives are comments, so they are read from the RAW text.
+    declared = REACHES.findall(text)
+    for d in declared:
+        if not os.path.isfile(d):
+            unresolvable.append(f"{rel}: `# gate-wiring: reaches {d}` names no such file")
+        else:
+            declared_edges.append(os.path.basename(d))
+    for m in DYNAMIC_INVOKE.finditer(body):
+        if not declared:
+            unresolvable.append(
+                f"{rel}: `{m.group(0).strip()}` runs a path this scanner cannot read, and the file "
+                f"declares nothing -- add `# gate-wiring: reaches <path>` lines naming what it runs, "
+                f"or skipping it would silently unreach every gate behind it")
     for m in PKF_RUN.finditer(body):
         name = _unquote(m.group(1))
         if "$" in name or name in ("--", ""):
@@ -140,6 +215,16 @@ for m in re.finditer(r"local\s+(\w+)\s*=\s*new Task\s*\{(.*?)\n\}", taskfile, re
     nm = re.search(r'name\s*=\s*"([^"]+)"', body)
     if nm:
         task_bodies[nm.group(1)] = body
+
+# Tasks built through the `scriptTask(name, script)` helper are just as real,
+# and parsing only `new Task { ... }` reported them as UNDEFINED -- so a
+# workflow invoking one would have failed the check and marked its script dark
+# (Codex P2 on #2591).
+for m in re.finditer(r"""(?:local\s+(\w+)\s*=\s*)?scriptTask\(\s*"([^"]+)"\s*,\s*"([^"]+)"\s*\)""", taskfile):
+    local, task_name, script = m.group(1), m.group(2), m.group(3)
+    task_bodies.setdefault(task_name, f'cmd = "bash {script}"')
+    if local:
+        local_to_task.setdefault(local, task_name)
 
 # ---- roots: the workflows
 workflows = [os.path.join(".github/workflows", f)
@@ -192,12 +277,18 @@ while pending_tasks:
 # reported five gates dark in CI, because a different order read a different
 # `run.sh`. A gate that answers differently on two machines is worse than no
 # gate, so: all copies, sorted, every one read.
+# NOTE: do not wrap os.walk() in sorted(). That materializes the whole walk
+# before the loop body runs, so pruning `dirnames[:]` has no effect and _build
+# (which holds whole COPIES of the tree, from seed rebuilds) gets scanned.
+# Collect first, sort after.
 by_basename = {}
-for dirpath, dirnames, filenames in sorted(os.walk(".")):
-    dirnames[:] = sorted(d for d in dirnames if d not in (".git", "node_modules", "_build", "target"))
-    for f in sorted(filenames):
+for dirpath, dirnames, filenames in os.walk("."):
+    dirnames[:] = [d for d in dirnames if d not in (".git", "node_modules", "_build", "target")]
+    for f in filenames:
         if f.endswith(".sh"):
             by_basename.setdefault(f, []).append(os.path.join(dirpath, f).lstrip("./"))
+for k in by_basename:
+    by_basename[k].sort()
 
 while pending_scripts:
     s = pending_scripts.pop()
@@ -210,7 +301,10 @@ while pending_scripts:
         continue
     for path in by_basename.get(s, []):
         text = read(path)
+        before = len(declared_edges)
         check_resolvable(path, text)
+        for nxt in declared_edges[before:]:
+            pending_scripts.append(nxt)
         for nxt in invoked_scripts(text):
             if nxt != s:  # a script naming itself in its own message is not an edge
                 pending_scripts.append(nxt)
@@ -221,6 +315,10 @@ stale_allow = [g for g in allow if g in reached_scripts]
 missing_allow = [g for g in allow if g not in gates]
 
 problems = []
+if no_reason:
+    problems.append(("allowlist rows with no reason -- a row here is a written admission, "
+                     "so say why on the same line",
+                     [f"  {g}" for g in sorted(no_reason)]))
 if unresolvable:
     problems.append(("references this scanner cannot resolve (unresolved is UNCHECKED, "
                      "not safe -- #2248)", sorted(set(unresolvable))))

--- a/scripts/check_gate_wiring_test.sh
+++ b/scripts/check_gate_wiring_test.sh
@@ -143,6 +143,62 @@ for _ in 1 2 3 4 5; do
 done
 ok "the answer is stable across repeated runs"
 
+# --- red 6: a MESSAGE is not an invocation. The first draft accepted any
+# non-comment line carrying a basename, so a reachable wrapper containing only
+# `echo "run bash scripts/check_dark.sh"` certified a wire that does not exist
+# (Codex P1 on #2591) -- documentation text marking a gate as run.
+reset_tree
+printf '#!/usr/bin/env bash\necho dark\n' > "$TMP_ROOT/scripts/check_dark.sh"
+printf 'echo "to run it by hand: bash scripts/check_dark.sh"\n' >> "$TMP_ROOT/scripts/check_direct.sh"
+grep -qF 'to run it by hand' "$TMP_ROOT/scripts/check_direct.sh" || fail "fixture 6 did not land"
+run && { cat "$TMP_ROOT/out" >&2; fail "a basename inside an echo certified a wire"; }
+grep -qF "check_dark.sh" "$TMP_ROOT/out" || fail "the finding did not name the still-dark gate"
+ok "a basename inside an echo is not an invocation"
+
+# --- red 7: a gate SELF-TEST is not evidence its production gate runs. A
+# self-test names its gate because it runs it against fixtures; left as an edge,
+# unwiring the real CI step would go unnoticed -- the dark-gate case itself
+# (Codex P1 on #2591). Measured on the real tree: this is what exposed
+# check_book_console.sh, wired only via its self-test, and red.
+reset_tree
+printf '#!/usr/bin/env bash\necho dark\n' > "$TMP_ROOT/scripts/check_dark.sh"
+printf '#!/usr/bin/env bash\nbash scripts/check_dark.sh --fixture\n' > "$TMP_ROOT/scripts/check_dark_test.sh"
+printf '      - run: bash scripts/check_dark_test.sh\n' >> "$TMP_ROOT/.github/workflows/ci.yml"
+grep -qF 'check_dark_test.sh' "$TMP_ROOT/.github/workflows/ci.yml" || fail "fixture 7 did not land"
+run && { cat "$TMP_ROOT/out" >&2; fail "a self-test certified its production gate as wired"; }
+grep -qF "check_dark.sh" "$TMP_ROOT/out" || fail "the finding did not name the gate the self-test hid"
+ok "a gate self-test does not certify its production gate as wired"
+
+# --- red 8: a DYNAMIC run must be declared, and the declaration is checked.
+reset_tree
+printf 'script="$(pick_lane)"\nbash "$script"\n' >> "$TMP_ROOT/scripts/check_direct.sh"
+grep -qF 'bash "$script"' "$TMP_ROOT/scripts/check_direct.sh" || fail "fixture 8 did not land"
+run && { cat "$TMP_ROOT/out" >&2; fail "an undeclared dynamic invocation was skipped"; }
+grep -qF "declares nothing" "$TMP_ROOT/out" || fail "the finding did not name the reason"
+ok "a dynamic run with no declaration fails rather than being skipped"
+
+reset_tree
+mkdir -p "$TMP_ROOT/lanes/x"
+printf '#!/usr/bin/env bash\nbash scripts/check_behind_dispatch.sh\n' > "$TMP_ROOT/lanes/x/go.sh"
+printf '#!/usr/bin/env bash\necho behind\n' > "$TMP_ROOT/scripts/check_behind_dispatch.sh"
+printf '# gate-wiring: reaches lanes/x/go.sh\nscript="$(pick_lane)"\nbash "$script"\n' >> "$TMP_ROOT/scripts/check_direct.sh"
+run || { cat "$TMP_ROOT/out" >&2; fail "a declared dynamic invocation was not followed"; }
+ok "a declared dynamic run resolves, and what is behind it counts as reached"
+
+reset_tree
+printf '# gate-wiring: reaches lanes/nope/go.sh\nscript="$(pick_lane)"\nbash "$script"\n' >> "$TMP_ROOT/scripts/check_direct.sh"
+run && { cat "$TMP_ROOT/out" >&2; fail "a declaration naming no file was accepted"; }
+grep -qF "names no such file" "$TMP_ROOT/out" || fail "the finding did not name the reason"
+ok "a declaration naming a file that does not exist is rejected"
+
+# --- red 9: an allowlist row with no reason is not a written admission.
+reset_tree
+printf '#!/usr/bin/env bash\necho dark\n' > "$TMP_ROOT/scripts/check_dark.sh"
+printf 'check_dark.sh\n' > "$TMP_ROOT/scripts/gate_wiring_allowlist.txt"
+run && { cat "$TMP_ROOT/out" >&2; fail "an allowlist row with no reason was accepted"; }
+grep -qF "no reason" "$TMP_ROOT/out" || fail "the finding did not name the reason"
+ok "an allowlist row with no reason is rejected"
+
 # --- red 4: a scan whose ROOTS vanish must fail, not report everything dark or
 # everything fine. An empty corpus is the shape that let five broken self-tests
 # sit green (#2252).

--- a/scripts/compiler_gate.sh
+++ b/scripts/compiler_gate.sh
@@ -71,6 +71,15 @@ for lane in "${selected[@]}"; do
   validate_lane "$lane"
 done
 
+# The lane entrypoints, declared for scripts/check_gate_wiring.sh (#2580): the
+# loop below runs a path built at RUNTIME from $lane, which a lexical scanner
+# cannot read. Rather than have it guess -- or stay silent, which is the same
+# as unchecked -- the targets are named here and the gate verifies each file
+# exists. GATE_LANES in tests/gates/lib.sh is the list these mirror.
+# gate-wiring: reaches tests/gates/bootstrap/run.sh
+# gate-wiring: reaches tests/gates/early/run.sh
+# gate-wiring: reaches tests/gates/mid/run.sh
+# gate-wiring: reaches tests/gates/late/run.sh
 for lane in "${selected[@]}"; do
   script="$(gate_lane_script "$lane")"
   if [ ! -f "$script" ]; then

--- a/tests/gates/late/run.sh
+++ b/tests/gates/late/run.sh
@@ -6003,6 +6003,13 @@ bash "$ROOT_DIR/scripts/check_gate_portability_test.sh"
 # message each mutation adds on top: block count, ja/en parity, and whether the
 # chapter's documented 42 -> 43 edit still applies. ~1s, no generation needed.
 bash "$ROOT_DIR/scripts/check_book_console_test.sh"
+# #2580: and the PRODUCTION gate, which ran nowhere in CI. Only its self-test
+# was wired here, and a self-test proves its own red/green -- not that the book
+# transcripts still match the launcher. check_gate_wiring.sh found it on its
+# first correct run, and it was RED: the launcher had grown an `at off=62`
+# line the chapter did not carry, and the paragraph under it still said the
+# report has no position at all, a gap #2202 closed.
+bash "$ROOT_DIR/scripts/check_book_console.sh"
 
 # 107/107. The host runner's `[crash debug]` dump is OFF by default (#2199).
 #      It is compiler-developer diagnostics -- heap bytes, the RC freelist, raw


### PR DESCRIPTION
Follow-up to #2591, which **merged before these fixes landed**. Codex reviewed it and left 8 findings; four were P1 and four of those were right about a gate that could report success while gates ran nowhere. #2591 is merged so it cannot carry them — hence this PR.

Fixing them found a real dark gate.

## 1. A gate self-test is not evidence (P1) — and this found one

Only `check_gate_wiring.sh`'s own self-test was excluded as an edge source. Every other `scripts/*_test.sh` names its production gate — it *runs* it against fixtures — so removing the real CI step left the self-test still naming it and the gate reported it **reached**. That is the dark-gate case itself, certified by the thing that proves nothing about CI.

**It found `check_book_console.sh`.** `tests/gates/late/run.sh` wired only `check_book_console_test.sh`; the production gate's pkf task is reachable only from `release-check`, which has no CI job. It was marked reached purely because the self-test contains `cp "$SCRIPT_DIR/check_book_console.sh"`.

A **fourth** instance of the failure #2580 exists for — and like `check_task_inputs.sh` before it, it was **red**:

```diff
        assert_eq failed
+         at off=62
          expected: 43
          actual:   42
```

The launcher had grown an `at off=62` line the book chapter did not carry, and the paragraph under the transcript still read *"The report does not yet carry a line number … (#2202)"* — a gap **#2202 closed in August**. Chapter corrected in both languages (`check-tutorial-translation-parity` green), production gate wired beside its self-test, and **the allowlist stays empty**. Parking it there would have made that file "a place gates hide", which the gate's own comment warns against.

## 2. A message is not an invocation (P1)

The edge regex accepted start-of-line plus arbitrary text, so `echo "run bash scripts/check_dark.sh"` in any reachable wrapper certified a wire. An edge now needs a **runner word**, and a line whose command **emits text** is not one — both halves are needed, since `echo "… bash …"` contains a runner word.

## 3. Dynamic runs were neither traversed nor rejected (P1)

`compiler_gate.sh` dispatches lanes as `script="$(gate_lane_script "$lane")"; bash "$script"`. Resolving that needs shell dataflow, which #2248 says does not converge — and its rule is to *remove the structure that needs it*. So the **silence** is what got removed: such a line must carry `# gate-wiring: reaches <path>` declarations in the same file, each verified to name a real file, and fails outright without them. `compiler_gate.sh` now declares its four lanes.

A dynamic `source` is deliberately not covered — it loads a library, and a library is not a gate.

## 4. `scriptTask(...)` tasks were invisible (P2)

Only `new Task { … }` was parsed, so a workflow invoking a helper-built task would have been reported as naming an **undefined task** and its script as dark. Kept lexical rather than shelling out to `pkf`: a gate that needs the task runner installed is the failure `check_gate_portability.sh` exists for.

## 5. Allowlist rows with no reason were accepted (P2)

A bare filename removed a gate from enforcement with no justification. Rejected now — the third way the allowlist goes stale loudly.

## Also

- Both tasks registered in `tasks { }` and `releaseCheck.deps` (P2 ×2). Without the first, `pkf run check-gate-wiring` **did not exist**.
- A bug of my own, caught while fixing the above: `sorted(os.walk("."))` materialises the walk before `dirnames[:]` can prune, so `_build` — which holds whole **copies** of the tree from seed rebuilds — was being scanned.

## Not fixed, stated as a boundary

The corpus is `check_*` / `lint_*`, which is what #2580 defines. The 27 `*_gate.sh` scripts are not covered — filed as #2592 rather than widened mid-change, since several would need investigation or an allowlist row each.

## Verification

20 self-test cases (six new), all green. Real tree: **41 gate scripts reachable from 10 workflows, 0 allowlisted**, stable across runs. `check-gate-portability`, `check-gate-self-tests`, `check-task-inputs`, `test_ci_compiler_gate_layout`, `check-tutorial-translation-parity`, `book-order`, `check-book-links` and `pkf run pre-commit` all ok.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q9zbiDqkfF7xYQ3v8aCQ3b

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q9zbiDqkfF7xYQ3v8aCQ3b)_