### PR TITLE
codegen: a module's oracle context is its real dependency closure (#2388)

### DIFF
--- a/lib/@vibe/compiler/codegen/wasi/index.vpkg
+++ b/lib/@vibe/compiler/codegen/wasi/index.vpkg
@@ -63,8 +63,8 @@ fn effect_lowering_prelude(stmts: Array[Stmt], entry_name: String, linked_import
 fn late_dce_prune_module(mod_bytes: Bytes) -> Bytes
 fn late_dce_prune_module_for(mod_bytes: Bytes, entry_name: String, exports_stripped: Bool) -> Bytes
 fn late_dce_prune_refusal() -> Int
-fn prelude_pass_module_oracle_step(k: Int, a: Array[Stmt], c: Array[Stmt], c_file_id: Array[Int], file_count: Int, entry_name: String, checker_eq_offsets: Array[Int], checker_eq_type_keys: Array[String], render: (Stmt) -> String) -> String with Exception
-fn prelude_module_full_oracle_line(a: Array[Stmt], c: Array[Stmt], c_file_id: Array[Int], file_count: Int, entry_name: String, checker_eq_offsets: Array[Int], checker_eq_type_keys: Array[String], render: (Stmt) -> String) -> String with Exception
+fn prelude_pass_module_oracle_step(k: Int, a: Array[Stmt], c: Array[Stmt], c_file_id: Array[Int], file_count: Int, dep_ids: Array[Array[Int]], entry_name: String, checker_eq_offsets: Array[Int], checker_eq_type_keys: Array[String], render: (Stmt) -> String) -> String with Exception
+fn prelude_module_full_oracle_line(a: Array[Stmt], c: Array[Stmt], c_file_id: Array[Int], file_count: Int, dep_ids: Array[Array[Int]], entry_name: String, checker_eq_offsets: Array[Int], checker_eq_type_keys: Array[String], render: (Stmt) -> String) -> String with Exception
 fn compile_wasi_module_replayed_impl(stmts: Array[Stmt], entry_name: String) -> Bytes with Exception
 fn compile_wasi_module_sliced_impl(stmts: Array[Stmt], entry_name: String) -> Bytes with Exception
 fn compile_wasi_module_rc_impl(stmts_in: Array[Stmt], entry_name: String) -> Bytes with Exception

--- a/lib/@vibe/compiler/codegen/wasi/linked_compile.vibe
+++ b/lib/@vibe/compiler/codegen/wasi/linked_compile.vibe
@@ -3620,6 +3620,30 @@ export fn effect_lowering_prelude(stmts: Array[Stmt], entry_name: String, linked
 /// a program onto `impl:Eq`, and a key that repeats is skipped by the content
 /// comparison -- so a per-module run could drop or change an implementation and
 /// still read `missing=0 content=0` (Codex P1 on #2622).
+/// Whether module `fi` may see module `cj`: `dep_ids[fi]` is fi's dependency
+/// closure as merge file ids. A file the caller could not place in the plan
+/// gets an empty row, which means it sees NOTHING rather than everything --
+/// a missing edge must narrow the context, never widen it, or the oracle
+/// answers about a module that had more than a driver would give it.
+fn oracle_ids_contain(dep_ids: Array[Array[Int]], fi: Int, cj: Int) -> Bool {
+  if fi < 0 || fi >= Array::length(dep_ids) {
+    false
+  } else {
+    let row = Array::get(dep_ids, fi)
+    let mut i = 0
+    let mut found = false
+    while i < Array::length(row) {
+      if Array::get(row, i) == cj {
+        found = true
+      } else {
+        ()
+      }
+      i = i + 1
+    }
+    found
+  }
+}
+
 fn oracle_type_key(t: TypeExpr) -> String {
   match t {
     TyName(n) => n,
@@ -4073,7 +4097,7 @@ fn oracle_keyed_line(a: Array[Stmt], trial: Array[Stmt], render: (Stmt) -> Strin
 /// Returns `FULL stmts=<whole> split=<trial>` plus the keyed line, which is the
 /// verdict: per-module synthesis lands at each module's position and repeats a
 /// program-level helper per module, so position and count are not the answer.
-export fn prelude_module_full_oracle_line(a: Array[Stmt], c: Array[Stmt], c_file_id: Array[Int], file_count: Int, entry_name: String, checker_eq_offsets: Array[Int], checker_eq_type_keys: Array[String], render: (Stmt) -> String) -> String with Exception {
+export fn prelude_module_full_oracle_line(a: Array[Stmt], c: Array[Stmt], c_file_id: Array[Int], file_count: Int, dep_ids: Array[Array[Int]], entry_name: String, checker_eq_offsets: Array[Int], checker_eq_type_keys: Array[String], render: (Stmt) -> String) -> String with Exception {
   let entry_fid = file_count - 1
   let mut k = 0
   while k < 17 {
@@ -4143,27 +4167,21 @@ export fn prelude_module_full_oracle_line(a: Array[Stmt], c: Array[Stmt], c_file
     let ctx: Array[Stmt] = []
     let mut cj = 0
     while cj < file_count {
-      // Every other file, which is WIDER than a real per-module compile sees.
-      // Two narrower rules were built and measured (Codex P1 on #2622), and
-      // neither holds at this granularity:
+      // This module's DEPENDENCY CLOSURE, not every other file: the edge set
+      // comes from `module_plan_data_fs`, the same resolved direct
+      // dependencies the check lane projects environments onto, closed
+      // transitively and mapped onto merge file ids by the caller.
       //
-      //  - "only files merged before this one" (dependencies precede
-      //    dependents) reports a false difference, because a `.vpkg`
-      //    contract is MATERIALIZED into a generated types file that the
-      //    merge lays FIRST, ahead of the implementation whose declarations
-      //    its own derives need: `PerceusAction::equals` then compares
-      //    `a.kind == b.kind` instead of calling `PerceusActionKind::equals`.
-      //  - grouping files into packages first does not exist to be had:
-      //    `collect_source_groups_fs` returns ONE group (`recursive`, 191
-      //    files) for the compiler closure, so there is no package partition
-      //    to split on.
-      //
-      // Exact import edges would settle it, and the merge drops `SImport`
-      // ("Skips SImport, SReExport (already resolved)"), so they have to come
-      // from the loader. That is filed on #2388 as what the per-module driver
-      // needs first, and until then this oracle's green is the weaker claim:
-      // no module needed anything the whole program did not have.
-      if cj == fi {
+      // It used to be every other file, which let a dependency read
+      // declarations from the entry that imports it (Codex P1 on #2622). Two
+      // cheaper rules were tried before the edges were available and both
+      // failed: "only files merged before this one" reports a FALSE
+      // difference, because a `.vpkg` contract is materialized into a
+      // generated types file the merge lays ahead of the implementation its
+      // own derives read (`PerceusAction::equals`); and there is no package
+      // partition to group on -- `collect_source_groups_fs` returns ONE group
+      // for the compiler closure.
+      if cj == fi || !oracle_ids_contain(dep_ids, fi, cj) {
         ()
       } else {
         let other = Array::get(ifaces, cj)
@@ -4208,7 +4226,7 @@ export fn prelude_module_full_oracle_line(a: Array[Stmt], c: Array[Stmt], c_file
   String::concat(line, oracle_keyed_line(a, trial, render))
 }
 
-export fn prelude_pass_module_oracle_step(k: Int, a: Array[Stmt], c: Array[Stmt], c_file_id: Array[Int], file_count: Int, entry_name: String, checker_eq_offsets: Array[Int], checker_eq_type_keys: Array[String], render: (Stmt) -> String) -> String with Exception {
+export fn prelude_pass_module_oracle_step(k: Int, a: Array[Stmt], c: Array[Stmt], c_file_id: Array[Int], file_count: Int, dep_ids: Array[Array[Int]], entry_name: String, checker_eq_offsets: Array[Int], checker_eq_type_keys: Array[String], render: (Stmt) -> String) -> String with Exception {
   let entry_fid = file_count - 1
   let mut file_of = c_file_id
   let mut j = 0
@@ -4296,10 +4314,8 @@ export fn prelude_pass_module_oracle_step(k: Int, a: Array[Stmt], c: Array[Stmt]
       let ctx: Array[Stmt] = []
       let mut cj = 0
       while cj < file_count {
-        // Every other file -- wider than a real per-module compile sees; the
-        // full-sequence oracle above records the two narrower rules that were
-        // measured and why neither holds at file granularity.
-        if cj == fi {
+        // This module's dependency closure, as above.
+        if cj == fi || !oracle_ids_contain(dep_ids, fi, cj) {
           ()
         } else {
           let other = Array::get(ifaces, cj)

--- a/lib/@vibe/compiler/entry/compiler/file_compile/file_compile.vibe
+++ b/lib/@vibe/compiler/entry/compiler/file_compile/file_compile.vibe
@@ -105,6 +105,7 @@ import @vibe/compiler/runtime {
   db_store_artifact,
   db_typecheck,
   db_typecheck_fs,
+  module_plan_data_fs,
   module_typed_lowering_offsets_for_path,
   parse_program_with_path,
   split_typed_lowering_offsets,
@@ -511,13 +512,14 @@ fn build_grouped_merged_stmts_gc(source_groups: Array[(String, Array[(String, St
 export fn prelude_module_oracle_report_fs(entry_path: String, entry_name: String, pass_limit: Int) -> String with Exception + Fs {
   let source_groups = collect_source_groups_fs(entry_path)
   let _ = prepare_file_fs_from_source_groups_persistent_cached(db_new(), entry_path, source_groups)
-  let (a, _, _, _) = prelude_oracle_merge(source_groups)
+  let (a, _, _, _, _) = prelude_oracle_merge(source_groups)
   let mut report = ""
   let mut k = 0
   while k <= pass_limit {
-    let (c, files, c_file_id, eq) = prelude_oracle_merge(source_groups)
+    let (c, files, file_paths, c_file_id, eq) = prelude_oracle_merge(source_groups)
     let (eq_offs, eq_keys) = eq
-    report = String::concat(report, prelude_pass_module_oracle_step(k, a, c, c_file_id, Array::length(files), entry_name, eq_offs, eq_keys, print_stmt))
+    let (dep_ids, _plan_unmatched, _files_unmatched) = oracle_dependency_closure_fs(entry_path, file_paths)
+    report = String::concat(report, prelude_pass_module_oracle_step(k, a, c, c_file_id, Array::length(files), dep_ids, entry_name, eq_offs, eq_keys, print_stmt))
     k = k + 1
   }
   report
@@ -531,13 +533,154 @@ export fn prelude_module_oracle_report_fs(entry_path: String, entry_name: String
 export fn prelude_module_full_oracle_report_fs(entry_path: String, entry_name: String) -> String with Exception + Fs {
   let source_groups = collect_source_groups_fs(entry_path)
   let _ = prepare_file_fs_from_source_groups_persistent_cached(db_new(), entry_path, source_groups)
-  let (a, _, _, _) = prelude_oracle_merge(source_groups)
-  let (c, files, c_file_id, eq) = prelude_oracle_merge(source_groups)
+  let (a, _, _, _, _) = prelude_oracle_merge(source_groups)
+  let (c, files, file_paths, c_file_id, eq) = prelude_oracle_merge(source_groups)
   let (eq_offs, eq_keys) = eq
-  prelude_module_full_oracle_line(a, c, c_file_id, Array::length(files), entry_name, eq_offs, eq_keys, print_stmt)
+  let (dep_ids, plan_unmatched, files_unmatched) = oracle_dependency_closure_fs(entry_path, file_paths)
+  String::concat(prelude_module_full_oracle_line(a, c, c_file_id, Array::length(files), dep_ids, entry_name, eq_offs, eq_keys, print_stmt), String::concat("  graph plan_unmatched=", String::concat(__to_string(plan_unmatched), String::concat(" files_unmatched=", String::concat(__to_string(files_unmatched), "\n")))))
 }
 
-fn prelude_oracle_merge(source_groups: Array[(String, Array[(String, String)])]) -> (Array[Stmt], Array[String], Array[Int], (Array[Int], Array[String])) with Exception {
+/// #2388: what each merged file may SEE, as merge file ids.
+///
+/// The module-mode oracles used to hand a module the interface of every other
+/// file in the closure, which is wider than any real per-module compile: a
+/// dependency could read declarations from the entry that imports it. The edge
+/// set that answers it is already computed on every FS compile --
+/// `module_plan_data_fs` returns each module's resolved DIRECT dependency
+/// paths, the same sequence `project_exact_dependency_envs` projects
+/// environments onto -- so this maps those paths onto the merge's file ids and
+/// closes them transitively.
+///
+/// Returns `(dep_ids, plan_unmatched, files_unmatched)`. The two counts are
+/// reported by the callers rather than swallowed: a plan path the merge has no
+/// file for, or a merged file the plan never named, means the two views
+/// disagree and the context is not the one this claims to build.
+fn oracle_dependency_closure_fs(entry_path: String, files: Array[String]) -> (Array[Array[Int]], Int, Int) with Exception + Fs {
+  let (order, _ranks, ordered_deps, _sources) = module_plan_data_fs(entry_path)
+  let n = Array::length(files)
+  // Direct edges, as ids.
+  let direct: Array[Array[Int]] = []
+  let mut i = 0
+  while i < n {
+    Array::push(direct, [])
+    i = i + 1
+  }
+  let mut plan_unmatched = 0
+  let mut pi = 0
+  while pi < Array::length(order) {
+    let owner = oracle_file_index_of(files, Array::get(order, pi))
+    if owner < 0 {
+      plan_unmatched = plan_unmatched + 1
+    } else {
+      let deps = Array::get(ordered_deps, pi)
+      let row = Array::get(direct, owner)
+      let mut di = 0
+      while di < Array::length(deps) {
+        let dep = oracle_file_index_of(files, Array::get(deps, di))
+        if dep < 0 {
+          plan_unmatched = plan_unmatched + 1
+        } else if oracle_int_contains(row, dep) {
+          ()
+        } else {
+          Array::push(row, dep)
+        }
+        di = di + 1
+      }
+    }
+    pi = pi + 1
+  }
+  let mut files_unmatched = 0
+  let mut fi = 0
+  while fi < n {
+    if oracle_plan_names_path(order, Array::get(files, fi)) {
+      ()
+    } else {
+      files_unmatched = files_unmatched + 1
+    }
+    fi = fi + 1
+  }
+  // Transitive closure per file: a module sees what its dependencies expose,
+  // which includes what THEY import (a re-exported name, a type it returns).
+  let closure: Array[Array[Int]] = []
+  fi = 0
+  while fi < n {
+    let seen: Array[Int] = []
+    let queue: Array[Int] = []
+    let mut qs = 0
+    let start = Array::get(direct, fi)
+    let mut si = 0
+    while si < Array::length(start) {
+      Array::push(queue, Array::get(start, si))
+      si = si + 1
+    }
+    while qs < Array::length(queue) {
+      let cur = Array::get(queue, qs)
+      qs = qs + 1
+      if oracle_int_contains(seen, cur) || cur == fi {
+        ()
+      } else {
+        Array::push(seen, cur)
+        let nexts = Array::get(direct, cur)
+        let mut ni = 0
+        while ni < Array::length(nexts) {
+          Array::push(queue, Array::get(nexts, ni))
+          ni = ni + 1
+        }
+      }
+    }
+    Array::push(closure, seen)
+    fi = fi + 1
+  }
+  (closure, plan_unmatched, files_unmatched)
+}
+
+fn oracle_file_index_of(files: Array[String], path: String) -> Int {
+  let mut i = 0
+  let mut found = 0 - 1
+  while i < Array::length(files) {
+    if found < 0 && Array::get(files, i) == path {
+      found = i
+    } else {
+      ()
+    }
+    i = i + 1
+  }
+  found
+}
+
+fn oracle_plan_names_path(order: Array[String], path: String) -> Bool {
+  let mut i = 0
+  let mut found = false
+  while i < Array::length(order) {
+    if Array::get(order, i) == path {
+      found = true
+    } else {
+      ()
+    }
+    i = i + 1
+  }
+  found
+}
+
+fn oracle_int_contains(arr: Array[Int], v: Int) -> Bool {
+  let mut i = 0
+  let mut found = false
+  while i < Array::length(arr) {
+    if Array::get(arr, i) == v {
+      found = true
+    } else {
+      ()
+    }
+    i = i + 1
+  }
+  found
+}
+
+/// The merge the module-mode oracles split. Returns the merged statements, the
+/// per-file display names, the per-file FULL PATHS (the merge's own `files`
+/// array holds basenames -- `index.vibe` is not a key, this closure has many),
+/// the per-statement file id, and the typed-`==` rows.
+fn prelude_oracle_merge(source_groups: Array[(String, Array[(String, String)])]) -> (Array[Stmt], Array[String], Array[String], Array[Int], (Array[Int], Array[String])) with Exception {
   let flat_paths: Array[String] = []
   let flat_bases: Array[Int] = []
   let clone_float_offsets: Array[Int] = []
@@ -550,7 +693,7 @@ fn prelude_oracle_merge(source_groups: Array[(String, Array[(String, String)])])
   } else {
     ()
   }
-  (stmts, files, stmt_file_id, (eq_offs, eq_keys))
+  (stmts, files, flat_paths, stmt_file_id, (eq_offs, eq_keys))
 }
 
 /// #2391: the merge every offsets-consuming linear FS lane shares -- each file

--- a/lib/@vibe/compiler/runtime/index.vpkg
+++ b/lib/@vibe/compiler/runtime/index.vpkg
@@ -276,6 +276,13 @@ fn parse_program_with_path(path: String, source: String) -> Array[Stmt] with Exc
 // the manifest's order. See typecheck_fs.vibe for the format and for why
 // both come off the same ingest step.
 fn module_plan_manifest_fs(entry_path: String) -> (String, Array[String]) with Exception + Fs
+// The planned module graph: (order, ranks, each module's resolved DIRECT
+// dependency paths, each module's ingested source), positionally aligned to
+// `order`. This is the edge set the check lane already projects environments
+// onto (project_exact_dependency_envs); #2388's module-mode oracles read it to
+// give a module the context a real per-module compile would have, instead of
+// every other file in the closure.
+fn module_plan_data_fs(entry_path: String) -> (Array[String], Array[Int], Array[Array[String]], Array[String]) with Exception + Fs
 // Trace-only exact graph evidence from module_plan_data_fs. The fingerprint
 // preimage preserves planned module order/ranks and dependency occurrences.
 fn artifact_input_trace_dependency_plan_evidence_fs(entry_path: String) -> (String, Int, Int) with Exception + Fs

--- a/lib/@vibe/compiler/runtime/typecheck_fs.vibe
+++ b/lib/@vibe/compiler/runtime/typecheck_fs.vibe
@@ -5775,7 +5775,7 @@ fn module_plan_index_of(items: Array[String], p: String) -> Int {
 /// and check_module parses that text -- never the raw bytes. Deriving deps
 /// from one and handing back the other is #1168's exact bug, so both come
 /// off the same `ingested` string here.
-fn module_plan_data_fs(entry_path: String) -> (Array[String], Array[Int], Array[Array[String]], Array[String]) with Exception + Fs {
+export fn module_plan_data_fs(entry_path: String) -> (Array[String], Array[Int], Array[Array[String]], Array[String]) with Exception + Fs {
   // `paths` doubles as the BFS queue: discovery pushes to it, `qi` walks it.
   let paths: Array[String] = []
   let deps_of: Array[Array[String]] = []

--- a/lib/@vibe/compiler/tests/prelude_module_oracle_test.vibe
+++ b/lib/@vibe/compiler/tests/prelude_module_oracle_test.vibe
@@ -145,4 +145,12 @@ test "the whole prelude per module reproduces the whole-program prelude" {
   // property: every declaration the whole-program prelude produced is produced
   // by the module that owns it, with the same body.
   inspect(String::trim(Array::get(lines, 1)), content = "keyed missing=0 extra=0 copies=1 content=0 renames=0 dup_keys=2 first_missing= first_content=")
+  // And the line that makes the two above mean anything: every module in the
+  // plan was found in the merge and vice versa, so each module's context was
+  // its real dependency closure. Measured while building this: the merge's
+  // own `files` array holds BASENAMES, and matching on those left every
+  // dependency row empty -- every module saw nothing, and the run reported a
+  // confident `missing=5 content=33` that was entirely an artifact. Without
+  // this assertion that reading is indistinguishable from a finding.
+  inspect(String::trim(Array::get(lines, Array::length(lines) - 2)), content = "graph plan_unmatched=0 files_unmatched=0")
 }


### PR DESCRIPTION
The item [#2622](https://github.com/mizchi/vibe-lang/pull/2622) left first on the #2388 line (parent epic #2386), and the measurement it produces.

## The gap

The module-mode oracles handed each module the interface of **every other file** in the closure. That is wider than any real per-module compile — a dependency could read declarations from the entry that imports it — so a whole-program pass leaning on an unrelated module's declarations stayed green. Codex raised it twice on #2622 and I could not express the restriction soundly there: merge order puts a materialized contract ahead of the implementation its own derives read, and `collect_source_groups_fs` returns one group for the whole closure.

## The edge set already existed

`module_plan_data_fs` returns each module's resolved **direct** dependency paths — the same sequence the check lane projects environments onto through `project_exact_dependency_envs`, and what `ModuleJob.dep_envs` carries in production. This exports it, maps it onto the merge's file ids, closes it transitively, and gives each module exactly that context. A file with no row sees **nothing** rather than everything: a missing edge must narrow the context, never widen it.

## The mapping is checked, not trusted

`prelude_oracle_merge` now returns the per-file **full paths**, because the merge's own `files` array holds basenames — and this closure has many `index.vibe`. Matching on basenames left every dependency row empty, so every module saw nothing, and the run reported:

```
keyed missing=5 extra=0 copies=313 content=33 …
  first_missing=let:MutMap::equals__N6_String__N3_Int
  let:MutSet::equals
    whole<… MutMap::equals(a.inner, b.inner) …>
    split<… (a.inner == b.inner) …>
```

Confident, plausible, and entirely an artifact. The report now carries `graph plan_unmatched= files_unmatched=`, the two-file test pins it at `0 0`, and reverting to the basename match turns that assertion red (`2 2`) — so this reading can never again pass for a finding.

## Measured

Compiler closure (`codegen_lexer_test.vibe`, 189 files), each module seeing only what it imports:

```
FULL stmts=4764 split=4836 modules=191
  keyed missing=0 extra=0 copies=321 content=1 renames=0 dup_keys=254
  graph plan_unmatched=0 files_unmatched=0
```

Against the previous context (every other file) the only movement is `content=0 → 1`. **That one difference is real**: `PerceusAction::equals` calls `PerceusActionKind::equals(a.kind, b.kind)` whole-program and compares `a.kind == b.kind` per module. `struct PerceusAction` is declared in `perceus/index.vpkg` — materialized into a generated types module — while `enum PerceusActionKind` lives in `perceus.vibe`, and a contract does not import the implementation it fronts, so the module that owns the struct cannot see that the field type has a structural comparator.

Harmless for this type: `PerceusActionKind` is a nullary enum, so both forms compare tags. Not harmless as a shape: a payload-carrying field type in the same position would get reference equality, which is the P0 class this epic exists for. **That is the per-module lane's one open item on this corpus**, and it is now located rather than suspected — either the derive defers to the link, where both declarations are visible, or the contract carries enough about the field type for the owning module to emit the call.

## Validation

- `prelude_module_oracle_test.vibe` (3 tests, now including the graph assertion), `desugar_trait_dicts_module_test.vibe` (10), `fixtures/hoisted_lambda_owner_names_test.vibe` (2, linear and gc lanes) pass.
- Red verified for the new assertion by restoring the basename match.
- stage0 → stage1 → stage2 selfhost build clean; `scripts/vibe_fmt.sh --check` clean on every changed file; `scripts/compiler_gate.sh` running locally as I open this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NAeZzkckdAwtQiubBFpdmM

---
_Generated by [Claude Code](https://claude.ai/code/session_01NAeZzkckdAwtQiubBFpdmM)_