### PR TITLE
codegen: an oracle for the whole prelude per module, and what it measures on the compiler closure (#2388)

### DIFF
--- a/lib/@vibe/compiler/codegen/wasi/index.vpkg
+++ b/lib/@vibe/compiler/codegen/wasi/index.vpkg
@@ -64,6 +64,7 @@ fn late_dce_prune_module(mod_bytes: Bytes) -> Bytes
 fn late_dce_prune_module_for(mod_bytes: Bytes, entry_name: String, exports_stripped: Bool) -> Bytes
 fn late_dce_prune_refusal() -> Int
 fn prelude_pass_module_oracle_step(k: Int, a: Array[Stmt], c: Array[Stmt], c_file_id: Array[Int], file_count: Int, entry_name: String, checker_eq_offsets: Array[Int], checker_eq_type_keys: Array[String], render: (Stmt) -> String) -> String with Exception
+fn prelude_module_full_oracle_line(a: Array[Stmt], c: Array[Stmt], c_file_id: Array[Int], file_count: Int, entry_name: String, checker_eq_offsets: Array[Int], checker_eq_type_keys: Array[String], render: (Stmt) -> String) -> String with Exception
 fn compile_wasi_module_replayed_impl(stmts: Array[Stmt], entry_name: String) -> Bytes with Exception
 fn compile_wasi_module_sliced_impl(stmts: Array[Stmt], entry_name: String) -> Bytes with Exception
 fn compile_wasi_module_rc_impl(stmts_in: Array[Stmt], entry_name: String) -> Bytes with Exception

--- a/lib/@vibe/compiler/codegen/wasi/linked_compile.vibe
+++ b/lib/@vibe/compiler/codegen/wasi/linked_compile.vibe
@@ -3779,16 +3779,24 @@ fn oracle_is_interface_stmt(s: Stmt) -> Bool {
   }
 }
 
-/// The interface form of a context statement: a function whose return type
-/// is spelled loses its body (`EUnit`), the shape a `.vpkg` contract carries,
-/// so no body-reading collector (the trivial-wrapper inliner above all) can
-/// see through the interface. A function with no return annotation keeps its
-/// body: the contract would carry the checker's elaborated return type, which
+/// The interface form of a context statement: a function loses its body
+/// (`EUnit`), the shape a `.vpkg` contract carries, so no body-reading
+/// collector (the trivial-wrapper inliner above all) can see through the
+/// interface.
+///
+/// A function with NO return annotation used to keep its body, on the argument
+/// that a contract would carry the checker's elaborated return type -- which
 /// the pass reads off the body's tail expression (`fn_return_head_of`,
-/// `collect_fn_eq_return_shape`), and the oracle has no other spelling of it.
+/// `collect_fn_eq_return_shape`) -- and the oracle had no other spelling of
+/// it. That made the simulated interface wider than the real boundary (Codex
+/// P1 on #2622). Measured with the bodies dropped anyway: the compiler closure
+/// reads `missing=0 extra=0 copies=328 content=0 renames=0`, unchanged, so on
+/// this corpus nothing was reading them and the interface can be what a
+/// contract actually is. A module that DID need the elaborated return type
+/// would now show up as a difference, which is the point.
 fn oracle_interface_form(s: Stmt) -> Stmt {
   match s {
-    SLet(exported, is_rec, name, ty, EFn(tps, bounds, params, Some(ret), eff, _)) => SLet(exported, is_rec, name, ty, EFn(tps, bounds, params, Some(ret), eff, EUnit)),
+    SLet(exported, is_rec, name, ty, EFn(tps, bounds, params, ret, eff, _)) => SLet(exported, is_rec, name, ty, EFn(tps, bounds, params, ret, eff, EUnit)),
     _ => s
   }
 }

