### PR TITLE
tests: pin that a colliding CALLED name does not reclassify another module's interpolation (#2600)

### DIFF
--- a/lib/@vibe/compiler/tests/interp_cross_module_call_collision_test.vibe
+++ b/lib/@vibe/compiler/tests/interp_cross_module_call_collision_test.vibe
@@ -1,0 +1,74 @@
+//# Imports
+
+// #2600: THIS FILE'S REGRESSION IS THAT IT COMPILES, the same way
+// interp_cross_module_name_collision_test.vibe's is.
+//
+// #2527 fixed the BARE-identifier half: a lowercase `EIdent` no longer falls
+// through to `fn_returns`, the program-wide FLAT table for the whole import
+// closure, so `CtVar(id) => "?t\{id}"` in core/types.vibe stopped picking up an
+// unrelated file's `fn id(n: String) -> Expr`. #2600 asks whether the CALL arm
+// -- `ECall(EIdent(fname), ..)`, which really does have `fname`'s return type
+// and so still consults that table -- has the same exposure.
+//
+// Measured, it does not, and this file is the measurement. Each declaration
+// below collides with a name the compiler's own sources CALL INSIDE AN
+// INTERPOLATION, and returns a type with no Show renderer:
+//
+//   lib/@vibe/core/bigint.vibe:454             out = "\{pad9(r)}\{out}"
+//   lib/@vibe/compiler/checker/checker_stmt.vibe:1699
+//                                              "... \{import_kind_article(actual)} ..."
+//
+// Both of those files are in this file's import closure (measured with
+// `vibe deps`: 31 and 114 entries respectively, containing bigint.vibe and
+// checker_stmt.vibe), so if the flat table answered for the call sites they
+// own, compiling this file would reject THEM -- positionless, and about files
+// that are correct. That is exactly how #2527 presented.
+//
+// The reason it holds: the FS lane runs the per-module entry
+// (`desugar_trait_dicts_module`), where `dtd_own_end` puts the module's OWN
+// statements before the read-only context block and `fn_return_type` is
+// first-match -- so the querying module's row already wins, which is the
+// "prefer the querying expression's own module" rule #2600's Done-when asks
+// for. If that ordering is ever changed, this file stops compiling.
+
+import @vibe/compiler/checker {
+  check_program
+}
+
+import @vibe/compiler/syntax {
+  lex, parse_program
+}
+
+import @vibe/core {
+  array_empty
+}
+
+//# Functions
+
+/// No Show renderer, deliberately: a wrong classification has to be reportable.
+struct NoRenderer {
+  v: Int
+}
+
+fn pad9(n: Int) -> NoRenderer {
+  NoRenderer::{ v: n }
+}
+
+fn import_kind_article(n: Int) -> NoRenderer {
+  NoRenderer::{ v: n }
+}
+
+//# Tests
+
+test "#2600: a colliding CALLED name does not reclassify another module's interpolation" {
+  // Exercised so they are not dead; the assertion that matters is that this
+  // file, and everything in its closure, compiled at all.
+  assert(pad9(1).v == 1)
+  assert(import_kind_article(2).v == 2)
+  let _ = array_empty()
+  let diags = handle {
+    let _ = check_program(parse_program(lex("let a = 1")))
+    ""
+  } with { Exception::Throw(msg) => msg }
+  assert(String::length(diags) == 0)
+}


### PR DESCRIPTION
Measurement for #2600, plus the regression that keeps it true.

#2600 asks whether the CALL arm of `infer_arg_type_name` has the exposure #2527 fixed for the bare-identifier arm: `fn_returns` is the program-wide **flat** table for the whole import closure, with first-match lookup and no module scoping, and the call arm still consults it — correctly, since `f(x)` really does have `f`'s return type.

**Measured, it does not reproduce.** This file is the measurement, in the same "the regression is that it compiles" shape as `interp_cross_module_name_collision_test.vibe`.

## The decisive probe

Each declaration collides with a name the compiler's own sources **call inside an interpolation**, and returns a type with no Show renderer:

| colliding name | interpolation site the compiler owns |
|---|---|
| `pad9` | `lib/@vibe/core/bigint.vibe:454` — `out = "\{pad9(r)}\{out}"` |
| `import_kind_article` | `lib/@vibe/compiler/checker/checker_stmt.vibe:1699` |

Both files are genuinely in this file's import closure — checked with `vibe deps` (31 and 114 entries, containing `bigint.vibe` and `checker_stmt.vibe`). If the flat table answered for the call sites they own, compiling this file would reject **them**, positionless and about files that are correct — exactly how #2527 presented. It compiles.

## Six further shapes

Two modules each with a private `fn helper` returning different types (one a Show-less struct), the second interpolating its own call: independent modules; the use above the declaration; both above; the interpolating module importing the colliding one; the entry colliding with a dependency; and the reverse. All six classify to their own module's return type, at run time on the linear/RC lane.

## Why it holds

The FS lane runs the per-module entry (`desugar_trait_dicts_module`), and `dtd_own_end` puts the module's **own** statements before the read-only context block — `dtd_is_own_index` is `lim < 0 || i < lim || i >= lim + ctx_len`. `collect_fn_returns` walks in order and `fn_return_type` is first-match, so the querying module's row already wins. That is the "prefer the querying expression's own module" rule #2600's Done-when asks for; it is structural rather than written down, which is presumably why reading the code suggested an exposure. This file makes it fail loudly if the ordering ever changes.

Worth recording: `local_fn_return_key` is **not** what saves it. That lookup is gated on `dtd_constructor_tracking` plus membership in `dtd_constructor_local_returns` (constructor-indexed generic receivers, #2338), so an ordinary program goes straight to the flat table.

I've proposed closing #2600 on the issue unless there's a shape the seven above miss; the burden is now a reproduction rather than a code reading, and this file is where one would go.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q9zbiDqkfF7xYQ3v8aCQ3b

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q9zbiDqkfF7xYQ3v8aCQ3b)_