### PR TITLE
normalize: a Trait::op wrapper is inserted with its trait, so a call in a fn body is checked (#2570)

### DIFF
--- a/lib/@vibe/compiler/normalize/desugar_trait_dict.vibe
+++ b/lib/@vibe/compiler/normalize/desugar_trait_dict.vibe
@@ -1496,6 +1496,20 @@ export fn derive_trait_namespace_operations(stmts: Array[Stmt]) -> Unit {
     }
     i = i + 1
   }
+  // Right after the last trait/impl, and NOT one statement further.
+  //
+  // #2570: this used to skip forward over the run of `SLet`/`SFnDecl` that
+  // follows, which put every wrapper BELOW the module's top-level functions.
+  // A `Trait::op(..)` inside a `fn` body was then a forward reference, and the
+  // checker's forward-reference hoist pre-binds a value whose EFn carries type
+  // parameters as `CtUnknown` -- every wrapper carries a `Self`-dispatch type
+  // parameter, so every wrapper hoisted as `CtUnknown`, which unifies with
+  // anything. Measured: result type, argument types and arity were all
+  // unchecked, `let z: String = Num::zero(p)` on a `-> Double` operation
+  // compiled and printed the Double's bits as a string, and the identical line
+  // inside a `test` body -- which sits below the old insertion point -- was
+  // correctly rejected. Inserting here makes the call an ordinary backward
+  // reference, so the wrapper's own statement has already bound its real type.
   let mut insertion = 0
   let mut si = 0
   while si < original_len {
@@ -1509,17 +1523,6 @@ export fn derive_trait_namespace_operations(stmts: Array[Stmt]) -> Unit {
       _ => ()
     }
     si = si + 1
-  }
-  while insertion < original_len {
-    match Array::get(stmts, insertion) {
-      SLet(_, _, _, _, _) => {
-        insertion = insertion + 1
-      },
-      SFnDecl(_, _, _, _, _) => {
-        insertion = insertion + 1
-      },
-      _ => break
-    }
   }
   let ordered = array_empty()
   si = 0

--- a/lib/@vibe/compiler/tests/desugar_trait_dicts_module_test.vibe
+++ b/lib/@vibe/compiler/tests/desugar_trait_dicts_module_test.vibe
@@ -102,17 +102,20 @@ test "the module entry threads the witness into a call of the context's bounded 
 test "the whole-program entry is the module entry with no context and everything own" {
   let stmts = parse_program(lex(String::concat(dep_src(), own_src())))
   desugar_trait_dicts(stmts)
-  inspect(stmt_names(stmts), content = "trait Hash, impl Hash, String::hash_key, map_key_to_string, Hash::hash_key, struct Key, fail_dep, struct Set, contains, struct Pair, fail_own, Key::equals, Set::equals, Pair::equals, __map_equals__N6_String__N7___Vfp_T, __exn_kind_cell, struct HashDict")
+  inspect(stmt_names(stmts), content = "trait Hash, impl Hash, Hash::hash_key, String::hash_key, map_key_to_string, struct Key, fail_dep, struct Set, contains, struct Pair, fail_own, Key::equals, Set::equals, Pair::equals, __map_equals__N6_String__N7___Vfp_T, __exn_kind_cell, struct HashDict")
 }
 
 test "the dependency's own run places its trait operation inside the module and its dict struct in the synthesized set" {
   let own = parse_program(lex(dep_src()))
   let ctx = parse_program(lex(own_src()))
   let synth = desugar_trait_dicts_module(own, ctx, [], [])
-  // The namespace operation is inserted after the trait's impls and the
-  // lets that immediately follow them, growing the module's own region; the
-  // context's structs are not derived for here.
-  inspect(stmt_names(own), content = "trait Hash, impl Hash, String::hash_key, map_key_to_string, Hash::hash_key, struct Key, fail_dep")
+  // The namespace operation is inserted directly after the trait's impls,
+  // growing the module's own region; the context's structs are not derived
+  // for here. It used to be placed one step further -- past the run of
+  // `let`/`fn` that immediately follows -- which made a `Trait::op(..)` call
+  // inside a `fn` body a forward reference the checker could not type
+  // (#2570), so `Hash::hash_key` now precedes `String::hash_key` here.
+  inspect(stmt_names(own), content = "trait Hash, impl Hash, Hash::hash_key, String::hash_key, map_key_to_string, struct Key, fail_dep")
   inspect(stmt_names(synth), content = "Key::equals, __exn_kind_cell, struct HashDict")
   inspect(stmt_names(ctx), content = "struct Set, contains, struct Pair, fail_own")
 }

