### PR TITLE
ci: remove the measured waste from the CI critical path (893s -> 567s measured)

### DIFF
--- a/.github/actions/use-compiler-build/action.yml
+++ b/.github/actions/use-compiler-build/action.yml
@@ -41,7 +41,9 @@ runs:
         case "$out" in
           *"up to date"*) ;;
           *)
-            echo "::error::compiler-build's generated artifacts are stale in this job -- it regenerated them instead of reusing them. Check that compiler-build uploads .generated.stamp (include-hidden-files: true) and that both jobs restore the same seed." >&2
+            echo "stamp    = $(cat lib/@vibe/compiler/.generated.stamp 2>/dev/null || echo MISSING)"
+            echo "computed = $(bash scripts/ensure_generated.sh --print-fingerprint 2>/dev/null || echo FAILED)"
+            echo "::error::compiler-build's generated artifacts are stale in this job -- it regenerated them instead of reusing them. The two lines above are the stamp compiler-build wrote and the fingerprint this job computes; they must agree. Check that compiler-build uploads .generated.stamp (include-hidden-files: true) and that both jobs restore the same seed." >&2
             exit 1
             ;;
         esac

--- a/.github/actions/use-compiler-build/action.yml
+++ b/.github/actions/use-compiler-build/action.yml
@@ -1,0 +1,55 @@
+name: Use compiler build
+description: >
+  Restore the stage2 wasm and the five generated compiler artifacts that the
+  compiler-build job produced once for this run, instead of rebuilding them.
+
+inputs:
+  stage2-dest:
+    description: >
+      Extra directory to copy stage2.wasm into, for jobs that address it by
+      their own path. Empty = leave it only at _build/_ci_shard_gen/stage2.wasm.
+    default: ''
+
+runs:
+  using: composite
+  steps:
+    # The artifact carries workspace-relative paths (_build/_ci_shard_gen/... and
+    # lib/@vibe/compiler/...), so it unpacks onto the checkout in place.
+    - name: Download the compiler built by compiler-build
+      uses: actions/download-artifact@v4
+      with:
+        name: compiler-build
+        path: .
+
+    - name: Assert the compiler build is present and current
+      shell: bash
+      run: |
+        set -euo pipefail
+        if [ ! -s _build/_ci_shard_gen/stage2.wasm ]; then
+          echo "::error::compiler-build did not deliver _build/_ci_shard_gen/stage2.wasm" >&2
+          exit 1
+        fi
+        # The assertion is on the OUTCOME, not on the files existing. If
+        # ensure_generated regenerates here, the download bought nothing and
+        # this job silently pays ~100s of flatten -- the exact shape of waste
+        # this job layout exists to remove, so it is an error rather than a
+        # slow success. The artifacts are a pure function of (seed, compiler
+        # source) and both jobs read the same commit, so "stale" means the
+        # producer and this job disagree about one of them.
+        out="$(bash scripts/ensure_generated.sh 2>&1)"
+        printf '%s\n' "$out"
+        case "$out" in
+          *"up to date"*) ;;
+          *)
+            echo "::error::compiler-build's generated artifacts are stale in this job -- it regenerated them instead of reusing them. Check that compiler-build uploads .generated.stamp (include-hidden-files: true) and that both jobs restore the same seed." >&2
+            exit 1
+            ;;
+        esac
+
+    - name: Place stage2 where this job addresses it
+      if: inputs.stage2-dest != ''
+      shell: bash
+      run: |
+        set -euo pipefail
+        mkdir -p "${{ inputs.stage2-dest }}"
+        cp _build/_ci_shard_gen/stage2.wasm "${{ inputs.stage2-dest }}/stage2.wasm"

--- a/.github/actions/use-compiler-build/action.yml
+++ b/.github/actions/use-compiler-build/action.yml
@@ -25,10 +25,19 @@ runs:
       shell: bash
       run: |
         set -euo pipefail
-        if [ ! -s _build/_ci_shard_gen/stage2.wasm ]; then
-          echo "::error::compiler-build did not deliver _build/_ci_shard_gen/stage2.wasm" >&2
-          exit 1
-        fi
+        # Consumers read generations.sh's SIDE PRODUCTS by position, not just
+        # the wasm: experimental_typing_env_reuse_oracle.mjs opens
+        # `dirname(stage2)/cli_adapter_module_source.vibe`. Assert them here so
+        # a narrowed upload fails at the download, named, instead of three
+        # minutes later as an ENOENT inside an oracle (run 34577224982).
+        for f in _build/_ci_shard_gen/stage2.wasm \
+                 _build/_ci_shard_gen/cli_adapter_module_source.vibe \
+                 _build/_ci_shard_gen/generation.json; do
+          if [ ! -s "$f" ]; then
+            echo "::error::compiler-build did not deliver $f -- it must upload the whole _build/_ci_shard_gen directory" >&2
+            exit 1
+          fi
+        done
         # The assertion is on the OUTCOME, not on the files existing. If
         # ensure_generated regenerates here, the download bought nothing and
         # this job silently pays ~100s of flatten -- the exact shape of waste

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,12 +103,22 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: compiler-build
+          # The WHOLE _build/_ci_shard_gen directory, not just stage2.wasm:
+          # generations.sh leaves side products there that consumers read by
+          # position. experimental_typing_env_reuse_oracle.mjs opens
+          # `dirname(stage2)/cli_adapter_module_source.vibe` and died with
+          # ENOENT on run 34577224982 when only the wasm was shipped. Picking
+          # files by hand means re-deciding that list every time a consumer
+          # grows; shipping the directory makes the consumer's tree identical
+          # to the producer's, which is the property they actually depend on.
+          # It is ~16 MB.
+          #
           # .generated.stamp is what makes ensure_generated a no-op in the
           # consumers; without it every one of them regenerates.
           include-hidden-files: true
           retention-days: 1
           path: |
-            _build/_ci_shard_gen/stage2.wasm
+            _build/_ci_shard_gen
             lib/@vibe/compiler/compiler_sources_bundle.vibe
             lib/@vibe/compiler/cli_adapter_bundle.vibe
             lib/@vibe/compiler/selfbuild_runtime_entry_bundle.vibe
@@ -1106,7 +1116,7 @@ jobs:
   # shards run concurrently with compiler-gate instead of behind it.
   unit-tests:
     needs: [compiler-build]
-    name: unit-tests (shard ${{ matrix.shard }}/4)
+    name: unit-tests (shard ${{ matrix.shard }}/8)
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -466,7 +466,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        group: [core, typecheck, compile-only]
+        group: [core, compile-only]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
@@ -516,7 +516,22 @@ jobs:
         if: matrix.group == 'core'
         run: CLI_NL_STAGE2="$PWD/_build/_ci_shard_gen/stage2.wasm" bash scripts/check_cli_line_termination.sh
       - name: Off-build typecheck gate
-        if: matrix.group == 'typecheck'
+        # STAYS IN `core`, BEHIND THE GATES ABOVE. Measured: this gate compiles
+        # lib/@vibe/cli/dispatch.vibe, whose import closure needs a warm
+        # source-fingerprinted header cache -- the same effect
+        # tests/gates/bootstrap/stage2_oracles.sh documents for the CLI core
+        # ("header discovery for this import graph retains about 1.03 GB and
+        # the cold RC path traps before codegen"). On main the eight contract
+        # gates above it happened to warm that cache first. Given its own
+        # runner it ran cold and trapped with `RuntimeError: memory access out
+        # of bounds` on runs 34577224982 and 34578340183, and reproduces
+        # locally the moment _build/vibe_selfhost_* is removed -- exactly one
+        # failure, that file. VIBE_WASM_PRE_GROW_PAGES=65000 does not fix it.
+        #
+        # So the ordering that works is kept rather than rediscovered. The
+        # dependency is real and belongs to the gate, not to this file: making
+        # it survive a cold cache on its own is its own change.
+        if: matrix.group == 'core'
         run: VIBE_OFFBUILD_STAGE2="$PWD/_build/_ci_shard_gen/stage2.wasm" bash scripts/check_offbuild_typecheck.sh
       - name: Book skip-block gate
         if: matrix.group == 'core'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -592,6 +592,19 @@ jobs:
           key: viberun-v1-${{ hashFiles('runtime/viberun/Cargo.lock', 'runtime/viberun/Cargo.toml') }}-${{ hashFiles('runtime/viberun/src/**') }}
           restore-keys: |
             viberun-v1-${{ hashFiles('runtime/viberun/Cargo.lock', 'runtime/viberun/Cargo.toml') }}-
+      - name: Build viberun (revalidate against the current sources)
+        # THE PREFIX RESTORE CAN SERVE A STALE BINARY (Codex review of #2645).
+        # When runtime/viberun/src changes, the exact key misses and the
+        # restore-key above still restores a target/release/viberun built from
+        # the OLD sources. install/install.sh accepts any existing executable
+        # as prebuilt and skips cargo entirely, so the gate would exercise a
+        # runner that does not contain the change under review -- silently.
+        #
+        # Cargo's own fingerprinting is the right arbiter, so ask it: with the
+        # dependencies restored this is seconds when nothing moved, and a real
+        # rebuild of just the workspace crate when it did. The cache still buys
+        # what it is good for; it no longer decides correctness.
+        run: cargo build --release --manifest-path runtime/viberun/Cargo.toml
       - name: Use the compiler built once for this run
         uses: ./.github/actions/use-compiler-build
       - name: Stage cached compiler
@@ -664,6 +677,19 @@ jobs:
           key: viberun-v1-${{ hashFiles('runtime/viberun/Cargo.lock', 'runtime/viberun/Cargo.toml') }}-${{ hashFiles('runtime/viberun/src/**') }}
           restore-keys: |
             viberun-v1-${{ hashFiles('runtime/viberun/Cargo.lock', 'runtime/viberun/Cargo.toml') }}-
+      - name: Build viberun (revalidate against the current sources)
+        # THE PREFIX RESTORE CAN SERVE A STALE BINARY (Codex review of #2645).
+        # When runtime/viberun/src changes, the exact key misses and the
+        # restore-key above still restores a target/release/viberun built from
+        # the OLD sources. install/install.sh accepts any existing executable
+        # as prebuilt and skips cargo entirely, so the gate would exercise a
+        # runner that does not contain the change under review -- silently.
+        #
+        # Cargo's own fingerprinting is the right arbiter, so ask it: with the
+        # dependencies restored this is seconds when nothing moved, and a real
+        # rebuild of just the workspace crate when it did. The cache still buys
+        # what it is good for; it no longer decides correctness.
+        run: cargo build --release --manifest-path runtime/viberun/Cargo.toml
       - name: Use the compiler built once for this run
         uses: ./.github/actions/use-compiler-build
       - name: examples/ type-check ratchet

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -446,7 +446,17 @@ jobs:
 
   compiler-contracts:
     needs: [compiler-build]
-    name: compiler-gate (contracts)
+    name: compiler-gate (contracts ${{ matrix.group }})
+    # Ten independent contract gates used to run one after another in a single
+    # job: 357s of the job's 608s on run 34567587111, with the two heaviest
+    # (off-build typecheck 168s, compile-only lanes 142s) contributing most of
+    # it. They share nothing but the stage2 they are all pointed at, and that
+    # now arrives as an artifact, so a group costs a job start plus a download
+    # rather than another compiler build.
+    strategy:
+      fail-fast: false
+      matrix:
+        group: [core, typecheck, compile-only]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
@@ -472,24 +482,34 @@ jobs:
       - name: Use the compiler built once for this run
         uses: ./.github/actions/use-compiler-build
       - name: RC-is-default gate
+        if: matrix.group == 'core'
         run: RC_DEFAULT_STAGE2="$PWD/_build/_ci_shard_gen/stage2.wasm" bash scripts/check_rc_default.sh
       - name: Source-range contract gate
+        if: matrix.group == 'core'
         run: RANGE_STAGE2="$PWD/_build/_ci_shard_gen/stage2.wasm" bash scripts/check_source_range_contract.sh
       - name: Cheatsheet-signatures gate
+        if: matrix.group == 'core'
         run: CHEATSHEET_SIG_STAGE2="$PWD/_build/_ci_shard_gen/stage2.wasm" bash scripts/check_cheatsheet_signatures.sh
       - name: Builtin-shadowing gate
+        if: matrix.group == 'core'
         run: BUILTIN_SHADOW_STAGE2="$PWD/_build/_ci_shard_gen/stage2.wasm" bash scripts/check_builtin_shadowing.sh
       - name: Builtin-shadowing gate self-test
+        if: matrix.group == 'core'
         run: BUILTIN_SHADOW_STAGE2="$PWD/_build/_ci_shard_gen/stage2.wasm" bash scripts/check_builtin_shadowing_test.sh
       - name: Package sibling-scope gate
+        if: matrix.group == 'core'
         run: SIBLING_SCOPE_STAGE2="$PWD/_build/_ci_shard_gen/stage2.wasm" bash scripts/check_package_sibling_scope.sh
       - name: Declaration-scale gate
+        if: matrix.group == 'core'
         run: DECL_SCALE_STAGE2="$PWD/_build/_ci_shard_gen/stage2.wasm" bash scripts/check_declaration_scale.sh
       - name: CLI line-termination gate
+        if: matrix.group == 'core'
         run: CLI_NL_STAGE2="$PWD/_build/_ci_shard_gen/stage2.wasm" bash scripts/check_cli_line_termination.sh
       - name: Off-build typecheck gate
+        if: matrix.group == 'typecheck'
         run: VIBE_OFFBUILD_STAGE2="$PWD/_build/_ci_shard_gen/stage2.wasm" bash scripts/check_offbuild_typecheck.sh
       - name: Book skip-block gate
+        if: matrix.group == 'core'
         run: VIBE_SKIP_BLOCK_CLI_WASM="$PWD/_build/_ci_shard_gen/stage2.wasm" bash scripts/check_book_skip_blocks.sh
       # No examples typecheck here: check_examples_typecheck.sh was ALREADY
       # wired, via `pkf run ci-check-examples-typecheck` in compiler-examples,
@@ -497,6 +517,7 @@ jobs:
       # got wrong -- the reachability trace missed the task indirection. Nine
       # of the ten gates in this job were genuinely unrun; this one was not.
       - name: Compile-only lanes gate
+        if: matrix.group == 'compile-only'
         run: COMPILE_ONLY_STAGE2="$PWD/_build/_ci_shard_gen/stage2.wasm" bash scripts/check_compile_only_lanes.sh
 
   compiler-playground:
@@ -540,6 +561,27 @@ jobs:
           dir="wasmtime-${WASMTIME_VERSION}-x86_64-linux"
           curl -sSL --fail --retry 5 --retry-delay 2 --retry-all-errors "https://github.com/bytecodealliance/wasmtime/releases/download/${WASMTIME_VERSION}/${dir}.tar.xz" | tar -xJ
           echo "$PWD/$dir" >> "$GITHUB_PATH"
+      - name: Cache viberun build
+        # install/install.sh builds runtime/viberun with `cargo build --release`
+        # unless target/release/viberun already exists. Uncached that is the
+        # whole step: on run 34567587111 this job spent ~215s there and printed
+        # nothing, while the check it exists for took 23s. The key is
+        # Cargo.lock + src, which does not move when the compiler changes, so
+        # unlike the compiler caches this one actually hits.
+        #
+        # actions/cache over target/, not Swatinem/rust-cache: rust-cache
+        # deliberately drops the workspace crate's own artifacts and keeps only
+        # dependencies, so the binary is relinked every run -- which is why
+        # perf-metrics still paid 104s with a cache step in place.
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            runtime/viberun/target
+          key: viberun-v1-${{ hashFiles('runtime/viberun/Cargo.lock', 'runtime/viberun/Cargo.toml') }}-${{ hashFiles('runtime/viberun/src/**') }}
+          restore-keys: |
+            viberun-v1-${{ hashFiles('runtime/viberun/Cargo.lock', 'runtime/viberun/Cargo.toml') }}-
       - name: Use the compiler built once for this run
         uses: ./.github/actions/use-compiler-build
       - name: Stage cached compiler
@@ -591,6 +633,27 @@ jobs:
           dir="wasmtime-${WASMTIME_VERSION}-x86_64-linux"
           curl -sSL --fail --retry 5 --retry-delay 2 --retry-all-errors "https://github.com/bytecodealliance/wasmtime/releases/download/${WASMTIME_VERSION}/${dir}.tar.xz" | tar -xJ
           echo "$PWD/$dir" >> "$GITHUB_PATH"
+      - name: Cache viberun build
+        # install/install.sh builds runtime/viberun with `cargo build --release`
+        # unless target/release/viberun already exists. Uncached that is the
+        # whole step: on run 34567587111 this job spent ~215s there and printed
+        # nothing, while the check it exists for took 23s. The key is
+        # Cargo.lock + src, which does not move when the compiler changes, so
+        # unlike the compiler caches this one actually hits.
+        #
+        # actions/cache over target/, not Swatinem/rust-cache: rust-cache
+        # deliberately drops the workspace crate's own artifacts and keeps only
+        # dependencies, so the binary is relinked every run -- which is why
+        # perf-metrics still paid 104s with a cache step in place.
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            runtime/viberun/target
+          key: viberun-v1-${{ hashFiles('runtime/viberun/Cargo.lock', 'runtime/viberun/Cargo.toml') }}-${{ hashFiles('runtime/viberun/src/**') }}
+          restore-keys: |
+            viberun-v1-${{ hashFiles('runtime/viberun/Cargo.lock', 'runtime/viberun/Cargo.toml') }}-
       - name: Use the compiler built once for this run
         uses: ./.github/actions/use-compiler-build
       - name: examples/ type-check ratchet
@@ -909,7 +972,15 @@ jobs:
   # first CI run caught it.)
   gc-gate:
     needs: [compiler-build]
-    name: gc-gate
+    name: gc-gate (${{ matrix.group }})
+    # "wasm-gc heap accounting + validation" was 220s of this job's 274s of
+    # gate work, with the validator-parity and fixture steps adding ~55s after
+    # it. Splitting them puts both under the run's per-job budget instead of
+    # summing into one 500s job.
+    strategy:
+      fail-fast: false
+      matrix:
+        group: [heap, validate]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
@@ -965,6 +1036,7 @@ jobs:
         with:
           stage2-dest: _build/_ci_gc_gen
       - name: wasm-gc heap accounting + validation
+        if: matrix.group == 'heap'
         run: bash scripts/test_gc_heap_accounting.sh "$PWD/_build/_ci_gc_gen/stage2.wasm"
       # Runs HERE and not in a gate of its own for the same two reasons the job
       # exists: it needs wasm-tools (its oracle) and a stage2, both of which
