### PR TITLE
loader: the manifest header scan sees an import written below a declaration (#2595)

### DIFF
--- a/lib/@vibe/compiler/loader/manifest_sources.vibe
+++ b/lib/@vibe/compiler/loader/manifest_sources.vibe
@@ -308,6 +308,51 @@ fn manifest_header_scan_source(path: String, source: String) -> String with Exce
   }
 }
 
+/// Does a top-level `import` / `export ./..` statement start at or after
+/// `from`? Column 0 only, which is where every one of them is written.
+///
+/// #2595: the header scan below stops at the first statement that is not
+/// `import` / `export`, which is what makes it a fast HEADER scan. An import
+/// written BELOW a declaration is then invisible to it. `loader/loader.vibe`
+/// has four of them, and `loader/manifest_sources.vibe` was reachable through
+/// none of its other deps, so the manifest-preferring collection closure
+/// silently omitted a file the manifest DOES list -- `vibe check
+/// lib/@vibe/compiler/loader/loader.vibe` then failed with `type_db: missing
+/// resolved dependency environment` for a file that compiles, and `vibe deps`
+/// on the same root returned a closure one entry short without saying so.
+///
+/// This test is deliberately LOOSE. Over-triggering costs one module-header
+/// parse for a file whose text merely looks like it has a late import (a string
+/// literal, say) and answers the same either way; under-triggering is the bug.
+/// `export` alone is not enough -- `export fn` / `export let` / `export struct`
+/// are ordinary declarations -- so it must be followed by a re-export path,
+/// which always begins with `.` (`./x.vibe`, `../x.vibe`).
+fn manifest_header_tail_has_top_level_import(source: String, from: Int) -> Bool {
+  let len = String::length(source)
+  let mut pos = from
+  let mut found = false
+  while pos < len && !found {
+    let at_line_start = pos == 0 || String::char_code_at(source, pos - 1) == 10
+    if at_line_start && starts_with_keyword_at(source, pos, "import") {
+      found = true
+    } else if at_line_start && starts_with_keyword_at(source, pos, "export") {
+      let mut probe = pos + String::length("export")
+      while probe < len && (String::char_code_at(source, probe) == 32 || String::char_code_at(source, probe) == 9) {
+        probe = probe + 1
+      }
+      if probe < len && String::char_code_at(source, probe) == '.' {
+        found = true
+      } else {
+        ()
+      }
+    } else {
+      ()
+    }
+    pos = pos + 1
+  }
+  found
+}
+
 fn collect_manifest_header_deps_from_source(path: String, raw_source: String, manifest_path_index: Map[String, Bool]) -> Array[String] with Exception + Fs {
   let deps = array_empty()
   let base_dir = dir_of_path(path)
@@ -348,6 +393,18 @@ fn collect_manifest_header_deps_from_source(path: String, raw_source: String, ma
       }
     }
   }
+  // #2595: the loop above stopped, either at end of file or at the first
+  // statement that is not `import` / `export`. In the second case a top-level
+  // import may still follow it, and the scan cannot see one. Ask the real
+  // module-header parser, which reads the whole file, and MERGE -- the
+  // fast-scan entries keep their manifest-preferred resolution
+  // (`resolve_manifest_dep_path`), so this can only ADD the deps that were
+  // missing, never re-resolve one that was already found.
+  let scanned = if pos < len && manifest_header_tail_has_top_level_import(source, pos) {
+    merge_impl_raws_dedupe(deps, load_or_parse_module_header_deps_with_context(path, raw_source))
+  } else {
+    deps
+  }
   // Mirror the full loader's unconditional `.vpkg` sibling auto-discovery
   // (ADR-0070 Phase 1): this fast textual scanner only sees deps the
   // contract's OWN `import ./x.vibe {}` lines spell out explicitly, so a
