### PR TITLE
fs_compile: the inline module entry compiles the statement merge, so its typed-lowering tables reach codegen (#2449)

### DIFF
--- a/lib/@vibe/compiler/entry/compiler/fs_compile/fs_compile.vibe
+++ b/lib/@vibe/compiler/entry/compiler/fs_compile/fs_compile.vibe
@@ -1,7 +1,7 @@
 //# Imports
 
 import @vibe/compiler/syntax {
-  lex, parse_program, rewrite_string_binops_stmts, shift_stmt_offsets, shift_stmts_offsets
+  lex, parse_program, print_program, rewrite_string_binops_stmts, shift_stmt_offsets, shift_stmts_offsets
 }
 
 import @vibe/core {
@@ -9,7 +9,7 @@ import @vibe/core {
 }
 
 import @vibe/compiler/codegen {
-  compile_module, compile_wasi_module
+  compile_module, compile_module_with_typed_offsets, compile_wasi_module
 }
 
 import @vibe/compiler/codegen/wasi {
@@ -31,6 +31,7 @@ import @vibe/compiler/core {
   append_import_alias_rewritten_non_import_stmts_with_renames,
   apply_export_renames_stmts,
   build_export_rename_plan,
+  builtin_iterator_serialized_boundary_markers,
   collect_import_alias_collision_locals,
   collect_import_alias_collision_refs,
   collect_import_value_renames,
@@ -564,24 +565,81 @@ export fn source_group_pruned_stmt_count(db: TypeDb, main_source: String, main_p
   count_executable_merge_stmts(pruned_stmts)
 }
 
+/// The statement filter `build_module_source` applies while reprinting: a
+/// module keeps its top-level function bindings and the serialized
+/// builtin-iterator boundary markers, and nothing else.
+///
+/// #2437/#2449: lifted out of the reprint so the statement merge can be
+/// filtered directly. Selecting statements preserves every node offset, which
+/// is what lets the rebased typed-lowering tables still name the right nodes.
+fn module_lane_filter_stmts(stmts: Array[Stmt]) -> Array[Stmt] {
+  let filtered = empty_stmt_array()
+  let mut i = 0
+  while i < Array::length(stmts) {
+    let stmt = Array::get(stmts, i)
+    let keep = match stmt {
+      SLet(_, _, _, _, expr) => match expr {
+        EFn(_, _, _, _, _, _) => true,
+        _ => false
+      },
+      _ => builtin_iterator_serialized_boundary_markers(stmt) is Some(_)
+    }
+    if keep {
+      Array::push(filtered, stmt)
+    } else {
+      ()
+    }
+    i = i + 1
+  }
+  filtered
+}
+
+/// #2437/#2449: the last of the three inline entries to leave the reprint.
+///
+/// It used to build `merged_source` by printing the merge, reparse that text
+/// UNLOCATED, and hand the result to `compile_module` -- so every node offset
+/// was -1, the per-module typed-lowering rows had no offset space to be
+/// rebased into, and this lane compiled with each channel EMPTY. What that
+/// costs is the pre-#2158 syntactic answer: a large `Int` rendering as the
+/// empty string, a `Double` through a projection not rendering as a Double,
+/// `a < b` on Strings comparing pointers wherever the desugar tracker cannot
+/// classify the shape syntactically.
+///
+/// It now takes the same route the two wasi entries below took under #2449:
+/// `merged_stmts_and_offsets_inline` rebases the rows `prepare_modules_cached`
+/// already published, so this is plumbing rather than a second check. The
+/// reprint's statement filter is applied to the merge instead
+/// (`module_lane_filter_stmts`).
+///
+/// Two deliberate consequences:
+///
+///   - The artifact kind is `module-typed`, not `module`. Same reason #2449
+///     split `wasi-typed` off `wasi`: this entry now emits DIFFERENT bytes for
+///     the same sources, and sharing a kind with an entry that compiles
+///     without the tables would let one silently return the other's lowering.
+///   - `db_merged_source` / `db_module_source` are no longer called here, so
+///     this entry no longer bumps their counters. It also no longer reprints
+///     the program twice.
+///
+/// The artifact key keeps EXACTLY the strength it had. It is derived from the
+/// merged program's own text, not from the input sources: private namespacing
+/// mangles names with the file PATH (`namespace_private_value_stmts`), so two
+/// programs whose sources are identical can merge to different statements, and
+/// a key hashed from the sources alone would hand the second call the first
+/// call's bytes. Printing here costs one print of a program that used to be
+/// printed TWICE -- and unlike before, nothing REPARSES that text, so the
+/// offsets survive.
 export fn compile_with_modules_cached(db: TypeDb, main_source: String, main_path: String, sources: Array[(String, String)]) -> (Bytes, TypeDb) with Exception {
   let next_db = prepare_modules_cached(db, main_path, main_source, sources)
   let ordered_sources = collect_inline_sources_ordered(main_path, main_source, sources)
-  let (merged_source, merge_fingerprint, merge_db) = db_merged_source(next_db, main_path, ordered_sources)
-  let (module_source, codegen_db) = db_module_source(merge_db, merge_fingerprint, merged_source)
-  let artifact_fingerprint = artifact_fingerprint_from_source(module_source)
-  match db_load_artifact(codegen_db, main_path, "module", "", artifact_fingerprint) {
-    Some(bytes) => (bytes, codegen_db),
+  let (merged_stmts, float_offsets, int_offsets, bool_offsets, _, _) = merged_stmts_and_offsets_inline(ordered_sources)
+  let filtered = module_lane_filter_stmts(merged_stmts)
+  let artifact_fingerprint = artifact_fingerprint_from_source(print_program(filtered))
+  match db_load_artifact(next_db, main_path, "module-typed", "", artifact_fingerprint) {
+    Some(bytes) => (bytes, next_db),
     None => {
-      // #2437: this entry does NOT go through the statement merge -- it
-      // reprints the program to `module_source` and reparses that text, so the
-      // per-module offsets have no space to be rebased into and the tables stay
-      // empty here. Routing this lane onto `merged_stmts_and_offsets_inline` is
-      // #2437's remaining work; it changes cache identity and output bytes, so
-      // it is not folded in here.
-      let stmts = parse_program(lex(module_source))
-      let bytes = compile_module(stmts)
-      (bytes, db_store_artifact(codegen_db, main_path, "module", "", artifact_fingerprint, bytes))
+      let bytes = compile_module_with_typed_offsets(filtered, float_offsets, int_offsets, bool_offsets)
+      (bytes, db_store_artifact(next_db, main_path, "module-typed", "", artifact_fingerprint, bytes))
     }
   }
 }

--- a/lib/@vibe/compiler/tests/cache_probe_test.vibe
+++ b/lib/@vibe/compiler/tests/cache_probe_test.vibe
@@ -73,12 +73,22 @@ test "cache probe: TypeDb reuses warm grouped merge state" {
   assert(eq(count2, count1))
 }
 
-test "cache probe: TypeDb reuses warm module source state" {
+test "cache probe: the module lane builds no module source at all (#2437)" {
+  // This used to assert `count1 > 0` -- a warm module-source cache entry to
+  // reuse. #2437/#2449 routed `compile_with_modules_cached` off the reprint and
+  // onto the statement merge, which is what lets the typed-lowering tables
+  // reach codegen: it compiles the merged statements directly, so there is no
+  // module source to cache and nothing to count.
+  //
+  // Asserting ZERO rather than deleting the case: the counter is the only
+  // observable that says whether this lane reprints, and a lane that quietly
+  // started reprinting again would take the offsets back down to -1 and empty
+  // the tables without any other test noticing.
   let encoded = selfbuild_probe_type_db_module_source_counts()
   let count1 = encoded / 1000
   let count2 = encoded % 1000
-  assert(count1 > 0)
-  assert(eq(count2, count1))
+  assert(eq(count1, 0))
+  assert(eq(count2, 0))
 }
 
 test "cache probe: TypeDb reuses warm codegen state" {

--- a/lib/@vibe/compiler/tests/compiler_cache_advanced_test.vibe
+++ b/lib/@vibe/compiler/tests/compiler_cache_advanced_test.vibe
@@ -160,13 +160,32 @@ test "compile_with_modules_cached: same output reuses compiled artifact after pa
   assert(eq(db_codegen_count(db2), codegen_count1))
 }
 
-test "compile_with_modules_cached: same source at different paths does not reuse module source cache" {
+test "compile_with_modules_cached: builds no module source, and shares the artifact by content (#2437)" {
+  // This used to assert that the module-source count GREW across two entry
+  // paths. #2437/#2449 routed this entry off the reprint and onto the statement
+  // merge, so it builds no module source at all -- the count stays 0, and the
+  // property the old assertion stood in for is the artifact one below.
+  //
+  // Measured before and after that change, the artifact behaviour is
+  // IDENTICAL: warm at the same path reuses, a second path with the same source
+  // reuses, and a different source recompiles. The key is derived from the
+  // merged program's own text, not from the input sources, because private
+  // namespacing mangles names with the file path -- a key hashed from the
+  // sources alone would hand the second call the first call's bytes.
   let main_source = "let main: () -> Int = () -> { 1 + 2 }"
+  let other_source = "let main: () -> Int = () -> { 1 + 3 }"
   let sources = empty_sources()
   let (_, db1) = compile_with_modules_cached(db_new(), main_source, "main_a.vibe", sources)
-  let module_source_count1 = db_module_source_count(db1)
-  let (_, db2) = compile_with_modules_cached(db1, main_source, "main_b.vibe", sources)
-  assert(db_module_source_count(db2) > module_source_count1)
+  assert(eq(db_module_source_count(db1), 0))
+  let codegen1 = db_codegen_count(db1)
+  assert(codegen1 > 0)
+  let (_, db2) = compile_with_modules_cached(db1, main_source, "main_a.vibe", sources)
+  assert(eq(db_codegen_count(db2), codegen1))
+  let (_, db3) = compile_with_modules_cached(db2, main_source, "main_b.vibe", sources)
+  assert(eq(db_codegen_count(db3), codegen1))
+  assert(eq(db_module_source_count(db3), 0))
+  let (_, db4) = compile_with_modules_cached(db3, other_source, "main_a.vibe", sources)
+  assert(db_codegen_count(db4) > codegen1)
 }
 
 test "compile_file_fs_module_cached: warm compile reuses compiled fs artifact cache" {

--- a/lib/@vibe/compiler/tests/module_lane_typed_offsets_test.vibe
+++ b/lib/@vibe/compiler/tests/module_lane_typed_offsets_test.vibe
@@ -23,10 +23,19 @@
 // lands in the same `CompileCtx.int_render_offsets` field those lanes read,
 // through the same consumers.
 //
-// The three FS module callers deliberately keep the no-offsets spelling and
-// are NOT covered here -- they run no whole-program check, so filling their
-// tables would add a second one over the reprinted merged closure. The
-// measurement and the reason are on `compile_module_expr_with_typed_offsets`.
+// #2449/#2437: `compile_with_modules_cached` -- the inline-source module entry
+// -- has joined them, and its half is pinned the same way at the bottom of
+// this file. It used to print the merge, REPARSE that text unlocated, and hand
+// the result to `compile_module`, so every offset was -1 and both tables were
+// empty; it now compiles the statement merge directly, whose per-file rebasing
+// gives the rows `prepare_modules_cached` already published an offset space to
+// land in. No second check: this is plumbing.
+//
+// The FS module callers (`compile_file_fs_module_cached_slow`, both copies)
+// still keep the no-offsets spelling -- routing THEM onto the statement merge
+// is #2437's remaining work, and it changes cache identity in ways this one
+// did not. The measurement and the reason are on
+// `compile_module_expr_with_typed_offsets`.
 
 import @vibe/compiler/entry/source_compile {
   compile_source as compile_source_with_offsets
@@ -34,6 +43,18 @@ import @vibe/compiler/entry/source_compile {
 
 import ./codegen_test_support.vibe {
   compile_source
+}
+
+import @vibe/compiler/entry/compiler/fs_compile {
+  compile_with_modules_cached
+}
+
+import @vibe/compiler/runtime {
+  db_new
+}
+
+import @vibe/core {
+  array_empty
 }
 
 /// A projection is the sharpest argument to use here: `ts_known_int` has no
@@ -57,4 +78,28 @@ test "#2437 a program with nothing to classify compiles byte-identically" {
   let with_tables = compile_source_with_offsets(module_lane_plain_source)
   let without_tables = compile_source(module_lane_plain_source)
   assert(with_tables == without_tables)
+}
+
+/// #2449/#2437: the same pair for the INLINE module entry.
+///
+/// `compile_with_modules_cached` runs `prepare_modules_cached`, so every module
+/// of the program has been checked in this process and published its
+/// typed-lowering rows -- there is nothing to add, only somewhere to put them.
+/// The control is `codegen_test_support`'s `compile_source`, which is the
+/// no-offsets `compile_module` over an unlocated parse: exactly what this entry
+/// used to do to itself.
+fn compile_inline_module(src: String) -> Bytes with Exception {
+  let (bytes, _) = compile_with_modules_cached(db_new(), src, "main.vibe", array_empty())
+  bytes
+}
+
+test "#2449 the inline module entry's typed-lowering tables reach codegen" {
+  assert(!(compile_inline_module(module_lane_projection_source) == compile_source(module_lane_projection_source)))
+}
+
+test "#2449 the inline module entry is inert where there is nothing to classify" {
+  // Not merely "does not crash": an offsets channel that moved bytes for a
+  // program with no render, no `eq` and no Double call result would be a
+  // regression rather than a fix.
+  assert(compile_inline_module(module_lane_plain_source) == compile_source(module_lane_plain_source))
 }


### PR DESCRIPTION
Closes #2449.

`compile_with_modules_cached` was the last of the issue's three inline entries still on the reprint — the other two (the linked-lane pair) were done when `merged_stmts_and_offsets_inline` landed.

It printed the merge to `module_source`, **reparsed that text unlocated**, and handed the result to `compile_module`. So every node offset was `-1`, the per-module typed-lowering rows had no offset space to be rebased into, and this lane compiled with each channel empty. What that costs is the pre-#2158 syntactic answer: a large `Int` rendering as the empty string, a `Double` through a projection not rendering as a Double, `a < b` on Strings comparing pointers wherever the desugar tracker cannot classify the shape syntactically.

It now takes the route #2449 gave the two wasi entries: `merged_stmts_and_offsets_inline` rebases the rows `prepare_modules_cached` already published. **No second check** — plumbing, which is what separates it from #2437's FS callers and their superlinear cost. The reprint's statement filter is lifted to `module_lane_filter_stmts` and applied to the merge; selecting statements preserves every offset, which keeps the rebased tables pointing at the right nodes.

## The artifact key, which is the part worth reading twice

The neighbouring wasi entries key on `build_merge_fingerprint_inline`, which hashes each source's **text and discards its path**. But private namespacing mangles names with the file path (`namespace_private_value_stmts`), so two programs with identical sources can merge to different statements — a source-derived key would hand the second call the first call's bytes.

So this entry keys on **the merged program's own text**, which is what the old `module_source` hash was. Printing for the key costs one print of a program that used to be printed *twice*, and nothing reparses it, so the offsets survive.

The artifact kind is `module-typed`, not `module` — same reason #2449 split `wasi-typed` off `wasi`. This entry emits different bytes for the same sources now, and sharing a kind with an entry that compiles without the tables lets one silently return the other's lowering.

## Cache behaviour: measured before and after, identical

| | before | after |
|---|---|---|
| warm, same path | reuse | reuse |
| second path, same source | reuse | reuse |
| different source | recompile | recompile |

What changed is that the entry no longer builds a module source at all, so it no longer bumps that counter — which is what breaks the two tests below.

## The two tests are rewritten, not deleted

The counter is the only observable that says whether this lane reprints. A lane that quietly started reprinting again would take the offsets back to `-1` and empty the tables with nothing else noticing. Both now assert **zero** module sources, and `compiler_cache_advanced_test` additionally pins the artifact property the old assertion stood in for.

## Verification

- **Red**: with the entry back on the reprint, `#2449 the inline module entry's typed-lowering tables reach codegen` fails.
- **Green**: the same pair `module_lane_typed_offsets_test.vibe` already uses for `compile_source` — byte-**different** for a program whose render argument no syntactic arm classifies, byte-**identical** for one with nothing to classify. The second half is the one that says the channel is inert where it should be.
- All four `scripts/compiler_gate.sh` lanes pass, and the `stage1 → stage2` self-compile is green.

#2437's FS callers (`compile_file_fs_module_cached_slow`, both copies) still keep the no-offsets spelling — routing those changes cache identity in ways this one did not, and that issue's three blockers still stand for them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q9zbiDqkfF7xYQ3v8aCQ3b

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q9zbiDqkfF7xYQ3v8aCQ3b)_