### PR TITLE
normalize: a hoisted lambda is named after the declaration it came out of (#2388)

### DIFF
--- a/fixtures/hoisted_lambda_owner_names_test.vibe
+++ b/fixtures/hoisted_lambda_owner_names_test.vibe
@@ -1,0 +1,45 @@
+// #2388: a lambda hoisted out of a declaration becomes a TOP-LEVEL definition
+// named after that declaration, so two modules cannot mint the same one. The
+// owner can be spelled in ways a plain `let` cannot be -- an impl method
+// carries `::`, a `test` block carries a free-form string -- and the key keeps
+// those distinguishable instead of folding them onto one name. This fixture
+// runs both shapes through codegen and executes them: the hoisted function is
+// called through the name the key produced.
+effect QLog {
+  Emit(String) -> Unit
+}
+
+struct Wrapper {
+  v: Int
+}
+
+trait Scale {
+  scaled(Self) -> Int
+}
+
+impl Scale for Wrapper {
+  scaled(self) -> Int {
+    let f = (a: Int) -> Int with QLog {
+      perform QLog::Emit("impl")
+      a * 2
+    }
+    handle {
+      f(self.v)
+    } with { QLog::Emit(_m) => resume(0) }
+  }
+}
+
+test "a lambda hoisted out of an impl method" {
+  inspect(Wrapper::scaled(Wrapper::{ v: 21 }), content = "42")
+}
+
+test "a lambda hoisted out of a test block" {
+  let f = (a: Int) -> Int with QLog {
+    perform QLog::Emit("test")
+    a + 1
+  }
+  let got = handle {
+    f(41)
+  } with { QLog::Emit(_m) => resume(0) }
+  inspect(got, content = "42")
+}

--- a/lib/@vibe/compiler/codegen/wasi/linked_compile.vibe
+++ b/lib/@vibe/compiler/codegen/wasi/linked_compile.vibe
@@ -4042,7 +4042,10 @@ export fn prelude_pass_module_oracle_step(k: Int, a: Array[Stmt], c: Array[Stmt]
         }
         cj = cj + 1
       }