--- a/lib/@vibe/compiler/tests/trait_namespace_op_in_fn_body_test.vibe
+++ b/lib/@vibe/compiler/tests/trait_namespace_op_in_fn_body_test.vibe
@@ -1,0 +1,116 @@
+//# Imports
+
+// #2570: inside a `fn` body a `Trait::op(..)` call was not type-checked at
+// all -- not the result, not the argument types, not the arity.
+//
+// `derive_trait_namespace_operations` synthesizes each `Trait::op` wrapper as
+// an `SLet` and used to insert it AFTER the run of top-level `SLet`/`SFnDecl`
+// that follows the last trait/impl. So a call from a `fn` body above it was a
+// FORWARD reference, and the checker's forward-reference hoist pre-binds a
+// generic value as `CtUnknown` -- every wrapper carries a `Self`-dispatch type
+// parameter, so every wrapper hoisted as `CtUnknown`, which unifies with
+// anything.
+//
+// Measured on the repro below, `let z: String = Num::zero(p)` -- declared
+// `-> Double` -- checked clean inside a `fn` body, compiled, and printed the
+// Double's bits as a string, while the identical line inside a `test` body
+// (which sits BELOW the insertion point) was correctly rejected. Same program,
+// same wrapper: the verdict depended on which site the checker typed.
+//
+// The reported symptom was narrower: `Num::zero(p) + Num::zero(p)` was
+// rejected as `expected Double, got Int`, because `infer_binop_type` tries the
+// `CtInt` candidate first and two UNCONSTRAINED operands unify with it. The
+// `Int::to_string(Num::zero(p) + 1)` case below is the discriminator -- it is
+// clean exactly when the operand is unconstrained.
+//
+// The fix inserts the wrappers immediately after the last trait/impl, so the
+// call is an ordinary BACKWARD reference and the wrapper's own statement has
+// already bound its real (generic) type.
+
+import @vibe/compiler/checker {
+  check_program
+}
+
+import @vibe/compiler/syntax {
+  lex, parse_program
+}
+
+//# Functions
+
+/// The checker's first diagnostic for `src`, or "" when it checks clean.
+/// Same fail-fast shape as checker_diag_report_test.vibe's `first_check_error`.
+fn diags_of(src: String) -> String {
+  handle {
+    let _ = check_program(parse_program(lex(src)))
+    ""
+  } with { Exception::Throw(msg) => msg }
+}
+
+fn rejects(src: String) -> Bool {
+  String::length(diags_of(src)) > 0
+}
+
+let trait_prelude = "trait Num {\n  zero(Self) -> Double\n}\n\nstruct P {\n  v: Double\n}\n\nimpl Num for P {\n  zero(p: P) -> Double {\n    0.5\n  }\n}\n\n"
+
+/// `body` placed inside a `fn` body, with `p: P` already in scope.
+fn in_fn_body(body: String) -> String {
+  String::concat(trait_prelude, String::concat("fn f() -> Unit with Stdout {\n  let p = P::{ v: 1.25 }\n", String::concat(body, "\n}\n")))
+}
+
+//# Tests
+
+test "the call's RESULT type is checked inside a fn body" {
+  // The silently-wrong case: this compiled and printed the Double's bits.
+  inspect(rejects(in_fn_body("  let z: String = Num::zero(p)\n  println(z)")), "true")
+}
+
+test "the call's ARGUMENT types are checked inside a fn body" {
+  inspect(rejects(in_fn_body("  println(Double::to_string(Num::zero(\"not a P\")))")), "true")
+}
+
+test "the call's ARITY is checked inside a fn body" {
+  inspect(rejects(in_fn_body("  println(Double::to_string(Num::zero(p, p)))")), "true")
+}
+
+test "a correct call inside a fn body still checks clean" {
+  inspect(rejects(in_fn_body("  let z: Double = Num::zero(p)\n  println(Double::to_string(z))")), "false")
+}
+
+// The reported symptom, on all three arithmetic operators. They share
+// `infer_binop_type`'s candidate ladder, so the issue's `+` was never alone.
+
+test "the SUM of two trait calls is a Double" {
+  inspect(rejects(in_fn_body("  println(Double::to_string(Num::zero(p) + Num::zero(p)))")), "false")
+}
+
+test "the DIFFERENCE of two trait calls is a Double" {
+  inspect(rejects(in_fn_body("  println(Double::to_string(Num::zero(p) - Num::zero(p)))")), "false")
+}
+
+test "the PRODUCT of two trait calls is a Double" {
+  inspect(rejects(in_fn_body("  println(Double::to_string(Num::zero(p) * Num::zero(p)))")), "false")
+}
+
+test "a trait call does NOT unify with Int -- the discriminator" {
+  // Clean exactly when the operand is unconstrained, which is what made the
+  // `+` ladder answer CtInt. `<` hides the same defect (its arm returns
+  // CtBool down every path), so this is the case that can observe it.
+  inspect(rejects(in_fn_body("  println(Int::to_string(Num::zero(p) + 1))")), "true")
+}
+
+test "the same call inside a test body was already checked, and still is" {
+  let src = String::concat(trait_prelude, "test \"t\" {\n  let p = P::{ v: 1.25 }\n  let z: String = Num::zero(p)\n  assert_true(String::length(z) >= 0)\n}\n")
+  inspect(rejects(src), "true")
+}
+
+// Controls: an ordinary generic top-level function is a forward reference too.
+// The fix does not touch the hoist, so these keep their existing behavior --
+// they are here so a later change to the hoist cannot move them unnoticed.
+
+test "a forward call to a generic identity is accepted" {
+  inspect(rejects("fn f() -> Int {\n  ident(1)\n}\nfn ident[T](x: T) -> T { x }\n"), "false")
+}
+
+test "a forward call to a generic identity at String is accepted" {
+  inspect(rejects("fn f() -> String {\n  ident(\"s\")\n}\nfn ident[T](x: T) -> T { x }\n"), "false")
+}