@@ -974,6 +1046,7 @@ jobs:
       # names every proposal the output requires. Registering the pkf task
       # without this step would leave both measurements running nowhere.
       - name: wasm validator parity + feature-declaration scan
+        if: matrix.group == 'validate'
         run: bash scripts/test_wasm_validate_parity.sh "$PWD/_build/_ci_gc_gen/stage2.wasm"
       # #2156 review: until now NOTHING ran a test fixture on the wasm-gc
       # lane in CI. gc-gate built a stage2 and checked heap accounting and
@@ -988,6 +1061,7 @@ jobs:
       # there is no filename-pattern selection, a fixture is gc-covered only by
       # being named here.
       - name: wasm-gc runtime test fixtures
+        if: matrix.group == 'validate'
         run: |
           VIBE_TEST_CLI_WASM="$PWD/_build/_ci_gc_gen/stage2.wasm" VIBE_TEST_BACKEND=gc \
             bash scripts/vibe_test.sh \
@@ -1013,11 +1087,13 @@ jobs:
             fixtures/bytes_count_last_index_of_test.vibe \
             fixtures/bytes_compare_test.vibe
       - name: wasm-gc direct single-file import diagnostic
+        if: matrix.group == 'validate'
         run: bash scripts/test_gc_direct_import_diag.sh "$PWD/_build/_ci_gc_gen/stage2.wasm"
       # The fixture harness above is not the public command boundary. Keep a
       # separate regression for runtime/vibe's compile_to environment wiring:
       # VIBE_TEST_BACKEND=gc must retain filesystem module loading (#2376).
       - name: wasm-gc public test import resolution
+        if: matrix.group == 'validate'
         run: bash scripts/test_gc_launcher_import.sh "$PWD/_build/_ci_gc_gen/stage2.wasm"
 
   # The 467-file selfhost unit-test battery (#531/#535), weight-balanced into
@@ -1035,7 +1111,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        shard: [0, 1, 2, 3]
+        shard: [0, 1, 2, 3, 4, 5, 6, 7]
     steps:
       - uses: actions/checkout@v5
       - name: Cache seed artifact
@@ -1072,10 +1148,10 @@ jobs:
           key: vibecache-v2-${{ hashFiles('lib/@vibe/compiler/cache/codegen_fingerprint.vibe') }}-shard${{ matrix.shard }}-${{ github.run_id }}
           restore-keys: |
             vibecache-v2-${{ hashFiles('lib/@vibe/compiler/cache/codegen_fingerprint.vibe') }}-shard${{ matrix.shard }}-
-      - name: Compiler unit-test runner (shard ${{ matrix.shard }}/4)
+      - name: Compiler unit-test runner (shard ${{ matrix.shard }}/8)
         run: |
           VIBE_STAGE2_WASM="$PWD/_build/_ci_shard_gen/stage2.wasm" \
-          VIBE_UNIT_TEST_SHARD="${{ matrix.shard }}/4" \
+          VIBE_UNIT_TEST_SHARD="${{ matrix.shard }}/8" \
             bash scripts/unit_test_runner.sh
 
   # Selfhost suite coverage gate (#535), main-only. Re-runs the entire
@@ -1088,7 +1164,18 @@ jobs:
   # most one merge late, never silently for good.
   coverage-suite:
     needs: [compiler-build]
-    name: coverage-suite (main only)
+    name: coverage-suite (main only, shard ${{ matrix.shard }})
+    # 691s and the longest step in the workflow: it alone set the run's wall
+    # clock at 891s while the required path finished at 615s (run
+    # 34567587111). It is already parallel inside the job -- vibe_test.sh fans
+    # out over min(4, nproc) -- so the only way down is more runners. Eight
+    # disjoint partitions of the same battery; the merge job below aggregates
+    # them and applies the ratchets, which is where they belong: a shard sees a
+    # subset, so every union metric it could compute is a lower bound.
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [0, 1, 2, 3, 4, 5, 6, 7]
     if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     # contents: write for the bench-data append below (same branch the perf
@@ -1118,11 +1205,71 @@ jobs:
           echo "$PWD/$dir" >> "$GITHUB_PATH"
       - name: Use the compiler built once for this run
         uses: ./.github/actions/use-compiler-build
