### PR TITLE
builtin/option: `Eq` has one declaration, not two (#2523 step 1)

### DIFF
--- a/lib/@vibe/builtin/option.vibe
+++ b/lib/@vibe/builtin/option.vibe
@@ -6,15 +6,15 @@ export {
   Option
 }
 
-export trait Eq
-
-impl Eq for Int
-
-impl Eq for Double
-
-impl Eq for Bool
-
-impl Eq for String
+// #2523 step 1: `Eq` has ONE declaration, in `./builtin_traits.vibe`. This
+// file used to re-declare it as a second marker (plus duplicates of the four
+// scalar impls that file already carries), which made the two definitions
+// conflict the moment either grew a method -- `trait 'Eq' has two different
+// definitions` on every consumer of the package. The `Option` impl is what
+// this file actually owns, and it travels with the imported declaration.
+import ./builtin_traits.vibe {
+  Eq
+}
 
 impl [T: Eq] Eq for Option[T]
 


### PR DESCRIPTION
Refs #2523. The prerequisite its fix direction needs, landed on its own and with no behaviour change.

## What

`lib/@vibe/builtin/option.vibe` re-declared `export trait Eq` as a second marker, plus duplicates of four scalar impls that `builtin_traits.vibe` already carries. It now imports the one declaration and keeps only the impl it actually owns, `impl [T: Eq] Eq for Option[T]`.

## Why it is a prerequisite — measured, not assumed

With the duplicate in place, giving `builtin_traits.vibe`'s `Eq` a method fails **every** consumer of the package:

```
lib/@vibe/builtin/builtin.vibe: trait 'Eq' has two different definitions:
'lib/@vibe/builtin/builtin_traits.vibe::Eq' and 'lib/@vibe/builtin/option.vibe::Eq'
— alias one with 'trait Eq as <NewName>' or import only one
```

With the dedupe, the same method-bearing spike compiles and its consumers pass. I verified both directions and then reverted the spike; this PR carries the dedupe alone.

## What it deliberately does NOT do

`Eq` stays a marker, so the #2612 guard (`marker_cmp_bound_is_unsound`) keeps firing and `[T: Eq]` at a non-scalar instantiation is still refused.

That order is the point, and it is [recorded on the issue](https://github.com/mizchi/vibe-lang/issues/2523#issuecomment-5624306113). The guard tests `trait_is_marker`, so adding the method **first** would stand it down while nothing dispatches — measured: `bare(p1, p2)` on two equal, distinct `Pt` answers `false` again. The operator-to-witness lowering has to exist before `Eq` grows a method, or today's clear refusal becomes a silently wrong answer.

## Verified

- all 22 `lib/@vibe/builtin` test files — 191 tests
- all four `compiler_gate.sh` lanes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q9zbiDqkfF7xYQ3v8aCQ3b

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q9zbiDqkfF7xYQ3v8aCQ3b)_