### PR TITLE
fixtures: a control beside the owned-scalar refusals (#2475)

### DIFF
--- a/fixtures/structural_eq_owned_scalar_control_test.vibe
+++ b/fixtures/structural_eq_owned_scalar_control_test.vibe
@@ -1,0 +1,58 @@
+//# #2475: the CONTROL for `structural_eq_owned_scalar_*_refused.vibe`.
+//#
+//# Those five fixtures prove that a program declaring `struct Int` REFUSES the
+//# comparison rather than guessing which `Int` a literal-derived shape means.
+//# On their own they prove only that something stopped: any breakage that makes
+//# the compiler refuse satisfies them, and so does a fix that refuses more
+//# rather than answering more.
+//#
+//# This file is the same five shapes with the ownership removed -- `struct Foo`
+//# instead of `struct Int` -- and it asserts they ANSWER, both ways round.
+//#
+//# What it guards, precisely: the eventual fix (#2475's builtin-scalar marker)
+//# changes what a program that OWNS the spelling does, and must leave every
+//# other program exactly as it is. Marking runs through shared producers --
+//# `dtd_scalar_shape`, `self_describing_fallback`, `infer_static_eq_type` --
+//# that every program uses, so "the owning program improved" and "no other
+//# program moved" are two different claims and this file is the second one.
+//#
+//# What it does NOT guard: the owning program's own behaviour. Measured while
+//# attempting the marker three times -- two attempts left every refusal in
+//# place while this control stayed green, and one moved three of the five owned
+//# fixtures from a clean refusal to `field access .value on a non-struct value`
+//# while this control STILL stayed green. Progress on the owned side is shown
+//# only by those fixtures moving from refused to answering, verified by running
+//# them.
+
+struct Foo {
+  value: String
+} derive (Eq)
+
+test "array literals answer when no `Int` is owned" {
+  assert(!([1] == [2]))
+  assert([1] == [1])
+}
+
+test "Some payloads answer when no `Int` is owned" {
+  assert(!(Some(1) == Some(2)))
+  assert(Some(1) == Some(1))
+  let a = Some(1)
+  let b = Some(2)
+  assert(!(a == b))
+}
+
+test "tuple literals answer when no `Int` is owned" {
+  assert(!((1, "a") == (2, "a")))
+  assert((1, "a") == (1, "a"))
+}
+
+test "untyped-empty pushes answer when no `Int` is owned" {
+  let left = []
+  Array::push(left, 1)
+  let right = []
+  Array::push(right, 2)
+  assert(!(left == right))
+  let same = []
+  Array::push(same, 1)
+  assert(left == same)
+}


### PR DESCRIPTION
Refs #2475. No compiler change — one fixture.

## Why

`structural_eq_owned_scalar_*_refused.vibe` prove that a program declaring `struct Int` **refuses** the comparison rather than guessing which `Int` a literal-derived shape means. On their own they prove only that *something stopped*: any breakage that makes the compiler refuse satisfies them, and so does a change that refuses more rather than answering more.

This adds the same five shapes with the ownership removed — `struct Foo` instead of `struct Int` — asserting they answer, both ways round (unequal is `false`, equal is `true`).

## What it guards, precisely

#2475's fix marks literals through shared producers (`dtd_scalar_shape`, `self_describing_fallback`, `infer_static_eq_type`) that **every** program uses. So "the owning program improved" and "no other program moved" are two different claims, and this file is the second one.

## What it deliberately does NOT guard

Stated in the fixture's own header, because I measured it. Attempting the marker three times:

- two attempts left every owned refusal in place while this control stayed green;
- one moved three of the five owned fixtures from a clean refusal to `field access .value on a non-struct value` — and this control **still** stayed green.

Progress on the owned side is shown only by those fixtures moving from refused to answering, verified by running them. Writing that limitation into the fixture is the point: a control believed to prove more than it does is how the next attempt gets certified.

## Verified

- 4 tests pass on the fixture itself
- auto-discovered by the fixture-execution gate (520 → 522 test-block fixtures, all accounted for)
- all four `compiler_gate.sh` lanes green
- `vibe fmt --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q9zbiDqkfF7xYQ3v8aCQ3b

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q9zbiDqkfF7xYQ3v8aCQ3b)_