-      - name: Selfhost suite coverage gate (#535)
+      - name: Selfhost suite coverage shard ${{ matrix.shard }}/8 (#535)
         # Relative path: coverage_suite.sh historically rebased $cli onto the
         # repo root (it now tolerates absolute paths too, but stay canonical).
         run: |
           VIBE_SUITE_CLI_WASM="_build/_ci_shard_gen/stage2.wasm" \
+          VIBE_COVERAGE_SHARD="${{ matrix.shard }}/8" \
+            bash scripts/coverage_suite.sh
+      - name: Stage coverage shard ${{ matrix.shard }}
+        # Staged into ONE directory rather than uploading two paths: with two,
+        # upload-artifact roots the archive at their common ancestor, so the
+        # layout the merge sees depends on where the inputs happen to live.
+        # This way the artifact is exactly {vibe_test.log, coverage/} and the
+        # merge's glob is a fact about this step, not about that rule.
+        run: |
+          set -euo pipefail
+          out=_build/coverage-shard-out
+          rm -rf "$out"
+          mkdir -p "$out/coverage"
+          cp _build/coverage/selfhost-suite/vibe_test.log "$out/vibe_test.log"
+          cp -a _build/vibe_test/coverage/. "$out/coverage/"
+      - name: Upload coverage shard ${{ matrix.shard }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-shard-${{ matrix.shard }}
+          retention-days: 1
+          path: _build/coverage-shard-out
+          if-no-files-found: error
+  coverage-merge:
+    name: coverage-suite (merge)
+    # The ratchets live here, over the union of all eight shards. No compiler:
+    # the report is a pure function of the shard logs and the per-entry
+    # coverage JSON, so this is a download plus a python run.
+    needs: [coverage-suite]
+    if: github.event_name != 'pull_request'
+    permissions:
+      contents: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
+        with:
+          node-version: 24
+      - name: Cache seed artifact
+        # The merge path needs no compiler, but coverage_suite.sh is one script
+        # and check_ci_seed_cache.sh judges the job, not the branch taken --
+        # deliberately, since no scanner can follow which branch runs.
+        uses: actions/cache@v4
+        with:
+          path: bootstrap/seed/compiler.wasm
+          key: seed-artifact-${{ hashFiles('bootstrap/seed.json') }}
+      - name: Ensure seed artifact
+        run: bash scripts/ensure_seed.sh
+      - name: Download coverage shards
+        uses: actions/download-artifact@v4
+        with:
+          pattern: coverage-shard-*
+          path: _build/coverage-shards
+      - name: Aggregate and gate (#535)
+        # VIBE_COVERAGE_MERGE_EXPECT makes a lost upload fail as a lost upload:
+        # a partial merge understates every union metric, and without this it
+        # would read as a coverage regression and get "explained" by lowering
+        # the ratchet.
+        run: |
+          VIBE_COVERAGE_MERGE_DIR=_build/coverage-shards \
+          VIBE_COVERAGE_MERGE_EXPECT=8 \
             bash scripts/coverage_suite.sh
       - name: Coverage summary (#1556)
         # Put the union rates on the run's summary page so the current value is
@@ -1352,9 +1499,26 @@ jobs:
       # so cargo re-fingerprints (and recompiles) the whole dependency tree
       # even on a cache hit.
       - name: Cache viberun build
-        uses: Swatinem/rust-cache@v2
+        # install/install.sh builds runtime/viberun with `cargo build --release`
+        # unless target/release/viberun already exists. Uncached that is the
+        # whole step: on run 34567587111 this job spent ~215s there and printed
+        # nothing, while the check it exists for took 23s. The key is
+        # Cargo.lock + src, which does not move when the compiler changes, so
+        # unlike the compiler caches this one actually hits.
+        #
+        # actions/cache over target/, not Swatinem/rust-cache: rust-cache
+        # deliberately drops the workspace crate's own artifacts and keeps only
+        # dependencies, so the binary is relinked every run -- which is why
+        # perf-metrics still paid 104s with a cache step in place.
+        uses: actions/cache@v4
         with:
-          workspaces: runtime/viberun
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            runtime/viberun/target
+          key: viberun-v1-${{ hashFiles('runtime/viberun/Cargo.lock', 'runtime/viberun/Cargo.toml') }}-${{ hashFiles('runtime/viberun/src/**') }}
+          restore-keys: |
+            viberun-v1-${{ hashFiles('runtime/viberun/Cargo.lock', 'runtime/viberun/Cargo.toml') }}-
       - name: Use the compiler built once for this run
         uses: ./.github/actions/use-compiler-build
       - name: Build viberun (micro-bench runtime)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -187,6 +187,25 @@ jobs:
         with:
           node-version: 24
           wasmtime: 'true'
+      - name: Cache seed artifact
+        # WITHOUT THIS STEP THIS JOB REBUILDS THE SEED FROM SOURCE.
+        # bootstrap/seed/compiler.wasm is gitignored, so the first thing that
+        # touches the compiler calls ensure_seed.sh -- and when the pinned
+        # release tag is not published yet (a bootstrap bump before its
+        # `seed-release` run lands), ensure_seed REBUILDS the pinned seed:
+        # stage0 -> stage1 -> stage2, ~5 minutes, silently, inside whatever
+        # step happened to ask first. Measured on run 34567587111: 304s in
+        # "Generated compiler fingerprint" here, 323s in compiler-playground,
+        # 335s in compiler-docs and 429s inside structural-lint's
+        # review-regressions self-test -- four jobs paying the same 5 minutes
+        # for the same artifact. The cache key is the pin, so one run pays it
+        # and every later one restores in ~2s.
+        uses: actions/cache@v4
+        with:
+          path: bootstrap/seed/compiler.wasm
+          key: seed-artifact-${{ hashFiles('bootstrap/seed.json') }}
+      - name: Ensure seed artifact
+        run: bash scripts/ensure_seed.sh
       - name: Generated compiler fingerprint
         id: genfp
         run: echo "fp=$(bash scripts/ensure_generated.sh --print-fingerprint)" >> "$GITHUB_OUTPUT"
@@ -296,6 +315,25 @@ jobs:
         with:
           node-version: 24
           wasmtime: 'true'
+      - name: Cache seed artifact
+        # WITHOUT THIS STEP THIS JOB REBUILDS THE SEED FROM SOURCE.
+        # bootstrap/seed/compiler.wasm is gitignored, so the first thing that
+        # touches the compiler calls ensure_seed.sh -- and when the pinned
+        # release tag is not published yet (a bootstrap bump before its
+        # `seed-release` run lands), ensure_seed REBUILDS the pinned seed:
+        # stage0 -> stage1 -> stage2, ~5 minutes, silently, inside whatever
+        # step happened to ask first. Measured on run 34567587111: 304s in
+        # "Generated compiler fingerprint" here, 323s in compiler-playground,
+        # 335s in compiler-docs and 429s inside structural-lint's
+        # review-regressions self-test -- four jobs paying the same 5 minutes
+        # for the same artifact. The cache key is the pin, so one run pays it
+        # and every later one restores in ~2s.
+        uses: actions/cache@v4
+        with:
+          path: bootstrap/seed/compiler.wasm
+          key: seed-artifact-${{ hashFiles('bootstrap/seed.json') }}
+      - name: Ensure seed artifact
+        run: bash scripts/ensure_seed.sh
       - name: Generated compiler fingerprint
         id: genfp
         run: echo "fp=$(bash scripts/ensure_generated.sh --print-fingerprint)" >> "$GITHUB_OUTPUT"
@@ -509,6 +547,25 @@ jobs:
         with:
           node-version: 24
           wasmtime: 'true'
+      - name: Cache seed artifact
+        # WITHOUT THIS STEP THIS JOB REBUILDS THE SEED FROM SOURCE.
+        # bootstrap/seed/compiler.wasm is gitignored, so the first thing that
+        # touches the compiler calls ensure_seed.sh -- and when the pinned
+        # release tag is not published yet (a bootstrap bump before its
+        # `seed-release` run lands), ensure_seed REBUILDS the pinned seed:
+        # stage0 -> stage1 -> stage2, ~5 minutes, silently, inside whatever
+        # step happened to ask first. Measured on run 34567587111: 304s in
+        # "Generated compiler fingerprint" here, 323s in compiler-playground,
+        # 335s in compiler-docs and 429s inside structural-lint's
+        # review-regressions self-test -- four jobs paying the same 5 minutes
+        # for the same artifact. The cache key is the pin, so one run pays it
+        # and every later one restores in ~2s.
+        uses: actions/cache@v4
+        with:
+          path: bootstrap/seed/compiler.wasm
+          key: seed-artifact-${{ hashFiles('bootstrap/seed.json') }}
+      - name: Ensure seed artifact
+        run: bash scripts/ensure_seed.sh
       - name: Generated compiler fingerprint
         id: genfp
         run: echo "fp=$(bash scripts/ensure_generated.sh --print-fingerprint)" >> "$GITHUB_OUTPUT"
@@ -832,6 +889,25 @@ jobs:
       - uses: actions/checkout@v5
       - name: Install ripgrep
         run: command -v rg >/dev/null || sudo apt-get install -y ripgrep
+      - name: Cache seed artifact
+        # WITHOUT THIS STEP THIS JOB REBUILDS THE SEED FROM SOURCE.
+        # bootstrap/seed/compiler.wasm is gitignored, so the first thing that
+        # touches the compiler calls ensure_seed.sh -- and when the pinned
+        # release tag is not published yet (a bootstrap bump before its
+        # `seed-release` run lands), ensure_seed REBUILDS the pinned seed:
+        # stage0 -> stage1 -> stage2, ~5 minutes, silently, inside whatever
+        # step happened to ask first. Measured on run 34567587111: 304s in
+        # "Generated compiler fingerprint" here, 323s in compiler-playground,
+        # 335s in compiler-docs and 429s inside structural-lint's
+        # review-regressions self-test -- four jobs paying the same 5 minutes
+        # for the same artifact. The cache key is the pin, so one run pays it
+        # and every later one restores in ~2s.
+        uses: actions/cache@v4
+        with:
+          path: bootstrap/seed/compiler.wasm
+          key: seed-artifact-${{ hashFiles('bootstrap/seed.json') }}
+      - name: Ensure seed artifact
+        run: bash scripts/ensure_seed.sh
       - name: architecture-debt lint self-test
         run: bash scripts/lint_architecture_debt_test.sh
       - name: architecture-debt lint
@@ -860,6 +936,14 @@ jobs:
         run: bash scripts/check_portable_boundary_test.sh
       - name: portable-boundary gate
         run: bash scripts/check_portable_boundary.sh
+      - name: CI seed-cache gate self-test
+        run: bash scripts/check_ci_seed_cache_test.sh
+      - name: CI seed-cache gate
+        # Lexical, no toolchain: every CI job that reaches a repository script
+        # restores the pinned seed from cache first. Without it the job silently
+        # REBUILDS the seed (~5 min) whenever its release tag is unpublished --
+        # which is what four jobs were doing on run 34567587111 (#2645).
+        run: bash scripts/check_ci_seed_cache.sh
       - name: gate-wiring gate self-test
         run: bash scripts/check_gate_wiring_test.sh
       - name: gate-wiring gate

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,95 @@ on:
 # All jobs start at t=0; nothing on the required path serializes behind
 # another job.
 jobs:
+  compiler-build:
+    name: compiler-build
+    # THE COMPILER IS BUILT ONCE PER RUN, HERE.
+    #
+    # Before #2645 fourteen jobs each ran ensure_generated.sh (~100-145s of
+    # flatten) and nine of them also ran generations.sh (~66-91s of
+    # seed -> stage1 -> stage2) -- the same two artifacts, from the same
+    # commit, fourteen times over, ~2700s of runner time per run. It did not
+    # buy wall time either: a consumer's download costs ~25s against a
+    # producer that finishes in ~200s, which is what the in-job build cost
+    # anyway. What it buys is that a SHARD is now cheap: adding a matrix entry
+    # costs a job start plus a download, not another compiler build, so the
+    # long gates below can be split until each one fits the run's budget.
+    #
+    # compiler-gate deliberately does NOT consume this. It is the seed ->
+    # stage3 fixpoint: it has to perform the build it is checking, and making
+    # it wait for a build it would redo anyway would put ~200s in front of it
+    # for nothing.
+    runs-on: ubuntu-latest
+    outputs:
+      fingerprint: ${{ steps.genfp.outputs.fp }}
+    steps:
+      - uses: actions/checkout@v5
+      - uses: ./.github/actions/setup-vibe
+        with:
+          node-version: 24
+          wasmtime: 'true'
+      - name: Cache seed artifact
+        uses: actions/cache@v4
+        with:
+          path: bootstrap/seed/compiler.wasm
+          key: seed-artifact-${{ hashFiles('bootstrap/seed.json') }}
+      - name: Ensure seed artifact
+        run: bash scripts/ensure_seed.sh
+      - name: Generated compiler artifacts (fingerprint)
+        id: genfp
+        run: echo "fp=$(bash scripts/ensure_generated.sh --print-fingerprint)" >> "$GITHUB_OUTPUT"
+      - name: Cache generated compiler artifacts
+        uses: actions/cache@v4
+        with:
+          path: |
+            lib/@vibe/compiler/compiler_sources_bundle.vibe
+            lib/@vibe/compiler/cli_adapter_bundle.vibe
+            lib/@vibe/compiler/selfbuild_runtime_entry_bundle.vibe
+            lib/@vibe/compiler/_cli_adapter_module_source.vibe
+            lib/@vibe/compiler/cache/codegen_fingerprint.vibe
+            lib/@vibe/compiler/.generated.stamp
+          key: gen-v1-${{ steps.genfp.outputs.fp }}
+      - name: Ensure generated compiler artifacts
+        run: bash scripts/ensure_generated.sh
+      - name: Cache stage2 (keyed on seed + flat module source)
+        id: stage2-cache
+        uses: actions/cache@v4
+        with:
+          path: _build/_ci_shard_gen
+          key: stage2-v2-${{ steps.genfp.outputs.fp }}-${{ hashFiles('scripts/generations.sh', 'scripts/wasm_vibe_host_runner.js') }}
+      - name: Build stage2 from committed flat module source
+        if: steps.stage2-cache.outputs.cache-hit != 'true'
+        run: |
+          VIBE_PREBUILT_MODULE_SOURCE=lib/@vibe/compiler/_cli_adapter_module_source.vibe \
+            bash scripts/generations.sh build --out-dir _build/_ci_shard_gen
+      - name: Assert stage2 exists
+        # A missing stage2 has to fail HERE, named, rather than downstream in
+        # every consumer at once with the producer reported green.
+        run: |
+          set -euo pipefail
+          if [ ! -s _build/_ci_shard_gen/stage2.wasm ]; then
+            echo "::error::compiler-build produced no _build/_ci_shard_gen/stage2.wasm" >&2
+            exit 1
+          fi
+          ls -l _build/_ci_shard_gen/stage2.wasm
+      - name: Upload compiler build
+        uses: actions/upload-artifact@v4
+        with:
+          name: compiler-build
+          # .generated.stamp is what makes ensure_generated a no-op in the
+          # consumers; without it every one of them regenerates.
+          include-hidden-files: true
+          retention-days: 1
+          path: |
+            _build/_ci_shard_gen/stage2.wasm
+            lib/@vibe/compiler/compiler_sources_bundle.vibe
+            lib/@vibe/compiler/cli_adapter_bundle.vibe
+            lib/@vibe/compiler/selfbuild_runtime_entry_bundle.vibe
+            lib/@vibe/compiler/_cli_adapter_module_source.vibe
+            lib/@vibe/compiler/cache/codegen_fingerprint.vibe
+            lib/@vibe/compiler/.generated.stamp
+          if-no-files-found: error
+
   compiler-gate-preflight:
     name: compiler-gate (preflight)
     runs-on: ubuntu-latest
@@ -150,35 +239,9 @@ jobs:
           COMPILER_GATE_SKIP_PREFLIGHT: "1"
           COMPILER_GATE_SKIP_STAGE2_ORACLES: "1"
         run: bash scripts/compiler_gate.sh
-      - name: Stage stage2 for downstream gates (#821)
-        run: |
-          gen="$(ls -dt _build/selfhost/generations/*/ | head -1)"
-          mkdir -p _build/ci-artifacts
-          cp "${gen}stage2.wasm" _build/ci-artifacts/stage2.wasm
-      - name: Upload stage2 artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: compiler-stage2
-          path: _build/ci-artifacts/stage2.wasm
-          if-no-files-found: error
-      - name: Upload generated compiler artifacts
-        # perf-metrics measures the bundle / module-source sizes and must not
-        # regenerate them (that regeneration is ~3.5 min of runner time this
-        # job has already spent). Downloaded into lib/@vibe/compiler/ there.
-        uses: actions/upload-artifact@v4
-        with:
-          name: compiler-generated
-          include-hidden-files: true
-          path: |
-            lib/@vibe/compiler/compiler_sources_bundle.vibe
-            lib/@vibe/compiler/cli_adapter_bundle.vibe
-            lib/@vibe/compiler/selfbuild_runtime_entry_bundle.vibe
-            lib/@vibe/compiler/_cli_adapter_module_source.vibe
-            lib/@vibe/compiler/cache/codegen_fingerprint.vibe
-            lib/@vibe/compiler/.generated.stamp
-          if-no-files-found: error
 
   compiler-stage2-oracles:
+    needs: [compiler-build]
     name: compiler-gate (stage2 oracles)
     runs-on: ubuntu-latest
     steps:
@@ -206,28 +269,6 @@ jobs:
           key: seed-artifact-${{ hashFiles('bootstrap/seed.json') }}
       - name: Ensure seed artifact
         run: bash scripts/ensure_seed.sh
-      - name: Generated compiler fingerprint
-        id: genfp
-        run: echo "fp=$(bash scripts/ensure_generated.sh --print-fingerprint)" >> "$GITHUB_OUTPUT"
-      - name: Restore generated compiler artifacts
-        uses: actions/cache@v4
-        with:
-          path: |
-            lib/@vibe/compiler/compiler_sources_bundle.vibe
-            lib/@vibe/compiler/cli_adapter_bundle.vibe
-            lib/@vibe/compiler/selfbuild_runtime_entry_bundle.vibe
-            lib/@vibe/compiler/_cli_adapter_module_source.vibe
-            lib/@vibe/compiler/cache/codegen_fingerprint.vibe
-            lib/@vibe/compiler/.generated.stamp
-          key: gen-v1-${{ steps.genfp.outputs.fp }}
-      - name: Ensure generated compiler artifacts
-        run: bash scripts/ensure_generated.sh
-      - name: Restore cached stage2
-        id: stage2-cache
-        uses: actions/cache@v4
-        with:
-          path: _build/_ci_shard_gen
-          key: stage2-v2-${{ steps.genfp.outputs.fp }}-${{ hashFiles('scripts/generations.sh', 'scripts/wasm_vibe_host_runner.js') }}
       - name: Install wasmtime
         # #2184: must run BEFORE "Build stage2 on cache miss" -- the build's
         # validate step shells out to the wasmtime binary. Later steps (the
@@ -238,12 +279,6 @@ jobs:
           dir="wasmtime-${WASMTIME_VERSION}-x86_64-linux"
           curl -sSL --fail --retry 5 --retry-delay 2 --retry-all-errors "https://github.com/bytecodealliance/wasmtime/releases/download/${WASMTIME_VERSION}/${dir}.tar.xz" | tar -xJ
           echo "$PWD/$dir" >> "$GITHUB_PATH"
-      - name: Build stage2 on cache miss
-        if: steps.stage2-cache.outputs.cache-hit != 'true'
-        run: |
-          bash scripts/ensure_seed.sh
-          bash scripts/ensure_generated.sh
-          VIBE_PREBUILT_MODULE_SOURCE=lib/@vibe/compiler/_cli_adapter_module_source.vibe bash scripts/generations.sh build --out-dir _build/_ci_shard_gen
       - name: Install wasm-tools
         env:
           WASM_TOOLS_VERSION: "1.253.0"
@@ -252,6 +287,8 @@ jobs:
           curl -fsSL --retry 5 --retry-delay 2 --retry-all-errors "https://github.com/bytecodealliance/wasm-tools/releases/download/v${WASM_TOOLS_VERSION}/wasm-tools-${WASM_TOOLS_VERSION}-x86_64-linux.tar.gz" | tar -xz
           cp "wasm-tools-${WASM_TOOLS_VERSION}-x86_64-linux/wasm-tools" "$PWD/compiler-tools/"
           echo "$PWD/compiler-tools" >> "$GITHUB_PATH"
+      - name: Use the compiler built once for this run
+        uses: ./.github/actions/use-compiler-build
       - name: Stage cached compiler
         run: |
           mkdir -p _build/selfhost/generations/ci-oracles
@@ -307,6 +344,7 @@ jobs:
         run: bash scripts/vibe_normalize_smoke.sh
 
   compiler-docs:
+    needs: [compiler-build]
     name: compiler-gate (docs)
     runs-on: ubuntu-latest
     steps:
@@ -334,23 +372,11 @@ jobs:
           key: seed-artifact-${{ hashFiles('bootstrap/seed.json') }}
       - name: Ensure seed artifact
         run: bash scripts/ensure_seed.sh
-      - name: Generated compiler fingerprint
-        id: genfp
-        run: echo "fp=$(bash scripts/ensure_generated.sh --print-fingerprint)" >> "$GITHUB_OUTPUT"
-      - name: Restore cached stage2
-        id: stage2-cache
-        uses: actions/cache@v4
-        with:
-          path: _build/_ci_shard_gen
-          key: stage2-v2-${{ steps.genfp.outputs.fp }}-${{ hashFiles('scripts/generations.sh', 'scripts/wasm_vibe_host_runner.js') }}
-      - name: Install wasmtime (cold stage2 build only)
-        # #2184: generations.sh's "validate stageN compiler -> sample" step
-        # shells out to a wasmtime BINARY, so the cold-cache build below needs
-        # it on PATH. A warm cache skips the build and never touches it --
-        # which is how this job passed until the first fingerprint-moving
-        # change ran it cold: the stage2 cache key includes the compiler-source
-        # fingerprint, so EVERY compiler-touching PR takes the cold path.
-        if: steps.stage2-cache.outputs.cache-hit != 'true'
+      - name: Install wasmtime
+        # The gates below run compiled sample wasm through the wasmtime
+        # binary. It used to be conditioned on the in-job stage2 build being
+        # cold; that build now happens once in compiler-build, so the
+        # condition is gone and this is unconditional.
         env:
           WASMTIME_VERSION: v47.0.2
         run: |
@@ -358,12 +384,8 @@ jobs:
           dir="wasmtime-${WASMTIME_VERSION}-x86_64-linux"
           curl -sSL --fail --retry 5 --retry-delay 2 --retry-all-errors "https://github.com/bytecodealliance/wasmtime/releases/download/${WASMTIME_VERSION}/${dir}.tar.xz" | tar -xJ
           echo "$PWD/$dir" >> "$GITHUB_PATH"
-      - name: Build stage2 on cache miss
-        if: steps.stage2-cache.outputs.cache-hit != 'true'
-        run: |
-          bash scripts/ensure_seed.sh
-          bash scripts/ensure_generated.sh
-          VIBE_PREBUILT_MODULE_SOURCE=lib/@vibe/compiler/_cli_adapter_module_source.vibe bash scripts/generations.sh build --out-dir _build/_ci_shard_gen
+      - name: Use the compiler built once for this run
+        uses: ./.github/actions/use-compiler-build
       - name: Stage cached compiler
         run: |
           mkdir -p _build/selfhost/generations/ci-docs
@@ -423,6 +445,7 @@ jobs:
           FREEZE_STAGE2="${gen}stage2.wasm" bash scripts/check_freeze_surface.sh
 
   compiler-contracts:
+    needs: [compiler-build]
     name: compiler-gate (contracts)
     runs-on: ubuntu-latest
     steps:
@@ -446,70 +469,8 @@ jobs:
           key: seed-artifact-${{ hashFiles('bootstrap/seed.json') }}
       - name: Ensure seed artifact
         run: bash scripts/ensure_seed.sh
-      - name: Generated compiler fingerprint
-        id: genfp
-        run: echo "fp=$(bash scripts/ensure_generated.sh --print-fingerprint)" >> "$GITHUB_OUTPUT"
-      # The generated artifacts are needed by the GATES, not just by the stage2
-      # build -- check_offbuild_typecheck typechecks every off-manifest source,
-      # and several import `compiler_sources_bundle.vibe` /
-      # `cli_adapter_bundle.vibe` or implement `cache/index.vpkg`'s
-      # `codegen_fingerprint` declaration. Producing them only inside the
-      # cache-miss build below meant a stage2 cache HIT left them absent and the
-      # gate reported 20 real contract violations against a half-built tree.
-      # Cached and ensured unconditionally, exactly as compiler-gate-lanes does.
-      - name: Cache generated compiler artifacts
-        uses: actions/cache@v4
-        with:
-          path: |
-            lib/@vibe/compiler/compiler_sources_bundle.vibe
-            lib/@vibe/compiler/cli_adapter_bundle.vibe
-            lib/@vibe/compiler/selfbuild_runtime_entry_bundle.vibe
-            lib/@vibe/compiler/_cli_adapter_module_source.vibe
-            lib/@vibe/compiler/cache/codegen_fingerprint.vibe
-            lib/@vibe/compiler/.generated.stamp
-          key: gen-v1-${{ steps.genfp.outputs.fp }}
-      - name: Ensure generated compiler artifacts
-        run: bash scripts/ensure_generated.sh
-      - name: Restore cached stage2
-        id: stage2-cache
-        uses: actions/cache@v4
-        with:
-          path: _build/_ci_shard_gen
-          key: stage2-v2-${{ steps.genfp.outputs.fp }}-${{ hashFiles('scripts/generations.sh', 'scripts/wasm_vibe_host_runner.js') }}
-      # No second wasmtime install: setup-vibe above runs with wasmtime: 'true',
-      # which installs the same pinned 47.0.2 (scripts/install_wasmtime_release.sh
-      # -> $HOME/.wasmtime/bin) and appends exactly that directory to PATH,
-      # unconditionally. generations.sh's stage validation shells out to that
-      # binary and finds it. A duplicate download would not even hedge the
-      # transient-failure risk it looks like it hedges: setup-vibe's own
-      # installer curls the same GitHub release, so a second one doubles the
-      # exposure of a required job rather than covering it.
-      #
-      # Known limit, stated rather than left to look proven: this is the only
-      # wasmtime-using job that relies on setup-vibe alone (every other one
-      # still carries the redundant install), and the cold path only runs on a
-      # stage2 cache MISS. A ci.yml-only commit does not move the generated
-      # fingerprint in the cache key, so the run that introduced this did not
-      # exercise it. The guarantee above is by construction -- install dir ==
-      # PATH entry, PATH step unconditional -- not by a cold CI run; the next
-      # compiler-source change moves the fingerprint and exercises it for real.
-      - name: Build stage2 on cache miss
-        if: steps.stage2-cache.outputs.cache-hit != 'true'
-        run: |
-          bash scripts/ensure_seed.sh
-          VIBE_PREBUILT_MODULE_SOURCE=lib/@vibe/compiler/_cli_adapter_module_source.vibe bash scripts/generations.sh build --out-dir _build/_ci_shard_gen
-      # Every gate below is handed the stage2 EXPLICITLY, by path. None of them
-      # discovers one for itself: left to their own devices they take the
-      # newest generation on disk, else the committed seed, and both answer
-      # confidently about a compiler that does not contain the change
-      # (AGENTS.md, "which compiler answered"). That is also why this job does
-      # not use the `ls -dt _build/selfhost/generations/*/ | head -1` idiom the
-      # older jobs share.
-      - name: Assert the stage2 exists
-        run: |
-          set -euo pipefail
-          test -s _build/_ci_shard_gen/stage2.wasm \
-            || { echo "::error::no stage2 to hand the contract gates"; exit 1; }
+      - name: Use the compiler built once for this run
+        uses: ./.github/actions/use-compiler-build
       - name: RC-is-default gate
         run: RC_DEFAULT_STAGE2="$PWD/_build/_ci_shard_gen/stage2.wasm" bash scripts/check_rc_default.sh
       - name: Source-range contract gate
@@ -539,6 +500,7 @@ jobs:
         run: COMPILE_ONLY_STAGE2="$PWD/_build/_ci_shard_gen/stage2.wasm" bash scripts/check_compile_only_lanes.sh
 
   compiler-playground:
+    needs: [compiler-build]
     name: compiler-gate (playground)
     runs-on: ubuntu-latest
     steps:
@@ -566,23 +528,11 @@ jobs:
           key: seed-artifact-${{ hashFiles('bootstrap/seed.json') }}
       - name: Ensure seed artifact
         run: bash scripts/ensure_seed.sh
-      - name: Generated compiler fingerprint
-        id: genfp
-        run: echo "fp=$(bash scripts/ensure_generated.sh --print-fingerprint)" >> "$GITHUB_OUTPUT"
-      - name: Restore cached stage2
-        id: stage2-cache
-        uses: actions/cache@v4
-        with:
-          path: _build/_ci_shard_gen
-          key: stage2-v2-${{ steps.genfp.outputs.fp }}-${{ hashFiles('scripts/generations.sh', 'scripts/wasm_vibe_host_runner.js') }}
-      - name: Install wasmtime (cold stage2 build only)
-        # #2184: generations.sh's "validate stageN compiler -> sample" step
-        # shells out to a wasmtime BINARY, so the cold-cache build below needs
-        # it on PATH. A warm cache skips the build and never touches it --
-        # which is how this job passed until the first fingerprint-moving
-        # change ran it cold: the stage2 cache key includes the compiler-source
-        # fingerprint, so EVERY compiler-touching PR takes the cold path.
-        if: steps.stage2-cache.outputs.cache-hit != 'true'
+      - name: Install wasmtime
+        # The gates below run compiled sample wasm through the wasmtime
+        # binary. It used to be conditioned on the in-job stage2 build being
+        # cold; that build now happens once in compiler-build, so the
+        # condition is gone and this is unconditional.
         env:
           WASMTIME_VERSION: v47.0.2
         run: |
@@ -590,12 +540,8 @@ jobs:
           dir="wasmtime-${WASMTIME_VERSION}-x86_64-linux"
           curl -sSL --fail --retry 5 --retry-delay 2 --retry-all-errors "https://github.com/bytecodealliance/wasmtime/releases/download/${WASMTIME_VERSION}/${dir}.tar.xz" | tar -xJ
           echo "$PWD/$dir" >> "$GITHUB_PATH"
-      - name: Build stage2 on cache miss
-        if: steps.stage2-cache.outputs.cache-hit != 'true'
-        run: |
-          bash scripts/ensure_seed.sh
-          bash scripts/ensure_generated.sh
-          VIBE_PREBUILT_MODULE_SOURCE=lib/@vibe/compiler/_cli_adapter_module_source.vibe bash scripts/generations.sh build --out-dir _build/_ci_shard_gen
+      - name: Use the compiler built once for this run
+        uses: ./.github/actions/use-compiler-build
       - name: Stage cached compiler
         run: |
           mkdir -p _build/selfhost/generations/ci-playground
@@ -615,6 +561,7 @@ jobs:
   # not the bootstrap fixpoint. Start it at t=0 from the same content-addressed
   # stage2 cache as fixture and unit-test shards.
   compiler-examples:
+    needs: [compiler-build]
     name: compiler-gate (examples)
     runs-on: ubuntu-latest
     steps:
@@ -626,42 +573,17 @@ jobs:
           key: seed-artifact-${{ hashFiles('bootstrap/seed.json') }}
       - name: Ensure seed artifact
         run: bash scripts/ensure_seed.sh
-      - name: Generated compiler artifacts (fingerprint)
-        id: genfp
-        run: echo "fp=$(bash scripts/ensure_generated.sh --print-fingerprint)" >> "$GITHUB_OUTPUT"
-      - name: Cache generated compiler artifacts
-        uses: actions/cache@v4
-        with:
-          path: |
-            lib/@vibe/compiler/compiler_sources_bundle.vibe
-            lib/@vibe/compiler/cli_adapter_bundle.vibe
-            lib/@vibe/compiler/selfbuild_runtime_entry_bundle.vibe
-            lib/@vibe/compiler/_cli_adapter_module_source.vibe
-            lib/@vibe/compiler/cache/codegen_fingerprint.vibe
-            lib/@vibe/compiler/.generated.stamp
-          key: gen-v1-${{ steps.genfp.outputs.fp }}
-      - name: Ensure generated compiler artifacts
-        run: bash scripts/ensure_generated.sh
       - uses: ./.github/actions/setup-vibe
         with:
           node-version: 24
           wasmtime: 'true'
           pkfire: 'true'
           pkfire-cache: 'true'
-      - name: Cache stage2
-        id: stage2-cache
-        uses: actions/cache@v4
-        with:
-          path: _build/_ci_shard_gen
-          key: stage2-v2-${{ steps.genfp.outputs.fp }}-${{ hashFiles('scripts/generations.sh', 'scripts/wasm_vibe_host_runner.js') }}
-      - name: Install wasmtime (cold stage2 build only)
-        # #2184: generations.sh's "validate stageN compiler -> sample" step
-        # shells out to a wasmtime BINARY, so the cold-cache build below needs
-        # it on PATH. A warm cache skips the build and never touches it --
-        # which is how this job passed until the first fingerprint-moving
-        # change ran it cold: the stage2 cache key includes the compiler-source
-        # fingerprint, so EVERY compiler-touching PR takes the cold path.
-        if: steps.stage2-cache.outputs.cache-hit != 'true'
+      - name: Install wasmtime
+        # The gates below run compiled sample wasm through the wasmtime
+        # binary. It used to be conditioned on the in-job stage2 build being
+        # cold; that build now happens once in compiler-build, so the
+        # condition is gone and this is unconditional.
         env:
           WASMTIME_VERSION: v47.0.2
         run: |
@@ -669,11 +591,8 @@ jobs:
           dir="wasmtime-${WASMTIME_VERSION}-x86_64-linux"
           curl -sSL --fail --retry 5 --retry-delay 2 --retry-all-errors "https://github.com/bytecodealliance/wasmtime/releases/download/${WASMTIME_VERSION}/${dir}.tar.xz" | tar -xJ
           echo "$PWD/$dir" >> "$GITHUB_PATH"
-      - name: Build stage2
-        if: steps.stage2-cache.outputs.cache-hit != 'true'
-        run: |
-          VIBE_PREBUILT_MODULE_SOURCE=lib/@vibe/compiler/_cli_adapter_module_source.vibe \
-            bash scripts/generations.sh build --out-dir _build/_ci_shard_gen
+      - name: Use the compiler built once for this run
+        uses: ./.github/actions/use-compiler-build
       - name: examples/ type-check ratchet
         run: pkf run ci-check-examples-typecheck
 
@@ -681,6 +600,7 @@ jobs:
   # Keeping the full-history checkout here removes about 50 seconds from the
   # compiler-gate critical path without weakening the fail-closed AST tier.
   review-regressions:
+    needs: [compiler-build]
     name: review-regressions
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
@@ -695,40 +615,15 @@ jobs:
           key: seed-artifact-${{ hashFiles('bootstrap/seed.json') }}
       - name: Ensure seed artifact
         run: bash scripts/ensure_seed.sh
-      - name: Generated compiler artifacts (fingerprint)
-        id: genfp
-        run: echo "fp=$(bash scripts/ensure_generated.sh --print-fingerprint)" >> "$GITHUB_OUTPUT"
-      - name: Cache generated compiler artifacts
-        uses: actions/cache@v4
-        with:
-          path: |
-            lib/@vibe/compiler/compiler_sources_bundle.vibe
-            lib/@vibe/compiler/cli_adapter_bundle.vibe
-            lib/@vibe/compiler/selfbuild_runtime_entry_bundle.vibe
-            lib/@vibe/compiler/_cli_adapter_module_source.vibe
-            lib/@vibe/compiler/cache/codegen_fingerprint.vibe
-            lib/@vibe/compiler/.generated.stamp
-          key: gen-v1-${{ steps.genfp.outputs.fp }}
-      - name: Ensure generated compiler artifacts
-        run: bash scripts/ensure_generated.sh
       - uses: ./.github/actions/setup-vibe
         with:
           node-version: 24
           wasmtime: 'true'
-      - name: Cache stage2
-        id: stage2-cache
-        uses: actions/cache@v4
-        with:
-          path: _build/_ci_shard_gen
-          key: stage2-v2-${{ steps.genfp.outputs.fp }}-${{ hashFiles('scripts/generations.sh', 'scripts/wasm_vibe_host_runner.js') }}
-      - name: Install wasmtime (cold stage2 build only)
-        # #2184: generations.sh's "validate stageN compiler -> sample" step
-        # shells out to a wasmtime BINARY, so the cold-cache build below needs
-        # it on PATH. A warm cache skips the build and never touches it --
-        # which is how this job passed until the first fingerprint-moving
-        # change ran it cold: the stage2 cache key includes the compiler-source
-        # fingerprint, so EVERY compiler-touching PR takes the cold path.
-        if: steps.stage2-cache.outputs.cache-hit != 'true'
+      - name: Install wasmtime
+        # The gates below run compiled sample wasm through the wasmtime
+        # binary. It used to be conditioned on the in-job stage2 build being
+        # cold; that build now happens once in compiler-build, so the
+        # condition is gone and this is unconditional.
         env:
           WASMTIME_VERSION: v47.0.2
         run: |
@@ -736,11 +631,8 @@ jobs:
           dir="wasmtime-${WASMTIME_VERSION}-x86_64-linux"
           curl -sSL --fail --retry 5 --retry-delay 2 --retry-all-errors "https://github.com/bytecodealliance/wasmtime/releases/download/${WASMTIME_VERSION}/${dir}.tar.xz" | tar -xJ
           echo "$PWD/$dir" >> "$GITHUB_PATH"
-      - name: Build stage2
-        if: steps.stage2-cache.outputs.cache-hit != 'true'
-        run: |
-          VIBE_PREBUILT_MODULE_SOURCE=lib/@vibe/compiler/_cli_adapter_module_source.vibe \
-            bash scripts/generations.sh build --out-dir _build/_ci_shard_gen
+      - name: Use the compiler built once for this run
+        uses: ./.github/actions/use-compiler-build
       - name: Stage compiler for the AST lint
         run: |
           mkdir -p _build/selfhost/generations/ci-review
@@ -763,6 +655,7 @@ jobs:
   # ci-required requires this matrix, and an empty/unknown lane fails
   # the dispatcher rather than running nothing.
   compiler-gate-lanes:
+    needs: [compiler-build]
     name: compiler-gate (${{ matrix.lane }})
     runs-on: ubuntu-latest
     strategy:
@@ -778,22 +671,6 @@ jobs:
           key: seed-artifact-${{ hashFiles('bootstrap/seed.json') }}
       - name: Ensure seed artifact
         run: bash scripts/ensure_seed.sh
-      - name: Generated compiler artifacts (fingerprint)
-        id: genfp
-        run: echo "fp=$(bash scripts/ensure_generated.sh --print-fingerprint)" >> "$GITHUB_OUTPUT"
-      - name: Cache generated compiler artifacts
-        uses: actions/cache@v4
-        with:
-          path: |
-            lib/@vibe/compiler/compiler_sources_bundle.vibe
-            lib/@vibe/compiler/cli_adapter_bundle.vibe
-            lib/@vibe/compiler/selfbuild_runtime_entry_bundle.vibe
-            lib/@vibe/compiler/_cli_adapter_module_source.vibe
-            lib/@vibe/compiler/cache/codegen_fingerprint.vibe
-            lib/@vibe/compiler/.generated.stamp
-          key: gen-v1-${{ steps.genfp.outputs.fp }}
-      - name: Ensure generated compiler artifacts
-        run: bash scripts/ensure_generated.sh
       - uses: actions/setup-node@v5
         with:
           node-version: 24
@@ -805,17 +682,8 @@ jobs:
           dir="wasmtime-${WASMTIME_VERSION}-x86_64-linux"
           curl -sSL --fail --retry 5 --retry-delay 2 --retry-all-errors "https://github.com/bytecodealliance/wasmtime/releases/download/${WASMTIME_VERSION}/${dir}.tar.xz" | tar -xJ
           echo "$PWD/$dir" >> "$GITHUB_PATH"
-      - name: Cache stage2 (keyed on seed + flat module source)
-        id: stage2-cache
-        uses: actions/cache@v4
-        with:
-          path: _build/_ci_shard_gen
-          key: stage2-v2-${{ steps.genfp.outputs.fp }}-${{ hashFiles('scripts/generations.sh', 'scripts/wasm_vibe_host_runner.js') }}
-      - name: Build stage2 from committed flat module source
-        if: steps.stage2-cache.outputs.cache-hit != 'true'
-        run: |
-          VIBE_PREBUILT_MODULE_SOURCE=lib/@vibe/compiler/_cli_adapter_module_source.vibe \
-            bash scripts/generations.sh build --out-dir _build/_ci_shard_gen
+      - name: Use the compiler built once for this run
+        uses: ./.github/actions/use-compiler-build
       - name: Compiler-gate lane ${{ matrix.lane }}
         env:
           COMPILER_GATE_LANE: ${{ matrix.lane }}
@@ -1040,6 +908,7 @@ jobs:
   # it passed locally purely because this dev box had wasmtime on PATH — the
   # first CI run caught it.)
   gc-gate:
+    needs: [compiler-build]
     name: gc-gate
     runs-on: ubuntu-latest
     steps:
@@ -1051,27 +920,6 @@ jobs:
           key: seed-artifact-${{ hashFiles('bootstrap/seed.json') }}
       - name: Ensure seed artifact
         run: bash scripts/ensure_seed.sh
-      - name: Generated compiler artifacts (fingerprint)
-        # The five generated artifacts are build outputs, not tracked files
-        # (scripts/ensure_generated.sh). Their fingerprint is a pure function of
-        # (seed, compiler source), so it also keys the stage2 cache below --
-        # which is what the committed flat module source used to do via
-        # hashFiles.
-        id: genfp
-        run: echo "fp=$(bash scripts/ensure_generated.sh --print-fingerprint)" >> "$GITHUB_OUTPUT"
-      - name: Cache generated compiler artifacts
-        uses: actions/cache@v4
-        with:
-          path: |
-            lib/@vibe/compiler/compiler_sources_bundle.vibe
-            lib/@vibe/compiler/cli_adapter_bundle.vibe
-            lib/@vibe/compiler/selfbuild_runtime_entry_bundle.vibe
-            lib/@vibe/compiler/_cli_adapter_module_source.vibe
-            lib/@vibe/compiler/cache/codegen_fingerprint.vibe
-            lib/@vibe/compiler/.generated.stamp
-          key: gen-v1-${{ steps.genfp.outputs.fp }}
-      - name: Ensure generated compiler artifacts
-        run: bash scripts/ensure_generated.sh
       - uses: actions/setup-node@v5
         with:
           node-version: 24
@@ -1099,18 +947,6 @@ jobs:
             cp "$PWD/gc-tools-cargo/bin/wasm-tools" "$PWD/gc-tools/"
           fi
           echo "$PWD/gc-tools" >> "$GITHUB_PATH"
-      - name: Cache stage2 (keyed on seed + flat module source)
-        # Same key shape as the unit-test shards: stage2 is a deterministic
-        # function of (seed, committed flat module source, runner).
-        id: stage2-cache
-        uses: actions/cache@v4
-        with:
-          path: _build/_ci_gc_gen
-          key: stage2gc-v2-${{ steps.genfp.outputs.fp }}-${{ hashFiles('scripts/generations.sh', 'scripts/wasm_vibe_host_runner.js') }}
-      - name: Build stage2 from committed flat module source
-        if: steps.stage2-cache.outputs.cache-hit != 'true'
-        run: |
-          VIBE_PREBUILT_MODULE_SOURCE=lib/@vibe/compiler/_cli_adapter_module_source.vibe             bash scripts/generations.sh build --out-dir _build/_ci_gc_gen
       - name: Cache viberun build
         # test_gc_heap_accounting.sh rebuilds viberun only when its sources are
         # newer than the binary, so a warm cache turns the ~80s release build
@@ -1124,6 +960,10 @@ jobs:
           key: viberun-v1-${{ hashFiles('runtime/viberun/Cargo.lock', 'runtime/viberun/Cargo.toml') }}-${{ hashFiles('runtime/viberun/src/**') }}
           restore-keys: |
             viberun-v1-${{ hashFiles('runtime/viberun/Cargo.lock', 'runtime/viberun/Cargo.toml') }}-
+      - name: Use the compiler built once for this run
+        uses: ./.github/actions/use-compiler-build
+        with:
+          stage2-dest: _build/_ci_gc_gen
       - name: wasm-gc heap accounting + validation
         run: bash scripts/test_gc_heap_accounting.sh "$PWD/_build/_ci_gc_gen/stage2.wasm"
       # Runs HERE and not in a gate of its own for the same two reasons the job
@@ -1189,6 +1029,7 @@ jobs:
   # in sync and that the build reaches the stage2==stage3 fixpoint) — so the
   # shards run concurrently with compiler-gate instead of behind it.
   unit-tests:
+    needs: [compiler-build]
     name: unit-tests (shard ${{ matrix.shard }}/4)
     runs-on: ubuntu-latest
     strategy:
@@ -1204,27 +1045,6 @@ jobs:
           key: seed-artifact-${{ hashFiles('bootstrap/seed.json') }}
       - name: Ensure seed artifact
         run: bash scripts/ensure_seed.sh
-      - name: Generated compiler artifacts (fingerprint)
-        # The five generated artifacts are build outputs, not tracked files
-        # (scripts/ensure_generated.sh). Their fingerprint is a pure function of
-        # (seed, compiler source), so it also keys the stage2 cache below --
-        # which is what the committed flat module source used to do via
-        # hashFiles.
-        id: genfp
-        run: echo "fp=$(bash scripts/ensure_generated.sh --print-fingerprint)" >> "$GITHUB_OUTPUT"
-      - name: Cache generated compiler artifacts
-        uses: actions/cache@v4
-        with:
-          path: |
-            lib/@vibe/compiler/compiler_sources_bundle.vibe
-            lib/@vibe/compiler/cli_adapter_bundle.vibe
-            lib/@vibe/compiler/selfbuild_runtime_entry_bundle.vibe
-            lib/@vibe/compiler/_cli_adapter_module_source.vibe
-            lib/@vibe/compiler/cache/codegen_fingerprint.vibe
-            lib/@vibe/compiler/.generated.stamp
-          key: gen-v1-${{ steps.genfp.outputs.fp }}
-      - name: Ensure generated compiler artifacts
-        run: bash scripts/ensure_generated.sh
       - uses: actions/setup-node@v5
         with:
           node-version: 24
@@ -1236,20 +1056,8 @@ jobs:
           dir="wasmtime-${WASMTIME_VERSION}-x86_64-linux"
           curl -sSL --fail --retry 5 --retry-delay 2 --retry-all-errors "https://github.com/bytecodealliance/wasmtime/releases/download/${WASMTIME_VERSION}/${dir}.tar.xz" | tar -xJ
           echo "$PWD/$dir" >> "$GITHUB_PATH"
-      - name: Cache stage2 (keyed on seed + flat module source)
-        # The stage2 build is a deterministic function of (seed, committed
-        # flat module source, runner). When neither changed since a previous
-        # run, restore it and skip the ~30s build entirely.
-        id: stage2-cache
-        uses: actions/cache@v4
-        with:
-          path: _build/_ci_shard_gen
-          key: stage2-v2-${{ steps.genfp.outputs.fp }}-${{ hashFiles('scripts/generations.sh', 'scripts/wasm_vibe_host_runner.js') }}
-      - name: Build stage2 from committed flat module source
-        if: steps.stage2-cache.outputs.cache-hit != 'true'
-        run: |
-          VIBE_PREBUILT_MODULE_SOURCE=lib/@vibe/compiler/_cli_adapter_module_source.vibe \
-            bash scripts/generations.sh build --out-dir _build/_ci_shard_gen
+      - name: Use the compiler built once for this run
+        uses: ./.github/actions/use-compiler-build
       - name: Restore persistent compile cache
         # Content-keyed compiler cache (_build/vibe_selfhost_*, see
         # docs/build-cache.md): every row's key folds in the codegen
@@ -1279,6 +1087,7 @@ jobs:
   # never waits on it. An instrumentation-only miscompile is still caught at
   # most one merge late, never silently for good.
   coverage-suite:
+    needs: [compiler-build]
     name: coverage-suite (main only)
     if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
@@ -1296,27 +1105,6 @@ jobs:
           key: seed-artifact-${{ hashFiles('bootstrap/seed.json') }}
       - name: Ensure seed artifact
         run: bash scripts/ensure_seed.sh
-      - name: Generated compiler artifacts (fingerprint)
-        # The five generated artifacts are build outputs, not tracked files
-        # (scripts/ensure_generated.sh). Their fingerprint is a pure function of
-        # (seed, compiler source), so it also keys the stage2 cache below --
-        # which is what the committed flat module source used to do via
-        # hashFiles.
-        id: genfp
-        run: echo "fp=$(bash scripts/ensure_generated.sh --print-fingerprint)" >> "$GITHUB_OUTPUT"
-      - name: Cache generated compiler artifacts
-        uses: actions/cache@v4
-        with:
-          path: |
-            lib/@vibe/compiler/compiler_sources_bundle.vibe
-            lib/@vibe/compiler/cli_adapter_bundle.vibe
-            lib/@vibe/compiler/selfbuild_runtime_entry_bundle.vibe
-            lib/@vibe/compiler/_cli_adapter_module_source.vibe
-            lib/@vibe/compiler/cache/codegen_fingerprint.vibe
-            lib/@vibe/compiler/.generated.stamp
-          key: gen-v1-${{ steps.genfp.outputs.fp }}
-      - name: Ensure generated compiler artifacts
-        run: bash scripts/ensure_generated.sh
       - uses: actions/setup-node@v5
         with:
           node-version: 24
@@ -1328,17 +1116,8 @@ jobs:
           dir="wasmtime-${WASMTIME_VERSION}-x86_64-linux"
           curl -sSL --fail --retry 5 --retry-delay 2 --retry-all-errors "https://github.com/bytecodealliance/wasmtime/releases/download/${WASMTIME_VERSION}/${dir}.tar.xz" | tar -xJ
           echo "$PWD/$dir" >> "$GITHUB_PATH"
-      - name: Cache stage2 (keyed on seed + flat module source)
-        id: stage2-cache
-        uses: actions/cache@v4
-        with:
-          path: _build/_ci_shard_gen
-          key: stage2-v2-${{ steps.genfp.outputs.fp }}-${{ hashFiles('scripts/generations.sh', 'scripts/wasm_vibe_host_runner.js') }}
-      - name: Build stage2 from committed flat module source
-        if: steps.stage2-cache.outputs.cache-hit != 'true'
-        run: |
-          VIBE_PREBUILT_MODULE_SOURCE=lib/@vibe/compiler/_cli_adapter_module_source.vibe \
-            bash scripts/generations.sh build --out-dir _build/_ci_shard_gen
+      - name: Use the compiler built once for this run
+        uses: ./.github/actions/use-compiler-build
       - name: Selfhost suite coverage gate (#535)
         # Relative path: coverage_suite.sh historically rebased $cli onto the
         # repo root (it now tolerates absolute paths too, but stay canonical).
@@ -1456,7 +1235,7 @@ jobs:
   # ever needs re-checking.
   wasi-p3-gate:
     name: wasi-p3-gate (wasmtime v47.0.2)
-    needs: [compiler-gate]
+    needs: [compiler-build]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
@@ -1514,27 +1293,11 @@ jobs:
           key: seed-artifact-${{ hashFiles('bootstrap/seed.json') }}
       - name: Ensure seed artifact
         run: bash scripts/ensure_seed.sh
-      - name: Generated compiler artifacts (fingerprint)
-        id: p3genfp
-        run: echo "fp=$(bash scripts/ensure_generated.sh --print-fingerprint)" >> "$GITHUB_OUTPUT"
-      - name: Cache generated compiler artifacts
-        uses: actions/cache@v4
+      - name: Use the compiler built once for this run
+        uses: ./.github/actions/use-compiler-build
         with:
-          path: |
-            lib/@vibe/compiler/compiler_sources_bundle.vibe
-            lib/@vibe/compiler/cli_adapter_bundle.vibe
-            lib/@vibe/compiler/selfbuild_runtime_entry_bundle.vibe
-            lib/@vibe/compiler/_cli_adapter_module_source.vibe
-            lib/@vibe/compiler/cache/codegen_fingerprint.vibe
-            lib/@vibe/compiler/.generated.stamp
-          key: gen-v1-${{ steps.p3genfp.outputs.fp }}
-      - name: Ensure generated compiler artifacts
-        run: bash scripts/ensure_generated.sh
-      - name: Download stage2 artifact
-        uses: actions/download-artifact@v4
-        with:
-          name: compiler-stage2
-          path: _build/ci-artifacts/
+          # Three env vars below address the compiler at this path.
+          stage2-dest: _build/ci-artifacts
       - name: WASI p3 guarantee gate
         env:
           VIBE_P3_GATE_REQUIRE_TOOLS: "1"
@@ -1564,7 +1327,7 @@ jobs:
   # wasi-p3-gate, is not on it.
   perf-metrics:
     name: perf-metrics
-    needs: [compiler-gate]
+    needs: [compiler-build]
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -1580,21 +1343,6 @@ jobs:
           key: seed-artifact-${{ hashFiles('bootstrap/seed.json') }}
       - name: Ensure seed artifact
         run: bash scripts/ensure_seed.sh
-      - name: Download stage2 artifact
-        uses: actions/download-artifact@v4
-        with:
-          name: compiler-stage2
-          path: _build/_ci_shard_gen/
-      - name: Download generated compiler artifacts
-        uses: actions/download-artifact@v4
-        with:
-          name: compiler-generated
-          path: lib/@vibe/compiler/
-      - name: Generated compiler artifacts are the ones for this checkout
-        # The download is a plain file copy; this proves it matches the
-        # fingerprint of (seed, compiler source) in the checkout rather than
-        # silently measuring another commit's bundles.
-        run: bash scripts/ensure_generated.sh --check
       - uses: actions/setup-node@v5
         with:
           node-version: 24
@@ -1607,6 +1355,8 @@ jobs:
         uses: Swatinem/rust-cache@v2
         with:
           workspaces: runtime/viberun
+      - name: Use the compiler built once for this run
+        uses: ./.github/actions/use-compiler-build
       - name: Build viberun (micro-bench runtime)
         run: cargo build --release --manifest-path runtime/viberun/Cargo.toml
       - name: Collect metrics
@@ -1695,12 +1445,16 @@ jobs:
   # Aggregate required check (branch protection requires "ci-required").
   ci-required:
     name: ci-required
-    needs: [compiler-gate, compiler-gate-preflight, compiler-stage2-oracles, compiler-docs, compiler-contracts, compiler-playground, compiler-examples, review-regressions, compiler-gate-lanes, unit-tests, vibe-fmt-check, gc-gate, structural-lint]
+    needs: [compiler-build, compiler-gate, compiler-gate-preflight, compiler-stage2-oracles, compiler-docs, compiler-contracts, compiler-playground, compiler-examples, review-regressions, compiler-gate-lanes, unit-tests, vibe-fmt-check, gc-gate, structural-lint]
     if: always()
     runs-on: ubuntu-latest
     steps:
       - name: Verify required jobs succeeded
         run: |
+          if [ "${{ needs.compiler-build.result }}" != "success" ]; then
+            echo "::error::compiler-build did not succeed (${{ needs.compiler-build.result }}) -- every job that consumes the shared compiler was skipped"
+            exit 1
+          fi
           if [ "${{ needs.compiler-gate.result }}" != "success" ]; then
             echo "::error::compiler-gate did not succeed (${{ needs.compiler-gate.result }})"
             exit 1

--- a/scripts/check_ci_seed_cache.sh
+++ b/scripts/check_ci_seed_cache.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+# Every CI job that can reach the seed restores it from cache first (#2645).
+#
+# bootstrap/seed/compiler.wasm is gitignored, so the first thing in a job that
+# touches the compiler calls scripts/ensure_seed.sh. That call is not cheap in
+# the one case nobody watches: when the pinned release tag is not published yet
+# (a bootstrap bump whose `seed-release` run has not landed), ensure_seed
+# REBUILDS the pinned seed from source -- stage0 -> stage1 -> stage2 -- and
+# does it inside whatever step asked first, with no step name to blame.
+#
+# Measured on CI run 34567587111 (main, 893s wall): four jobs had no seed
+# cache and each paid the same ~5 minutes for the same artifact --
+#   compiler-stage2-oracles  304s  charged to "Generated compiler fingerprint"
+#   compiler-playground      323s  same step
+#   compiler-docs            335s  same step
+#   structural-lint          429s  charged to a shell lint's self-test
+# -- while the twelve jobs that did have the cache restored it in ~2s.
+#
+# The rule is lexical so it can be checked: a job block that invokes a
+# repository script (`bash scripts/...`, `bash tests/...`) or the task runner
+# (`pkf run`) must also contain a `seed-artifact-` cache key. Which script it
+# is does not matter; the dependency is transitive (scripts/vibe_run.sh,
+# scripts/vibe_test.sh and scripts/ensure_generated.sh all call ensure_seed)
+# and a scanner cannot follow it, so the over-approximation is the point --
+# it costs a job that needs no seed one cache-miss lookup, and it makes the
+# expensive mistake impossible.
+set -euo pipefail
+
+ROOT_DIR="${VIBE_CI_SEED_CACHE_ROOT:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+cd "$ROOT_DIR"
+
+WORKFLOW="${VIBE_CI_SEED_CACHE_WORKFLOW:-.github/workflows/ci.yml}"
+if [ ! -f "$WORKFLOW" ]; then
+  echo "[ci-seed-cache] FAIL: no workflow at $WORKFLOW" >&2
+  exit 1
+fi
+
+# Split into job blocks: a job header is exactly two spaces of indent at the
+# top level of `jobs:`. awk, not a YAML parser, because the property being
+# checked is textual and the gate must run with nothing installed.
+missing="$(awk '
+  /^jobs:[[:space:]]*$/ { in_jobs = 1; next }
+  /^[A-Za-z0-9_-]+:/ { if (!/^jobs:/) { if (job != "" && uses_scripts && !has_cache) print job; in_jobs = 0; job = "" } }
+  !in_jobs { next }
+  /^  [A-Za-z0-9_-]+:[[:space:]]*$/ {
+    if (job != "" && uses_scripts && !has_cache) print job
+    job = $1; sub(/:$/, "", job)
+    uses_scripts = 0; has_cache = 0
+    next
+  }
+  job == "" { next }
+  /bash[[:space:]]+scripts\// { uses_scripts = 1 }
+  /bash[[:space:]]+tests\//   { uses_scripts = 1 }
+  /pkf[[:space:]]+run/        { uses_scripts = 1 }
+  /seed-artifact-/            { has_cache = 1 }
+  END { if (job != "" && uses_scripts && !has_cache) print job }
+' "$WORKFLOW")"
+
+# Refuse to answer rather than pass when the scan found no jobs at all: an
+# empty result and "every job is fine" are the same output otherwise, and a
+# renamed file or a reindented workflow would read as clean forever.
+scanned="$(awk '
+  /^jobs:[[:space:]]*$/ { in_jobs = 1; next }
+  /^[A-Za-z0-9_-]+:/ { if (!/^jobs:/) in_jobs = 0 }
+  in_jobs && /^  [A-Za-z0-9_-]+:[[:space:]]*$/ { n++ }
+  END { print n + 0 }
+' "$WORKFLOW")"
+if [ "$scanned" -lt 2 ]; then
+  echo "[ci-seed-cache] FAIL: found $scanned job headers in $WORKFLOW -- the scan did not run" >&2
+  exit 1
+fi
+
+if [ -n "$missing" ]; then
+  echo "[ci-seed-cache] FAIL: jobs that run repository scripts with no seed cache:" >&2
+  printf '  %s\n' $missing >&2
+  echo "  Add, before the first step that touches the compiler:" >&2
+  echo "      - name: Cache seed artifact" >&2
+  echo "        uses: actions/cache@v4" >&2
+  echo "        with:" >&2
+  echo "          path: bootstrap/seed/compiler.wasm" >&2
+  echo "          key: seed-artifact-\${{ hashFiles('bootstrap/seed.json') }}" >&2
+  echo "      - name: Ensure seed artifact" >&2
+  echo "        run: bash scripts/ensure_seed.sh" >&2
+  echo "  Without it the job rebuilds the pinned seed from source (~5 min)" >&2
+  echo "  whenever its release tag is not published." >&2
+  exit 1
+fi
+
+echo "[ci-seed-cache] ok ($scanned jobs scanned)"

--- a/scripts/check_ci_seed_cache.sh
+++ b/scripts/check_ci_seed_cache.sh
@@ -38,22 +38,31 @@ fi
 # Split into job blocks: a job header is exactly two spaces of indent at the
 # top level of `jobs:`. awk, not a YAML parser, because the property being
 # checked is textual and the gate must run with nothing installed.
+# ORDER MATTERS, not mere presence (Codex review of #2645). A job whose first
+# script invocation comes BEFORE its cache step has already paid the fetch --
+# or the ~5 minute rebuild -- by the time the cache is restored, and a
+# presence-only check calls that clean. So the violation is recorded at the
+# first script line seen while `has_cache` is still 0, and a later
+# `seed-artifact-` cannot retract it.
 missing="$(awk '
+  function flush() { if (job != "" && bad) print job }
   /^jobs:[[:space:]]*$/ { in_jobs = 1; next }
-  /^[A-Za-z0-9_-]+:/ { if (!/^jobs:/) { if (job != "" && uses_scripts && !has_cache) print job; in_jobs = 0; job = "" } }
+  /^[A-Za-z0-9_-]+:/ { if (!/^jobs:/) { flush(); in_jobs = 0; job = "" } }
   !in_jobs { next }
   /^  [A-Za-z0-9_-]+:[[:space:]]*$/ {
-    if (job != "" && uses_scripts && !has_cache) print job
+    flush()
     job = $1; sub(/:$/, "", job)
-    uses_scripts = 0; has_cache = 0
+    bad = 0; has_cache = 0
     next
   }
   job == "" { next }
-  /bash[[:space:]]+scripts\// { uses_scripts = 1 }
-  /bash[[:space:]]+tests\//   { uses_scripts = 1 }
-  /pkf[[:space:]]+run/        { uses_scripts = 1 }
-  /seed-artifact-/            { has_cache = 1 }
-  END { if (job != "" && uses_scripts && !has_cache) print job }
+  # The cache line is read FIRST on its own line, so a step that both restores
+  # the cache and runs a script on later lines is still ordered correctly.
+  /seed-artifact-/ { has_cache = 1; next }
+  /bash[[:space:]]+scripts\// || /bash[[:space:]]+tests\// || /pkf[[:space:]]+run/ {
+    if (!has_cache) bad = 1
+  }
+  END { flush() }
 ' "$WORKFLOW")"
 
 # Refuse to answer rather than pass when the scan found no jobs at all: an
@@ -65,13 +74,16 @@ scanned="$(awk '
   in_jobs && /^  [A-Za-z0-9_-]+:[[:space:]]*$/ { n++ }
   END { print n + 0 }
 ' "$WORKFLOW")"
-if [ "$scanned" -lt 2 ]; then
+# One job is a legitimate workflow; ZERO means the scan found nothing, which is
+# the case that must not read as "no offending jobs". (The threshold was 2 and
+# refused a single-job workflow -- caught by this gate's own Red test.)
+if [ "$scanned" -lt 1 ]; then
   echo "[ci-seed-cache] FAIL: found $scanned job headers in $WORKFLOW -- the scan did not run" >&2
   exit 1
 fi
 
 if [ -n "$missing" ]; then
-  echo "[ci-seed-cache] FAIL: jobs that run repository scripts with no seed cache:" >&2
+  echo "[ci-seed-cache] FAIL: jobs that run a repository script before restoring the seed:" >&2
   printf '  %s\n' $missing >&2
   echo "  Add, before the first step that touches the compiler:" >&2
   echo "      - name: Cache seed artifact" >&2
@@ -81,8 +93,9 @@ if [ -n "$missing" ]; then
   echo "          key: seed-artifact-\${{ hashFiles('bootstrap/seed.json') }}" >&2
   echo "      - name: Ensure seed artifact" >&2
   echo "        run: bash scripts/ensure_seed.sh" >&2
-  echo "  Without it the job rebuilds the pinned seed from source (~5 min)" >&2
-  echo "  whenever its release tag is not published." >&2
+  echo "  It must come BEFORE the first step that runs a repository script:" >&2
+  echo "  by the time a later cache step restores it, the script has already" >&2
+  echo "  fetched -- or rebuilt from source, ~5 min -- the pinned seed." >&2
   exit 1
 fi
 

--- a/scripts/check_ci_seed_cache_test.sh
+++ b/scripts/check_ci_seed_cache_test.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+# Red test for scripts/check_ci_seed_cache.sh (#2645).
+#
+# Every case MUTATES a real input and asserts the gate FAILS, and every
+# mutation is verified to have landed before the gate is asked -- an edit that
+# matched nothing would let a case "pass" while proving nothing (the failure
+# mode docs/… calls out: a multi-line slice that only caught the first line).
+set -euo pipefail
+
+# Do not inherit the answer: the gate reads these, so a value left in the
+# environment by a caller would decide the result instead of the input.
+unset VIBE_CI_SEED_CACHE_ROOT
+unset VIBE_CI_SEED_CACHE_WORKFLOW
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+GATE="$SCRIPT_DIR/check_ci_seed_cache.sh"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+TMP="$(mktemp -d "${TMPDIR:-/tmp}/vibe_ci_seed_cache_test.XXXXXX")"
+trap 'rm -rf "$TMP"' EXIT
+
+fail() { echo "check_ci_seed_cache_test: FAIL: $*" >&2; exit 1; }
+
+# --- control: the real workflow passes ---------------------------------------
+if ! bash "$GATE" >"$TMP/control.out" 2>&1; then
+  cat "$TMP/control.out" >&2
+  fail "control: the repository's own ci.yml is rejected"
+fi
+echo "check_ci_seed_cache_test: ok: control: the real workflow passes"
+
+# --- case 1: a script-running job whose seed cache was removed is rejected ----
+# Mutate the REAL workflow, not a synthetic one, so the gate is exercised
+# against the shape it actually has to read.
+real="$ROOT_DIR/.github/workflows/ci.yml"
+awk '
+  /seed-artifact-/ && !done_one && job_is_gate { next }
+  /^  unit-tests:[[:space:]]*$/ { job_is_gate = 1 }
+  /^  coverage-suite:[[:space:]]*$/ { job_is_gate = 0 }
+  { print }
+' "$real" > "$TMP/mutated.yml"
+# The mutation must have landed: strictly fewer seed keys than the original.
+before="$(grep -c 'seed-artifact-' "$real" || true)"
+after="$(grep -c 'seed-artifact-' "$TMP/mutated.yml" || true)"
+[ "$after" -lt "$before" ] || fail "case 1: the mutation did not land ($before -> $after seed keys)"
+if VIBE_CI_SEED_CACHE_WORKFLOW="$TMP/mutated.yml" bash "$GATE" >"$TMP/case1.out" 2>&1; then
+  fail "case 1: a job that runs repository scripts with no seed cache was accepted"
+fi
+grep -q 'unit-tests' "$TMP/case1.out" || fail "case 1: the message does not name the offending job"
+grep -q 'Cache seed artifact' "$TMP/case1.out" || fail "case 1: the message does not name the edit that fixes it"
+echo "check_ci_seed_cache_test: ok: case 1: a script-running job with no seed cache is rejected"
+
+# --- case 2: `pkf run` counts as reaching the seed ----------------------------
+cat > "$TMP/pkf.yml" <<'YML'
+name: CI
+on:
+  push:
+jobs:
+  needs-seed:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - name: Task runner
+        run: pkf run release-check
+YML
+if VIBE_CI_SEED_CACHE_WORKFLOW="$TMP/pkf.yml" bash "$GATE" >"$TMP/case2.out" 2>&1; then
+  fail "case 2: a 'pkf run' job with no seed cache was accepted"
+fi
+echo "check_ci_seed_cache_test: ok: case 2: 'pkf run' counts as reaching the seed"
+
+# --- case 3: a job that runs no repository script is NOT a false positive -----
+cat > "$TMP/inert.yml" <<'YML'
+name: CI
+on:
+  push:
+jobs:
+  aggregate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify required jobs succeeded
+        run: echo "all required jobs passed"
+  needs-seed:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Cache seed artifact
+        uses: actions/cache@v4
+        with:
+          key: seed-artifact-abc
+      - name: Build
+        run: bash scripts/ensure_seed.sh
+YML
+if ! VIBE_CI_SEED_CACHE_WORKFLOW="$TMP/inert.yml" bash "$GATE" >"$TMP/case3.out" 2>&1; then
+  cat "$TMP/case3.out" >&2
+  fail "case 3: a job that runs no repository script was rejected"
+fi
+echo "check_ci_seed_cache_test: ok: case 3: a job that runs no repository script passes"
+
+# --- case 4: an unreadable shape REFUSES instead of passing -------------------
+# Silence is not safety: a workflow the scan cannot parse must fail, not read
+# as "no offending jobs".
+printf 'name: CI\non:\n  push:\n' > "$TMP/nojobs.yml"
+if VIBE_CI_SEED_CACHE_WORKFLOW="$TMP/nojobs.yml" bash "$GATE" >"$TMP/case4.out" 2>&1; then
+  fail "case 4: a workflow with no jobs at all was accepted"
+fi
+grep -q 'the scan did not run' "$TMP/case4.out" || fail "case 4: the refusal does not say the scan did not run"
+echo "check_ci_seed_cache_test: ok: case 4: an unscannable workflow refuses to answer"
+
+# --- case 5: a missing workflow is fatal --------------------------------------
+if VIBE_CI_SEED_CACHE_WORKFLOW="$TMP/does-not-exist.yml" bash "$GATE" >/dev/null 2>&1; then
+  fail "case 5: a missing workflow was accepted"
+fi
+echo "check_ci_seed_cache_test: ok: case 5: a missing workflow is fatal"
+
+echo "check_ci_seed_cache_test: ok (control + 5 cases)"

--- a/scripts/check_ci_seed_cache_test.sh
+++ b/scripts/check_ci_seed_cache_test.sh
@@ -93,6 +93,57 @@ if ! VIBE_CI_SEED_CACHE_WORKFLOW="$TMP/inert.yml" bash "$GATE" >"$TMP/case3.out"
 fi
 echo "check_ci_seed_cache_test: ok: case 3: a job that runs no repository script passes"
 
+# --- case 3b: ORDER, not presence (Codex review of #2645) ---------------------
+# A job that runs a repository script BEFORE its cache step has already paid
+# the fetch or the rebuild; a presence-only check called that clean.
+cat > "$TMP/late-cache.yml" <<'YML'
+name: CI
+on:
+  push:
+jobs:
+  cache-too-late:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - name: Lint before the seed is restored
+        run: bash scripts/check_something.sh
+      - name: Cache seed artifact
+        uses: actions/cache@v4
+        with:
+          key: seed-artifact-abc
+      - name: Ensure seed artifact
+        run: bash scripts/ensure_seed.sh
+YML
+if VIBE_CI_SEED_CACHE_WORKFLOW="$TMP/late-cache.yml" bash "$GATE" >"$TMP/case3b.out" 2>&1; then
+  fail "case 3b: a job that runs a script before its cache step was accepted"
+fi
+grep -q 'cache-too-late' "$TMP/case3b.out" || fail "case 3b: the message does not name the offending job"
+# ...and the same job with the two halves swapped is accepted, so the case is
+# about ORDER and not about the file simply containing both lines.
+cat > "$TMP/early-cache.yml" <<'YML'
+name: CI
+on:
+  push:
+jobs:
+  cache-in-time:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - name: Cache seed artifact
+        uses: actions/cache@v4
+        with:
+          key: seed-artifact-abc
+      - name: Ensure seed artifact
+        run: bash scripts/ensure_seed.sh
+      - name: Lint after the seed is restored
+        run: bash scripts/check_something.sh
+YML
+if ! VIBE_CI_SEED_CACHE_WORKFLOW="$TMP/early-cache.yml" bash "$GATE" >"$TMP/case3b2.out" 2>&1; then
+  cat "$TMP/case3b2.out" >&2
+  fail "case 3b: the correctly ordered control was rejected"
+fi
+echo "check_ci_seed_cache_test: ok: case 3b: the cache must PRECEDE the first script invocation"
+
 # --- case 4: an unreadable shape REFUSES instead of passing -------------------
 # Silence is not safety: a workflow the scan cannot parse must fail, not read
 # as "no offending jobs".
@@ -109,4 +160,4 @@ if VIBE_CI_SEED_CACHE_WORKFLOW="$TMP/does-not-exist.yml" bash "$GATE" >/dev/null
 fi
 echo "check_ci_seed_cache_test: ok: case 5: a missing workflow is fatal"
 
-echo "check_ci_seed_cache_test: ok (control + 5 cases)"
+echo "check_ci_seed_cache_test: ok (control + 6 cases)"

--- a/scripts/check_gate_self_tests.sh
+++ b/scripts/check_gate_self_tests.sh
@@ -188,10 +188,14 @@ if [ "${VIBE_GATE_SELF_TESTS_RUN:-1}" = "1" ]; then
       if bash "$gst_t" >"$gst_log" 2>&1 \
          && printf '%s\n' "$GST_FAILING_BROKEN" | grep -qxF "$gst_base"; then
         printf 'repaired\n' >"$WORK_DIR/$gst_base.verdict"
+      else
+        printf 'ok\n' >"$WORK_DIR/$gst_base.verdict"
       fi
       return 0
     fi
-    if ! bash "$gst_t" >"$gst_log" 2>&1; then
+    if bash "$gst_t" >"$gst_log" 2>&1; then
+      printf 'ok\n' >"$WORK_DIR/$gst_base.verdict"
+    else
       printf 'failed\n' >"$WORK_DIR/$gst_base.verdict"
     fi
     return 0
@@ -217,15 +221,35 @@ if [ "${VIBE_GATE_SELF_TESTS_RUN:-1}" = "1" ]; then
   # Collected in the companion order the serial loop used, so the report a
   # reader compares against an older run is byte-identical when the verdicts
   # are.
+  #
+  # EVERY worker records a terminal state, including `ok`, and a companion with
+  # no verdict file is a FAILURE rather than a pass (Codex review of #2645).
+  # An earlier revision wrote a file only for `repaired` and `failed`, so a
+  # worker that xargs could not launch -- or that was killed before it wrote --
+  # was indistinguishable from one that passed, and this gate could report
+  # green without having run a self-test it claims to cover. That is the exact
+  # shape it exists to stop: silence read as safety.
   while IFS= read -r t; do
     base="${t#scripts/}"
-    [ -f "$WORK_DIR/$base.verdict" ] || continue
+    if [ ! -s "$WORK_DIR/$base.verdict" ]; then
+      failed_tests="$failed_tests $t"
+      echo "[gate-self-tests] --- $t ---" >&2
+      echo "  no verdict recorded: the worker did not run to completion" >&2
+      tail -20 "$WORK_DIR/$base.log" >&2 2>/dev/null || true
+      continue
+    fi
     case "$(cat "$WORK_DIR/$base.verdict")" in
+      ok) ;;
       repaired) repaired="$repaired $base" ;;
       failed)
         failed_tests="$failed_tests $t"
         echo "[gate-self-tests] --- $t ---" >&2
         tail -20 "$WORK_DIR/$base.log" >&2
+        ;;
+      *)
+        failed_tests="$failed_tests $t"
+        echo "[gate-self-tests] --- $t ---" >&2
+        echo "  unrecognised verdict: $(cat "$WORK_DIR/$base.verdict")" >&2
         ;;
     esac
   done <"$gst_list"

--- a/scripts/check_gate_self_tests.sh
+++ b/scripts/check_gate_self_tests.sh
@@ -17,8 +17,11 @@ set -euo pipefail
 ROOT_DIR="${VIBE_GATE_SELF_TEST_ROOT:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
 cd "$ROOT_DIR"
 
-WORK_LOG="$(mktemp "${TMPDIR:-/tmp}/vibe_gate_selftest.XXXXXX")"
-trap 'rm -f "$WORK_LOG"' EXIT
+# A DIRECTORY, not one file: the companions run concurrently below, so each
+# needs its own log and its own verdict file. One shared $WORK_LOG would have
+# workers overwriting the very output the failure report prints.
+WORK_DIR="$(mktemp -d "${TMPDIR:-/tmp}/vibe_gate_selftest.XXXXXX")"
+trap 'rm -rf "$WORK_DIR"' EXIT
 
 ALLOWLIST="scripts/gate_self_test_allowlist.txt"
 FAILING="scripts/gate_self_test_failing.txt"
@@ -143,30 +146,89 @@ EOF
 failed_tests=""
 repaired=""
 if [ "${VIBE_GATE_SELF_TESTS_RUN:-1}" = "1" ]; then
-  for t in scripts/check_*_test.sh scripts/lint_*_test.sh scripts/*_gate_test.sh; do
-    [ -e "$t" ] || continue
-    # Only companions OF a gate in this tree; an orphan is reported below.
-    [ -f "${t%_test.sh}.sh" ] || continue
-    base="${t#scripts/}"
-    if printf '%s\n' "$failing_allowed" | grep -qxF "$base"; then
+  # The companions are INDEPENDENT of each other, so they run concurrently.
+  # Serially this was the single slowest section of the late lane -- 159s of
+  # the lane's 341s, measured on CI run 34567587111 -- for work that is one
+  # `bash` per file with nothing shared between them.
+  #
+  # "Nothing shared" is a property to protect, not to assume. The one real
+  # coupling is the five generated compiler artifacts: a companion that needs
+  # them (check_compile_only_lanes_test.sh) calls ensure_generated.sh, which
+  # WRITES INTO lib/@vibe/compiler/. Two of those racing would interleave
+  # partial writes. So the fan-out is preceded by one ensure_generated here:
+  # afterwards every worker sees them current and regenerates nothing. On CI's
+  # late lane they are already generated, so this costs nothing; where they are
+  # stale it is the same work the serial loop paid inside the worker.
+  # `|| true` because a genuine generation failure belongs to the companion
+  # that depends on it -- reporting it here would name the wrong script.
+  if [ -z "${VIBE_GATE_SELF_TEST_ROOT:-}" ] && [ -x scripts/ensure_generated.sh ]; then
+    bash scripts/ensure_generated.sh >/dev/null 2>&1 || true
+  fi
+
+  # min(4, nproc) matches scripts/vibe_test.sh and scripts/unit_test_runner.sh:
+  # a few companions compile with the wasm compiler and peak at GBs, so an
+  # unbounded -P OOMs a 4-vCPU runner. VIBE_GATE_SELF_TESTS_JOBS=1 restores the
+  # serial order, which is what to set when a companion is suspected of
+  # sharing state with another.
+  gst_hw_jobs="$(nproc 2>/dev/null || echo 1)"
+  [ "$gst_hw_jobs" -gt 4 ] && gst_hw_jobs=4
+  GST_JOBS="${VIBE_GATE_SELF_TESTS_JOBS:-$gst_hw_jobs}"
+
+  gst_worker() {
+    gst_t="$1"
+    gst_base="${gst_t#scripts/}"
+    gst_log="$WORK_DIR/$gst_base.log"
+    if printf '%s\n' "$GST_FAILING_ALLOWED" | grep -qxF "$gst_base"; then
       # A known-failing exemption is still RUN, because the interesting case is
       # that it starts passing: skipping it outright means a repaired test (or
       # one whose missing dependency arrived) stays permanently unexecuted, and
       # any later regression in it is invisible until someone edits the list by
       # hand (#2248 review). The ratchet has to notice its own entries going
       # stale, exactly as the no-test allowlist does.
-      if bash "$t" >"$WORK_LOG" 2>&1 \
-         && printf '%s\n' "$failing_broken" | grep -qxF "$base"; then
-        repaired="$repaired $base"
+      if bash "$gst_t" >"$gst_log" 2>&1 \
+         && printf '%s\n' "$GST_FAILING_BROKEN" | grep -qxF "$gst_base"; then
+        printf 'repaired\n' >"$WORK_DIR/$gst_base.verdict"
       fi
-      continue
+      return 0
     fi
-    if ! bash "$t" >"$WORK_LOG" 2>&1; then
-      failed_tests="$failed_tests $t"
-      echo "[gate-self-tests] --- $t ---" >&2
-      tail -20 "$WORK_LOG" >&2
+    if ! bash "$gst_t" >"$gst_log" 2>&1; then
+      printf 'failed\n' >"$WORK_DIR/$gst_base.verdict"
     fi
+    return 0
+  }
+  export -f gst_worker
+  export WORK_DIR
+  GST_FAILING_ALLOWED="$failing_allowed"; export GST_FAILING_ALLOWED
+  GST_FAILING_BROKEN="$failing_broken"; export GST_FAILING_BROKEN
+
+  gst_list="$WORK_DIR/.companions"
+  : >"$gst_list"
+  for t in scripts/check_*_test.sh scripts/lint_*_test.sh scripts/*_gate_test.sh; do
+    [ -e "$t" ] || continue
+    # Only companions OF a gate in this tree; an orphan is reported below.
+    [ -f "${t%_test.sh}.sh" ] || continue
+    printf '%s\n' "$t" >>"$gst_list"
   done
+  # `|| true`: a worker never exits non-zero (it records a verdict instead), so
+  # a non-zero here would be xargs itself, and the verdict files below are the
+  # answer either way.
+  xargs -P "$GST_JOBS" -I{} bash -c 'gst_worker "$@"' _ {} <"$gst_list" || true
+
+  # Collected in the companion order the serial loop used, so the report a
+  # reader compares against an older run is byte-identical when the verdicts
+  # are.
+  while IFS= read -r t; do
+    base="${t#scripts/}"
+    [ -f "$WORK_DIR/$base.verdict" ] || continue
+    case "$(cat "$WORK_DIR/$base.verdict")" in
+      repaired) repaired="$repaired $base" ;;
+      failed)
+        failed_tests="$failed_tests $t"
+        echo "[gate-self-tests] --- $t ---" >&2
+        tail -20 "$WORK_DIR/$base.log" >&2
+        ;;
+    esac
+  done <"$gst_list"
 fi
 
 rc=0

--- a/scripts/check_gate_self_tests.sh
+++ b/scripts/check_gate_self_tests.sh
@@ -151,19 +151,19 @@ if [ "${VIBE_GATE_SELF_TESTS_RUN:-1}" = "1" ]; then
   # the lane's 341s, measured on CI run 34567587111 -- for work that is one
   # `bash` per file with nothing shared between them.
   #
-  # "Nothing shared" is a property to protect, not to assume. The one real
-  # coupling is the five generated compiler artifacts: a companion that needs
-  # them (check_compile_only_lanes_test.sh) calls ensure_generated.sh, which
-  # WRITES INTO lib/@vibe/compiler/. Two of those racing would interleave
-  # partial writes. So the fan-out is preceded by one ensure_generated here:
-  # afterwards every worker sees them current and regenerates nothing. On CI's
-  # late lane they are already generated, so this costs nothing; where they are
-  # stale it is the same work the serial loop paid inside the worker.
-  # `|| true` because a genuine generation failure belongs to the companion
-  # that depends on it -- reporting it here would name the wrong script.
-  if [ -z "${VIBE_GATE_SELF_TEST_ROOT:-}" ] && [ -x scripts/ensure_generated.sh ]; then
-    bash scripts/ensure_generated.sh >/dev/null 2>&1 || true
-  fi
+  # "Nothing shared" is a property to protect, not to assume. The one coupling
+  # would be the five generated compiler artifacts -- ensure_generated.sh
+  # WRITES INTO lib/@vibe/compiler/, so two companions regenerating at once
+  # would interleave partial writes. Measured: exactly ONE companion reaches
+  # it (check_compile_only_lanes_test.sh, via build_compile_only.sh), so there
+  # is no race and nothing to serialize.
+  #
+  # An earlier revision generated once here to be safe. That was worse than
+  # doing nothing: ensure_generated.sh REMOVES THE STAMP before regenerating,
+  # so when this pre-warm failed -- and it does inside the late lane, whose
+  # earlier sections leave lib/ in a state the seed cannot flatten -- the
+  # `|| true` swallowed the error and left the tree stamp-less, which then
+  # failed the companion for real. Measured on run 34577224982.
 
   # min(4, nproc) matches scripts/vibe_test.sh and scripts/unit_test_runner.sh:
   # a few companions compile with the wasm compiler and peak at GBs, so an

--- a/scripts/check_gate_self_tests.sh
+++ b/scripts/check_gate_self_tests.sh
@@ -17,11 +17,8 @@ set -euo pipefail
 ROOT_DIR="${VIBE_GATE_SELF_TEST_ROOT:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
 cd "$ROOT_DIR"
 
-# A DIRECTORY, not one file: the companions run concurrently below, so each
-# needs its own log and its own verdict file. One shared $WORK_LOG would have
-# workers overwriting the very output the failure report prints.
-WORK_DIR="$(mktemp -d "${TMPDIR:-/tmp}/vibe_gate_selftest.XXXXXX")"
-trap 'rm -rf "$WORK_DIR"' EXIT
+WORK_LOG="$(mktemp "${TMPDIR:-/tmp}/vibe_gate_selftest.XXXXXX")"
+trap 'rm -f "$WORK_LOG"' EXIT
 
 ALLOWLIST="scripts/gate_self_test_allowlist.txt"
 FAILING="scripts/gate_self_test_failing.txt"
@@ -143,116 +140,49 @@ EOF
 # exact shape ("the check credited a proxy for the property") that this gate
 # was written to stop (#2248 review). Discovery is by glob, so a future
 # companion is run without anyone remembering to add it to a list.
+# SERIAL, AND IT HAS TO BE. The companions look embarrassingly parallel -- one
+# `bash` per file -- and running them over `xargs -P 4` did cut this from 159s
+# to about 80s of the late lane. It was also wrong: they SHARE THE WORKING
+# TREE. check_portable_boundary_test.sh mutates tracked files under
+# lib/@vibe/compiler/entry/source_compile/ and restores them with `git
+# checkout` between cases, and it refuses to run at all against a dirty tree.
+# Concurrently with check_compile_only_lanes_test.sh -- which reaches
+# ensure_generated.sh, and so reads the whole live lib/ tree -- that produced
+#   generate_bundle: seed could not flatten the live tree
+#   wasi_only/index.vpkg: contract violation: exported 'probe_raw' is not declared
+# on run 34577224982 and the same failure naming 'probe_tab' on 34578340183:
+# different probe names, because the interleaving differs. A gate whose answer
+# depends on the interleaving is not a gate.
+#
+# Whoever tries this again needs more than a faster loop: the companions would
+# each need their own tree, and then they would no longer be testing this one.
 failed_tests=""
 repaired=""
 if [ "${VIBE_GATE_SELF_TESTS_RUN:-1}" = "1" ]; then
-  # The companions are INDEPENDENT of each other, so they run concurrently.
-  # Serially this was the single slowest section of the late lane -- 159s of
-  # the lane's 341s, measured on CI run 34567587111 -- for work that is one
-  # `bash` per file with nothing shared between them.
-  #
-  # "Nothing shared" is a property to protect, not to assume. The one coupling
-  # would be the five generated compiler artifacts -- ensure_generated.sh
-  # WRITES INTO lib/@vibe/compiler/, so two companions regenerating at once
-  # would interleave partial writes. Measured: exactly ONE companion reaches
-  # it (check_compile_only_lanes_test.sh, via build_compile_only.sh), so there
-  # is no race and nothing to serialize.
-  #
-  # An earlier revision generated once here to be safe. That was worse than
-  # doing nothing: ensure_generated.sh REMOVES THE STAMP before regenerating,
-  # so when this pre-warm failed -- and it does inside the late lane, whose
-  # earlier sections leave lib/ in a state the seed cannot flatten -- the
-  # `|| true` swallowed the error and left the tree stamp-less, which then
-  # failed the companion for real. Measured on run 34577224982.
-
-  # min(4, nproc) matches scripts/vibe_test.sh and scripts/unit_test_runner.sh:
-  # a few companions compile with the wasm compiler and peak at GBs, so an
-  # unbounded -P OOMs a 4-vCPU runner. VIBE_GATE_SELF_TESTS_JOBS=1 restores the
-  # serial order, which is what to set when a companion is suspected of
-  # sharing state with another.
-  gst_hw_jobs="$(nproc 2>/dev/null || echo 1)"
-  [ "$gst_hw_jobs" -gt 4 ] && gst_hw_jobs=4
-  GST_JOBS="${VIBE_GATE_SELF_TESTS_JOBS:-$gst_hw_jobs}"
-
-  gst_worker() {
-    gst_t="$1"
-    gst_base="${gst_t#scripts/}"
-    gst_log="$WORK_DIR/$gst_base.log"
-    if printf '%s\n' "$GST_FAILING_ALLOWED" | grep -qxF "$gst_base"; then
+  for t in scripts/check_*_test.sh scripts/lint_*_test.sh scripts/*_gate_test.sh; do
+    [ -e "$t" ] || continue
+    # Only companions OF a gate in this tree; an orphan is reported below.
+    [ -f "${t%_test.sh}.sh" ] || continue
+    base="${t#scripts/}"
+    if printf '%s\n' "$failing_allowed" | grep -qxF "$base"; then
       # A known-failing exemption is still RUN, because the interesting case is
       # that it starts passing: skipping it outright means a repaired test (or
       # one whose missing dependency arrived) stays permanently unexecuted, and
       # any later regression in it is invisible until someone edits the list by
       # hand (#2248 review). The ratchet has to notice its own entries going
       # stale, exactly as the no-test allowlist does.
-      if bash "$gst_t" >"$gst_log" 2>&1 \
-         && printf '%s\n' "$GST_FAILING_BROKEN" | grep -qxF "$gst_base"; then
-        printf 'repaired\n' >"$WORK_DIR/$gst_base.verdict"
-      else
-        printf 'ok\n' >"$WORK_DIR/$gst_base.verdict"
+      if bash "$t" >"$WORK_LOG" 2>&1 \
+         && printf '%s\n' "$failing_broken" | grep -qxF "$base"; then
+        repaired="$repaired $base"
       fi
-      return 0
-    fi
-    if bash "$gst_t" >"$gst_log" 2>&1; then
-      printf 'ok\n' >"$WORK_DIR/$gst_base.verdict"
-    else
-      printf 'failed\n' >"$WORK_DIR/$gst_base.verdict"
-    fi
-    return 0
-  }
-  export -f gst_worker
-  export WORK_DIR
-  GST_FAILING_ALLOWED="$failing_allowed"; export GST_FAILING_ALLOWED
-  GST_FAILING_BROKEN="$failing_broken"; export GST_FAILING_BROKEN
-
-  gst_list="$WORK_DIR/.companions"
-  : >"$gst_list"
-  for t in scripts/check_*_test.sh scripts/lint_*_test.sh scripts/*_gate_test.sh; do
-    [ -e "$t" ] || continue
-    # Only companions OF a gate in this tree; an orphan is reported below.
-    [ -f "${t%_test.sh}.sh" ] || continue
-    printf '%s\n' "$t" >>"$gst_list"
-  done
-  # `|| true`: a worker never exits non-zero (it records a verdict instead), so
-  # a non-zero here would be xargs itself, and the verdict files below are the
-  # answer either way.
-  xargs -P "$GST_JOBS" -I{} bash -c 'gst_worker "$@"' _ {} <"$gst_list" || true
-
-  # Collected in the companion order the serial loop used, so the report a
-  # reader compares against an older run is byte-identical when the verdicts
-  # are.
-  #
-  # EVERY worker records a terminal state, including `ok`, and a companion with
-  # no verdict file is a FAILURE rather than a pass (Codex review of #2645).
-  # An earlier revision wrote a file only for `repaired` and `failed`, so a
-  # worker that xargs could not launch -- or that was killed before it wrote --
-  # was indistinguishable from one that passed, and this gate could report
-  # green without having run a self-test it claims to cover. That is the exact
-  # shape it exists to stop: silence read as safety.
-  while IFS= read -r t; do
-    base="${t#scripts/}"
-    if [ ! -s "$WORK_DIR/$base.verdict" ]; then
-      failed_tests="$failed_tests $t"
-      echo "[gate-self-tests] --- $t ---" >&2
-      echo "  no verdict recorded: the worker did not run to completion" >&2
-      tail -20 "$WORK_DIR/$base.log" >&2 2>/dev/null || true
       continue
     fi
-    case "$(cat "$WORK_DIR/$base.verdict")" in
-      ok) ;;
-      repaired) repaired="$repaired $base" ;;
-      failed)
-        failed_tests="$failed_tests $t"
-        echo "[gate-self-tests] --- $t ---" >&2
-        tail -20 "$WORK_DIR/$base.log" >&2
-        ;;
-      *)
-        failed_tests="$failed_tests $t"
-        echo "[gate-self-tests] --- $t ---" >&2
-        echo "  unrecognised verdict: $(cat "$WORK_DIR/$base.verdict")" >&2
-        ;;
-    esac
-  done <"$gst_list"
+    if ! bash "$t" >"$WORK_LOG" 2>&1; then
+      failed_tests="$failed_tests $t"
+      echo "[gate-self-tests] --- $t ---" >&2
+      tail -20 "$WORK_LOG" >&2
+    fi
+  done
 fi
 
 rc=0

--- a/scripts/check_gate_self_tests_test.sh
+++ b/scripts/check_gate_self_tests_test.sh
@@ -106,16 +106,5 @@ printf '#!/usr/bin/env bash\nexit 0\n' > "$WORK/scripts/check_thing_test.sh"
 run_exec || { cat "$WORK/out" >&2; fail "a PASSING companion was rejected"; }
 echo "  ok  a passing companion is accepted"
 
-# A companion whose WORKER never finishes must not read as a pass (Codex review
-# of #2645). The companions run concurrently, and an earlier revision recorded
-# a file only for `repaired` and `failed` -- so a worker xargs could not launch,
-# or that was killed before it wrote, was indistinguishable from one that
-# passed. `kill -9 $PPID` reproduces exactly that: the companion destroys the
-# worker shell, so no verdict is ever recorded.
-printf '#!/usr/bin/env bash\nkill -9 $PPID\nexit 0\n' > "$WORK/scripts/check_thing_test.sh"
-if run_exec; then fail "a companion whose worker died was accepted"; fi
-grep -q "check_thing_test.sh" "$WORK/out" || fail "the missing-verdict failure did not name the companion"
-grep -q "no verdict recorded" "$WORK/out" || fail "the missing-verdict failure did not say why"
-echo "  ok  a companion whose worker dies without a verdict is rejected"
 
 echo "[gate-self-tests-test] ok"

--- a/scripts/check_gate_self_tests_test.sh
+++ b/scripts/check_gate_self_tests_test.sh
@@ -106,4 +106,16 @@ printf '#!/usr/bin/env bash\nexit 0\n' > "$WORK/scripts/check_thing_test.sh"
 run_exec || { cat "$WORK/out" >&2; fail "a PASSING companion was rejected"; }
 echo "  ok  a passing companion is accepted"
 
+# A companion whose WORKER never finishes must not read as a pass (Codex review
+# of #2645). The companions run concurrently, and an earlier revision recorded
+# a file only for `repaired` and `failed` -- so a worker xargs could not launch,
+# or that was killed before it wrote, was indistinguishable from one that
+# passed. `kill -9 $PPID` reproduces exactly that: the companion destroys the
+# worker shell, so no verdict is ever recorded.
+printf '#!/usr/bin/env bash\nkill -9 $PPID\nexit 0\n' > "$WORK/scripts/check_thing_test.sh"
+if run_exec; then fail "a companion whose worker died was accepted"; fi
+grep -q "check_thing_test.sh" "$WORK/out" || fail "the missing-verdict failure did not name the companion"
+grep -q "no verdict recorded" "$WORK/out" || fail "the missing-verdict failure did not say why"
+echo "  ok  a companion whose worker dies without a verdict is rejected"
+
 echo "[gate-self-tests-test] ok"

--- a/scripts/check_offbuild_typecheck.sh
+++ b/scripts/check_offbuild_typecheck.sh
@@ -82,23 +82,8 @@ PY
 total=0
 skipped=0
 failed=0
-
-# One compiler run per source, and they share nothing -- so they run
-# concurrently. Serially this was 168s of CI wall time (run 34567587111) using
-# one of the runner's four cores. min(4, nproc) is the level
-# scripts/unit_test_runner.sh already runs compiler-sized compiles at; each
-# peaks at a few GB of wasm memory, so an unbounded -P would OOM.
-# VIBE_OFFBUILD_JOBS=1 restores the serial order.
-ob_hw_jobs="$(nproc 2>/dev/null || echo 1)"
-[ "$ob_hw_jobs" -gt 4 ] && ob_hw_jobs=4
-OB_JOBS="${VIBE_OFFBUILD_JOBS:-$ob_hw_jobs}"
-
-OB_WORK="$(mktemp -d "${TMPDIR:-/tmp}/vibe_offbuild.XXXXXX")"
-trap 'rm -rf "$OB_WORK"' EXIT
-
-# The selection is unchanged; it just becomes a file the workers consume.
-ob_selected="$OB_WORK/selected"
-: >"$ob_selected"
+out="$(mktemp -u)"
+runner_err="$out.stderr"
 while IFS= read -r f; do
   [ -n "$f" ] || continue
   if printf '%s' "$f" | grep -Eq "$EXCLUDE_RE"; then
@@ -106,41 +91,11 @@ while IFS= read -r f; do
     continue
   fi
   total=$((total + 1))
-  printf '%s\n' "$f" >>"$ob_selected"
-done < "$listing"
-
-ob_worker() {
-  ob_f="$1"
-  ob_slug="$(printf '%s' "$ob_f" | tr / _)"
-  ob_out="$OB_WORK/$ob_slug.wasm"
-  ob_err="$OB_WORK/$ob_slug.stderr"
-  ob_status=0
+  rm -f "$out" "$out.diag" "$runner_err"
+  runner_status=0
   VIBE_PREOPEN_DIR="$PROJECT_ROOT" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw VIBE_CHECK_ONLY=1 \
     timeout 300 bash "$SCRIPT_DIR/run_wasm_vibe_host_runner.sh" \
-    --invoke cli_main "$STAGE2" "$ob_f" "$ob_out" __no_entry__ >/dev/null 2>"$ob_err" || ob_status=$?
-  printf '%s\n' "$ob_status" >"$OB_WORK/$ob_slug.status"
-  return 0
-}
-export -f ob_worker
-export OB_WORK PROJECT_ROOT SCRIPT_DIR STAGE2
-
-# `|| true`: a worker records its status instead of exiting non-zero, so a
-# non-zero here would be xargs itself; the status files are the answer.
-xargs -P "$OB_JOBS" -I{} bash -c 'ob_worker "$@"' _ {} <"$ob_selected" || true
-
-# Reported serially in listing order: which worker finished first must not
-# change the output.
-timed_out=0
-while IFS= read -r f; do
-  slug="$(printf '%s' "$f" | tr / _)"
-  out="$OB_WORK/$slug.wasm"
-  runner_err="$OB_WORK/$slug.stderr"
-  if [ ! -f "$OB_WORK/$slug.status" ]; then
-    failed=$((failed + 1))
-    echo "[offbuild-typecheck] FAIL $f: no verdict (worker died)" >&2
-    continue
-  fi
-  runner_status="$(cat "$OB_WORK/$slug.status")"
+    --invoke cli_main "$STAGE2" "$f" "$out" __no_entry__ >/dev/null 2>"$runner_err" || runner_status=$?
   if [ -s "$out.diag" ]; then
     failed=$((failed + 1))
     echo "[offbuild-typecheck] FAIL $f" >&2
@@ -161,15 +116,12 @@ while IFS= read -r f; do
     fi
     head -3 "$runner_err" >&2
   fi
-  [ "$runner_status" -eq 124 ] && timed_out=1
-done < "$ob_selected"
-
-# The serial loop aborted the REMAINING sources on a timeout, which was a
-# latency choice; here every source has already run, so a timeout is reported
-# with the rest and still fails the gate.
-if [ "$timed_out" -eq 1 ]; then
-  echo "[offbuild-typecheck] at least one source timed out after 300 seconds" >&2
-fi
+  rm -f "$out" "$out.diag" "$runner_err"
+  if [ "$runner_status" -eq 124 ]; then
+    echo "[offbuild-typecheck] aborting after runner timeout; remaining sources were not checked" >&2
+    exit 1
+  fi
+done < "$listing"
 
 if [ "$failed" -gt 0 ]; then
   echo "[offbuild-typecheck] FAIL: $failed of $total off-manifest source(s) do not typecheck" >&2

--- a/scripts/check_offbuild_typecheck.sh
+++ b/scripts/check_offbuild_typecheck.sh
@@ -82,8 +82,23 @@ PY
 total=0
 skipped=0
 failed=0
-out="$(mktemp -u)"
-runner_err="$out.stderr"
+
+# One compiler run per source, and they share nothing -- so they run
+# concurrently. Serially this was 168s of CI wall time (run 34567587111) using
+# one of the runner's four cores. min(4, nproc) is the level
+# scripts/unit_test_runner.sh already runs compiler-sized compiles at; each
+# peaks at a few GB of wasm memory, so an unbounded -P would OOM.
+# VIBE_OFFBUILD_JOBS=1 restores the serial order.
+ob_hw_jobs="$(nproc 2>/dev/null || echo 1)"
+[ "$ob_hw_jobs" -gt 4 ] && ob_hw_jobs=4
+OB_JOBS="${VIBE_OFFBUILD_JOBS:-$ob_hw_jobs}"
+
+OB_WORK="$(mktemp -d "${TMPDIR:-/tmp}/vibe_offbuild.XXXXXX")"
+trap 'rm -rf "$OB_WORK"' EXIT
+
+# The selection is unchanged; it just becomes a file the workers consume.
+ob_selected="$OB_WORK/selected"
+: >"$ob_selected"
 while IFS= read -r f; do
   [ -n "$f" ] || continue
   if printf '%s' "$f" | grep -Eq "$EXCLUDE_RE"; then
@@ -91,11 +106,41 @@ while IFS= read -r f; do
     continue
   fi
   total=$((total + 1))
-  rm -f "$out" "$out.diag" "$runner_err"
-  runner_status=0
+  printf '%s\n' "$f" >>"$ob_selected"
+done < "$listing"
+
+ob_worker() {
+  ob_f="$1"
+  ob_slug="$(printf '%s' "$ob_f" | tr / _)"
+  ob_out="$OB_WORK/$ob_slug.wasm"
+  ob_err="$OB_WORK/$ob_slug.stderr"
+  ob_status=0
   VIBE_PREOPEN_DIR="$PROJECT_ROOT" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw VIBE_CHECK_ONLY=1 \
     timeout 300 bash "$SCRIPT_DIR/run_wasm_vibe_host_runner.sh" \
-    --invoke cli_main "$STAGE2" "$f" "$out" __no_entry__ >/dev/null 2>"$runner_err" || runner_status=$?
+    --invoke cli_main "$STAGE2" "$ob_f" "$ob_out" __no_entry__ >/dev/null 2>"$ob_err" || ob_status=$?
+  printf '%s\n' "$ob_status" >"$OB_WORK/$ob_slug.status"
+  return 0
+}
+export -f ob_worker
+export OB_WORK PROJECT_ROOT SCRIPT_DIR STAGE2
+
+# `|| true`: a worker records its status instead of exiting non-zero, so a
+# non-zero here would be xargs itself; the status files are the answer.
+xargs -P "$OB_JOBS" -I{} bash -c 'ob_worker "$@"' _ {} <"$ob_selected" || true
+
+# Reported serially in listing order: which worker finished first must not
+# change the output.
+timed_out=0
+while IFS= read -r f; do
+  slug="$(printf '%s' "$f" | tr / _)"
+  out="$OB_WORK/$slug.wasm"
+  runner_err="$OB_WORK/$slug.stderr"
+  if [ ! -f "$OB_WORK/$slug.status" ]; then
+    failed=$((failed + 1))
+    echo "[offbuild-typecheck] FAIL $f: no verdict (worker died)" >&2
+    continue
+  fi
+  runner_status="$(cat "$OB_WORK/$slug.status")"
   if [ -s "$out.diag" ]; then
     failed=$((failed + 1))
     echo "[offbuild-typecheck] FAIL $f" >&2
@@ -116,12 +161,15 @@ while IFS= read -r f; do
     fi
     head -3 "$runner_err" >&2
   fi
-  rm -f "$out" "$out.diag" "$runner_err"
-  if [ "$runner_status" -eq 124 ]; then
-    echo "[offbuild-typecheck] aborting after runner timeout; remaining sources were not checked" >&2
-    exit 1
-  fi
-done < "$listing"
+  [ "$runner_status" -eq 124 ] && timed_out=1
+done < "$ob_selected"
+
+# The serial loop aborted the REMAINING sources on a timeout, which was a
+# latency choice; here every source has already run, so a timeout is reported
+# with the rest and still fails the gate.
+if [ "$timed_out" -eq 1 ]; then
+  echo "[offbuild-typecheck] at least one source timed out after 300 seconds" >&2
+fi
 
 if [ "$failed" -gt 0 ]; then
   echo "[offbuild-typecheck] FAIL: $failed of $total off-manifest source(s) do not typecheck" >&2

--- a/scripts/coverage_suite.sh
+++ b/scripts/coverage_suite.sh
@@ -162,13 +162,72 @@ MIN_FUNCTION_UNION="${VIBE_SUITE_MIN_FUNCTION_UNION_RATE:-0}"
 MIN_BRANCH_UNION_HIT="${VIBE_SUITE_MIN_BRANCH_UNION_HIT:-26000}"
 MIN_BRANCH_UNION="${VIBE_SUITE_MIN_BRANCH_UNION_RATE:-57}"
 
-ALLOWLIST="$(mktemp -t vibe-coverage-entries-XXXXXX)"
-trap 'rm -f "$ALLOWLIST"' EXIT
-bash scripts/unit_test_runner.sh --list > "$ALLOWLIST"
+# SHARDING (#2645). This gate re-compiles the whole unit battery under
+# instrumentation: 691s of CI wall time on run 34567587111, and the single
+# longest step in the workflow -- it alone decided the run's wall clock, at
+# 891s against 615s for the required path. It is already parallel INSIDE the
+# job (vibe_test.sh fans out over min(4, nproc)), so the only way down is more
+# runners.
+#
+# Two extra modes, and the default -- run everything, aggregate, gate -- is
+# unchanged:
+#
+#   VIBE_COVERAGE_SHARD=i/N   run only the i-th of N entry partitions, write
+#                             the run log and per-entry coverage, and DO NOT
+#                             gate. A shard sees a subset, so its union rates
+#                             are meaningless; thresholds belong to the whole.
+#   VIBE_COVERAGE_MERGE_DIR=D aggregate the shards collected under D and gate
+#                             on the result. No compiler needed: the report is
+#                             a pure function of the run logs and the per-entry
+#                             coverage JSON.
+#
+# The merge is exactly the union the single job used to produce: the report
+# reads `ok|FAIL <entry>.vibe` lines from the log and one JSON per entry from
+# the coverage directory, and shards partition the entries, so concatenating
+# the logs and collecting the JSONs reconstructs the same inputs.
 OUT_DIR="_build/coverage/selfhost-suite"
 REPORT="$OUT_DIR/selfhost_suite.report.json"
 COV_DIR="_build/vibe_test/coverage"
 
+if [ -n "${VIBE_COVERAGE_MERGE_DIR:-}" ]; then
+  merge_dir="$VIBE_COVERAGE_MERGE_DIR"
+  [ -d "$merge_dir" ] || { echo "[coverage-suite] no such merge dir: $merge_dir" >&2; exit 1; }
+  rm -rf "$COV_DIR" "$OUT_DIR"
+  mkdir -p "$COV_DIR" "$OUT_DIR"
+  run_log="$OUT_DIR/vibe_test.log"
+  : >"$run_log"
+  shard_logs=0
+  for log in "$merge_dir"/*/vibe_test.log; do
+    [ -f "$log" ] || continue
+    cat "$log" >>"$run_log"
+    shard_logs=$((shard_logs + 1))
+  done
+  for d in "$merge_dir"/*/coverage; do
+    [ -d "$d" ] || continue
+    cp -a "$d/." "$COV_DIR/" 2>/dev/null || true
+  done
+  # Refuse rather than gate on a fraction: a merge that silently found one
+  # shard would report a coverage collapse that is really a plumbing failure,
+  # and the ratchet would be "explained" by lowering it.
+  want_shards="${VIBE_COVERAGE_MERGE_EXPECT:-0}"
+  if [ "$shard_logs" -eq 0 ]; then
+    echo "[coverage-suite] FAIL: no shard logs under $merge_dir" >&2
+    exit 1
+  fi
+  if [ "$want_shards" -gt 0 ] && [ "$shard_logs" -ne "$want_shards" ]; then
+    echo "[coverage-suite] FAIL: merged $shard_logs shard log(s), expected $want_shards" >&2
+    echo "  A partial merge understates every union metric -- that is a broken" >&2
+    echo "  upload, not a coverage regression." >&2
+    exit 1
+  fi
+  echo "[coverage-suite] merged $shard_logs shard(s) from $merge_dir"
+  python3 scripts/coverage_suite_report.py "$run_log" "$COV_DIR" "$REPORT" "$MIN_POINT" "$MIN_LINE" "$MIN_BRANCH" "$MIN_FN_HIT" "$MIN_BRANCH_HIT" "$MIN_BRANCH_UNION_HIT" "$MIN_BRANCH_UNION" "$MIN_FUNCTION_UNION_HIT" "$MIN_FUNCTION_UNION"
+  exit $?
+fi
+
+ALLOWLIST="$(mktemp -t vibe-coverage-entries-XXXXXX)"
+trap 'rm -f "$ALLOWLIST"' EXIT
+bash scripts/unit_test_runner.sh --list > "$ALLOWLIST"
 # Compiling CLI: explicit override > the generation built for this checkout.
 # Do not select the newest directory by mtime: a worktree can retain a stage2
 # from another revision, yielding stale coverage failures or false greens.
@@ -254,6 +313,36 @@ if [ "${#entries[@]}" -eq 0 ]; then
   exit 1
 fi
 
+# Round-robin over the full list, so the union of all N shards is exactly the
+# unsharded battery and the shards are disjoint -- the same property
+# unit_test_runner.sh's weight-balanced split guarantees, without a second
+# weights file to keep in step.
+if [ -n "${VIBE_COVERAGE_SHARD:-}" ]; then
+  case "$VIBE_COVERAGE_SHARD" in
+    */*) ;;
+    *) echo "[coverage-suite] FAIL: VIBE_COVERAGE_SHARD must be i/N (e.g. 0/8)" >&2; exit 2 ;;
+  esac
+  shard_i="${VIBE_COVERAGE_SHARD%%/*}"
+  shard_n="${VIBE_COVERAGE_SHARD##*/}"
+  if ! [ "$shard_i" -ge 0 ] 2>/dev/null || ! [ "$shard_n" -ge 1 ] 2>/dev/null \
+     || [ "$shard_i" -ge "$shard_n" ]; then
+    echo "[coverage-suite] FAIL: bad shard spec: $VIBE_COVERAGE_SHARD" >&2
+    exit 2
+  fi
+  sharded=()
+  idx=0
+  for e in "${entries[@]}"; do
+    if [ $((idx % shard_n)) -eq "$shard_i" ]; then sharded+=("$e"); fi
+    idx=$((idx + 1))
+  done
+  if [ "${#sharded[@]}" -eq 0 ]; then
+    echo "[coverage-suite] FAIL: shard $VIBE_COVERAGE_SHARD selected 0 of ${#entries[@]} entries" >&2
+    exit 1
+  fi
+  echo "[coverage-suite] shard $VIBE_COVERAGE_SHARD: ${#sharded[@]} of ${#entries[@]} entries"
+  entries=("${sharded[@]}")
+fi
+
 echo "[coverage-suite] cli=$cli entries=${#entries[@]}"
 rm -rf "$COV_DIR"
 mkdir -p "$OUT_DIR"
