### PR TITLE
check: report a qualified `fn` definition of a builtin name (#2378)

### DIFF
--- a/lib/@vibe/compiler/cli_adapter.vibe
+++ b/lib/@vibe/compiler/cli_adapter.vibe
@@ -114,6 +114,7 @@ import @vibe/compiler/syntax {
 }
 
 import ./cli_support.vibe {
+  check_builtin_shadowing_warnings_from_source_groups,
   check_deprecated_warnings_from_source_groups,
   check_linked_file_source_groups,
   check_redundant_import_warnings_from_source_groups,
@@ -1354,6 +1355,18 @@ fn cli_main_with_lanes(fs_lanes: (FsLane, String, String) -> (Bytes, String) wit
         StringBuilder::push(out_text, Array::get(redundant_import_warns, rwi))
         StringBuilder::push(out_text, "\n")
         rwi = rwi + 1
+      }
+      // #2378: a qualified `fn` definition of a builtin name replaces that
+      // builtin program-wide, including in files that never import it, and
+      // until now nothing said so -- which is the "silently wrong" property
+      // that made it P0. A WARNING rather than a rejection: it breaks no
+      // existing program, and the reject-vs-warn choice stays open above it.
+      let builtin_shadow_warns = check_builtin_shadowing_warnings_from_source_groups(input_path, checked_source_groups)
+      let mut bwi = 0
+      while bwi < Array::length(builtin_shadow_warns) {
+        StringBuilder::push(out_text, Array::get(builtin_shadow_warns, bwi))
+        StringBuilder::push(out_text, "\n")
+        bwi = bwi + 1
       }
       // Unstable-surface warnings (ADR-0068). `docs/spec/stable-surface.md`
       // section 6 used to claim this surface "is reached only through

--- a/lib/@vibe/compiler/cli_support.vibe
+++ b/lib/@vibe/compiler/cli_support.vibe
@@ -13,7 +13,7 @@ import @vibe/compiler/codegen/common_base {
 }
 
 import @vibe/compiler/core {
-  Stmt, dir_of_path, executable_export_kept_bytes, is_contract_ext, unstable_package_note
+  Expr, Stmt, builtin_registry, dir_of_path, executable_export_kept_bytes, is_contract_ext, unstable_package_note
 }
 
 import @vibe/compiler/cache {
@@ -816,6 +816,82 @@ export fn check_redundant_import_warnings_from_source_groups(input_path: String,
       while i < Array::length(rows) {
         let (_, _, msg) = Array::get(rows, i)
         Array::push(out, locate_type_error(source, String::concat("warning: ", msg)))
+        i = i + 1
+      }
+      out
+    },
+    None => array_empty()
+  }
+}
+
+/// Does the builtin registry own `name`? Unfiltered on `checker_visible`, the
+/// same way `scripts/check_builtin_shadowing.sh` reads the registry: a
+/// definition colliding with a codegen-internal name is still a collision, and
+/// fail-closed is the direction this question wants.
+fn registry_owns_name(name: String) -> Bool {
+  let rows = builtin_registry()
+  let mut i = 0
+  let mut found = false
+  while i < Array::length(rows) {
+    let (row_name, _, _, _, _) = Array::get(rows, i)
+    if row_name == name {
+      found = true
+      i = Array::length(rows)
+    } else {
+      i = i + 1
+    }
+  }
+  found
+}
+
+/// #2378: a qualified definition (`Type::method`) of a name the builtin
+/// registry owns replaces that builtin for the WHOLE linked program, including
+/// files that never import it -- and nothing said so.
+///
+/// The rule is narrow because the leak is. Measured: a BARE `fn eq` in a
+/// dependency does not leak (export namespacing renames every non-entry value
+/// def to `name_exp_<path>`), while `fn String::index_of` does.
+/// `append_export_def_name` excludes a name containing `::` from that rename on
+/// purpose -- `collect_export_def_value_names`'s doc comment says "ordinary
+/// `Type::method` lets remain global receiver dispatch" -- so this shape, and
+/// only this shape, is program-wide.
+///
+/// A VALUE ALIAS is exempt, and that is not a convenience: `lib/@vibe/fs/fs.vibe`
+/// records that `perform Fs::<Op>` lowers to a call of the builtin NAME
+/// `Fs::<op>`, that a real fn DEF occupying that name hijacks the lowering
+/// (measured there: an arity-broken wasm call), and that a bare value alias
+/// does not participate in that resolution at all. So `export let Fs::exists =
+/// exists` is a re-export of the builtin, while `export fn Fs::exists(..)` is a
+/// replacement of it. Only the second is reported.
+///
+/// Reported at the DEFINING file, which is where the edit goes. Measured
+/// against `lib/**`: zero rows today.
+export fn check_builtin_shadowing_warnings_from_source_groups(input_path: String, source_groups: Array[(String, Array[(String, String)])]) -> Array[String] with Exception + Fs {
+  let source = match checked_entry_source(input_path, source_groups) {
+    Some(snapshot) => snapshot,
+    None => return array_empty()
+  }
+  match checked_warning_stmts(input_path, source) {
+    Some(stmts) => {
+      let out = array_empty()
+      let mut i = 0
+      while i < Array::length(stmts) {
+        match Array::get(stmts, i) {
+          SLet(_, _, name, _, value) => {
+            let qualified = String::index_of(name, "::") > 0
+            let is_fn_def = match value {
+              EFn(_, _, _, _, _, _) => true,
+              _ => false
+            }
+            if qualified && is_fn_def && registry_owns_name(name) {
+              let tail = String::concat("` -- a qualified definition of a builtin name replaces that builtin for the whole linked program, including files that never import it. Use a different name, or `let ", String::concat(name, " = <builtin>` if you mean to re-export it."))
+              Array::push(out, locate_type_error(source, String::concat("warning: rename `", String::concat(name, tail))))
+            } else {
+              ()
+            }
+          },
+          _ => ()
+        }
         i = i + 1
       }
       out

--- a/lib/@vibe/compiler/index.vpkg
+++ b/lib/@vibe/compiler/index.vpkg
@@ -524,6 +524,7 @@ fn verify_culprit_off_marker_snapshot(input_path: String, source_groups: Array[(
 fn check_deprecated_warnings(input_path: String) -> Array[String] with Exception + Fs
 fn check_deprecated_warnings_from_source_groups(input_path: String, source_groups: Array[(String, Array[(String, String)])]) -> Array[String] with Exception + Fs
 fn check_redundant_import_warnings(input_path: String) -> Array[String] with Exception + Fs
+fn check_builtin_shadowing_warnings_from_source_groups(input_path: String, source_groups: Array[(String, Array[(String, String)])]) -> Array[String] with Exception + Fs
 fn check_redundant_import_warnings_from_source_groups(input_path: String, source_groups: Array[(String, Array[(String, String)])]) -> Array[String] with Exception + Fs
 fn check_unstable_surface_warnings_from_path(input_path: String) -> Array[String] with Exception + Fs
 fn check_unstable_surface_warnings_from_closure() -> Array[String] with Exception + Fs

--- a/tests/gates/early/run.sh
+++ b/tests/gates/early/run.sh
@@ -2039,6 +2039,55 @@ for eqrefuse_src in fixtures/structural_eq_untyped_empty_*_refused.vibe fixtures
     exit 1
   fi
 done
+# #2378: `vibe check` reports a qualified `fn` definition of a builtin name.
+#
+# The leak is narrow and so is the rule. Measured on the seed: a BARE `fn eq` in
+# a dependency does NOT leak (export namespacing renames every non-entry value
+# def to `name_exp_<path>`), while `fn String::index_of` DOES -- a caller that
+# imports only an unrelated name from that file gets the override, silently.
+# `append_export_def_name` excludes a name containing `::` from the rename on
+# purpose ("ordinary `Type::method` lets remain global receiver dispatch"), so
+# this shape, and only this shape, is program-wide.
+#
+# Three cases, not one. A gate that only asserts the warning fires would pass on
+# a rule that warns about everything; the two clean cases are what make it mean
+# something. The VALUE ALIAS case is the sharp one: `lib/@vibe/fs/fs.vibe`
+# records that a bare alias does not participate in the name-to-fn-def
+# resolution the lowering uses, while a real fn def does -- so an alias
+# re-exports the builtin and must stay silent.
+echo "[compiler-gate] a qualified fn definition of a builtin name is reported (#2378)"
+bsdir="_build/_gate_builtin_shadow_warn"
+rm -rf "$bsdir"; mkdir -p "$bsdir"
+printf 'export fn String::index_of(s: String, sub: String) -> Int {\n  0 - 999\n}\n' > "$bsdir/shadow_fn.vibe"
+printf 'fn my_index_of(s: String, sub: String) -> Int {\n  0 - 999\n}\n\nexport let String::index_of = my_index_of\n' > "$bsdir/alias.vibe"
+printf 'export fn eq(a: Int, b: Int) -> Bool {\n  false\n}\n' > "$bsdir/bare.vibe"
+bs_check() { # <src> <tag>
+  rm -f "$bsdir/$2.out" "$bsdir/$2.out.diag"
+  VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_CHECK_ONLY=1 VIBE_IMPORT_ABI=raw \
+    bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
+    "$1" "$bsdir/$2.out" "" >/dev/null 2>&1 || true
+}
+bs_check "$bsdir/shadow_fn.vibe" shadow_fn
+if ! grep -qF 'rename `String::index_of`' "$bsdir/shadow_fn.out" 2>/dev/null; then
+  echo "[compiler-gate] FAIL: a qualified fn definition of a builtin name was not reported (#2378)" >&2
+  cat "$bsdir/shadow_fn.out" "$bsdir/shadow_fn.out.diag" 2>/dev/null >&2; exit 1
+fi
+if ! grep -qE 'never import it' "$bsdir/shadow_fn.out" 2>/dev/null; then
+  echo "[compiler-gate] FAIL: the #2378 report does not say why the name is program-wide" >&2
+  cat "$bsdir/shadow_fn.out" >&2; exit 1
+fi
+bs_check "$bsdir/alias.vibe" alias
+if grep -qF 'rename `' "$bsdir/alias.out" 2>/dev/null; then
+  echo "[compiler-gate] FAIL: a VALUE ALIAS at a builtin name was reported; it re-exports the builtin (#2378)" >&2
+  cat "$bsdir/alias.out" >&2; exit 1
+fi
+bs_check "$bsdir/bare.vibe" bare
+if grep -qF 'rename `' "$bsdir/bare.out" 2>/dev/null; then
+  echo "[compiler-gate] FAIL: a BARE definition was reported; export namespacing already scopes it (#2378)" >&2
+  cat "$bsdir/bare.out" >&2; exit 1
+fi
+echo "[compiler-gate] qualified fn reported; value alias and bare name stay silent ok (#2378)"
+
 # The rungs that stay a RUNTIME trap. These fire while GENERATING a comparator
 # for a generic shape, not at a comparison the program performs -- the
 # compiler's own sources reach two of them (`List` and `AvlTree` at a formal

--- a/tests/gates/registry.tsv
+++ b/tests/gates/registry.tsv
@@ -47,6 +47,7 @@ x-parser-binder-context-spine	bootstrap	parser binder-context spine
 14c/14	early	14c/14 UFCS-on-bounded-tparam dict dispatch (#931)
 15/15	early	15/15 derive(Ord/Show) structural-generation regression
 15b/15	early	15b/15 extended derive (enum Ord/Show, Default, Eq, Hash + Map keys)
+x-builtin-shadow-qualified-fn-reported	early	a qualified fn definition of a builtin name is reported (#2378)
 x-structural-equality-untyped-empty-mutation-fail-	early	structural equality untyped-empty mutation fail-closed (#1681/#2157)
 x-untyped-empty-equality-answers-typed-channel	early	untyped-empty equality answers through the typed channel (#2391)
 x-untyped-empty-equality-unbounded-formal-rejected	early	untyped-empty equality on an unbounded formal is rejected at check time (#2474)


### PR DESCRIPTION
Refs #2378. The silence is the P0; this removes it.

## What

A definition of `String::index_of` replaces the builtin for the **whole linked program**, including files that never import it, and nothing said so. `vibe check` now reports it at the defining file:

```
warning: rename `String::index_of` -- a qualified definition of a builtin name
replaces that builtin for the whole linked program, including files that never
import it. Use a different name, or `let String::index_of = <builtin>` if you
mean to re-export it.
```

## Why the rule is exactly this narrow

Measured on the seed, same shape both times — a dep defines the name plus `unrelated_helper`, and the caller imports **only** `unrelated_helper`:

| definition in the dep | what the caller sees |
|---|---|
| `export fn String::index_of(..) -> Int { -999 }` | **-999** — the leak |
| `export fn eq(a: Int, b: Int) -> Bool { false }` | `true` — no leak |

Bare names are already per-file: export namespacing renames every non-entry value def to `name_exp_<path>`, and the compiled export table of the leaking program shows both spellings side by side. Qualified names are excluded from that rename **on purpose** — `collect_export_def_value_names`'s doc comment says *"ordinary `Type::method` lets remain global receiver dispatch"*. So `Type::method`, and only `Type::method`, is program-wide.

**A value alias is exempt**, and not as a convenience. `lib/@vibe/fs/fs.vibe` records that `perform Fs::<Op>` lowers to a call of the builtin *name* `Fs::<op>`, that a real `fn` def at that name hijacks the lowering (measured there as an arity-broken wasm call), and that a bare alias does not participate in that resolution at all. `export let Fs::exists = exists` re-exports the builtin; `export fn Fs::exists(..)` replaces it. Only the second is reported.

## A warning, not a rejection

It breaks no existing program, costs nothing at runtime (a registry lookup at check time — no emitted code), and leaves the reject-vs-warn question open above it. Measured against `lib/**`: **zero** rows fire today, so it is zero-noise.

## Gate: three rows, not one

A gate that only asserts the warning fires would pass on a rule that warns about everything. The two silent cases are what make it mean something, and the value-alias case is the sharp one.

Red-tested by making the collector return empty — exactly the "was not reported" case fails, while the value-alias and bare-name cases still pass.

All four `compiler_gate.sh` lanes green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q9zbiDqkfF7xYQ3v8aCQ3b

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q9zbiDqkfF7xYQ3v8aCQ3b)_