@@ -363,9 +420,9 @@ fn collect_manifest_header_deps_from_source(path: String, raw_source: String, ma
       Array::push(discovered_deps, resolve_manifest_dep_path(base_dir, Array::get(discovered_raws, di), manifest_path_index))
       di = di + 1
     }
-    merge_impl_raws_dedupe(deps, discovered_deps)
+    merge_impl_raws_dedupe(scanned, discovered_deps)
   } else {
-    deps
+    scanned
   }
 }
 

--- a/lib/@vibe/compiler/tests/loader_manifest_sources_test.vibe
+++ b/lib/@vibe/compiler/tests/loader_manifest_sources_test.vibe
@@ -496,3 +496,63 @@ test "try_collect_manifest_sources_fs: a LISTED sibling is still collected (#257
     None => assert(false)
   }
 }
+
+test "try_collect_manifest_sources_fs: an import written BELOW a declaration is still collected (#2595)" {
+  // The manifest header scan stops at the first statement that is not
+  // `import` / `export`, which is what makes it a fast HEADER scan. A
+  // top-level import placed after a declaration was therefore invisible, and
+  // the file it names never entered the source set -- so the failure surfaced
+  // three layers later as `type_db: missing resolved dependency environment`
+  // for a file the manifest DOES list.
+  //
+  // Measured on `lib/@vibe/compiler/loader/loader.vibe`, which has four such
+  // imports: `vibe check` on it failed on a file that compiles, and
+  // `vibe deps` returned a closure one entry short without saying so. The
+  // other manifest roots were clean, because their late-imported siblings
+  // happened to be reachable through some other dep.
+  //
+  // Red-testing this by hand needs `VIBE_BUILD_CACHE_DIR=$(mktemp -d)`. The
+  // manifest header rows are cached persistently under a key that includes the
+  // COMPILER's version tag, so reverting the fix and re-running on the same
+  // `vibe test` compiler reads back the rows the fixed run just wrote, and the
+  // case passes while proving nothing.
+  let base_dir = "/tmp/vibe_compiler_manifest_late_import"
+  let manifest_path = String::concat(base_dir, "/compiler_sources_manifest.tsv")
+  let early_path = String::concat(base_dir, "/early.vibe")
+  let late_path = String::concat(base_dir, "/late.vibe")
+  let main_path = String::concat(base_dir, "/main.vibe")
+  Fs::mkdir_p(base_dir)
+  Fs::write_bytes(manifest_path, string_to_bytes("# group\tpath\ncore\tearly.vibe\ncore\tlate.vibe\nentry\tmain.vibe\n"))
+  Fs::write_bytes(early_path, string_to_bytes("export let early_value: () -> Int = () -> { 1 }"))
+  Fs::write_bytes(late_path, string_to_bytes("export let late_value: () -> Int = () -> { 2 }"))
+  Fs::write_bytes(main_path, string_to_bytes("import ./early.vibe { early_value }\nlet gap: Int = 0\nimport ./late.vibe { late_value }\nlet run: () -> Int = () -> { early_value() + late_value() + gap }"))
+  match try_collect_manifest_sources_fs(main_path) {
+    Some((_, sources)) => {
+      assert(has_source_path(sources, early_path))
+      assert(has_source_path(sources, late_path))
+      assert(eq(Array::length(sources), 3))
+    },
+    None => assert(false)
+  }
+}
+
+test "try_collect_manifest_sources_fs: a re-export written BELOW a declaration is still collected (#2595)" {
+  // Same scan, the other statement form it understands. `export` alone does
+  // not qualify -- `export let` here is an ordinary declaration -- so the
+  // detector requires the re-export path that follows it.
+  let base_dir = "/tmp/vibe_compiler_manifest_late_reexport"
+  let manifest_path = String::concat(base_dir, "/compiler_sources_manifest.tsv")
+  let late_path = String::concat(base_dir, "/late.vibe")
+  let main_path = String::concat(base_dir, "/main.vibe")
+  Fs::mkdir_p(base_dir)
+  Fs::write_bytes(manifest_path, string_to_bytes("# group\tpath\ncore\tlate.vibe\nentry\tmain.vibe\n"))
+  Fs::write_bytes(late_path, string_to_bytes("export let late_value: () -> Int = () -> { 2 }"))
+  Fs::write_bytes(main_path, string_to_bytes("let gap: Int = 0\nexport ./late.vibe { late_value }\nlet run: () -> Int = () -> { gap }"))
+  match try_collect_manifest_sources_fs(main_path) {
+    Some((_, sources)) => {
+      assert(has_source_path(sources, late_path))
+      assert(eq(Array::length(sources), 2))
+    },
+    None => assert(false)
+  }
+}


