### PR TITLE
codegen: test the SOURCE spelling for a shadow, not only the canonical one (#2585 review)

### DIFF
--- a/fixtures/to_string_alias_shadowed_builtin_test.vibe
+++ b/fixtures/to_string_alias_shadowed_builtin_test.vibe
@@ -1,0 +1,54 @@
+// #2585 review (Codex P1, second round): a shadow declared under a
+// SOURCE-COMPATIBLE ALIAS spelling.
+//
+// `canonical_builtin_name` folds `String::byte_at` onto `String::char_code_at`
+// (ADR-0098 Phase 1), but a call resolves by what the source wrote. Testing
+// only the canonical name looked for `String::char_code_at`, found nothing,
+// and classified this String-returning call as the Int-returning builtin --
+// so the packed string pointer went through the integer formatter.
+//
+// Measured on main at `cfc01cc`: `156766306305` for the first two cases,
+// bare and through a join, with no diagnostic.
+//
+// Its own file because the declaration shadows the name module-wide.
+
+fn String::byte_at(s: String, i: Int) -> String {
+  s
+}
+
+test "#2585: an alias-spelled shadow is not the Int builtin (bare call)" {
+  inspect(__to_string(String::byte_at("abc", 0)), "abc")
+}
+
+test "#2585: an alias-spelled shadow is not the Int builtin (through a join)" {
+  let flag = true
+  inspect(__to_string(if flag {
+    String::byte_at("aaa", 0)
+  } else {
+    String::byte_at("bbb", 0)
+  }), "aaa")
+}
+
+test "#2585: an alias-spelled shadow is not a Bool/String builtin either" {
+  // cc_builtin_call_ret_kind had the same canonicalize-then-test shape, and
+  // older: it is what decides the Bool / String return kinds.
+  let flag = true
+  inspect(if flag {
+    String::byte_at("zz", 0)
+  } else {
+    ""
+  }, "zz")
+}
+
+test "#2585: an UNSHADOWED builtin must still classify (the control)" {
+  // Without this, "guard everything" would pass the cases above while
+  // silently reopening #2585 itself.
+  let xs = [1, 2, 3]
+  inspect(__to_string(Array::length(xs)), "3")
+  let flag = true
+  inspect(__to_string(if flag {
+    Array::length(xs)
+  } else {
+    0
+  }), "3")
+}

--- a/lib/@vibe/compiler/codegen/expr/compile_call.vibe
+++ b/lib/@vibe/compiler/codegen/expr/compile_call.vibe
@@ -1045,7 +1045,8 @@ export fn cc_builtin_call_ret_kind(e: Expr, local_names: Array[String], ctx: Com
   if expr_tag(e) == 8 {
     let bcallee = get_ecall_callee(e)
     if is_eident(bcallee) {
-      let bn = canonical_builtin_name(get_eident_name(bcallee))
+      let cn = get_eident_name(bcallee)
+      let bn = canonical_builtin_name(cn)
       let kind = if bn == "eq" || bn == "not" || bn == "String::equals" || bn == "String::contains" || bn == "String::starts_with" || bn == "String::ends_with" || bn == "Array::contains" || bn == "Array::any" || bn == "Array::all" || bn == "Map::has_key" || bn == "Map::has" || bn == "map_has" || bn == "MapBuilder::has_key" || bn == "Path::is_absolute" || bn == "Fs::exists" || bn == "Fs::is_dir" || bn == "Fs::is_file" {
         1
       } else if bn == "__to_string" || bn == "Int::to_string" || bn == "Double::to_string" || bn == "Float::to_string" || bn == "String::concat" || bn == "String::substring" || bn == "String::trim" || bn == "String::from_char_code" || bn == "String::join" || bn == "Env::get" || bn == "Env::args_get" || bn == "Fs::read_file" || bn == "Fs::getcwd" || bn == "sh" {
@@ -1053,17 +1054,15 @@ export fn cc_builtin_call_ret_kind(e: Expr, local_names: Array[String], ctx: Com
       } else {
         0
       }
+      // Same alias hole as the tag-8 arm, and older than it: this test used
+      // to look only at the CANONICAL name, so a user `fn String::from_byte`
+      // (canonical `String::from_char_code`) was not seen as a shadow.
       if kind == 0 {
         0
-      } else if find_local_slot(local_names, bn) >= 0 {
+      } else if cc_name_or_alias_shadowed(cn, bn, local_names, ctx) {
         0
       } else {
-        let fi = cc_ft_first_idx(ctx.func_table, bn)
-        if fi >= 0 && fi < ctx.num_user_funcs {
-          0
-        } else {
-          kind
-        }
+        kind
       }
     } else {
       0
@@ -1544,7 +1543,7 @@ fn ts_known_int(e: Expr, local_names: Array[String], ctx: CompileCtx) -> Bool wi
     match get_ecall_callee(e) {
       EIdent(cn, _) => {
         let bn = canonical_builtin_name(cn)
-        ts_int_returning_builtin_name(bn) && !ts_name_is_shadowed(bn, local_names, ctx)
+        ts_int_returning_builtin_name(bn) && !cc_name_or_alias_shadowed(cn, bn, local_names, ctx)
       },
       _ => false
     }
@@ -1606,19 +1605,51 @@ fn ts_int_returning_builtin_name(bn: String) -> Bool {
 
 /// #2585 review (Codex P1): does the source shadow this builtin name?
 ///
-/// The two tests are `cc_builtin_call_ret_kind`'s, unchanged: a LOCAL of the
-/// same name (the call resolves to a closure value, not the builtin), or a USER
-/// `fn` of that name in the func table (`fi < num_user_funcs` -- the builtin
-/// entries sit above that boundary). Shadowing a qualified builtin name is
-/// supported and exercised in-tree; `borrow_returning_names_test.vibe` declares
-/// `fn Map::iter_get` exactly this way and asserts the source declaration is
-/// what wins.
-fn ts_name_is_shadowed(bn: String, local_names: Array[String], ctx: CompileCtx) -> Bool {
-  if find_local_slot(local_names, bn) >= 0 {
+/// The two tests: a LOCAL of the same name (the call resolves to a closure
+/// value, not the builtin), or a USER `fn` of that name in the func table
+/// (`fi < num_user_funcs` -- the builtin entries sit above that boundary).
+/// Shadowing a qualified builtin name is supported and exercised in-tree;
+/// `borrow_returning_names_test.vibe` declares `fn Map::iter_get` exactly this
+/// way and asserts the source declaration is what wins.
+fn cc_single_name_shadowed(n: String, local_names: Array[String], ctx: CompileCtx) -> Bool {
+  if find_local_slot(local_names, n) >= 0 {
     true
   } else {
-    let fi = cc_ft_first_idx(ctx.func_table, bn)
+    let fi = cc_ft_first_idx(ctx.func_table, n)
     fi >= 0 && fi < ctx.num_user_funcs
+  }
+}
+
+/// #2585 review (Codex P1, second round): the test must use the SOURCE
+/// spelling as well as the canonical one.
+///
+/// `canonical_builtin_name` folds source-compatible aliases onto one internal
+/// name (`String::byte_at` -> `String::char_code_at`, ADR-0098 Phase 1), but a
+/// call resolves by what the source WROTE. So a user `fn String::byte_at(..)
+/// -> String` sits in the func table under `String::byte_at`, while a test on
+/// the canonical name alone looks for `String::char_code_at`, finds nothing,
+/// and classifies the call as the Int-returning builtin it is not.
+///
+/// Measured on main at `cfc01cc`, with that declaration in scope:
+///
+///   __to_string(String::byte_at("abc", 0))                 -> 156766306305
+///   __to_string(if c { String::byte_at("aaa", 0) } else .. -> 156766306305
+///   the same shadow spelled String::char_code_at           -> "abc"
+///   unshadowed Array::length                               -> "3"
+///
+/// i.e. the packed string pointer through the integer formatter, silently,
+/// exactly where the canonical spelling was already handled.
+///
+/// BOTH names are tested because either spelling can carry the definition.
+/// Over-guarding costs only the pre-#2585 fallback (the runtime string-pointer
+/// heuristic), which is the fail-closed direction.
+fn cc_name_or_alias_shadowed(cn: String, bn: String, local_names: Array[String], ctx: CompileCtx) -> Bool {
+  if cc_single_name_shadowed(cn, local_names, ctx) {
+    true
+  } else if bn == cn {
+    false
+  } else {
+    cc_single_name_shadowed(bn, local_names, ctx)
   }
 }
 


### PR DESCRIPTION
Follow-up to #2586, which **merged before this was addressed**. Codex left a second P1 on commit `d4ac4ba` after the first shadow fix; #2586 is merged so it cannot carry it — hence this PR.

**The finding is right, and the defect is live on `main`.** Measured on `cfc01cc`.

## What is wrong

`canonical_builtin_name` folds source-compatible aliases onto one internal name (`String::byte_at` → `String::char_code_at`, ADR-0098 Phase 1). Both classifiers canonicalized **first** and then asked whether that name was shadowed. But a call resolves by what the source **wrote** — so a user `fn String::byte_at(s: String, i: Int) -> String` sits in the func table under `String::byte_at`, the test looks for `String::char_code_at`, finds nothing, and the call is classified as the Int-returning builtin it is not.

With that declaration in scope:

| expression | main (`cfc01cc`) | with this fix |
|---|---|---|
| `__to_string(String::byte_at("abc", 0))` | **`156766306305`** | `abc` |
| the same through an `if` join | **`156766306305`** | `aaa` |
| the same shadow spelled `String::char_code_at` | `abc` | `abc` |
| unshadowed `Array::length` | `3` | `3` |

The packed string pointer through the integer formatter, silently, in exactly the position the canonical spelling already handled.

## Two sites, not one

`cc_builtin_call_ret_kind` has the identical canonicalize-then-test shape and is **older** than the #2585 arms — it is what decides the Bool / String return kinds, and it misses an alias-spelled shadow the same way (e.g. a user `fn String::from_byte`, canonical `String::from_char_code`).

Both now go through one `cc_name_or_alias_shadowed`, which tests the source spelling and, when it differs, the canonical one too. Testing both is deliberate: either spelling can carry the definition, and over-guarding costs only the pre-#2585 fallback (the runtime string-pointer heuristic), which is the fail-closed direction.

## Verification

`fixtures/to_string_alias_shadowed_builtin_test.vibe`, **4 tests**: the bare call, the join, the Bool/String return kind (the older site), and an **unshadowed `Array::length` control** — without which "guard everything" would pass the first three while silently reopening #2585.

**Red/green across two real compilers**, not asserted:

| compiler | result |
|---|---|
| stage2 built from merged main | `FAIL` — `actual: 156766306305`, `expected: abc` |
| stage2 built from this tree | `ok`, 4 tests |

The two locks #2586 shipped stay green: `to_string_shadowed_builtin_test` (5 tests), `to_string_join_shapes_test` (9 tests). `scripts/generations.sh build` green through stage2 plus both validations; `check-vibe-fmt` ok on both files. CI: **29/29 green**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q9zbiDqkfF7xYQ3v8aCQ3b