### PR TITLE
docs/codegen: the borrow-mask analysis is BOUNDED, not a fixpoint (#2637 follow-up)

### DIFF
--- a/docs/incremental-build.md
+++ b/docs/incremental-build.md
@@ -278,9 +278,19 @@ samples all three on both lanes after all 17 prelude passes, which is where the
 real compile runs them, and compares the whole-program answer against the union
 of the per-module ones.
 
-Unlike the evidence facts above, these are interprocedural **fixpoints**, so the
-two lanes differ in both directions and the directions do not mean the same
-thing. Measured on `lib/@vibe/cli/entry.vibe`, 365 modules:
+Unlike the evidence facts above, all three are **interprocedural** — each reads
+the classification of callees that may live in another module — so the two lanes
+differ in both directions and the directions do not mean the same thing.
+
+Two of them iterate to a fixpoint (`compute_borrow_returning_names`'s `while
+changed`, `compute_may_return_view_fns`' callee-edge worklist).
+`compute_borrow_param_user_fns` does **not**: it is round 0 plus **one bounded
+transitive round** reading round 0's immutable snapshot, and deliberately stops
+there. That distinction constrains the link-time design below — closing it
+transitively would compute a larger borrow set than today's ABI, which is a
+behaviour change rather than the same answer computed differently.
+
+Measured on `lib/@vibe/cli/entry.vibe`, 365 modules:
 
 ```
 ANALYSIS dce_entry=0 borrow_ret=378/363:-15:MutSortedSet::delete+0:
@@ -315,15 +325,18 @@ can delete a generated helper outright. The oracle cannot reproduce either —
 so it reports the condition and prints `unmeasured` instead of counts when it
 holds. The closure numbers above are a `dce_entry=0` measurement: the same
 closure through `vibe build` would give different sets, though not a different
-conclusion, since neither transform makes an interprocedural fixpoint
+conclusion, since neither transform makes an interprocedural analysis
 decompose.
 
 So these phases do not decompose as written. What a module can compute alone is
 its own contribution; the disqualifications and the callee edges are the
 program's. That makes them the same shape as the evidence pass (#2633) — the
-module collects, the link unions and decides — with one difference that matters:
-an evidence disagreement produces two programs that cannot link, and a borrow
-disagreement produces two that link and disagree about ownership.
+module collects, the link unions and decides — with two differences that matter.
+An evidence disagreement produces two programs that cannot link, and a borrow
+disagreement produces two that link and disagree about ownership. And the link's
+closing step is not one shape: a fixpoint for the two analyses that iterate, and
+**exactly one** bounded transitive round for the borrow masks, because that is
+what the shipped ABI is.
 
 ## User-visible KPI contract
 

--- a/lib/@vibe/compiler/codegen/wasi/linked_compile.vibe
+++ b/lib/@vibe/compiler/codegen/wasi/linked_compile.vibe
@@ -4448,9 +4448,20 @@ export fn prelude_module_full_oracle_line(a: Array[Stmt], c: Array[Stmt], c_file
   // not intervene; `an_dce_entry` above is that condition, and the line says
   // which case it measured rather than leaving the reader to assume.
   //
-  // Unlike the evidence facts above, these are interprocedural FIXPOINTS, so
+  // Unlike the evidence facts above, all three are INTERPROCEDURAL -- each
+  // reads the classification of callees that may live in another module -- so
   // the two lanes can differ in either direction and the directions do not
-  // mean the same thing:
+  // mean the same thing.
+  //
+  // Two of them iterate to a fixpoint (`compute_borrow_returning_names`'s
+  // `while changed`, `compute_may_return_view_fns`' callee-edge worklist).
+  // `compute_borrow_param_user_fns` does NOT: it is round 0 plus ONE bounded
+  // transitive round reading round 0's immutable snapshot, and deliberately
+  // stops there (its contract in common_analysis.vibe). The distinction is
+  // not pedantry -- a link-time implementation that closed it transitively
+  // would compute a LARGER borrow set than today's ABI, which is a behaviour
+  // change rather than the same answer computed differently (Codex round on
+  // #2637).
   //
   //   whole has a name the union lacks -- a module was conservative about a
   //     callee it cannot see. Slower, sound.

--- a/lib/@vibe/compiler/tests/prelude_module_oracle_test.vibe
+++ b/lib/@vibe/compiler/tests/prelude_module_oracle_test.vibe
@@ -330,9 +330,11 @@ test "the import closure the oracle runs under is the module's own, and places e
 }
 
 // #2575 item 4: the may_return / borrow analyses are the phases between the
-// prelude and codegen, and unlike the evidence facts (#2633) they are
-// interprocedural FIXPOINTS. This is the program that shows they do not
-// decompose, in BOTH directions at once:
+// prelude and codegen, and unlike the evidence facts (#2633) all three are
+// INTERPROCEDURAL -- each reads the classification of callees that may live in
+// another module. Two iterate to a fixpoint; `compute_borrow_param_user_fns`
+// is round 0 plus ONE bounded transitive round and stops there. This is the
+// program that shows neither shape decomposes, in BOTH directions at once:
 //
 //   helper  head_of(xs: Array[Int]) -> Int     reads xs, never consumes it
 //           pick(xs: Array[String]) -> String  returns an interior view


### PR DESCRIPTION
A Codex finding on #2637 that arrived after it was merged. Comment, test comment and `docs/incremental-build.md` only — no behaviour change.

## What was wrong

#2637 called all three of the post-prelude analyses "interprocedural fixpoints". `compute_borrow_param_user_fns` is not one. Its contract:

> Round 0 uses `md_consume_count` without a user borrow set and exactly preserves the original conservative result. One bounded transitive round then reads that immutable snapshot through `md_consume_count_pre` … **This deliberately stops after one extra layer**: deeper closure is a possible future worklist extension, while every intermediate result stays sound.

The other two do converge — `compute_borrow_returning_names` has a `while changed` loop, `compute_may_return_view_fns` a callee-edge worklist that re-walks a function when one of its callees enters the set.

## Why it is worth a follow-up rather than a note

It reaches the design, not only the prose. The link-time shape that measurement argues for is "the module collects, the link closes over the union", and written as *one* shape that becomes a transitive closure for all three. For the borrow masks a transitive closure computes a **larger** set than the shipped ABI — a behaviour change presented as an implementation of the same thing, which is exactly the substitution a roadmap note should not license.

So the doc now says the link's closing step is a fixpoint for the two that iterate and **exactly one** bounded round for the borrow masks, because that is what the shipped ABI is.

## What does not change

What the three share, and what every number in #2637 rests on, is that they are **interprocedural**: each reads the classification of callees that may live in another module. Bounded-transitive does not decompose any more than a fixpoint does. The 88 unsound entries, the 30 mask disagreements and the 167/180 conservative ones all stand; #2638 carries the same correction.

## Verification

- `bash scripts/compiler_gate.sh` → `[compiler-gate] ok` (stage2==stage3 fixpoint holds).
- `bash scripts/vibe_test.sh lib/@vibe/compiler/tests/prelude_module_oracle_test.vibe` → 6 passed.
- `bash scripts/vibe_fmt.sh --check` clean on both `.vibe` files.

Refs #2637, #2638, #2575.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NAeZzkckdAwtQiubBFpdmM

---
_Generated by [Claude Code](https://claude.ai/code/session_01NAeZzkckdAwtQiubBFpdmM)_