### PR TITLE
vibe symbols: refuse an argument it cannot serve, and sweep a whole tree in one process (#2381)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -444,6 +444,18 @@ CI shard では:
 ```bash
 # 宣言アウトライン (NAME KIND START END / 行)。go-to-def / outline の基盤
 vibe symbols file.vibe
+# Several paths, or a directory, are swept in ONE compiler process and every
+# line gains a leading PATH field: `PATH NAME KIND START END [DOC]` (#2381).
+# That is what makes a repo-wide rule about DECLARATIONS affordable -- one
+# process per file was ~1.08 s, so all of `lib/` took ~17 minutes; the whole
+# tree in one sweep is ~43 s. `--with-path` forces the PATH field on for a
+# single file, so a caller building the list programmatically gets one field
+# order whether the list held one entry or a thousand.
+# An unrecognised argument is REFUSED (it used to be accepted and ignored), a
+# file that cannot be parsed is NAMED on stderr while the rows that were read
+# still reach stdout, and either failure exits non-zero.
+vibe symbols lib
+vibe symbols --with-path file.vibe
 
 # カーソル位置 (1-based line,col) の識別子の推論型。hover の基盤
 vibe type-at file.vibe <line> <col>

--- a/docs/editor-and-debugging.md
+++ b/docs/editor-and-debugging.md
@@ -51,11 +51,30 @@ where it converts.
 vibe type-at <file.vibe> <line> <col>     # inferred type of the identifier at 1-based (line, BYTE col)
 vibe binding-at <file.vibe> <line> <col>  # source spans (START END byte offsets) of every occurrence of that binding
 vibe symbols <file.vibe>                  # declaration outline (NAME KIND START END [DOC] per line)
+vibe symbols <dir> | vibe symbols a.vibe b.vibe   # BATCH: one sweep, PATH NAME KIND START END [DOC] per line
+vibe symbols --with-path <file.vibe>      # force the PATH field on for a single file
 vibe symbols --legend                     # KIND NAME table (LSP SymbolKind v1, 2026-08-17)
 vibe check <file.vibe>                    # all diagnostics, one per line on stdout; empty output = clean, exit 1 if not
 vibe check --single-file <file.vibe>      # same, analysing the buffer ALONE (no FS import resolution)
 vibe check --single-file --json <file.vibe>  # same diagnostics as a JSON array of LSP Diagnostic objects (#820)
 ```
+
+- `symbols` takes **several paths, or a directory** (#2381). Each root is one
+  compiler process rather than one per file, which is what makes a repository
+  rule about declarations affordable: `lib/` is ~43 s in a single sweep, where
+  one process per file was ~1.08 s each — about 17 minutes for the same 966
+  files. Whenever the invocation can produce lines from more than one file, and
+  under `--with-path`, every line gains a leading `PATH` field so the field
+  order never depends on how many files happened to match.
+- An argument `symbols` does not recognise is **refused**. It used to be
+  accepted and ignored: `vibe symbols a.vibe b.vibe` printed `a.vibe`'s outline
+  and exited 0, and so did a typo'd flag — a complete-looking answer to a
+  question nobody asked.
+- A file that cannot be lexed or parsed is **named on stderr** and makes the
+  command exit non-zero, while the declarations that WERE read still reach
+  stdout. Aborting at the first bad file would lose the sweep (one
+  `declare`-form file under `lib/` does that to all 966); dropping it silently
+  would be a partial inventory that reads as a complete one.
 
 - `type-at` powers hover. Empty output means there is no env-visible
   identifier at that position. Field accesses resolve at BOTH positions of

--- a/docs/source-range-contract.md
+++ b/docs/source-range-contract.md
@@ -30,6 +30,7 @@ query surface passes them through unconverted. Two spellings of the same thing:
 | surface | what it reports | unit | base | interval |
 |---|---|---|---|---|
 | `vibe symbols` | `NAME KIND START END` | byte offset | 0 | half-open |
+| `vibe symbols` (batch) | `PATH NAME KIND START END` | byte offset | 0 | half-open |
 | `vibe binding-at` | `START END` per occurrence | byte offset | 0 | half-open |
 | `vibe escapes` | `NAME START END` | byte offset | 0 | half-open |
 | `vibe allocs` | `FN SITE OFFSET` | byte offset | 0 | point |

--- a/lib/@vibe/compiler/cli_adapter.vibe
+++ b/lib/@vibe/compiler/cli_adapter.vibe
@@ -48,6 +48,7 @@ import @vibe/compiler/runtime {
   set_incremental_interface_trace_enabled,
   set_incremental_typecheck_telemetry_enabled,
   set_scheduler_trace_path,
+  symbol_spans_fs_report,
   symbol_spans_with_docs,
   type_at_source
 }
@@ -367,6 +368,41 @@ fn join_symbol_spans(syms: Array[(String, Int, Int, Int, String)]) -> String {
       ()
     } else {
       let head = String::concat(name, String::concat(" ", String::concat(__to_string(kind), String::concat(" ", String::concat(__to_string(s), String::concat(" ", __to_string(e)))))))
+      let line = if String::length(doc) == 0 {
+        head
+      } else {
+        String::concat(head, String::concat(" ", escape_doc_field(doc)))
+      }
+      if first {
+        StringBuilder::push(acc, line)
+        first = false
+      } else {
+        StringBuilder::push(acc, "\n")
+        StringBuilder::push(acc, line)
+      }
+    }
+    i = i + 1
+  }
+  StringBuilder::freeze(acc)
+}
+
+/// The batch form of `join_symbol_spans` (#2381): the same fields with the
+/// source PATH prepended, one `PATH NAME KIND START END [DOC]` per
+/// declaration. The path goes FIRST because it is the field a caller groups or
+/// filters on, and it cannot contain a space in this repository's trees; DOC
+/// stays last for the reason it always was -- it is the only field that can.
+fn join_symbol_spans_with_path(rows: Array[(String, String, Int, Int, Int, String)]) -> String {
+  let n = Array::length(rows)
+  // O(N) join via StringBuilder; per-record String::concat was O(N2) (issue #366).
+  let acc = StringBuilder::new()
+  let mut first = true
+  let mut i = 0
+  while i < n {
+    let (path, name, kind, s, e, doc) = Array::get(rows, i)
+    if String::length(name) == 0 {
+      ()
+    } else {
+      let head = String::concat(path, String::concat(" ", String::concat(name, String::concat(" ", String::concat(__to_string(kind), String::concat(" ", String::concat(__to_string(s), String::concat(" ", __to_string(e)))))))))
       let line = if String::length(doc) == 0 {
         head
       } else {
@@ -1665,11 +1701,36 @@ fn cli_main_with_lanes(fs_lanes: (FsLane, String, String) -> (Bytes, String) wit
   // convention as VIBE_CHECK_ONLY below: `output_path` itself (the outline
   // wire format LSP clients parse) is untouched on failure, so this can't
   // emit a "plausible but wrong" symbol list.
+  //
+  // #2381: `VIBE_SYMBOLS_WITH_PATH=1` answers the same question over a whole
+  // TREE instead, one `PATH NAME KIND START END [DOC]` per declaration --
+  // `input_path` may then be a directory. The launcher turns it on whenever
+  // the invocation can produce lines from more than one file (several paths,
+  // or a directory) and for an explicit `--with-path`, so the field order a
+  // caller sees never depends on how many files happened to match.
   if Env::get("VIBE_SYMBOLS") == "1" {
     return handle {
-      let src = Fs::read_file(input_path)
-      let syms = symbol_spans_with_docs(src)
-      Fs::write_bytes(output_path, adapter_string_to_bytes(line_terminated(join_symbol_spans(syms))))
+      if Env::get("VIBE_SYMBOLS_WITH_PATH") == "1" {
+        let (rows, failures) = symbol_spans_fs_report(input_path)
+        Fs::write_bytes(output_path, adapter_string_to_bytes(line_terminated(join_symbol_spans_with_path(rows))))
+        // The rows that WERE read still go to stdout; the files that could not
+        // be read go to the same `.diag` sidecar a thrown Error uses, so the
+        // launcher reports them on stderr and exits non-zero. Aborting the
+        // whole sweep at the first bad file would lose the answer the batch
+        // mode exists for -- one unparseable file under `lib/` took the entire
+        // 966-file sweep with it -- and dropping it silently is the partial
+        // inventory that reads as complete.
+        if Array::length(failures) > 0 {
+          let _ = emit_compile_diag(output_path, String::join(failures, "\n"))
+          ()
+        } else {
+          ()
+        }
+      } else {
+        let src = Fs::read_file(input_path)
+        let syms = symbol_spans_with_docs(src)
+        Fs::write_bytes(output_path, adapter_string_to_bytes(line_terminated(join_symbol_spans(syms))))
+      }
       0
     } with { Exception::Throw(msg) => emit_compile_diag(output_path, msg) }
   }

--- a/lib/@vibe/compiler/compiler_sources_manifest.tsv
+++ b/lib/@vibe/compiler/compiler_sources_manifest.tsv
@@ -209,7 +209,9 @@ runtime	runtime/typecheck_fs.vibe
 runtime	runtime/type_at.vibe
 runtime	runtime/binding_at.vibe
 runtime	runtime/doc_at.vibe
+runtime	runtime/source_walk.vibe
 runtime	runtime/symbol_spans.vibe
+runtime	runtime/symbol_spans_fs.vibe
 runtime	runtime/alloc_spans.vibe
 runtime	runtime/escape_spans.vibe
 runtime	runtime/rc_query.vibe

--- a/lib/@vibe/compiler/runtime/grep_fs.vibe
+++ b/lib/@vibe/compiler/runtime/grep_fs.vibe
@@ -30,6 +30,10 @@ import @vibe/compiler/incremental {
   RippleDb, ripple_get_deps, ripple_get_fingerprint, ripple_new, ripple_set_source
 }
 
+import ./source_walk.vibe {
+  source_walk_collect_files
+}
+
 import ./grep.vibe {
   GrepTyped,
   grep_check_filters,
@@ -61,62 +65,6 @@ fn grep_fs_empty_env_cache() -> Array[(String, TypeEnv)] {
 
 fn grep_fs_empty_pairs() -> Array[(String, String)] {
   array_empty()
-}
-
-fn grep_fs_is_source_name(name: String) -> Bool {
-  String::ends_with(name, ".vibe") || String::ends_with(name, ".vibex")
-}
-
-/// Directories a recursive sweep does not descend into: build output and
-/// vendored trees are not the user's source, and walking them dominates the
-/// runtime. `deps` is where `vibe fetch` vendors packages (and, since relative
-/// imports nest, each vendored package's own `deps` under that), so the
-/// default `vibe grep ... .` would otherwise report the whole transitive
-/// dependency tree as if it were project code.
-///
-/// This only applies while RECURSING. A directory named here is still searched
-/// when the caller names it: `vibe grep --pattern '..' deps` asks for exactly
-/// that, and a skip list must not override what was asked for.
-fn grep_fs_skip_dir(name: String) -> Bool {
-  String::starts_with(name, ".") || name == "_build" || name == "node_modules" || name == "dist" || name == "target" || name == "deps"
-}
-
-fn grep_fs_join(dir: String, name: String) -> String {
-  if String::ends_with(dir, "/") {
-    String::concat(dir, name)
-  } else {
-    String::concat(dir, String::concat("/", name))
-  }
-}
-
-/// Collect the `.vibe` / `.vibex` files under `root`, in directory order. An
-/// explicitly named file is taken whatever its extension: the caller asked for
-/// that file by name.
-fn grep_fs_collect_files(root: String, out: Array[String]) -> Unit with Fs {
-  if Fs::is_dir(root) {
-    let names = Fs::readdir(root)
-    let mut i = 0
-    while i < Array::length(names) {
-      let name = Array::get(names, i)
-      let child = grep_fs_join(root, name)
-      if Fs::is_dir(child) {
-        if !grep_fs_skip_dir(name) {
-          grep_fs_collect_files(child, out)
-        } else {
-          ()
-        }
-      } else if grep_fs_is_source_name(name) {
-        Array::push(out, child)
-      } else {
-        ()
-      }
-      i = i + 1
-    }
-  } else if Fs::is_file(root) {
-    Array::push(out, root)
-  } else {
-    ()
-  }
 }
 
 /// The typed context for `path`, resolved the way `vibe check` resolves it.
@@ -221,7 +169,7 @@ export fn grep_scan_fs_report(root: String, pattern: String, wheres: Array[Strin
   let pat = grep_compile_pattern(pattern)
   grep_check_filters(pat, wheres, where_rows)
   let files = grep_empty_strings()
-  grep_fs_collect_files(root, files)
+  source_walk_collect_files(root, files)
   let typed = grep_needs_typing(wheres, where_rows, only)
   let has_typed_filter = Array::length(wheres) > 0 || Array::length(where_rows) > 0
   let out = grep_empty_strings()

--- a/lib/@vibe/compiler/runtime/index.vpkg
+++ b/lib/@vibe/compiler/runtime/index.vpkg
@@ -178,6 +178,23 @@ fn doc_at_source(source: String, line: Int, col: Int) -> String
 fn symbol_spans(source: String) -> Array[(String, Int, Int, Int)] with Exception
 fn symbol_spans_with_docs(source: String) -> Array[(String, Int, Int, Int, String)] with Exception
 
+// --- source_walk.vibe: the ONE directory walk the repo-wide query primitives
+// share. The skip policy is a user-visible answer -- two sweeps disagreeing
+// about it report different corpora for the same root -- so it has one home.
+fn source_walk_empty_paths() -> Array[String]
+fn source_walk_is_source_name(name: String) -> Bool
+fn source_walk_skip_dir(name: String) -> Bool
+fn source_walk_join(dir: String, name: String) -> String
+fn source_walk_collect_files(root: String, out: Array[String]) -> Unit with Fs
+
+// --- symbol_spans_fs.vibe (#2381): the same declaration outline over a whole
+// tree, each row carrying its path. Parse-only, like the single-file query.
+// The `_report` form returns the rows it read AND the files it could not: a
+// partial declaration inventory that does not say so reads as a complete one,
+// and aborting at the first bad file loses the sweep the mode exists for.
+fn symbol_spans_fs_report(root: String) -> (Array[(String, String, Int, Int, Int, String)], Array[String]) with Exception + Fs
+fn symbol_spans_fs(root: String) -> Array[(String, String, Int, Int, Int, String)] with Exception + Fs
+
 // --- escape_spans.vibe (#1262): the `let mut` bindings a closure captures, so
 // codegen lowers them to a heap ref cell instead of a wasm local. Calls
 // codegen's own `is_mut_captured_in`, so the answer IS the lowering decision.

--- a/lib/@vibe/compiler/runtime/source_walk.vibe
+++ b/lib/@vibe/compiler/runtime/source_walk.vibe
@@ -1,0 +1,88 @@
+//# Imports
+
+// The one directory walk the repo-wide query primitives share: `vibe grep`'s
+// filesystem tier (grep_fs.vibe) and `vibe symbols`' batch mode
+// (symbol_spans_fs.vibe).
+//
+// It is its own file because the SKIP POLICY -- which directories a recursive
+// sweep refuses to descend into -- is a user-visible answer, not an
+// implementation detail. Two sweeps that disagree about it report different
+// corpora for the same root and nothing says so, which is the silent-wrong
+// shape CLAUDE.md ranks above crashing. One policy, one place.
+//
+// Deliberately dependency-light: `Fs` and nothing else. `vibe symbols` is a
+// parse-only query, and it must not acquire the checker's FS lane
+// (typecheck_fs.vibe, which grep_fs.vibe does need) merely to enumerate files.
+
+import @vibe/core {
+  array_empty
+}
+
+//# Functions
+
+/// A fresh path accumulator for `source_walk_collect_files`.
+export fn source_walk_empty_paths() -> Array[String] {
+  array_empty()
+}
+
+/// The extensions a RECURSIVE sweep collects. A file the caller NAMES is taken
+/// whatever its extension -- naming it is the request.
+export fn source_walk_is_source_name(name: String) -> Bool {
+  String::ends_with(name, ".vibe") || String::ends_with(name, ".vibex")
+}
+
+/// Directories a recursive sweep does not descend into: build output and
+/// vendored trees are not the user's source, and walking them dominates the
+/// runtime. `deps` is where `vibe fetch` vendors packages (and, since relative
+/// imports nest, each vendored package's own `deps` under that), so a default
+/// sweep of `.` would otherwise report the whole transitive dependency tree as
+/// if it were project code.
+///
+/// This only applies while RECURSING. A directory named here is still searched
+/// when the caller names it: `vibe grep ... deps` asks for exactly that, and a
+/// skip list must not override what was asked for.
+export fn source_walk_skip_dir(name: String) -> Bool {
+  String::starts_with(name, ".") || name == "_build" || name == "node_modules" || name == "dist" || name == "target" || name == "deps"
+}
+
+export fn source_walk_join(dir: String, name: String) -> String {
+  if String::ends_with(dir, "/") {
+    String::concat(dir, name)
+  } else {
+    String::concat(dir, String::concat("/", name))
+  }
+}
+
+/// Collect the `.vibe` / `.vibex` files under `root` into `out`, in directory
+/// order. `Fs::readdir` returns byte-sorted names, so the result is
+/// deterministic for a given tree -- a gate can diff it.
+///
+/// A root that is neither a directory nor a file contributes nothing. Callers
+/// that must distinguish "empty" from "not there" check the root themselves;
+/// the CLI launchers do, before reaching here.
+export fn source_walk_collect_files(root: String, out: Array[String]) -> Unit with Fs {
+  if Fs::is_dir(root) {
+    let names = Fs::readdir(root)
+    let mut i = 0
+    while i < Array::length(names) {
+      let name = Array::get(names, i)
+      let child = source_walk_join(root, name)
+      if Fs::is_dir(child) {
+        if !source_walk_skip_dir(name) {
+          source_walk_collect_files(child, out)
+        } else {
+          ()
+        }
+      } else if source_walk_is_source_name(name) {
+        Array::push(out, child)
+      } else {
+        ()
+      }
+      i = i + 1
+    }
+  } else if Fs::is_file(root) {
+    Array::push(out, root)
+  } else {
+    ()
+  }
+}

--- a/lib/@vibe/compiler/runtime/symbol_spans_fs.vibe
+++ b/lib/@vibe/compiler/runtime/symbol_spans_fs.vibe
@@ -1,0 +1,113 @@
+//# Imports
+
+// `vibe symbols` over a whole tree (#2381).
+//
+// symbol_spans.vibe answers for ONE source string. That is the right shape for
+// an editor, and the wrong one for a repository rule: one process per file
+// costs ~1.08 s, so the 966 `.vibe` files under `lib/` took ~17 minutes and any
+// rule of the form "no file in `lib/**` may declare X" was written as a lexical
+// shell scan instead -- which is exactly what CLAUDE.md's recurrence-prevention
+// policy routes people away from. #2380 shipped such a scan and paid for it:
+// an anchored `^(export )?fn` regex missed four real declarations.
+//
+// So this file walks the tree ONCE inside the compiler and returns every
+// declaration with the path it came from. It is parse-only, like the
+// single-file query: no import resolution, no checker, one parse per file.
+//
+// A file that does not parse is REPORTED, not skipped. `vibe grep` skips it
+// with a warning and still exits 0, because a sweep for matches is meaningful
+// over the files that did parse. A DECLARATION INVENTORY is not: a caller
+// asking "does anything under lib/ declare X" would read a short answer as
+// "no", which is the same under-selection `vibe deps` refuses for a truncated
+// import closure.
+//
+// But aborting at the first bad file is not the answer either -- measured, one
+// unparseable file (`builtins/declarations.vibe`, whose `declare` form
+// symbol_spans does not accept) took the whole `lib/` sweep with it, which is
+// the one call the batch mode exists for. So the split is: every declaration
+// that WAS read comes back, every file that could not be read comes back too,
+// and the caller is told which is which. The CLI puts the rows on stdout, the
+// failures on stderr, and exits non-zero -- the same shape as `vibe check`.
+
+import @vibe/core {
+  array_empty
+}
+
+import ./source_walk.vibe {
+  source_walk_collect_files, source_walk_empty_paths
+}
+
+import ./symbol_spans.vibe {
+  symbol_spans_with_docs
+}
+
+//# Functions
+
+fn symbols_fs_empty_rows() -> Array[(String, String, Int, Int, Int, String)] {
+  array_empty()
+}
+
+fn symbols_fs_empty_syms() -> Array[(String, Int, Int, Int, String)] {
+  array_empty()
+}
+
+/// Every declaration under `root`, one row per declaration, each carrying the
+/// path it came from: `(path, name, kind, start, end, doc)`, PLUS one message
+/// per file that could not be read. The five span fields are exactly what
+/// `symbol_spans_with_docs` returns for that file, so the batch answer and the
+/// single-file answer cannot drift.
+///
+/// `root` may be a file or a directory; a directory is walked recursively with
+/// source_walk.vibe's shared skip policy. Files come back in byte-sorted
+/// directory order and declarations in source order, so the whole result is
+/// deterministic for a given tree.
+///
+/// A non-empty second element means the inventory is INCOMPLETE. It is never
+/// empty silently: see the header note.
+export fn symbol_spans_fs_report(root: String) -> (Array[(String, String, Int, Int, Int, String)], Array[String]) with Exception + Fs {
+  let files = source_walk_empty_paths()
+  source_walk_collect_files(root, files)
+  let out = symbols_fs_empty_rows()
+  let failures = source_walk_empty_paths()
+  let mut i = 0
+  while i < Array::length(files) {
+    let path = Array::get(files, i)
+    let source = Fs::read_file(path)
+    // Recording the failure and reading it after the handle keeps the arm's
+    // own effect row explicit; the message names the file either way.
+    let mut failed = false
+    let mut failure = ""
+    let syms = handle {
+      symbol_spans_with_docs(source)
+    } with { Exception::Throw(msg) => {
+      failed = true
+      failure = msg
+      symbols_fs_empty_syms()
+    } }
+    if failed {
+      Array::push(failures, String::concat(path, String::concat(": ", failure)))
+    } else {
+      let mut j = 0
+      while j < Array::length(syms) {
+        let (name, kind, s, e, doc) = Array::get(syms, j)
+        Array::push(out, (path, name, kind, s, e, doc))
+        j = j + 1
+      }
+    }
+    i = i + 1
+  }
+  (out, failures)
+}
+
+/// Result-only wrapper for callers that want the sweep to be all-or-nothing.
+/// The CLI uses `symbol_spans_fs_report` so it can print the rows it did read
+/// alongside the files it could not.
+export fn symbol_spans_fs(root: String) -> Array[(String, String, Int, Int, Int, String)] with Exception + Fs {
+  let (rows, failures) = symbol_spans_fs_report(root)
+  if Array::length(failures) > 0 {
+    throw(Array::get(failures, 0))
+  } else {
+    ()
+  }
+  rows
+}

--- a/lib/@vibe/compiler/runtime/symbol_spans_fs_test.vibe
+++ b/lib/@vibe/compiler/runtime/symbol_spans_fs_test.vibe
@@ -1,0 +1,131 @@
+//# Imports
+
+// Batch `vibe symbols` (#2381). Lives next to symbol_spans_fs.vibe because it
+// needs `Fs`; symbol_spans_test.vibe stays on the pure source-string seam.
+
+import ./symbol_spans_fs.vibe {
+  symbol_spans_fs, symbol_spans_fs_report
+}
+
+import ./source_walk.vibe {
+  source_walk_collect_files, source_walk_empty_paths, source_walk_skip_dir
+}
+
+import @vibe/core {
+  inspect
+}
+
+//# Functions
+
+/// `PATH NAME KIND` per row, one row per line -- the fields a reader of this
+/// file can check by eye. The two offsets are symbol_spans' own answer and are
+/// pinned by symbol_spans_test.vibe, so repeating them here would only couple
+/// this file to unrelated edits.
+fn rows_text(rows: Array[(String, String, Int, Int, Int, String)]) -> String {
+  let acc = StringBuilder::new()
+  let mut i = 0
+  while i < Array::length(rows) {
+    let (path, name, kind, _, _, _) = Array::get(rows, i)
+    StringBuilder::push(acc, String::concat(path, String::concat(" ", String::concat(name, String::concat(" ", String::concat(__to_string(kind), "\n"))))))
+    i = i + 1
+  }
+  StringBuilder::freeze(acc)
+}
+
+/// `inspect` renders a Bool as 1/0; the policy reads better as yes/no.
+fn yn(b: Bool) -> String {
+  if b {
+    "yes"
+  } else {
+    "no"
+  }
+}
+
+fn lines_text(lines: Array[String]) -> String {
+  let acc = StringBuilder::new()
+  let mut i = 0
+  while i < Array::length(lines) {
+    StringBuilder::push(acc, String::concat(Array::get(lines, i), "\n"))
+    i = i + 1
+  }
+  StringBuilder::freeze(acc)
+}
+
+//# Tests
+
+test "symbol_spans_fs_report: a directory sweep carries the path and descends" {
+  let dir = "_build/vibe_symbols_fs_sweep"
+  Fs::mkdir_p(String::concat(dir, "/sub"))
+  Fs::write_file(String::concat(dir, "/a.vibe"), "export struct Point { x: Int }\n")
+  Fs::write_file(String::concat(dir, "/b.vibe"), "export let zero = 0\n")
+  Fs::write_file(String::concat(dir, "/sub/c.vibe"), "export fn deep() -> Int { 1 }\n")
+  // A non-source file in the same directory must not appear.
+  Fs::write_file(String::concat(dir, "/notes.txt"), "export let ghost = 1\n")
+  let (rows, failures) = symbol_spans_fs_report(dir)
+  inspect(rows_text(rows), "_build/vibe_symbols_fs_sweep/a.vibe Point 23\n_build/vibe_symbols_fs_sweep/b.vibe zero 13\n_build/vibe_symbols_fs_sweep/sub/c.vibe deep 12\n")
+  inspect(Array::length(failures), "0")
+}
+
+test "symbol_spans_fs_report: an unparseable file is reported, and the rest still come back" {
+  // The unparseable file sorts FIRST, so a sweep that aborted on it would
+  // return nothing at all -- which is what one `declare`-using file under
+  // `lib/` did to all 966 before this shape.
+  let dir = "_build/vibe_symbols_fs_partial"
+  Fs::mkdir_p(dir)
+  Fs::write_file(String::concat(dir, "/a_broken.vibe"), "export fn broken( {\n")
+  Fs::write_file(String::concat(dir, "/b_good.vibe"), "export let kept = 1\n")
+  let (rows, failures) = symbol_spans_fs_report(dir)
+  inspect(rows_text(rows), "_build/vibe_symbols_fs_partial/b_good.vibe kept 13\n")
+  inspect(lines_text(failures), "_build/vibe_symbols_fs_partial/a_broken.vibe: expected parameter name, got '{' at #4\n")
+}
+
+test "symbol_spans_fs: a single named file is a root too" {
+  let dir = "_build/vibe_symbols_fs_one"
+  Fs::mkdir_p(dir)
+  let path = String::concat(dir, "/only.vibe")
+  Fs::write_file(path, "export fn one() -> Int { 1 }\n")
+  inspect(rows_text(symbol_spans_fs(path)), "_build/vibe_symbols_fs_one/only.vibe one 12\n")
+}
+
+test "symbol_spans_fs: the all-or-nothing wrapper throws, naming the file" {
+  let dir = "_build/vibe_symbols_fs_throws"
+  Fs::mkdir_p(dir)
+  Fs::write_file(String::concat(dir, "/bad.vibe"), "export fn broken( {\n")
+  let msg = handle {
+    let _ = symbol_spans_fs(dir)
+    "no throw"
+  } with { Exception::Throw(m) => m }
+  inspect(msg, "_build/vibe_symbols_fs_throws/bad.vibe: expected parameter name, got '{' at #4")
+}
+
+test "source_walk_collect_files: build and vendor directories are not descended into" {
+  let dir = "_build/vibe_source_walk_skip"
+  Fs::mkdir_p(String::concat(dir, "/node_modules"))
+  Fs::mkdir_p(String::concat(dir, "/deps"))
+  Fs::mkdir_p(String::concat(dir, "/src"))
+  Fs::write_file(String::concat(dir, "/node_modules/vendored.vibe"), "let a = 1\n")
+  Fs::write_file(String::concat(dir, "/deps/pkg.vibe"), "let b = 1\n")
+  Fs::write_file(String::concat(dir, "/src/own.vibe"), "let c = 1\n")
+  let files = source_walk_empty_paths()
+  source_walk_collect_files(dir, files)
+  inspect(lines_text(files), "_build/vibe_source_walk_skip/src/own.vibe\n")
+}
+
+test "source_walk_collect_files: a NAMED skip directory is still swept" {
+  // The skip list applies while recursing, never to what the caller asked for.
+  let dir = "_build/vibe_source_walk_named"
+  Fs::mkdir_p(String::concat(dir, "/deps"))
+  Fs::write_file(String::concat(dir, "/deps/pkg.vibe"), "let b = 1\n")
+  let files = source_walk_empty_paths()
+  source_walk_collect_files(String::concat(dir, "/deps"), files)
+  inspect(lines_text(files), "_build/vibe_source_walk_named/deps/pkg.vibe\n")
+}
+
+test "source_walk_skip_dir: the policy itself" {
+  inspect(yn(source_walk_skip_dir("_build")), "yes")
+  inspect(yn(source_walk_skip_dir(".git")), "yes")
+  inspect(yn(source_walk_skip_dir("node_modules")), "yes")
+  inspect(yn(source_walk_skip_dir("deps")), "yes")
+  inspect(yn(source_walk_skip_dir("lib")), "no")
+  inspect(yn(source_walk_skip_dir("dependencies")), "no")
+}

--- a/runtime/vibe
+++ b/runtime/vibe
@@ -54,7 +54,8 @@
 #   vibe type-at <file.vibe> <line> <col> print the inferred type at a position
 #   vibe doc-at  <file.vibe> <line> <col> print the `///` doc comment at a position (#854)
 #   vibe binding-at <file.vibe> <line> <col> print binding occurrence spans (START END per line)
-#   vibe symbols <file.vibe>              print declaration outline (NAME KIND START END [DOC] per line)
+#   vibe symbols [--with-path] <path>...  print declaration outline (NAME KIND START END [DOC] per line;
+#                                       a directory / several paths / --with-path prefix each line with PATH)
 #   vibe symbols --legend                 print KIND NAME table (LSP SymbolKind v1, 2026-08-17)
 #   vibe escapes [--strict] <file.vibe>   print the `let mut` bindings a closure
 #                                         captures -- the ones codegen boxes into
@@ -198,7 +199,7 @@ VIBE_SELECTOR_ORDER="VIBE_LSP VIBE_CHECK_ONLY VIBE_COVERAGE
   VIBE_PUBLISH_CHECK VIBE_MODULE_JOB_DIR VIBE_PUBLISH_ENV_CACHE
   VIBE_LIST_DEPS VIBE_MODULE_PLAN VIBE_REPIN VIBE_FS_COMPILE VIBE_FMT
   VIBE_NORMALIZE VIBE_INSPECT_UPDATE VIBE_TYPE_AT VIBE_DOC_AT
-  VIBE_BINDING_AT VIBE_SYMBOLS VIBE_ESCAPES VIBE_ESCAPES_STRICT
+  VIBE_BINDING_AT VIBE_SYMBOLS VIBE_SYMBOLS_WITH_PATH VIBE_ESCAPES VIBE_ESCAPES_STRICT
   VIBE_RC_CLASSIFY VIBE_RC_PLAN VIBE_ALLOCS VIBE_DEPS VIBE_DEPS_DIRECT
   VIBE_GREP VIBE_GREP_JSON VIBE_DIAGNOSTICS VIBE_DIAGNOSTICS_JSON
   VIBE_EMIT_COVERAGE_DRIVER_SOURCE VIBE_EMIT_MERGED_SOURCE VIBE_EMIT_WIT
@@ -1502,10 +1503,10 @@ case "$cmd" in
     if [ -s "$out" ]; then cat "$out"; fi
     ;;
   symbols)
-    # vibe symbols <file.vibe>
+    # vibe symbols [--with-path] <file.vibe|dir>...
     # vibe symbols --legend
     # Print the declaration outline, one `NAME KIND START END [DOC]` per line
-    # (KIND = LSP SymbolKind int, START/END = char offsets of the name).
+    # (KIND = LSP SymbolKind int, START/END = byte offsets of the name).
     # AST-accurate (no line-regex scan): handles multi-line decls and
     # module-nested symbols. Empty output means the file declares no top-level
     # symbols. Powers LSP document-outline / go-to-definition.
@@ -1516,6 +1517,20 @@ case "$cmd" in
     # contain spaces, so `cut -d" " -f1-4` still reads the fixed part. Inside
     # it a newline is the two characters `\n` and a backslash is doubled, so
     # one declaration is always one line.
+    #
+    # BATCH (#2381): several paths, or a directory, are swept in ONE compiler
+    # process each and every line gains a leading PATH field:
+    # `PATH NAME KIND START END [DOC]`. That is what makes a repo-wide rule
+    # affordable -- one process per file cost ~1.08 s, so `lib/` took ~17
+    # minutes and rules about declarations got written as shell regex instead.
+    # `--with-path` forces the PATH field on for a single file, so a caller
+    # building the path list programmatically gets ONE field order whether the
+    # list ended up with one entry or a hundred.
+    #
+    # An unrecognised argument is REFUSED. It used to be accepted and ignored:
+    # `vibe symbols a.vibe b.vibe` printed a.vibe's symbols and exited 0, and
+    # so did a typo'd flag -- a confident, complete-looking answer to a
+    # question nobody asked (#2381).
     # `--legend` prints the versioned KIND table (v1 / 2026-08-17): one
     # `KIND NAME` per line, no decoration, never empty. `--help`/`-h` print
     # usage plus a pointer at that table. Neither flag changes the file
@@ -1536,41 +1551,74 @@ case "$cmd" in
         ;;
       --help|-h)
         printf '%s\n' \
-          'usage: vibe symbols <file.vibe>' \
+          'usage: vibe symbols [--with-path] <file.vibe|dir>...' \
           '       vibe symbols --legend' \
           'Prints NAME KIND START END [DOC] per declaration.' \
+          'With several paths, a directory, or --with-path, each line gains a leading PATH field.' \
           'DOC is the `///` doc comment, omitted when there is none; newlines in it are escaped as \n.' \
           'KIND integers are LSP SymbolKind; print the table with `vibe symbols --legend`.'
         exit 0
         ;;
     esac
-    [ "$#" -ge 1 ] || die "usage: vibe symbols <file.vibe>"
-    src="$1"
-    [ -f "$src" ] || die "not found: $src"
+    sym_with_path=0
+    sym_paths=()
+    while [ "$#" -gt 0 ]; do
+      case "$1" in
+        --with-path) sym_with_path=1; shift ;;
+        --) shift; while [ "$#" -gt 0 ]; do sym_paths+=("$1"); shift; done ;;
+        -*) die "symbols: unknown flag: $1 (see \`vibe symbols --help\`)" ;;
+        *) sym_paths+=("$1"); shift ;;
+      esac
+    done
+    [ "${#sym_paths[@]}" -ge 1 ] || die "usage: vibe symbols [--with-path] <file.vibe|dir>..."
+    # More than one root, or a directory root, can produce lines from more than
+    # one file -- so the PATH field is not optional there.
+    [ "${#sym_paths[@]}" -eq 1 ] || sym_with_path=1
+    for sym_path in "${sym_paths[@]}"; do
+      [ -e "$sym_path" ] || die "not found: $sym_path"
+      if [ -d "$sym_path" ]; then sym_with_path=1; fi
+    done
     # Use the portable .wasm (not the AOT .cwasm): the recovering-parser path
     # trapped under the precompiled image on some hosts, and these LSP queries
     # are latency-amortized, so prefer correctness.
     cli="$CLI_WASM"; [ -f "$cli" ] || cli="$(pick_cli)"
     out="$(mktemp -t vibe-symbols-XXXXXX)"
     trap 'rm -f "$out" "$out.diag"' EXIT
-    # Clear any inherited compile-mode envs so this query can't be diverted to the
-    # compile path (which would emit wasm bytes instead of the symbol list).
-    env $(selector_clears_before VIBE_SYMBOLS) -u VIBE_FS_COMPILE -u VIBE_DIAGNOSTICS -u VIBE_NORMALIZE -u VIBE_FMT -u VIBE_TYPE_AT -u VIBE_DOC_AT \
-        -u VIBE_BINDING_AT -u VIBE_ESCAPES -u VIBE_ESCAPES_STRICT -u VIBE_ALLOCS -u VIBE_COVERAGE -u VIBE_DEBUG -u VIBE_DEBUG_BREAK \
-        -u VIBE_EMIT_MODULE_SOURCE \
-      VIBE_SYMBOLS=1 \
-      VIBE_IMPORT_ABI=raw \
-      "$RUNNER" "$cli" "$src" "$out" >/dev/null 2>&1 || true
-    # #946: a lex/parse error crashing `symbol_spans` used to leave `$out`
-    # empty with no way to tell that apart from "genuinely no symbols" (both
-    # looked identical to a caller). The adapter now routes a thrown Error to
-    # `$out.diag` (same sidecar convention as `check)` below) instead of
-    # `$out` itself, so stdout here stays a pure outline (no risk of a
-    # "plausible but wrong" symbol line) while stderr surfaces the failure.
-    if [ -s "$out.diag" ]; then
-      echo "error: $(cat "$out.diag")" >&2
-    fi
-    if [ -s "$out" ]; then cat "$out"; fi
+    sym_status=0
+    for sym_path in "${sym_paths[@]}"; do
+      : >"$out"; rm -f "$out.diag"
+      # Clear any inherited compile-mode envs so this query can't be diverted to the
+      # compile path (which would emit wasm bytes instead of the symbol list).
+      env $(selector_clears_before VIBE_SYMBOLS) -u VIBE_FS_COMPILE -u VIBE_DIAGNOSTICS -u VIBE_NORMALIZE -u VIBE_FMT -u VIBE_TYPE_AT -u VIBE_DOC_AT \
+          -u VIBE_BINDING_AT -u VIBE_ESCAPES -u VIBE_ESCAPES_STRICT -u VIBE_ALLOCS -u VIBE_COVERAGE -u VIBE_DEBUG -u VIBE_DEBUG_BREAK \
+          -u VIBE_EMIT_MODULE_SOURCE \
+        VIBE_SYMBOLS=1 \
+        VIBE_SYMBOLS_WITH_PATH="$sym_with_path" \
+        VIBE_IMPORT_ABI=raw \
+        "$RUNNER" "$cli" "$sym_path" "$out" >/dev/null 2>&1 || true
+      # #946: a lex/parse error crashing `symbol_spans` used to leave `$out`
+      # empty with no way to tell that apart from "genuinely no symbols" (both
+      # looked identical to a caller). The adapter now routes a thrown Error to
+      # `$out.diag` (same sidecar convention as `check)` below) instead of
+      # `$out` itself, so stdout here stays a pure outline (no risk of a
+      # "plausible but wrong" symbol line) while stderr surfaces the failure.
+      #
+      # #2381: and the EXIT CODE now says so too. Reporting the failure on
+      # stderr while exiting 0 is the same defect as accepting an argument and
+      # ignoring it: a caller testing `$?` is told the outline is complete.
+      #
+      # #2381: and the batch lane puts one line per UNREADABLE FILE there,
+      # while stdout still carries every declaration it did read. A sweep that
+      # aborted at the first bad file would lose the whole answer -- one file
+      # under `lib/` does that to all 966 -- and one that dropped it silently
+      # would be the partial inventory that reads as complete.
+      if [ -s "$out.diag" ]; then
+        sed 's/^/error: /' "$out.diag" >&2
+        sym_status=1
+      fi
+      if [ -s "$out" ]; then cat "$out"; fi
+    done
+    exit "$sym_status"
     ;;
   escapes)
     # vibe escapes [--strict] <file.vibe>

--- a/scripts/test_vibe_symbols.sh
+++ b/scripts/test_vibe_symbols.sh
@@ -129,6 +129,99 @@ else
   bad "symbols should find add/adds/once/Show/Point+impl; got: $out_tb"
 fi
 
+# --- #2381: arguments are no longer accepted and ignored --------------------
+# Every case below used to print a.vibe's outline and exit 0, so a caller who
+# believed they had asked about two files -- or who typo'd a flag -- got a
+# confident, complete-looking answer to a different question.
+a1="$WORK/args_a.vibe"; printf 'export let alpha = 1\n' > "$a1"
+a2="$WORK/args_b.vibe"; printf 'export let beta = 1\n'  > "$a2"
+
+if out_bad="$("$VIBE" symbols "$a1" --bogus-flag 2>&1)"; then
+  bad "symbols must refuse an unknown flag; it exited 0 with: $out_bad"
+else
+  case "$out_bad" in
+    *"unknown flag: --bogus-flag"*) ok "symbols refuses an unknown flag" ;;
+    *) bad "symbols refused, but not about the flag: $out_bad" ;;
+  esac
+fi
+
+if out_missing="$("$VIBE" symbols "$a1" /nonexistent/path.vibe 2>&1)"; then
+  bad "symbols must refuse a path that does not exist; it exited 0 with: $out_missing"
+else
+  case "$out_missing" in
+    *"not found: /nonexistent/path.vibe"*) ok "symbols refuses a path that does not exist" ;;
+    *) bad "symbols refused, but not about the missing path: $out_missing" ;;
+  esac
+fi
+
+# --- #2381: batch mode ------------------------------------------------------
+# Two paths answer about BOTH, and every line names the file it came from.
+out_two="$("$VIBE" symbols "$a1" "$a2")"
+if printf '%s\n' "$out_two" | grep -qE "^$a1 alpha 13 [0-9]+ [0-9]+$" \
+   && printf '%s\n' "$out_two" | grep -qE "^$a2 beta 13 [0-9]+ [0-9]+$"; then
+  ok "symbols over two files answers about both, PATH-prefixed"
+else
+  bad "symbols over two files should report alpha and beta with paths; got: $out_two"
+fi
+
+# A directory is swept recursively, and a non-source file in it is not read.
+bd="$WORK/batchdir"; mkdir -p "$bd/sub"
+printf 'export let top = 1\n'          > "$bd/top.vibe"
+printf 'export let nested = 1\n'       > "$bd/sub/nested.vibe"
+printf 'export let ghost = 1\n'        > "$bd/notes.txt"
+out_dir="$("$VIBE" symbols "$bd")"
+if printf '%s\n' "$out_dir" | grep -qE "^$bd/top.vibe top 13 " \
+   && printf '%s\n' "$out_dir" | grep -qE "^$bd/sub/nested.vibe nested 13 " \
+   && ! printf '%s\n' "$out_dir" | grep -q 'ghost'; then
+  ok "symbols over a directory descends and reads only source files"
+else
+  bad "symbols over a directory should find top and nested but not ghost; got: $out_dir"
+fi
+
+# The field order must not depend on how many files matched: --with-path forces
+# the PATH column on for a caller whose computed list happens to hold one entry.
+out_one="$("$VIBE" symbols --with-path "$a1")"
+if printf '%s\n' "$out_one" | grep -qE "^$a1 alpha 13 [0-9]+ [0-9]+$"; then
+  ok "symbols --with-path prefixes a single file too"
+else
+  bad "symbols --with-path should prefix the path; got: $out_one"
+fi
+
+# ... and one bare path still emits exactly the four fields it always did.
+out_plain="$("$VIBE" symbols "$a1")"
+if printf '%s\n' "$out_plain" | grep -qE '^alpha 13 [0-9]+ [0-9]+$'; then
+  ok "symbols on one named file keeps the un-prefixed format"
+else
+  bad "symbols on one file should stay NAME KIND START END; got: $out_plain"
+fi
+
+# --- #2381: a failure is reported AND says so in the exit code --------------
+# The unparseable file sorts first, so a sweep that aborted on it would return
+# nothing; one that dropped it silently would be a partial inventory reading as
+# a complete one. Both halves are asserted: the good rows AND the named failure.
+pd="$WORK/partialdir"; mkdir -p "$pd"
+printf 'export fn broken( {\n'  > "$pd/a_broken.vibe"
+printf 'export let kept = 1\n' > "$pd/b_good.vibe"
+p_out="$WORK/partial.out"; p_err="$WORK/partial.err"
+if "$VIBE" symbols "$pd" >"$p_out" 2>"$p_err"; then
+  bad "symbols must exit non-zero when a file could not be read"
+else
+  if grep -qE "^$pd/b_good.vibe kept 13 " "$p_out" \
+     && grep -q "a_broken.vibe" "$p_err"; then
+    ok "symbols reports the readable rows, names the unreadable file, and exits non-zero"
+  else
+    bad "symbols partial sweep: out=[$(cat "$p_out")] err=[$(cat "$p_err")]"
+  fi
+fi
+
+# The single-file lane says it failed in the exit code too (it used to print
+# the error on stderr and exit 0).
+if "$VIBE" symbols "$pd/a_broken.vibe" >/dev/null 2>&1; then
+  bad "symbols on an unparseable file must exit non-zero"
+else
+  ok "symbols on an unparseable file exits non-zero"
+fi
+
 echo "----"
 echo "passed: $pass, failed: $fail"
 [ "$fail" -eq 0 ]