### PR DESCRIPTION
Fixes #2595.

## The cause

`collect_manifest_header_deps_from_source` is a fast textual **header** scan: it stops at the first top-level statement that is not `import` / `export`. A top-level import written *below* a declaration is invisible to it, and the file it names never enters the manifest-preferring collection closure.

`lib/@vibe/compiler/loader/loader.vibe` has four such imports — its first declaration is at line 111, and `./ingestion_pipeline_telemetry.vibe` (367), `./manifest_sources.vibe` (371), the `export ./manifest_sources.vibe` re-export (386) and `@vibe/compiler/cache` (401) all follow it. Three of those happened to be reachable through some other dep. `loader/manifest_sources.vibe` was not, so its environment row was never seeded and the failure surfaced three layers later in `project_exact_dependency_envs`:

```console
$ vibe check lib/@vibe/compiler/loader/loader.vibe
error: type_db: missing resolved dependency environment: lib/@vibe/compiler/loader/manifest_sources.vibe
```

for a file the manifest **does** list (row 233) and that the compiler builds from. That also explains the issue's scope table exactly: the other four manifest roots were clean because none of them had a late-imported sibling that nothing else reached.

`vibe deps` on the same root was lying in the same way, one line shorter — a 125-entry closure instead of 126, silently. The rule in CLAUDE.md is that its errors are fatal precisely so a short answer is never mistaken for a complete one.

## The fix

The scan keeps its shape. When it stops before end of file, a loose textual test asks whether a line beginning (column 0) with `import`, or with `export` followed by a re-export path, still follows. If so, the real module-header parser — which reads the whole file — is asked for that file's deps, and the two lists are **merged**.

Merging rather than replacing: the fast-scan entries keep their manifest-preferred resolution (`resolve_manifest_dep_path`), so this can only *add* the deps that were missing, never re-resolve one that was already found. The test is deliberately loose in the safe direction — over-triggering (a string literal that looks like a late import) costs one parse and answers the same; under-triggering is what the bug was. `export` alone does not qualify, since `export fn` / `export let` / `export struct` are ordinary declarations.

## Verification

- **Red**, with `VIBE_BUILD_CACHE_DIR=$(mktemp -d)`: without the fix the new late-import case fails.
  It **passes** on a shared cache — the manifest header rows are cached persistently under a key that includes the *compiler's* version tag, so reverting the fix and re-running on the same `vibe test` compiler reads back the rows the fixed run just wrote. I hit that first and nearly certified nothing; the test carries a note so the next person does not.
- **Green**: 22/22 in `loader_manifest_sources_test.vibe`, on an isolated cache and on the shared one.
- **End to end**, on a stage2 built from this tree: `vibe check lib/@vibe/compiler/loader/loader.vibe` is clean, its closure is 126 entries and contains `manifest_sources.vibe`, and the four roots #2595 measured as clean stay clean.
- All four `scripts/compiler_gate.sh` lanes pass.

The two new cases are self-contained (a temp dir with its own manifest, one file with a late `import` and one with a late re-export), so they do not depend on `loader.vibe` keeping its late imports.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q9zbiDqkfF7xYQ3v8aCQ3b

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q9zbiDqkfF7xYQ3v8aCQ3b)_