### PR TITLE
cheatsheet: document `sleep`, and say once that raw wasm opcodes are not user surface (#2590)

### DIFF
--- a/docs/cheatsheet.md
+++ b/docs/cheatsheet.md
@@ -2080,11 +2080,24 @@ Console::write_stream` does not admit `Console::read_stream` (#1496).
 | `StdinStream::next` | `(StdinStream) -> Int` (`-1` after EOF) | `Async` |
 | `StdinStream::close` | `(StdinStream) -> Unit` (idempotent once it succeeds) | `Async` |
 | `StdinStream::read_chunk` | `(StdinStream, Int) -> Option[String]` | `Async` |
+| `sleep` | `(Int) -> Unit` — the argument is **milliseconds** | `Async` |
 
 The four stdin providers are **direct-call only**. To pass one as a value,
 define a wrapper whose `with` row names `Stdin` / `Async` explicitly — the
 checker rejects an alias to the builtin itself or a value-position
 reference.
+
+**Raw wasm opcodes are not part of this surface.** The `i32_*` / `i64_*` /
+`f32_*` / `f64_*` names (`i32_store`, `i32_load8_u`, `f64_neg`,
+`f32_demote_f64`, …) that appear in `lib/@vibe/compiler/builtins/declarations.vibe`
+under "WASM intrinsics (low-level)" are what the backends emit through: they
+have no `checker_visible` registry row and no namespace lookup, so spelling one
+in vibe source is `unknown name` (#2343). The block says so at its head and
+`tests/gates/early/run.sh` section 4g checks the claim, so their absence here is
+a decision, not an omission — do not add them from an old table. The
+`__`-prefixed operator names (`__add`, `__index`, `__eq`, …) are internal for the
+same reason; the **Operators** table above documents the spellings that reach
+them.
 
 **JSON**: `Json::stringify: (Any) -> String`, `parse: (String) -> Json`,
 `type_of: (Json) -> String`, `get: (Json, String) -> Json`,


### PR DESCRIPTION
Closes #2590.

## The gap was smaller than the issue said

#2590 listed 11 user-facing builtins as missing from the Signature reference. Re-measured with the gate's **own** extractor: **10 of the 11 are already documented and already checked.**

The issue's list came from grepping the qualified spellings. The reference writes them in shorthand under a bolded heading — `slice: (Array[T], Int, Int) -> Array[T]` under **Array**, `push(ArrayBuilder[T], T) -> Unit` under **Builder** — and `check_cheatsheet_signatures.sh` reads exactly that form: its receiver heuristic anchors on the heading and re-anchors on any qualified name. Running its extractor over `docs/cheatsheet.md` unmodified:

| name | extracted? |
|---|---|
| `Array::slice` | yes |
| `Map::has_key` / `Map::keys` / `Map::values` | yes |
| `ArrayBuilder::new` / `push` / `freeze` | yes |
| `MapBuilder::new` / `set` / `freeze` | yes |
| **`sleep`** | **no** |

So they are not only documented, they are verified against `lookup_builtin` on every CI run.

## `sleep`

Genuinely absent, and it has a real registry row:

```vibe
("sleep", CtFn(reg_p1(CtInt), CtUnit, Some("Async")), true, false, true),
```

It joins the I/O table beside the other `Async` rows, carrying the unit its host implementation actually uses (`Duration::from_millis`, `runtime/viberun`). The gate now reports **62** signatures instead of 61.

## The intrinsics decision

The issue's second half asked for a **decision** about `i32_*` / `f32_*` / `f64_*` rather than leaving their absence to look like an accident. It turns out to be decided and enforced already — `declarations.vibe` heads that block "CODEGEN-INTERNAL: not reachable from user code", the names have no `checker_visible` row, and `tests/gates/early/run.sh` section 4g checks the claim is true (#2343).

What was missing is that the cheatsheet never said so, which is exactly what let this be re-opened from an old table. It says so now, together with the `__`-prefixed operator names, which are internal for the same reason — and it says *why*, so the next person comparing against a snapshot stops there.

## Not done

The "registry name absent from the Signature reference" **census**. Today's gate checks that what is *documented* is correct; it cannot see a builtin documented nowhere. That is a different gate, it needs its own allowlist, and it is the same shape and tradeoff as #2584 — tracked there rather than widened into this change.

## Verification

- `check-cheatsheet-signatures`: **ok (62 builtin signatures match by arity; 15 documented library functions all named in the import caveat)**.
- **Red-proven**: with the new row mutated to `(Int, Int) -> Unit`, the gate FAILS with `sleep documented as (Int, Int) -> Unit (2 args) but the checker says (Int) -> () with Async (1 args)` — so the row is checked work, not a guess. Restored, gate green again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q9zbiDqkfF7xYQ3v8aCQ3b

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q9zbiDqkfF7xYQ3v8aCQ3b)_