### PR DESCRIPTION
Closes #2381. Two halves of one P0, both the same shape: a confident, complete-looking answer to a question nobody asked.

## 1. Extra arguments were accepted and ignored, exit 0

```console
$ vibe symbols a.vibe b.vibe          # printed a.vibe's symbols only
$ echo $?
0
$ vibe symbols a.vibe --bogus-flag    # same
$ echo $?
0
```

The arm now parses its arguments. An unknown flag and a path that does not exist are both refused, and `--help` lists what is accepted.

## 2. There was no way to ask about many files

One process per file cost ~1.08 s, so the 966 `.vibe` files under `lib/` took ~17 minutes. That is why #2380 shipped `check_builtin_shadowing.sh` as a lexical shell scan — the thing CLAUDE.md's recurrence-prevention policy routes people away from — and its anchored `^(export )?fn` regex missed four real declarations (`export let Fs::exists = exists` and three siblings).

`vibe symbols` now takes **several paths, or a directory**, and sweeps each root in ONE compiler process:

```console
$ time vibe symbols lib
...
real    0m43.413s
$ wc -l < out            # 25886 declarations
$ awk '{print $1}' out | sort -u | wc -l   # 998 files
```

Every line carries the file it came from: `PATH NAME KIND START END [DOC]`. The PATH field appears whenever the invocation can produce lines from more than one file, and `--with-path` forces it on for a single file — so a caller building the list programmatically gets **one** field order whether the list ended up with one entry or a thousand. One bare path is unchanged: exactly the four (or five) fields it always emitted.

