### PR TITLE
gates: restore builtin-shadowing enforcement, on the compiler's answer instead of a regex (#2602)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -478,6 +478,10 @@ jobs:
         run: RANGE_STAGE2="$PWD/_build/_ci_shard_gen/stage2.wasm" bash scripts/check_source_range_contract.sh
       - name: Cheatsheet-signatures gate
         run: CHEATSHEET_SIG_STAGE2="$PWD/_build/_ci_shard_gen/stage2.wasm" bash scripts/check_cheatsheet_signatures.sh
+      - name: Builtin-shadowing gate
+        run: BUILTIN_SHADOW_STAGE2="$PWD/_build/_ci_shard_gen/stage2.wasm" bash scripts/check_builtin_shadowing.sh
+      - name: Builtin-shadowing gate self-test
+        run: BUILTIN_SHADOW_STAGE2="$PWD/_build/_ci_shard_gen/stage2.wasm" bash scripts/check_builtin_shadowing_test.sh
       - name: Package sibling-scope gate
         run: SIBLING_SCOPE_STAGE2="$PWD/_build/_ci_shard_gen/stage2.wasm" bash scripts/check_package_sibling_scope.sh
       - name: Declaration-scale gate

--- a/Taskfile.pkl
+++ b/Taskfile.pkl
@@ -750,6 +750,31 @@ local checkCheatsheetSignatures = new Task {
   // building, and on a reused workspace from an unrelated generation.
   deps { selfhostGeneration }
 }
+// NOT `scriptTask`: the ALLOWLIST is an input too. Without it, editing the
+// exemption list replays a cached "ok" -- the list would stop being checked by
+// the one gate that reads it, which is how an allowlist goes stale unnoticed
+// (#2138 review, same reason as checkCheatsheetSignatures above).
+local checkBuiltinShadowing = new Task {
+  name = "check-builtin-shadowing"
+  description = "no file under lib/** defines a name the builtin registry owns (#2378)"
+  cmd = "bash scripts/check_builtin_shadowing.sh"
+  inputs {
+    ...compilerProbeInputs
+    ...scriptSources
+    "scripts/builtin_shadowing_allowlist.txt"
+  }
+  // The oracle is `vibe symbols`, so it must be THIS checkout's compiler:
+  // left alone the gate takes the newest generation on disk, else the seed,
+  // and answers confidently about a compiler that does not contain the change.
+  deps { selfhostGeneration }
+}
+local testCheckBuiltinShadowing = new Task {
+  name = "test-check-builtin-shadowing"
+  description = "the builtin-shadowing gate can actually fail (#2248)"
+  cmd = "bash scripts/check_builtin_shadowing_test.sh"
+  inputs { ...compilerProbeInputs; ...scriptSources }
+  deps { selfhostGeneration }
+}
 local checkCliLineTermination =
   scriptTask("check-cli-line-termination", "scripts/check_cli_line_termination.sh")
 local checkDeclarationScale =
