### PR TITLE
loader: a compiler sibling missing from the manifest now names the manifest (#2573)

### DIFF
--- a/lib/@vibe/compiler/loader/manifest_sources.vibe
+++ b/lib/@vibe/compiler/loader/manifest_sources.vibe
@@ -1148,6 +1148,41 @@ export fn probe_manifest_scan_paths_count(entry_path: String) -> Int with Except
 
 //# Source collection
 
+/// #2573: a needed path INSIDE the manifest's own tree that the manifest does
+/// not list.
+///
+/// The build reads the compiler's sources from `compiler_sources_manifest.tsv`,
+/// so an unlisted sibling never enters the ripple db at all. `step_module_fs`
+/// then answers `missing:<path>` for it, its importer folds that
+/// pseudo-fingerprint, and the failure surfaced three layers away as
+/// `type_db: missing resolved dependency environment: <the sibling>` -- an
+/// infrastructure message that names neither the manifest nor the rule in
+/// docs/adding-modules.md, and that points at the one file which is fine.
+/// Measured on #2569: it cost a full investigation of the module planner and
+/// the persistent caches before the manifest turned up, and a trivial sibling
+/// with no imports fails identically, so the content is irrelevant.
+///
+/// Only a path inside `base_dir` is judged. Whatever the manifest reaches
+/// outside its own tree is listed with a `../` row, which `join_path`
+/// normalizes into the index; and a generated `_build/` types stub (#1840) is
+/// never a row -- `load_planned_module_source` reads it from disk.
+fn verify_manifest_needed_paths(base_dir: String, manifest_path: String, manifest_path_index: Map[String, Bool], needed_paths: Array[String]) -> Unit with Exception {
+  let prefix = String::concat(base_dir, "/")
+  let tab = String::from_char_code(9)
+  let mut i = 0
+  while i < Array::length(needed_paths) {
+    let path = Array::get(needed_paths, i)
+    let inside = String::starts_with(path, prefix)
+    if inside && !Map::has_key(manifest_path_index, path) && !is_manifest_external_terminal_dep(path) {
+      let rel = path[String::length(prefix): String::length(path)]
+      throw("add a row `<group>" + tab + rel + "` to " + manifest_path + ": " + path + " is imported from inside the compiler tree but is not listed there, so the build never reads it." + " Use the group the rows for its directory already use (docs/adding-modules.md, \"Only when the compiler consumes it\").")
+    } else {
+      ()
+    }
+    i = i + 1
+  }
+}
+
 export fn try_collect_manifest_sources_fs(entry_path: String) -> Option[(String, Array[(String, String)])] with Exception + Fs {
   match try_load_manifest_rows(entry_path) {
     Some((base_dir, rows)) => {
@@ -1155,6 +1190,7 @@ export fn try_collect_manifest_sources_fs(entry_path: String) -> Option[(String,
       let manifest_path_index = build_manifest_path_index_from_rows(base_dir, rows)
       let header_rows = load_or_collect_manifest_header_rows(entry_path, manifest_path, manifest_path_index)
       let needed_paths = collect_needed_paths_from_manifest_headers(entry_path, manifest_path_index, header_rows)
+      verify_manifest_needed_paths(base_dir, manifest_path, manifest_path_index, needed_paths)
       let needed_path_index = build_manifest_path_index(needed_paths)
       let sources = load_manifest_sources_by_path_index(base_dir, rows, needed_path_index)
       Some((manifest_path, sources))
@@ -1170,6 +1206,7 @@ export fn try_collect_manifest_source_groups_fs(entry_path: String) -> Option[(S
       let manifest_path_index = build_manifest_path_index_from_rows(base_dir, rows)
       let header_rows = load_or_collect_manifest_header_rows(entry_path, manifest_path, manifest_path_index)
       let needed_paths = collect_needed_paths_from_manifest_headers(entry_path, manifest_path_index, header_rows)
+      verify_manifest_needed_paths(base_dir, manifest_path, manifest_path_index, needed_paths)
       let needed_path_index = build_manifest_path_index(needed_paths)
       let groups = load_manifest_source_groups_by_path_index(base_dir, rows, needed_path_index)
       Some((manifest_path, groups))

--- a/lib/@vibe/compiler/tests/loader_manifest_sources_test.vibe
+++ b/lib/@vibe/compiler/tests/loader_manifest_sources_test.vibe
@@ -436,3 +436,63 @@ test "try_collect_manifest_sources_fs: does not treat export type as re-export p
     None => assert(false)
   }
 }
+
+test "try_collect_manifest_sources_fs: an unlisted sibling names the manifest, not type_db (#2573)" {
+  // Before #2573 this path produced nothing here at all: the unlisted sibling
+  // simply never entered the source set, and the failure surfaced three layers
+  // later as `type_db: missing resolved dependency environment: <sibling>` --
+  // which names the one file that is fine and neither the manifest nor the
+  // rule in docs/adding-modules.md.
+  let base_dir = "/tmp/vibe_compiler_manifest_unlisted_sibling"
+  let manifest_path = String::concat(base_dir, "/compiler_sources_manifest.tsv")
+  let unlisted_path = String::concat(base_dir, "/core/unlisted.vibe")
+  let main_path = String::concat(base_dir, "/main.vibe")
+  Fs::mkdir_p(String::concat(base_dir, "/core"))
+  Fs::write_bytes(manifest_path, string_to_bytes("# group\tpath\nentry\tmain.vibe\n"))
+  Fs::write_bytes(unlisted_path, string_to_bytes("export let add: () -> Int = () -> { 1 }"))
+  Fs::write_bytes(main_path, string_to_bytes("import ./core/unlisted.vibe { add }\nlet run: () -> Int = () -> { add() }"))
+  let message = handle {
+    let _ = try_collect_manifest_sources_fs(main_path)
+    "no throw"
+  } with { Exception::Throw(msg) => msg }
+  assert(String::contains(message, "add a row `<group>"))
+  assert(String::contains(message, "core/unlisted.vibe"))
+  assert(String::contains(message, manifest_path))
+  assert(String::contains(message, "docs/adding-modules.md"))
+  assert(!String::contains(message, "type_db"))
+}
+
+test "try_collect_manifest_source_groups_fs: the grouped collector says the same thing (#2573)" {
+  let base_dir = "/tmp/vibe_compiler_manifest_unlisted_sibling_groups"
+  let manifest_path = String::concat(base_dir, "/compiler_sources_manifest.tsv")
+  Fs::mkdir_p(String::concat(base_dir, "/core"))
+  Fs::write_bytes(manifest_path, string_to_bytes("# group\tpath\nentry\tmain.vibe\n"))
+  Fs::write_bytes(String::concat(base_dir, "/core/unlisted.vibe"), string_to_bytes("export let add: () -> Int = () -> { 1 }"))
+  Fs::write_bytes(String::concat(base_dir, "/main.vibe"), string_to_bytes("import ./core/unlisted.vibe { add }\nlet run: () -> Int = () -> { add() }"))
+  let message = handle {
+    let _ = try_collect_manifest_source_groups_fs(String::concat(base_dir, "/main.vibe"))
+    "no throw"
+  } with { Exception::Throw(msg) => msg }
+  assert(String::contains(message, "core/unlisted.vibe"))
+  assert(String::contains(message, manifest_path))
+}
+
+test "try_collect_manifest_sources_fs: a LISTED sibling is still collected (#2573 control)" {
+  // The check must not fire on the shape it is meant to leave alone -- without
+  // this the test above would pass on a checker that rejected everything.
+  let base_dir = "/tmp/vibe_compiler_manifest_listed_sibling"
+  let manifest_path = String::concat(base_dir, "/compiler_sources_manifest.tsv")
+  let sibling_path = String::concat(base_dir, "/core/listed.vibe")
+  let main_path = String::concat(base_dir, "/main.vibe")
+  Fs::mkdir_p(String::concat(base_dir, "/core"))
+  Fs::write_bytes(manifest_path, string_to_bytes("# group\tpath\ncore\tcore/listed.vibe\nentry\tmain.vibe\n"))
+  Fs::write_bytes(sibling_path, string_to_bytes("export let add: () -> Int = () -> { 1 }"))
+  Fs::write_bytes(main_path, string_to_bytes("import ./core/listed.vibe { add }\nlet run: () -> Int = () -> { add() }"))
+  match try_collect_manifest_sources_fs(main_path) {
+    Some((_, sources)) => {
+      assert(has_source_path(sources, sibling_path))
+      assert(has_source_path(sources, main_path))
+    },
+    None => assert(false)
+  }
+}


### PR DESCRIPTION
Closes #2573.

## What it said

Add a file under `lib/@vibe/compiler/<pkg>/`, export it through the package facade and `index.vpkg`, import it from another compiler file, and the failure arrives three layers from the cause:

```
$ vibe check lib/@vibe/compiler/codegen/wasi/linked_compile.vibe
type_db: missing resolved dependency environment: lib/@vibe/compiler/core/const_bool_params.vibe
```

The named file is fine and checks clean on its own. So does the importer. The message names neither the manifest nor the rule in `docs/adding-modules.md`, and measured on #2569 it cost a full investigation of the module planner and the persistent caches before the manifest turned up. A trivial sibling with no imports fails identically, so the file's content is irrelevant.

## Why

Roots inside the compiler tree take their source set from `compiler_sources_manifest.tsv` (`collect_source_groups_fs` → `try_load_manifest_rows`), so an unlisted sibling never enters the ripple db. `step_module_fs` answers `missing:<path>` for it, its importer folds that pseudo-fingerprint, and `project_exact_dependency_envs` throws the infrastructure message.

## What it says now

`verify_manifest_needed_paths` runs where the manifest source set is built — both collectors, right after the needed-path closure — and leads with the edit:

```
$ vibe check lib/@vibe/compiler/codegen/wasi/linked_compile.vibe
error: add a row `<group>	core/_probe_unlisted_2573.vibe` to lib/@vibe/compiler/compiler_sources_manifest.tsv:
lib/@vibe/compiler/core/_probe_unlisted_2573.vibe is imported from inside the compiler tree but is not
listed there, so the build never reads it. Use the group the rows for its directory already use
(docs/adding-modules.md, "Only when the compiler consumes it").
$ echo $?
1
```

Only a path inside `base_dir` is judged. Whatever the manifest reaches outside its own tree is listed with a `../` row, which `join_path` normalizes into the index; and a generated `_build/` types stub (#1840) is never a row, because `load_planned_module_source` reads it from disk.

`type_db: missing resolved dependency environment` stays reserved for the infrastructure case it was written for.

## Verification

- **`lib/@vibe/compiler/tests/loader_manifest_sources_test.vibe`: 20 tests (3 new), all green** on this checkout's stage2 — the unlisted sibling through `try_collect_manifest_sources_fs`, the same through `try_collect_manifest_source_groups_fs`, and a control asserting a **listed** sibling is still collected (without which the first two would pass on a checker that rejected everything).
- **End to end**, on a real unlisted sibling under `lib/@vibe/compiler/core/` imported from a manifest-listed file: `vibe check` on the importing root prints the new message and exits 1. Before the change the same tree answered with a message that pointed elsewhere.
- **No false positive on the real tree**: `scripts/generations.sh build` is green (stage0 → stage1 → stage2 plus both validations), which is the entire compiler closure through the two checked collectors.

## Found while measuring this, filed not fixed

`vibe check lib/@vibe/compiler/loader/loader.vibe` fails on **main** with that same `type_db:` message for `loader/manifest_sources.vibe` — a file the manifest **does** list (row 233). Different cause, same string; the new check correctly does not fire there, which is what leaves the infrastructure message alone and visible. Filed as #2595 with the measured per-root table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q9zbiDqkfF7xYQ3v8aCQ3b

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q9zbiDqkfF7xYQ3v8aCQ3b)_