### PR TITLE
checker: a generic top-level fn hoists as a real SCHEME, so a forward call's arguments are checked (#2610)

### DIFF
--- a/lib/@vibe/compiler/checker/checker_stmt.vibe
+++ b/lib/@vibe/compiler/checker/checker_stmt.vibe
@@ -2072,29 +2072,222 @@ fn hoisted_fn_signature(value: Expr, defs: Array[TypeDef]) -> Type {
   }
 }
 
-/// The type to pre-bind for a hoisted `SLet`: its annotation when it has one,
-/// otherwise a `fn`'s own signature (#2318), otherwise unknown.
-fn hoisted_value_type(annotation: Option[TypeExpr], value: Expr, defs: Array[TypeDef]) -> Type {
-  match annotation {
-    Some(type_expr) => resolve_type_expr(type_expr, defs),
-    None => hoisted_fn_signature(value, defs)
+/// Is one of `tparams` used as an APPLICATION HEAD anywhere in `te`?
+///
+/// `F[A]` under `[F[_], A]` is the shape the `EFn` arm handles by making the
+/// formal RIGID (`#hktformal.`) instead of a unification variable, precisely so
+/// `F[A]` cannot unify with `Array[Int]`. The hoist has no way to reproduce
+/// that here, so a binder with one keeps the #2607 per-slot mask.
+fn hoist_te_applies_formal(te: TypeExpr, tparams: Array[String]) -> Bool {
+  match te {
+    TyName(_) => false,
+    TyUnit => false,
+    TyApp(head, args) => if hoist_is_type_param(tparams, head) {
+      true
+    } else {
+      let mut i = 0
+      let mut found = false
+      while i < Array::length(args) && !found {
+        if hoist_te_applies_formal(Array::get(args, i), tparams) {
+          found = true
+        } else {
+          ()
+        }
+        i = i + 1
+      }
+      found
+    },
+    TyFn(ps, r, _) => if hoist_te_applies_formal(r, tparams) {
+      true
+    } else {
+      let mut i = 0
+      let mut found = false
+      while i < Array::length(ps) && !found {
+        if hoist_te_applies_formal(Array::get(ps, i), tparams) {
+          found = true
+        } else {
+          ()
+        }
+        i = i + 1
+      }
+      found
+    },
+    TyTuple(items) => {
+      let mut i = 0
+      let mut found = false
+      while i < Array::length(items) && !found {
+        if hoist_te_applies_formal(Array::get(items, i), tparams) {
+          found = true
+        } else {
+          ()
+        }
+        i = i + 1
+      }
+      found
+    }
   }
 }
 
-fn hoist_merged_source_values(stmts: Array[Stmt], start: Int, env: TypeEnv, defs: Array[TypeDef]) -> TypeEnv {
+/// Does this binder carry a higher-kinded formal? A DECLARED one (`[F[_]]`)
+/// records its arity in the key; an inferred one shows up as a formal in
+/// application-head position.
+fn hoist_has_hkt_formal(tparams: Array[String], params: Array[(String, Option[TypeExpr])], ret: Option[TypeExpr]) -> Bool {
+  let mut i = 0
+  let mut found = false
+  while i < Array::length(tparams) && !found {
+    if type_param_arity(Array::get(tparams, i)) > 0 {
+      found = true
+    } else {
+      ()
+    }
+    i = i + 1
+  }
+  let mut pi = 0
+  while pi < Array::length(params) && !found {
+    match Array::get(params, pi) {
+      (_, Some(te)) => if hoist_te_applies_formal(te, tparams) {
+        found = true
+      } else {
+        ()
+      },
+      _ => ()
+    }
+    pi = pi + 1
+  }
+  if found {
+    ()
+  } else {
+    match ret {
+      Some(te) => if hoist_te_applies_formal(te, tparams) {
+        found = true
+      } else {
+        ()
+      },
+      _ => ()
+    }
+  }
+  found
+}
+
+/// One slot of a hoisted SCHEME: resolved with the binder's formals shadowing
+/// `defs`, then mapped onto this scheme's own variables. Same two-step every
+/// other generic binder in this file uses (see the `SEnum` constructor
+/// signatures); an unannotated slot stays `CtUnknown`.
+fn hoisted_scheme_slot(annotation: Option[TypeExpr], tparams: Array[String], vars: Array[Type], defs: Array[TypeDef]) -> Type {
+  match annotation {
+    Some(type_expr) => subst_type_params(resolve_type_expr_shadowed(type_expr, defs, tparams), tparams, vars),
+    _ => CtUnknown
+  }
+}
+
+/// The declared bounds, re-keyed from formal name to this scheme's variable id.
+fn hoisted_scheme_bounds(tparams: Array[String], tbounds: Array[(String, Array[String])], ids: Array[Int]) -> Array[(Int, Array[String])] {
+  let out = array_empty()
+  let mut i = 0
+  while i < Array::length(tbounds) {
+    let (bname, blist) = Array::get(tbounds, i)
+    let mut j = 0
+    while j < Array::length(tparams) {
+      if Array::get(tparams, j) == bname {
+        Array::push(out, (Array::get(ids, j), blist))
+      } else {
+        ()
+      }
+      j = j + 1
+    }
+    i = i + 1
+  }
+  out
+}
+
+/// #2610: a generic top-level `fn` hoists as a real SCHEME.
+///
+/// #2607 made the hoist mask a generic signature per SLOT rather than whole, so
+/// a forward call's arity and concrete return type are checked. The slots that
+/// MENTION a formal still read as unannotated, and for a function whose
+/// parameters are generic that is every argument -- so
+///
+///   fn caller() -> Int { len("not an array") }
+///   fn len[T](xs: Array[T]) -> Int { Array::length(xs) }
+///
+/// compiled and printed `0`, while the same call written BELOW the definition
+/// was rejected (`argument type mismatch for len: expected Array[?t4], got
+/// String`). Source order decided the verdict, one slot further in than before.
+///
+/// A single pre-binding shared by every call site cannot be a concrete `CtFn`,
+/// but it can be a `CtForAll`: fresh variables for the binder's formals, the
+/// declared bounds attached, and each call site instantiates its own copy --
+/// exactly what the binding's own statement produces when it is reached. This
+/// consumes counter ids, so it returns the next counter with the type.
+///
+/// Two shapes keep the #2607 mask and consume nothing: a higher-kinded formal
+/// (see `hoist_has_hkt_formal`), and an optional or labeled parameter, where a
+/// legitimate call may omit an argument and a strict arity would be a false
+/// error (#2318's surviving exclusion).
+fn hoisted_fn_scheme(value: Expr, defs: Array[TypeDef], c: Int) -> (Type, Int) {
+  match value {
+    EFn(tparams, tbounds, params, ret, eff, _body) => {
+      let tplen = Array::length(tparams)
+      if tplen == 0 || hoist_has_hkt_formal(tparams, params, ret) {
+        (hoisted_fn_signature(value, defs), c)
+      } else {
+        let ids = array_empty()
+        let vars = array_empty()
+        let mut vi = 0
+        while vi < tplen {
+          let vid = c + vi
+          Array::push(ids, vid)
+          Array::push(vars, CtVar(vid))
+          vi = vi + 1
+        }
+        let ptys = array_empty()
+        let mut usable = true
+        let mut i = 0
+        while i < Array::length(params) {
+          let (pname, pann) = Array::get(params, i)
+          if labeled_param_base_name(pname) != pname {
+            usable = false
+          } else {
+            Array::push(ptys, hoisted_scheme_slot(pann, tparams, vars, defs))
+          }
+          i = i + 1
+        }
+        if usable {
+          (CtForAll(ids, hoisted_scheme_bounds(tparams, tbounds, ids), CtFn(ptys, hoisted_scheme_slot(ret, tparams, vars, defs), eff)), c + tplen)
+        } else {
+          (CtUnknown, c)
+        }
+      }
+    },
+    _ => (CtUnknown, c)
+  }
+}
+
+/// The type to pre-bind for a hoisted `SLet`: its annotation when it has one,
+/// otherwise a `fn`'s own signature (#2318), otherwise unknown.
+fn hoisted_value_type(annotation: Option[TypeExpr], value: Expr, defs: Array[TypeDef], c: Int) -> (Type, Int) {
+  match annotation {
+    Some(type_expr) => (resolve_type_expr(type_expr, defs), c),
+    None => hoisted_fn_scheme(value, defs, c)
+  }
+}
+
+fn hoist_merged_source_values(stmts: Array[Stmt], start: Int, env: TypeEnv, defs: Array[TypeDef], c: Int) -> (TypeEnv, Int) {
   let mut out = env
+  let mut next_c = c
   let mut i = start
   while i < Array::length(stmts) && !(Array::get(stmts, i) is SReExportSourceBoundary(_, _)) {
     match Array::get(stmts, i) {
       SLet(_, _, name, annotation, value) => {
-        let ty = hoisted_value_type(annotation, value, defs)
+        let (ty, nc) = hoisted_value_type(annotation, value, defs, next_c)
+        next_c = nc
         out = env_bind(out, name, ty)
       },
       _ => ()
     }
     i = i + 1
   }
-  out
+  (out, next_c)
 }
 
 /// Map the stable type-declaration schedule back to the retained statement
@@ -2195,7 +2388,8 @@ fn check_stmts_with_binders(raw_stmts: Array[Stmt], i: Int, env: TypeEnv, defs: 
   while hoist_i < Array::length(stmts) {
     match Array::get(stmts, hoist_i) {
       SLet(_, _, hname, hann, hval) => {
-        let ht = hoisted_value_type(hann, hval, defs)
+        let (ht, hnc) = hoisted_value_type(hann, hval, defs, cur_c)
+        cur_c = hnc
         cur_env = env_bind(cur_env, hname, ht)
       },
       _ => ()
@@ -2935,7 +3129,9 @@ fn check_stmts_with_binders(raw_stmts: Array[Stmt], i: Int, env: TypeEnv, defs: 
       },
       SReExportSourceBoundary(_, surface_only_names) => {
         let blocked = env_with_reexport_surface_blockers(env, surface_only_names)
-        (hoist_merged_source_values(stmts, idx + 1, blocked, defs), s, c)
+        match hoist_merged_source_values(stmts, idx + 1, blocked, defs, c) {
+          (hoisted_env, hoisted_c) => (hoisted_env, s, hoisted_c)
+        }
       },
       SAliasDecl(_, _) => (env, s, c)
       ,

--- a/lib/@vibe/compiler/tests/hoisted_generic_fn_signature_test.vibe
+++ b/lib/@vibe/compiler/tests/hoisted_generic_fn_signature_test.vibe
@@ -104,3 +104,42 @@ test "an optional or labeled parameter still disqualifies the signature" {
 test "a non-generic forward call keeps the #2318 behavior" {
   inspect(rejects(forward("fn caller() -> String {\n  plain(1)\n}\n", "fn plain(x: Int) -> Int { x }\n")), "true")
 }
+
+// #2610: the argument slots. #2607's per-slot mask left them unchecked, because
+// they are exactly the slots that mention a formal -- so for a function whose
+// parameters are generic, that was every argument. Measured, `len("not an
+// array")` above the definition compiled and printed `0`. A single pre-binding
+// shared by every call site cannot be a concrete `CtFn`, but it can be a
+// `CtForAll`, which each call site instantiates. The polymorphism controls
+// above and below are what keep that honest.
+
+test "a forward call's ARGUMENT types are checked" {
+  inspect(rejects(forward("fn caller() -> Int {\n  len(\"not an array\")\n}\n", len_defn)), "true")
+}
+
+test "the same wrong argument BELOW the definition was always checked" {
+  inspect(rejects(String::concat(len_defn, "fn caller() -> Int {\n  len(\"not an array\")\n}\n")), "true")
+}
+
+test "two parameters sharing one formal must agree, forward" {
+  let defn = "fn pick[T](a: T, b: T) -> T { a }\n"
+  inspect(rejects(forward("fn caller() -> Int {\n  pick(1, \"s\")\n}\n", defn)), "true")
+}
+
+test "two parameters sharing one formal at the same type are accepted, forward" {
+  let defn = "fn pick[T](a: T, b: T) -> T { a }\n"
+  inspect(rejects(forward("fn caller() -> Int {\n  pick(1, 2)\n}\n", defn)), "false")
+}
+
+test "a bounded formal's forward call is accepted at a scalar" {
+  let defn = "fn eqb[T: Eq](a: T, b: T) -> Bool { a == b }\n"
+  inspect(rejects(forward("fn caller() -> Bool {\n  eqb(1, 1)\n}\n", defn)), "false")
+}
+
+test "a higher-kinded formal keeps the per-slot mask" {
+  // `F[A]` is made RIGID by the EFn arm so it cannot unify with `Array[Int]`,
+  // and the hoist has no way to reproduce that -- so this binder is left on
+  // #2607's mask rather than given a scheme whose `CtVar` would.
+  let defn = "fn hk[F[_], A](x: F[A]) -> Int { 0 }\n"
+  inspect(rejects(forward("fn caller() -> Int {\n  hk([1, 2])\n}\n", defn)), "false")
+}


### PR DESCRIPTION
Fixes #2610 (P0, silent-wrong).

## The defect

#2607 made the forward-reference hoist mask a generic signature per **slot** rather than whole, so a forward call's arity and concrete return type are checked. The slots that *mention* a formal still read as unannotated — and for a function whose parameters are generic, that is every argument:

```vibe
fn caller() -> Int {
  len("not an array")
}
fn len[T](xs: Array[T]) -> Int { Array::length(xs) }
```

Compiles clean, and prints **`0`** on the production linear/RC lane — the String read as an array. The same call written *below* the definition was rejected (`argument type mismatch for len: expected Array[?t4], got String`), so source order decided the verdict, one slot further in than before #2607.

## The fix

A single pre-binding shared by every call site cannot be a concrete `CtFn`, but it can be a **`CtForAll`**: fresh variables for the binder's formals, the declared bounds re-keyed onto them, and each call site instantiates its own copy — exactly what the binding's own statement produces when it is reached.

The two steps (resolve with the formals shadowing `defs`, then `subst_type_params` onto this scheme's variables) are the same ones the `SEnum` constructor signatures in this file already use, so no new mechanism is introduced. Building the scheme consumes counter ids, so `hoisted_value_type` and `hoist_merged_source_values` thread the fresh-variable counter and return the next one; both call sites had it in scope already.

Two shapes keep #2607's per-slot mask and consume nothing:

- a **higher-kinded formal**, declared (`[F[_]]`, arity in the key) or inferred (a formal in application-head position). The `EFn` arm makes those rigid (`#hktformal.`) precisely so `F[A]` cannot unify with `Array[Int]`; the hoist cannot reproduce that, and a plain `CtVar` here would let it.
- an **optional or labeled parameter**, where a legitimate call may omit an argument and a strict arity would be a false error (#2318's surviving exclusion).

**Static only**: this changes what the checker pre-binds. No runtime guard is emitted and generated code is unchanged.

## Verification

- **Red**: with the scheme reverted, the new argument case fails (`a forward call's ARGUMENT types are checked`: `false`, want `true`).
- **Green**: 16/16 in `hoisted_generic_fn_signature_test.vibe`. The new cases pin the argument check in both directions, two parameters sharing one formal (`pick(1, "s")` rejected, `pick(1, 2)` accepted), a bounded formal at a scalar, and the higher-kinded bail-out.
- **Polymorphism survives**, which is what a scheme has to buy: a generic identity forward-called at `Int` and at `String`, and **both from one caller** — `let a: Int = ident(1)` beside `let b: String = ident("s")` prints `1s` through a stage2 built from this tree.
- **End to end**: the program above is rejected at `line 2:3`.
- **Blast radius**: the `stage1 → stage2` self-compile puts the whole compiler through the stricter check, and all four `scripts/compiler_gate.sh` lanes (`bootstrap`, `early`, `mid`, `late`) pass.

This closes the residue #2607 left, so the forward-reference direction is now checked the same way the backward one always was: result type, argument types and arity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q9zbiDqkfF7xYQ3v8aCQ3b

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q9zbiDqkfF7xYQ3v8aCQ3b)_