### PR TITLE
entry/file_compile: the FS module lane compiles the statement merge (#2437)

### DIFF
--- a/lib/@vibe/compiler/entry/compiler/file_compile/file_compile.vibe
+++ b/lib/@vibe/compiler/entry/compiler/file_compile/file_compile.vibe
@@ -5,6 +5,7 @@ import @vibe/compiler/syntax {
   lex_with_offsets,
   parse_program,
   parse_program_located,
+  print_program,
   print_stmt,
   rewrite_string_binops_stmts,
   shift_stmt_offsets,
@@ -33,6 +34,7 @@ import @vibe/compiler/core {
   append_non_import_stmts_without_alias_rewrite,
   apply_export_renames_stmts,
   build_export_rename_plan,
+  builtin_iterator_serialized_boundary_markers,
   collect_import_alias_collision_locals,
   collect_import_alias_collision_refs,
   collect_import_value_renames,
@@ -53,7 +55,7 @@ import @vibe/compiler/core {
 }
 
 import @vibe/compiler/codegen {
-  compile_module, compile_wasi_module
+  compile_module_with_typed_offsets, compile_wasi_module
 }
 
 import @vibe/compiler/codegen/common_base {
@@ -96,9 +98,7 @@ import @vibe/compiler/checker {
 import @vibe/compiler/runtime {
   TypeDb,
   artifact_input_trace_dependency_plan_evidence_fs,
-  db_grouped_merged_source,
   db_load_artifact,
-  db_module_source,
   db_new,
   db_set_source,
   db_store_artifact,
@@ -558,6 +558,37 @@ fn merged_stmts_and_offsets(source_groups: Array[(String, Array[(String, String)
   // #2441: the typed-`==` rows ride the same disjoint offset spaces.
   let (eq_offs, eq_keys) = union_module_typed_eq_rows(flat_paths, flat_bases)
   (rewrite_string_binops_stmts(merged, rels, pluses, typed_lowering_binop_anchor), floats, int_renders, bool_renders, eq_offs, eq_keys)
+}
+
+/// The statement filter `build_module_source` (runtime.vibe) applies while
+/// reprinting: a module keeps its top-level function bindings and the
+/// serialized builtin-iterator boundary markers, and nothing else.
+///
+/// #2437: lifted out of the reprint so the statement merge can be filtered
+/// directly. Selecting statements preserves every node offset, which is what
+/// lets the rebased typed-lowering tables still name the right nodes. Kept
+/// byte-identical to `fs_compile`'s copy on purpose -- the two lanes must
+/// agree on what a module contains.
+fn module_lane_filter_stmts(stmts: Array[Stmt]) -> Array[Stmt] {
+  let filtered = array_empty()
+  let mut i = 0
+  while i < Array::length(stmts) {
+    let stmt = Array::get(stmts, i)
+    let keep = match stmt {
+      SLet(_, _, _, _, expr) => match expr {
+        EFn(_, _, _, _, _, _) => true,
+        _ => false
+      },
+      _ => builtin_iterator_serialized_boundary_markers(stmt) is Some(_)
+    }
+    if keep {
+      Array::push(filtered, stmt)
+    } else {
+      ()
+    }
+    i = i + 1
+  }
+  filtered
 }
 
 /// Interior-line breakpoints (span-arc step5): the basename of a file path (text
@@ -1666,6 +1697,57 @@ export fn compile_file_fs_mode_cached_profiled(db: TypeDb, entry_path: String, e
   }
 }
 
+/// #2437: the last FS caller to leave the reprint.
+///
+/// It used to print the merge into `merged_source`, reparse + filter + print
+/// THAT into `module_source`, reparse the result UNLOCATED, and hand it to
+/// `compile_module` -- so every node offset was -1, the per-module
+/// typed-lowering rows had no offset space to be rebased into, and this lane
+/// compiled with every channel EMPTY. What that costs is the pre-#2158
+/// syntactic answer: a large `Int` rendering as the empty string, a `Double`
+/// through a projection not rendering as a Double, `a < b` on Strings
+/// comparing pointers wherever the desugar tracker cannot classify the shape
+/// syntactically.
+///
+/// It now takes the route #2449 gave the inline entries, one layer up:
+/// `merged_stmts_and_offsets` rebases the rows the check above already
+/// published, so this is PLUMBING rather than the second whole-program check
+/// this issue measured at +330 ms on a 960-function program (superlinear --
+/// seconds per cold compile at compiler size). Two prints and two parses go
+/// away with it; the reprint's statement filter is applied to the merge
+/// instead (`module_lane_filter_stmts`), which preserves every node offset.
+///
+/// The precondition the inline siblings have to argue for is free here. The
+/// memo is keyed by PATH, and `ensure_fingerprint_fs_impl` RESETS it and then
+/// leaves a row for every module of the closure: a module served from the
+/// persistent type-env cache counts as reused only if its offsets sidecar
+/// loads too (`ensure_module_typed_lowering_offsets`), and otherwise it is
+/// rechecked. So there is no window where a row left by an earlier compile of
+/// a different source at the same path can be read.
+///
+/// Two deliberate consequences:
+///
+///   - The in-db artifact kind is `module-typed`, not `module`. `fs_compile`
+///     carries a second copy of this entry that still compiles WITHOUT the
+///     tables and still writes `module`; sharing a kind would let one entry
+///     silently return the other's lowering on a shared `TypeDb`. The two
+///     PERSISTENT kinds were already distinct (`file-compile-module` vs
+///     `fs-compile-module`) and that key folds in `codegen_fingerprint()`, a
+///     hash of every compiler source, so entries written before this change
+///     cold-miss on their own.
+///   - `db_grouped_merged_source` / `db_module_source` are no longer called
+///     here, so this entry no longer bumps their counters. Those counters were
+///     this lane's only behavioural coverage, so the tests that read them were
+///     rewritten rather than deleted.
+///
+/// The artifact key keeps exactly the strength it had. It is derived from the
+/// merged program's own text, not from the input sources: private namespacing
+/// mangles names with the file PATH (`namespace_private_value_stmts`), so two
+/// programs whose sources are identical can merge to different statements, and
+/// a key hashed from the sources alone would hand the second call the first
+/// call's bytes. Printing here costs one print of a program that used to be
+/// printed TWICE -- and unlike before, nothing REPARSES that text, so the
+/// offsets survive.
 fn compile_file_fs_module_cached_slow(db: TypeDb, entry_path: String) -> (Bytes, TypeDb) with Exception + Fs {
   let source_groups = collect_source_groups_fs(entry_path)
   let persistent_artifact_fingerprint = build_file_compile_module_artifact_fingerprint_for_entry_path(source_groups, entry_path)
@@ -1673,16 +1755,15 @@ fn compile_file_fs_module_cached_slow(db: TypeDb, entry_path: String) -> (Bytes,
     Some(bytes) => (bytes, db),
     None => {
       let next_db = prepare_file_fs_from_source_groups_persistent_cached(db, entry_path, source_groups)
-      let (merged_source, merge_fingerprint, module_db) = db_grouped_merged_source(next_db, source_groups)
-      let (module_source, codegen_db) = db_module_source(module_db, merge_fingerprint, merged_source)
-      let artifact_fingerprint = artifact_fingerprint_from_source(module_source)
-      match db_load_artifact(codegen_db, entry_path, "module", "", artifact_fingerprint) {
-        Some(bytes) => (bytes, codegen_db),
+      let (merged_stmts, float_offsets, int_offsets, bool_offsets, _, _) = merged_stmts_and_offsets(source_groups)
+      let filtered = module_lane_filter_stmts(merged_stmts)
+      let artifact_fingerprint = artifact_fingerprint_from_source(print_program(filtered))
+      match db_load_artifact(next_db, entry_path, "module-typed", "", artifact_fingerprint) {
+        Some(bytes) => (bytes, next_db),
         None => {
-          let merged_stmts = parse_program(lex(module_source))
-          let bytes = compile_module(merged_stmts)
+          let bytes = compile_module_with_typed_offsets(filtered, float_offsets, int_offsets, bool_offsets)
           store_persistent_artifact("file-compile-module", "", persistent_artifact_fingerprint, bytes)
-          (bytes, db_store_artifact(codegen_db, entry_path, "module", "", artifact_fingerprint, bytes))
+          (bytes, db_store_artifact(next_db, entry_path, "module-typed", "", artifact_fingerprint, bytes))
         }
       }
     }

--- a/lib/@vibe/compiler/tests/compiler_cache_advanced_test.vibe
+++ b/lib/@vibe/compiler/tests/compiler_cache_advanced_test.vibe
@@ -213,7 +213,19 @@ test "compile_file_fs_module_cached: same output reuses compiled artifact after 
   assert(eq(db_codegen_count(db2), codegen_count1))
 }
 
-test "compile_file_fs_module_cached: same source at different entry paths does not reuse module source cache" {
+test "compile_file_fs_module_cached: builds no module source, and shares the artifact by content (#2437)" {
+  // This used to assert that the module-source count GREW across two entry
+  // paths. #2437 routed this lane off the reprint and onto the statement merge,
+  // so it builds no module source at all -- the count stays 0, and the property
+  // the old assertion stood in for now lives in two places: the artifact one
+  // below (identical merged text at two paths shares), and the
+  // dependency-mangling case in `compiler_cache_prepare_test` (different merged
+  // text at two paths does not).
+  //
+  // Same shape as the inline lane's case above, one layer up. Asserting ZERO
+  // rather than deleting: the counter is the only observable that says whether
+  // this lane reprints, and a lane that quietly started reprinting again would
+  // take the offsets back to -1 and empty the tables silently.
   let main_path1 = "/tmp/vibe_compiler_module_source_cache_same_source_a.vibe"
   let main_path2 = "/tmp/vibe_compiler_module_source_cache_same_source_b.vibe"
   let source = "let run: () -> Int = () -> { 1 + 2 }"
@@ -222,7 +234,10 @@ test "compile_file_fs_module_cached: same source at different entry paths does n
   clear_file_compile_module_cache(main_path1)
   clear_file_compile_module_cache(main_path2)
   let (_, db1) = compile_file_fs_module_cached(db_new(), main_path1)
-  let module_source_count1 = db_module_source_count(db1)
+  assert(eq(db_module_source_count(db1), 0))
+  let codegen_count1 = db_codegen_count(db1)
+  assert(codegen_count1 > 0)
   let (_, db2) = compile_file_fs_module_cached(db1, main_path2)
-  assert(db_module_source_count(db2) > module_source_count1)
+  assert(eq(db_module_source_count(db2), 0))
+  assert(eq(db_codegen_count(db2), codegen_count1))
 }

--- a/lib/@vibe/compiler/tests/compiler_cache_prepare_test.vibe
+++ b/lib/@vibe/compiler/tests/compiler_cache_prepare_test.vibe
@@ -21,7 +21,7 @@ import @vibe/compiler/entry/compiler/fs_compile {
 }
 
 import ../type_db.vibe {
-  db_merge_count, db_new, db_parse_count, db_typecheck_count
+  db_codegen_count, db_merge_count, db_new, db_parse_count, db_typecheck_count
 }
 
 //# Functions
@@ -78,27 +78,53 @@ test "prepare_modules_cached: warm prepare reuses parsed modules" {
   assert(eq(db_parse_count(db2), parse_count1))
 }
 
-test "compile_file_fs_module_cached: warm compile reuses merged module cache" {
+test "compile_file_fs_module_cached: the FS module lane builds no merged source at all (#2437)" {
+  // This used to assert only that the merge counter did not GROW across a warm
+  // recompile. #2437 routed this lane off the reprint and onto the statement
+  // merge, which is what lets the typed-lowering tables reach codegen: it
+  // compiles the merged statements directly, so `db_grouped_merged_source` is
+  // never called and there is nothing to count.
+  //
+  // Asserting ZERO rather than deleting the case: the counter is the only
+  // observable that says whether this lane reprints, and a lane that quietly
+  // started reprinting again would take every node offset back to -1 and empty
+  // the tables without any other test noticing.
   let helper_path = "/tmp/vibe_compiler_cache_helper.vibe"
   let main_path = "/tmp/vibe_compiler_cache_main.vibe"
   Fs::write_bytes(helper_path, string_to_bytes("export let add: (Int, Int) -> Int = (a, b) -> { a + b }"))
   Fs::write_bytes(main_path, string_to_bytes("import ./vibe_compiler_cache_helper.vibe { add }\nlet run: () -> Int = () -> { add(1, 2) }"))
   let (_, db1) = compile_file_fs_module_cached(db_new(), main_path)
-  let merge_count1 = db_merge_count(db1)
+  assert(eq(db_merge_count(db1), 0))
   let (_, db2) = compile_file_fs_module_cached(db1, main_path)
-  assert(eq(db_merge_count(db2), merge_count1))
+  assert(eq(db_merge_count(db2), 0))
 }
 
-test "compile_file_fs_module_cached: same source at different entry paths does not reuse merge cache" {
-  let main_path1 = "/tmp/vibe_compiler_merge_cache_same_source_a.vibe"
-  let main_path2 = "/tmp/vibe_compiler_merge_cache_same_source_b.vibe"
-  let source = "let run: () -> Int = () -> { 1 + 2 }"
-  Fs::write_bytes(main_path1, string_to_bytes(source))
-  Fs::write_bytes(main_path2, string_to_bytes(source))
+test "compile_file_fs_module_cached: a dependency at a different path is a different artifact (#2437)" {
+  // The property the deleted "does not reuse merge cache" case stood in for.
+  // The path-aware merge cache is gone, so the artifact key carries this alone
+  // -- and it is derived from the MERGED program's text rather than from the
+  // input sources for exactly this reason: private namespacing mangles a
+  // dependency's names with its file PATH, so two programs with byte-identical
+  // sources at different paths merge to DIFFERENT statements. A key hashed
+  // from the sources alone would hand the second call the first call's bytes.
+  //
+  // Both entries have the same text and import a helper with the same text;
+  // only the helper's path differs. The entry's own defs are never renamed, so
+  // this is the case that isolates the dependency mangling.
+  let helper_path1 = "/tmp/vibe_compiler_merge_dep_a_helper.vibe"
+  let helper_path2 = "/tmp/vibe_compiler_merge_dep_b_helper.vibe"
+  let main_path1 = "/tmp/vibe_compiler_merge_dep_a_main.vibe"
+  let main_path2 = "/tmp/vibe_compiler_merge_dep_b_main.vibe"
+  let helper_source = "export let add: (Int, Int) -> Int = (a, b) -> { a + b }"
+  Fs::write_bytes(helper_path1, string_to_bytes(helper_source))
+  Fs::write_bytes(helper_path2, string_to_bytes(helper_source))
+  Fs::write_bytes(main_path1, string_to_bytes("import ./vibe_compiler_merge_dep_a_helper.vibe { add }\nlet run: () -> Int = () -> { add(1, 2) }"))
+  Fs::write_bytes(main_path2, string_to_bytes("import ./vibe_compiler_merge_dep_b_helper.vibe { add }\nlet run: () -> Int = () -> { add(1, 2) }"))
   clear_file_compile_module_cache(main_path1)
   clear_file_compile_module_cache(main_path2)
   let (_, db1) = compile_file_fs_module_cached(db_new(), main_path1)
-  let merge_count1 = db_merge_count(db1)
+  let codegen_count1 = db_codegen_count(db1)
+  assert(codegen_count1 > 0)
   let (_, db2) = compile_file_fs_module_cached(db1, main_path2)
-  assert(db_merge_count(db2) > merge_count1)
+  assert(db_codegen_count(db2) > codegen_count1)
 }

--- a/lib/@vibe/compiler/tests/module_lane_typed_offsets_test.vibe
+++ b/lib/@vibe/compiler/tests/module_lane_typed_offsets_test.vibe
@@ -31,11 +31,14 @@
 // gives the rows `prepare_modules_cached` already published an offset space to
 // land in. No second check: this is plumbing.
 //
-// The FS module callers (`compile_file_fs_module_cached_slow`, both copies)
-// still keep the no-offsets spelling -- routing THEM onto the statement merge
-// is #2437's remaining work, and it changes cache identity in ways this one
-// did not. The measurement and the reason are on
-// `compile_module_expr_with_typed_offsets`.
+// #2437: the FS module entry (`compile_file_fs_module_cached`) has joined them
+// too, and its half is pinned the same way at the bottom of this file. It is
+// the one the CLI reaches. `fs_compile`'s second copy of
+// `compile_file_fs_module_cached_slow` -- reachable only through the
+// `@vibe/compiler` facade, whose package cannot see the grouped statement
+// merge -- keeps the no-offsets spelling deliberately, which is why the two
+// carry DIFFERENT in-db artifact kinds (`module-typed` vs `module`): sharing
+// one would let a shared `TypeDb` hand an entry the other's lowering.
 
 import @vibe/compiler/entry/source_compile {
   compile_source as compile_source_with_offsets
@@ -47,6 +50,10 @@ import ./codegen_test_support.vibe {
 
 import @vibe/compiler/entry/compiler/fs_compile {
   compile_with_modules_cached
+}
+
+import @vibe/compiler/entry/compiler/file_compile {
+  compile_file_fs_module_cached
 }
 
 import @vibe/compiler/runtime {
@@ -102,4 +109,33 @@ test "#2449 the inline module entry is inert where there is nothing to classify"
   // program with no render, no `eq` and no Double call result would be a
   // regression rather than a fix.
   assert(compile_inline_module(module_lane_plain_source) == compile_source(module_lane_plain_source))
+}
+
+/// #2437: the same pair for the FS module entry -- the one `compile_job_cached`
+/// routes an empty entry name to.
+///
+/// `compile_file_fs_module_cached` runs the FS check before the merge, and
+/// `ensure_fingerprint_fs_impl` resets the per-path memo and then leaves a row
+/// for every module of the closure, so the rows are both present and current
+/// by construction. As above, the control is `codegen_test_support`'s
+/// `compile_source`: the no-offsets `compile_module` over an unlocated parse,
+/// which is exactly what this entry used to do to itself after printing the
+/// program twice.
+fn compile_fs_module(path: String, src: String) -> Bytes with Exception + Fs {
+  Fs::write_file(path, src)
+  let (bytes, _) = compile_file_fs_module_cached(db_new(), path)
+  bytes
+}
+
+test "#2437 the FS module entry's typed-lowering tables reach codegen" {
+  let with_tables = compile_fs_module("/tmp/vibe_fs_module_typed_offsets_projection.vibe", module_lane_projection_source)
+  assert(!(with_tables == compile_source(module_lane_projection_source)))
+}
+
+test "#2437 the FS module entry is inert where there is nothing to classify" {
+  // Not merely "does not crash": an offsets channel that moved bytes for a
+  // program with no render, no `eq` and no Double call result would be a
+  // regression rather than a fix.
+  let with_tables = compile_fs_module("/tmp/vibe_fs_module_typed_offsets_plain.vibe", module_lane_plain_source)
+  assert(with_tables == compile_source(module_lane_plain_source))
 }


### PR DESCRIPTION
Closes #2437 — the remaining work after #2449.

## What was wrong

`compile_file_fs_module_cached_slow` printed the merge into `merged_source`, reparsed + filtered + printed that into `module_source`, reparsed the result **unlocated**, and handed it to `compile_module`. Every node offset was `-1`, so the per-module typed-lowering rows had no offset space to be rebased into and this lane compiled with **every channel empty** — a large `Int` rendering as the empty string, a `Double` through a projection not rendering as a `Double`, `a < b` on Strings comparing pointers wherever the desugar tracker cannot classify the shape syntactically.

## What changed

It takes the route #2449 gave the inline entries, one layer up: `merged_stmts_and_offsets` rebases the rows the FS check above already published, and the reprint's statement filter is applied to the merge instead (`module_lane_filter_stmts`, kept identical to `fs_compile`'s copy so the two lanes agree on what a module contains).

This is **plumbing, not the second whole-program check** the issue measured at +330 ms on 960 functions. Two prints and two parses go away; one print comes back, for the artifact key.

The precondition the inline siblings have to argue for is free here: `ensure_fingerprint_fs_impl` **resets** the per-path memo and then leaves a row for every module of the closure — a module served from the persistent type-env cache counts as reused only if its offsets sidecar loads too (`ensure_module_typed_lowering_offsets`). There is no window where a row from an earlier compile of a different source at the same path can be read.

## The three things the issue said to settle first

**1. The artifact key.** The in-db kind is `module-typed`, not `module`. `fs_compile` carries a second copy of this entry that still compiles without the tables and still writes `module`; sharing a kind would let a shared `TypeDb` hand one entry the other's lowering. The two *persistent* kinds were already distinct (`file-compile-module` vs `fs-compile-module`) and that key folds in `codegen_fingerprint()` — a hash of every compiler source — so entries written before this change cold-miss on their own. The key stays derived from the **merged program's own text**, not from the input sources: private namespacing mangles a dependency's names with its file path, so identical sources at different paths can merge to different statements.

**2. The counter tests are rewritten, not deleted.** `db_merge_count` and `db_module_source_count` now assert **zero**, with the reason recorded in the test: they are the only observable that says whether this lane reprints, and a lane that quietly started reprinting again would take every offset back to `-1` and empty the tables without anything else noticing. The path-sensitivity the old "does not reuse merge cache" case stood in for moves to a new case that isolates dependency mangling — two entries with byte-identical text importing byte-identical helpers at *different paths* must not share an artifact.

**3. The output bytes change on purpose**, so the check is the pair `module_lane_typed_offsets_test` already uses: byte-**identical** for a program with nothing to classify, byte-**different** for one with something.

## Red tests

Each mutation is caught by exactly one case, so none of them is passing for an unrelated reason:

| mutation | fails |
|---|---|
| empty tables at the `compile_module_with_typed_offsets` call | "the FS module entry's typed-lowering tables reach codegen" — while "inert" still passes |
| constant in-db artifact key | "a dependency at a different path is a different artifact" — while the identical-text case still passes |
| path-aware artifact key (`entry_path ++ text`) | "same output reuses compiled artifact after path-aware merge" — while the dependency case still passes |

## Performance

**No regression.** 20 extra 800-function module compiles through this entry, isolated `VIBE_BUILD_CACHE_DIR` per run, measured as the delta against a single-compile control:

| | deltas over 20 compiles (ms) |
|---|---|
| before | 3291, 3335, 3765 |
| after | 1657, 1921, 2714, 3073, 3092, 4101 |

The direction is an improvement — the lane does strictly less work — but the noise floor at this scale is larger than the effect worth claiming, so the honest reading is unchanged-or-better.

All four `compiler_gate.sh` lanes green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q9zbiDqkfF7xYQ3v8aCQ3b

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q9zbiDqkfF7xYQ3v8aCQ3b)_