### PR TITLE
parser: `try { .. } with { .. }` names the keyword, not the arm (#2444)

### DIFF
--- a/lib/@vibe/parser/parser_expr_dispatch.vibe
+++ b/lib/@vibe/parser/parser_expr_dispatch.vibe
@@ -512,6 +512,11 @@ fn parse_handle_arm(tokens: Array[Token], starts: Array[Int], pos: Int, effect_n
 
 fn parse_qualified_handle_arm(tokens: Array[Token], starts: Array[Int], pos: Int, parse_recur: (Array[Token], Int, Int, Option[ParserBinderContext]) -> (Expr, Int) with Exception, context: Option[ParserBinderContext]) -> ((Pat, Expr), Int) with Exception {
   let (effect_label, operation_pos, operation_name) = match peek(tokens, pos) {
+    // #2444: a SUFFIX handler takes its arms directly, so a `{` here means the
+    // caller wrote a braced handler set with no `handle` block in front of it.
+    // The old message said the arms were spelled wrong, which sent the reader
+    // to the one part of the source that was already correct.
+    TLBrace => throw("a braced handler set belongs to a `handle { ... } with { ... }`; a SUFFIX handler is written `with Effect::Op(_) => expr`, with no braces at #\{pos}"),
     TIdent(effect_name) => {
       let (label, after_label) = match peek(tokens, pos + 1) {
         TLBracket => collect_row_item_targs(tokens, pos + 2, 1, String::concat(effect_name, "[")),

--- a/lib/@vibe/parser/parser_expr_primary.vibe
+++ b/lib/@vibe/parser/parser_expr_primary.vibe
@@ -1344,6 +1344,23 @@ fn parse_ident_primary(tokens: Array[Token], starts: Array[Int], pos: Int, name:
       },
       _ => (EIdent(name, offset_at(starts, pos)), pos + 1)
     }
+  } else if name == "try" {
+    match peek(tokens, pos + 1) {
+      // #2444: `try` is not a keyword in vibe -- `handle` is the only
+      // handler-set introducer. Without this arm `try` parsed as an ordinary
+      // identifier, the following `{ ... }` as a separate block, and the
+      // `with {` after it as a SUFFIX handler (`with Effect::Op(_) => e`,
+      // which takes no braces). So the error the user got was "handler-set
+      // arms must name a fully qualified operation such as
+      // `Exception::Throw(_)`" -- naming the text they had already written --
+      // anchored on the enclosing `fn` rather than on anything they typed.
+      //
+      // `try` before `{` cannot be anything else: an identifier is never
+      // applied to a block. Everywhere else `try` stays an ordinary
+      // identifier, exactly like `record` and `map` above.
+      TLBrace => throw("`try` is not a keyword in vibe -- write `handle { ... } with { ... }` at #\{pos}"),
+      _ => (EIdent(name, offset_at(starts, pos)), pos + 1)
+    }
   } else if name == "map" {
     match peek(tokens, pos + 1) {
       // #960 Stage 2: the `map { ... }` literal is retired. `map` before `{`

--- a/lib/@vibe/parser/parser_smoke_test.vibe
+++ b/lib/@vibe/parser/parser_smoke_test.vibe
@@ -688,3 +688,42 @@ test "#2535: a real value-position type-parameter header still parses as one" {
   assert(Array::length(bound.0) == 1)
   assert(Array::length(bound.1) == 1)
 }
+
+test "#2444: `try { .. } with { .. }` names the keyword, not the arm" {
+  // The old message was "handler-set arms must name a fully qualified
+  // operation such as `Exception::Throw(_)`" -- while the arm already WAS
+  // exactly that, anchored on the enclosing `fn`. Both halves pointed away
+  // from the fix, which is that `try` is not a keyword.
+  let src = "fn safe(x: Int) -> Int with Exception {\n  try {\n    x\n  } with {\n    Exception::Throw(_) => 0\n  }\n}\n"
+  let msg = handle {
+    let (tokens, starts, _) = lex_with_offsets(src)
+    let _ = parse_program_located(tokens, starts, src)
+    "ok"
+  } with { Exception::Throw(m) => m }
+  assert(String::contains(msg, "`try` is not a keyword"))
+  assert(String::contains(msg, "handle { ... } with { ... }"))
+  assert(!String::contains(msg, "handler-set arms must name"))
+  // Anchored on the `try` token (line 2), not on the enclosing `fn` (line 1).
+  assert(String::contains(msg, "line 2:"))
+}
+
+test "#2444: `handle` still parses, and `try` is still an ordinary identifier" {
+  // The controls. Without them the test above would pass on a parser that had
+  // simply started rejecting every handler set, or every use of the name.
+  let handled = parse_program(lex("fn safe(x: Int) -> Int with Exception { handle { x } with { Exception::Throw(_) => 0 } }\n"))
+  assert(Array::length(handled) == 1)
+  let named = parse_program(lex("fn f() -> Int {\n  let try = 3\n  try + 1\n}\n"))
+  assert(Array::length(named) == 1)
+}
+
+test "#2444: a braced SUFFIX handler says braces are the problem" {
+  let src = "fn g() -> Int with Exception {\n  with { Exception::Throw(_) => 0 }\n  1\n}\n"
+  let msg = handle {
+    let (tokens, starts, _) = lex_with_offsets(src)
+    let _ = parse_program_located(tokens, starts, src)
+    "ok"
+  } with { Exception::Throw(m) => m }
+  assert(String::contains(msg, "with no braces"))
+  assert(String::contains(msg, "with Effect::Op(_) => expr"))
+  assert(!String::contains(msg, "handler-set arms must name"))
+}


### PR DESCRIPTION
Closes #2444.

## What it said

```vibe
fn safe(x: Int) -> Int with Exception {
  try {
    risky(x)
  } with {
    Exception::Throw(_) => 0
  }
}
```
```
line 5:1: handler-set arms must name a fully qualified operation such as `Exception::Throw(_)`
```

The arm **is** `Exception::Throw(_)`, and `5:1` is the `fn safe` line rather than anything the reader typed. Both halves point away from the fix, which is that `try` is not a keyword in vibe — `handle` is the only handler-set introducer.

## Why it read that way

`try` lexed as an ordinary identifier, `{ risky(x) }` as a separate block, and the `with {` after it as a **suffix** handler (`with Effect::Op(_) => expr`), which takes no braces. So the arm parser was handed a `{` and reported the only thing it knew: that an arm has to name a qualified operation.

## Now

```
line 6:3: `try` is not a keyword in vibe -- write `handle { ... } with { ... }`
```

anchored on the `try` token. `try` before `{` cannot be anything else — an identifier is never applied to a block — and everywhere else `try` stays an ordinary identifier, exactly like `record` and `map` in the same dispatch.

The suffix-handler arm parser also stopped blaming the arm for a brace it never saw:

```
line 2:8: a braced handler set belongs to a `handle { ... } with { ... }`; a SUFFIX handler is
written `with Effect::Op(_) => expr`, with no braces
```

That is the message for the shape reached **without** `try` (a bare `with { ... }` in statement position), so the way in is closed from both sides.

Measured, same tree:

| source | before | after |
|---|---|---|
| `try { .. } with { .. }`, multi-line | `5:1 handler-set arms must name…` | `6:3 \`try\` is not a keyword…` |
| `try { .. } with { .. }`, one line | `handler-set arms must name…` | `2:41 \`try\` is not a keyword…` |
| `handle { .. } with { .. }` | clean | clean |
| `let try = 3` then `try + 1` | clean | clean |
| bare `with { .. }` in a block | `handler-set arms must name…` | `2:8 …with no braces` |

## Verification

- **Three tests** in `lib/@vibe/parser/parser_smoke_test.vibe` (60 total, all green): the `try` form (asserting the new text, the *absence* of the old text, and the line-2 anchor rather than the enclosing `fn` on line 1), the braced suffix handler, and a control asserting `handle { .. } with { .. }` still parses **and** `let try = 3` is still an ordinary binding — without which the first two would pass on a parser that had started rejecting every handler set, or every use of the name.
- **Red-proven**: with only the two parser arms reverted and the tests kept, the file FAILS.
- `scripts/generations.sh build` green through stage2 plus both validations; `check-vibe-fmt` ok on all three files.

## Note on the formatter

The issue records that the CST formatter reprints a `try`'s `} with { .. }` as `} with\n  Arm => e`, which then does not parse — and that it does **not** do this for `handle`. That only ever mangles a program the compiler already rejects, and this change rejects it at the `try` token before the formatter's shape matters. Left alone deliberately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q9zbiDqkfF7xYQ3v8aCQ3b

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q9zbiDqkfF7xYQ3v8aCQ3b)_