@@ -1819,6 +1844,8 @@ local releaseCheck = new Task {
     checkDeclarationScale
     checkCliLineTermination
     checkCheatsheetSignatures
+    checkBuiltinShadowing
+    testCheckBuiltinShadowing
     checkPackageSiblingScope
     checkDocCommands
     checkRcDefault
@@ -1923,6 +1950,8 @@ tasks {
   checkDeclarationScale
   checkCliLineTermination
   checkCheatsheetSignatures
+  checkBuiltinShadowing
+  testCheckBuiltinShadowing
   checkPackageSiblingScope
   checkDocCommands
   checkRcDefault

--- a/scripts/builtin_shadowing_allowlist.txt
+++ b/scripts/builtin_shadowing_allowlist.txt
@@ -1,0 +1,31 @@
+# Names under lib/** that the builtin registry also owns (#2378 / #2602).
+#
+# Format: `<name> <reason>`. A row with no reason is REJECTED -- an
+# unexplained exemption is how a list like this goes stale unnoticed.
+#
+# THIS LIST SHRINKS ONLY. A name that stops being declared makes the gate
+# fail, so a row cannot outlive its subject.
+#
+# Every row below predates the gate; none was measured as safe. #2378 flags
+# three of them as worth checking on their own merits and they are marked.
+# Kinds are the compiler's own answer (`vibe symbols`): 12 = Function,
+# 13 = Variable -- a kind-13 row is a VALUE ALIAS, the shape the removed
+# lexical scan could not see.
+
+Fs::exists pre-existing, unmeasured: kind 13 value alias in lib/@vibe/fs/fs.vibe re-exporting the builtin under the Fs namespace
+Fs::read_file pre-existing, unmeasured: kind 13 value alias in lib/@vibe/fs/fs.vibe
+Fs::stat_token pre-existing, unmeasured: kind 13 value alias in lib/@vibe/fs/fs.vibe
+Fs::write_file pre-existing, unmeasured: kind 13 value alias in lib/@vibe/fs/fs.vibe
+Int::clz pre-existing: helper in lib/@vibe/builtin/int_test.vibe, a test file, so the override is scoped to that test program
+Int::ctz pre-existing: helper in lib/@vibe/builtin/int_test.vibe, same scope
+Int::popcount pre-existing: helper in lib/@vibe/builtin/int_test.vibe, same scope
+String::equals pre-existing, unmeasured: defined in lib/@vibe/builtin/string.vibe beside the six SIMD names #2378 removed
+String::trim pre-existing, unmeasured: defined in lib/@vibe/builtin/string.vibe, same file
+__compact_fingerprint_hash pre-existing, unmeasured: defined in lib/@vibe/cache/cache.vibe
+__to_string DELIBERATE: the ADR-0091 polyfills in lib/@vibe/compiler/core/polyfill.vibe and lib/@vibe/parser/polyfill.vibe override it on purpose (#2378 names this as the legitimate-override case)
+compiler_sources generated: lib/@vibe/compiler/compiler_sources_bundle.vibe is produced by scripts/generate_bundle.sh, not hand-written
+eq pre-existing, UNMEASURED and flagged by #2378: lib/@vibe/builtin/float.vibe (kind 13) and lib/@vibe/semver/semver.vibe (kind 12) both define it, and structural equality lowers through a builtin of this name
+not pre-existing: helper in lib/@vibe/compiler/tests/lexer_edge_test.vibe, a test file
+print pre-existing, flagged by #2378: lib/@vibe/console/io.vibe and lib/@vibex/shell/commands.vibe both define it
+println pre-existing, flagged by #2378: lib/@vibe/console/io.vibe and lib/@vibex/shell/commands.vibe both define it
+resolve_path pre-existing, unmeasured: lib/@vibe/module/path.vibe and lib/@vibe/compiler/entry/compiler/fs_compile/closure_order.vibe both define it

--- a/scripts/check_builtin_shadowing.sh
+++ b/scripts/check_builtin_shadowing.sh
@@ -1,0 +1,168 @@
+#!/usr/bin/env bash
+# #2378 / #2602: no file under `lib/**` may DEFINE a name the builtin registry
+# owns.
+#
+# Why it matters (#2378, P0): a top-level definition wins over the builtin for
+# the WHOLE linked program -- not the defining file, not the importer's import
+# list. A file that never mentions the name gets the override anyway, and
+# nothing is reported. Measured there: `lib/@vibe/builtin/string.vibe` carried
+# scalar re-implementations of six SIMD builtins, so importing ANY name from
+# that package replaced `String::index_of` and five siblings program-wide --
+# 0.8us -> 174us on a sparse search, and `String::split(s, "")` changed from a
+# hard trap into `[s]`. The ANSWER differed, not just the speed.
+#
+# A gate for this existed and was removed, for a good reason recorded at the
+# head of `lib/@vibe/builtin/string.vibe`: it was a lexical scan, and it
+# "silently missed value aliases, declarations sharing a line, declarations
+# behind an attribute, declarations wrapped after their keyword, and
+# `r#`-spelled names -- deciding what a declaration binds is the compiler's
+# job." Asking the compiler cost ~1.08 s per file, about 17 minutes for `lib/`.
+#
+# #2381 removed that blocker: `vibe symbols <dir>` now sweeps a whole tree in
+# ONE process (measured: all of `lib/` in ~45 s, 25,904 declarations across 998
+# files) and answers from the parsed AST. So this gate asks the compiler.
+#
+# It matters that it is the AST answer and not a regex: of the names this
+# finds today, FIVE are kind 13 -- value aliases like
+# `export let Fs::exists = exists` -- which an anchored `^(export )?fn` regex
+# cannot see, and whose absence is what #2380 paid for.
+#
+# This is containment for THIS repository only. The language-level half of
+# #2378 -- whether `vibe check` should reject or warn, and whether
+# program-wide resolution is itself the bug -- is untouched.
+set -euo pipefail
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+REGISTRY="lib/@vibe/compiler/core/builtin_registry.vibe"
+ALLOWLIST="${BUILTIN_SHADOW_ALLOWLIST:-scripts/builtin_shadowing_allowlist.txt}"
+SWEEP_ROOT="${BUILTIN_SHADOW_ROOT:-lib}"
+
+# The ONE file under the sweep root that is not a vibe program: its `declare`
+# form is read by the binary encoder, and the general parser rejects it by
+# design. Named explicitly so an unreadable file is never inherited as noise --
+# any OTHER unreadable path fails this gate.
+EXPECTED_UNREADABLE="${BUILTIN_SHADOW_EXPECTED_UNREADABLE:-lib/@vibe/compiler/builtins/declarations.vibe}"
+
+. "$(dirname "$0")/resolve_stage2.sh"
+STAGE2="$(resolve_stage2 builtin-shadowing "${BUILTIN_SHADOW_STAGE2:-}")" || exit 1
+
+[ -f "$REGISTRY" ] || { echo "builtin-shadowing: FAIL: no registry at $REGISTRY" >&2; exit 1; }
+[ -e "$SWEEP_ROOT" ] || { echo "builtin-shadowing: FAIL: sweep root does not exist: $SWEEP_ROOT" >&2; exit 1; }
+
+WORK="$ROOT_DIR/_build/_builtin_shadowing"
+rm -rf "$WORK"; mkdir -p "$WORK"
+trap 'rm -rf "$WORK"' EXIT
+
+RUNNER="$ROOT_DIR/scripts/run_wasm_vibe_host_runner.sh"
+[ -f "$RUNNER" ] || { echo "builtin-shadowing: FAIL: missing host runner: $RUNNER" >&2; exit 1; }
+
+# `vibe symbols <dir>`, one process for the whole tree. The launcher is not
+# used: this drives cli_main directly, the same way scripts/vibe_grep_bin.sh
+# does, so the gate needs no installed `vibe`.
+SYMS="$WORK/syms.txt"
+env -u VIBE_FS_COMPILE -u VIBE_DIAGNOSTICS -u VIBE_NORMALIZE -u VIBE_FMT -u VIBE_TYPE_AT -u VIBE_DOC_AT \
+    -u VIBE_BINDING_AT -u VIBE_ESCAPES -u VIBE_ESCAPES_STRICT -u VIBE_ALLOCS -u VIBE_DEPS -u VIBE_GREP \
+    -u VIBE_COVERAGE -u VIBE_DEBUG -u VIBE_DEBUG_BREAK -u VIBE_EMIT_MODULE_SOURCE \
+  VIBE_SYMBOLS=1 \
+  VIBE_SYMBOLS_WITH_PATH=1 \
+  VIBE_IMPORT_ABI=raw \
+  VIBE_PREOPEN_DIR="${VIBE_PREOPEN_DIR:-$ROOT_DIR}" \
+  bash "$RUNNER" --invoke cli_main "$STAGE2" "$SWEEP_ROOT" "$SYMS" >/dev/null 2>"$WORK/runner.err" || true
+
+if [ ! -s "$SYMS" ]; then
+  echo "builtin-shadowing: FAIL: the symbols sweep produced nothing for '$SWEEP_ROOT'." >&2
+  echo "  An empty sweep is NOT 'no shadowing' -- it is an unchecked tree." >&2
+  [ -s "$WORK/syms.txt.diag" ] && sed 's/^/  diag: /' "$WORK/syms.txt.diag" >&2
+  [ -s "$WORK/runner.err" ] && sed 's/^/  runner: /' "$WORK/runner.err" >&2
+  exit 1
+fi
+
+# A file the sweep could not read is a HOLE, not a pass: its declarations were
+# never inspected. Exactly one path is expected (see EXPECTED_UNREADABLE).
+if [ -s "$SYMS.diag" ]; then
+  while IFS= read -r diag_line || [ -n "$diag_line" ]; do
+    [ -n "$diag_line" ] || continue
+    case "$diag_line" in
+      "$EXPECTED_UNREADABLE"*) : ;;
+      *)
+        echo "builtin-shadowing: FAIL: a file under '$SWEEP_ROOT' could not be read, so its" >&2
+        echo "  declarations were not inspected: $diag_line" >&2
+        exit 1
+        ;;
+    esac
+  done < "$SYMS.diag"
+fi
+
+# Every name the registry owns. Rows look like
+#   ("String::length", CtFn(..), true, false, true),
+# and a row's first field is the name. checker_visible is NOT filtered on: a
+# definition colliding with a codegen-internal name is still a collision, and
+# fail-closed is the direction this gate wants.
+awk '
+  match($0, /^[ \t]*\("[A-Za-z_][A-Za-z0-9_]*(::[A-Za-z0-9_]+)?"/) {
+    s = substr($0, RSTART, RLENGTH)
+    gsub(/^[ \t]*\("/, "", s); gsub(/"$/, "", s)
+    print s
+  }
+' "$REGISTRY" | sort -u > "$WORK/registry.txt"
+
+if [ ! -s "$WORK/registry.txt" ]; then
+  echo "builtin-shadowing: FAIL: extracted zero names from $REGISTRY." >&2
+  echo "  The row shape must have changed; this gate would pass vacuously." >&2
+  exit 1
+fi
+
+# Declarations that BIND a value: KIND 12 (Function) and 13 (Variable). 13 is
+# the one a regex misses (`export let Fs::exists = exists`).
+awk '$3 == 12 || $3 == 13 { print $2 }' "$SYMS" | sort -u > "$WORK/declared.txt"
+comm -12 "$WORK/registry.txt" "$WORK/declared.txt" > "$WORK/found.txt"
+
+# Allowlist: `<name> <reason...>`. A row with no reason is rejected -- an
+# unexplained exemption is how a list like this goes stale unnoticed.
+: > "$WORK/allowed.txt"
+allow_bad=0
+if [ -f "$ALLOWLIST" ]; then
+  while IFS= read -r line || [ -n "$line" ]; do
+    case "$line" in ''|'#'*) continue ;; esac
+    name="${line%% *}"
+    reason="${line#"$name"}"
+    reason="${reason# }"
+    if [ -z "$reason" ] || [ "$reason" = "$name" ]; then
+      echo "builtin-shadowing: FAIL: allowlist row has no reason: $line" >&2
+      allow_bad=1
+      continue
+    fi
+    printf '%s\n' "$name" >> "$WORK/allowed.txt"
+  done < "$ALLOWLIST"
+fi
+[ "$allow_bad" -eq 0 ] || exit 1
+sort -u "$WORK/allowed.txt" -o "$WORK/allowed.txt"
+
+new_hits="$(comm -23 "$WORK/found.txt" "$WORK/allowed.txt")"
+stale="$(comm -13 "$WORK/found.txt" "$WORK/allowed.txt")"
+
+status=0
+if [ -n "$new_hits" ]; then
+  echo "builtin-shadowing: FAIL: these are declared under '$SWEEP_ROOT' and the builtin" >&2
+  echo "  registry already owns them. A definition wins for the WHOLE linked program," >&2
+  echo "  including files that never import it (#2378), so rename it:" >&2
+  printf '%s\n' "$new_hits" | while IFS= read -r n; do
+    [ -n "$n" ] || continue
+    printf '    %s\n' "$n" >&2
+    awk -v n="$n" '$2 == n && ($3 == 12 || $3 == 13) { printf "      %s (kind %s)\n", $1, $3 }' "$SYMS" >&2
+  done
+  status=1
+fi
+
+if [ -n "$stale" ]; then
+  echo "builtin-shadowing: FAIL: allowlisted names that are no longer declared." >&2
+  echo "  The list shrinks only -- delete these rows:" >&2
+  printf '%s\n' "$stale" | sed 's/^/    /' >&2
+  status=1
+fi
+
+[ "$status" -eq 0 ] || exit 1
+
+files="$(awk '{ print $1 }' "$SYMS" | sort -u | wc -l | tr -d ' ')"
+echo "builtin-shadowing: ok ($(wc -l < "$WORK/registry.txt" | tr -d ' ') registry names vs $(wc -l < "$WORK/declared.txt" | tr -d ' ') declared under '$SWEEP_ROOT' across $files files; $(wc -l < "$WORK/found.txt" | tr -d ' ') allowlisted, 0 new)"

--- a/scripts/check_builtin_shadowing.sh
+++ b/scripts/check_builtin_shadowing.sh
@@ -57,18 +57,83 @@ trap 'rm -rf "$WORK"' EXIT
 RUNNER="$ROOT_DIR/scripts/run_wasm_vibe_host_runner.sh"
 [ -f "$RUNNER" ] || { echo "builtin-shadowing: FAIL: missing host runner: $RUNNER" >&2; exit 1; }
 
-# `vibe symbols <dir>`, one process for the whole tree. The launcher is not
-# used: this drives cli_main directly, the same way scripts/vibe_grep_bin.sh
+# `vibe symbols`, driving cli_main directly the way scripts/vibe_grep_bin.sh
 # does, so the gate needs no installed `vibe`.
+#
+# TWO LANES, because the compiler that answers is not always one that can sweep
+# a directory. Batch mode is #2381; the committed seed predates it and reads the
+# directory as a FILE (`EISDIR`), which comes back as an empty sweep. Measured
+# in CI: the `late` lane has no generation on disk, falls back to the seed, and
+# every case of this gate's own self-test failed there for that reason and no
+# other -- exactly the "a gate must not assume its environment" defect of #2252.
+#
+# So: probe once, then take the batch lane when it works and a per-file lane
+# when it does not. The per-file lane asks the same question of the same
+# compiler, one file at a time, and is BOUNDED -- past the cap it refuses
+# rather than grinding (one process per file was ~1.08 s, about 17 minutes for
+# `lib/`, which is the cost #2381 removed and this gate must not silently
+# re-pay).
+sym_run() { # <input path> <output path> <with_path 0|1>
+  env -u VIBE_FS_COMPILE -u VIBE_DIAGNOSTICS -u VIBE_NORMALIZE -u VIBE_FMT -u VIBE_TYPE_AT -u VIBE_DOC_AT \
+      -u VIBE_BINDING_AT -u VIBE_ESCAPES -u VIBE_ESCAPES_STRICT -u VIBE_ALLOCS -u VIBE_DEPS -u VIBE_GREP \
+      -u VIBE_COVERAGE -u VIBE_DEBUG -u VIBE_DEBUG_BREAK -u VIBE_EMIT_MODULE_SOURCE \
+    VIBE_SYMBOLS=1 \
+    VIBE_SYMBOLS_WITH_PATH="$3" \
+    VIBE_IMPORT_ABI=raw \
+    VIBE_PREOPEN_DIR="${VIBE_PREOPEN_DIR:-$ROOT_DIR}" \
+    bash "$RUNNER" --invoke cli_main "$STAGE2" "$1" "$2" >/dev/null 2>>"$WORK/runner.err" || true
+}
+
 SYMS="$WORK/syms.txt"
-env -u VIBE_FS_COMPILE -u VIBE_DIAGNOSTICS -u VIBE_NORMALIZE -u VIBE_FMT -u VIBE_TYPE_AT -u VIBE_DOC_AT \
-    -u VIBE_BINDING_AT -u VIBE_ESCAPES -u VIBE_ESCAPES_STRICT -u VIBE_ALLOCS -u VIBE_DEPS -u VIBE_GREP \
-    -u VIBE_COVERAGE -u VIBE_DEBUG -u VIBE_DEBUG_BREAK -u VIBE_EMIT_MODULE_SOURCE \
-  VIBE_SYMBOLS=1 \
-  VIBE_SYMBOLS_WITH_PATH=1 \
-  VIBE_IMPORT_ABI=raw \
-  VIBE_PREOPEN_DIR="${VIBE_PREOPEN_DIR:-$ROOT_DIR}" \
-  bash "$RUNNER" --invoke cli_main "$STAGE2" "$SWEEP_ROOT" "$SYMS" >/dev/null 2>"$WORK/runner.err" || true
+FALLBACK_CAP="${BUILTIN_SHADOW_FALLBACK_CAP:-50}"
+
+sym_run "$SWEEP_ROOT" "$SYMS" 1
+
+# Did the batch lane actually work? A compiler without it leaves nothing and
+# an EISDIR diag. Distinguish that from a genuinely empty tree by asking
+# whether the root holds any source at all.
+batch_worked=1
+if [ ! -s "$SYMS" ] && [ -d "$SWEEP_ROOT" ]; then
+  if grep -q "EISDIR" "$SYMS.diag" 2>/dev/null; then
+    batch_worked=0
+  elif [ ! -s "$SYMS.diag" ]; then
+    batch_worked=0
+  fi
+fi
+
+if [ "$batch_worked" -eq 0 ]; then
+  # Enumerate the way source_walk.vibe does when RECURSING: `.vibe` / `.vibex`,
+  # skipping build output and vendored trees. This shell-side selection exists
+  # ONLY for the fallback -- the batch lane uses the compiler's own walk, which
+  # is the answer that cannot drift.
+  : > "$WORK/files.txt"
+  find "$SWEEP_ROOT" \( -name '.*' -o -name '_build' -o -name 'node_modules' -o -name 'dist' -o -name 'target' -o -name 'deps' \) -prune -o \
+       -type f \( -name '*.vibe' -o -name '*.vibex' \) -print > "$WORK/files.txt" 2>/dev/null || true
+  n_files="$(wc -l < "$WORK/files.txt" | tr -d ' ')"
+  if [ "$n_files" -gt "$FALLBACK_CAP" ]; then
+    echo "builtin-shadowing: FAIL: this compiler cannot sweep a directory (batch symbols is #2381)," >&2
+    echo "  and '$SWEEP_ROOT' holds $n_files files -- more than the $FALLBACK_CAP-file fallback cap." >&2
+    echo "  One process per file costs ~1.08 s, about 17 minutes here; that is the cost #2381" >&2
+    echo "  removed and this gate will not silently re-pay it." >&2
+    echo "  Build a compiler that has it:  pkf run generation" >&2
+    echo "  (or hand one over:  BUILTIN_SHADOW_STAGE2=<path to stage2.wasm>)" >&2
+    exit 1
+  fi
+  : > "$SYMS"; : > "$SYMS.diag"
+  while IFS= read -r one || [ -n "$one" ]; do
+    [ -n "$one" ] || continue
+    sym_run "$one" "$WORK/one.txt" 0
+    if [ -s "$WORK/one.txt.diag" ]; then
+      printf '%s: ' "$one" >> "$SYMS.diag"
+      cat "$WORK/one.txt.diag" >> "$SYMS.diag"
+      printf '\n' >> "$SYMS.diag"
+    fi
+    if [ -s "$WORK/one.txt" ]; then
+      awk -v p="$one" '{ print p, $0 }' "$WORK/one.txt" >> "$SYMS"
+    fi
+    rm -f "$WORK/one.txt" "$WORK/one.txt.diag"
+  done < "$WORK/files.txt"
+fi
 
 if [ ! -s "$SYMS" ]; then
   echo "builtin-shadowing: FAIL: the symbols sweep produced nothing for '$SWEEP_ROOT'." >&2

--- a/scripts/check_builtin_shadowing_test.sh
+++ b/scripts/check_builtin_shadowing_test.sh
@@ -1,0 +1,151 @@
+#!/usr/bin/env bash
+# Self-test for check_builtin_shadowing.sh (#2248: a gate means nothing until
+# it is shown it CAN fail).
+#
+# Every case MUTATES a real tree and asserts the gate rejects it, and every
+# case first asserts the mutation actually landed -- an edit that matches
+# nothing passes while proving nothing, which is the failure #2248 records.
+#
+# The value-alias case (kind 13) is the one that matters most: the lexical
+# scan this gate replaces passed on exactly that shape, so a self-test that
+# only covers `fn` would certify the same hole.
+set -euo pipefail
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+# #2252: never inherit the knobs under test. Each case sets them explicitly.
+unset BUILTIN_SHADOW_ALLOWLIST BUILTIN_SHADOW_ROOT BUILTIN_SHADOW_EXPECTED_UNREADABLE || true
+
+GATE="$ROOT_DIR/scripts/check_builtin_shadowing.sh"
+WORK="$ROOT_DIR/_build/_builtin_shadowing_selftest"
+rm -rf "$WORK"; mkdir -p "$WORK"
+trap 'rm -rf "$WORK"' EXIT
+
+pass=0; fail=0
+ok()  { echo "ok: $1"; pass=$((pass + 1)); }
+bad() { echo "FAIL: $1" >&2; fail=$((fail + 1)); }
+
+# A tree the gate must accept: one file, nothing the registry owns.
+fresh_tree() { # <dir>
+  rm -rf "$1"; mkdir -p "$1"
+  printf 'export fn unrelated_helper(n: Int) -> Int {\n  n + 1\n}\n' > "$1/clean.vibe"
+}
+
+empty_allowlist() { # <path>
+  printf '# self-test allowlist\n' > "$1"
+}
+
+# run_gate <tree> <allowlist> -> prints output, returns the gate's status
+run_gate() {
+  BUILTIN_SHADOW_ROOT="$1" BUILTIN_SHADOW_ALLOWLIST="$2" \
+    bash "$GATE" 2>&1 || return $?
+}
+
+TREE="$WORK/tree"
+ALLOW="$WORK/allow.txt"
+
+# --- 0. GREEN control -------------------------------------------------------
+# Without this every case below could "pass" on a gate that rejects anything.
+fresh_tree "$TREE"; empty_allowlist "$ALLOW"
+if out="$(run_gate "$TREE" "$ALLOW")"; then
+  ok "a tree with no shadowing is accepted"
+else
+  bad "the clean control was rejected: $out"
+fi
+
+# --- 1. kind 12: a `fn` shadowing a builtin ---------------------------------
+fresh_tree "$TREE"; empty_allowlist "$ALLOW"
+printf 'export fn String::length(s: String) -> Int {\n  -1\n}\n' > "$TREE/shadow_fn.vibe"
+if ! grep -q 'fn String::length' "$TREE/shadow_fn.vibe"; then
+  bad "mutation 1 did not land"
+elif out="$(run_gate "$TREE" "$ALLOW")"; then
+  bad "a \`fn String::length\` shadow was accepted: $out"
+else
+  case "$out" in
+    *"String::length"*) ok "a \`fn\` shadowing a builtin is rejected, and named" ;;
+    *) bad "rejected, but did not name String::length: $out" ;;
+  esac
+fi
+
+# --- 2. kind 13: a VALUE ALIAS shadowing a builtin --------------------------
+# The shape the removed regex missed (`export let Fs::exists = exists`).
+fresh_tree "$TREE"; empty_allowlist "$ALLOW"
+printf 'fn local_exists(p: String) -> Bool {\n  String::length(p) > 0\n}\n\nexport let Fs::exists = local_exists\n' > "$TREE/shadow_alias.vibe"
+if ! grep -q 'let Fs::exists' "$TREE/shadow_alias.vibe"; then
+  bad "mutation 2 did not land"
+elif out="$(run_gate "$TREE" "$ALLOW")"; then
+  bad "a VALUE ALIAS shadow was accepted -- this is the regex's blind spot: $out"
+else
+  case "$out" in
+    *"Fs::exists"*) ok "a value-alias (kind 13) shadow is rejected, and named" ;;
+    *) bad "rejected, but did not name Fs::exists: $out" ;;
+  esac
+fi
+
+# --- 3. an allowlist row with a reason suppresses exactly that name ---------
+fresh_tree "$TREE"
+printf 'export fn String::length(s: String) -> Int {\n  -1\n}\n' > "$TREE/shadow_fn.vibe"
+printf '# self-test allowlist\nString::length deliberate, for the self-test\n' > "$ALLOW"
+if out="$(run_gate "$TREE" "$ALLOW")"; then
+  ok "an allowlisted name with a reason is accepted"
+else
+  bad "an allowlisted name was still rejected: $out"
+fi
+
+# --- 4. an allowlist row with NO reason is rejected -------------------------
+fresh_tree "$TREE"
+printf 'export fn String::length(s: String) -> Int {\n  -1\n}\n' > "$TREE/shadow_fn.vibe"
+printf '# self-test allowlist\nString::length\n' > "$ALLOW"
+if out="$(run_gate "$TREE" "$ALLOW")"; then
+  bad "a reasonless allowlist row was accepted: $out"
+else
+  case "$out" in
+    *"no reason"*) ok "an allowlist row with no reason is rejected" ;;
+    *) bad "rejected, but not about the missing reason: $out" ;;
+  esac
+fi
+
+# --- 5. a STALE allowlist row is rejected -----------------------------------
+# The list shrinks only; a row that outlives its subject must not linger.
+fresh_tree "$TREE"
+printf '# self-test allowlist\nString::length it was removed from the tree, so this row is stale\n' > "$ALLOW"
+if out="$(run_gate "$TREE" "$ALLOW")"; then
+  bad "a stale allowlist row was accepted: $out"
+else
+  case "$out" in
+    *"no longer declared"*) ok "a stale allowlist row is rejected" ;;
+    *) bad "rejected, but not about staleness: $out" ;;
+  esac
+fi
+
+# --- 6. an UNREADABLE file fails, rather than being skipped -----------------
+# A file the sweep cannot parse had its declarations inspected by nobody.
+# Silence there is "unchecked", not "clean".
+fresh_tree "$TREE"; empty_allowlist "$ALLOW"
+printf 'export fn broken( {\n' > "$TREE/unparseable.vibe"
+if ! grep -q 'fn broken(' "$TREE/unparseable.vibe"; then
+  bad "mutation 6 did not land"
+elif out="$(run_gate "$TREE" "$ALLOW")"; then
+  bad "an unreadable file was skipped silently: $out"
+else
+  case "$out" in
+    *"could not be read"*) ok "an unreadable file fails the gate instead of being skipped" ;;
+    *) bad "rejected, but not about the unreadable file: $out" ;;
+  esac
+fi
+
+# --- 7. an EMPTY sweep fails ------------------------------------------------
+# "Nothing came back" must never read as "nothing is wrong".
+rm -rf "$TREE"; mkdir -p "$TREE"; empty_allowlist "$ALLOW"
+if out="$(run_gate "$TREE" "$ALLOW")"; then
+  bad "an empty sweep was accepted as clean: $out"
+else
+  case "$out" in
+    *"produced nothing"*) ok "an empty sweep fails instead of passing vacuously" ;;
+    *) bad "rejected, but not about the empty sweep: $out" ;;
+  esac
+fi
+
+echo "----"
+echo "passed: $pass, failed: $fail"
+[ "$fail" -eq 0 ]