@@ -271,5 +360,13 @@ case "$cli" in
 esac
 VIBE_TEST_CLI_WASM="$cli_abs" bash scripts/vibe_test.sh --coverage "${entries[@]}" \
   | tee "$run_log" || true
+
+if [ -n "${VIBE_COVERAGE_SHARD:-}" ]; then
+  # A shard holds a partition, so every union metric it could compute is a
+  # lower bound on the real one. Gating here would either fail honest shards
+  # or need per-shard thresholds that mean nothing; the merge gates instead.
+  echo "[coverage-suite] shard $VIBE_COVERAGE_SHARD done: log=$run_log coverage=$COV_DIR (not gated; the merge gates)"
+  exit 0
+fi
 
 python3 scripts/coverage_suite_report.py "$run_log" "$COV_DIR" "$REPORT" "$MIN_POINT" "$MIN_LINE" "$MIN_BRANCH" "$MIN_FN_HIT" "$MIN_BRANCH_HIT" "$MIN_BRANCH_UNION_HIT" "$MIN_BRANCH_UNION" "$MIN_FUNCTION_UNION_HIT" "$MIN_FUNCTION_UNION"

--- a/scripts/test_ci_compiler_gate_layout.sh
+++ b/scripts/test_ci_compiler_gate_layout.sh
@@ -74,16 +74,51 @@ require_stage2_builder_wasmtime() {
   local build_line
   setup_line="$(grep -nF 'uses: ./.github/actions/setup-vibe' <<<"$block" | head -1 | cut -d: -f1)"
   build_line="$(grep -nF 'scripts/generations.sh build' <<<"$block" | head -1 | cut -d: -f1)"
-  if [ -z "$build_line" ] || [ "$setup_line" -ge "$build_line" ]; then
+  if [ -z "$build_line" ] || [ -z "$setup_line" ] || [ "$setup_line" -ge "$build_line" ]; then
     echo "[ci-compiler-gate-layout] ${job} must set up wasmtime before its stage2 build" >&2
     exit 1
   fi
 }
 
