### PR TITLE
codegen: the may_return / borrow analyses do NOT decompose per module, measured (#2575 item 4)

### DIFF
--- a/docs/incremental-build.md
+++ b/docs/incremental-build.md
@@ -269,6 +269,50 @@ Not every remaining row is attributed to one of these two yet. The counters name
 the first of each kind rather than all of them, and reading the rest out is the
 next measurement, not a conclusion available now.
 
+### The phases after the prelude (#2575 item 4)
+
+Between the prelude and codegen `linked_compile` runs three whole-program
+analyses: `compute_borrow_returning_names`, `compute_borrow_param_user_fns`
+(ADR-0092, per-position masks) and `compute_may_return_view_fns`. The oracle
+samples all three on both lanes after all 17 prelude passes, which is where the
+real compile runs them, and compares the whole-program answer against the union
+of the per-module ones.
+
+Unlike the evidence facts above, these are interprocedural **fixpoints**, so the
+two lanes differ in both directions and the directions do not mean the same
+thing. Measured on `lib/@vibe/cli/entry.vibe`, 365 modules:
+
+```
+ANALYSIS borrow_ret=378/363:-15:MutSortedSet::delete+0:
+         borrow_fns=2705/2626:-167:alloc_site_kind_dep_...+88:__arr_equals__N4_Expr
+         borrow_masks=2705/2626:-197:agg_expr_of_ident_exp_...#12+118:__arr_equals__N4_Expr#3
+         view_ret=2123/1943:-180:HashSet::size+0:
+```
+
+- **A name the whole program has and the union lacks** is a module being
+  conservative about a callee it cannot see: `via(xs) = pick(xs)` is not
+  classified view-returning by its own module when `pick` lives across the
+  import. Slower, sound; 167 on the borrow set and 180 on the view set.
+- **A name the union has and the whole program lacks** is a module qualifying a
+  function the whole program **disqualified**. `ca_collect_nonident_args`
+  disqualifies a callee from a *call site*, which may live in another module, so
+  a module reading only its own statements hands back the borrowed ABI for a
+  parameter the program says is consumed. 88 of them, and this is the unsound
+  direction.
+
+The net (2705 − 2626 = 79) hides all 88 behind the 167, which is why both
+directions are counted rather than subtracted. The mask row is the same question
+one level finer: 118 against 88 means 30 functions are in **both** sets under
+**different** masks — the names agree and the ABI does not, which a comparison on
+names alone reports as agreement.
+
+So these phases do not decompose as written. What a module can compute alone is
+its own contribution; the disqualifications and the callee edges are the
+program's. That makes them the same shape as the evidence pass (#2633) — the
+module collects, the link unions and decides — with one difference that matters:
+an evidence disagreement produces two programs that cannot link, and a borrow
+disagreement produces two that link and disagree about ownership.
+
 ## User-visible KPI contract
 
 Measure these endpoints separately:

--- a/docs/incremental-build.md
+++ b/docs/incremental-build.md
@@ -283,9 +283,9 @@ two lanes differ in both directions and the directions do not mean the same
 thing. Measured on `lib/@vibe/cli/entry.vibe`, 365 modules:
 
 ```
-ANALYSIS borrow_ret=378/363:-15:MutSortedSet::delete+0:
-         borrow_fns=2705/2626:-167:alloc_site_kind_dep_...+88:__arr_equals__N4_Expr
-         borrow_masks=2705/2626:-197:agg_expr_of_ident_exp_...#12+118:__arr_equals__N4_Expr#3
+ANALYSIS dce_entry=0 borrow_ret=378/363:-15:MutSortedSet::delete+0:
+         borrow_fns=2706/2627:-167:alloc_site_kind_dep_...+88:__arr_equals__N4_Expr
+         borrow_masks=2706/2627:-197:agg_expr_of_ident_exp_...#12+118:__arr_equals__N4_Expr#3
          view_ret=2123/1943:-180:HashSet::size+0:
 ```
 
@@ -300,11 +300,23 @@ ANALYSIS borrow_ret=378/363:-15:MutSortedSet::delete+0:
   parameter the program says is consumed. 88 of them, and this is the unsound
   direction.
 
-The net (2705 − 2626 = 79) hides all 88 behind the 167, which is why both
+The net (2706 − 2627 = 79) hides all 88 behind the 167, which is why both
 directions are counted rather than subtracted. The mask row is the same question
 one level finer: 118 against 88 means 30 functions are in **both** sets under
 **different** masks — the names agree and the ABI does not, which a comparison on
 names alone reports as agreement.
+
+`dce_entry` is the sample point's own caveat. Production runs
+`fold_const_bool_params` and `dce_stmts` between the prelude and these
+analyses, gated on the merged program defining `entry_name`; a folded constant
+`Bool` argument can delete a consuming branch and change a borrow mask, and DCE
+can delete a generated helper outright. The oracle cannot reproduce either —
+`dce_stmts` is rooted at the entry and the split lane has no per-module entry —
+so it reports the condition and prints `unmeasured` instead of counts when it
+holds. The closure numbers above are a `dce_entry=0` measurement: the same
+closure through `vibe build` would give different sets, though not a different
+conclusion, since neither transform makes an interprocedural fixpoint
+decompose.
 
 So these phases do not decompose as written. What a module can compute alone is
 its own contribution; the disqualifications and the callee edges are the

--- a/lib/@vibe/compiler/codegen/wasi/linked_compile.vibe
+++ b/lib/@vibe/compiler/codegen/wasi/linked_compile.vibe
@@ -526,6 +526,96 @@ fn lc_set_cmp(whole: Array[String], union: Array[String]) -> String {
   }
 }
 