--- a/lib/@vibe/compiler/codegen/wasi/linked_compile.vibe
+++ b/lib/@vibe/compiler/codegen/wasi/linked_compile.vibe
@@ -3615,6 +3615,75 @@ export fn effect_lowering_prelude(stmts: Array[Stmt], entry_name: String, linked
 // per-statement file ids on stable statement keys (a declaration's kind and
 // name): an inserted statement belongs to the file of the statement before
 // it, which is also where a per-module run would put it.
+/// A type as a key, for telling one impl of a trait from another. Keying an
+/// impl by its TRAIT alone (what this did) collapses every `impl Eq for ...` in
+/// a program onto `impl:Eq`, and a key that repeats is skipped by the content
+/// comparison -- so a per-module run could drop or change an implementation and
+/// still read `missing=0 content=0` (Codex P1 on #2622).
+fn oracle_type_key(t: TypeExpr) -> String {
+  match t {
+    TyName(n) => n,
+    TyApp(n, args) => {
+      let out = StringBuilder::new()
+      StringBuilder::push(out, n)
+      StringBuilder::push(out, "[")
+      let mut i = 0
+      while i < Array::length(args) {
+        if i > 0 {
+          StringBuilder::push(out, ",")
+        } else {
+          ()
+        }
+        StringBuilder::push(out, oracle_type_key(Array::get(args, i)))
+        i = i + 1
+      }
+      StringBuilder::push(out, "]")
+      StringBuilder::freeze(out)
+    },
+    TyTuple(elems) => {
+      let out = StringBuilder::new()
+      StringBuilder::push(out, "(")
+      let mut i = 0
+      while i < Array::length(elems) {
+        if i > 0 {
+          StringBuilder::push(out, ",")
+        } else {
+          ()
+        }
+        StringBuilder::push(out, oracle_type_key(Array::get(elems, i)))
+        i = i + 1
+      }
+      StringBuilder::push(out, ")")
+      StringBuilder::freeze(out)
+    },
+    TyFn(params, ret, eff) => {
+      let out = StringBuilder::new()
+      StringBuilder::push(out, "fn(")
+      let mut i = 0
+      while i < Array::length(params) {
+        if i > 0 {
+          StringBuilder::push(out, ",")
+        } else {
+          ()
+        }
+        StringBuilder::push(out, oracle_type_key(Array::get(params, i)))
+        i = i + 1
+      }
+      StringBuilder::push(out, ")->")
+      StringBuilder::push(out, oracle_type_key(ret))
+      match eff {
+        Some(row) => {
+          StringBuilder::push(out, " with ")
+          StringBuilder::push(out, row)
+        },
+        None => ()
+      }
+      StringBuilder::freeze(out)
+    },
+    TyUnit => "Unit"
+  }
+}
+
 fn oracle_stmt_key(s: Stmt) -> String {
   match s {
     SLet(_, _, n, _, _) => String::concat("let:", n),
@@ -3624,7 +3693,7 @@ fn oracle_stmt_key(s: Stmt) -> String {
     SStruct(_, n, _, _, _, _) => String::concat("struct:", n),
     STypeAlias(_, n, _, _) => String::concat("alias:", n),
     STrait(_, n, _, _, _, _) => String::concat("trait:", n),
-    SImpl(_, _, n, _) => String::concat("impl:", n),
+    SImpl(_, _, n, ty) => String::concat("impl:", String::concat(n, String::concat(":", oracle_type_key(ty)))),
     SExternLet(n, _) => String::concat("extern:", n),
     SImport(p, _) => String::concat("import:", p),
     STest(n, _) => String::concat("test:", n),
@@ -3845,8 +3914,9 @@ fn oracle_strip_counters(s: String) -> String {
 /// repeat within `a` are skipped (a repeated key cannot be matched). Returns
 /// `keyed missing=<in a only> extra=<in trial only> copies=<repeats in trial>
 /// content=<same key, different content, not a fresh-name rename>
-/// renames=<same key, fresh-name renames only>` plus the first missing key and
-/// the first content-differing key.
+/// renames=<same key, fresh-name renames only> dup_keys=<statements the
+/// comparison cannot speak for, because their key repeats in `a`>` plus the
+/// first missing key and the first content-differing key.
 fn oracle_keyed_line(a: Array[Stmt], trial: Array[Stmt], render: (Stmt) -> String) -> String {
   let wmap: MutMap[String, Int] = MutMap::new_string()
   let mut ki = 0
@@ -3856,6 +3926,27 @@ fn oracle_keyed_line(a: Array[Stmt], trial: Array[Stmt], render: (Stmt) -> Strin
       MutMap::set(wmap, key, 0 - 1)
     } else {
       MutMap::set(wmap, key, ki)
+    }
+    ki = ki + 1
+  }
+  // Statements whose key is not unique in the whole-program result. Their
+  // content is NOT compared (there is no single node to compare against) and
+  // one occurrence in the trial answers for all of them, so the rest of the
+  // line is a verdict about everything except these. Reported rather than left
+  // implicit: a reader who does not know the number cannot tell how much of
+  // the program `content=0` covers (Codex P1 on #2622). Shapes with no name of
+  // their own -- a bare expression statement, a destructuring `let` -- are
+  // what is left here now that an impl is keyed by trait AND type.
+  let mut dup_keys = 0
+  ki = 0
+  while ki < Array::length(a) {
+    match MutMap::get(wmap, oracle_stmt_key(Array::get(a, ki))) {
+      Some(widx) => if widx < 0 {
+        dup_keys = dup_keys + 1
+      } else {
+        ()
+      },
+      None => ()
     }
     ki = ki + 1
   }
@@ -3942,7 +4033,7 @@ fn oracle_keyed_line(a: Array[Stmt], trial: Array[Stmt], render: (Stmt) -> Strin
     }
     ki = ki + 1
   }
-  String::concat("  keyed missing=", String::concat(Int::to_string(missing), String::concat(" extra=", String::concat(Int::to_string(extra), String::concat(" copies=", String::concat(Int::to_string(copies), String::concat(" content=", String::concat(Int::to_string(content), String::concat(" renames=", String::concat(Int::to_string(renames), String::concat(" first_missing=", String::concat(first_missing, String::concat(" first_content=", String::concat(first_content, "\n"))))))))))))))
+  String::concat("  keyed missing=", String::concat(Int::to_string(missing), String::concat(" extra=", String::concat(Int::to_string(extra), String::concat(" copies=", String::concat(Int::to_string(copies), String::concat(" content=", String::concat(Int::to_string(content), String::concat(" renames=", String::concat(Int::to_string(renames), String::concat(" dup_keys=", String::concat(Int::to_string(dup_keys), String::concat(" first_missing=", String::concat(first_missing, String::concat(" first_content=", String::concat(first_content, "\n"))))))))))))))))
 }
 
 /// One step of the oracle: pass `k`. `a` is the whole-program state after

--- a/lib/@vibe/compiler/codegen/wasi/linked_compile.vibe
+++ b/lib/@vibe/compiler/codegen/wasi/linked_compile.vibe
@@ -3937,6 +3937,140 @@ fn oracle_keyed_line(a: Array[Stmt], trial: Array[Stmt], render: (Stmt) -> Strin
 /// diff=<count> first=<index> file=<id> status=same|differs`, followed on a
 /// difference by the two renderings' heads. `render` is the AST printer (this
 /// package cannot reach @vibe/compiler/syntax; the caller passes it).
+/// #2388: the WHOLE prelude per module, in one run.
+///
+/// `prelude_pass_module_oracle_step` answers "is pass k per-module-safe when
+/// every earlier pass ran whole-program" -- it advances the split side through
+/// 0..k-1 as one program and only splits for pass k. The driver this epic is
+/// heading for needs the stronger property: each module goes through EVERY
+/// pass alone, and the results are linked. A pass can be safe under the first
+/// question and not under the second, because per-module output of an earlier
+/// pass is what a later one then reads.
+///
+/// So this splits ONCE and never runs a pass whole-program on the split side.
+/// The one pass with a per-module entry (`desugar_trait_dicts_module`) gets
+/// each module's dependency interface, taken after the passes before it have
+/// run per module -- the same pre-pass, declaration-only form the step oracle
+/// uses, and the form a `.vpkg` contract carries.
+///
+/// Returns `FULL stmts=<whole> split=<trial>` plus the keyed line, which is the
+/// verdict: per-module synthesis lands at each module's position and repeats a
+/// program-level helper per module, so position and count are not the answer.
+export fn prelude_module_full_oracle_line(a: Array[Stmt], c: Array[Stmt], c_file_id: Array[Int], file_count: Int, entry_name: String, checker_eq_offsets: Array[Int], checker_eq_type_keys: Array[String], render: (Stmt) -> String) -> String with Exception {
+  let entry_fid = file_count - 1
+  let mut k = 0
+  while k < 17 {
+    oracle_apply_pass(k, a, entry_name, checker_eq_offsets, checker_eq_type_keys)
+    k = k + 1
+  }
+  let parts: Array[Array[Stmt]] = []
+  let mut fi = 0
+  while fi < file_count {
+    Array::push(parts, array_empty())
+    fi = fi + 1
+  }
+  let mut si = 0
+  while si < Array::length(c) {
+    let part = Array::get(parts, Array::get(c_file_id, si))
+    Array::push(part, Array::get(c, si))
+    si = si + 1
+  }
+  // Everything before the trait-dict entry, per module.
+  fi = 0
+  while fi < file_count {
+    let part_entry = if fi == entry_fid {
+      entry_name
+    } else {
+      ""
+    }
+    let mut j = 0
+    while j < 4 {
+      oracle_apply_pass(j, Array::get(parts, fi), part_entry, checker_eq_offsets, checker_eq_type_keys)
+      j = j + 1
+    }
+    fi = fi + 1
+  }
+  let ifaces: Array[Array[Stmt]] = []
+  let mut pf = 0
+  while pf < file_count {
+    let src = Array::get(parts, pf)
+    let dst: Array[Stmt] = []
+    let mut ps = 0
+    while ps < Array::length(src) {
+      if oracle_is_interface_stmt(Array::get(src, ps)) {
+        Array::push(dst, oracle_interface_form(Array::get(src, ps)))
+      } else {
+        ()
+      }
+      ps = ps + 1
+    }
+    Array::push(ifaces, dst)
+    pf = pf + 1
+  }
+  // The trait-dict entry with that interface, then the rest of the prelude,
+  // per module.
+  fi = 0
+  while fi < file_count {
+    let part_entry = if fi == entry_fid {
+      entry_name
+    } else {
+      ""
+    }
+    let part = Array::get(parts, fi)
+    let own_keys: MutMap[String, Int] = MutMap::new_string()
+    let mut ok = 0
+    while ok < Array::length(part) {
+      MutMap::set(own_keys, oracle_stmt_key(Array::get(part, ok)), 1)
+      ok = ok + 1
+    }
+    let ctx: Array[Stmt] = []
+    let mut cj = 0
+    while cj < file_count {
+      if cj == fi {
+        ()
+      } else {
+        let other = Array::get(ifaces, cj)
+        let mut ci = 0
+        while ci < Array::length(other) {
+          let cs = Array::get(other, ci)
+          if MutMap::has(own_keys, oracle_stmt_key(cs)) {
+            ()
+          } else {
+            Array::push(ctx, cs)
+          }
+          ci = ci + 1
+        }
+      }
+      cj = cj + 1
+    }
+    let synthesized = desugar_trait_dicts_module(part, ctx, "f\{fi}", checker_eq_offsets, checker_eq_type_keys)
+    let mut sy = 0
+    while sy < Array::length(synthesized) {
+      Array::push(part, Array::get(synthesized, sy))
+      sy = sy + 1
+    }
+    let mut j2 = 5
+    while j2 < 17 {
+      oracle_apply_pass(j2, part, part_entry, checker_eq_offsets, checker_eq_type_keys)
+      j2 = j2 + 1
+    }
+    fi = fi + 1
+  }
+  let trial: Array[Stmt] = []
+  fi = 0
+  while fi < file_count {
+    let part = Array::get(parts, fi)
+    let mut oi = 0
+    while oi < Array::length(part) {
+      Array::push(trial, Array::get(part, oi))
+      oi = oi + 1
+    }
+    fi = fi + 1
+  }
+  let line = String::concat("FULL stmts=", String::concat(Int::to_string(Array::length(a)), String::concat(" split=", String::concat(Int::to_string(Array::length(trial)), "\n"))))
+  String::concat(line, oracle_keyed_line(a, trial, render))
+}
+
 export fn prelude_pass_module_oracle_step(k: Int, a: Array[Stmt], c: Array[Stmt], c_file_id: Array[Int], file_count: Int, entry_name: String, checker_eq_offsets: Array[Int], checker_eq_type_keys: Array[String], render: (Stmt) -> String) -> String with Exception {
   let entry_fid = file_count - 1
   let mut file_of = c_file_id

--- a/lib/@vibe/compiler/codegen/wasi/linked_compile.vibe
+++ b/lib/@vibe/compiler/codegen/wasi/linked_compile.vibe
@@ -3866,6 +3866,14 @@ fn oracle_is_interface_stmt(s: Stmt) -> Bool {
 fn oracle_interface_form(s: Stmt) -> Stmt {
   match s {
     SLet(exported, is_rec, name, ty, EFn(tps, bounds, params, ret, eff, _)) => SLet(exported, is_rec, name, ty, EFn(tps, bounds, params, ret, eff, EUnit)),
+    // A non-function value loses its initializer too. `export let config:
+    // Config = …` used to go into the context whole, and `dtd_run` reads
+    // initializers (`collect_local_binder_names`,
+    // `collect_toplevel_constructor_vars`), so the split run could make a
+    // rewrite by inspecting a dependency's implementation -- which a `.vpkg`,
+    // carrying `let config: Config` and nothing else, does not expose (Codex
+    // P1 on #2622).
+    SLet(exported, is_rec, name, ty, _) => SLet(exported, is_rec, name, ty, EUnit),
     _ => s
   }
 }

--- a/lib/@vibe/compiler/codegen/wasi/linked_compile.vibe
+++ b/lib/@vibe/compiler/codegen/wasi/linked_compile.vibe
@@ -3749,22 +3749,32 @@ fn oracle_head(s: String) -> String {
 
 /// #2388: a module's dependency interface as the per-module pass sees it --
 /// what another file contributes without its bodies being compiled here:
-/// type, trait, suberror and impl declarations, and every top-level
-/// definition (a function's signature drives witness threading at a call
-/// site and the exception kind of a throw whose payload it returns; an
+/// EXPORTED type, trait, suberror and impl declarations, and exported
+/// top-level definitions (a function's signature drives witness threading at a
+/// call site and the exception kind of a throw whose payload it returns; an
 /// explicit `T::op` suppresses a derive). Bodies ride along unread: the
 /// module entry never rewrites or emits a context statement, which is the
 /// bodyless form a `.vpkg` contract carries.
+///
+/// The export test is the point. This used to admit PRIVATE declarations too,
+/// which made the oracle more permissive than any real driver -- `index.vpkg`
+/// is the bodyless PUBLIC boundary, so a pass reading a dependency's private
+/// declaration stayed green here while a per-module compile could not see it
+/// (Codex P1 on #2622).
 fn oracle_is_interface_stmt(s: Stmt) -> Bool {
   match s {
-    SEnum(_, _, _, _, _) => true,
-    SStruct(_, _, _, _, _, _) => true,
-    STypeAlias(_, _, _, _) => true,
-    SSuberror(_, _, _) => true,
-    STrait(_, _, _, _, _, _) => true,
+    SEnum(exported, _, _, _, _) => exported,
+    SStruct(exported, _, _, _, _, _) => exported,
+    STypeAlias(exported, _, _, _) => exported,
+    SSuberror(exported, _, _) => exported,
+    STrait(exported, _, _, _, _, _) => exported,
+    // An impl carries no export flag and is not addressed by name: trait
+    // resolution is global, and a contract that dropped a dependency's impls
+    // would make its bounded generics unusable.
     SImpl(_, _, _, _) => true,
-    SLet(_, _, _, _, _) => true,
-    SLetMut(_, _, _) => true,
+    SLet(exported, _, _, _, _) => exported,
+    // A top-level mutable binding is never part of a package's surface.
+    SLetMut(_, _, _) => false,
     _ => false
   }
 }
@@ -4026,6 +4036,26 @@ export fn prelude_module_full_oracle_line(a: Array[Stmt], c: Array[Stmt], c_file
     let ctx: Array[Stmt] = []
     let mut cj = 0
     while cj < file_count {
+      // Every other file, which is WIDER than a real per-module compile sees.
+      // Two narrower rules were built and measured (Codex P1 on #2622), and
+      // neither holds at this granularity:
+      //
+      //  - "only files merged before this one" (dependencies precede
+      //    dependents) reports a false difference, because a `.vpkg`
+      //    contract is MATERIALIZED into a generated types file that the
+      //    merge lays FIRST, ahead of the implementation whose declarations
+      //    its own derives need: `PerceusAction::equals` then compares
+      //    `a.kind == b.kind` instead of calling `PerceusActionKind::equals`.
+      //  - grouping files into packages first does not exist to be had:
+      //    `collect_source_groups_fs` returns ONE group (`recursive`, 191
+      //    files) for the compiler closure, so there is no package partition
+      //    to split on.
+      //
+      // Exact import edges would settle it, and the merge drops `SImport`
+      // ("Skips SImport, SReExport (already resolved)"), so they have to come
+      // from the loader. That is filed on #2388 as what the per-module driver
+      // needs first, and until then this oracle's green is the weaker claim:
+      // no module needed anything the whole program did not have.
       if cj == fi {
         ()
       } else {
@@ -4067,7 +4097,7 @@ export fn prelude_module_full_oracle_line(a: Array[Stmt], c: Array[Stmt], c_file
     }
     fi = fi + 1
   }
-  let line = String::concat("FULL stmts=", String::concat(Int::to_string(Array::length(a)), String::concat(" split=", String::concat(Int::to_string(Array::length(trial)), "\n"))))
+  let line = String::concat("FULL stmts=", String::concat(Int::to_string(Array::length(a)), String::concat(" split=", String::concat(Int::to_string(Array::length(trial)), String::concat(" modules=", String::concat(Int::to_string(file_count), "\n"))))))
   String::concat(line, oracle_keyed_line(a, trial, render))
 }
 
@@ -4159,6 +4189,9 @@ export fn prelude_pass_module_oracle_step(k: Int, a: Array[Stmt], c: Array[Stmt]
       let ctx: Array[Stmt] = []
       let mut cj = 0
       while cj < file_count {
+        // Every other file -- wider than a real per-module compile sees; the
+        // full-sequence oracle above records the two narrower rules that were
+        // measured and why neither holds at file granularity.
         if cj == fi {
           ()
         } else {

--- a/lib/@vibe/compiler/entry/compiler/file_compile/file_compile.vibe
+++ b/lib/@vibe/compiler/entry/compiler/file_compile/file_compile.vibe
@@ -78,6 +78,7 @@ import @vibe/compiler/codegen/wasi {
   compile_wasi_module_with_sources_coverage_impl_with_typed_offsets,
   compile_wasi_module_with_sources_trace_impl_with_typed_offsets,
   effect_lowering_prelude,
+  prelude_module_full_oracle_line,
   prelude_pass_module_oracle_step
 }
 
@@ -520,6 +521,20 @@ export fn prelude_module_oracle_report_fs(entry_path: String, entry_name: String
     k = k + 1
   }
   report
+}
+
+/// #2388 measurement: the same closure through the WHOLE prelude per module.
+/// `prelude_module_oracle_report_fs` reports pass by pass from a whole-program
+/// state; this one splits once and runs every pass on each file alone, which is
+/// the property a real per-module driver needs. One `FULL ...` line plus the
+/// keyed comparison.
+export fn prelude_module_full_oracle_report_fs(entry_path: String, entry_name: String) -> String with Exception + Fs {
+  let source_groups = collect_source_groups_fs(entry_path)
+  let _ = prepare_file_fs_from_source_groups_persistent_cached(db_new(), entry_path, source_groups)
+  let (a, _, _, _) = prelude_oracle_merge(source_groups)
+  let (c, files, c_file_id, eq) = prelude_oracle_merge(source_groups)
+  let (eq_offs, eq_keys) = eq
+  prelude_module_full_oracle_line(a, c, c_file_id, Array::length(files), entry_name, eq_offs, eq_keys, print_stmt)
 }
 
 fn prelude_oracle_merge(source_groups: Array[(String, Array[(String, String)])]) -> (Array[Stmt], Array[String], Array[Int], (Array[Int], Array[String])) with Exception {

--- a/lib/@vibe/compiler/entry/compiler/file_compile/index.vpkg
+++ b/lib/@vibe/compiler/entry/compiler/file_compile/index.vpkg
@@ -40,6 +40,7 @@ fn compile_file_fs_mode(entry_path: String, entry_name: String, mode: String) ->
 fn compile_file_fs_mode_gc(entry_path: String, entry_name: String) -> Bytes with Exception + Fs
 fn compile_file_fs_mode_rc(entry_path: String, entry_name: String) -> Bytes with Exception + Fs
 fn prelude_module_oracle_report_fs(entry_path: String, entry_name: String, pass_limit: Int) -> String with Exception + Fs
+fn prelude_module_full_oracle_report_fs(entry_path: String, entry_name: String) -> String with Exception + Fs
 fn compile_file_fs_mode_rc_body_cached(entry_path: String, entry_name: String, cache_mode: String) -> Bytes with Exception + Fs
 // #1553 observation-only heap-mark lanes (VIBE_PROFILE_MEMORY_MARKS=1); same
 // pipelines as the respective RC/bump FS helpers, Env only for the runner's

--- a/lib/@vibe/compiler/tests/prelude_module_oracle_test.vibe
+++ b/lib/@vibe/compiler/tests/prelude_module_oracle_test.vibe
@@ -106,7 +106,7 @@ test "two files that each hoist a local lambda mint top-level names the other mo
   // says the copies agree); `missing=0 content=0` is the property under test:
   // every declaration the whole-program run produced is produced by the module
   // that owns it, under the same name and with the same body.
-  inspect(keyed_line_of(report, "desugar_trait_dicts_with_typed_eq"), content = "keyed missing=0 extra=0 copies=1 content=0 renames=0 first_missing= first_content=")
+  inspect(keyed_line_of(report, "desugar_trait_dicts_with_typed_eq"), content = "keyed missing=0 extra=0 copies=1 content=0 renames=0 dup_keys=2 first_missing= first_content=")
   // `evidence_dict_pass` synthesizes a dict struct per module the same way, so
   // its verdict is its keyed line too. It used to differ in CONTENT here: the
   // hoisted function was appended at the end of the merged program, the
@@ -115,7 +115,7 @@ test "two files that each hoist a local lambda mint top-level names the other mo
   // was threaded (`stmts=11 split=10`). With the hoist placing its output next
   // to its owner, the declarations agree and only the position of the one
   // synthesized struct is left.
-  inspect(keyed_line_of(report, "evidence_dict_pass"), content = "keyed missing=0 extra=0 copies=1 content=0 renames=0 first_missing= first_content=")
+  inspect(keyed_line_of(report, "evidence_dict_pass"), content = "keyed missing=0 extra=0 copies=1 content=0 renames=0 dup_keys=2 first_missing= first_content=")
   // What the rest of the report says on this program, as measured.
   let statuses: Array[String] = []
   let lines = oracle_lines(report)
@@ -144,5 +144,5 @@ test "the whole prelude per module reproduces the whole-program prelude" {
   // link-time dedup by name folds; `missing=0 extra=0 content=0` is the
   // property: every declaration the whole-program prelude produced is produced
   // by the module that owns it, with the same body.
-  inspect(String::trim(Array::get(lines, 1)), content = "keyed missing=0 extra=0 copies=1 content=0 renames=0 first_missing= first_content=")
+  inspect(String::trim(Array::get(lines, 1)), content = "keyed missing=0 extra=0 copies=1 content=0 renames=0 dup_keys=2 first_missing= first_content=")
 }

--- a/lib/@vibe/compiler/tests/prelude_module_oracle_test.vibe
+++ b/lib/@vibe/compiler/tests/prelude_module_oracle_test.vibe
@@ -1,5 +1,5 @@
 import @vibe/compiler/entry/compiler/file_compile {
-  prelude_module_oracle_report_fs
+  prelude_module_full_oracle_report_fs, prelude_module_oracle_report_fs
 }
 
 //# Functions
@@ -125,4 +125,24 @@ test "two files that each hoist a local lambda mint top-level names the other mo
     i = i + 1
   }
   inspect(String::join(statuses, ","), content = "same,same,same,same,same,same,same,same,same,same,same,same,same,same,same,differs,same")
+}
+
+// #2388: the same program through the WHOLE prelude per module, which is the
+// property a real per-module driver needs -- each module alone through every
+// pass, then linked. The pass-by-pass oracle above cannot answer it: it
+// advances the split side through the earlier passes as ONE program, so a pass
+// there never reads another pass's per-module output.
+test "the whole prelude per module reproduces the whole-program prelude" {
+  let helper_path = "/tmp/vibe_full_oracle_helper.vibe"
+  let main_path = "/tmp/vibe_full_oracle_main.vibe"
+  Fs::write_file(helper_path, "effect HLog {\n  Emit(String) -> Unit\n}\n\nexport fn helper_use() -> Int {\n  let f = (a: Int) -> Int with HLog {\n    perform HLog::Emit(\"helper\")\n    a\n  }\n  handle {\n    f(1)\n  } with {\n    HLog::Emit(_m) => resume(0)\n  }\n}\n")
+  Fs::write_file(main_path, "import ./vibe_full_oracle_helper.vibe {\n  helper_use\n}\n\neffect MLog {\n  Emit(String) -> Unit\n}\n\nfn main_use() -> Int {\n  let f = (a: Int) -> Int with MLog {\n    perform MLog::Emit(\"main\")\n    a + 1\n  }\n  handle {\n    f(2)\n  } with {\n    MLog::Emit(_m) => resume(0)\n  }\n}\n\ntest \"hoisted\" {\n  inspect(helper_use() + main_use(), content = \"4\")\n}\n")
+  let report = prelude_module_full_oracle_report_fs(main_path, "__no_entry__")
+  let lines = String::split(report, "\n")
+  inspect(String::trim(Array::get(lines, 0)), content = "FULL stmts=11 split=11")
+  // `copies=1` is the one program-level helper synthesized per module, which a
+  // link-time dedup by name folds; `missing=0 extra=0 content=0` is the
+  // property: every declaration the whole-program prelude produced is produced
+  // by the module that owns it, with the same body.
+  inspect(String::trim(Array::get(lines, 1)), content = "keyed missing=0 extra=0 copies=1 content=0 renames=0 first_missing= first_content=")
 }

--- a/lib/@vibe/compiler/tests/prelude_module_oracle_test.vibe
+++ b/lib/@vibe/compiler/tests/prelude_module_oracle_test.vibe
@@ -139,7 +139,7 @@ test "the whole prelude per module reproduces the whole-program prelude" {
   Fs::write_file(main_path, "import ./vibe_full_oracle_helper.vibe {\n  helper_use\n}\n\neffect MLog {\n  Emit(String) -> Unit\n}\n\nfn main_use() -> Int {\n  let f = (a: Int) -> Int with MLog {\n    perform MLog::Emit(\"main\")\n    a + 1\n  }\n  handle {\n    f(2)\n  } with {\n    MLog::Emit(_m) => resume(0)\n  }\n}\n\ntest \"hoisted\" {\n  inspect(helper_use() + main_use(), content = \"4\")\n}\n")
   let report = prelude_module_full_oracle_report_fs(main_path, "__no_entry__")
   let lines = String::split(report, "\n")
-  inspect(String::trim(Array::get(lines, 0)), content = "FULL stmts=11 split=11")
+  inspect(String::trim(Array::get(lines, 0)), content = "FULL stmts=11 split=11 modules=2")
   // `copies=1` is the one program-level helper synthesized per module, which a
   // link-time dedup by name folds; `missing=0 extra=0 content=0` is the
   // property: every declaration the whole-program prelude produced is produced


### PR DESCRIPTION
The measurement #2388 needs before a real per-module driver is built (parent epic #2386), and its answer on the compiler's own closure.

## What was missing

`prelude_pass_module_oracle_step` advances the split side through passes 0..k-1 as **one program** and only splits for pass k. That answers "is pass k per-module-safe *from a whole-program state*". A driver needs the stronger property: each module through **every** pass alone, then linked. A pass can be safe under the first question and not the second, because what a later pass reads is then an earlier pass's per-module output — which is exactly how the hoist attribution bug in [#2620](https://github.com/mizchi/vibe-lang/pull/2620) reached `evidence_dict_pass`.

## What this adds

`prelude_module_full_oracle_line` splits once and never runs a pass whole-program on the split side. The one pass with a per-module entry (`desugar_trait_dicts_module`) gets each module's dependency interface, taken after the passes before it have run per module. `prelude_module_full_oracle_report_fs` drives it over an entry's closure and reports one `FULL …` line plus the keyed comparison.

## Measured

| program | line | keyed |
|---|---|---|
| two-file (both files hoist an effectful local `f`) | `FULL stmts=11 split=11 modules=2` | `missing=0 extra=0 copies=1 content=0 renames=0 dup_keys=2` |
| **compiler closure** (`codegen_lexer_test.vibe`, 189 files) | `FULL stmts=4763 split=4835 modules=191` | `missing=0 extra=0 copies=321 content=0 renames=0 dup_keys=254` |

On the compiler's own closure, **every declaration the whole-program prelude produces is produced by the module that owns it, with the same body** — and, after the review rounds below, **from its dependencies' declarations alone**. The 72-statement difference is the per-module helper duplication a link-time dedup by name folds (`copies`).

## What the review rounds changed, and what they measured

Codex found seven things across five rounds; all of them are the same family — *the simulated boundary is wider than a real one*. Each fix was measured on the closure rather than argued:

| finding | outcome |
|---|---|
| private declarations in the interface | exported-only; closure **unchanged** |
| unannotated functions kept their bodies | dropped; closure **unchanged** |
| non-function values kept their initializers | dropped; closure **unchanged** |
| impls all keyed `impl:Eq` | keyed by trait **and** type; `copies` 328 → 321 |
| duplicate keys silently skip the content check | reported as `dup_keys=` (254 of 4,763 on the closure) |
| context is every other file, not the imported ones | **not fixed** — two candidate rules built and measured, neither sound at this granularity (below) |
| passes 9 and 2 do not receive linked imports / artifact authorization | **not fixed** — latent false `differs`, both unfired, same missing metadata |

The three "unchanged" rows together say something stronger than this PR opened with: on this corpus the per-module property does not rest on any dependency implementation detail.

The context restriction has no sound expression at file granularity: "only files merged before this one" reports a **false** difference (a `.vpkg` is materialized into a generated types file the merge lays ahead of the implementation its own derives read — `PerceusAction::equals`), and there is no package partition to group on (`collect_source_groups_fs` returns one `recursive` group of 191 files). Exact import edges would settle it and the merge drops `SImport`, so they must come from the loader. That, and the linked-imports/authorization metadata, are now the first item on the #2388 line — [written up there](https://github.com/mizchi/vibe-lang/issues/2388#issuecomment-5624740433), with the measurements, and in the code where the context is built.

## Validation

- `lib/@vibe/compiler/tests/prelude_module_oracle_test.vibe` pins the two-file case (3 tests); `desugar_trait_dicts_module_test.vibe` (10) and `fixtures/hoisted_lambda_owner_names_test.vibe` (2, linear and gc lanes) pass.
- The closure run is minutes long, so its numbers are recorded here and on #2388 rather than in the suite.
- stage0 → stage1 → stage2 selfhost build clean at every step; `scripts/vibe_fmt.sh --check` clean on every changed file; CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NAeZzkckdAwtQiubBFpdmM