### PR TITLE
checker: the forward-reference hoist masks a generic fn's signature per SLOT, not whole (#2607)

### DIFF
--- a/lib/@vibe/compiler/checker/checker_stmt.vibe
+++ b/lib/@vibe/compiler/checker/checker_stmt.vibe
@@ -1928,23 +1928,128 @@ fn hoisted_binding_type(annotation: Option[TypeExpr], defs: Array[TypeDef]) -> T
 /// `Option[TypeExpr]` into a type, so there is one implementation of that rule
 /// rather than a copy per slot.
 ///
-/// Two shapes ARE excluded, because for them a synthesized signature would be
-/// WRONG rather than merely imprecise:
-///
-///   - a type parameter makes a concrete `CtFn` a lie at every call site;
-///   - an optional or labeled parameter (a trailing `~`/`?` in the raw AST
-///     name, see `labeled_param_base_name`) may be omitted by a legitimate
-///     call, so a strict arity would report a false error.
-///
-/// Both keep the `CtUnknown` the hoist gave everything before this. Ordered
+/// One shape IS excluded, because for it a synthesized signature would be
+/// WRONG rather than merely imprecise: an optional or labeled parameter (a
+/// trailing `~`/`?` in the raw AST name, see `labeled_param_base_name`) may be
+/// omitted by a legitimate call, so a strict arity would report a false error.
+/// It keeps the `CtUnknown` the hoist gave everything before this. Ordered
 /// (backward-reference) code is unaffected either way: the binding's own
 /// statement fills in the precise type when it is reached and shadows this
 /// pre-binding.