## A partial inventory that does not say so reads as a complete one

The first shape of this aborted on the first unparseable file, and `lib/@vibe/compiler/builtins/declarations.vibe` — whose `declare` form the general parser rejects **by design**, since that file is read by the binary encoder rather than compiled — took all 966 files with it. Skipping it silently the way `vibe grep` does is worse for this query: a caller asking "does anything under `lib/` declare X" reads a short answer as "no".

So the sweep reports both halves. The declarations it read go to stdout, the files it could not read are **named on stderr**, and the command exits non-zero — the same shape as `vibe check`:

```console
$ vibe symbols lib > out
error: lib/@vibe/compiler/builtins/declarations.vibe: 'declare' is not supported
$ echo $?
1
$ wc -l < out
25886
```

The single-file lane now exits non-zero on a failure too. It used to print the error on stderr and exit 0, which is the same defect as accepting an argument and ignoring it: a caller testing `$?` is told the outline is complete.

## One directory walk, not two

`vibe grep`'s filesystem tier had the only source-tree walk, and its skip policy (`_build`, `node_modules`, `deps`, …) was private to it. Two sweeps that disagree about that policy report different corpora for the same root and nothing says so, so it moved to `runtime/source_walk.vibe` and `grep_fs.vibe` now calls it. `Fs::readdir` is byte-sorted, so a sweep is deterministic and a gate can diff it. Deliberately dependency-light: `vibe symbols` is a parse-only query and must not acquire the checker's FS lane (`typecheck_fs.vibe`, which `grep_fs.vibe` does need) merely to enumerate files.

## Verification

- **`scripts/test_vibe_symbols.sh`: 17 cases (8 new), all green** against a fresh `install/install.sh` build — unknown flag, missing path, two files, a directory that descends and reads only source files, `--with-path`, the un-prefixed single-file format, the partial sweep (readable rows AND the named failure AND the non-zero exit), and the single-file exit code.
- **`lib/@vibe/compiler/runtime/symbol_spans_fs_test.vibe`: 7 unit tests**, including the skip policy and a *named* skip directory still being swept (the skip list applies while recursing, never to what the caller asked for).
- `check-selector-precedence`, `check-cli-line-termination`, `check-source-range-contract`, `check-doc-commands`, `check-gate-wiring`, `check-gate-portability`, `check-gate-self-tests`, `check-freeze-surface`, `check-package-sibling-scope`, and `check-vibe-fmt` on every touched file: ok.
- `vibe grep` re-measured after the walker move — both the sweep and the skip policy.

Docs updated: `AGENTS.md` (`CLAUDE.md`), `docs/editor-and-debugging.md`, `docs/source-range-contract.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q9zbiDqkfF7xYQ3v8aCQ3b

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q9zbiDqkfF7xYQ3v8aCQ3b)_