### PR TITLE
tests: the normalizer scalar-scan guard tracks the current shape, and is wired to run (#2538)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -888,6 +888,14 @@ jobs:
       # is a release-check dep, but release-check has no CI job either, so its
       # one enforcement point was a local sign-off nobody re-runs on a green
       # tree -- and it had been failing on main since #1614, ~300 commits.
+      # #2538: the same lesson, one issue later. This guard on
+      # `dinsp_scan`'s shape sat red for a week because it was referenced by no
+      # pkf task, no gate lane and no CI job. It is now a release-check dep --
+      # and, per the note directly above, that is NOT enforcement on its own,
+      # so it gets a job here. It reads two source files and runs in ~1s, which
+      # is what structural-lint is for.
+      - name: normalizer scalar-scan structure guard
+        run: node --test tests/normalizer_scalar_scan_compaction_test.mjs
       - name: method-style-naming lint self-test
         run: bash scripts/lint_method_style_naming_test.sh
       - name: method-style-naming lint

--- a/Taskfile.pkl
+++ b/Taskfile.pkl
@@ -170,6 +170,23 @@ local testArtifactInputTrace = new Task {
   }
 }
 
+local testNormalizerScalarScan = new Task {
+  name = "test-normalizer-scalar-scan"
+  description =
+    "structural guard on desugar_trait_dict's dinsp_scan: scalar Bool modes, the mode-7 census cell, and full Expr/Pat arm coverage"
+  // #2538: this file existed for a week asserting a `dinsp_scan` shape two
+  // slices had already changed, and nothing noticed -- it was referenced by no
+  // pkf task, no gate lane and no CI job, so it was never protecting anything
+  // whatever it asserted. Wiring it is the half of that issue that keeps the
+  // next drift visible.
+  cmd = "node --test tests/normalizer_scalar_scan_compaction_test.mjs"
+  inputs {
+    "tests/normalizer_scalar_scan_compaction_test.mjs"
+    "lib/@vibe/compiler/normalize/desugar_trait_dict.vibe"
+    "lib/@vibe/ast/index.vpkg"
+  }
+}
+
 local testSelfcompileHeapPolicy = new Task {
   name = "test-selfcompile-heap-policy"
   description =
@@ -1828,6 +1845,7 @@ local releaseCheck = new Task {
     testPreCommit
     testCheckMethodStyleNaming
     checkMethodStyleNaming
+    testNormalizerScalarScan
     testCheckCanonicalIteratorCalls
     checkCanonicalIteratorCalls
     testCheckFreezeSurface
@@ -1893,6 +1911,7 @@ tasks {
   testIncrementalInvalidationOracle
   testIncrementalInvalidationTrace
   testArtifactInputTrace
+  testNormalizerScalarScan
   testSelfcompileHeapPolicy
   testCoverageDriverExposure
   formalSelfhostOracle

--- a/tests/normalizer_scalar_scan_compaction_test.mjs
+++ b/tests/normalizer_scalar_scan_compaction_test.mjs
@@ -167,38 +167,64 @@ function assertCanonicalBody(part, expected, label) {
   assert.equal(canonical(part.body), canonical(expected), label);
 }
 
+// The mode-7 arm's byte range in `dinsp_scan`'s body, so a cell write can be
+// required to live inside it rather than merely to exist somewhere.
+function censusArmText(body) {
+  const masked = maskNonCode(body);
+  const head = masked.indexOf("mode == 7");
+  assert.notEqual(head, -1, "mode 7 arm must exist");
+  const open = masked.indexOf("{", head);
+  assert.notEqual(open, -1, "mode 7 arm must have a block");
+  const block = balanced(body, open);
+  return { start: open, end: block.end };
+}
+
 function definitionCount(name) {
   return [...maskNonCode(source).matchAll(new RegExp(`\\bfn\\s+${name}\\s*\\(`, "g"))].length;
 }
 
 const scan = functionPartsIn(source, "dinsp_scan");
+const hereUses = functionPartsIn(source, "dinsp_here_uses");
+const hereBinds = functionPartsIn(source, "dinsp_here_binds");
 const marker = functionPartsIn(source, "dlh_marker_only_called_directly");
 const assigned = functionPartsIn(source, "dlh_names_ever_assigned");
 const collector = functionPartsIn(source, "collect_pat_binders");
 const contains = functionPartsIn(source, "str_array_contains");
 
-for (const kept of ["dinsp_scan", "collect_pat_binders", "str_array_contains"]) assert.equal(definitionCount(kept), 1, `${kept} unique`);
+for (const kept of ["dinsp_scan", "dinsp_here_uses", "dinsp_here_binds", "collect_pat_binders", "str_array_contains"]) assert.equal(definitionCount(kept), 1, `${kept} unique`);
 for (const removed of ["dlh_mocd_scan", "dlh_naa_scan", "dlh_pat_binds", "relabel_pat_binds", "dlh_contains", "relabel_shadowed", "expr_has_labeled_arg", "arr_has_labeled_arg", "pairs_have_labeled_arg", "arms_have_labeled_arg"]) assert.equal(definitionCount(removed), 0, `${removed} removed`);
 assertCanonicalBody(marker, "!dinsp_scan(expr, 4, marker)", "direct marker wrapper");
 assertCanonicalBody(assigned, `let mut i = 0 let mut found = false while !found && i < Array::length(names) { found = dinsp_scan(expr, 5, Array::get(names, i)) i = i + 1 } found`, "many-name scalar assignment wrapper");
-assert.doesNotMatch(marker.text + assigned.text + scan.text, /Array\[Bool\]|\[\s*false\s*\]|Array::set|expr_children|->\s*Option|->\s*\(/);
 
+// The compaction property. `Array::set` is NOT in the blanket list any more:
+// #2537 gave mode 7 a module-level `Int` pair cell so ONE walk answers both
+// "binds inspect?" and "calls inspect?", replacing two walks -- reverting that
+// to keep the scan cell-free would cost the walk it saves. So the cell is
+// allowed, and scoped instead: every `Array::set` in the scan must be inside
+// the mode-7 arm and must target `dinsp_census_cell`. A cell introduced
+// anywhere else, or a second cell, still fails.
+assert.doesNotMatch(marker.text + assigned.text + scan.text, /Array\[Bool\]|\[\s*false\s*\]|expr_children|->\s*Option|->\s*\(/);
+const censusArm = censusArmText(scan.body);
+for (const [where, text] of [["marker wrapper", marker.text], ["assignment wrapper", assigned.text]]) {
+  assert.doesNotMatch(text, /Array::set/, `${where} must stay cell-free`);
+}
+function assertCellDiscipline(body, label) {
+  const arm = censusArmText(body);
+  const sets = [...maskNonCode(body).matchAll(/Array::set\(([A-Za-z0-9_]+)/g)];
+  assert.ok(sets.length > 0, `${label}: mode 7 records its census through a cell`);
+  for (const found of sets) {
+    assert.equal(found[1], "dinsp_census_cell", `${label}: the only cell the scan writes is the census cell`);
+    assert.ok(found.index >= arm.start && found.index < arm.end, `${label}: every cell write is inside the mode 7 arm`);
+  }
+}
+assertCellDiscipline(scan.body, "dinsp_scan");
+
+// The LEAF matches, in source order. Modes 0 and 1 are not here: #2537 moved
+// their predicates into `dinsp_here_uses` / `dinsp_here_binds` (asserted
+// separately below) so mode 7 could answer both in ONE walk, and mode 7 itself
+// has no `match expr` at all -- it calls those two and records the pair.
 const modeArms = [
-  [
-    { role: "inspect-call", pattern: "ECall(callee, args, _)", body: `match callee { EIdent(n, _) => n == "inspect" && Array::length(args) == 2, _ => false }` },
-    { role: "inspect-default", pattern: "_", body: "false" }
-  ],
-  [
-    { role: "let-binder", pattern: "ELet(n, _, _, _)", body: `n == "inspect"` },
-    { role: "letrec-binder", pattern: "ELetRec(n, _, _)", body: `n == "inspect"` },
-    { role: "letmut-binder", pattern: "ELetMut(n, _, _, _)", body: `n == "inspect"` },
-    { role: "for-binder", pattern: "EForIn(v, _, _, _)", body: `v == "inspect"` },
-    { role: "parameter-binder", pattern: "EFn(_, _, params, _, _, _)", body: `dinsp_params_bind(params, "inspect")` },
-    { role: "match-binder", pattern: "EMatch(_, arms)", body: `dinsp_arms_bind(arms, "inspect")` },
-    { role: "handle-binder", pattern: "EHandle(_, arms)", body: `dinsp_arms_bind(arms, "inspect")` },
-    { role: "binder-default", pattern: "_", body: "false" }
-  ],
-  [
+  { mode: 2, arms: [
     { role: "identifier", pattern: "EIdent(n, _)", body: "n == name" },
     { role: "let-name", pattern: "ELet(n, _, _, _)", body: "n == name" },
     { role: "letrec-name", pattern: "ELetRec(n, _, _)", body: "n == name" },
@@ -210,22 +236,52 @@ const modeArms = [
     { role: "match-name", pattern: "EMatch(_, arms)", body: "dinsp_arms_bind(arms, name)" },
     { role: "handle-name", pattern: "EHandle(_, arms)", body: "dinsp_arms_bind(arms, name)" },
     { role: "mention-default", pattern: "_", body: "false" }
-  ],
-  [
+  ] },
+  { mode: 3, arms: [
     { role: "labeled-wrapper-self", pattern: "ELabeledArg(_, _, _)", body: "true" },
+    // #1952: a block-local `(a: Int, b?: Int)` is the second reason the
+    // relabel walk can change a statement. Without this arm the statement was
+    // skipped and the omitted argument reached the checker as an arity error.
+    { role: "optional-parameter-lambda", pattern: "EFn(_, _, params, _, _, _)", body: "dinsp_params_optional(params)" },
     { role: "labeled-default", pattern: "_", body: "false" }
-  ],
-  [
+  ] },
+  { mode: 4, arms: [
     { role: "marker-value", pattern: "EIdent(n, _)", body: "n == name" },
     { role: "marker-assign", pattern: "EAssign(n, _, _)", body: "n == name" },
     { role: "marker-assignop", pattern: "EAssignOp(n, _, _, _)", body: "n == name" },
     { role: "marker-default", pattern: "_", body: "false" }
-  ],
-  [
+  ] },
+  // #2386: the third and last reason the relabel walk can change a statement
+  // -- a call to a TOP-LEVEL optional-parameter fn by name. An omitted
+  // optional leaves no syntactic trace at the call site, but the callee's name
+  // is one, so this reads the same table the walk reads.
+  { mode: 6, arms: [
+    { role: "top-level-optional-callee", pattern: "ECall(callee, _, _)", body: `match callee { EIdent(n, _) => match optional_param_flags(n) { Some(_) => true, None => false }, _ => false }` },
+    { role: "optional-call-default", pattern: "_", body: "false" }
+  ] },
+  // The `else`, i.e. mode 5.
+  { mode: 5, arms: [
     { role: "captured-assign", pattern: "EAssign(n, _, _)", body: "n == name" },
     { role: "captured-assignop", pattern: "EAssignOp(n, _, _, _)", body: "n == name" },
     { role: "assignment-default", pattern: "_", body: "false" }
-  ]
+  ] }
+];
+
+// Modes 0 and 1, as their own predicates. Same arms they had inline, so
+// splitting them out for the census cost no coverage.
+const hereUsesArms = [
+  { role: "inspect-call", pattern: "ECall(callee, args, _)", body: `match callee { EIdent(n, _) => n == "inspect" && Array::length(args) == 2, _ => false }` },
+  { role: "inspect-default", pattern: "_", body: "false" }
+];
+const hereBindsArms = [
+  { role: "let-binder", pattern: "ELet(n, _, _, _)", body: `n == "inspect"` },
+  { role: "letrec-binder", pattern: "ELetRec(n, _, _)", body: `n == "inspect"` },
+  { role: "letmut-binder", pattern: "ELetMut(n, _, _, _)", body: `n == "inspect"` },
+  { role: "for-binder", pattern: "EForIn(v, _, _, _)", body: `v == "inspect"` },
+  { role: "parameter-binder", pattern: "EFn(_, _, params, _, _, _)", body: `dinsp_params_bind(params, "inspect")` },
+  { role: "match-binder", pattern: "EMatch(_, arms)", body: `dinsp_arms_bind(arms, "inspect")` },
+  { role: "handle-binder", pattern: "EHandle(_, arms)", body: `dinsp_arms_bind(arms, "inspect")` },
+  { role: "binder-default", pattern: "_", body: "false" }
 ];
 
 const recursiveArms = [
@@ -238,10 +294,24 @@ const recursiveArms = [
 ].map(([role, pattern, body]) => ({ role, pattern, body }));
 
 const scanMatches = matchExprArms(scan.body);
-assert.equal(scanMatches.length, 7, "six mode leaf matches and one recursive match");
-for (let mode = 0; mode < 6; mode += 1) assertArms(scanMatches[mode], modeArms[mode], `mode ${mode}`);
-assertArms(scanMatches[6], recursiveArms, "recursive Expr descent");
-const recursiveConstructors = scanMatches[6].map(({ pattern }) => pattern.match(/^([A-Z][A-Za-z0-9_]*)/)?.[1]);
+// Driven by the list, not a literal: a new mode with its own `match expr` is
+// covered by adding one entry above rather than by editing a number that no
+// longer says what it counts. #2386 added mode 6 and the literal `7` here went
+// stale for a week without anything noticing (#2538).
+assert.equal(scanMatches.length, modeArms.length + 1, `${modeArms.length} mode leaf matches and one recursive match`);
+modeArms.forEach(({ mode, arms }, i) => assertArms(scanMatches[i], arms, `mode ${mode}`));
+assertArms(scanMatches[scanMatches.length - 1], recursiveArms, "recursive Expr descent");
+assertArms(matchExprArms(hereUses.body)[0], hereUsesArms, "dinsp_here_uses");
+assertArms(matchExprArms(hereBinds.body)[0], hereBindsArms, "dinsp_here_binds");
+// Mode 7 is the census: both bits recorded as the walk finds them, and the
+// walk stops early only once BOTH are known. Pinned exactly, because "records
+// a bit somewhere" is what the cell exemption above would otherwise permit.
+assert.equal(canonical(scan.body.slice(censusArm.start + 1, censusArm.end - 1)),
+  canonical(`if dinsp_here_uses(expr) { Array::set(dinsp_census_cell, 0, 1) } else { () }
+    if dinsp_here_binds(expr) { Array::set(dinsp_census_cell, 1, 1) } else { () }
+    Array::get(dinsp_census_cell, 0) != 0 && Array::get(dinsp_census_cell, 1) != 0`),
+  "mode 7 census body");
+const recursiveConstructors = scanMatches[scanMatches.length - 1].map(({ pattern }) => pattern.match(/^([A-Z][A-Za-z0-9_]*)/)?.[1]);
 assert.deepEqual(new Set(recursiveConstructors), new Set(enumConstructors("Expr")), "all current Expr constructors covered");
 assert.equal(recursiveConstructors.length, new Set(recursiveConstructors).size, "no duplicate Expr arms");
 
@@ -272,13 +342,43 @@ for (const [name, body] of helperBodies) assertCanonicalBody(functionPartsIn(sou
 function expectMutationFailure(label, check) {
   assert.throws(check, assert.AssertionError, `${label} must be rejected`);
 }
-const wrongChild = scan.body.replace("dinsp_scan(c, mode, name) || dinsp_scan(t, mode, name) || dinsp_scan(f, mode, name)", "dinsp_scan(t, mode, name) || dinsp_scan(c, mode, name) || dinsp_scan(f, mode, name)");
-expectMutationFailure("swapped recursive child", () => assertArms(matchExprArms(wrongChild)[6], recursiveArms, "mutated Expr"));
-const wrongDirect = scan.body.replace("ECall(callee, args, _) => if mode == 4 {", "ECall(callee, args, _) => if mode == 5 {");
-expectMutationFailure("wrong direct-callee mode", () => assertArms(matchExprArms(wrongDirect)[6], recursiveArms, "mutated call"));
-const wrongPat = collector.body.replace("collect_pat_binders(a, out)\n      collect_pat_binders(b, out)", "collect_pat_binders(b, out)\n      collect_pat_binders(a, out)");
+
+// A mutation that matched nothing passes every assertion below while proving
+// nothing -- the exact way a red test "passes" (AGENTS.md, "red test は
+// 「変異が当たったこと」を先に検証する"). Measured instance in this repo: a
+// multi-line order block meant one slice only ever grabbed its first line.
+function mutate(text, from, to, label) {
+  const out = typeof from === "string" ? text.replace(from, to) : text.replace(from, to);
+  assert.notEqual(out, text, `${label}: the mutation matched nothing`);
+  return out;
+}
+const wrongChild = mutate(scan.body, "dinsp_scan(c, mode, name) || dinsp_scan(t, mode, name) || dinsp_scan(f, mode, name)", "dinsp_scan(t, mode, name) || dinsp_scan(c, mode, name) || dinsp_scan(f, mode, name)", "swapped recursive child");
+expectMutationFailure("swapped recursive child", () => assertArms(matchExprArms(wrongChild).at(-1), recursiveArms, "mutated Expr"));
+const wrongDirect = mutate(scan.body, "ECall(callee, args, _) => if mode == 4 {", "ECall(callee, args, _) => if mode == 5 {", "wrong direct-callee mode");
+expectMutationFailure("wrong direct-callee mode", () => assertArms(matchExprArms(wrongDirect).at(-1), recursiveArms, "mutated call"));
+const wrongPat = mutate(collector.body, "collect_pat_binders(a, out)\n      collect_pat_binders(b, out)", "collect_pat_binders(b, out)\n      collect_pat_binders(a, out)", "reversed POr binder order");
 expectMutationFailure("reversed POr binder order", () => assertArms(parseMatchAt(wrongPat, maskNonCode(wrongPat).search(/\bmatch\s+p\s*\{/)), expectedPatArms, "mutated Pat"));
-expectMutationFailure("membership comparator", () => assert.equal(canonical(contains.body.replace("== val", "!= val")), canonical(membershipBody)));
+expectMutationFailure("membership comparator", () => assert.equal(canonical(mutate(contains.body, "== val", "!= val", "membership comparator")), canonical(membershipBody)));
+
+// #2538: the material #2386 and #2537 added, mutated. The exemption the cell
+// rule grants is narrow, and these are what say so -- an exemption nobody can
+// break is indistinguishable from no rule at all.
+const strayCell = mutate(scan.body, "} else if mode == 2 {", "} else if mode == 2 {\n    Array::set(dinsp_census_cell, 0, 1)", "cell write outside the mode 7 arm");
+expectMutationFailure("cell write outside the mode 7 arm", () => assertCellDiscipline(strayCell, "mutated stray"));
+const otherCell = mutate(scan.body, "Array::set(dinsp_census_cell, 1, 1)", "Array::set(dinsp_other_cell, 1, 1)", "a second cell");
+expectMutationFailure("a second cell", () => assertCellDiscipline(otherCell, "mutated other"));
+const noCell = mutate(scan.body, /Array::set\(dinsp_census_cell, \d, 1\)/g, "()", "census recorded without the cell");
+expectMutationFailure("census recorded without the cell", () => assertCellDiscipline(noCell, "mutated none"));
+const halfCensus = mutate(scan.body, "Array::set(dinsp_census_cell, 1, 1)", "Array::set(dinsp_census_cell, 0, 1)", "census records one bit twice");
+expectMutationFailure("census records one bit twice", () => {
+  const arm = censusArmText(halfCensus);
+  assert.equal(canonical(halfCensus.slice(arm.start + 1, arm.end - 1)),
+    canonical(halfCensus.slice(censusArm.start + 1, censusArm.end - 1).replace("Array::set(dinsp_census_cell, 0, 1)", "KEEP")));
+});
+const droppedMode = mutate(scan.body, /\} else if mode == 6 \{[\s\S]*?\n  \} else \{/, "} else {", "a dropped mode");
+expectMutationFailure("a dropped mode", () => assert.equal(matchExprArms(droppedMode).length, modeArms.length + 1));
+const wrongOptionalArm = mutate(scan.body, "EFn(_, _, params, _, _, _) => dinsp_params_optional(params),", "EFn(_, _, params, _, _, _) => dinsp_params_bind(params, name),", "mode 3 optional-parameter arm");
+expectMutationFailure("mode 3 optional-parameter arm", () => assertArms(matchExprArms(wrongOptionalArm)[1], modeArms[1].arms, "mutated mode 3"));
 
 const synthetic = `fn probe(expr: Expr) -> Bool {
   let escaped = "quoted \\\" match expr { [ ( ) ] }"


### PR DESCRIPTION
Fixes #2538.

`tests/normalizer_scalar_scan_compaction_test.mjs` pinned `dinsp_scan`'s shape as of 2026-08-31 and had been red since #2386 added mode 6 as a seventh leaf `match expr`, then redder since #2537 moved modes 0 and 1 into `dinsp_here_uses` / `dinsp_here_binds` and added mode 7's census cell.

**It was referenced by no pkf task, no gate lane and no CI job** — which is why it could go red and stay red. Whatever it asserted, it was protecting nothing. Both halves of the issue are here.

## The cell (question 1 in the issue)

The issue offered two ways out: keep `dinsp_scan` strictly scalar and move the census elsewhere, or accept the cell and drop `Array::set` from the forbidden list. #2537 introduced that cell so **one** walk answers both "binds inspect?" and "calls inspect?", replacing two — reverting it to keep the scan cell-free would cost the walk it saves, so the second option is the one the design policy settles on.

But it is **scoped, not exempted**:

- every `Array::set` in the scan must be inside the mode-7 arm and must target `dinsp_census_cell`;
- the census body itself is pinned exactly;
- the two wrappers (`dlh_marker_only_called_directly`, `dlh_names_ever_assigned`) must stay cell-free.

A cell introduced anywhere else, a second cell, a census that drops the cell, or one that records one bit twice all fail.

## The arm inventory (question 2)

Modes 0 and 1 are asserted as their own predicates now — same arms, so splitting them out for the census cost no coverage. The five remaining leaf matches are listed in source order, with mode 3's #1952 optional-parameter arm and mode 6 added. The count assertion is **driven by that list** rather than a literal `7`, which is the specific thing that went stale.

Every mutation now goes through a `mutate()` helper that asserts the edit actually matched. A mutation that hits nothing passes every assertion while proving nothing — the file had nine such edits written as bare `.replace()`, which is the same hole AGENTS.md records from the `check_selector_precedence.sh` episode.

## The wiring (question 3)

A `test-normalizer-scalar-scan` pkf task, a `release-check` dep, **and** a `structural-lint` CI step.

The third is not redundant. The comment two lines above it in `ci.yml` records that `release-check` has no CI job of its own, which is how the method-style-naming ratchet stayed broken on main for ~300 commits. Wiring only into `release-check` would have repeated exactly the failure this issue is about.

## Verified it can fail

Against the two real drifts that caused the issue, through `pkf run test-normalizer-scalar-scan`:

| mutation | result |
|---|---|
| remove mode 6 (what #2386 added) | `5 mode leaf matches and one recursive match: actual 5, expected 6` |
| move a census write out of the mode-7 arm | `every cell write is inside the mode 7 arm: actual false, expected true` |

Green restored after both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q9zbiDqkfF7xYQ3v8aCQ3b

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q9zbiDqkfF7xYQ3v8aCQ3b)_