--- a/scripts/check_builtin_shadowing_test.sh
+++ b/scripts/check_builtin_shadowing_test.sh
@@ -146,6 +146,29 @@ else
   esac
 fi
 
+# --- 8. a compiler that cannot sweep a directory REFUSES, not grinds --------
+# Batch symbols is #2381; the committed seed predates it and reads a directory
+# as a file. The per-file fallback covers small trees (every case above runs
+# through it when this suite is handed a seed), but it must never silently
+# re-pay the ~17 minutes #2381 removed. Pinned with the seed explicitly and a
+# cap of 0, so the assertion does not depend on which compiler is ambient.
+fresh_tree "$TREE"; empty_allowlist "$ALLOW"
+if [ -s "$ROOT_DIR/bootstrap/seed/compiler.wasm" ]; then
+  if out="$(BUILTIN_SHADOW_STAGE2="$ROOT_DIR/bootstrap/seed/compiler.wasm" \
+            BUILTIN_SHADOW_FALLBACK_CAP=0 \
+            BUILTIN_SHADOW_ROOT="$TREE" BUILTIN_SHADOW_ALLOWLIST="$ALLOW" \
+            bash "$GATE" 2>&1)"; then
+    bad "past the fallback cap the gate passed instead of refusing: $out"
+  else
+    case "$out" in
+      *"fallback cap"*) ok "past the fallback cap the gate refuses, naming the fix" ;;
+      *) bad "refused, but not about the cap: $out" ;;
+    esac
+  fi
+else
+  bad "no committed seed to pin the no-batch lane against"
+fi
+
 echo "----"
 echo "passed: $pass, failed: $fail"
 [ "$fail" -eq 0 ]


