### PR TITLE
normalize: a lowercase bare name no longer reads its type out of another module's fn table (#2527)

### DIFF
--- a/lib/@vibe/compiler/normalize/desugar_trait_dict.vibe
+++ b/lib/@vibe/compiler/normalize/desugar_trait_dict.vibe
@@ -2246,6 +2246,36 @@ fn lookup_var_type(var_types: Array[(String, String)], name: String) -> Option[S
 /// Bare `Green` -> `Color` via fn_returns; qualified `Color::Green` first tries
 /// the whole name (no match) then the member `Green` confirming its enum equals
 /// the head — so `let a = Color::Green` seeds `a -> Color` for `==` dispatch.
+/// #2527: is a BARE identifier in value position a nullary constructor?
+///
+/// It is exactly when its head is uppercase (`Green`, `None`) or it is
+/// qualified (`Color::Green`). A lowercase bare name is a variable or a
+/// function VALUE, and neither has the type `fn_returns` would report for it.
+///
+/// This matters because `fn_returns` is the program-wide FLAT table for the
+/// whole import closure, with no module scoping: consulting it for a lowercase
+/// name answers about a same-spelled function in another module. Measured --
+/// `CtVar(id) => "?t\{id}"` in `core/types.vibe`, where `id` is an `Int` bound
+/// by the match arm and so absent from `var_types`, picked up a test file's
+/// `fn id(n: String) -> Expr` and rejected THAT file with "cannot interpolate
+/// a value of type `Expr`: it has no Show renderer". The named file had no
+/// interpolation, the suggested fix (`derive(Show)` on `Expr`) was wrong, and
+/// renaming the helper was the only way out.
+///
+/// The CALL arm is a different question -- `f(x)` really does have `f`'s
+/// return type -- so it keeps asking `ctor_enum_of_name` unchanged, and the
+/// cross-module ambiguity there is #2527's remaining half.
+fn dtd_name_is_constructor_shaped(name: String) -> Bool {
+  if String::contains(name, "::") {
+    true
+  } else if String::length(name) == 0 {
+    false
+  } else {
+    let c = String::char_code_at(name, 0)
+    c >= 'A' && c <= 'Z'
+  }
+}
+
 fn ctor_enum_of_name(fn_returns: Array[(String, String)], name: String) -> Option[String] {
   match fn_return_type(fn_returns, name) {
     Some(t) => Some(t),
@@ -2439,7 +2469,13 @@ fn infer_arg_type_name(arg: Expr, struct_sets: Array[(String, Array[String])], v
     } else {
       match lookup_var_type(var_types, name) {
         Some(t) => Some(t),
-        None => ctor_enum_of_name(fn_returns, name)
+        // #2527: only a constructor-shaped name may fall through to the flat
+        // program-wide table -- see dtd_name_is_constructor_shaped.
+        None => if dtd_name_is_constructor_shaped(name) {
+          ctor_enum_of_name(fn_returns, name)
+        } else {
+          None
+        }
       }
     },
     // #1341 (Codex P1 on #1369): a PROJECTION (`h.s`). The object's type name

--- a/lib/@vibe/compiler/tests/interp_cross_module_name_collision_test.vibe
+++ b/lib/@vibe/compiler/tests/interp_cross_module_name_collision_test.vibe
@@ -1,0 +1,57 @@
+//# Imports
+
+// #2527: this file's REGRESSION IS THAT IT COMPILES.
+//
+// A top-level `fn id` returning a declared enum with no Show renderer used to
+// make this file fail with
+//
+//   cannot interpolate a value of type `Expr`: it has no Show renderer --
+//   add `derive(Show)` to `Expr`, or define `fn Expr::to_string(v) -> String`
+//
+// -- positionless, and about a file that contains no interpolation at all. The
+// interpolation was `CtVar(id) => "?t\{id}"` in `core/types.vibe`, where `id`
+// is an `Int` bound by the match arm and therefore absent from `var_types`.
+// The classification fell through to `fn_returns`, the program-wide FLAT table
+// for the whole import closure, and found THIS file's `id`.
+//
+// `mk` compiled and `id` did not, so the trigger was purely the name. Both
+// spellings the issue measured are kept below.
+
+import @vibe/compiler/core {
+  Expr
+}
+
+import @vibe/core {
+  array_empty
+}
+
+//# Functions
+
+fn id(n: String) -> Expr {
+  EIdent(n, -1)
+}
+
+fn call(f: String, args: Array[Expr]) -> Expr {
+  ECall(EIdent(f, -1), args, -1)
+}
+
+fn no_args() -> Array[Expr] {
+  array_empty()
+}
+
+//# Tests
+
+test "#2527: a colliding helper name does not break an unrelated module's interpolation" {
+  // The helpers are exercised so they are not dead, but the assertion that
+  // matters is that this file compiled at all.
+  let is_ident = match id("x") {
+    EIdent(_, _) => true,
+    _ => false
+  }
+  assert(is_ident)
+  let is_call = match call("f", no_args()) {
+    ECall(_, _, _) => true,
+    _ => false
+  }
+  assert(is_call)
+}


### PR DESCRIPTION
Closes #2527 (the `EIdent` half; see **What is left** below).

## What happened

A test file that only **defines** a helper failed to compile. The helper was never called and the file contained no interpolation:

```vibe
import @vibe/compiler/core { Expr }

fn id(n: String) -> Expr { EIdent(n, -1) }

test "id defined but never called" { assert_eq(1, 1) }
```
```
cannot interpolate a value of type `Expr`: it has no Show renderer -- add `derive(Show)` to `Expr`,
or define `fn Expr::to_string(v) -> String` (#1445)
```

Positionless, about a file with nothing to interpolate, proposing a fix (`derive(Show)` on `Expr`) that is wrong. Renaming the helper was the only way out — `fn mk` compiled, `fn id` did not, so the trigger was purely the name.

## The interpolation it was actually about

`lib/@vibe/compiler/core/types.vibe:2279`:

```vibe
CtVar(id) => "?t\{id}"
```

`id` there is an `Int` bound by the match arm, and match-arm binders are not in `var_types`. So `infer_arg_type_name`'s `EIdent` arm fell through to `ctor_enum_of_name(fn_returns, "id")` — and `fn_returns` is the program-wide **flat** table for the whole import closure, with no module scoping. It found the test file's `id -> Expr` and reported a missing renderer for a value that is an `Int`.

## The fix

A **bare** identifier in value position is a nullary constructor or nothing, and a nullary constructor's head is always uppercase (`Green`, `None`); a qualified name (`Color::Green`) keeps its existing path. A lowercase bare name is a variable or a function *value*, and neither has the type `fn_returns` would report for it — so it no longer asks.

## What is left

The **call** arm is a different question — `f(x)` really does have `f`'s return type — so it still consults the same flat table, and the cross-module ambiguity there is untouched. It is not reachable from the shape this issue reports (a match-arm binder), and narrowing it needs the per-module scoping the issue's "Expected" section describes. Worth doing; not folded in here.

The issue also notes a P0 one step away: if the colliding type *does* have a `to_string`, the wrong renderer would be dispatched silently rather than erroring. That variant is closed for the `EIdent` path by this change, for the same reason — a lowercase bare name no longer reaches the table at all.

## Verification

`lib/@vibe/compiler/tests/interp_cross_module_name_collision_test.vibe` is the issue's repro, carrying **both** names it measured (`id` and `call`). Its regression is that it compiles at all, so it is red and green in the sharpest possible way:

| compiler | result |
|---|---|
| committed seed (no fix) | `FAIL (compile)` — the exact message above |
| this checkout's stage2 | `ok`, 1 test |

Also green on the built stage2: `bool_interp_test`, `bool_interp_no_literal_test`, `interp_function_return_test`, `interp_show_binding_test`, `show_array_from_call_test`, `show_to_string_method_test`, `string_interp_test`, `derive_ord_show_test`, `derive_enum_ord_show_test`, `interp_show_single_file_diag_test`, `show_shim_render_rows_test`, `structural_eq_contexts_test`, `generic_derive_eq_test` — plus `scripts/generations.sh build` through stage2 and both validations, and `check-vibe-fmt` on both touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q9zbiDqkfF7xYQ3v8aCQ3b

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q9zbiDqkfF7xYQ3v8aCQ3b)_