-      let synthesized = desugar_trait_dicts_module(part, ctx, checker_eq_offsets, checker_eq_type_keys)
+      // The oracle's module identity is the file index: it is what makes two
+      // files' nameless top-level statements distinguishable here, the way a
+      // module path would in a real per-module run (#2388).
+      let synthesized = desugar_trait_dicts_module(part, ctx, "f\{fi}", checker_eq_offsets, checker_eq_type_keys)
       let mut sy = 0
       while sy < Array::length(synthesized) {
         Array::push(part, Array::get(synthesized, sy))

--- a/lib/@vibe/compiler/normalize/desugar_trait_dict.vibe
+++ b/lib/@vibe/compiler/normalize/desugar_trait_dict.vibe
@@ -16804,43 +16804,39 @@ let dlh_owner: Array[String] = [""]
 /// in the merged program, which is unique there but not across modules.
 let dlh_module_tag: Array[String] = [""]
 
-/// A generated top-level name may not carry `::`: that spelling is how a
-/// namespaced operation is written (`String::hash_key`), and the passes and
-/// codegen after this one split on it. Owners spelled that way -- a trait
-/// operation, an impl method -- would otherwise mint a hoisted name that reads
-/// as a namespace member of a type that does not have one.
-fn dlh_sanitize_owner(name: String) -> String {
-  let out = StringBuilder::new()
-  let mut i = 0
-  while i < String::length(name) {
-    let c = String::char_code_at(name, i)
-    if c == 58 {
-      StringBuilder::push(out, "_")
-    } else {
-      StringBuilder::push(out, String::from_char_code(c))
-    }
-    i = i + 1
-  }
-  StringBuilder::freeze(out)
-}
-
 /// The owner key of a module's top-level statement at index `idx`: its own name
 /// where it has one, and otherwise the module tag (a per-module run) or the
 /// statement's position (the whole-program run, where the position is the
 /// merged program's and so unique).
+///
+/// Every arm has to be INJECTIVE -- two owners may never produce one key, or
+/// the collision this key exists to prevent comes back one level down. So a
+/// declaration's name goes in VERBATIM, `::` and all: rewriting it (`::` ->
+/// `_`, the first version of this) maps an impl method `Wrapper::scaled` and a
+/// legal declaration spelled `Wrapper__scaled` onto one key (Codex P1 on
+/// #2618). A generated top-level name carrying `::` is already what the
+/// compiler does elsewhere -- a `test "Json::get"` block becomes the top-level
+/// `__test_Json::get` -- and the call path is covered by
+/// fixtures/hoisted_lambda_owner_names_test.vibe.
+///
+/// The other arms name things that are not declarations, so they are kept out
+/// of the declaration namespace by a leading `:`: a source name is
+/// `[A-Za-z_][A-Za-z0-9_]*` possibly joined by `::`, so it can never START with
+/// a colon, and `test_foo` -- which a top-level `let test_foo` could also spell
+/// -- becomes `:t:foo`.
 fn dlh_owner_key(stmt: Stmt, idx: Int) -> String {
   match stmt {
-    SLet(_, _, name, _, _) => dlh_sanitize_owner(name),
-    SLetMut(name, _, _) => dlh_sanitize_owner(name),
-    STest(name, _) => "test_\{dlh_sanitize_owner(name)}",
-    SBench(name, _) => "bench_\{dlh_sanitize_owner(name)}",
+    SLet(_, _, name, _, _) => name,
+    SLetMut(name, _, _) => name,
+    STest(name, _) => ":t:\{name}",
+    SBench(name, _) => ":b:\{name}",
     SLetPat(pat, _) => {
       let binders = empty_str_array()
       collect_pat_binders(pat, binders)
       if Array::length(binders) == 0 {
         dlh_anonymous_owner_key(idx)
       } else {
-        dlh_sanitize_owner(Array::get(binders, 0))
+        Array::get(binders, 0)
       }
     },
     _ => dlh_anonymous_owner_key(idx)
@@ -16850,9 +16846,9 @@ fn dlh_owner_key(stmt: Stmt, idx: Int) -> String {
 fn dlh_anonymous_owner_key(idx: Int) -> String {
   let tag = Array::get(dlh_module_tag, 0)
   if String::length(tag) == 0 {
-    "s\{idx}"
+    ":s:\{idx}"
   } else {
-    "\{tag}_s\{idx}"
+    ":s:\{tag}:\{idx}"
   }
 }
 

--- a/lib/@vibe/compiler/normalize/desugar_trait_dict.vibe
+++ b/lib/@vibe/compiler/normalize/desugar_trait_dict.vibe
@@ -16778,6 +16778,92 @@ fn dlh_letbind_literal_args(callee: Expr, args: Array[Expr], off: Int, ctr: Arra
   wrapped
 }
 
+/// #2388: the top-level declaration whose body is being hoisted, and the
+/// module tag to fall back on when that declaration has no name of its own.
+///
+/// A hoisted lambda becomes a TOP-LEVEL definition, so its name has to be a
+/// function of the module that owns it and of nothing else. It used to come
+/// from a counter that ran across the whole program, which makes the spelling
+/// depend on how many lambdas EARLIER FILES hoisted: compiled whole-program a
+/// module's `let f` is `__hoisted_lam_7_f`, compiled alone it is
+/// `__hoisted_lam_0_f`, and two modules compiled alone both mint
+/// `__hoisted_lam_0_f` and collide when the link concatenates them.
+///
+/// The owner's own name is already unique across a merged program -- the merge
+/// renames a private name to `<name>_dep_<path>` and an exported one must be
+/// unique for the link to resolve it at all -- so deriving the spelling from it
+/// gives the same name whether the pass runs whole-program or per module, and
+/// gives two modules different names. The counter then only has to separate
+/// lambdas hoisted out of the SAME declaration, so it restarts at each one.
+let dlh_owner: Array[String] = [""]
+
+/// The module tag set by the per-module entry (`desugar_trait_dicts_module`),
+/// empty for the whole-program entry. Read only for a top-level statement that
+/// binds no name -- a bare expression statement -- where there is nothing to
+/// derive an owner from; the whole-program lane numbers those by their position
+/// in the merged program, which is unique there but not across modules.
+let dlh_module_tag: Array[String] = [""]
+
+/// A generated top-level name may not carry `::`: that spelling is how a
+/// namespaced operation is written (`String::hash_key`), and the passes and
+/// codegen after this one split on it. Owners spelled that way -- a trait
+/// operation, an impl method -- would otherwise mint a hoisted name that reads
+/// as a namespace member of a type that does not have one.
+fn dlh_sanitize_owner(name: String) -> String {
+  let out = StringBuilder::new()
+  let mut i = 0
+  while i < String::length(name) {
+    let c = String::char_code_at(name, i)
+    if c == 58 {
+      StringBuilder::push(out, "_")
+    } else {
+      StringBuilder::push(out, String::from_char_code(c))
+    }
+    i = i + 1
+  }
+  StringBuilder::freeze(out)
+}
+
+/// The owner key of a module's top-level statement at index `idx`: its own name
+/// where it has one, and otherwise the module tag (a per-module run) or the
+/// statement's position (the whole-program run, where the position is the
+/// merged program's and so unique).
+fn dlh_owner_key(stmt: Stmt, idx: Int) -> String {
+  match stmt {
+    SLet(_, _, name, _, _) => dlh_sanitize_owner(name),
+    SLetMut(name, _, _) => dlh_sanitize_owner(name),
+    STest(name, _) => "test_\{dlh_sanitize_owner(name)}",
+    SBench(name, _) => "bench_\{dlh_sanitize_owner(name)}",
+    SLetPat(pat, _) => {
+      let binders = empty_str_array()
+      collect_pat_binders(pat, binders)
+      if Array::length(binders) == 0 {
+        dlh_anonymous_owner_key(idx)
+      } else {
+        dlh_sanitize_owner(Array::get(binders, 0))
+      }
+    },
+    _ => dlh_anonymous_owner_key(idx)
+  }
+}
+
+fn dlh_anonymous_owner_key(idx: Int) -> String {
+  let tag = Array::get(dlh_module_tag, 0)
+  if String::length(tag) == 0 {
+    "s\{idx}"
+  } else {
+    "\{tag}_s\{idx}"
+  }
+}
+
+/// The top-level name of the `idx`-th lambda hoisted out of the current
+/// declaration. `__hoisted_lam_` stays the prefix: the gc backend's
+/// float-return collection treats it as a hint and takes provenance (the
+/// before-set) as the authority, so the spelling is free to carry the owner.
+fn dlh_hoisted_name(idx: Int, name: String) -> String {
+  "__hoisted_lam_\{Array::get(dlh_owner, 0)}_\{idx}_\{name}"
+}
+
 fn dlh_hoist_expr(expr: Expr, hoisted: Array[Stmt], ctr: Array[Int]) -> Expr {
   match expr {
     ELet(name, v, b, soff) => match v {
@@ -16825,7 +16911,7 @@ fn dlh_hoist_expr(expr: Expr, hoisted: Array[Stmt], ctr: Array[Int]) -> Expr {
         if hoistable {
           let idx = Array::get(ctr, 0)
           Array::set(ctr, 0, idx + 1)
-          let fresh = "__hoisted_lam_\{idx}_\{name}"
+          let fresh = dlh_hoisted_name(idx, name)
           Array::push(hoisted, SLet(false, false, fresh, None, hoisted_fn))
           dlh_subst(rest, name, fresh)
         } else if dlh_has_perform(fbody) && Array::length(bad) > 0 {
@@ -16856,7 +16942,7 @@ fn dlh_hoist_expr(expr: Expr, hoisted: Array[Stmt], ctr: Array[Int]) -> Expr {
               EFn(tp2, bnds2, _, rt2, eff2, hb2) => EFn(tp2, bnds2, new_params, rt2, eff2, hb2),
               _ => hoisted_fn
             }
-            let fresh = "__hoisted_lam_\{idx}_\{name}"
+            let fresh = dlh_hoisted_name(idx, name)
             Array::push(hoisted, SLet(false, false, fresh, None, hoisted_fn2))
             dlh_prepend_and_rename_calls(rest_marked, marker, fresh, captured)
           } else {
@@ -17005,15 +17091,22 @@ fn dlh_hoist_stmt(stmt: Stmt, hoisted: Array[Stmt], ctr: Array[Int]) -> Stmt {
 }
 
 /// In-place hoisting of non-capturing effectful local lambdas across the program.
+///
+/// #2388: the counter restarts at every top-level declaration and the hoisted
+/// name carries the declaration it came out of (`dlh_owner`), so what a module
+/// mints depends on that module alone -- see `dlh_owner`'s comment for why a
+/// program-wide counter cannot survive a per-module run.
 export fn desugar_hoist_local_lambdas(stmts: Array[Stmt]) -> Unit {
   let hoisted = array_empty()
-  let ctr = [0]
   let n = dtd_own_end(stmts)
   let mut i = 0
   while i < n {
+    let ctr = [0]
+    Array::set(dlh_owner, 0, dlh_owner_key(Array::get(stmts, i), i))
     Array::set(stmts, i, dlh_hoist_stmt(Array::get(stmts, i), hoisted, ctr))
     i = i + 1
   }
+  Array::set(dlh_owner, 0, "")
   let mut h = 0
   while h < Array::length(hoisted) {
     Array::push(stmts, Array::get(hoisted, h))
@@ -20577,6 +20670,7 @@ fn eq_ty_mentions_scope_formal(t: TypeExpr) -> Bool {
 export fn desugar_trait_dicts_with_typed_eq(stmts: Array[Stmt], typed_eq_offsets: Array[Int], typed_eq_keys: Array[String]) -> Unit with Exception {
   Array::set(dtd_own_limit, 0, 0 - 1)
   Array::set(dtd_ctx_len, 0, 0)
+  Array::set(dlh_module_tag, 0, "")
   dtd_run(stmts, typed_eq_offsets, typed_eq_keys)
 }
 
@@ -20592,7 +20686,13 @@ export fn desugar_trait_dicts_with_typed_eq(stmts: Array[Stmt], typed_eq_offsets
 /// declares is this module's definition. Only the trait namespace operations
 /// are placed inside `own` (right after their trait, as the whole-program
 /// entry does), which is why the entry tracks how much the own region grew.
-export fn desugar_trait_dicts_module(own: Array[Stmt], ctx: Array[Stmt], typed_eq_offsets: Array[Int], typed_eq_keys: Array[String]) -> Array[Stmt] with Exception {
+///
+/// `module_tag` names this module for the one generated top-level name that
+/// cannot be derived from a declaration -- a lambda hoisted out of a bare
+/// expression statement (see `dlh_owner`). Every other hoisted name comes from
+/// the declaration that owns it and so is already module-unique; pass "" to
+/// number the nameless ones by position, as the whole-program entry does.
+export fn desugar_trait_dicts_module(own: Array[Stmt], ctx: Array[Stmt], module_tag: String, typed_eq_offsets: Array[Int], typed_eq_keys: Array[String]) -> Array[Stmt] with Exception {
   let stmts: Array[Stmt] = []
   let mut i = 0
   while i < Array::length(own) {
@@ -20607,6 +20707,7 @@ export fn desugar_trait_dicts_module(own: Array[Stmt], ctx: Array[Stmt], typed_e
   Array::set(dtd_own_limit, 0, Array::length(own))
   Array::set(dtd_ctx_len, 0, Array::length(ctx))
   Array::set(dtd_own_growth, 0, 0)
+  Array::set(dlh_module_tag, 0, module_tag)
   dtd_run(stmts, typed_eq_offsets, typed_eq_keys)
   let own_n = Array::length(own)
   let own_end = own_n + Array::get(dtd_own_growth, 0)
@@ -20627,6 +20728,7 @@ export fn desugar_trait_dicts_module(own: Array[Stmt], ctx: Array[Stmt], typed_e
   }
   Array::set(dtd_own_limit, 0, 0 - 1)
   Array::set(dtd_ctx_len, 0, 0)
+  Array::set(dlh_module_tag, 0, "")
   synthesized
 }
 

--- a/lib/@vibe/compiler/normalize/desugar_trait_dict.vibe
+++ b/lib/@vibe/compiler/normalize/desugar_trait_dict.vibe
@@ -16890,8 +16890,17 @@ fn dlh_anonymous_owner_key(idx: Int) -> String {
 /// declaration. `__hoisted_lam_` stays the prefix: the gc backend's
 /// float-return collection treats it as a hint and takes provenance (the
 /// before-set) as the authority, so the spelling is free to carry the owner.
+///
+/// The owner is LENGTH-PREFIXED, because joining the three parts with `_` is
+/// not injective even when each part is (Codex P1 on #2618): a local
+/// `bar_1_baz` hoisted first out of `foo`, and a local `baz` hoisted second
+/// out of `foo_0_bar`, both read `__hoisted_lam_foo_0_bar_1_baz`, and both
+/// declarations are legal. With the length in front, the owner's extent is
+/// decidable and the rest is unambiguous on its own -- the counter is digits
+/// and a local name can never begin with one.
 fn dlh_hoisted_name(idx: Int, name: String) -> String {
-  "__hoisted_lam_\{dlh_owner_key()}_\{idx}_\{name}"
+  let owner = dlh_owner_key()
+  "__hoisted_lam_\{String::length(owner)}_\{owner}_\{idx}_\{name}"
 }
 
 fn dlh_hoist_expr(expr: Expr, hoisted: Array[Stmt], ctr: Array[Int]) -> Expr {

--- a/lib/@vibe/compiler/normalize/desugar_trait_dict.vibe
+++ b/lib/@vibe/compiler/normalize/desugar_trait_dict.vibe
@@ -16795,7 +16795,17 @@ fn dlh_letbind_literal_args(callee: Expr, args: Array[Expr], off: Int, ctr: Arra
 /// gives the same name whether the pass runs whole-program or per module, and
 /// gives two modules different names. The counter then only has to separate
 /// lambdas hoisted out of the SAME declaration, so it restarts at each one.
-let dlh_owner: Array[String] = [""]
+let dlh_owner_name: Array[String] = [""]
+
+/// What `dlh_owner_name` holds: 0 a declaration's own name, 1 a test block's
+/// name, 2 a bench block's, 3 nothing (a statement that binds no name). The
+/// key itself is built only when a lambda is actually hoisted -- a compile of
+/// the compiler walks ~4,600 top-level statements and hoists none of them, so
+/// building one string per statement was ~138 kB of bump heap per compile,
+/// measured on the selfcompile KPI.
+let dlh_owner_kind: Array[Int] = [0]
+
+let dlh_owner_idx: Array[Int] = [0]
 
 /// The module tag set by the per-module entry (`desugar_trait_dicts_module`),
 /// empty for the whole-program entry. Read only for a top-level statement that
@@ -16804,10 +16814,11 @@ let dlh_owner: Array[String] = [""]
 /// in the merged program, which is unique there but not across modules.
 let dlh_module_tag: Array[String] = [""]
 
-/// The owner key of a module's top-level statement at index `idx`: its own name
-/// where it has one, and otherwise the module tag (a per-module run) or the
-/// statement's position (the whole-program run, where the position is the
-/// merged program's and so unique).
+/// Record which top-level statement the hoist is walking, so a lambda it
+/// hoists can be named after it: the statement's own name where it has one,
+/// and otherwise the module tag (a per-module run) or the statement's position
+/// (the whole-program run, where the position is the merged program's and so
+/// unique). `dlh_owner_key` spells the recorded owner out.
 ///
 /// Every arm has to be INJECTIVE -- two owners may never produce one key, or
 /// the collision this key exists to prevent comes back one level down. So a
@@ -16824,22 +16835,45 @@ let dlh_module_tag: Array[String] = [""]
 /// `[A-Za-z_][A-Za-z0-9_]*` possibly joined by `::`, so it can never START with
 /// a colon, and `test_foo` -- which a top-level `let test_foo` could also spell
 /// -- becomes `:t:foo`.
-fn dlh_owner_key(stmt: Stmt, idx: Int) -> String {
+fn dlh_set_owner(stmt: Stmt, idx: Int) -> Unit {
+  Array::set(dlh_owner_idx, 0, idx)
+  Array::set(dlh_owner_kind, 0, 0)
   match stmt {
-    SLet(_, _, name, _, _) => name,
-    SLetMut(name, _, _) => name,
-    STest(name, _) => ":t:\{name}",
-    SBench(name, _) => ":b:\{name}",
+    SLet(_, _, name, _, _) => Array::set(dlh_owner_name, 0, name),
+    SLetMut(name, _, _) => Array::set(dlh_owner_name, 0, name),
+    STest(name, _) => {
+      Array::set(dlh_owner_kind, 0, 1)
+      Array::set(dlh_owner_name, 0, name)
+    },
+    SBench(name, _) => {
+      Array::set(dlh_owner_kind, 0, 2)
+      Array::set(dlh_owner_name, 0, name)
+    },
     SLetPat(pat, _) => {
       let binders = empty_str_array()
       collect_pat_binders(pat, binders)
       if Array::length(binders) == 0 {
-        dlh_anonymous_owner_key(idx)
+        Array::set(dlh_owner_kind, 0, 3)
       } else {
-        Array::get(binders, 0)
+        Array::set(dlh_owner_name, 0, Array::get(binders, 0))
       }
     },
-    _ => dlh_anonymous_owner_key(idx)
+    _ => Array::set(dlh_owner_kind, 0, 3)
+  }
+}
+
+/// The recorded owner as a key. Called once per lambda actually hoisted.
+fn dlh_owner_key() -> String {
+  let kind = Array::get(dlh_owner_kind, 0)
+  let name = Array::get(dlh_owner_name, 0)
+  if kind == 1 {
+    ":t:\{name}"
+  } else if kind == 2 {
+    ":b:\{name}"
+  } else if kind == 3 {
+    dlh_anonymous_owner_key(Array::get(dlh_owner_idx, 0))
+  } else {
+    name
   }
 }
 
@@ -16857,7 +16891,7 @@ fn dlh_anonymous_owner_key(idx: Int) -> String {
 /// float-return collection treats it as a hint and takes provenance (the
 /// before-set) as the authority, so the spelling is free to carry the owner.
 fn dlh_hoisted_name(idx: Int, name: String) -> String {
-  "__hoisted_lam_\{Array::get(dlh_owner, 0)}_\{idx}_\{name}"
+  "__hoisted_lam_\{dlh_owner_key()}_\{idx}_\{name}"
 }
 
 fn dlh_hoist_expr(expr: Expr, hoisted: Array[Stmt], ctr: Array[Int]) -> Expr {
@@ -17089,20 +17123,21 @@ fn dlh_hoist_stmt(stmt: Stmt, hoisted: Array[Stmt], ctr: Array[Int]) -> Stmt {
 /// In-place hoisting of non-capturing effectful local lambdas across the program.
 ///
 /// #2388: the counter restarts at every top-level declaration and the hoisted
-/// name carries the declaration it came out of (`dlh_owner`), so what a module
+/// name carries the declaration it came out of (`dlh_owner_name`), so what a module
 /// mints depends on that module alone -- see `dlh_owner`'s comment for why a
 /// program-wide counter cannot survive a per-module run.
 export fn desugar_hoist_local_lambdas(stmts: Array[Stmt]) -> Unit {
   let hoisted = array_empty()
   let n = dtd_own_end(stmts)
+  let ctr = [0]
   let mut i = 0
   while i < n {
-    let ctr = [0]
-    Array::set(dlh_owner, 0, dlh_owner_key(Array::get(stmts, i), i))
+    Array::set(ctr, 0, 0)
+    dlh_set_owner(Array::get(stmts, i), i)
     Array::set(stmts, i, dlh_hoist_stmt(Array::get(stmts, i), hoisted, ctr))
     i = i + 1
   }
-  Array::set(dlh_owner, 0, "")
+  Array::set(dlh_owner_name, 0, "")
   let mut h = 0
   while h < Array::length(hoisted) {
     Array::push(stmts, Array::get(hoisted, h))
@@ -20685,7 +20720,7 @@ export fn desugar_trait_dicts_with_typed_eq(stmts: Array[Stmt], typed_eq_offsets
 ///
 /// `module_tag` names this module for the one generated top-level name that
 /// cannot be derived from a declaration -- a lambda hoisted out of a bare
-/// expression statement (see `dlh_owner`). Every other hoisted name comes from
+/// expression statement (see `dlh_owner_name`). Every other hoisted name comes from
 /// the declaration that owns it and so is already module-unique; pass "" to
 /// number the nameless ones by position, as the whole-program entry does.
 export fn desugar_trait_dicts_module(own: Array[Stmt], ctx: Array[Stmt], module_tag: String, typed_eq_offsets: Array[Int], typed_eq_keys: Array[String]) -> Array[Stmt] with Exception {

--- a/lib/@vibe/compiler/normalize/index.vpkg
+++ b/lib/@vibe/compiler/normalize/index.vpkg
@@ -90,7 +90,7 @@ fn validate_serializable_reexport_references(stmts: Array[Stmt]) -> Unit with Ex
 fn desugar_array_spread(stmts: Array[Stmt]) -> Unit
 fn desugar_trait_dicts(stmts: Array[Stmt]) -> Unit with Exception
 fn desugar_trait_dicts_with_typed_eq(stmts: Array[Stmt], typed_eq_offsets: Array[Int], typed_eq_keys: Array[String]) -> Unit with Exception
-fn desugar_trait_dicts_module(own: Array[Stmt], ctx: Array[Stmt], typed_eq_offsets: Array[Int], typed_eq_keys: Array[String]) -> Array[Stmt] with Exception
+fn desugar_trait_dicts_module(own: Array[Stmt], ctx: Array[Stmt], module_tag: String, typed_eq_offsets: Array[Int], typed_eq_keys: Array[String]) -> Array[Stmt] with Exception
 fn synthesized_dict_field_trait(struct_name: String, field_name: String) -> String
 
 // --- unbox_tuple_loop.vibe (#1262)

--- a/lib/@vibe/compiler/tests/desugar_trait_dicts_module_test.vibe
+++ b/lib/@vibe/compiler/tests/desugar_trait_dicts_module_test.vibe
@@ -242,3 +242,37 @@ test "a hoisted lambda is named after the declaration it came out of, so two mod
   inspect(render_named(dep_synth, "__hoisted_lam_dep_use_0_f") == whole4_named("__hoisted_lam_dep_use_0_f"), content = "true")
   inspect(whole4_named("__hoisted_lam_own_use_0_f"), content = "let __hoisted_lam_own_use_0_f = (a: Int) -> Int with OwnLog { { perform OwnLog::Emit(\"own\"); (a + 1) } }")
 }
+
+/// The top-level names this pass minted for hoisted lambdas, in program order.
+fn hoisted_names(stmts: Array[Stmt]) -> String {
+  let out: Array[String] = []
+  let mut i = 0
+  while i < Array::length(stmts) {
+    match Array::get(stmts, i) {
+      SLet(_, _, n, _, _) => if String::starts_with(n, "__hoisted_lam_") {
+        Array::push(out, n)
+      } else {
+        ()
+      },
+      _ => ()
+    }
+    i = i + 1
+  }
+  String::join(out, ", ")
+}
+
+// #2618 review (Codex P1): the owner key has to be INJECTIVE, or the collision
+// it exists to prevent comes back one level down. Four owners that a
+// non-injective key folds into two: an impl method `Wrapper::scaled` against a
+// legal declaration spelled `Wrapper__scaled` (the first version replaced `::`
+// with `_`), and a `test "probe"` block against a declaration `test_probe`
+// (the first version prefixed a test's name with `test_`).
+fn collide_src() -> String {
+  "effect CLog {\n  Emit(String) -> Unit\n}\n\nstruct Wrapper {\n  v: Int\n}\n\ntrait Scale {\n  scaled(Self) -> Int\n}\n\nimpl Scale for Wrapper {\n  scaled(self) -> Int {\n    let f = (a: Int) -> Int with CLog {\n      perform CLog::Emit(\"impl\")\n      a\n    }\n    f(self.v)\n  }\n}\n\nexport fn Wrapper__scaled(v: Int) -> Int with CLog {\n  let f = (a: Int) -> Int with CLog {\n    perform CLog::Emit(\"plain\")\n    a\n  }\n  f(v)\n}\n\nexport fn test_probe() -> Int with CLog {\n  let f = (a: Int) -> Int with CLog {\n    perform CLog::Emit(\"fn\")\n    a\n  }\n  f(1)\n}\n\ntest \"probe\" {\n  let f = (a: Int) -> Int with CLog {\n    perform CLog::Emit(\"test\")\n    a\n  }\n  f(2)\n}\n"
+}
+
+test "owners that a spelling rewrite would fold together keep different hoisted names" {
+  let stmts = parse_program(lex(collide_src()))
+  desugar_trait_dicts(stmts)
+  inspect(hoisted_names(stmts), content = "__hoisted_lam_Wrapper::scaled_0_f, __hoisted_lam_Wrapper__scaled_0_f, __hoisted_lam_test_probe_0_f, __hoisted_lam_:t:probe_0_f")
+}

--- a/lib/@vibe/compiler/tests/desugar_trait_dicts_module_test.vibe
+++ b/lib/@vibe/compiler/tests/desugar_trait_dicts_module_test.vibe
@@ -146,10 +146,10 @@ test "a hoisted local lambda's labeled call is reordered in a per-module run" {
   // back with the synthesized set; the labeled-argument stage must still
   // visit it -- the call to the dependency's `sub` binds by position after
   // this pass, and a call left labeled here would bind `y = a` to `x`.
-  inspect(stmt_names(synth), content = "__hoisted_lam_use_local_0_f")
-  inspect(render_named(synth, "__hoisted_lam_use_local_0_f"), content = "let __hoisted_lam_use_local_0_f = (a: Int) -> Int with Log { { perform Log::Emit(\"x\"); { let g = (b: Int, c?: Option[Int]) -> Int { b }; g(a, None) } } }")
-  inspect(whole2_named("__hoisted_lam_use_local_0_f"), content = "let __hoisted_lam_use_local_0_f = (a: Int) -> Int with Log { { perform Log::Emit(\"x\"); { let g = (b: Int, c?: Option[Int]) -> Int { b }; g(a, None) } } }")
-  inspect(render_named(synth, "__hoisted_lam_use_local_0_f") == whole2_named("__hoisted_lam_use_local_0_f"), content = "true")
+  inspect(stmt_names(synth), content = "__hoisted_lam_9_use_local_0_f")
+  inspect(render_named(synth, "__hoisted_lam_9_use_local_0_f"), content = "let __hoisted_lam_9_use_local_0_f = (a: Int) -> Int with Log { { perform Log::Emit(\"x\"); { let g = (b: Int, c?: Option[Int]) -> Int { b }; g(a, None) } } }")
+  inspect(whole2_named("__hoisted_lam_9_use_local_0_f"), content = "let __hoisted_lam_9_use_local_0_f = (a: Int) -> Int with Log { { perform Log::Emit(\"x\"); { let g = (b: Int, c?: Option[Int]) -> Int { b }; g(a, None) } } }")
+  inspect(render_named(synth, "__hoisted_lam_9_use_local_0_f") == whole2_named("__hoisted_lam_9_use_local_0_f"), content = "true")
   inspect(render_named(own, "use_local") == whole2_named("use_local"), content = "true")
 }
 
@@ -233,14 +233,14 @@ test "a hoisted lambda is named after the declaration it came out of, so two mod
   let ctx_for_dep = parse_program(lex(own4_src()))
   let own_synth = desugar_trait_dicts_module(own, ctx_for_own, "", [], [])
   let dep_synth = desugar_trait_dicts_module(dep, ctx_for_dep, "", [], [])
-  inspect(stmt_names(own_synth), content = "__hoisted_lam_own_use_0_f")
-  inspect(stmt_names(dep_synth), content = "__hoisted_lam_dep_use_0_f")
+  inspect(stmt_names(own_synth), content = "__hoisted_lam_7_own_use_0_f")
+  inspect(stmt_names(dep_synth), content = "__hoisted_lam_7_dep_use_0_f")
   // What each module mints alone is what the whole-program run mints for it:
   // the counter restarts at every declaration and the name carries that
   // declaration, so neither spelling depends on the other module.
-  inspect(render_named(own_synth, "__hoisted_lam_own_use_0_f") == whole4_named("__hoisted_lam_own_use_0_f"), content = "true")
-  inspect(render_named(dep_synth, "__hoisted_lam_dep_use_0_f") == whole4_named("__hoisted_lam_dep_use_0_f"), content = "true")
-  inspect(whole4_named("__hoisted_lam_own_use_0_f"), content = "let __hoisted_lam_own_use_0_f = (a: Int) -> Int with OwnLog { { perform OwnLog::Emit(\"own\"); (a + 1) } }")
+  inspect(render_named(own_synth, "__hoisted_lam_7_own_use_0_f") == whole4_named("__hoisted_lam_7_own_use_0_f"), content = "true")
+  inspect(render_named(dep_synth, "__hoisted_lam_7_dep_use_0_f") == whole4_named("__hoisted_lam_7_dep_use_0_f"), content = "true")
+  inspect(whole4_named("__hoisted_lam_7_own_use_0_f"), content = "let __hoisted_lam_7_own_use_0_f = (a: Int) -> Int with OwnLog { { perform OwnLog::Emit(\"own\"); (a + 1) } }")
 }
 
 /// The top-level names this pass minted for hoisted lambdas, in program order.
@@ -274,5 +274,25 @@ fn collide_src() -> String {
 test "owners that a spelling rewrite would fold together keep different hoisted names" {
   let stmts = parse_program(lex(collide_src()))
   desugar_trait_dicts(stmts)
-  inspect(hoisted_names(stmts), content = "__hoisted_lam_Wrapper::scaled_0_f, __hoisted_lam_Wrapper__scaled_0_f, __hoisted_lam_test_probe_0_f, __hoisted_lam_:t:probe_0_f")
+  inspect(hoisted_names(stmts), content = "__hoisted_lam_15_Wrapper::scaled_0_f, __hoisted_lam_15_Wrapper__scaled_0_f, __hoisted_lam_10_test_probe_0_f, __hoisted_lam_8_:t:probe_0_f")
+}
+
+// #2618 review (Codex P1, round 2): each part of the name being injective is
+// not enough -- joining owner, counter and local name with `_` is ambiguous
+// about where the owner ends. The pair Codex named: a local `bar_1_baz`
+// hoisted first out of `foo`, and a local `baz` hoisted second out of
+// `foo_0_bar`, both read `__hoisted_lam_foo_0_bar_1_baz`. The owner's length
+// in front decides its extent. (The hoist walks a body inside out, so the
+// SECOND counter value goes to the lambda written FIRST -- hence `baz` above
+// `first` here.)
+fn ambiguous_join_src() -> String {
+  "effect JLog {\n  Emit(String) -> Unit\n}\n\nexport fn foo() -> Int with JLog {\n  let bar_1_baz = (a: Int) -> Int with JLog {\n    perform JLog::Emit(\"one\")\n    a\n  }\n  bar_1_baz(1)\n}\n\nexport fn foo_0_bar() -> Int with JLog {\n  let baz = (a: Int) -> Int with JLog {\n    perform JLog::Emit(\"two\")\n    a\n  }\n  let first = (a: Int) -> Int with JLog {\n    perform JLog::Emit(\"three\")\n    a\n  }\n  baz(1) + first(2)\n}\n"
+}
+
+test "the owner, the counter and the local name join into one name unambiguously" {
+  let stmts = parse_program(lex(ambiguous_join_src()))
+  desugar_trait_dicts(stmts)
+  // Without the length in front, the first and the third read the same:
+  // `__hoisted_lam_foo_0_bar_1_baz`.
+  inspect(hoisted_names(stmts), content = "__hoisted_lam_3_foo_0_bar_1_baz, __hoisted_lam_9_foo_0_bar_0_first, __hoisted_lam_9_foo_0_bar_1_baz")
 }

--- a/lib/@vibe/compiler/tests/desugar_trait_dicts_module_test.vibe
+++ b/lib/@vibe/compiler/tests/desugar_trait_dicts_module_test.vibe
@@ -87,7 +87,7 @@ fn whole_named(name: String) -> String with Exception {
 test "the module entry threads the witness into a call of the context's bounded generic" {
   let ctx = parse_program(lex(dep_src()))
   let own = parse_program(lex(own_src()))
-  let synth = desugar_trait_dicts_module(own, ctx, [], [])
+  let synth = desugar_trait_dicts_module(own, ctx, "", [], [])
   inspect(render_named(own, "contains") == whole_named("contains"), content = "true")
   inspect(render_named(own, "contains"), content = "export let rec contains = [T: Hash](__dict_Hash_T: HashDict[T], s: Set[T], value: T) -> Bool { Map::has_key(s.entries, map_key_to_string(__dict_Hash_T, value)) }")
   // The context is read, never rewritten or extended: its trait gets no
@@ -108,7 +108,7 @@ test "the whole-program entry is the module entry with no context and everything
 test "the dependency's own run places its trait operation inside the module and its dict struct in the synthesized set" {
   let own = parse_program(lex(dep_src()))
   let ctx = parse_program(lex(own_src()))
-  let synth = desugar_trait_dicts_module(own, ctx, [], [])
+  let synth = desugar_trait_dicts_module(own, ctx, "", [], [])
   // The namespace operation is inserted directly after the trait's impls,
   // growing the module's own region; the context's structs are not derived
   // for here. It used to be placed one step further -- past the run of
@@ -123,7 +123,7 @@ test "the dependency's own run places its trait operation inside the module and 
 test "generated local names restart at every declaration, so a module compiled after the dependency gets the names it gets alone" {
   let ctx = parse_program(lex(dep_src()))
   let own = parse_program(lex(own_src()))
-  let synth = desugar_trait_dicts_module(own, ctx, [], [])
+  let synth = desugar_trait_dicts_module(own, ctx, "", [], [])
   // Whole-program, the dependency's `Key::equals` and `fail_dep` would have
   // consumed the tuple-binder and payload counters first.
   inspect(render_named(synth, "Pair::equals"), content = "let Pair::equals = (a: Pair, b: Pair) -> Bool { (match a.p { (__teq_l0_0, __teq_l0_1) => match b.p { (__teq_r0_0, __teq_r0_1) => (((__teq_l0_0 + 0) == (__teq_r0_0 + 0)) && ((__teq_l0_1 == __teq_r0_1) && true)) } } && true) }")
@@ -141,22 +141,22 @@ fn whole2_named(name: String) -> String with Exception {
 test "a hoisted local lambda's labeled call is reordered in a per-module run" {
   let ctx = parse_program(lex(dep2_src()))
   let own = parse_program(lex(own2_src()))
-  let synth = desugar_trait_dicts_module(own, ctx, [], [])
+  let synth = desugar_trait_dicts_module(own, ctx, "", [], [])
   // The hoisted function is appended after the context block, so it comes
   // back with the synthesized set; the labeled-argument stage must still
   // visit it -- the call to the dependency's `sub` binds by position after
   // this pass, and a call left labeled here would bind `y = a` to `x`.
-  inspect(stmt_names(synth), content = "__hoisted_lam_0_f")
-  inspect(render_named(synth, "__hoisted_lam_0_f"), content = "let __hoisted_lam_0_f = (a: Int) -> Int with Log { { perform Log::Emit(\"x\"); { let g = (b: Int, c?: Option[Int]) -> Int { b }; g(a, None) } } }")
-  inspect(whole2_named("__hoisted_lam_0_f"), content = "let __hoisted_lam_0_f = (a: Int) -> Int with Log { { perform Log::Emit(\"x\"); { let g = (b: Int, c?: Option[Int]) -> Int { b }; g(a, None) } } }")
-  inspect(render_named(synth, "__hoisted_lam_0_f") == whole2_named("__hoisted_lam_0_f"), content = "true")
+  inspect(stmt_names(synth), content = "__hoisted_lam_use_local_0_f")
+  inspect(render_named(synth, "__hoisted_lam_use_local_0_f"), content = "let __hoisted_lam_use_local_0_f = (a: Int) -> Int with Log { { perform Log::Emit(\"x\"); { let g = (b: Int, c?: Option[Int]) -> Int { b }; g(a, None) } } }")
+  inspect(whole2_named("__hoisted_lam_use_local_0_f"), content = "let __hoisted_lam_use_local_0_f = (a: Int) -> Int with Log { { perform Log::Emit(\"x\"); { let g = (b: Int, c?: Option[Int]) -> Int { b }; g(a, None) } } }")
+  inspect(render_named(synth, "__hoisted_lam_use_local_0_f") == whole2_named("__hoisted_lam_use_local_0_f"), content = "true")
   inspect(render_named(own, "use_local") == whole2_named("use_local"), content = "true")
 }
 
 test "a trivial wrapper defined in the dependency is not inlined by a per-module run" {
   let ctx = parse_program(lex(dep2_src()))
   let own = parse_program(lex(own2_src()))
-  let _ = desugar_trait_dicts_module(own, ctx, [], [])
+  let _ = desugar_trait_dicts_module(own, ctx, "", [], [])
   // The whole-program run reads `apply`'s body and inlines the call; a
   // dependency interface carries no body, so a per-module run cannot, and
   // must not pretend to by reading the body it happens to be handed.
@@ -197,9 +197,48 @@ test "a trait namespace operation carries the same synthetic offset whether its 
   // trait's statement index.
   let own = parse_program(lex(dep_src()))
   let ctx = parse_program(lex(own2_src()))
-  let _ = desugar_trait_dicts_module(own, ctx, [], [])
+  let _ = desugar_trait_dicts_module(own, ctx, "", [], [])
   let whole = parse_program(lex(String::concat(own2_src(), dep_src())))
   desugar_trait_dicts(whole)
   inspect(wrapper_call_off(own, "Hash::hash_key"), content = "-2")
   inspect(wrapper_call_off(whole, "Hash::hash_key"), content = "-2")
+}
+
+// #2388: a hoisted lambda becomes a TOP-LEVEL definition, so its name has to
+// be a function of the module that owns it. These two modules each hoist a
+// local `f`. Measured on these two sources before the fresh name carried its
+// owner: each module compiled alone minted `__hoisted_lam_0_f`, so a link that
+// concatenates them had two different bodies under one name, and neither
+// matched the whole-program run, which numbered them `__hoisted_lam_0_f` (the
+// dependency's) and `__hoisted_lam_1_f` (this module's) by the order the files
+// happened to be merged in.
+fn dep4_src() -> String {
+  "effect DepLog {\n  Emit(String) -> Unit\n}\n\nexport fn dep_use() -> Int with DepLog {\n  let f = (a: Int) -> Int with DepLog {\n    perform DepLog::Emit(\"dep\")\n    a\n  }\n  f(1)\n}\n"
+}
+
+fn own4_src() -> String {
+  "effect OwnLog {\n  Emit(String) -> Unit\n}\n\nexport fn own_use() -> Int with OwnLog {\n  let f = (a: Int) -> Int with OwnLog {\n    perform OwnLog::Emit(\"own\")\n    a + 1\n  }\n  f(2)\n}\n"
+}
+
+fn whole4_named(name: String) -> String with Exception {
+  let stmts = parse_program(lex(String::concat(dep4_src(), own4_src())))
+  desugar_trait_dicts(stmts)
+  render_named(stmts, name)
+}
+
+test "a hoisted lambda is named after the declaration it came out of, so two modules cannot mint the same top-level name" {
+  let own = parse_program(lex(own4_src()))
+  let dep = parse_program(lex(dep4_src()))
+  let ctx_for_own = parse_program(lex(dep4_src()))
+  let ctx_for_dep = parse_program(lex(own4_src()))
+  let own_synth = desugar_trait_dicts_module(own, ctx_for_own, "", [], [])
+  let dep_synth = desugar_trait_dicts_module(dep, ctx_for_dep, "", [], [])
+  inspect(stmt_names(own_synth), content = "__hoisted_lam_own_use_0_f")
+  inspect(stmt_names(dep_synth), content = "__hoisted_lam_dep_use_0_f")
+  // What each module mints alone is what the whole-program run mints for it:
+  // the counter restarts at every declaration and the name carries that
+  // declaration, so neither spelling depends on the other module.
+  inspect(render_named(own_synth, "__hoisted_lam_own_use_0_f") == whole4_named("__hoisted_lam_own_use_0_f"), content = "true")
+  inspect(render_named(dep_synth, "__hoisted_lam_dep_use_0_f") == whole4_named("__hoisted_lam_dep_use_0_f"), content = "true")
+  inspect(whole4_named("__hoisted_lam_own_use_0_f"), content = "let __hoisted_lam_own_use_0_f = (a: Int) -> Int with OwnLog { { perform OwnLog::Emit(\"own\"); (a + 1) } }")
 }

--- a/lib/@vibe/compiler/tests/prelude_module_oracle_test.vibe
+++ b/lib/@vibe/compiler/tests/prelude_module_oracle_test.vibe
@@ -53,3 +53,71 @@ test "every pre-codegen pass agrees between whole-program and per-file runs on a
   // both sides; a run that skipped either side could not report them equal.
   inspect(String::starts_with(Array::get(lines, 0), "PASS elaborate_heap_params stmts="), content = "true")
 }
+
+/// The `keyed ...` line the oracle prints under one pass: the verdict for a
+/// pass whose per-module run synthesizes program-level statements, which land
+/// at each module's position and repeat per module, so position and count are
+/// not the comparison.
+fn keyed_line_of(report: String, pass: String) -> String {
+  let lines = String::split(report, "\n")
+  let mut out = "<none>"
+  let mut seen = false
+  let mut i = 0
+  while i < Array::length(lines) {
+    let line = Array::get(lines, i)
+    if String::starts_with(line, String::concat("PASS ", pass)) {
+      seen = true
+    } else if seen && String::contains(line, "keyed ") {
+      if out == "<none>" {
+        out = String::trim(line)
+      } else {
+        ()
+      }
+    } else if String::starts_with(line, "PASS ") {
+      seen = false
+    } else {
+      ()
+    }
+    i = i + 1
+  }
+  out
+}
+
+// #2388: two files that each hoist a non-capturing effectful local lambda, and
+// both call it `f`. A hoisted lambda becomes a TOP-LEVEL definition, so a name
+// minted from a program-wide counter makes what a module mints depend on the
+// files compiled before it. Measured on this program before the name carried
+// the declaration it came out of:
+//
+//   keyed missing=1 extra=0 copies=2 content=2 first_missing=let:__hoisted_lam_1_f
+//     whole<let __hoisted_lam_0_f = (a: Int) -> Int with HLog { ... "helper" ... }>
+//     split<let __hoisted_lam_0_f = (a: Int) -> Int with MLog { ... "main" ... }>
+//
+// -- one name, two different bodies, which a link that concatenates the modules
+// resolves by silently keeping one of them.
+test "two files that each hoist a local lambda mint top-level names the other module cannot collide with" {
+  let helper_path = "/tmp/vibe_prelude_oracle_hoist_helper.vibe"
+  let main_path = "/tmp/vibe_prelude_oracle_hoist_main.vibe"
+  Fs::write_file(helper_path, "effect HLog {\n  Emit(String) -> Unit\n}\n\nexport fn helper_use() -> Int {\n  let f = (a: Int) -> Int with HLog {\n    perform HLog::Emit(\"helper\")\n    a\n  }\n  handle {\n    f(1)\n  } with {\n    HLog::Emit(_m) => resume(0)\n  }\n}\n")
+  Fs::write_file(main_path, "import ./vibe_prelude_oracle_hoist_helper.vibe {\n  helper_use\n}\n\neffect MLog {\n  Emit(String) -> Unit\n}\n\nfn main_use() -> Int {\n  let f = (a: Int) -> Int with MLog {\n    perform MLog::Emit(\"main\")\n    a + 1\n  }\n  handle {\n    f(2)\n  } with {\n    MLog::Emit(_m) => resume(0)\n  }\n}\n\ntest \"hoisted\" {\n  inspect(helper_use() + main_use(), content = \"4\")\n}\n")
+  let report = prelude_module_oracle_report_fs(main_path, "__no_entry__", 16)
+  // `copies=1` is the one program-level helper this pass synthesizes per
+  // module by design (a link-time dedup by name folds it, and `content=0`
+  // says the copies agree); `missing=0 content=0` is the property under test:
+  // every declaration the whole-program run produced is produced by the module
+  // that owns it, under the same name and with the same body.
+  inspect(keyed_line_of(report, "desugar_trait_dicts_with_typed_eq"), content = "keyed missing=0 extra=0 copies=1 content=0 renames=0 first_missing= first_content=")
+  // What the rest of the report says on this program, as measured. The
+  // trait-dict pass's positional status is `differs` by design (see above).
+  // `evidence_dict_pass` is a separate, still-open per-module gap: whole
+  // program it threads the handler's dictionary into the hoisted function's
+  // call, per file it does not.
+  let statuses: Array[String] = []
+  let lines = oracle_lines(report)
+  let mut i = 0
+  while i < Array::length(lines) {
+    Array::push(statuses, status_of(Array::get(lines, i)))
+    i = i + 1
+  }
+  inspect(String::join(statuses, ","), content = "same,same,same,same,differs,same,same,same,same,same,same,same,same,same,same,differs,same")
+}


### PR DESCRIPTION
Next step on the #2388 per-module line (parent epic #2386): the generated top-level names a module mints now depend on that module alone.

## The defect

`desugar_hoist_local_lambdas` minted `__hoisted_lam_<counter>_<name>` from a counter that ran across the whole program, so what a module minted depended on how many lambdas **earlier files** hoisted. Two files that each hoist a non-capturing effectful local `f`:

| | file A | file B |
|---|---|---|
| whole-program | `__hoisted_lam_0_f` | `__hoisted_lam_1_f` |
| each module alone | `__hoisted_lam_0_f` | `__hoisted_lam_0_f` |

One top-level name, two different bodies — a link that concatenates the modules resolves that by silently keeping one of them. This is the item #2388's last status comment filed as blocking the real per-module run.

## The fix

The counter restarts at every top-level declaration, and the name carries the declaration it came out of. That name is already unique across a merged program — the merge renames a private name to `<name>_dep_<path>` and an exported one to `<name>_exp_<path>` — so the per-module run and the whole-program run mint the **same** name, and two modules cannot mint the same one.

The name has to be **injective in every part**, which took two review rounds (both from Codex, both reproduced before fixing):

- The owner key: a declaration's name goes in verbatim, `::` and all. Rewriting `::` to `_` folded an impl method `Wrapper::scaled` onto a legal declaration `Wrapper__scaled`; the same fold sat in the `test_<name>` arm. What is not a declaration is kept out of the declaration namespace by a leading `:` (a source name can never start with one): `:t:<test name>`, `:b:<bench name>`, `:s:<index>`.
- The join: `<owner>_<idx>_<local>` left the owner's extent undecidable — a local `bar_1_baz` under `foo` and a local `baz` under `foo_0_bar` both read `__hoisted_lam_foo_0_bar_1_baz`. The owner is length-prefixed now; the rest needs nothing, since the counter is digits and a local name can never begin with one.

A top-level statement that binds no name — a bare expression statement — has nothing to derive from. `desugar_trait_dicts_module` takes a `module_tag` for exactly those; the whole-program entry numbers them by their position in the merged program, which is unique there. The oracle passes the file index as its module identity ([why that, and not agreement between the lanes](https://github.com/mizchi/vibe-lang/pull/2618#discussion_r3981916500)).

## Measurement

The per-pass module oracle on a two-file program where both files hoist (the new case in `prelude_module_oracle_test.vibe`), keyed line for `desugar_trait_dicts_with_typed_eq`:

| | keyed line |
|---|---|
| before | `missing=1 extra=0 copies=2 content=2 renames=0 first_missing=let:__hoisted_lam_1_f` |
| after | `missing=0 extra=0 copies=1 content=0 renames=0` |

with the first content difference being the collision itself:

```
whole<let __hoisted_lam_0_f = (a: Int) -> Int with HLog { { perform HLog::Emit("helper"); a } }>
split<let __hoisted_lam_0_f = (a: Int) -> Int with MLog { { perform MLog::Emit("main"); (a + 1) } }>
```

`copies=1` after is the one program-level helper this pass synthesizes per module by design, which a link-time dedup by name folds.

On the **compiler closure** (`codegen_lexer_test.vibe`, 189 files) the keyed line is unchanged, measured on main and again on this head: `missing=0 extra=0 copies=328 content=0 renames=0`. The closure hoists no lambda.

**Allocation** (`scripts/selfcompile_kpi.sh`, all three compilers over the same checkout so the compiler is the only variable; `heap_ptr_bytes` is deterministic):

| compiler | heap_ptr | Δ vs main |
|---|---:|---:|
| main `efe0954` | 848,204,000 | — |
| first version (a key string + a counter array per statement) | 848,341,800 | +137,800 |
| head (key built only where a name is minted) | 848,209,640 | +5,640 |

## Also measured

- The other generated-name templates the prelude mints (`__edpw_<i>`, `__aw_f_<n>` / `__aw_v_<n>`, `__shadow_<n>_<name>`, `__m_scrut_<n>`, `__exn_payload<n>`, `__show_v<n>`, `__dlh_iife_<n>`, `__dlh_cc_marker_<n>`) are local names or already derived from a declaration's name. The hoisted lambda was the one program-wide **top-level** minting.
- A separate, still-open per-module gap this program surfaces: `evidence_dict_pass` differs on it, because `desugar_hoist_local_lambdas` appends its output at the END of the merged program and the provenance re-alignment then attributes a dependency's hoisted function to the entry file. Written up on [#2388](https://github.com/mizchi/vibe-lang/issues/2388#issuecomment-5622707588); it is the next slice, not this one.

## Validation

- Red verified for every claim above against the pre-change sources — the before columns are runs, not readings of the code.
- `desugar_trait_dicts_module_test.vibe` (10 tests), `prelude_module_oracle_test.vibe` (2), `fixtures/hoisted_lambda_owner_names_test.vibe` (2, linear and gc lanes) pass on this head.
- `bash scripts/compiler_gate.sh` (`pkf run test`) locally: `[compiler-gate] ok`, 126/126 groups, on the first commit. On this head the same gates run in CI — `compiler-gate` plus its early / mid / late / contracts / docs / examples / playground / preflight / stage2-oracles shards, `gc-gate`, `wasi-p3-gate`, four unit-test shards, `review-regressions`, `structural-lint`, `vibe-fmt-check` — all green.
- stage0 → stage1 → stage2 selfhost build clean at every step; `scripts/vibe_fmt.sh --check` clean on every changed file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NAeZzkckdAwtQiubBFpdmM