### PR DESCRIPTION
Closes #2602. Restores the containment half of **#2378** (open, P0).

## `lib/**` currently has no gate at all

#2378's body says it does:

> `scripts/check_builtin_shadowing.sh` (gated) fails the build if `lib/**` grows a new one. `scripts/builtin_shadowing_allowlist.txt` records the 12 that predate the gate and shrinks only.

Neither file is in the tree, and nothing references either name. `lib/@vibe/builtin/string.vibe` records **why**, at its own head:

> **NOTHING ENFORCES THIS.** #2378 is where the diagnostic belongs. A lexical check was tried and removed: it silently missed value aliases, declarations sharing a line, declarations behind an attribute, declarations wrapped after their keyword, and `r#`-spelled names — deciding what a declaration binds is the compiler's job.

Removing it was right. Asking the compiler instead was not affordable: ~1.08 s per file, about 17 minutes for `lib/`.

## #2381 removed that blocker

`vibe symbols <dir>` now sweeps a whole tree in one process. This gate drives `cli_main` directly — the way `scripts/vibe_grep_bin.sh` does, so no installed `vibe` is needed — and reads the parsed AST.

**Measured: 172 registry names against 18,198 declarations across 999 files, in 44 s.**

## It finds what the regex could not

17 names today, and **five are kind 13 — value aliases** like `export let Fs::exists = exists`. That is precisely the shape an anchored `^(export )?fn` regex cannot see, and the one #2380 paid for.