### PR DESCRIPTION
Fixes #2570 (P0, silent-wrong).

## The defect

`derive_trait_namespace_operations` synthesizes each `Trait::op` wrapper as an `SLet` and inserted it after the last trait/impl **and** after the run of `SLet`/`SFnDecl` that follows. That put every wrapper *below* the module's top-level functions, so a `Trait::op(..)` call inside a `fn` body was a **forward reference** — and the checker's forward-reference hoist pre-binds a value whose `EFn` carries type parameters as `CtUnknown`. Every wrapper carries a `Self`-dispatch type parameter, so every wrapper hoisted as `CtUnknown`, which unifies with anything.

Inside a `fn` body, nothing about the call was checked — not the result type, not the argument types, not the arity:

```vibe
trait Num { zero(Self) -> Double }
struct P { v: Double }
impl Num for P { zero(p: P) -> Double { 0.5 } }

fn as_string() -> String {
  let p = P::{ v: 1.25 }
  let z: String = Num::zero(p)   // checked clean, on a `-> Double` operation
  z
}
```

That compiled on the production linear/RC lane and printed `284` — the Double's bits read as a string. The identical line inside a `test` body — which sits *below* the old insertion point — was correctly rejected, so the verdict depended on which site the checker typed.

The reported symptom was narrower: `Num::zero(p) + Num::zero(p)` was rejected as `expected Double, got Int`, because `infer_binop_type` tries the `CtInt` candidate first and two **unconstrained** operands unify with it. `-` and `*` share that ladder and failed identically; `<` returns `CtBool` down every path, so there the same defect was silent.

## The fix

Insert the wrappers immediately after the last trait/impl and not one statement further. The call is then an ordinary backward reference: the wrapper's own statement has already bound its real (generic) type by the time a `fn` body is checked. Eleven lines deleted, plus the comment recording why they must not come back.

This is a **static** fix — a statement's position in the pre-check list. No runtime guard is emitted and no generated code changes shape.

## Verification

- **Red**: with the skip restored, the new test's first case fails (`the call's RESULT type is checked inside a fn body`: `false`, want `true`).
- **Green**: 11/11 in `lib/@vibe/compiler/tests/trait_namespace_op_in_fn_body_test.vibe`.
- **End to end**, through a stage2 built from this tree: the issue's repro compiles and prints `1`, and `let z: String = Num::zero(p)` is rejected at `line 10:19`. Against the committed seed (no fix) the repro fails with the issue's `return type mismatch: expected Double, got Int`.
- All four `scripts/compiler_gate.sh` lanes pass: `bootstrap`, `early`, `mid`, `late`.

The regression covers all three arithmetic operators, the argument-type and arity cases, the `Int::to_string(Num::zero(p) + 1)` discriminator (clean exactly when the operand is unconstrained — the case that can observe what `<` hides), the `test`-body control, and two generic-forward-call controls so a later change to the hoist cannot move them unnoticed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q9zbiDqkfF7xYQ3v8aCQ3b

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q9zbiDqkfF7xYQ3v8aCQ3b)_