+/// #2575 item 4: membership over a name set, as a map, so the comparison
+/// below is linear. `lc_str_array_has` is a scan, and these sets are 2700
+/// names each on the compiler's own closure.
+fn lc_name_index(names: Array[String]) -> MutMap[String, Int] {
+  let idx: MutMap[String, Int] = MutMap::new_string()
+  let mut i = 0
+  while i < Array::length(names) {
+    MutMap::set(idx, Array::get(names, i), 1)
+    i = i + 1
+  }
+  idx
+}
+
+/// #2575 item 4: `<count>` when the two sets agree, else
+/// `<whole>/<union>:-<missing count>:<first>+<extra count>:<first>`.
+///
+/// `lc_set_cmp`'s shape with both differences COUNTED. On the compiler's own
+/// closure the sizes alone read `2705/2626`, which invites subtraction -- and
+/// 79 is the NET, not the number of names each lane has that the other does
+/// not (167 and 88). The two directions mean opposite things here: a missing
+/// name is a module being conservative, an extra one is a module qualifying a
+/// function the whole program disqualified. A report that lets them cancel
+/// hides the unsound one behind the one that is merely slow.
+fn lc_set_cmp_counted(whole: Array[String], union: Array[String]) -> String {
+  let whole_idx = lc_name_index(whole)
+  let union_idx = lc_name_index(union)
+  let mut missing = 0
+  let mut first_missing = ""
+  let mut i = 0
+  while i < Array::length(whole) {
+    let n = Array::get(whole, i)
+    if MutMap::has(union_idx, n) {
+      ()
+    } else {
+      missing = missing + 1
+      if first_missing == "" {
+        first_missing = n
+      } else {
+        ()
+      }
+    }
+    i = i + 1
+  }
+  let mut extra = 0
+  let mut first_extra = ""
+  let mut j = 0
+  while j < Array::length(union) {
+    let n = Array::get(union, j)
+    if MutMap::has(whole_idx, n) {
+      ()
+    } else {
+      extra = extra + 1
+      if first_extra == "" {
+        first_extra = n
+      } else {
+        ()
+      }
+    }
+    j = j + 1
+  }
+  if missing == 0 && extra == 0 && Array::length(whole) == Array::length(union) {
+    Int::to_string(Array::length(whole))
+  } else {
+    String::concat(String::concat(Int::to_string(Array::length(whole)), String::concat("/", Int::to_string(Array::length(union)))), String::concat(String::concat(String::concat(":-", Int::to_string(missing)), String::concat(":", first_missing)), String::concat(String::concat("+", Int::to_string(extra)), String::concat(":", first_extra))))
+  }
+}
+
+/// #2575 item 4: the borrow analysis answers with a NAME and a per-position
+/// MASK, and the mask is what decides the ABI. Comparing names alone reports
+/// agreement for a function both lanes list under different masks, which is
+/// exactly the disagreement that matters, so pair them.
+fn lc_name_mask_pairs(names: Array[String], masks: Array[Int]) -> Array[String] {
+  let out = lc_fresh_string_array()
+  let mut i = 0
+  while i < Array::length(names) {
+    let m = if i < Array::length(masks) {
+      Int::to_string(Array::get(masks, i))
+    } else {
+      // The analysis returns the masks aligned to the sorted names, so a short
+      // list is a contract break rather than a missing entry. Reported instead
+      // of defaulted to 0: a 0 here reads as "borrows nothing", which is a
+      // real answer this lane would then be inventing.
+      "?"
+    }
+    Array::push(out, String::concat(Array::get(names, i), String::concat("#", m)))
+    i = i + 1
+  }
+  out
+}
+
 fn lc_fresh_string_array() -> Array[String] {
   ArrayBuilder::freeze(ArrayBuilder::new())
 }
@@ -4333,6 +4423,31 @@ export fn prelude_module_full_oracle_line(a: Array[Stmt], c: Array[Stmt], c_file
     oracle_apply_pass(k, a, entry_name, checker_eq_offsets, checker_eq_type_keys)
     k = k + 1
   }
+  // #2575 item 4: the three whole-program analyses `linked_compile` runs
+  // between the prelude and codegen. Sampled HERE on both lanes -- after all
+  // 17 passes -- because that is where the real compile runs them, over the
+  // program the prelude leaves behind.
+  //
+  // Unlike the evidence facts above, these are interprocedural FIXPOINTS, so
+  // the two lanes can differ in either direction and the directions do not
+  // mean the same thing:
+  //
+  //   whole has a name the union lacks -- a module was conservative about a
+  //     callee it cannot see. Slower, sound.
+  //   the union has a name whole lacks -- a module QUALIFIED a function the
+  //     whole program disqualified. `ca_collect_nonident_args` disqualifies a
+  //     callee from a CALL SITE, which may live in another module, so this
+  //     direction is reachable and it is the unsound one.
+  //
+  // The same `exclude` list on both lanes, deliberately: the real compile
+  // excludes by name regardless of module, and deriving it per module from
+  // `part_entry` would let the exclude list, rather than the program, produce
+  // a difference.
+  let an_exclude = [entry_name, "main", "_start", "cli_main"]
+  let an_bret_w = sorted_names_of(compute_borrow_returning_names(a))
+  let an_bmask_w = lc_fresh_int_array()
+  let an_bfns_w = compute_borrow_param_user_fns(a, an_exclude, an_bmask_w)
+  let an_view_w = sorted_names_of(compute_may_return_view_fns(a))
   let whole_invisible = eq_invisible_nominals_list()
   eq_invisible_nominals_reset()
   let parts: Array[Array[Stmt]] = []
