### PR TITLE
scripts: a `test "X"` block label is not a declaration of X (#2378)

### DIFF
--- a/scripts/builtin_shadowing_allowlist.txt
+++ b/scripts/builtin_shadowing_allowlist.txt
@@ -16,14 +16,10 @@ Fs::exists pre-existing, unmeasured: kind 13 value alias in lib/@vibe/fs/fs.vibe
 Fs::read_file pre-existing, unmeasured: kind 13 value alias in lib/@vibe/fs/fs.vibe
 Fs::stat_token pre-existing, unmeasured: kind 13 value alias in lib/@vibe/fs/fs.vibe
 Fs::write_file pre-existing, unmeasured: kind 13 value alias in lib/@vibe/fs/fs.vibe
-Int::clz pre-existing: helper in lib/@vibe/builtin/int_test.vibe, a test file, so the override is scoped to that test program
-Int::ctz pre-existing: helper in lib/@vibe/builtin/int_test.vibe, same scope
-Int::popcount pre-existing: helper in lib/@vibe/builtin/int_test.vibe, same scope
 __compact_fingerprint_hash pre-existing, unmeasured: defined in lib/@vibe/cache/cache.vibe
 __to_string DELIBERATE: the ADR-0091 polyfills in lib/@vibe/compiler/core/polyfill.vibe and lib/@vibe/parser/polyfill.vibe override it on purpose (#2378 names this as the legitimate-override case)
 compiler_sources generated: lib/@vibe/compiler/compiler_sources_bundle.vibe is produced by scripts/generate_bundle.sh, not hand-written
 eq pre-existing, UNMEASURED and flagged by #2378: lib/@vibe/builtin/float.vibe (kind 13) and lib/@vibe/semver/semver.vibe (kind 12) both define it, and structural equality lowers through a builtin of this name
-not pre-existing: helper in lib/@vibe/compiler/tests/lexer_edge_test.vibe, a test file
 print pre-existing, flagged by #2378: lib/@vibe/console/io.vibe and lib/@vibex/shell/commands.vibe both define it
 println pre-existing, flagged by #2378: lib/@vibe/console/io.vibe and lib/@vibex/shell/commands.vibe both define it
 resolve_path pre-existing, unmeasured: lib/@vibe/module/path.vibe and lib/@vibe/compiler/entry/compiler/fs_compile/closure_order.vibe both define it

--- a/scripts/check_builtin_shadowing.sh
+++ b/scripts/check_builtin_shadowing.sh
@@ -181,7 +181,49 @@ fi
 # Declarations that BIND a value: KIND 12 (Function) and 13 (Variable). 13 is
 # the one a regex misses (`export let Fs::exists = exists`).
 awk '$3 == 12 || $3 == 13 { print $2 }' "$SYMS" | sort -u > "$WORK/declared.txt"
-comm -12 "$WORK/registry.txt" "$WORK/declared.txt" > "$WORK/found.txt"
+comm -12 "$WORK/registry.txt" "$WORK/declared.txt" > "$WORK/found_raw.txt"
+
+# A `test "X"` / `bench "X"` BLOCK is not a declaration of X.
+#
+# `vibe symbols` gives a block its quoted label under kind 12 on purpose --
+# `symbol_spans.vibe`'s own header says "Tests/benches use Function (12) --
+# LSP has no Test kind" -- and this gate read those labels as definitions.
+# Measured before this filter: `lib/@vibe/builtin/int_test.vibe` contributed
+# `Int::popcount`, `Int::ctz` and `Int::clz` from `test "Int::popcount" { ... }`
+# and its two siblings, and all three sat on the allowlist with a reason
+# ("helper in ... a test file, so the override is scoped to that test program")
+# describing a shadow that does not exist. A gate that reports three things
+# that are not happening is a gate whose output nobody can read.
+#
+# The test is lexical and cheap: a block label's span starts INSIDE the quotes,
+# so the byte before START is `"`. No declaration's name can have one there --
+# `fn`, `let`, `export let` and `impl` all put an identifier character or a
+# space before the name. Only the handful of rows whose name the registry
+# already owns is inspected, so the cost is bounded by the intersection, not by
+# the 18k-row sweep.
+awk 'NR == FNR { want[$1] = 1; next } ($3 == 12 || $3 == 13) && ($2 in want) { print $1, $2, $4 }' \
+  "$WORK/found_raw.txt" "$SYMS" > "$WORK/cand_rows.txt"
+: > "$WORK/real.txt"
+while IFS=' ' read -r cand_path cand_name cand_start || [ -n "$cand_path" ]; do
+  [ -n "$cand_path" ] || continue
+  # A span at offset 0 has no preceding byte, so it cannot be a quoted label.
+  if [ "$cand_start" -gt 0 ] 2>/dev/null; then
+    prev="$(dd if="$cand_path" bs=1 skip=$((cand_start - 1)) count=1 2>/dev/null)"
+    [ "$prev" = '"' ] && continue
+  fi
+  printf '%s\n' "$cand_name" >> "$WORK/real.txt"
+done < "$WORK/cand_rows.txt"
+sort -u "$WORK/real.txt" -o "$WORK/real.txt"
+comm -12 "$WORK/found_raw.txt" "$WORK/real.txt" > "$WORK/found.txt"
+
+# Silence about a row this filter could not resolve would be indistinguishable
+# from "no shadowing". Every candidate row must have produced a verdict.
+if [ "$(wc -l < "$WORK/cand_rows.txt" | tr -d ' ')" -eq 0 ] && [ -s "$WORK/found_raw.txt" ]; then
+  echo "builtin-shadowing: FAIL: $(wc -l < "$WORK/found_raw.txt" | tr -d ' ') registry names are declared," >&2
+  echo "  but the test/bench-label filter matched no rows for any of them. That is an" >&2
+  echo "  unchecked tree, not a clean one." >&2
+  exit 1
+fi
 
 # Allowlist: `<name> <reason...>`. A row with no reason is rejected -- an
 # unexplained exemption is how a list like this goes stale unnoticed.

--- a/scripts/check_builtin_shadowing_test.sh
+++ b/scripts/check_builtin_shadowing_test.sh
@@ -53,6 +53,35 @@ else
   bad "the clean control was rejected: $out"
 fi
 
+# --- 1b. a `test "<builtin name>"` BLOCK is not a declaration ----------------
+# `vibe symbols` reports a test/bench block under its quoted label with kind 12
+# (LSP has no Test kind), and the gate used to read those labels as
+# definitions: four allowlist rows described shadows that did not exist. The
+# pair below is what makes the filter meaningful -- the block must be ACCEPTED
+# while a real definition of the same name in the same tree is still REJECTED,
+# so "accepted" cannot be coming from the gate having stopped looking.
+fresh_tree "$TREE"; empty_allowlist "$ALLOW"
+printf 'test "String::length" {\n  assert(true)\n}\n' > "$TREE/label_test.vibe"
+if ! grep -q 'test "String::length"' "$TREE/label_test.vibe"; then
+  bad "mutation 1b did not land"
+elif out="$(run_gate "$TREE" "$ALLOW")"; then
+  ok "a test block LABELLED with a builtin name is not a shadow"
+else
+  bad "a test block label was reported as a shadow: $out"
+fi
+
+# ...and the same tree, plus one real definition, must still fail.
+printf 'export fn String::length(s: String) -> Int {\n  -1\n}\n' > "$TREE/real_def.vibe"
+if ! grep -q 'fn String::length' "$TREE/real_def.vibe"; then
+  bad "mutation 1b-pair did not land"
+elif out="$(run_gate "$TREE" "$ALLOW")"; then
+  bad "a real definition beside a test label was accepted: $out"
+elif printf '%s' "$out" | grep -q 'String::length'; then
+  ok "a real definition beside a test label is still rejected, and named"
+else
+  bad "rejected without naming String::length: $out"
+fi
+
 # --- 1. kind 12: a `fn` shadowing a builtin ---------------------------------
 fresh_tree "$TREE"; empty_allowlist "$ALLOW"
 printf 'export fn String::length(s: String) -> Int {\n  -1\n}\n' > "$TREE/shadow_fn.vibe"


### PR DESCRIPTION
Refs #2378. `check_builtin_shadowing.sh` was reporting four shadows that do not exist.

## What was wrong

The gate read every kind-12 symbol as a definition that could shadow a builtin. `vibe symbols` gives a test/bench **block** its quoted label under kind 12 on purpose — `symbol_spans.vibe`'s own header says *"Tests/benches use Function (12) — LSP has no Test kind"* — so four block labels were counted as declarations:

| reported name | what is actually there | file |
|---|---|---|
| `Int::popcount` | `test "Int::popcount" { … }` | `lib/@vibe/builtin/int_test.vibe` |
| `Int::ctz` | `test "Int::ctz" { … }` | same |
| `Int::clz` | `test "Int::clz" { … }` | same |
| `not` | `test "not" { … }` | `lib/@vibe/compiler/tests/lexer_edge_test.vibe` |

All four sat on `scripts/builtin_shadowing_allowlist.txt` with a reason describing a shadow that was never there — *"helper in … a test file, so the override is scoped to that test program"*. A gate that reports four things that are not happening is a gate whose output nobody reads carefully, which is how a real fifth row goes unnoticed.

## The test

Lexical and cheap: a block label's span starts **inside** the quotes, so the byte before `START` is `"`, and no declaration's name can have one there (`fn`, `let`, `export let`, `impl` all put an identifier character or a space before the name).

It runs only over rows whose name the registry already owns, so the cost is bounded by the intersection rather than by the 18k-row sweep. A candidate set that produces no verdicts **fails** rather than passing as clean — silence and "no shadowing" must not look the same.

## The allowlist shrinks 15 → 11

It is a ratchet, so the rows had to go with the fix: the gate rejects an allowlisted name that is no longer declared. That is what turned up `not` — it was not one of the three I set out to remove, and the ratchet found it for me.

## Red test

With the filter disabled, **exactly** the new case fails:

```
FAIL: a test block label was reported as a shadow
ok:   a real definition beside a test label is still rejected, and named
```

The pair matters: the same tree gains a real `export fn String::length` and must still be rejected, so the acceptance in the first case cannot be the gate having gone blind.

Self-test 9 cases → 11. `check_gate_portability.sh` and `check_gate_self_tests.sh` both ok (the filter uses `dd`/`awk`/`comm`, no ripgrep, no bare `sed -i`). All four `compiler_gate.sh` lanes green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q9zbiDqkfF7xYQ3v8aCQ3b

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q9zbiDqkfF7xYQ3v8aCQ3b)_