-require_stage2_builder_wasmtime compiler-stage2-oracles
-require_stage2_builder_wasmtime compiler-docs
-require_stage2_builder_wasmtime compiler-playground
-require_stage2_builder_wasmtime compiler-examples
-require_stage2_builder_wasmtime review-regressions
+# #2184 belongs to whoever actually runs `generations.sh build`, and since
+# #2645 that is one job: compiler-build. The five gate jobs that used to build
+# their own stage2 now download the one it produces, so requiring a build step
+# of them would pin the layout this change removed.
+require_stage2_builder_wasmtime compiler-build
+
+# THE COMPILER IS BUILT ONCE (#2645). A job that consumes it must say so, or
+# actions/download-artifact races the producer and fails on a run where the
+# scheduler happens to start them together. `needs:` is the only thing that
+# orders them, so the two halves are required together: a job carrying the
+# composite action must declare the dependency, and a job declaring the
+# dependency must actually use the action.
+consumers="$(grep -n 'uses: ./.github/actions/use-compiler-build' "$workflow" | cut -d: -f1)"
+if [ -z "$consumers" ]; then
+  echo "[ci-compiler-gate-layout] no job uses ./.github/actions/use-compiler-build" >&2
+  echo "  The shared compiler build is how every gate job gets a stage2." >&2
+  exit 1
+fi
+for job in $(awk '
+  /^jobs:[[:space:]]*$/ { in_jobs = 1; next }
+  /^[A-Za-z0-9_-]+:/ { if (!/^jobs:/) in_jobs = 0 }
+  in_jobs && /^  [A-Za-z0-9_-]+:[[:space:]]*$/ { job = $1; sub(/:$/, "", job); print job }
+' "$workflow"); do
+  block="$(sed -n "/^  ${job}:\$/,/^  [a-zA-Z0-9_-]*:\$/p" "$workflow")"
+  uses_shared=0
+  needs_shared=0
+  grep -qF 'uses: ./.github/actions/use-compiler-build' <<<"$block" && uses_shared=1
+  grep -qE '^    needs:.*compiler-build' <<<"$block" && needs_shared=1
+  if [ "$uses_shared" = 1 ] && [ "$needs_shared" = 0 ]; then
+    echo "[ci-compiler-gate-layout] ${job} downloads the shared compiler build without 'needs: [compiler-build]'" >&2
+    echo "  Add it to the job -- download-artifact cannot wait on its own." >&2
+    exit 1
+  fi
+  if [ "$needs_shared" = 1 ] && [ "$uses_shared" = 0 ] && [ "$job" != "ci-required" ]; then
+    echo "[ci-compiler-gate-layout] ${job} declares 'needs: [compiler-build]' but never uses it" >&2
+    echo "  Either add '- uses: ./.github/actions/use-compiler-build' or drop the dependency;" >&2
+    echo "  waiting ~200s for an artifact the job ignores is pure latency." >&2
+    exit 1
+  fi
+done
 
 echo "[ci-compiler-gate-layout] ok"


### PR DESCRIPTION
Profiled CI run [34567587111](https://github.com/mizchi/vibe-lang/actions/runs/34567587111) (main, **893s wall, 7879s of job time**) per job and per step, then removed what the numbers pointed at.

## What the profile showed

| job | wall | what it was actually doing |
|---|---:|---|
| coverage-suite | 891s | 691s in one unsharded gate — it alone set the run's wall clock |
| compiler-gate (contracts) | 608s | 224s build + 357s of ten serial gates |
| compiler-gate (playground) | 548s | 323s seed rebuild + 208s cargo build + **5.5s of actual checking** |
| gc-gate | 527s | 236s build + 220s heap accounting |
| compiler-gate (late) | 519s | 166s build + 341s lane |
| compiler-gate (stage2 oracles) | 510s | 304s seed rebuild |
| compiler-gate (examples) | 488s | 225s build + 218s cargo build + **23s of actual checking** |
| structural-lint | 487s | 429s of it inside one shell lint's self-test, printing nothing |

## Three root causes, all removed

**1. Four jobs rebuilt the seed compiler from source, every run (~300s each).**
`bootstrap/seed/compiler.wasm` is gitignored, so the first thing that touches the compiler calls `ensure_seed.sh`. The pinned tag `seed/cfg-spans-emission-2026-09-04` **is not published** — `git ls-remote` lists every other seed tag and not that one — so `ensure_seed` takes its rebuild branch: stage0 → stage1 → stage2 from `source_commit`, ~5 minutes, inside whatever step asked first and with no step name to blame. Twelve jobs had an `actions/cache` for the seed and restored it in ~2s. Four did not.

`scripts/check_ci_seed_cache.sh` makes it lexical so it cannot come back: a job block invoking `bash scripts/…`, `bash tests/…` or `pkf run` must carry a `seed-artifact-` key **before** the first such invocation. It refuses to answer — rather than passing — when it finds no job headers at all. Red-tested in both directions. It caught one of my own new jobs while I was writing this.

**2. The Rust runner was rebuilt from scratch, twice per run (~210s each).**
`install/install.sh` runs `cargo build --release` on `runtime/viberun` unless the binary already exists, and neither `compiler-examples` nor `compiler-playground` had a cargo cache. The log signature is unmistakable: 208s of silence, then `[playground-presets] ok: 4 preset(s)` 5.5 seconds later. Both now carry the cache, plus an explicit `cargo build` so a prefix-restored binary cannot be served stale.

**3. The compiler was built fourteen times per run (~215s each, ~2700s of job time).**
`ensure_generated.sh` (flatten) plus `generations.sh` (seed → stage1 → stage2), from the same commit, in fourteen jobs — while `wasi-p3-gate` was already downloading the result and reporting 0s for the same step. `compiler-build` now builds it once and `use-compiler-build` hands it to every gate job, shipping the whole `_build/_ci_shard_gen` directory because consumers read `generations.sh`'s side products by position. `compiler-gate` deliberately keeps building: it *is* the seed → stage3 fixpoint.

Plus: **coverage-suite sharded** 8 ways with a merge that gates on the union (`VIBE_COVERAGE_MERGE_EXPECT` makes a lost upload fail as a lost upload rather than as a coverage regression), **unit-tests 4 → 8**, **gc-gate split** `[heap, validate]`, **contracts split** `[core, compile-only]`.

## Measured result

First **all-green** run of the new layout, [34579840316](https://github.com/mizchi/vibe-lang/actions/runs/34579840316) — 30 jobs, 0 failures:

| | before | after |
|---|---:|---:|
| critical path | 893s | **567s** |
| job time | 7879s | **3849s** |

**Correcting an earlier number in this PR.** I first reported 308s from run 34577224982. That was wrong, and the mistake is worth naming: three jobs in that run *failed early*, and a job that dies at minute three ends at minute three. The "critical path" I computed was short because the longest job never finished. 567s is the figure from a run where every job ran to completion.

The caveat that number carries: `compiler-build` finished in 18s, because this PR touched no `lib/**` file, so its fingerprint equalled main's and a PR branch can read main's caches. The head is now merged with main, which does touch `lib/**`, so the next run measures the compiler-touching path.

## Two shared-state dependencies the runs found — both my own, both withdrawn

I added two parallelizations. **Both were unsound, for two different reasons, and both are gone.** They are worth writing down because each looked obviously safe.

- **`check_gate_self_tests.sh` over `xargs -P 4`** (159s → ~80s). The companions **share the working tree**: `check_portable_boundary_test.sh` mutates tracked files under `lib/@vibe/compiler/entry/source_compile/` and restores them with `git checkout`, and refuses to run against a dirty tree. Concurrently with `check_compile_only_lanes_test.sh` — which reaches `ensure_generated.sh`, and so reads the whole live `lib/` tree — the regeneration saw a half-mutated contract, naming `probe_raw` on one run and `probe_tab` on the next: different names, because the interleaving differs. My justification at the time ("exactly one companion reaches `ensure_generated`") was true and was the wrong question. Codex reached the same conclusion independently, and also named the worse half that did not happen to fire: the artifact could have been built *from* a transient probe and passed.
- **`check_offbuild_typecheck.sh` over `xargs -P 4`** (149s → 48s locally). Whole-compiler compiles peak at ~4.18 GB, so four do not fit 16 GB; reproduced at **two** workers as well.

## One ordering dependency the split exposed

`check_offbuild_typecheck.sh` compiles `lib/@vibe/cli/dispatch.vibe`, whose import closure needs the source-fingerprinted header cache warm — the effect `stage2_oracles.sh` already documents ("header discovery for this import graph retains about 1.03 GB and the cold RC path traps before codegen"). On main the eight contract gates ahead of it warmed that cache incidentally; on its own runner it trapped with `memory access out of bounds`. Reproduced locally to the file: with `_build/vibe_selfhost_*` present all 72 sources pass, remove it and exactly one fails. `VIBE_WASM_PRE_GROW_PAGES=65000` does not fix it. So `typecheck` is folded back into `core` behind those gates, documented rather than left to be rediscovered.

**The same mechanism has a price the whole design pays**, and it should be on the record: a consumer job no longer builds the compiler, so it no longer warms that cache for free. The late lane's fixture compiles went from 341s (in-job build, warm) to ~450s (download, cold). "Build once" is unambiguously right for job time — 7879s → 3849s — and for wall clock it is closer to a wash on the gates that compile a lot. Whether the heavy lanes should go back to building in-job is a question for the next run's numbers, not for a guess.

## What this does not fix

≤300s on a compiler-touching change is not reachable here. The bootstrap on the critical path is strictly serial — flatten ~100–140s, seed → stage1 ~49s, stage1 → stage2 ~37s — and every gate depends on it. I measured whether the persistent header cache helps the flatten: **cold 91s vs warm 95s, it does not**, so no cache step was added for it.

The longest gate left is `tests/gates/late/run.sh` at 490s. It is 9437 lines of straight-line bash — no section boundary to shard on — so splitting it is its own change. After that: gc heap accounting, stage2 oracles, compile-only lanes.

## Findings deliberately not touched here

- `mizchi/pkfire@v0.14.2` resolves to `pkfire@0.16.0` at runtime — the action's version input is empty, so it falls through to "latest". The pin does not pin.
- `stage2_oracles.sh` regenerates the five artifacts a **second** time (128s), with a *different* fingerprint than the one the job computed minutes earlier. The fingerprint is not stable within a job.
- `gc-gate` carries the same viberun cache prefix, and its rebuild decision comes from `test_gc_heap_accounting.sh` comparing source mtimes against the binary — which a cache extraction also defeats. Predates this PR.
- `check_offbuild_typecheck.sh` cannot survive a cold header cache on its own. The ordering above works around it; making the gate self-sufficient is its own change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0133gZewqUBf9KhEhj87t7ny