### PR TITLE
checker: a FrozenArray receiver is checked, in both directions (#2454)

### DIFF
--- a/fixtures/gc_region_arena_free.vibe
+++ b/fixtures/gc_region_arena_free.vibe
@@ -36,7 +36,10 @@ fn freeze_reads_back() -> Int {
   region r {
     let l = MutList::empty(r)
     MutList::push(l, 9)
-    Array::get(MutList::freeze(l), 0)
+    // #2454: `MutList::freeze` yields a FrozenArray, so read it with the
+    // frozen accessor. `Array::get` on it is the exact confusion the phantom
+    // type exists to prevent, and the checker now says so.
+    FrozenArray::get(MutList::freeze(l), 0)
   }
 }
 

--- a/lib/@vibe/compiler/checker/checker.vibe
+++ b/lib/@vibe/compiler/checker/checker.vibe
@@ -4631,6 +4631,30 @@ fn head_kind(t: Type) -> Int {
       // Keeping it in the unresolved CtNamed bucket lets direct builtins such
       // as `Map::iter_get(1, 0)` reinterpret an arbitrary scalar as a map.
       17
+    } else if name == "FrozenArray" {
+      // #2454: `FrozenArray[T]` is a checker-only phantom over `Array[T]`'s
+      // runtime layout (#906), and while it sat in the tolerated `0` bucket the
+      // distinction it exists for was not held apart AT ALL. All three of these
+      // checked clean:
+      //
+      //   fn f(x: Array[Int]) -> Int { FrozenArray::length(x) }
+      //   fn g(x: Array[Int]) -> Int { FrozenArray::get(x, 0) }
+      //   fn h(x: FrozenArray[Int]) -> Int { Array::get(x, 0) }
+      //
+      // A certain head is all three need. The `FrozenArray::*` rows carry real
+      // parameter types since #2451, so `builtin_param_head` reads
+      // `FrozenArray[T]` for their receiver and the existing head check rejects
+      // an `Array` there; the `Array::*` rows expect head 9, which now rejects a
+      // `FrozenArray`. Nothing goes wrong at RUN time either way -- the copy
+      // contract is codegen's (fixtures/frozen_array_copies_test.vibe) -- so
+      // this is a missing diagnostic being added, not a wrong answer being
+      // fixed.
+      //
+      // This is the MutList / Attempt / Map treatment, not ByteStream's: that
+      // one stayed out of head_kind and got its own predicate because only the
+      // Array sites needed it. Here both directions need a head, so the head is
+      // where it belongs.
+      18
     } else {
       0
     },
@@ -4671,6 +4695,26 @@ fn slice_receiver_is_invalid(receiver: Type, receiver_had_error: Bool) -> Bool {
 /// (ADR-0012) into user programs. Recognise a Stream receiver so the Array
 /// head-check sites can reject it explicitly; head_kind itself is unchanged
 /// (other CtNamed heads stay tolerated, the #826 discipline).
+/// #2454: a `FrozenArray::*` receiver that is not a FrozenArray.
+///
+/// The three arms below recover the element type by pattern-matching the
+/// receiver and falling back to a tolerant `CtUnknown` -- which cannot report,
+/// so an `Array[Int]` receiver checked clean and the phantom distinction (#906)
+/// was not held apart in either direction. Ground-gated like every other
+/// receiver head check here: head 0 means "unresolved, tolerate", so a generic
+/// or still-open receiver stays accepted and only a certain wrong head is
+/// rejected. Head 18 is FrozenArray.
+///
+/// The message leads with the edit, not with the phantom-type theory.
+fn reject_non_frozen_receiver(recv: Type, name: String, callee_off: Int, errors: Array[String]) -> Unit {
+  let k = head_kind(recv)
+  if k != 0 && k != 18 {
+    Array::push(errors, String::concat("argument type mismatch for ", String::concat(name, String::concat(": receiver type ", String::concat(type_to_string(recv), String::concat(" is not a FrozenArray -- freeze it first with FrozenArray::from_array(x)", off_marker_len(callee_off, String::length(name))))))))
+  } else {
+    ()
+  }
+}
+
 fn is_bytestream_named_type(t: Type) -> Bool {
   match t {
     CtNamed(n, _) => n == "ByteStream",
@@ -9860,6 +9904,13 @@ fn check_expr_capture_impl(expr: Expr, env: TypeEnv, defs: Array[TypeDef], s: Su
           // element type back into an ordinary Array[T], same shape as
           // ArrayBuilder::freeze above.
           let (fa_ty, s1, c1) = check_expr_capture(Array::get(args, 0), env, defs, s, c, errors, tytab, capture, lane)
+          // #2454: the receiver must BE a FrozenArray. The tolerant `else`
+          // below recovers the element type and cannot report -- so
+          // `FrozenArray::to_array` on an `Array[Int]` checked clean, and the
+          // distinction this phantom type exists for was not held apart at
+          // all. Ground-gated exactly like `Array::get`'s receiver check
+          // (head 0 = unresolved, tolerate); head 18 is FrozenArray.
+          reject_non_frozen_receiver(subst_apply(s1, fa_ty), name, callee_off, errors)
           let result = match subst_apply(s1, fa_ty) {
             CtNamed(fn0, fargs) => if fn0 == "FrozenArray" && Array::length(fargs) == 1 {
               CtArray(subst_apply(s1, Array::get(fargs, 0)))
@@ -9874,6 +9925,13 @@ fn check_expr_capture_impl(expr: Expr, env: TypeEnv, defs: Array[TypeDef], s: Su
           // FrozenArray receiver instead of CtArray.
           let (fa_ty, s1, c1) = check_expr_capture(Array::get(args, 0), env, defs, s, c, errors, tytab, capture, lane)
           let (_, s2, c2) = check_expr_capture(Array::get(args, 1), env, defs, s1, c1, errors, tytab, capture, lane)
+          // #2454: the receiver must BE a FrozenArray. The tolerant `else`
+          // below recovers the element type and cannot report -- so
+          // `FrozenArray::get` on an `Array[Int]` checked clean, and the
+          // distinction this phantom type exists for was not held apart at
+          // all. Ground-gated exactly like `Array::get`'s receiver check
+          // (head 0 = unresolved, tolerate); head 18 is FrozenArray.
+          reject_non_frozen_receiver(subst_apply(s2, fa_ty), name, callee_off, errors)
           let result = match subst_apply(s2, fa_ty) {
             CtNamed(fn1, fargs1) => if fn1 == "FrozenArray" && Array::length(fargs1) == 1 {
               subst_apply(s2, Array::get(fargs1, 0))
@@ -9887,7 +9945,11 @@ fn check_expr_capture_impl(expr: Expr, env: TypeEnv, defs: Array[TypeDef], s: Su
           // #906: length is not element-type-dependent -- always Int, but the
           // receiver still needs checking (consistent with every other builtin
           // branch here checking all of its arguments).
-          let (_, s1, c1) = check_expr_capture(Array::get(args, 0), env, defs, s, c, errors, tytab, capture, lane)
+          let (fa_len_ty, s1, c1) = check_expr_capture(Array::get(args, 0), env, defs, s, c, errors, tytab, capture, lane)
+          // #2454: this arm did not look at the receiver's SHAPE at all -- it
+          // checked the argument for effects and returned CtInt, so
+          // `FrozenArray::length(x)` on an `Array[Int]` checked clean.
+          reject_non_frozen_receiver(subst_apply(s1, fa_len_ty), name, callee_off, errors)
           (tab_call_ty(tytab, call_off, CtInt, capture, lane), s1, c1)
         } else if name == "MutList::empty" && Array::length(args) == 1 {
           // ADR-0090 Phase 1: MutList[T, r] is a checker-only phantom over

--- a/lib/@vibe/compiler/tests/checker_frozen_array_receiver_test.vibe
+++ b/lib/@vibe/compiler/tests/checker_frozen_array_receiver_test.vibe
@@ -1,0 +1,91 @@
+//# Imports
+
+// #2454: the `FrozenArray::*` receiver refinements were TOLERANT -- they
+// recovered the element type by pattern-matching the receiver and fell back to
+// `CtUnknown`, which cannot report. So the phantom distinction `FrozenArray[T]`
+// exists for (#906) was not held apart in EITHER direction, and all three of
+// these checked clean:
+//
+//   fn f(x: Array[Int]) -> Int { FrozenArray::length(x) }
+//   fn g(x: Array[Int]) -> Int { FrozenArray::get(x, 0) }
+//   fn h(x: FrozenArray[Int]) -> Int { Array::get(x, 0) }
+//
+// Nothing goes wrong at RUN time -- the copy contract is codegen's
+// (fixtures/frozen_array_copies_test.vibe) -- so this pins a DIAGNOSTIC.
+
+import @vibe/compiler/checker {
+  check_program
+}
+
+import @vibe/compiler/syntax {
+  lex, parse_program
+}
+
+//# Functions
+
+/// The checker's first diagnostic for `src`, or "" when it checks clean.
+/// Same fail-fast shape as checker_diag_report_test.vibe's `first_check_error`.
+fn diags_of(src: String) -> String {
+  handle {
+    let _ = check_program(parse_program(lex(src)))
+    ""
+  } with { Exception::Throw(msg) => msg }
+}
+
+fn rejects(src: String) -> Bool {
+  String::length(diags_of(src)) > 0
+}
+
+//# Tests
+
+test "#2454: an Array receiver is rejected by FrozenArray::length" {
+  let d = diags_of("fn f(x: Array[Int]) -> Int { FrozenArray::length(x) }\n")
+  assert(String::contains(d, "FrozenArray::length"))
+  assert(String::contains(d, "Array[Int]"))
+  // The message must name the EDIT, not the phantom-type theory.
+  assert(String::contains(d, "FrozenArray::from_array"))
+}
+
+test "#2454: an Array receiver is rejected by FrozenArray::get" {
+  let d = diags_of("fn g(x: Array[Int]) -> Int { FrozenArray::get(x, 0) }\n")
+  assert(String::contains(d, "FrozenArray::get"))
+  assert(String::contains(d, "Array[Int]"))
+}
+
+test "#2454: an Array receiver is rejected by FrozenArray::to_array" {
+  let d = diags_of("fn i(x: Array[Int]) -> Array[Int] { FrozenArray::to_array(x) }\n")
+  assert(String::contains(d, "FrozenArray::to_array"))
+}
+
+test "#2454: a FrozenArray receiver is rejected by Array::get" {
+  // The other direction, which the Array head check now sees because
+  // FrozenArray has a certain head kind rather than sitting in the tolerated
+  // `0` bucket.
+  let d = diags_of("fn h(x: FrozenArray[Int]) -> Int { Array::get(x, 0) }\n")
+  assert(String::contains(d, "Array::get"))
+  assert(String::contains(d, "FrozenArray[Int]"))
+}
+
+test "#2454: the legitimate shapes stay clean (the control)" {
+  // Without this, every assertion above would pass on a checker that had
+  // simply started rejecting FrozenArray entirely.
+  assert(!rejects("fn ok1(x: FrozenArray[Int]) -> Int { FrozenArray::get(x, 0) }\n"))
+  assert(!rejects("fn ok2(x: FrozenArray[Int]) -> Int { FrozenArray::length(x) }\n"))
+  assert(!rejects("fn ok3(a: Array[Int]) -> Int { FrozenArray::get(FrozenArray::from_array(a), 0) }\n"))
+  assert(!rejects("fn ok4(x: FrozenArray[Int]) -> Int { Array::get(FrozenArray::to_array(x), 0) }\n"))
+}
+
+test "#2454: an unresolved receiver stays tolerated" {
+  // Ground-gated, like every other receiver head check here: head 0 means
+  // "unresolved, tolerate". Over-rejecting a generic receiver would be a
+  // worse bug than the one being fixed.
+  assert(!rejects("fn ok5[T](x: T) -> Int { FrozenArray::length(x) }\n"))
+}
+
+test "#2454: the element type is still recovered from the receiver" {
+  // The refinement's USEFUL half must survive: `FrozenArray::get` on a
+  // `FrozenArray[Int]` is an Int, not CtUnknown.
+  let d = diags_of("fn e(x: FrozenArray[Int]) -> String { let s: String = FrozenArray::get(x, 0)\n  s }\n")
+  assert(String::contains(d, "expected String"))
+  assert(String::contains(d, "Int"))
+}


### PR DESCRIPTION
Closes #2454.

`FrozenArray[T]` is a checker-only phantom over `Array[T]`'s runtime layout (#906). The distinction exists so a reader can tell a frozen snapshot from a live array — and the checker was not holding them apart at all:

```vibe
fn f(x: Array[Int]) -> Int { FrozenArray::length(x) }   // CLEAN
fn g(x: Array[Int]) -> Int { FrozenArray::get(x, 0) }   // CLEAN
fn h(x: FrozenArray[Int]) -> Int { Array::get(x, 0) }   // CLEAN
```

## Two independent tolerances, one per direction

**Into FrozenArray.** The `FrozenArray::*` arms recover the element type by pattern-matching the receiver and falling back to `CtUnknown`. A fallback cannot report, so a wrong receiver got a tolerant answer instead of a diagnostic — the `else` branch the issue names. `FrozenArray::length`'s arm did not look at the receiver's shape at all.

**Out of FrozenArray.** `head_kind` maps every other `CtNamed` to `0` = "unresolved, tolerate", so the `Array::*` receiver head check — the one that already rejects `Array::get("str", 0)` — never saw a `FrozenArray` coming.

## The fix

`FrozenArray` gets a **certain head kind (18)**, the treatment `MutList` (15), `Attempt` (16) and `Map` (17) already have. That alone fixes direction two.

For direction one the three arms call one shared `reject_non_frozen_receiver`, ground-gated exactly like every other receiver head check here — head 0 stays tolerated, so a generic or still-open receiver is untouched and only a *certain* wrong head is rejected. The refinement's useful half is unchanged: the element type is still recovered from a real `FrozenArray[T]`.

This is ByteStream's problem with the opposite answer. That one deliberately stayed out of `head_kind` and got its own predicate because only the Array sites needed it; here **both** directions need a head, so the head is where it belongs.

Measured, same tree:

| program | before | after |
|---|---|---|
| `FrozenArray::length(x: Array[Int])` | clean | `receiver type Array[Int] is not a FrozenArray -- freeze it first with FrozenArray::from_array(x)` |
| `FrozenArray::get(x: Array[Int], 0)` | clean | rejected, same shape |
| `FrozenArray::to_array(x: Array[Int])` | clean | rejected, same shape (a **fourth** site with the same tolerance, not in the issue) |
| `Array::get(x: FrozenArray[Int], 0)` | clean | `receiver type FrozenArray[Int]` |
| `FrozenArray::get(x: FrozenArray[Int], 0)` | clean | clean |
| `FrozenArray::get(FrozenArray::from_array(a), 0)` | clean | clean |
| `Array::get(FrozenArray::to_array(x), 0)` | clean | clean |
| `fn ok[T](x: T) { FrozenArray::length(x) }` | clean | clean (unresolved stays tolerated) |

Nothing goes wrong at **run** time either way — the copy contract is codegen's (`fixtures/frozen_array_copies_test.vibe`) — so this adds a missing diagnostic rather than fixing a wrong answer. P2, as the issue says.

## Verification

`lib/@vibe/compiler/tests/checker_frozen_array_receiver_test.vibe`, **7 tests**: the three from the issue, `to_array`, a control asserting the four legitimate shapes stay clean, a control asserting an unresolved receiver stays tolerated, and one asserting the element type is still recovered. Without the two controls the rest would pass on a checker that had simply started rejecting FrozenArray outright.

**Red-proven**: with only the checker change reverted and the tests kept, the file FAILS.

- `scripts/generations.sh build` green through stage2 plus both validations — so the compiler's own ~150 `FrozenArray`/`FixedArray`/`MutList` call sites still check.
- `compiler_gate.sh early` ok (39/39).
- Green on the built stage2: `frozen_array_copies_test` (5), `builtin_value_form_test` (9), `checker_fixed_array_test` (3), `builtin_ident_value_test` (34), `builtins_test` (88), `checker_diag_report_test` (3).

## Scope note

The issue asks whether `FixedArray::*` and `MutList::*` move with `FrozenArray`. `MutList` already has a head kind; **`FixedArray` is left alone here** rather than folded in unmeasured — it wants its own before/after. `ArrayBuilder` is deliberately opaque and stays as it is.

The issue's second "done when" asks for an arm to be *deleted* in favour of the row's scheme. This keeps the arms — they still do the useful element-type recovery — and removes their **tolerance**, which is the substance. A scheme-based rewrite is a larger, separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q9zbiDqkfF7xYQ3v8aCQ3b

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q9zbiDqkfF7xYQ3v8aCQ3b)_