The allowlist carries all 17 with a reason each and **shrinks only**: a row whose subject stops being declared fails the gate, so it cannot outlive its subject. Three rows are marked flagged-but-unmeasured by #2378 (`eq`, `print`/`println`, and the deliberate `__to_string` polyfills) rather than quietly blessed.

## Fails closed, in four ways

| situation | result |
|---|---|
| a file the sweep cannot read | **FAIL** — its declarations were inspected by nobody; silence is "unchecked", not "clean". Exactly one path is expected (`builtins/declarations.vibe`, whose `declare` form the general parser rejects by design); any other fails |
| an empty sweep | **FAIL** — "nothing came back" must never read as "nothing is wrong" |
| zero names extracted from the registry | **FAIL** — a changed row shape cannot make the gate pass vacuously |
| an allowlist row with no reason | **FAIL** |

## Verification

**`scripts/check_builtin_shadowing_test.sh`: 8 cases, all green.** Each mutates a real tree, asserts the mutation landed *first*, then asserts the gate rejects it. It includes:

- a **green control** — without it every other case would pass on a gate that rejects everything;
- the **kind-13 value-alias** case, which is the one that matters: a self-test covering only `fn` would certify the same hole the removed scan had.

**End to end on the real tree**, not a fixture:

```console
$ # with `export let String::index_of = ..` added under lib/@vibe/core/
$ bash scripts/check_builtin_shadowing.sh; echo $?
builtin-shadowing: FAIL: these are declared under 'lib' and the builtin
  registry already owns them...
    String::index_of
      lib/@vibe/core/_probe_shadow_2602.vibe (kind 13)
1
$ # removed
$ bash scripts/check_builtin_shadowing.sh; echo $?
builtin-shadowing: ok (172 registry names vs 18198 declared under 'lib' across 999 files; 17 allowlisted, 0 new)
0
```

`check-gate-wiring`, `check-gate-portability`, `check-gate-self-tests` and `check-task-inputs` all ok — the first of those **flagged this gate as dark** until the CI step existed, which is what it is for.

Wired into `ci.yml` beside the other gates handed an explicit stage2, and registered in `tasks { }` and `releaseCheck.deps`. Both tasks carry `deps { selfhostGeneration }` and the allowlist is a declared input, so editing the exemption list cannot replay a cached "ok".

## Scope

Containment for this repository only. The language-level half of #2378 — reject vs. warn, whose diagnostic it is, whether program-wide resolution is itself the bug — is untouched, and this does nothing for a user's own code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q9zbiDqkfF7xYQ3v8aCQ3b

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q9zbiDqkfF7xYQ3v8aCQ3b)_