@@ -4390,6 +4505,12 @@ export fn prelude_module_full_oracle_line(a: Array[Stmt], c: Array[Stmt], c_file
   let ev_decl_u = lc_fresh_string_array()
   let ev_handled_u = lc_fresh_string_array()
   let ev_perf_u = lc_fresh_string_array()
+  // #2575 item 4: the union of the per-module answers to the three analyses
+  // sampled on the whole lane above.
+  let an_bret_u = lc_fresh_string_array()
+  let an_bfns_u = lc_fresh_string_array()
+  let an_pairs_u = lc_fresh_string_array()
+  let an_view_u = lc_fresh_string_array()
   fi = 0
   while fi < file_count {
     let part_entry = if fi == entry_fid {
@@ -4469,6 +4590,15 @@ export fn prelude_module_full_oracle_line(a: Array[Stmt], c: Array[Stmt], c_file
       lc_apply_pass_recording(j2, part, part_entry, checker_eq_offsets, checker_eq_type_keys, synth_keys)
       j2 = j2 + 1
     }
+    // #2575 item 4: this module's answer to the same three analyses, from its
+    // own statements alone -- the counterpart of the whole-lane sample above,
+    // taken at the same point in the pass order.
+    let part_bmask = lc_fresh_int_array()
+    let part_bfns = compute_borrow_param_user_fns(part, an_exclude, part_bmask)
+    lc_union_into(an_bret_u, sorted_names_of(compute_borrow_returning_names(part)))
+    lc_union_into(an_bfns_u, part_bfns)
+    lc_union_into(an_pairs_u, lc_name_mask_pairs(part_bfns, part_bmask))
+    lc_union_into(an_view_u, sorted_names_of(compute_may_return_view_fns(part)))
     fi = fi + 1
   }
   let trial: Array[Stmt] = []
@@ -4532,6 +4662,7 @@ export fn prelude_module_full_oracle_line(a: Array[Stmt], c: Array[Stmt], c_file
   let split_invisible = eq_invisible_nominals_list()
   let tail = String::concat(String::concat(String::concat(" modules=", Int::to_string(file_count)), String::concat(" collisions=", Int::to_string(Array::length(collisions)))), String::concat(String::concat(" invisible_whole=", Int::to_string(Array::length(whole_invisible))), String::concat(String::concat(" invisible_split=", Int::to_string(Array::length(split_invisible))), String::concat(" linked_dups=", String::concat(Int::to_string(linked_dups), "\n")))))
   let ev_line = String::concat(String::concat(String::concat("EVIDENCE declared=", lc_set_cmp(ev_decl_w, ev_decl_u)), String::concat(" handled=", lc_set_cmp(ev_handled_w, ev_handled_u))), String::concat(" performed=", String::concat(lc_set_cmp(ev_perf_w, ev_perf_u), "\n")))
+  let an_line = String::concat(String::concat(String::concat("ANALYSIS borrow_ret=", lc_set_cmp_counted(an_bret_w, an_bret_u)), String::concat(" borrow_fns=", lc_set_cmp_counted(an_bfns_w, an_bfns_u))), String::concat(String::concat(" borrow_masks=", lc_set_cmp_counted(lc_name_mask_pairs(an_bfns_w, an_bmask_w), an_pairs_u)), String::concat(" view_ret=", String::concat(lc_set_cmp_counted(an_view_w, an_view_u), "\n"))))
   let line = String::concat(String::concat(head, mid), tail)
   let mut collision_lines = ""
   let mut ldi = 0
@@ -4551,7 +4682,7 @@ export fn prelude_module_full_oracle_line(a: Array[Stmt], c: Array[Stmt], c_file
     ini = ini + 1
   }
   let line2 = String::concat(String::concat(line, collision_lines), invisible_lines)
-  String::concat(String::concat(line2, oracle_keyed_line(a, linked, render)), ev_line)
+  String::concat(String::concat(String::concat(line2, oracle_keyed_line(a, linked, render)), ev_line), an_line)
 }
 
 export fn prelude_pass_module_oracle_step(k: Int, a: Array[Stmt], c: Array[Stmt], c_file_id: Array[Int], file_count: Int, entry_name: String, checker_eq_offsets: Array[Int], checker_eq_type_keys: Array[String], render: (Stmt) -> String) -> String with Exception {

--- a/lib/@vibe/compiler/codegen/wasi/linked_compile.vibe
+++ b/lib/@vibe/compiler/codegen/wasi/linked_compile.vibe
@@ -4402,6 +4402,25 @@ fn link_key_is_definition(k: String) -> Bool {
 
 export fn prelude_module_full_oracle_line(a: Array[Stmt], c: Array[Stmt], c_file_id: Array[Int], file_count: Int, entry_name: String, checker_eq_offsets: Array[Int], checker_eq_type_keys: Array[String], import_closure: Array[Array[Int]], render: (Stmt) -> String) -> String with Exception {
   let entry_fid = file_count - 1
+  // #2637 review (Codex P2): production runs `fold_const_bool_params` and
+  // `dce_stmts` BETWEEN the prelude and the three analyses sampled below, and
+  // `late_dce_has_entry` is the necessary condition for either
+  // (`compile_wasi_module_linked_impl_with_typed_offsets`). A folded constant
+  // Bool argument can delete a consuming branch and change a borrow MASK, and
+  // DCE can delete a generated helper outright, so a sample taken before them
+  // describes a program the real compile does not analyse.
+  //
+  // Read HERE, from the unmutated `a`, because production reads it before the
+  // prelude too (line 6138, against the prelude's 6205) -- the passes append
+  // and rewrite, so asking after them is a different question.
+  //
+  // The oracle cannot reproduce those transforms: `dce_stmts` is rooted at the
+  // ENTRY, and the split lane has no per-module entry -- every module's
+  // exports are roots for its dependents, so there is no module-local answer
+  // to root it at. So when the condition holds the four columns report
+  // `unmeasured` rather than a number: a count taken at the wrong point would
+  // read exactly like one taken at the right one.
+  let an_dce_entry = lc_defines_top_level(a, entry_name)
   // #2631: which nominals each lane could not see. A raw `==` on a non-scalar
   // name that is not a type formal compares an aggregate by reference, so this
   // is the property, not a statistic about it.
@@ -4425,8 +4444,9 @@ export fn prelude_module_full_oracle_line(a: Array[Stmt], c: Array[Stmt], c_file
   }
   // #2575 item 4: the three whole-program analyses `linked_compile` runs
   // between the prelude and codegen. Sampled HERE on both lanes -- after all
-  // 17 passes -- because that is where the real compile runs them, over the
-  // program the prelude leaves behind.
+  // 17 passes -- which is where the real compile runs them WHEN late DCE does
+  // not intervene; `an_dce_entry` above is that condition, and the line says
+  // which case it measured rather than leaving the reader to assume.
   //
   // Unlike the evidence facts above, these are interprocedural FIXPOINTS, so
   // the two lanes can differ in either direction and the directions do not
@@ -4662,7 +4682,17 @@ export fn prelude_module_full_oracle_line(a: Array[Stmt], c: Array[Stmt], c_file
   let split_invisible = eq_invisible_nominals_list()
   let tail = String::concat(String::concat(String::concat(" modules=", Int::to_string(file_count)), String::concat(" collisions=", Int::to_string(Array::length(collisions)))), String::concat(String::concat(" invisible_whole=", Int::to_string(Array::length(whole_invisible))), String::concat(String::concat(" invisible_split=", Int::to_string(Array::length(split_invisible))), String::concat(" linked_dups=", String::concat(Int::to_string(linked_dups), "\n")))))
   let ev_line = String::concat(String::concat(String::concat("EVIDENCE declared=", lc_set_cmp(ev_decl_w, ev_decl_u)), String::concat(" handled=", lc_set_cmp(ev_handled_w, ev_handled_u))), String::concat(" performed=", String::concat(lc_set_cmp(ev_perf_w, ev_perf_u), "\n")))
-  let an_line = String::concat(String::concat(String::concat("ANALYSIS borrow_ret=", lc_set_cmp_counted(an_bret_w, an_bret_u)), String::concat(" borrow_fns=", lc_set_cmp_counted(an_bfns_w, an_bfns_u))), String::concat(String::concat(" borrow_masks=", lc_set_cmp_counted(lc_name_mask_pairs(an_bfns_w, an_bmask_w), an_pairs_u)), String::concat(" view_ret=", String::concat(lc_set_cmp_counted(an_view_w, an_view_u), "\n"))))
+  let an_head = String::concat("ANALYSIS dce_entry=", if an_dce_entry {
+    "1"
+  } else {
+    "0"
+  })
+  let an_cols = if an_dce_entry {
+    " borrow_ret=unmeasured borrow_fns=unmeasured borrow_masks=unmeasured view_ret=unmeasured"
+  } else {
+    String::concat(String::concat(String::concat(" borrow_ret=", lc_set_cmp_counted(an_bret_w, an_bret_u)), String::concat(" borrow_fns=", lc_set_cmp_counted(an_bfns_w, an_bfns_u))), String::concat(String::concat(" borrow_masks=", lc_set_cmp_counted(lc_name_mask_pairs(an_bfns_w, an_bmask_w), an_pairs_u)), String::concat(" view_ret=", lc_set_cmp_counted(an_view_w, an_view_u))))
+  }
+  let an_line = String::concat(String::concat(an_head, an_cols), "\n")
   let line = String::concat(String::concat(head, mid), tail)
   let mut collision_lines = ""
   let mut ldi = 0

--- a/lib/@vibe/compiler/tests/prelude_module_oracle_test.vibe
+++ b/lib/@vibe/compiler/tests/prelude_module_oracle_test.vibe
@@ -10,14 +10,14 @@ import @vibe/compiler/entry/compiler/file_compile {
 // `inspect` (desugar_inspect_calls changes it) and calls across the import
 // (the alias and evidence passes see both sides) must agree on every pass.
 
-/// The report's `EVIDENCE ...` line, or "" .
-fn evidence_line_of(report: String) -> String {
+/// The report line starting with `prefix`, or "" .
+fn report_line_of(report: String, prefix: String) -> String {
   let lines = String::split(report, "\n")
   let mut out = ""
   let mut i = 0
   while i < Array::length(lines) {
     let line = Array::get(lines, i)
-    if String::starts_with(line, "EVIDENCE ") {
+    if String::starts_with(line, prefix) {
       out = line
     } else {
       ()
@@ -25,6 +25,16 @@ fn evidence_line_of(report: String) -> String {
     i = i + 1
   }
   out
+}
+
+/// The report's `EVIDENCE ...` line, or "" .
+fn evidence_line_of(report: String) -> String {
+  report_line_of(report, "EVIDENCE ")
+}
+
+/// The report's `ANALYSIS ...` line, or "" .
+fn analysis_line_of(report: String) -> String {
+  report_line_of(report, "ANALYSIS ")
 }
 
 fn oracle_lines(report: String) -> Array[String] {
@@ -228,6 +238,43 @@ test "the whole prelude per module reproduces the whole-program prelude" {
   // says the pass's INPUTS decompose per module even though its decision does
   // not -- the decision is a union that runs backwards along the import graph.
   inspect(String::trim(evidence_line_of(report)), content = "EVIDENCE declared=2 handled=2 performed=2")
+  // #2575 item 4: the three analyses `linked_compile` runs between the prelude
+  // and codegen, sampled on both lanes after all 17 passes. Agreement here is
+  // the CONTROL for the test below, which shows the same line reporting a
+  // difference: without one of the two, a bare count could mean either "the
+  // lanes agree" or "the instrument cannot tell them apart".
+  //
+  // `borrow_fns=0` and `borrow_masks=0` are honest but vacuous on this
+  // program -- no function of it qualifies for the borrowed ABI at all -- and
+  // that is why they are not the pin this property rests on.
+  //
+  // Red-tested by dropping module 0 from the union: `view_ret` reads
+  // `2/0:-2:__hoisted_lam_48_helper_use_exp_..._0_f+0:` and names what went
+  // missing. `borrow_ret` does NOT move under that mutation and is the weakest
+  // column here on purpose -- `compute_borrow_returning_names` is SEEDED with
+  // the borrow-returning builtins, which every module's answer carries, so its
+  // union survives losing a module. Read it as a check that the seed agrees,
+  // not that the analysis decomposes.
+  //
+  // On the compiler's own CLI closure (365 modules, measured 2026-09-11 on
+  // this change) the same line reads:
+  //
+  //   ANALYSIS borrow_ret=378/363:-15:MutSortedSet::delete+0:
+  //            borrow_fns=2705/2626:-167:alloc_site_kind_dep_...+88:__arr_equals__N4_Expr
+  //            borrow_masks=2705/2626:-197:agg_expr_of_ident_exp_...#12+118:__arr_equals__N4_Expr#3
+  //            view_ret=2123/1943:-180:HashSet::size+0:
+  //
+  // 88 functions take the borrowed ABI from their own module that the whole
+  // program refuses, and the net (2705 - 2626 = 79) hides every one of them
+  // behind the 167 the modules were conservative about. 118 against 88 on the
+  // mask row is the other half: 30 functions are in BOTH sets under DIFFERENT
+  // masks -- the names agree and the ABI does not, which a name-only
+  // comparison reports as agreement.
+  //
+  // `stmts` in the block above predates this change and is not re-measured
+  // here: the corpus is the compiler's own closure, so the code doing the
+  // measuring is inside what is being measured, and adding it moves the count.
+  inspect(String::trim(analysis_line_of(report)), content = "ANALYSIS borrow_ret=7 borrow_fns=0 borrow_masks=0 view_ret=2")
   // `missing=0 extra=0 content=0` is the property: every declaration the
   // whole-program prelude produced is produced by the module that owns it,
   // with the same body. `copies` is what remains after the link, and
@@ -274,4 +321,50 @@ test "the import closure the oracle runs under is the module's own, and places e
   Fs::write_file(lone_b, "test \"lone\" {\n  inspect(1, content = \"1\")\n}\n")
   let _ = lone_a
   inspect(String::trim(prelude_module_import_closure_report_fs(lone_b)), content = "CLOSURE files=1 edges=0 unresolved=0")
+}
+
+// #2575 item 4: the may_return / borrow analyses are the phases between the
+// prelude and codegen, and unlike the evidence facts (#2633) they are
+// interprocedural FIXPOINTS. This is the program that shows they do not
+// decompose, in BOTH directions at once:
+//
+//   helper  head_of(xs: Array[Int]) -> Int     reads xs, never consumes it
+//           pick(xs: Array[String]) -> String  returns an interior view
+//   main    via(xs) = pick(xs)                 tail-calls ACROSS the import
+//           head_of(build())                   a non-ident argument, from HERE
+//
+// so that:
+//
+//   `via` is classified by the whole program and NOT by its own module, which
+//     cannot see that `pick` returns a view. The union is missing it. Sound:
+//     a module that cannot see a callee is conservative about it.
+//
+//   `head_of` is qualified for the borrowed ABI by ITS module and disqualified
+//     by the whole program, because `ca_collect_nonident_args` disqualifies a
+//     callee from a CALL SITE -- and the call site is in the other module. The
+//     union has a name the whole program does not. This is the UNSOUND
+//     direction: a per-module driver shipping this would hand a caller the
+//     borrowed ABI for a parameter the callee's own program says is consumed.
+//
+// `borrow_fns=2/2:-1:via+1:head_of_exp__...` is why the comparison is set
+// equality and not sizes: both lanes list exactly two functions and they are
+// DIFFERENT two. A comparison on sizes reports agreement here, which is the
+// one case this measurement exists to detect.
+test "the may_return and borrow analyses do not decompose per module, in both directions" {
+  let helper_path = "/tmp/vibe_analysis_oracle_helper.vibe"
+  let main_path = "/tmp/vibe_analysis_oracle_main.vibe"
+  Fs::write_file(helper_path, "export fn head_of(xs: Array[Int]) -> Int {\n  Array::get(xs, 0)\n}\n\nexport fn pick(xs: Array[String]) -> String {\n  Array::get(xs, 0)\n}\n")
+  Fs::write_file(main_path, "import ./vibe_analysis_oracle_helper.vibe {\n  head_of,\n  pick\n}\n\nfn build() -> Array[Int] {\n  [1, 2, 3]\n}\n\nfn via(xs: Array[String]) -> String {\n  pick(xs)\n}\n\ntest \"t\" {\n  let ss = [\"a\"]\n  inspect(String::concat(Int::to_string(head_of(build())), via(ss)), content = \"1a\")\n}\n")
+  let report = prelude_module_full_oracle_report_fs(main_path, "__no_entry__")
+  // `<whole>/<union>:-<missing count>:<first>+<extra count>:<first>`, and a
+  // bare count when the two sets agree. The export-rename suffix on
+  // `head_of` is the merge's, and it is in the expectation rather than
+  // stripped: the name a module mints is what a link folds by, so a
+  // measurement that matched on the bare name would be answering a question
+  // the link does not ask.
+  inspect(String::trim(analysis_line_of(report)), content = "ANALYSIS borrow_ret=10/9:-1:via+0: borrow_fns=2/2:-1:via+1:head_of_exp__tmp_vibe_analysis_oracle_helper_vibe borrow_masks=2/2:-1:via#1+1:head_of_exp__tmp_vibe_analysis_oracle_helper_vibe#1 view_ret=3/2:-1:via+0:")
+  // The prelude itself still agrees on this program, so the difference above
+  // is the analyses' and not a per-module prelude that already diverged.
+  let lines = String::split(report, "\n")
+  inspect(String::trim(Array::get(lines, 1)), content = "keyed missing=0 extra=0 copies=1 content=0 renames=0 dup_keys=2 dup_defs=0 dup_def_keys= first_copy=reexport_boundary first_missing= first_content=")
 }

--- a/lib/@vibe/compiler/tests/prelude_module_oracle_test.vibe
+++ b/lib/@vibe/compiler/tests/prelude_module_oracle_test.vibe
@@ -259,22 +259,28 @@ test "the whole prelude per module reproduces the whole-program prelude" {
   // On the compiler's own CLI closure (365 modules, measured 2026-09-11 on
   // this change) the same line reads:
   //
-  //   ANALYSIS borrow_ret=378/363:-15:MutSortedSet::delete+0:
-  //            borrow_fns=2705/2626:-167:alloc_site_kind_dep_...+88:__arr_equals__N4_Expr
-  //            borrow_masks=2705/2626:-197:agg_expr_of_ident_exp_...#12+118:__arr_equals__N4_Expr#3
+  //   ANALYSIS dce_entry=0 borrow_ret=378/363:-15:MutSortedSet::delete+0:
+  //            borrow_fns=2706/2627:-167:alloc_site_kind_dep_...+88:__arr_equals__N4_Expr
+  //            borrow_masks=2706/2627:-197:agg_expr_of_ident_exp_...#12+118:__arr_equals__N4_Expr#3
   //            view_ret=2123/1943:-180:HashSet::size+0:
   //
   // 88 functions take the borrowed ABI from their own module that the whole
-  // program refuses, and the net (2705 - 2626 = 79) hides every one of them
+  // program refuses, and the net (2706 - 2627 = 79) hides every one of them
   // behind the 167 the modules were conservative about. 118 against 88 on the
   // mask row is the other half: 30 functions are in BOTH sets under DIFFERENT
   // masks -- the names agree and the ABI does not, which a name-only
   // comparison reports as agreement.
   //
+  // `dce_entry=0`, so these are the sets WITHOUT late DCE: the oracle runs
+  // that closure under `__no_entry__`. A `vibe build` of the same closure
+  // folds and prunes first and would report different sets -- not a different
+  // conclusion, since neither transform makes an interprocedural fixpoint
+  // decompose, but the counts are this program's and not that one's.
+  //
   // `stmts` in the block above predates this change and is not re-measured
   // here: the corpus is the compiler's own closure, so the code doing the
   // measuring is inside what is being measured, and adding it moves the count.
-  inspect(String::trim(analysis_line_of(report)), content = "ANALYSIS borrow_ret=7 borrow_fns=0 borrow_masks=0 view_ret=2")
+  inspect(String::trim(analysis_line_of(report)), content = "ANALYSIS dce_entry=0 borrow_ret=7 borrow_fns=0 borrow_masks=0 view_ret=2")
   // `missing=0 extra=0 content=0` is the property: every declaration the
   // whole-program prelude produced is produced by the module that owns it,
   // with the same body. `copies` is what remains after the link, and
@@ -362,9 +368,40 @@ test "the may_return and borrow analyses do not decompose per module, in both di
   // stripped: the name a module mints is what a link folds by, so a
   // measurement that matched on the bare name would be answering a question
   // the link does not ask.
-  inspect(String::trim(analysis_line_of(report)), content = "ANALYSIS borrow_ret=10/9:-1:via+0: borrow_fns=2/2:-1:via+1:head_of_exp__tmp_vibe_analysis_oracle_helper_vibe borrow_masks=2/2:-1:via#1+1:head_of_exp__tmp_vibe_analysis_oracle_helper_vibe#1 view_ret=3/2:-1:via+0:")
+  inspect(String::trim(analysis_line_of(report)), content = "ANALYSIS dce_entry=0 borrow_ret=10/9:-1:via+0: borrow_fns=2/2:-1:via+1:head_of_exp__tmp_vibe_analysis_oracle_helper_vibe borrow_masks=2/2:-1:via#1+1:head_of_exp__tmp_vibe_analysis_oracle_helper_vibe#1 view_ret=3/2:-1:via+0:")
   // The prelude itself still agrees on this program, so the difference above
   // is the analyses' and not a per-module prelude that already diverged.
   let lines = String::split(report, "\n")
   inspect(String::trim(Array::get(lines, 1)), content = "keyed missing=0 extra=0 copies=1 content=0 renames=0 dup_keys=2 dup_defs=0 dup_def_keys= first_copy=reexport_boundary first_missing= first_content=")
+}
+
+// #2637 review (Codex P2): production runs `fold_const_bool_params` and
+// `dce_stmts` BETWEEN the prelude and the three analyses, gated on
+// `late_dce_has_entry` -- the merged program defining `entry_name`. A folded
+// constant Bool argument can delete a consuming branch and change a borrow
+// MASK, and DCE can delete a generated helper outright, so a sample taken
+// before them measures a program the real compile does not analyse.
+//
+// The oracle cannot reproduce them: `dce_stmts` is rooted at the ENTRY and the
+// split lane has no per-module entry. So it reports the condition and, when it
+// holds, refuses to print a count -- a number taken at the wrong point reads
+// exactly like one taken at the right point.
+//
+// One program, both answers, so this tests the PREDICATE and not just that the
+// branch exists: the same two files read `dce_entry=1 ... unmeasured` under a
+// real entry name and `dce_entry=0` with counts under one the program does not
+// define.
+test "the analyses refuse to answer where production would have run late DCE first" {
+  let helper_path = "/tmp/vibe_dce_gate_helper.vibe"
+  let main_path = "/tmp/vibe_dce_gate_main.vibe"
+  Fs::write_file(helper_path, "export fn head_of(xs: Array[Int]) -> Int {\n  Array::get(xs, 0)\n}\n")
+  Fs::write_file(main_path, "import ./vibe_dce_gate_helper.vibe {\n  head_of\n}\n\nfn main() -> Int {\n  head_of([1, 2, 3])\n}\n")
+  inspect(String::trim(analysis_line_of(prelude_module_full_oracle_report_fs(main_path, "main"))), content = "ANALYSIS dce_entry=1 borrow_ret=unmeasured borrow_fns=unmeasured borrow_masks=unmeasured view_ret=unmeasured")
+  // The control. `__no_entry__` is a name no program defines, so production
+  // would not have run either transform and the sample point is its own. The
+  // counts are live here rather than merely present -- this program shows the
+  // unsound direction too (`+1:head_of_exp__...`, qualified by its own module
+  // and disqualified by the whole program through the call site in `main`), so
+  // a guard that suppressed the columns unconditionally could not pass this.
+  inspect(String::trim(analysis_line_of(prelude_module_full_oracle_report_fs(main_path, "__no_entry__"))), content = "ANALYSIS dce_entry=0 borrow_ret=9/8:-1:main+0: borrow_fns=0/1:-0:+1:head_of_exp__tmp_vibe_dce_gate_helper_vibe borrow_masks=0/1:-0:+1:head_of_exp__tmp_vibe_dce_gate_helper_vibe#1 view_ret=2/1:-1:main+0:")
 }


### PR DESCRIPTION
#2575 item 4 asks for the phases between the prelude and codegen "measured the same way by the oracle". This measures the three of them `linked_compile` runs — `compute_borrow_returning_names`, `compute_borrow_param_user_fns` (ADR-0092, per-position masks) and `compute_may_return_view_fns`.

They do not decompose, and one of the two directions is unsound.

## Method

Sampled on both lanes after all 17 prelude passes, with the **same** `exclude` list on both so a difference cannot come from the exclude list instead of the program. Same discipline as `875dc48`: the sample point is the load-bearing part — see **The sample point's own caveat** below, which is the Codex round on this PR.

Unlike the evidence facts (#2633) these are interprocedural **fixpoints**, so the lanes differ in both directions and the directions mean opposite things.

## Measured — `lib/@vibe/cli/entry.vibe`, 365 modules

```
ANALYSIS dce_entry=0 borrow_ret=378/363:-15:MutSortedSet::delete+0:
         borrow_fns=2706/2627:-167:alloc_site_kind_dep_...+88:__arr_equals__N4_Expr
         borrow_masks=2706/2627:-197:agg_expr_of_ident_exp_...#12+118:__arr_equals__N4_Expr#3
         view_ret=2123/1943:-180:HashSet::size+0:
```

| direction | meaning | count |
|---|---|---:|
| whole has it, union lacks it | a module being conservative about a callee it cannot see. Sound, slower. | 167 / 180 |
| the **union** has it, whole lacks it | a module **qualified** a function the whole program **disqualified** — `ca_collect_nonident_args` disqualifies a callee from a *call site*, which may live in another module, so the module hands back the borrowed ABI for a parameter the program says is consumed | **88** |

Filed as #2638 (P1, blocker).

## Two reporting decisions, each because the obvious form answers wrong

**Both directions counted, not subtracted.** The net is 2706 − 2627 = 79, which reads as "the modules are 79 short" and hides all 88 unsound entries behind the 167 conservative ones.

**Name *and* mask, not name.** `borrow_masks` reads 118 against `borrow_fns`' 88, so **30 functions are in both sets under different masks** — the names agree and the ABI does not. A comparison on names alone reports those as agreement, and the mask is what decides the calling convention.

## The sample point's own caveat (`dce_entry`, Codex round)

Production runs `fold_const_bool_params` and `dce_stmts` **between** the prelude and these analyses, gated on `late_dce_has_entry` — the merged program defining `entry_name`. A folded constant `Bool` argument can delete a consuming branch and change a borrow mask, and DCE can delete a generated helper outright.

The oracle cannot reproduce them, structurally rather than for want of plumbing: `dce_stmts` is rooted at the **entry**, and the split lane has no per-module entry — every module's exports are roots for its dependents. So it reports the condition and refuses to print counts past it:

```
ANALYSIS dce_entry=1 borrow_ret=unmeasured borrow_fns=unmeasured borrow_masks=unmeasured view_ret=unmeasured
```

rather than leaving the caveat in prose: a count taken at the wrong point reads exactly like one taken at the right point. The predicate is read from the **unmutated** statements before any pass runs, because production reads it at line 6138 against the prelude's 6205.

The closure numbers above are therefore a no-DCE measurement. A `vibe build` of the same closure would report different sets — not a different conclusion, since neither transform makes an interprocedural fixpoint decompose.

## Tests — three, each testing something the others do not

**The agreement control**, on the existing two-file program: `ANALYSIS dce_entry=0 borrow_ret=7 borrow_fns=0 borrow_masks=0 view_ret=2`. Red-tested by dropping module 0 from the union — `view_ret` reads `2/0:-2:__hoisted_lam_48_..._0_f+0:` and names what went missing. `borrow_ret` does **not** move under that mutation and the test says so: `compute_borrow_returning_names` is seeded with the borrow-returning builtins, which every module carries, so its union survives losing a module. `borrow_fns=0 borrow_masks=0` there is honest but vacuous, and the comment says that too.

**The difference**, on a two-file program built to produce both directions at once:

```
helper  head_of(xs: Array[Int]) -> Int     reads xs, never consumes it
        pick(xs: Array[String]) -> String  returns an interior view
main    via(xs) = pick(xs)                 tail-calls ACROSS the import
        head_of(build())                   a non-ident argument, from HERE
```

reading `borrow_fns=2/2:-1:via+1:head_of_exp__...` — both lanes list exactly two functions and they are **different** two, which is the case a comparison on sizes reports as agreement.

**The `dce_entry` predicate**, one program with both answers so what is tested is the predicate and not that the branch exists: under a real entry name it reads `dce_entry=1 … unmeasured`, and under `__no_entry__` the same two files read `dce_entry=0` with live counts — including the unsound direction — so a guard that suppressed the columns unconditionally could not pass it.

## Scope

`prelude_module_full_oracle_line` has one caller, the oracle driver; nothing on the production compile path changed. The corpus is the compiler's own closure, so the code doing the measuring is inside what is measured — adding these functions moves `stmts` and the set sizes by a few (the perf report's `heap_ptr_bytes +0.08%` is that: ~5 KB of added source at the compiler's measured ~112 bytes of allocation per source byte ≈ 0.6 MiB of 815 MiB).

## Verification

- `bash scripts/compiler_gate.sh` → `[compiler-gate] ok` (stage2==stage3 fixpoint holds), on both commits.
- `bash scripts/vibe_test.sh lib/@vibe/compiler/tests/prelude_module_oracle_test.vibe` → 6 passed, on the committed seed **and** on this checkout's stage2.
- `bash scripts/vibe_fmt.sh --check` clean on both changed `.vibe` files.

`pkf run test` cannot run in this container: it fails identically **on an unmodified `origin/main`** with `sort: /lib/x86_64-linux-gnu/libc.so.6: version 'GLIBC_ABI_DT_X86_64_PLT' not found (required by /nix/store/…-glibc-2.42-67/lib/libdl.so.2)` — a nix glibc leaking into the task environment, unrelated to what the gate checks (the #2252 class). Running `scripts/compiler_gate.sh` directly, which is what that task invokes, passes.

Refs #2575, #2388, #2386. Closes nothing; opens #2638.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NAeZzkckdAwtQiubBFpdmM