### PR TITLE
checker: a marker Eq / Ord bound is refused at a non-scalar instantiation (#2523)

### DIFF
--- a/fixtures/derive_struct_eq_marker_impl_test.vibe
+++ b/fixtures/derive_struct_eq_marker_impl_test.vibe
@@ -1,15 +1,25 @@
 // #1967: was fixtures/derive_struct_eq_marker_impl.vibe + __DATA__.last "true".
-// derive(LocalEq) is no longer a known marker. Current derive(Eq) plus
-// [T: Eq] keeps same(Point, Point) as true once the struct has impl Eq.
+//
+// #2523: this used to pin that `impl Eq for Point` makes a `[T: Eq]` bound
+// SATISFIABLE at `Point`, with a `fn same[T: Eq](a, b) { true }` whose body
+// never compared -- so it blessed the shape without ever observing what it
+// answers. Measured, it answers by REFERENCE: two equal, distinct `Point`
+// give `false` and one `Point` compared with itself gives `true`. The bound
+// is now refused at a non-scalar instantiation
+// (fixtures/err_type_eq_marker_bound_struct.vibe pins the refusal and its
+// message), so what this fixture pins is what `derive(Eq)` actually delivers:
+// a structural comparator at a CONCRETE site, which is unaffected.
 
 struct Point { x: Int; y: Int } derive(Eq)
 
 impl Eq for Point
 
-fn same[T: Eq](a: T, b: T) -> Bool {
-  true
-}
-
-test "same equal Points is true" {
-  inspect(same(Point::{ x: 1, y: 1 }, Point::{ x: 1, y: 1 }), "true")
+test "derive(Eq) compares two Points by content" {
+  let a = Point::{ x: 1, y: 1 }
+  let b = Point::{ x: 1, y: 1 }
+  let c = Point::{ x: 1, y: 2 }
+  inspect(a == b, "true")
+  inspect(a == c, "false")
+  inspect(Point::equals(a, b), "true")
+  inspect(Point::equals(a, c), "false")
 }

--- a/fixtures/derive_struct_ord_implies_eq_test.vibe
+++ b/fixtures/derive_struct_ord_implies_eq_test.vibe
@@ -1,19 +1,24 @@
 // #1967: was fixtures/derive_struct_ord_implies_eq.vibe + __DATA__.last "true".
-// derive(LocalOrd) is no longer a known marker. Current derive(Ord) plus
-// impl Ord still implies Eq, so the Token pair stays true.
+//
+// #2523: this used to pin that `impl Ord for Token` makes both a `[T: Ord]`
+// and a `[T: Eq]` bound satisfiable at `Token`, through `fn same[T](a, b) {
+// true }` bodies that never compared. Both bounds are now refused at a
+// non-scalar instantiation (fixtures/err_type_ord_marker_bound_struct.vibe),
+// because a marker `Ord` dispatches to the builtin `<` and that is a REFERENCE
+// comparison on an aggregate. What survives -- and is what `derive(Ord)` is
+// for -- is the comparator at a CONCRETE site.
 
 struct Token { value: Int } derive(Ord)
 
 impl Ord for Token
 
-fn same[T: Ord](a: T, b: T) -> Bool {
-  true
-}
-
-fn accepts_eq[T: Eq](value: T) -> Bool {
-  true
-}
-
-test "Ord Token is accepted as Eq and same is true" {
-  inspect(same(Token::{ value: 1 }, Token::{ value: 1 }) && accepts_eq(Token::{ value: 1 }), "true")
+test "derive(Ord) orders two Tokens by content" {
+  let a = Token::{ value: 1 }
+  let b = Token::{ value: 1 }
+  let c = Token::{ value: 2 }
+  inspect(a == b, "true")
+  inspect(a == c, "false")
+  inspect(Token::compare(a, c) < 0, "true")
+  inspect(Token::compare(c, a) > 0, "true")
+  inspect(Token::compare(a, b) == 0, "true")
 }

--- a/fixtures/err_type_eq_marker_bound_struct.vibe
+++ b/fixtures/err_type_eq_marker_bound_struct.vibe
@@ -1,0 +1,27 @@
+// #2523: `Eq` is a MARKER trait -- `export trait Eq` in
+// lib/@vibe/builtin/builtin_traits.vibe declares no methods -- so `[T: Eq]`'s
+// `==` has no dictionary to dispatch through and lowers to the builtin
+// comparison. That is right for the five scalars the marker registers impls
+// for, and REFERENCE identity for anything else.
+//
+// So `impl Eq for Pt` used to turn a clear error into a wrong answer: measured
+// on the production linear/RC lane, `bare(p1, p2)` on two EQUAL, distinct `Pt`
+// answered `false` and `bare(p1, p1)` on the same object answered `true`,
+// while `p1 == p2` at a concrete site answered `true`.
+//
+// The BOUND is refused at this instantiation, not the impl -- `impl Eq for Pt`
+// stays a legal declaration (a marker impl can be a tag), and a concrete
+// `p1 == p2` still compares structurally
+// (fixtures/derive_struct_eq_marker_impl_test.vibe).
+
+struct Pt { v: Int } derive(Eq)
+
+impl Eq for Pt
+
+fn bare[T: Eq](x: T, y: T) -> Bool {
+  x == y
+}
+
+fn main() -> Unit with Stdout {
+  println(__to_string(bare(Pt::{ v: 1 }, Pt::{ v: 1 })))
+}

--- a/fixtures/err_type_ord_marker_bound_struct.vibe
+++ b/fixtures/err_type_ord_marker_bound_struct.vibe
@@ -1,0 +1,17 @@
+// #2523, the `Ord` half. A marker `Ord` dispatches to the builtin `<`, which
+// on an aggregate compares by REFERENCE, so an `impl Ord for Token` cannot
+// make `[T: Ord]` order two `Token` by content. Refused at the instantiation;
+// `Token::compare` at a concrete site is unaffected
+// (fixtures/derive_struct_ord_implies_eq_test.vibe).
+
+struct Token { value: Int } derive(Ord)
+
+impl Ord for Token
+
+fn smaller[T: Ord](a: T, b: T) -> Bool {
+  a < b
+}
+
+fn main() -> Unit with Stdout {
+  println(__to_string(smaller(Token::{ value: 1 }, Token::{ value: 2 })))
+}

--- a/lib/@vibe/compiler/checker/checker_stmt.vibe
+++ b/lib/@vibe/compiler/checker/checker_stmt.vibe
@@ -3416,9 +3416,74 @@ fn check_stmts_with_binders(raw_stmts: Array[Stmt], i: Int, env: TypeEnv, defs: 
 fn unsatisfied_bound_hint(env: TypeEnv, trait_name: String, resolved: Type) -> String {
   if trait_impl_declared_for_ctor(env, trait_name, resolved) && trait_is_marker(env, trait_name) {
     let display = trait_reference_display(trait_name)
-    String::concat(": an `impl ", String::concat(display, String::concat(" for ", String::concat(type_constructor_name(resolved), String::concat("` IS declared, but `", String::concat(display, String::concat("` is a marker trait (declared with no methods) so it dispatches to the builtin `==` / `<`, and those are REFERENCE equality on `Array` / `Bytes` -- honouring the impl would make the comparison silently wrong. Give `", String::concat(display, "` at least one method so the impl dispatches through the witness dictionary, or drop the bound"))))))))
+    let ctor = type_constructor_name(resolved)
+    // String::concat rather than `\{}` interpolation, for the reason recorded
+    // at the SResource diagnostic above.
+    let declared = String::concat(": an `impl ", String::concat(display, String::concat(" for ", String::concat(ctor, "` IS declared, but `"))))
+    let why = String::concat(display, String::concat("` is a marker trait (declared with no methods) so it dispatches to the builtin `==` / `<`, and those compare `", String::concat(ctor, "` by REFERENCE")))
+    let cost = " -- honouring the impl would make the comparison silently wrong: two equal values answer `false`, and one value compared with itself answers `true`"
+    let edit = String::concat(". Give `", String::concat(display, "` at least one method so the impl dispatches through the witness dictionary, or drop the bound"))
+    String::concat(declared, String::concat(why, String::concat(cost, edit)))
   } else {
     ""
+  }
+}
+
+/// #2523: does the builtin `==` / `<` compare a value of this type by VALUE?
+///
+/// Exactly the scalars `lib/@vibe/builtin/builtin_traits.vibe` registers marker
+/// impls for. Everything else -- `Array`, `Bytes`, a tuple, an `Option`, a
+/// declared struct or enum -- is compared by REFERENCE where the type has been
+/// erased, which is the whole reason this predicate exists.
+///
+/// Erring toward `false` costs a correct program a diagnostic, which the gates
+/// see; erring toward `true` keeps a silently wrong answer, which nothing sees.
+fn marker_cmp_is_by_value(ty: Type) -> Bool {
+  match ty {
+    CtInt => true,
+    CtDouble => true,
+    CtBool => true,
+    CtChar => true,
+    CtString => true,
+    CtNamed(name, args) => Array::length(args) == 0 && (name == "Int" || name == "Double" || name == "Bool" || name == "Char" || name == "String"),
+    _ => false
+  }
+}
+
+/// #2523: would satisfying this bound make the comparison silently wrong?
+///
+/// `Eq` and `Ord` are declared in `@vibe/builtin` as MARKER traits -- `export
+/// trait Eq` with no methods -- so there is no dictionary for `[T: Eq]`'s `==`
+/// to dispatch through and it lowers to the builtin comparison. That is right
+/// for the five scalars the markers register impls for, and REFERENCE identity
+/// for anything else.
+///
+/// So a user `impl Eq for Pt` turned a clear error into a wrong answer.
+/// Measured on the production linear/RC lane with `fn bare[T: Eq](x: T, y: T)
+/// { x == y }`: `bare(p1, p2)` on two EQUAL, distinct `Pt` answered `false`
+/// and `bare(p1, p1)` on the same object answered `true`, while `p1 == p2` at a
+/// concrete site and `Pt::equals(p1, p2)` both answered `true`. The comparator
+/// exists and works; the bound simply never reaches it.
+///
+/// What is refused is the BOUND at this instantiation, not the impl. That is
+/// what keeps it narrow: `impl Eq for Pt` remains a legal declaration (a marker
+/// impl can be a tag), a concrete `p1 == p2` still compares structurally, and
+/// only the instantiation that would answer by identity is rejected. The edit
+/// is named by `unsatisfied_bound_hint`, which has said exactly this since
+/// #1503 and until now could only fire when the bound failed for some other
+/// reason.
+///
+/// A program whose own `Eq` carries a method is not a marker, dispatches
+/// through a real witness dictionary, and is left alone -- that is the shape
+/// ADR-0097 wants, and landing it deletes this guard.
+fn marker_cmp_bound_is_unsound(env: TypeEnv, trait_bound: String, resolved: Type) -> Bool {
+  let display = trait_reference_display(trait_bound)
+  if display != "Eq" && display != "Ord" {
+    false
+  } else if not(trait_is_marker(env, trait_bound)) {
+    false
+  } else {
+    not(marker_cmp_is_by_value(resolved))
   }
 }
 
@@ -3459,6 +3524,10 @@ fn check_program_bounds(env: TypeEnv, s: Subst, defs: Array[TypeDef], errors: Ar
             // ADR-0068: `Send` is judged structurally from the type
             // definitions (type_send_ok), not from user impls.
             type_send_ok(env, s, defs, resolved)
+          } else if marker_cmp_bound_is_unsound(env, resolved_bound, resolved) {
+            // #2523: a marker `Eq` / `Ord` cannot make a non-scalar compare by
+            // content, so no impl may satisfy it here.
+            false
           } else {
             type_implements_trait(env, s, resolved, resolved_bound)
           }

--- a/lib/@vibe/compiler/tests/marker_cmp_bound_test.vibe
+++ b/lib/@vibe/compiler/tests/marker_cmp_bound_test.vibe
@@ -1,0 +1,93 @@
+//# Imports
+
+// #2523: `Eq` and `Ord` are MARKER traits -- `lib/@vibe/builtin/builtin_traits.vibe`
+// declares `export trait Eq` with no methods -- so a `[T: Eq]` bound's `==` has
+// no dictionary to dispatch through and lowers to the builtin comparison. That
+// is correct for the five scalars the markers register impls for, and REFERENCE
+// identity for anything else.
+//
+// Both ways a program could reach for it ended badly. `derive (Eq)` alone does
+// not satisfy the bound (`no impl `Eq` for `Pt``); adding `impl Eq for Pt`
+// replaced that error with a wrong answer. Measured on the production
+// linear/RC lane with `fn bare[T: Eq](x: T, y: T) { x == y }`:
+//
+//   bare(1, 1)                       true    (correct)
+//   bare(p1, p2)  equal, distinct    FALSE   (reference identity)
+//   bare(p1, p3)  different          false
+//   bare(p1, p1)  same object        TRUE    (reference identity)
+//   p1 == p2      concrete site      true    (correct, structural)
+//
+// What is refused is the BOUND at this instantiation, not the impl: the impl
+// stays a legal declaration (a marker impl can be a tag) and the concrete site
+// keeps answering by content. Giving `Eq` a real method makes it non-marker,
+// dispatches through a witness dictionary, and deletes this guard (ADR-0097).
+
+import @vibe/compiler/checker {
+  check_program
+}
+
+import @vibe/compiler/syntax {
+  lex, parse_program
+}
+
+//# Functions
+
+fn diags_of(src: String) -> String {
+  handle {
+    let _ = check_program(parse_program(lex(src)))
+    ""
+  } with { Exception::Throw(msg) => msg }
+}
+
+fn rejects(src: String) -> Bool {
+  String::length(diags_of(src)) > 0
+}
+
+/// A marker `Eq` with the builtin's scalar impls, a declared aggregate that
+/// also has one, and a bounded generic that compares.
+let eq_prelude = "trait Eq\nimpl Eq for Int\nimpl Eq for String\nstruct Pt {\n  v: Int\n}\nimpl Eq for Pt\nfn bare[T: Eq](x: T, y: T) -> Bool {\n  x == y\n}\n"
+
+//# Tests
+
+test "a marker Eq bound at a declared struct is refused" {
+  inspect(rejects(String::concat(eq_prelude, "let r = bare(Pt::{ v: 1 }, Pt::{ v: 1 })\n")), "true")
+}
+
+test "the refusal names the edit, not just the missing impl" {
+  let msg = diags_of(String::concat(eq_prelude, "let r = bare(Pt::{ v: 1 }, Pt::{ v: 1 })\n"))
+  inspect(String::contains(msg, "is a marker trait (declared with no methods)"), "true")
+  inspect(String::contains(msg, "compare `Pt` by REFERENCE"), "true")
+  inspect(String::contains(msg, "Give `Eq` at least one method"), "true")
+}
+
+test "the same bound at a scalar is accepted" {
+  inspect(rejects(String::concat(eq_prelude, "let r = bare(1, 1)\n")), "false")
+  inspect(rejects(String::concat(eq_prelude, "let r = bare(\"a\", \"a\")\n")), "false")
+}
+
+test "a concrete == on the same struct still checks clean" {
+  inspect(rejects(String::concat(eq_prelude, "let a = Pt::{ v: 1 }\nlet b = Pt::{ v: 1 }\nlet r = a == b\n")), "false")
+}
+
+test "the impl on its own is still a legal declaration" {
+  inspect(rejects(eq_prelude), "false")
+}
+
+test "an Eq that carries a method is not a marker and is left alone" {
+  // The ADR-0097 shape: a real witness dictionary, so the bound is sound and
+  // this guard must not fire.
+  let src = "trait Eq {\n  equals(Self, Self) -> Bool\n}\nstruct Pt {\n  v: Int\n}\nimpl Eq for Pt {\n  equals(a: Pt, b: Pt) -> Bool {\n    a.v == b.v\n  }\n}\nfn bare[T: Eq](x: T, y: T) -> Bool {\n  T::equals(x, y)\n}\nlet r = bare(Pt::{ v: 1 }, Pt::{ v: 1 })\n"
+  inspect(rejects(src), "false")
+}
+
+test "a marker Ord bound at a declared struct is refused too" {
+  let src = "trait Ord\nimpl Ord for Int\nstruct Token {\n  value: Int\n}\nimpl Ord for Token\nfn smaller[T: Ord](a: T, b: T) -> Bool {\n  a < b\n}\nlet r = smaller(Token::{ value: 1 }, Token::{ value: 2 })\n"
+  inspect(rejects(src), "true")
+}
+
+test "a non-comparison marker trait is untouched" {
+  // `Sealed` is a tag: its bound never lowers to `==` or `<`, so nothing about
+  // it can be silently wrong and this guard has no business refusing it.
+  let src = "trait Sealed\nstruct Pt {\n  v: Int\n}\nimpl Sealed for Pt\nfn tagged[T: Sealed](x: T) -> Int {\n  0\n}\nlet r = tagged(Pt::{ v: 1 })\n"
+  inspect(rejects(src), "false")
+}

--- a/tests/gates/late/run.sh
+++ b/tests/gates/late/run.sh
@@ -939,6 +939,19 @@ send_check_reject "err_type_send_user_impl.vibe" '`Send` is a compiler-judged st
 # #1090 review: the coinductive guard keys on constructor + ARGS — a
 # recursive occurrence with different arguments must still be checked.
 send_check_reject "err_type_send_nonregular_recursion.vibe" 'no impl `Send` for `LoopT[Int]`' "nonreg"
+# #2523: the same shape for the COMPARISON markers. `Eq` / `Ord` are declared
+# with no methods, so a `[T: Eq]` / `[T: Ord]` bound lowers to the builtin
+# `==` / `<` -- correct for the five scalars the markers register impls for,
+# REFERENCE identity for anything else. A user `impl Eq for Pt` used to make
+# the bound satisfiable and the answer wrong (two EQUAL, distinct `Pt` gave
+# `false`; one `Pt` against itself gave `true`). The bound is refused at the
+# instantiation, not the impl, so the message matters as much as the refusal:
+# the plain "no impl" half is misleading when an impl IS declared three lines
+# above, and the hint is what names the edit.
+send_check_reject "err_type_eq_marker_bound_struct.vibe" 'no impl `Eq` for `Pt`' "eqmarker"
+send_check_reject "err_type_eq_marker_bound_struct.vibe" 'is a marker trait (declared with no methods)' "eqmarker2"
+send_check_reject "err_type_eq_marker_bound_struct.vibe" 'Give `Eq` at least one method' "eqmarker3"
+send_check_reject "err_type_ord_marker_bound_struct.vibe" 'no impl `Ord` for `Token`' "ordmarker"
 # #1090 review: bounds are enforced on the IMPORT (check_program_with_env /
 # FS) path too — a consumer importing a [T: Send] fn must not bypass it.
 cat > "$senddir/send_dep.vibe" <<'SENDDEP'


### PR DESCRIPTION
Addresses #2523 (P0, silent-wrong) — as the **stopgap**, not the ADR-0097 fix. Landed on your call after I measured what it costs.

## The defect

`Eq` and `Ord` are declared in `@vibe/builtin` as **marker traits** — `export trait Eq` with no methods — so `[T: Eq]`'s `==` has no dictionary to dispatch through and lowers to the builtin comparison. That is correct for the five scalars the markers register impls for, and reference identity for anything else.

Both ways a program could reach for it ended badly. `derive (Eq)` alone does not satisfy the bound; adding `impl Eq for Pt` replaced that error with a wrong answer. Measured on the production linear/RC lane with `fn bare[T: Eq](x: T, y: T) { x == y }`:

| expression | answer |
|---|---|
| `bare(1, 1)` | `true` |
| `bare(p1, p2)` — equal, distinct | **`false`** |
| `bare(p1, p3)` — different | `false` |
| `bare(p1, p1)` — same object | **`true`** |
| `p1 == p2` at a concrete site | `true` |

## The change

Refuse the **bound at this instantiation**, not the impl — one arm in `check_program_bounds`, beside the existing `Send` arm. That keeps it narrow:

- `impl Eq for Pt` stays a legal declaration (a marker impl can be a tag);
- a concrete `p1 == p2` still compares structurally;
- a non-comparison marker (`Sealed`) is untouched, because its bound never lowers to `==` or `<`;
- an `Eq` that **carries a method** is not a marker, dispatches through a real witness dictionary, and the guard does not fire.

That last one is the deletion condition: landing ADR-0097's `equals(Self, Self) -> Bool` removes this guard. Until then it is the difference between a wrong answer and a message naming the edit.

The message comes from `unsatisfied_bound_hint`, which has described exactly this since #1503 and until now could only fire when the bound failed for some *other* reason:

```
no impl `Eq` for `Pt`: an `impl Eq for Pt` IS declared, but `Eq` is a marker trait
(declared with no methods) so it dispatches to the builtin `==` / `<`, and those
compare `Pt` by REFERENCE -- honouring the impl would make the comparison silently
wrong: two equal values answer `false`, and one value compared with itself answers
`true`. Give `Eq` at least one method so the impl dispatches through the witness
dictionary, or drop the bound
```

Its wording said "REFERENCE equality on `Array` / `Bytes`", which was the #1503 case rather than the rule; it now names the offending type and what the wrongness looks like.

**Static only**: no runtime guard is emitted and generated code is unchanged.

## The two fixtures

`fixtures/derive_struct_eq_marker_impl_test.vibe` and `fixtures/derive_struct_ord_implies_eq_test.vibe` were rewritten under #1967 to pin that `impl Eq for Point` / `impl Ord for Token` makes the bound **satisfiable** — through `fn same[T](a, b) { true }` bodies that never compared, so they blessed the shape without ever observing what it answers.

They now pin what `derive(Eq)` / `derive(Ord)` actually deliver — the comparator at a concrete site, which this change does not touch. The refused shape moves to two new `fixtures/err_type_{eq,ord}_marker_bound_struct.vibe`, asserted in the late lane through the existing `send_check_reject` helper.

## Verification

- **Red**: with the guard reverted, `a marker Eq bound at a declared struct is refused` fails (`false`, want `true`).
- **Green**: 8/8 in `lib/@vibe/compiler/tests/marker_cmp_bound_test.vibe` — the scalar instantiations, the concrete `==`, the bare impl, the `Ord` half, a method-bearing `Eq` (must **not** fire), and a `Sealed` tag marker (must **not** fire).
- **The gate rows assert the message**, not just the refusal, and I checked all three needles against a deliberately wrong one so they discriminate. The plain "no impl" half of the message is misleading when an impl *is* declared three lines above, so the hint is the part worth pinning.
- All four `scripts/compiler_gate.sh` lanes pass, and the `stage1 → stage2` self-compile puts the whole compiler through the stricter check.

#2523 stays open at P1 for the witness-dictionary work; this closes the door in the meantime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q9zbiDqkfF7xYQ3v8aCQ3b

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q9zbiDqkfF7xYQ3v8aCQ3b)_