### PR TITLE
normalize: a hoisted lambda is placed next to the declaration it came out of (#2388)

### DIFF
--- a/lib/@vibe/compiler/codegen/wasi/linked_compile.vibe
+++ b/lib/@vibe/compiler/codegen/wasi/linked_compile.vibe
@@ -4118,7 +4118,14 @@ export fn prelude_pass_module_oracle_step(k: Int, a: Array[Stmt], c: Array[Stmt]
     "differs"
   }
   let line = String::concat("PASS ", String::concat(oracle_pass_name(k), String::concat(" stmts=", String::concat(Int::to_string(nn), String::concat(" split=", String::concat(Int::to_string(nt), String::concat(" diff=", String::concat(Int::to_string(diffs), String::concat(" first=", String::concat(Int::to_string(first), String::concat(" file=", String::concat(Int::to_string(first_file), String::concat(" status=", String::concat(status, "\n"))))))))))))))
-  let line2 = if k == 4 {
+  // The keyed comparison is the verdict for any pass that SYNTHESIZES
+  // program-level statements: per-module they land at each module's position
+  // and may repeat, so a positional `differs` says nothing about whether the
+  // two runs produced the same declarations. It used to be printed for the
+  // trait-dict pass only, which left every other pass's `differs` unreadable
+  // (#2388: `evidence_dict_pass` differed by the position of one synthesized
+  // dict struct, and there was no line saying so).
+  let line2 = if k == 4 || diffs > 0 {
     String::concat(line, oracle_keyed_line(a, trial, render))
   } else {
     line

--- a/lib/@vibe/compiler/normalize/desugar_trait_dict.vibe
+++ b/lib/@vibe/compiler/normalize/desugar_trait_dict.vibe
@@ -17178,19 +17178,28 @@ export fn desugar_hoist_local_lambdas(stmts: Array[Stmt]) -> Unit {
 fn dlh_place_after_owners(stmts: Array[Stmt], hoisted: Array[Stmt], hoisted_owner: Array[Int]) -> Unit {
   let total = Array::length(stmts)
   let ordered: Array[Stmt] = []
+  // `hoisted_owner` rises with the statement the walk was on, and one owner's
+  // entries are contiguous, so ONE advancing index visits each entry once.
+  // Restarting the scan per statement (the first version of this, Codex P2 on
+  // #2620) makes the placement O(statements x hoists) -- 25 million probes on a
+  // generated program with 5,000 declarations that each hoist one lambda.
+  let mut hi = 0
   let mut si = 0
   while si < total {
     Array::push(ordered, Array::get(stmts, si))
-    let mut hi = 0
-    while hi < Array::length(hoisted) {
-      if Array::get(hoisted_owner, hi) == si {
-        Array::push(ordered, Array::get(hoisted, hi))
-      } else {
-        ()
-      }
+    while hi < Array::length(hoisted) && Array::get(hoisted_owner, hi) == si {
+      Array::push(ordered, Array::get(hoisted, hi))
       hi = hi + 1
     }
     si = si + 1
+  }
+  // An entry whose owner is not a statement of this array would otherwise be
+  // dropped silently; there is no such entry (an owner index is a position in
+  // `stmts`), and if one appeared it lands where the pass used to put every
+  // hoist -- the end -- rather than nowhere.
+  while hi < Array::length(hoisted) {
+    Array::push(ordered, Array::get(hoisted, hi))
+    hi = hi + 1
   }
   // The module's own region grew, and the dependency-interface block after it
   // moved by the same amount -- the same bookkeeping the trait namespace

--- a/lib/@vibe/compiler/normalize/desugar_trait_dict.vibe
+++ b/lib/@vibe/compiler/normalize/desugar_trait_dict.vibe
@@ -17137,20 +17137,78 @@ fn dlh_hoist_stmt(stmt: Stmt, hoisted: Array[Stmt], ctr: Array[Int]) -> Stmt {
 /// program-wide counter cannot survive a per-module run.
 export fn desugar_hoist_local_lambdas(stmts: Array[Stmt]) -> Unit {
   let hoisted = array_empty()
+  let hoisted_owner: Array[Int] = []
   let n = dtd_own_end(stmts)
   let ctr = [0]
   let mut i = 0
   while i < n {
     Array::set(ctr, 0, 0)
     dlh_set_owner(Array::get(stmts, i), i)
+    let before = Array::length(hoisted)
     Array::set(stmts, i, dlh_hoist_stmt(Array::get(stmts, i), hoisted, ctr))
+    let mut b = before
+    while b < Array::length(hoisted) {
+      Array::push(hoisted_owner, i)
+      b = b + 1
+    }
     i = i + 1
   }
   Array::set(dlh_owner_name, 0, "")
-  let mut h = 0
-  while h < Array::length(hoisted) {
-    Array::push(stmts, Array::get(hoisted, h))
-    h = h + 1
+  if Array::length(hoisted) == 0 {
+    ()
+  } else {
+    dlh_place_after_owners(stmts, hoisted, hoisted_owner)
+  }
+}
+
+/// #2388: put each hoisted function directly after the declaration it came out
+/// of, instead of at the end of the program.
+///
+/// The end is where they used to go, and it made a hoisted function belong to
+/// nobody: a merged program's per-statement file provenance gives a statement
+/// it has not seen the file of the statement BEFORE it, so a lambda hoisted out
+/// of a dependency was attributed to whatever file the program happens to end
+/// with. Two passes later the owning module's part called a function it did not
+/// contain, and `evidence_dict_pass` could not thread the handler's dictionary
+/// into that call (measured on the two-file program in
+/// `prelude_module_oracle_test.vibe`: `stmts=11 split=10`, the dictionary
+/// present whole-program and absent per file). Next to its owner, a hoisted
+/// function is in its module by construction -- for that provenance, for the
+/// per-module entry's own region, and for the link.
+fn dlh_place_after_owners(stmts: Array[Stmt], hoisted: Array[Stmt], hoisted_owner: Array[Int]) -> Unit {
+  let total = Array::length(stmts)
+  let ordered: Array[Stmt] = []
+  let mut si = 0
+  while si < total {
+    Array::push(ordered, Array::get(stmts, si))
+    let mut hi = 0
+    while hi < Array::length(hoisted) {
+      if Array::get(hoisted_owner, hi) == si {
+        Array::push(ordered, Array::get(hoisted, hi))
+      } else {
+        ()
+      }
+      hi = hi + 1
+    }
+    si = si + 1
+  }
+  // The module's own region grew, and the dependency-interface block after it
+  // moved by the same amount -- the same bookkeeping the trait namespace
+  // operations do when they insert next to their trait.
+  Array::set(dtd_own_growth, 0, Array::get(dtd_own_growth, 0) + Array::length(hoisted))
+  if Array::get(dtd_own_limit, 0) >= 0 {
+    Array::set(dtd_own_limit, 0, Array::get(dtd_own_limit, 0) + Array::length(hoisted))
+  } else {
+    ()
+  }
+  let mut oi = 0
+  while oi < Array::length(ordered) {
+    if oi < total {
+      Array::set(stmts, oi, Array::get(ordered, oi))
+    } else {
+      Array::push(stmts, Array::get(ordered, oi))
+    }
+    oi = oi + 1
   }
 }
 

--- a/lib/@vibe/compiler/tests/desugar_trait_dicts_module_test.vibe
+++ b/lib/@vibe/compiler/tests/desugar_trait_dicts_module_test.vibe
@@ -142,14 +142,17 @@ test "a hoisted local lambda's labeled call is reordered in a per-module run" {
   let ctx = parse_program(lex(dep2_src()))
   let own = parse_program(lex(own2_src()))
   let synth = desugar_trait_dicts_module(own, ctx, "", [], [])
-  // The hoisted function is appended after the context block, so it comes
-  // back with the synthesized set; the labeled-argument stage must still
-  // visit it -- the call to the dependency's `sub` binds by position after
-  // this pass, and a call left labeled here would bind `y = a` to `x`.
-  inspect(stmt_names(synth), content = "__hoisted_lam_9_use_local_0_f")
-  inspect(render_named(synth, "__hoisted_lam_9_use_local_0_f"), content = "let __hoisted_lam_9_use_local_0_f = (a: Int) -> Int with Log { { perform Log::Emit(\"x\"); { let g = (b: Int, c?: Option[Int]) -> Int { b }; g(a, None) } } }")
-  inspect(whole2_named("__hoisted_lam_9_use_local_0_f"), content = "let __hoisted_lam_9_use_local_0_f = (a: Int) -> Int with Log { { perform Log::Emit(\"x\"); { let g = (b: Int, c?: Option[Int]) -> Int { b }; g(a, None) } } }")
-  inspect(render_named(synth, "__hoisted_lam_9_use_local_0_f") == whole2_named("__hoisted_lam_9_use_local_0_f"), content = "true")
+  // #2388: the hoisted function goes next to the declaration it came out of,
+  // so it is one of the module's OWN statements and the synthesized set stays
+  // empty here. It used to be appended past the context block, which made it
+  // belong to whatever the program ended with.
+  inspect(stmt_names(own), content = "forty_two, via_apply, use_local, __hoisted_lam_9_use_local_0_f")
+  inspect(stmt_names(synth), content = "")
+  // The labeled-argument stage must still visit it -- the call to the
+  // dependency's `sub` binds by position after this pass, and a call left
+  // labeled here would bind `y = a` to `x`.
+  inspect(render_named(own, "__hoisted_lam_9_use_local_0_f"), content = "let __hoisted_lam_9_use_local_0_f = (a: Int) -> Int with Log { { perform Log::Emit(\"x\"); { let g = (b: Int, c?: Option[Int]) -> Int { b }; g(a, None) } } }")
+  inspect(render_named(own, "__hoisted_lam_9_use_local_0_f") == whole2_named("__hoisted_lam_9_use_local_0_f"), content = "true")
   inspect(render_named(own, "use_local") == whole2_named("use_local"), content = "true")
 }
 
@@ -233,13 +236,16 @@ test "a hoisted lambda is named after the declaration it came out of, so two mod
   let ctx_for_dep = parse_program(lex(own4_src()))
   let own_synth = desugar_trait_dicts_module(own, ctx_for_own, "", [], [])
   let dep_synth = desugar_trait_dicts_module(dep, ctx_for_dep, "", [], [])
-  inspect(stmt_names(own_synth), content = "__hoisted_lam_7_own_use_0_f")
-  inspect(stmt_names(dep_synth), content = "__hoisted_lam_7_dep_use_0_f")
+  // The hoisted function is one of the module's own statements now (#2388), so
+  // each module's name shows up there rather than in the synthesized set.
+  inspect(stmt_names(own), content = "?, own_use, __hoisted_lam_7_own_use_0_f")
+  inspect(stmt_names(dep), content = "?, dep_use, __hoisted_lam_7_dep_use_0_f")
+  inspect(String::concat(stmt_names(own_synth), stmt_names(dep_synth)), content = "")
   // What each module mints alone is what the whole-program run mints for it:
   // the counter restarts at every declaration and the name carries that
   // declaration, so neither spelling depends on the other module.
-  inspect(render_named(own_synth, "__hoisted_lam_7_own_use_0_f") == whole4_named("__hoisted_lam_7_own_use_0_f"), content = "true")
-  inspect(render_named(dep_synth, "__hoisted_lam_7_dep_use_0_f") == whole4_named("__hoisted_lam_7_dep_use_0_f"), content = "true")
+  inspect(render_named(own, "__hoisted_lam_7_own_use_0_f") == whole4_named("__hoisted_lam_7_own_use_0_f"), content = "true")
+  inspect(render_named(dep, "__hoisted_lam_7_dep_use_0_f") == whole4_named("__hoisted_lam_7_dep_use_0_f"), content = "true")
   inspect(whole4_named("__hoisted_lam_7_own_use_0_f"), content = "let __hoisted_lam_7_own_use_0_f = (a: Int) -> Int with OwnLog { { perform OwnLog::Emit(\"own\"); (a + 1) } }")
 }
 

--- a/lib/@vibe/compiler/tests/prelude_module_oracle_test.vibe
+++ b/lib/@vibe/compiler/tests/prelude_module_oracle_test.vibe
@@ -107,11 +107,16 @@ test "two files that each hoist a local lambda mint top-level names the other mo
   // every declaration the whole-program run produced is produced by the module
   // that owns it, under the same name and with the same body.
   inspect(keyed_line_of(report, "desugar_trait_dicts_with_typed_eq"), content = "keyed missing=0 extra=0 copies=1 content=0 renames=0 first_missing= first_content=")
-  // What the rest of the report says on this program, as measured. The
-  // trait-dict pass's positional status is `differs` by design (see above).
-  // `evidence_dict_pass` is a separate, still-open per-module gap: whole
-  // program it threads the handler's dictionary into the hoisted function's
-  // call, per file it does not.
+  // `evidence_dict_pass` synthesizes a dict struct per module the same way, so
+  // its verdict is its keyed line too. It used to differ in CONTENT here: the
+  // hoisted function was appended at the end of the merged program, the
+  // provenance re-alignment attributed it to the entry file, and the module
+  // that owned it then called a function it did not contain, so no dictionary
+  // was threaded (`stmts=11 split=10`). With the hoist placing its output next
+  // to its owner, the declarations agree and only the position of the one
+  // synthesized struct is left.
+  inspect(keyed_line_of(report, "evidence_dict_pass"), content = "keyed missing=0 extra=0 copies=1 content=0 renames=0 first_missing= first_content=")
+  // What the rest of the report says on this program, as measured.
   let statuses: Array[String] = []
   let lines = oracle_lines(report)
   let mut i = 0
@@ -119,5 +124,5 @@ test "two files that each hoist a local lambda mint top-level names the other mo
     Array::push(statuses, status_of(Array::get(lines, i)))
     i = i + 1
   }
-  inspect(String::join(statuses, ","), content = "same,same,same,same,differs,same,same,same,same,same,same,same,same,same,same,differs,same")
+  inspect(String::join(statuses, ","), content = "same,same,same,same,same,same,same,same,same,same,same,same,same,same,same,differs,same")
 }


### PR DESCRIPTION
The slice after [#2618](https://github.com/mizchi/vibe-lang/pull/2618) on the #2388 per-module line (parent epic #2386): a synthesized top-level definition now carries the module it belongs to, because it sits in it.

## The defect

`desugar_hoist_local_lambdas` appended its hoisted functions at the **end** of the merged program, which made them belong to nobody. A merged program's per-statement file provenance gives a statement it has not seen the file of the statement *before* it, so a lambda hoisted out of a dependency was attributed to whatever file the program happens to end with. Two passes later the module that owned it called a function it did not contain:

```
whole: export let rec helper_use_exp_… = () -> Int { __hoisted_lam_…_0_f(record { Emit: (_m) -> { 0 } }, 1) }
split: export let rec helper_use_exp_… = () -> Int { __hoisted_lam_…_0_f(1) }
```

— `evidence_dict_pass` could not read the callee's row, so it threaded no dictionary, and the per-file side ended one statement short.

## The fix

Each hoisted function goes directly after the declaration it came out of, with the same own-region bookkeeping the trait namespace operations already do when they insert next to their trait (`dtd_own_growth` / `dtd_own_limit`). In the per-module entry the hoisted function is therefore one of the module's **own** statements rather than part of the synthesized set.

## Measurement

The per-pass module oracle on the two-file program where both files hoist a local `f` (`prelude_module_oracle_test.vibe`):

| pass | before | after |
|---|---|---|
| `desugar_trait_dicts_with_typed_eq` | `differs` (position) | **`same`** |
| `evidence_dict_pass` | `stmts=11 split=10`, no dictionary threaded per file | `stmts=11 split=11`, keyed **`missing=0 extra=0 copies=1 content=0 renames=0`** |

So on this program the per-module run now produces the same declarations as the whole-program run on **every** pass; what is left is the position of one synthesized dict struct, which a link-time dedup by name folds — the same shape as the trait-dict pass's `copies`.

**The oracle also prints its keyed line for every pass that differs**, not for the trait-dict pass alone. The keyed comparison is the verdict for any pass that synthesizes program-level statements; without it, a `differs` on such a pass said nothing about whether the two runs agreed — which is exactly what left the evidence-pass difference unreadable until I chased it by hand.

Unchanged where it should be:

- compiler closure keyed line: `missing=0 extra=0 copies=328 content=0 renames=0`, same as main (it hoists no lambda).
- selfcompile KPI over the same input (a worktree at `efe0954`, so the compiler is the only variable): **848,204,344** against main's **848,204,000**.

## Validation

- `lib/@vibe/compiler/tests/desugar_trait_dicts_module_test.vibe` (10 tests), `prelude_module_oracle_test.vibe` (2), `fixtures/hoisted_lambda_owner_names_test.vibe` (2, linear and gc lanes) pass.
- stage0 → stage1 → stage2 selfhost build clean; `scripts/vibe_fmt.sh --check` clean on every changed file.
- `bash scripts/compiler_gate.sh` running locally as I open this; CI runs the same gates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NAeZzkckdAwtQiubBFpdmM

---
_Generated by [Claude Code](https://claude.ai/code/session_01NAeZzkckdAwtQiubBFpdmM)_