### PR TITLE
parser: a top-level `let` bound to an array of identifiers no longer swallows the next item (#2535)

### DIFF
--- a/lib/@vibe/parser/parser_expr.vibe
+++ b/lib/@vibe/parser/parser_expr.vibe
@@ -288,18 +288,76 @@ fn apply_value_bracket_type_params(tps: Array[String], tbs: Array[(String, Array
   }
 }
 
+/// Skip the bracket group starting at `pos` (which must be a `[`), returning
+/// the position just past its matching `]`. Bounded by the token count so an
+/// unbalanced source cannot spin here.
+fn skip_bracket_group(tokens: Array[Token], pos: Int) -> Int {
+  let limit = Array::length(tokens)
+  let mut scan_pos = pos + 1
+  let mut depth = 1
+  while depth > 0 && scan_pos <= limit {
+    match peek(tokens, scan_pos) {
+      TLBracket => {
+        depth = depth + 1
+      },
+      TRBracket => {
+        depth = depth - 1
+      },
+      _ => ()
+    }
+    scan_pos = scan_pos + 1
+  }
+  scan_pos
+}
+
+/// #2535: does the bracket group that ends at `scan_pos` head a LAMBDA?
+///
+/// This is the whole difference between a value-position type-parameter header
+/// and an array literal, and the shape of the group cannot decide it: `[a, b]`
+/// is a comma-separated list of identifiers either way. What separates them is
+/// what comes AFTER — a header always introduces a lambda, so the next token
+/// is its parameter list `(`. Consecutive headers are legal
+/// (`let f = [A][B](..)`), so a run of bracket groups is skipped first and the
+/// parameter list is required at the end of the run.
+///
+/// Without this the top-level `let xs = [a, b]` was read as `let xs = [A, B]`
+/// followed by a value, the header scan swallowed the array literal, and the
+/// NEXT top-level item became `unexpected token: let`. `false` and `true` lex
+/// as `TIdent`, which is why the bug was first seen as "two or more Bool
+/// literals" (#2535) rather than "two or more identifiers".
+fn value_bracket_header_heads_lambda(tokens: Array[Token], scan_pos: Int) -> Bool {
+  let limit = Array::length(tokens)
+  let mut p = scan_pos
+  let mut done = false
+  let mut heads_lambda = false
+  while !done {
+    match peek(tokens, p) {
+      TLParen => {
+        heads_lambda = true
+        done = true
+      },
+      TLBracket => {
+        let next_p = skip_bracket_group(tokens, p)
+        if next_p > p && next_p <= limit {
+          p = next_p
+        } else {
+          done = true
+        }
+      },
+      _ => {
+        done = true
+      }
+    }
+  }
+  heads_lambda
+}
+
 fn skip_generic_value_start(tokens: Array[Token], pos: Int) -> Int {
   match peek(tokens, pos) {
     TLBracket => match peek(tokens, pos + 1) {
       TIdent(_) => {
-        let maybe_generic = match peek(tokens, pos + 2) {
-          TRBracket => match peek(tokens, pos + 3) {
-            TLParen => true,
-            // Consecutive value headers: the outer header is reconciled here;
-            // the inner header is parsed by the generic-expression lane.
-            TLBracket => true,
-            _ => false
-          },
+        let header_shaped = match peek(tokens, pos + 2) {
+          TRBracket => true,
           TColon => true,
           TComma => true,
           // A constructor-kind binder starts with a nested `[_]`. Restrict
@@ -311,22 +369,13 @@ fn skip_generic_value_start(tokens: Array[Token], pos: Int) -> Int {
           },
           _ => false
         }
-        if maybe_generic {
-          let mut scan_pos = pos + 1
-          let mut depth = 1
-          while depth > 0 {
-            match peek(tokens, scan_pos) {
-              TLBracket => {
-                depth = depth + 1
-              },
-              TRBracket => {
-                depth = depth - 1
-              },
-              _ => ()
-            }
-            scan_pos = scan_pos + 1
+        if header_shaped {
+          let scan_pos = skip_bracket_group(tokens, pos)
+          if value_bracket_header_heads_lambda(tokens, scan_pos) {
+            scan_pos
+          } else {
+            pos
           }
-          scan_pos
         } else {
           pos
         }

--- a/lib/@vibe/parser/parser_smoke_test.vibe
+++ b/lib/@vibe/parser/parser_smoke_test.vibe
@@ -654,3 +654,37 @@ test "#2344 a parenthesized `~` operand does not steal a control brace" {
   // the parens -- this is what the `TTilde` row must not have broken.
   assert(String::starts_with(tilde_printed("fn main() -> Unit { let f = (n) { n } }"), "THROW"))
 }
+
+test "#2535: a top-level `let` bound to an array of identifiers does not swallow the next item" {
+  // `[a, b]` and a value-position type-parameter header `[A, B]` have the
+  // SAME shape; only what follows tells them apart. The header scan used to
+  // accept the shape alone, skip past the `]`, and take the next top-level
+  // item as the value -- so `let other` became `unexpected token: let`.
+  let stmts = parse_program(lex("let a = 1\nlet b = 2\nlet cell = [a, b]\nlet other = 3\n"))
+  assert(Array::length(stmts) == 4)
+}
+
+test "#2535: the Bool spelling of the same bug (`false` lexes as an ident)" {
+  // This is how the bug was first seen: "two or more Bool literals". `false`
+  // and `true` are `TIdent`, which is why one Bool element was fine and two
+  // were not -- the second element supplied the comma the header shape wanted.
+  assert(Array::length(parse_program(lex("let cell = [false, false]\nlet other = 1\n"))) == 2)
+  assert(Array::length(parse_program(lex("let cell = [true, true]\nfn main() -> Int { 1 }\n"))) == 2)
+  assert(Array::length(parse_program(lex("let cell = [false, false, false]\nlet other = 1\n"))) == 2)
+  // One element never had the comma, so it always worked; keep it pinned.
+  assert(Array::length(parse_program(lex("let cell = [false]\nlet other = 1\n"))) == 2)
+  // An annotation did not change the answer either way.
+  assert(Array::length(parse_program(lex("let cell: Array[Bool] = [false, false]\nlet other = 1\n"))) == 2)
+}
+
+test "#2535: a real value-position type-parameter header still parses as one" {
+  // The control the fix must not break: the header IS followed by a parameter
+  // list, which is exactly what distinguishes it from an array literal.
+  let one = fn_generic_lanes_at(parse_program(lex("let idf = [T](x: T) -> T { x }\n")), 0)
+  assert(Array::length(one.0) == 1)
+  let two = fn_generic_lanes_at(parse_program(lex("let pair = [A, B](a: A, b: B) -> A { a }\n")), 0)
+  assert(Array::length(two.0) == 2)
+  let bound = fn_generic_lanes_at(parse_program(lex("let shown = [T: Show](x: T) -> String { \"s\" }\n")), 0)
+  assert(Array::length(bound.0) == 1)
+  assert(Array::length(bound.1) == 1)
+}


### PR DESCRIPTION
Closes #2535.

## What happened

```vibe
let cell = [false, false]
let other = 1
```
```
line 2:1: unexpected token: let
```

The diagnostic points at the **next** top-level item, so it reads as a stray-token error in unrelated code. `[false]` was fine, `[0, 0]` was fine, and the same `let` inside a `fn` body was fine.

## It was never about Bool

`false` and `true` lex as `TIdent` (`lexer.vibe:241`). Measured on this checkout's stage2:

```vibe
let a = 1
let b = 2
let cell = [a, b]      // swallows the next item too
let other = 3
```
```
line 4:1: unexpected token: let
```

So the real rule is **any top-level `let` bound to an array of two or more identifiers**. The Bool framing in the issue is that spelling of it; the one-element cases worked because they had no comma.

## Why

`skip_generic_value_start` recognizes a value-position type-parameter header (`let f = [T](x: T) -> T { x }`) so `parse_value_bracket_header` can lift it onto the lambda. It decided from the **shape** alone: `[` `ident` then `]` / `:` / `,`. But `[a, b]` and `[A, B]` *have* the same shape — a comma-separated list of identifiers — so an array literal matched, the scan skipped past its `]`, and the value the `let` then parsed was the next top-level item.

That is also why `[false, 0]` failed *differently* (`expected type parameter name or ']'`, thrown from the header parse it had already committed to) and why annotating the type changed nothing: both lanes reach the same scan.

## The fix

The shape cannot decide it; what **follows** can. A type-parameter header always introduces a lambda, so the token after its `]` is the parameter list `(`. An array literal has no parameter list. `value_bracket_header_heads_lambda` requires it, skipping a run of bracket groups first so consecutive headers (`let f = [A][B](..)`) still work.

Two cleanups fall out:

- the bracket scan is one bounded helper (`skip_bracket_group`) instead of an unbounded `while depth > 0` that an unbalanced source could spin in;
- the `TRBracket` arm no longer needs its own hand-written `TLParen`/`TLBracket` lookahead — it asks the same question as every other arm.

Measured after the fix, same tree:

| source | before | after |
|---|---|---|
| `let cell = [false, false]` + `let other` | `2:1 unexpected token: let` | clean |
| `let cell = [true, true]` + `fn main` | `2:1 unexpected token: fn` | clean |
| `let cell: Array[Bool] = [false, false]` + `let other` | `2:1 unexpected token: let` | clean |
| `let cell = [a, b]` (idents) + `let other` | `4:1 unexpected token: let` | clean |
| `let cell = [false, 0]` | `expected type parameter name or ']'` | `array elements have incompatible types: expected Bool, got Int` |
| `let idf = [T](x: T) -> T { x }` | clean | clean |
| `let pair = [A, B](a: A, b: B) -> A { a }` | clean | clean |

## Verification

- **Three tests** in `lib/@vibe/parser/parser_smoke_test.vibe` (57 total, all green): the identifier form, the Bool spelling from the issue (including the one-element and annotated cases that already worked, so they stay pinned), and a control asserting a real `[T]` / `[A, B]` / `[T: Show]` header still lands on the lambda's `type_params` / `bounds` — without which the first two would pass on a parser that had simply stopped recognizing headers.
- **Red-proven**: with only the parser fix reverted and the tests kept, the file FAILS.
- `scripts/generations.sh build` green (stage0 → stage1 → stage2 plus both validations), so the compiler still parses its own sources; `check-vibe-fmt` ok on both files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q9zbiDqkfF7xYQ3v8aCQ3b

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q9zbiDqkfF7xYQ3v8aCQ3b)_