+///
+/// #2607: a type parameter used to disqualify the WHOLE signature, for a reason
+/// that is true only of PART of it -- `[T](x: T) -> Double` cannot hoist as a
+/// concrete `CtFn`, because one pre-binding is shared by every call site and `T`
+/// is not the same type at each. That is a fact about the SLOTS THAT MENTION a
+/// parameter, not about the signature, and collapsing the whole thing to
+/// `CtUnknown` threw the arity and any concrete return type away with it.
+///
+/// Measured on the production linear/RC lane:
+///
+///   fn caller() -> String { len([1, 2]) }        // len returns Int
+///   fn len[T](xs: Array[T]) -> Int { Array::length(xs) }
+///
+/// compiled clean and printed `2`, and `String::length(caller())` answered `4`
+/// -- an Int in a String slot, no diagnostic at any stage. The identical program
+/// with the definition ABOVE the caller was rejected, so source order decided
+/// the verdict. A forward call with one argument too many was clean too, and
+/// then failed at run with no message.
+///
+/// Not a corner: every `Trait::op` wrapper `derive_trait_namespace_operations`
+/// synthesizes carries a `Self`-dispatch type parameter, which is the mechanism
+/// #2570 ran into from the other side.
+///
+/// So the mask is per slot: a parameter or return annotation that mentions one
+/// of the binder's own type parameters reads as unannotated (`CtUnknown`,
+/// unifies with anything, unchecked exactly as before), and every other slot
+/// resolves normally. Arity is checked either way.
+fn hoist_is_type_param(tparams: Array[String], name: String) -> Bool {
+  let mut i = 0
+  let mut found = false
+  while i < Array::length(tparams) && !found {
+    if type_param_name(Array::get(tparams, i)) == name {
+      found = true
+    } else {
+      ()
+    }
+    i = i + 1
+  }
+  found
+}
+
+/// Does `ty` mention one of `tparams` anywhere? Head positions count: `T[Int]`
+/// under `[T[_]]` is as unresolvable as bare `T`.
+fn hoist_mentions_type_param(ty: TypeExpr, tparams: Array[String]) -> Bool {
+  match ty {
+    TyName(name) => hoist_is_type_param(tparams, name),
+    TyApp(head, args) => if hoist_is_type_param(tparams, head) {
+      true
+    } else {
+      let mut i = 0
+      let mut found = false
+      while i < Array::length(args) && !found {
+        if hoist_mentions_type_param(Array::get(args, i), tparams) {
+          found = true
+        } else {
+          ()
+        }
+        i = i + 1
+      }
+      found
+    },
+    TyFn(ps, r, _) => if hoist_mentions_type_param(r, tparams) {
+      true
+    } else {
+      let mut i = 0
+      let mut found = false
+      while i < Array::length(ps) && !found {
+        if hoist_mentions_type_param(Array::get(ps, i), tparams) {
+          found = true
+        } else {
+          ()
+        }
+        i = i + 1
+      }
+      found
+    },
+    TyTuple(items) => {
+      let mut i = 0
+      let mut found = false
+      while i < Array::length(items) && !found {
+        if hoist_mentions_type_param(Array::get(items, i), tparams) {
+          found = true
+        } else {
+          ()
+        }
+        i = i + 1
+      }
+      found
+    },
+    TyUnit => false
+  }
+}
+
+/// `hoisted_binding_type`, with the per-slot type-parameter mask of #2607.
+///
+/// Masking a slot is exactly "treat it as unannotated": `hoisted_binding_type`
+/// already turns that into `CtUnknown`, and its doc says why that is the right
+/// answer for a slot the hoist cannot know. Routing through it keeps one
+/// implementation of that rule rather than a second copy here.
+fn hoisted_slot_type(annotation: Option[TypeExpr], tparams: Array[String], defs: Array[TypeDef]) -> Type {
+  let readable = match annotation {
+    Some(type_expr) => if hoist_mentions_type_param(type_expr, tparams) {
+      None
+    } else {
+      annotation
+    },
+    _ => annotation
+  }
+  hoisted_binding_type(readable, defs)
+}
+
 fn hoisted_fn_signature(value: Expr, defs: Array[TypeDef]) -> Type {
   match value {
-    EFn(tparams, _bounds, params, ret, eff, _body) => if Array::length(tparams) > 0 {
-      CtUnknown
-    } else {
+    EFn(tparams, _bounds, params, ret, eff, _body) => {
       let ptys = array_empty()
       let mut usable = true
       let mut i = 0
@@ -1953,12 +2058,12 @@ fn hoisted_fn_signature(value: Expr, defs: Array[TypeDef]) -> Type {
         if labeled_param_base_name(pname) != pname {
           usable = false
         } else {
-          Array::push(ptys, hoisted_binding_type(pann, defs))
+          Array::push(ptys, hoisted_slot_type(pann, tparams, defs))
         }
         i = i + 1
       }
       if usable {
-        CtFn(ptys, hoisted_binding_type(ret, defs), eff)
+        CtFn(ptys, hoisted_slot_type(ret, tparams, defs), eff)
       } else {
         CtUnknown
       }

--- a/lib/@vibe/compiler/tests/hoisted_generic_fn_signature_test.vibe
+++ b/lib/@vibe/compiler/tests/hoisted_generic_fn_signature_test.vibe
@@ -1,0 +1,106 @@
+//# Imports
+
+// #2607: a forward call to a GENERIC top-level `fn` was unchecked -- the half
+// #2318 excluded.
+//
+// #2318 gave the forward-reference hoist a real signature for a top-level `fn`,
+// so a call placed ABOVE the definition is checked. It excluded a `fn` with type
+// parameters, on the grounds that "a type parameter makes a concrete `CtFn` a
+// lie at every call site". That is true of the SLOTS THAT MENTION a parameter,
+// not of the signature: collapsing the whole thing to `CtUnknown` threw away the
+// arity and any concrete return type with it, and `CtUnknown` unifies with
+// anything.
+//
+// Measured on the production linear/RC lane, `fn caller() -> String { len([1,2]) }`
+// above `fn len[T](xs: Array[T]) -> Int` compiled clean and printed `2`, with
+// `String::length(caller())` answering `4` -- an `Int` in a `String` slot, no
+// diagnostic at any stage. Moving the definition above the caller rejected the
+// same program (`return type mismatch: expected String, got Int`), so source
+// order decided the verdict.
+//
+// The fix masks per slot: a parameter or return annotation that mentions one of
+// the binder's own type parameters resolves to `CtUnknown` (unchecked exactly as
+// before), every other slot resolves normally, and arity is checked either way.
+
+import @vibe/compiler/checker {
+  check_program
+}
+
+import @vibe/compiler/syntax {
+  lex, parse_program
+}
+
+//# Functions
+
+/// The checker's first diagnostic for `src`, or "" when it checks clean.
+fn diags_of(src: String) -> String {
+  handle {
+    let _ = check_program(parse_program(lex(src)))
+    ""
+  } with { Exception::Throw(msg) => msg }
+}
+
+fn rejects(src: String) -> Bool {
+  String::length(diags_of(src)) > 0
+}
+
+/// `caller` above `defn`: the forward-reference direction, which is the one
+/// the hoist answers for.
+fn forward(caller: String, defn: String) -> String {
+  String::concat(caller, defn)
+}
+
+let len_defn = "fn len[T](xs: Array[T]) -> Int { Array::length(xs) }\n"
+
+let ident_defn = "fn ident[T](x: T) -> T { x }\n"
+
+//# Tests
+
+test "a forward call's concrete RETURN type is checked" {
+  inspect(rejects(forward("fn caller() -> String {\n  len([1, 2])\n}\n", len_defn)), "true")
+}
+
+test "the same call BELOW the definition was always checked" {
+  inspect(rejects(String::concat(len_defn, "fn caller() -> String {\n  len([1, 2])\n}\n")), "true")
+}
+
+test "a forward call's ARITY is checked" {
+  inspect(rejects(forward("fn caller() -> Int {\n  len([1, 2], 3)\n}\n", len_defn)), "true")
+}
+
+test "a correct forward call is accepted" {
+  inspect(rejects(forward("fn caller() -> Int {\n  len([1, 2])\n}\n", len_defn)), "false")
+}
+
+// The masked slots. A parameter or return that mentions the binder's own type
+// parameter has no one right answer for a pre-binding every call site shares,
+// so it stays `CtUnknown` -- these must NOT start being rejected.
+
+test "a forward call to a generic identity is accepted at Int" {
+  inspect(rejects(forward("fn caller() -> Int {\n  ident(1)\n}\n", ident_defn)), "false")
+}
+
+test "a forward call to a generic identity is accepted at String" {
+  inspect(rejects(forward("fn caller() -> String {\n  ident(\"s\")\n}\n", ident_defn)), "false")
+}
+
+test "two calls to one generic forward binding may pick different types" {
+  let src = String::concat("fn caller() -> String {\n  let a: Int = ident(1)\n  let b: String = ident(\"s\")\n  String::concat(__to_string(a), b)\n}\n", ident_defn)
+  inspect(rejects(src), "false")
+}
+
+test "a parameter slot that mentions the type parameter stays unchecked" {
+  let src = String::concat("fn caller() -> Int {\n  pick(1, 2)\n}\n", "fn pick[T](a: T, b: T) -> T { a }\n")
+  inspect(rejects(src), "false")
+}
+
+test "an optional or labeled parameter still disqualifies the signature" {
+  // The other #2318 exclusion, which this change does not touch: a legitimate
+  // call may omit the parameter, so a strict arity would report a false error.
+  let src = String::concat("fn caller() -> Int {\n  opt(1)\n}\n", "fn opt[T](a: T, b?: Int) -> Int { 0 }\n")
+  inspect(rejects(src), "false")
+}
+
+test "a non-generic forward call keeps the #2318 behavior" {
+  inspect(rejects(forward("fn caller() -> String {\n  plain(1)\n}\n", "fn plain(x: Int) -> Int { x }\n")), "true")
+}


### PR DESCRIPTION
Fixes #2607 (P0, silent-wrong).

## The defect

#2318 gave the checker's forward-reference hoist a real signature for a top-level `fn`, so a call placed *above* the definition is checked. It deliberately excluded a `fn` with type parameters:

> a type parameter makes a concrete `CtFn` a lie at every call site

That is true of **the slots that mention a parameter**, not of the signature. Collapsing the whole thing to `CtUnknown` threw away the arity and any concrete return type with it, and `CtUnknown` unifies with anything.

```vibe
fn caller() -> String {
  len([1, 2])            // len returns Int
}
fn len[T](xs: Array[T]) -> Int { Array::length(xs) }
```

Compiles clean. On the production linear/RC lane, `caller()` prints `2` and `String::length(caller())` answers `4` — an `Int` in a `String` slot, no diagnostic at any stage. The identical program with the definition moved *above* the caller is correctly rejected (`return type mismatch: expected String, got Int`), so source order decided the verdict. A forward call with one argument too many was clean too, and then failed at run with no message at all.

Not a corner: every `Trait::op` wrapper carries a `Self`-dispatch type parameter, which is the mechanism #2570 ran into from the other side.

## The fix

The mask is per slot. A parameter or return annotation that mentions one of the binder's own type parameters reads as **unannotated**; every other slot resolves normally; arity is checked either way.

Masked slots route through `hoisted_binding_type`, which already owns the "a slot the hoist cannot know is `CtUnknown`" rule and documents why — one implementation of it, and no new `None => CtUnknown` for ARCH010 to count. The other #2318 exclusion (an optional or labeled parameter, where a legitimate call may omit an argument) is untouched.

**Static only**: this changes what the checker pre-binds. No runtime guard is emitted and generated code is unchanged.

## Verification

- **Red**: with the mask reverted, the new test's first case fails (`a forward call's concrete RETURN type is checked`: `false`, want `true`).
- **Green**: 10/10 in `lib/@vibe/compiler/tests/hoisted_generic_fn_signature_test.vibe`.
- **End to end**, through a stage2 built from this tree: the program above is rejected at `line 2:3`, and the correct `-> Int` version still prints `2`.
- **Blast radius**: the `stage1 → stage2` self-compile puts the whole compiler through the stricter check and is green, and all four `scripts/compiler_gate.sh` lanes (`bootstrap`, `early`, `mid`, `late`) pass.

The test carries the masked-slot controls as well as the fixed cases, so a later change to the hoist cannot quietly start rejecting them: a generic identity forward-called at `Int` and at `String`, two calls to one generic binding picking different types, a `[T](a: T, b: T) -> T` parameter slot, and the optional-parameter exclusion.

## What this does not close

The argument **types** of a generic forward call stay unchecked, because those slots do mention the parameter. Closing that needs the hoist to build a real `CtForAll` with fresh variables and the declared bounds, duplicating a good deal of the `EFn` arm (HKT formals, eq groups, bound registration into the subst). #2607 records that as the residue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q9zbiDqkfF7xYQ3v8aCQ3b

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q9zbiDqkfF7xYQ3v8aCQ3b)_