### PR TITLE
#2642 review fixes, and the perf report cut to coverage + 大/中/小

### DIFF
--- a/bench/perf/README.md
+++ b/bench/perf/README.md
@@ -123,15 +123,15 @@ The `perf-metrics` job in `.github/workflows/ci.yml` runs on every PR and every 
   for human and LLM readers alike (the #1207/#1867 reports are the record).
   The readings stay in the `bench-data` snapshots for offline analysis.
 
-  **Four sections: coverage, then one per SIZE TIER** — 大 the compiler
-  itself, 中 a real program, 小 a micro case — with the axes (memory, code
+  **Four sections: coverage, then one per SIZE TIER** — Large the compiler
+  itself, Medium a real program, Small a micro case — with the axes (memory, code
   size, benchmark) as columns and **one representative row per tier**:
 
   | tier | memory | code | benchmark |
   |---|---|---|---|
-  | 大 | selfcompile `heap_ptr_bytes` | `stage2.wasm` | B/op `parse_checker_vibe` |
-  | 中 | `expr_eval` heap | `expr_eval` wasm | `expr_eval` fuel |
-  | 小 | — | `fib` wasm | B/op `fib30` |
+  | Large | selfcompile `heap_ptr_bytes` | `stage2.wasm` | B/op `parse_checker_vibe` |
+  | Medium | `expr_eval` heap | `expr_eval` wasm | `expr_eval` fuel |
+  | Small | — | `fib` wasm | B/op `fib30` |
 
   It used to render every tracked series instead: ~50 rows, of which ~48 read
   `±0` on an ordinary PR. A reader cannot find the row that moved in that, so

--- a/bench/perf/README.md
+++ b/bench/perf/README.md
@@ -116,12 +116,38 @@ The `perf-metrics` job in `.github/workflows/ci.yml` runs on every PR and every 
   - **advisory** (wall time, noisy on shared runners): selfcompile `wall_ms`
     (median of 3) and `ns_p50` per tracked bench — recorded in the snapshot
     for history, **not rendered** in the report (below).
-- `scripts/bench_report.mjs current.json [baseline.json]` renders the
-  markdown comparison — **deterministic rows only**, flagged at ±2%. Advisory
-  wall times are deliberately absent: runner-speed variance swung every wall
-  row ±15-40% on unrelated PRs, which made the section noise for human and
-  LLM readers alike (the #1207/#1867 reports are the record). The readings
-  stay in the `bench-data` snapshots for offline analysis.
+- `scripts/bench_report.mjs current.json [baseline.json] [coverage.json]`
+  renders the markdown comparison — **deterministic rows only**, flagged at
+  ±2%. Advisory wall times are deliberately absent: runner-speed variance
+  swung every wall row ±15-40% on unrelated PRs, which made the section noise
+  for human and LLM readers alike (the #1207/#1867 reports are the record).
+  The readings stay in the `bench-data` snapshots for offline analysis.
+
+  **Four sections: coverage, then one per SIZE TIER** — 大 the compiler
+  itself, 中 a real program, 小 a micro case — with the axes (memory, code
+  size, benchmark) as columns and **one representative row per tier**:
+
+  | tier | memory | code | benchmark |
+  |---|---|---|---|
+  | 大 | selfcompile `heap_ptr_bytes` | `stage2.wasm` | B/op `parse_checker_vibe` |
+  | 中 | `expr_eval` heap | `expr_eval` wasm | `expr_eval` fuel |
+  | 小 | — | `fib` wasm | B/op `fib30` |
+
+  It used to render every tracked series instead: ~50 rows, of which ~48 read
+  `±0` on an ordinary PR. A reader cannot find the row that moved in that, so
+  the report got skipped rather than read.
+
+  The representatives are named constants (`REPRESENTATIVE` in the script),
+  never computed from the data — a row whose subject changes when the data
+  changes is not a series, and its Δ would be meaningless.
+
+  **Cutting to one row per tier does not create a blind spot**: the report
+  re-checks EVERY tracked metric, rendered or not, and emits one
+  `drift outside the rows above` line naming whatever passed ±2%. A flat run
+  says `no drift ≥±2% in any other tracked series` rather than staying silent,
+  so "nothing moved" and "nothing was checked" do not look alike. Correctness
+  lines (golden-output and gc-parity mismatches) survive every cut — they are
+  the loudest thing in the report by design.
 - **Per-PR**: the workflow upserts a sticky "📊 Perf report" comment on the
   PR (marker `<!-- vibe-perf-report -->`), comparing against the latest
   main snapshot. Pushing new commits updates the same comment.
@@ -172,9 +198,11 @@ serialized without fuel instrumentation). It composes with the existing
 
 ### Test coverage in the perf report (main-only measurement)
 
-The report's "Test coverage" section shows the selfhost suite's **union**
-rates (function / branch — each source function/branch counted once, #1556)
-with a percentage-point trend vs the previous measurement. The numbers come
+The report's "Coverage" section — first, because it is the only one that
+answers "is the suite still looking at the code" rather than "did a number
+move" — shows the selfhost suite's **union** rates (function / branch, each
+source function/branch counted once, #1556) with a percentage-point trend vs
+the previous measurement. The numbers come
 from ci.yml's `coverage-suite` job, which is **main-only** (it re-runs the
 whole test battery instrumented — too expensive per PR): after the ratchet
 gate it extracts a compact snapshot (`scripts/coverage_bench_snapshot.mjs`)

--- a/docs/incremental-build.md
+++ b/docs/incremental-build.md
@@ -302,14 +302,29 @@ Only the counters distinguish the two directions, which is why
 context is what a real compile exposes.** The closure is a deliberate
 under-approximation, because the header scan returns a module's deps and its
 export *names* with no record of which deps a dep re-exports. So a type that
-reaches a module through `export ./b.vibe { Box }` is named there and its
-declaration is not in the context, and the comparison reports a difference with
-every edge resolved. That is the safe direction — an under-approximation can
-manufacture a difference but never hide one — and it is a *property*, not a
-hazard to remember: `prelude_module_oracle_test.vibe` uses exactly that
-re-export chain to make a module defer on demand, which is what the deferral
-fixture needs and what an `opaque` contract declaration does on the real
-closure.
+reaches a module through `export ./b.vibe { Box }` is named in that module with
+its declaration absent from the context, and the split lane takes a different
+path than an exact context would. `prelude_module_oracle_test.vibe` uses exactly
+that chain to make a module defer on demand, which is also what an `opaque`
+contract declaration does on the real closure.
+
+**The under-approximation is not one-sided, and this matters more than it
+sounds.** The older framing — "an under-approximation can only manufacture a
+difference, never hide one" — was true while a module that could not build a
+helper produced a `missing` row. It stopped being true when the link learned to
+MINT (#2634): a module that cannot see enough now **defers**, and
+`eq_mint_deferred_into` builds the helper against the concatenated program,
+which is the whole program. A module that under an exact context would have
+synthesized a *differing* helper can therefore defer instead and receive the
+whole-program one, and the comparison goes green over a difference that a real
+per-module compile would have had.
+
+So `missing=0 content=0` supports **"the linked program equals the
+whole-program one"** — which is the question a per-module driver actually has —
+and NOT "every module synthesized faithfully". `SYNTH deferred= minted=` is what
+separates them: it counts how much of the green is the link's work rather than
+the modules'. Read them together or the headline number claims more than it
+shows.
 
 ### How the comparator family closed (#2634) — 9 rows, now zero
 

--- a/docs/incremental-build.md
+++ b/docs/incremental-build.md
@@ -157,10 +157,9 @@ header scan (`load_or_parse_module_header_fs` — the same scan the FS typecheck
 lane plans module order with), with a dependency that names a `.vpkg` contract
 expanded to that package's sibling implementations. It has to come from the
 loader because the merge drops `SImport` / `SReExport` as already resolved, so
-the edges cannot be read back off the merged program. Four corrections were
-needed to land on that rule, and the counters only mean what they say under a
-rule that matches a real compile — they are set out with their measurements in
-[The context rule this holds under](#the-context-rule-this-holds-under) below.
+the edges cannot be read back off the merged program. The counters only mean
+what they say under a rule that matches a real compile; what that takes is
+[The context rule](#the-context-rule) below.
 
 **One hop, not transitive.** Closing transitively hands A the declarations of a
 module C that A's dependency B imports *privately* — context no real compile of
@@ -186,9 +185,9 @@ unfolded that it should have folded.
 
 ### What a comparator may depend on
 
-`invisible_whole=0` is the load-bearing number, and it holds under every one of
-the four context rules below: a program that type-checks whole can see every
-nominal it compares.
+`invisible_whole=0` is the load-bearing number, and it does not depend on the
+context rule at all: a program that type-checks whole can see every nominal it
+compares.
 So a lane that sees fewer is the only one that can reach the question, and what
 it does there used to differ.
 
@@ -275,17 +274,12 @@ allocates, in the **dependency** of a two-file program, reads `validators=1`:
 the whole-program run walks it and the per-module union reports the same one
 diagnostic. The clean two-file control reads `0`.
 
-### The context rule this holds under
+### The context rule
 
-Four corrections to get right, and they are worth keeping because three were the
-same mistake and the fourth was its mirror image:
-
-| rule | reachable pairs | `missing` | `content` |
-|---|---:|---:|---:|
-| every other file | 132 860 | 1 | 4 |
-| transitive closure | 32 017 | 1 | 4 |
-| own direct imports | 1 415 | 6 | 9 |
-| **direct + package deps** | **11 342** | **0** | **0** |
+Three constraints. A rule that misses any of them produces counters that do not
+mean what they say, and it can miss in either direction: too wide and a green
+means less than it looks, too narrow and the comparison manufactures a
+difference that is not there.
 
 - A module sees what it **directly imports** — not what its dependencies import.
   A transitive closure hands A the declarations of a module its dependency
@@ -301,11 +295,10 @@ same mistake and the fourth was its mirror image:
   what a module sees is exactly the published surface: nothing transitive,
   nothing private, no bodies.
 
-The first three rules were too wide and produced greens that meant less than
-they looked; the fourth was too narrow and manufactured a difference that was
-not there. Both directions are errors, and only the counters distinguish them —
-which is why `edges_unresolved` and `invisible_*` are reported rather than
-assumed.
+Only the counters distinguish the two directions, which is why
+`edges_unresolved` and `invisible_*` are reported rather than assumed:
+`edges_unresolved=0` says the closure the modules ran under is the whole
+closure, so a difference that survives it is the program's.
 
 ### How the comparator family closed (#2634) — 9 rows, now zero
 
@@ -322,7 +315,7 @@ content  CbfTable::equals   AliasIdx::equals   ExportRenamePlan::equals
 
 #2631's sibling one level up. That issue was a comparator whose *body* depended
 on module visibility, and is fixed — which is why `collisions=0` survives a
-non-zero `invisible_split` under every context rule tried.
+non-zero `invisible_split`.
 
 **Measured which half of "never emits" it is**, because the two have different
 fixes: a module can fail to *record* the need, or record it and fail to emit.

--- a/docs/incremental-build.md
+++ b/docs/incremental-build.md
@@ -308,16 +308,14 @@ path than an exact context would. `prelude_module_oracle_test.vibe` uses exactly
 that chain to make a module defer on demand, which is also what an `opaque`
 contract declaration does on the real closure.
 
-**The under-approximation is not one-sided, and this matters more than it
-sounds.** The older framing — "an under-approximation can only manufacture a
-difference, never hide one" — was true while a module that could not build a
-helper produced a `missing` row. It stopped being true when the link learned to
-MINT (#2634): a module that cannot see enough now **defers**, and
-`eq_mint_deferred_into` builds the helper against the concatenated program,
-which is the whole program. A module that under an exact context would have
-synthesized a *differing* helper can therefore defer instead and receive the
-whole-program one, and the comparison goes green over a difference that a real
-per-module compile would have had.
+**The approximation can hide a difference as well as manufacture one.**
+Narrowing a module's context does not only restrict what it sees, it changes
+what it *does*: a module that cannot see enough **defers**, and
+`eq_mint_deferred_into` builds the helper at the link against the concatenated
+program — which is the whole program. So a module that would have synthesized a
+*differing* helper under an exact context receives the whole-program one
+instead, and the comparison is green over a difference a real per-module
+compile would have had.
 
 So `missing=0 content=0` supports **"the linked program equals the
 whole-program one"** — which is the question a per-module driver actually has —

--- a/docs/incremental-build.md
+++ b/docs/incremental-build.md
@@ -165,11 +165,12 @@ what they say under a rule that matches a real compile; what that takes is
 module C that A's dependency B imports *privately* — context no real compile of
 A exposes. Closing only across re-export edges would be the exact rule, and the
 header scan does not distinguish them (it returns a module's deps and its export
-*names*, with no record of which deps a dep re-exports), so this takes the safe
-side: an under-approximation can only *manufacture* a difference, never hide
-one. `edges_unresolved` is reported for the same reason — a dropped edge narrows
-a module's context, but a closure built from every edge and one built from half
-of them otherwise look identical.
+*names*, with no record of which deps a dep re-exports), so this takes the
+narrower side. That narrowing is not free of consequences in either direction —
+[The context rule](#the-context-rule) below says what it can and cannot hide.
+`edges_unresolved` is reported for its own reason: a dropped edge narrows a
+module's context further, and a closure built from every edge and one built from
+half of them otherwise look identical.
 
 ### The four counters
 

--- a/docs/incremental-build.md
+++ b/docs/incremental-build.md
@@ -245,15 +245,20 @@ arguments are themselves whole-program computations
 from each module's own statements on the split side, so `content=0` covers them:
 the per-module computation produced the same rewrites.
 
-One thing it does **not** model, and it is not covered by that zero:
+The pass dispatch takes production's non-statement inputs through a
+`PreludeEnv` — `linked_imports` for `lc_waiter_hooks_available` (pass 9,
+`await_poll_pass`) and the `iw_names` / `iw_wats` arrays `lc_extract_inline_wasm`
+fills (pass 8). Both used to be hard-coded empty there. That was harmless for a
+measurement comparing declarations and is not for a production driver:
+discarding the inline-wasm arrays loses every `inline_wasm` body, and an empty
+`linked_imports` answers "no waiter hooks" regardless of the program.
 
-- **`await_poll_pass`** is modelled with an empty `linked_imports`, where
-  production passes the real list. So the oracle exercises that pass, but not
-  with production's input. Still unmeasured.
-
-This list had two entries when it was written. The validators were the other
-one, and they graduated: they are measured now, by the counter below rather
-than by `missing` / `content` / `renames`, which cannot see a diagnostic.
+The oracle's own two lanes still pass `prelude_env_none()`, and for the RC
+production lane that is production-faithful — it hands
+`compile_wasi_module_linked_impl_*` an empty `linked_imports` anyway, and the
+inline-wasm arrays are empty for any program without `inline_wasm`. What
+changed is that a production caller can now supply the real values instead of
+the driver being unable to accept them.
 
 None of this weakens the decomposition result for what it covers. It bounds it.
 

--- a/docs/incremental-build.md
+++ b/docs/incremental-build.md
@@ -246,20 +246,20 @@ arguments are themselves whole-program computations
 from each module's own statements on the split side, so `content=0` covers them:
 the per-module computation produced the same rewrites.
 
-The pass dispatch takes production's non-statement inputs through a
-`PreludeEnv` — `linked_imports` for `lc_waiter_hooks_available` (pass 9,
-`await_poll_pass`) and the `iw_names` / `iw_wats` arrays `lc_extract_inline_wasm`
-fills (pass 8). Both used to be hard-coded empty there. That was harmless for a
-measurement comparing declarations and is not for a production driver:
-discarding the inline-wasm arrays loses every `inline_wasm` body, and an empty
-`linked_imports` answers "no waiter hooks" regardless of the program.
+Two passes read something besides the statements, and the dispatch takes both
+through a `PreludeEnv`: `linked_imports` for `lc_waiter_hooks_available`
+(pass 9, `await_poll_pass`) and the `iw_names` / `iw_wats` arrays
+`lc_extract_inline_wasm` fills (pass 8). A driver that has to PRODUCE the
+program needs both — those arrays are what carries an `inline_wasm` body to
+codegen, and `linked_imports` decides whether any linked import supplies the
+waiter hooks `await_poll_pass` lowers against.
 
-The oracle's own two lanes still pass `prelude_env_none()`, and for the RC
-production lane that is production-faithful — it hands
+The oracle's two lanes pass `prelude_env_none()`, and what that bounds is
+lane-specific. For the RC production lane it is faithful: that lane hands
 `compile_wasi_module_linked_impl_*` an empty `linked_imports` anyway, and the
-inline-wasm arrays are empty for any program without `inline_wasm`. What
-changed is that a production caller can now supply the real values instead of
-the driver being unable to accept them.
+inline-wasm arrays are empty for any program without `inline_wasm`. For a lane
+that links real imports, or a program that uses `inline_wasm`, a measurement
+taken under `prelude_env_none()` is not evidence about that lane.
 
 None of this weakens the decomposition result for what it covers. It bounds it.
 

--- a/docs/incremental-build.md
+++ b/docs/incremental-build.md
@@ -296,9 +296,20 @@ difference that is not there.
   nothing private, no bodies.
 
 Only the counters distinguish the two directions, which is why
-`edges_unresolved` and `invisible_*` are reported rather than assumed:
-`edges_unresolved=0` says the closure the modules ran under is the whole
-closure, so a difference that survives it is the program's.
+`edges_unresolved` and `invisible_*` are reported rather than assumed.
+
+**`edges_unresolved=0` says no direct dependency edge was DROPPED — not that the
+context is what a real compile exposes.** The closure is a deliberate
+under-approximation, because the header scan returns a module's deps and its
+export *names* with no record of which deps a dep re-exports. So a type that
+reaches a module through `export ./b.vibe { Box }` is named there and its
+declaration is not in the context, and the comparison reports a difference with
+every edge resolved. That is the safe direction — an under-approximation can
+manufacture a difference but never hide one — and it is a *property*, not a
+hazard to remember: `prelude_module_oracle_test.vibe` uses exactly that
+re-export chain to make a module defer on demand, which is what the deferral
+fixture needs and what an `opaque` contract declaration does on the real
+closure.
 
 ### How the comparator family closed (#2634) — 9 rows, now zero
 

--- a/lib/@vibe/compiler/codegen/wasi/index.vpkg
+++ b/lib/@vibe/compiler/codegen/wasi/index.vpkg
@@ -89,6 +89,12 @@ fn compile_wasi_module_sliced_impl(stmts: Array[Stmt], entry_name: String) -> By
 fn compile_wasi_module_rc_impl(stmts_in: Array[Stmt], entry_name: String) -> Bytes with Exception
 fn compile_wasi_module_rc_cached_impl(stmts_in: Array[Stmt], entry_name: String, body_cache_in: CodegenBodyCache, body_cache_out: CodegenBodyCache) -> Bytes with Exception
 fn compile_wasi_module_rc_cached_impl_with_typed_offsets(stmts_in: Array[Stmt], entry_name: String, body_cache_in: CodegenBodyCache, body_cache_out: CodegenBodyCache, checker_float_call_offsets: Array[Int], checker_int_render_offsets: Array[Int], checker_bool_render_offsets: Array[Int], checker_eq_offsets: Array[Int], checker_eq_type_keys: Array[String]) -> Bytes with Exception
+// #2575 item 2: the same compile, given the merged program's
+// statement-to-module map. `prov` carries `files` + `stmt_file_id` and an
+// EMPTY `file_nls` -- a per-module prelude needs which module a statement came
+// from, not which line. Inert until read: every break-lane consumer is behind
+// `dbg_line_on`, which requires `debug_break`.
+fn compile_wasi_module_rc_cached_impl_with_prov(stmts_in: Array[Stmt], entry_name: String, body_cache_in: CodegenBodyCache, body_cache_out: CodegenBodyCache, prov: DbgProv, checker_float_call_offsets: Array[Int], checker_int_render_offsets: Array[Int], checker_bool_render_offsets: Array[Int], checker_eq_offsets: Array[Int], checker_eq_type_keys: Array[String]) -> Bytes with Exception
 fn compile_wasi_module_rc_impl_with_typed_offsets(stmts_in: Array[Stmt], entry_name: String, checker_float_call_offsets: Array[Int], checker_int_render_offsets: Array[Int], checker_bool_render_offsets: Array[Int], checker_eq_offsets: Array[Int], checker_eq_type_keys: Array[String]) -> Bytes with Exception
 fn compile_wasi_module_rc_shadow_impl(stmts_in: Array[Stmt], entry_name: String) -> Bytes with Exception
 fn compile_wasi_module_rc_shadow_impl_with_typed_offsets(stmts_in: Array[Stmt], entry_name: String, checker_float_call_offsets: Array[Int], checker_int_render_offsets: Array[Int], checker_bool_render_offsets: Array[Int], checker_eq_offsets: Array[Int], checker_eq_type_keys: Array[String]) -> Bytes with Exception

--- a/lib/@vibe/compiler/codegen/wasi/linked_compile.vibe
+++ b/lib/@vibe/compiler/codegen/wasi/linked_compile.vibe
@@ -45,6 +45,7 @@ import @vibe/compiler/normalize {
   desugar_trait_dicts_module,
   desugar_trait_dicts_with_typed_eq,
   eq_deferred_requests_list,
+  eq_deferred_reset,
   eq_invisible_nominals_list,
   eq_invisible_nominals_reset,
   eq_mint_deferred_into,
@@ -467,17 +468,38 @@ fn lc_apply_pass_recording(k: Int, part: Array[Stmt], part_entry: String, checke
   }
 }
 
-/// #2388: the prelude's validating passes over one statement list. They return
-/// a message or "", and `effect_lowering_prelude` collects them into its error
-/// list -- so they are part of the prelude's OUTPUT and not visible in any
-/// comparison keyed on declarations.
-fn lc_collect_validator_diags(stmts: Array[Stmt], out: Array[String]) -> Unit {
+/// #2388: the prelude's validating passes. They return a message or "", and
+/// `effect_lowering_prelude` collects them into its error list -- so they are
+/// part of the prelude's OUTPUT and not visible in any comparison keyed on
+/// declarations.
+///
+/// TWO functions, at two points, because production runs them at two points and
+/// a validator reads the program in front of it. They were one call collecting
+/// both, taken before pass 0 on the whole lane and after pass 4 on the split
+/// lane, so the two lanes were reading DIFFERENT programs and `DIAGS
+/// validators` could differ for the sample point rather than for what a module
+/// can see (#2642 review, Codex P2).
+///
+/// Stated as alignment, not as a measured bug: three shapes were probed for one
+/// that answers differently at the two points -- a `#zero_alloc` fn beside a
+/// lambda-hoisting fn, one beside a `derive (Eq)` struct, and one whose own body
+/// compares two structs -- and all three read the same under both. The change is
+/// still right (production's order is the one the oracle is supposed to model,
+/// and matching it costs nothing), but nothing here is pinned by a program that
+/// distinguishes them.
+fn lc_collect_zero_alloc_diag(stmts: Array[Stmt], out: Array[String]) -> Unit {
   let za = zero_alloc_check(stmts)
   if za != "" && !lc_str_array_has(out, za) {
     Array::push(out, za)
   } else {
     ()
   }
+}
+
+/// The other one, and it belongs AFTER pass 5: `effect_lowering_prelude`
+/// validates the provider surface once the merged AST carries canonical import
+/// value names and qualified type heads, and `unbox_tuple_loop_params` has run.
+fn lc_collect_stdin_provider_diag(stmts: Array[Stmt], out: Array[String]) -> Unit {
   let sp = lc_validate_stdin_provider_stmts(stmts)
   if sp != "" && !lc_str_array_has(out, sp) {
     Array::push(out, sp)
@@ -4489,6 +4511,11 @@ fn prelude_run_per_module(c: Array[Stmt], c_file_id: Array[Int], file_count: Int
   // deriving it per module from `part_entry` would let the exclude list, rather
   // than the program, produce a difference.
   let an_exclude = lc_analysis_exclude(entry_name)
+  // This lane's boundary: the deferral and refusal registries accumulate across
+  // the modules below, which is what `eq_mint_deferred_into` reads at the link,
+  // so they are cleared HERE rather than per module. Without it they also
+  // carried every earlier program's entries (#2642 review, Codex P2).
+  eq_deferred_reset()
   let parts: Array[Array[Stmt]] = []
   let mut fi = 0
   while fi < file_count {
@@ -4514,6 +4541,9 @@ fn prelude_run_per_module(c: Array[Stmt], c_file_id: Array[Int], file_count: Int
     } else {
       ""
     }
+    // Before pass 0, where production runs it: `zero_alloc_check` is the first
+    // thing `effect_lowering_prelude` does, on the body the source wrote.
+    lc_collect_zero_alloc_diag(Array::get(parts, fi), st.diags)
     let mut j = 0
     while j < 4 {
       lc_apply_pass_recording(j, Array::get(parts, fi), part_entry, checker_eq_offsets, checker_eq_type_keys, synth_keys)
@@ -4609,7 +4639,6 @@ fn prelude_run_per_module(c: Array[Stmt], c_file_id: Array[Int], file_count: Int
       Array::push(part, Array::get(synthesized, sy))
       sy = sy + 1
     }
-    lc_collect_validator_diags(part, st.diags)
     let mut j2 = 5
     while j2 < 17 {
       if j2 == 15 {
@@ -4633,6 +4662,12 @@ fn prelude_run_per_module(c: Array[Stmt], c_file_id: Array[Int], file_count: Int
         ()
       } else {
         lc_apply_pass_recording(j2, part, part_entry, checker_eq_offsets, checker_eq_type_keys, synth_keys)
+      }
+      // After pass 5, where production runs it.
+      if j2 == 5 {
+        lc_collect_stdin_provider_diag(part, st.diags)
+      } else {
+        ()
       }
       j2 = j2 + 1
     }
@@ -4798,7 +4833,7 @@ export fn prelude_module_full_oracle_line(a: Array[Stmt], c: Array[Stmt], c_file
   // miss a violation or invent one, and nothing else in this report would say
   // so.
   let diag_w = lc_fresh_string_array()
-  lc_collect_validator_diags(a, diag_w)
+  lc_collect_zero_alloc_diag(a, diag_w)
   let mut k = 0
   let ev_req_w = lc_fresh_string_array()
   let ev_ref_w = lc_fresh_string_array()
@@ -4816,6 +4851,13 @@ export fn prelude_module_full_oracle_line(a: Array[Stmt], c: Array[Stmt], c_file
       lc_union_into(ev_req_w, eq_synthesis_requests_list())
       lc_union_into(ev_ref_w, eq_typed_refusals_list())
       lc_union_into(ev_def_w, eq_deferred_requests_list())
+    } else {
+      ()
+    }
+    // After pass 5, where production runs it, and where the split lane samples
+    // it too.
+    if k == 5 {
+      lc_collect_stdin_provider_diag(a, diag_w)
     } else {
       ()
     }

--- a/lib/@vibe/compiler/codegen/wasi/linked_compile.vibe
+++ b/lib/@vibe/compiler/codegen/wasi/linked_compile.vibe
@@ -6528,9 +6528,16 @@ export fn compile_wasi_module_linked_impl_with_typed_offsets(stmts: Array[Stmt],
   let pre_prelude_let_files = lc_fresh_int_array()
   // The same, keyed by OWNER: what a lambda hoisted out of each statement
   // would name itself after (`hoisted_lambda_owner_of_stmt`, the hoist's own
-  // arms rather than a mirror of them here). Built only when there is
-  // provenance to attach -- the break lane -- so an ordinary compile pays
-  // nothing, which is why it is not folded into the name scan below.
+  // arms rather than a mirror of them here). Built for the BREAK LANE only --
+  // one `hoisted_lambda_owner_of_stmt` per top-level statement, ~9.9k of them
+  // on the compiler's own closure -- so an ordinary compile pays nothing.
+  //
+  // The condition is `debug_break` itself. It used to be "prov carries any
+  // stmt_file_id", which was a PROXY for the break lane and correct only while
+  // the break lane was the only caller that filled provenance. #2575 item 2
+  // gives the ordinary lane a real `stmt_file_id` (a per-module prelude needs
+  // it), and under the old guard that would have silently switched this scan on
+  // for every compile while `dbg_line_on` kept the arrays unread.
   let pre_prelude_owner_keys = lc_fresh_string_array()
   let pre_prelude_owner_files = lc_fresh_int_array()
   let dbg_prov_len = Array::length(prov.stmt_file_id)
@@ -6545,7 +6552,7 @@ export fn compile_wasi_module_linked_impl_with_typed_offsets(stmts: Array[Stmt],
     } else {
       0
     }
-    if dbg_prov_len > 0 {
+    if debug_break {
       // EVERY statement, including the ones with no name to be known by. A
       // binderless `let _ = ..` holding an effectful local lambda gets an
       // anonymous owner from its POSITION (`:s:<idx>`), which is why the index
@@ -12152,8 +12159,29 @@ export fn compile_wasi_module_rc_cached_impl(stmts_in: Array[Stmt], entry_name: 
 /// call-result offsets (#2158), so the body-cached FS lane compiles the same
 /// program the ordinary rc lane does and their outputs stay byte-comparable.
 export fn compile_wasi_module_rc_cached_impl_with_typed_offsets(stmts_in: Array[Stmt], entry_name: String, body_cache_in: CodegenBodyCache, body_cache_out: CodegenBodyCache, checker_float_call_offsets: Array[Int], checker_int_render_offsets: Array[Int], checker_bool_render_offsets: Array[Int], checker_eq_offsets: Array[Int], checker_eq_type_keys: Array[String]) -> Bytes with Exception {
+  compile_wasi_module_rc_cached_impl_with_prov(stmts_in, entry_name, body_cache_in, body_cache_out, empty_dbg_prov(), checker_float_call_offsets, checker_int_render_offsets, checker_bool_render_offsets, checker_eq_offsets, checker_eq_type_keys)
+}
+
+/// #2575 item 2: the same RC production compile, given the merged program's
+/// statement-to-module map.
+///
+/// `prov` carries `files` (one basename per module) and `stmt_file_id` (one
+/// module id per merged PRE-PRELUDE top-level statement). It does NOT carry
+/// `file_nls` -- the per-file newline tables are the expensive half of the
+/// break lane's provenance and a per-module prelude has no use for them.
+///
+/// The map is what `prelude_run_per_module` needs and cannot currently be
+/// given: `effect_lowering_prelude` takes only the merged statement array, so
+/// no production compile can split it by module. Carrying it to codegen is the
+/// prerequisite, and it is INERT until something reads it -- every break-lane
+/// consumer is behind `dbg_line_on`, which requires `debug_break`, and the
+/// owner-key scan above now tests that flag rather than the presence of
+/// provenance. `linked_compile_prov_inert_test.vibe` pins the inertness the
+/// only way that settles it: the same program compiled both ways, byte for
+/// byte.
+export fn compile_wasi_module_rc_cached_impl_with_prov(stmts_in: Array[Stmt], entry_name: String, body_cache_in: CodegenBodyCache, body_cache_out: CodegenBodyCache, prov: DbgProv, checker_float_call_offsets: Array[Int], checker_int_render_offsets: Array[Int], checker_bool_render_offsets: Array[Int], checker_eq_offsets: Array[Int], checker_eq_type_keys: Array[String]) -> Bytes with Exception {
   let stmts = elaborate_heap_params(stmts_in)
-  compile_wasi_module_linked_impl_with_typed_offsets(stmts, entry_name, array_empty(), array_empty(), false, true, false, false, false, false, true, empty_dbg_prov(), body_cache_in, body_cache_out, 0, 0 - 1, checker_float_call_offsets, checker_int_render_offsets, checker_bool_render_offsets, checker_eq_offsets, checker_eq_type_keys)
+  compile_wasi_module_linked_impl_with_typed_offsets(stmts, entry_name, array_empty(), array_empty(), false, true, false, false, false, false, true, prov, body_cache_in, body_cache_out, 0, 0 - 1, checker_float_call_offsets, checker_int_render_offsets, checker_bool_render_offsets, checker_eq_offsets, checker_eq_type_keys)
 }
 
 /// Preserve the post-lowering AST for the explicit `no-dce` compile mode.

--- a/lib/@vibe/compiler/codegen/wasi/linked_compile.vibe
+++ b/lib/@vibe/compiler/codegen/wasi/linked_compile.vibe
@@ -447,14 +447,46 @@ fn lc_fresh_bytes_array() -> Array[Bytes] {
 /// The diff is over the key SET rather than the tail, because a pass may
 /// insert rather than append (#2620 places a hoisted lambda next to its own
 /// declaration), and a tail diff would then attribute the wrong keys.
-fn lc_apply_pass_recording(k: Int, part: Array[Stmt], part_entry: String, checker_eq_offsets: Array[Int], checker_eq_type_keys: Array[String], synth_keys: Array[String]) -> Unit with Exception {
+/// #2575 item 2: the inputs the prelude's passes take BESIDES the statements.
+///
+/// Two passes read them, and the pass dispatch used to hard-code an empty
+/// value for both -- which is fine for a measurement that compares
+/// declarations and NOT for a production per-module driver:
+///
+///   pass 8  `lc_extract_inline_wasm(stmts, iw_names, iw_wats)` -- production
+///           COLLECTS the extracted module into the caller's arrays and hands
+///           them to codegen. Discarding them into fresh arrays loses every
+///           `inline_wasm` body.
+///   pass 9  `lc_waiter_hooks_available(stmts, linked_imports)` -- whether any
+///           linked import provides the waiter hooks decides how
+///           `await_poll_pass` lowers. Empty answers "no" regardless.
+///
+/// `prelude_env_none()` is the honest value where there is nothing to pass:
+/// the RC production lane hands `compile_wasi_module_linked_impl_*` an empty
+/// `linked_imports` anyway, so for THAT lane empty is production-faithful, and
+/// the inline-wasm arrays are empty for any program without `inline_wasm`.
+struct PreludeEnv {
+  linked_imports: Array[(String, String, Int, Int)];
+  iw_names: Array[String];
+  iw_wats: Array[String]
+}
+
+fn prelude_env_none() -> PreludeEnv {
+  PreludeEnv::{
+    linked_imports: array_empty(),
+    iw_names: lc_fresh_string_array(),
+    iw_wats: lc_fresh_string_array(),
+  }
+}
+
+fn lc_apply_pass_recording(k: Int, part: Array[Stmt], part_entry: String, checker_eq_offsets: Array[Int], checker_eq_type_keys: Array[String], synth_keys: Array[String], env: PreludeEnv) -> Unit with Exception {
   let before: MutMap[String, Int] = MutMap::new_string()
   let mut i = 0
   while i < Array::length(part) {
     MutMap::set(before, oracle_stmt_key(Array::get(part, i)), 1)
     i = i + 1
   }
-  oracle_apply_pass(k, part, part_entry, checker_eq_offsets, checker_eq_type_keys)
+  oracle_apply_pass(k, part, part_entry, checker_eq_offsets, checker_eq_type_keys, env)
   let mut j = 0
   while j < Array::length(part) {
     let key = oracle_stmt_key(Array::get(part, j))
@@ -4008,7 +4040,7 @@ fn oracle_pass_name(k: Int) -> String {
   }
 }
 
-fn oracle_apply_pass(k: Int, stmts: Array[Stmt], entry_name: String, checker_eq_offsets: Array[Int], checker_eq_type_keys: Array[String]) -> Unit with Exception {
+fn oracle_apply_pass(k: Int, stmts: Array[Stmt], entry_name: String, checker_eq_offsets: Array[Int], checker_eq_type_keys: Array[String], env: PreludeEnv) -> Unit with Exception {
   match k {
     0 => {
       // elaborate_heap_params returns a fresh array; the oracle keeps every
@@ -4034,8 +4066,8 @@ fn oracle_apply_pass(k: Int, stmts: Array[Stmt], entry_name: String, checker_eq_
       let _ = lc_inject_stdin_surface_wrappers(stmts)
       ()
     },
-    8 => lc_extract_inline_wasm(stmts, lc_fresh_string_array(), lc_fresh_string_array()),
-    9 => await_poll_pass(stmts, lc_stmts_call_host_future(stmts), lc_waiter_hooks_available(stmts, array_empty())),
+    8 => lc_extract_inline_wasm(stmts, env.iw_names, env.iw_wats),
+    9 => await_poll_pass(stmts, lc_stmts_call_host_future(stmts), lc_waiter_hooks_available(stmts, env.linked_imports)),
     10 => rewrite_self_tail_calls(stmts),
     11 => wrap_entry_exception_boundary(stmts, entry_name),
     12 => {
@@ -4501,7 +4533,7 @@ fn lc_analysis_exclude(entry_name: String) -> Array[String] {
   [entry_name, "main", "_start", "cli_main"]
 }
 
-fn prelude_run_per_module(c: Array[Stmt], c_file_id: Array[Int], file_count: Int, entry_name: String, checker_eq_offsets: Array[Int], checker_eq_type_keys: Array[String], import_closure: Array[Array[Int]], render: (Stmt) -> String, st: PreludeSplitStats) -> Array[Stmt] with Exception {
+fn prelude_run_per_module(c: Array[Stmt], c_file_id: Array[Int], file_count: Int, entry_name: String, checker_eq_offsets: Array[Int], checker_eq_type_keys: Array[String], import_closure: Array[Array[Int]], render: (Stmt) -> String, st: PreludeSplitStats, env: PreludeEnv) -> Array[Stmt] with Exception {
   let entry_fid = file_count - 1
   // #2575 item 4: the three analyses `linked_compile` runs between the prelude
   // and codegen are sampled per module here, and on the whole program by the
@@ -4546,7 +4578,7 @@ fn prelude_run_per_module(c: Array[Stmt], c_file_id: Array[Int], file_count: Int
     lc_collect_zero_alloc_diag(Array::get(parts, fi), st.diags)
     let mut j = 0
     while j < 4 {
-      lc_apply_pass_recording(j, Array::get(parts, fi), part_entry, checker_eq_offsets, checker_eq_type_keys, synth_keys)
+      lc_apply_pass_recording(j, Array::get(parts, fi), part_entry, checker_eq_offsets, checker_eq_type_keys, synth_keys, env)
       j = j + 1
     }
     fi = fi + 1
@@ -4661,7 +4693,7 @@ fn prelude_run_per_module(c: Array[Stmt], c_file_id: Array[Int], file_count: Int
       if j2 == 15 || j2 == 16 {
         ()
       } else {
-        lc_apply_pass_recording(j2, part, part_entry, checker_eq_offsets, checker_eq_type_keys, synth_keys)
+        lc_apply_pass_recording(j2, part, part_entry, checker_eq_offsets, checker_eq_type_keys, synth_keys, env)
       }
       // After pass 5, where production runs it.
       if j2 == 5 {
@@ -4704,8 +4736,8 @@ fn prelude_run_per_module(c: Array[Stmt], c_file_id: Array[Int], file_count: Int
   let minted = eq_mint_deferred_into(trial)
   Array::set(st.counts, 0, minted)
   // #2633: the whole-program phases, run once on the linked program.
-  oracle_apply_pass(15, trial, entry_name, checker_eq_offsets, checker_eq_type_keys)
-  oracle_apply_pass(16, trial, entry_name, checker_eq_offsets, checker_eq_type_keys)
+  oracle_apply_pass(15, trial, entry_name, checker_eq_offsets, checker_eq_type_keys, env)
+  oracle_apply_pass(16, trial, entry_name, checker_eq_offsets, checker_eq_type_keys, env)
   // LINK. Up to here `trial` is the modules concatenated, which holds one copy
   // of each program-level helper per module that needed it. Folding them is
   // what a per-module driver's link step does (#2575 item 3), and doing it
@@ -4839,7 +4871,7 @@ export fn prelude_module_full_oracle_line(a: Array[Stmt], c: Array[Stmt], c_file
   let ev_ref_w = lc_fresh_string_array()
   let ev_def_w = lc_fresh_string_array()
   while k < 15 {
-    oracle_apply_pass(k, a, entry_name, checker_eq_offsets, checker_eq_type_keys)
+    oracle_apply_pass(k, a, entry_name, checker_eq_offsets, checker_eq_type_keys, prelude_env_none())
     // #2634: sampled right after pass 4 (`desugar_trait_dicts_with_typed_eq`),
     // which is where a container comparator or a generic specialization is
     // requested AND emitted. The per-module side samples at the same point --
@@ -4872,7 +4904,7 @@ export fn prelude_module_full_oracle_line(a: Array[Stmt], c: Array[Stmt], c_file
   // program carries.
   let (ev_decl_w, ev_handled_w, ev_perf_w) = evidence_module_facts(a)
   while k < 17 {
-    oracle_apply_pass(k, a, entry_name, checker_eq_offsets, checker_eq_type_keys)
+    oracle_apply_pass(k, a, entry_name, checker_eq_offsets, checker_eq_type_keys, prelude_env_none())
     k = k + 1
   }
   // #2575 item 4: the three whole-program analyses `linked_compile` runs
@@ -4910,7 +4942,7 @@ export fn prelude_module_full_oracle_line(a: Array[Stmt], c: Array[Stmt], c_file
   let whole_invisible = eq_invisible_nominals_list()
   eq_invisible_nominals_reset()
   let st = prelude_split_stats_new()
-  let linked = prelude_run_per_module(c, c_file_id, file_count, entry_name, checker_eq_offsets, checker_eq_type_keys, import_closure, render, st)
+  let linked = prelude_run_per_module(c, c_file_id, file_count, entry_name, checker_eq_offsets, checker_eq_type_keys, import_closure, render, st, prelude_env_none())
   let split_invisible = eq_invisible_nominals_list()
   let ev_req_u = st.requests
   let ev_ref_u = st.refusals
@@ -5023,7 +5055,7 @@ export fn prelude_pass_module_oracle_step(k: Int, a: Array[Stmt], c: Array[Stmt]
       Array::push(old_keys, oracle_stmt_key(Array::get(c, qi)))
       qi = qi + 1
     }
-    oracle_apply_pass(j, c, entry_name, checker_eq_offsets, checker_eq_type_keys)
+    oracle_apply_pass(j, c, entry_name, checker_eq_offsets, checker_eq_type_keys, prelude_env_none())
     file_of = oracle_realign(old_keys, file_of, c)
     j = j + 1
   }
@@ -5046,7 +5078,7 @@ export fn prelude_pass_module_oracle_step(k: Int, a: Array[Stmt], c: Array[Stmt]
   // from `a` and limited to keys that existed before the pass (a
   // synthesized statement belongs to its own module's output, not to a
   // sibling's context).
-  oracle_apply_pass(k, a, entry_name, checker_eq_offsets, checker_eq_type_keys)
+  oracle_apply_pass(k, a, entry_name, checker_eq_offsets, checker_eq_type_keys, prelude_env_none())
   let pre_keys: MutMap[String, Int] = MutMap::new_string()
   let mut pk = 0
   while pk < Array::length(c) {
@@ -5130,7 +5162,7 @@ export fn prelude_pass_module_oracle_step(k: Int, a: Array[Stmt], c: Array[Stmt]
         sy = sy + 1
       }
     } else {
-      oracle_apply_pass(k, part, part_entry, checker_eq_offsets, checker_eq_type_keys)
+      oracle_apply_pass(k, part, part_entry, checker_eq_offsets, checker_eq_type_keys, prelude_env_none())
     }
     let mut oi = 0
     while oi < Array::length(part) {

--- a/lib/@vibe/compiler/entry/compiler/file_compile/file_compile.vibe
+++ b/lib/@vibe/compiler/entry/compiler/file_compile/file_compile.vibe
@@ -820,22 +820,21 @@ fn oracle_import_closure(source_groups: Array[(String, Array[(String, String)])]
   // this takes the safe side instead: direct-only is an UNDER-approximation,
   // and `unresolved` is reported rather than swallowed for the same reason.
   //
-  // This used to add "and an under-approximation can only manufacture a
-  // difference, never hide one". That held when a module which could not build
-  // a helper produced a `missing` row, and STOPPED holding when the link
-  // learned to MINT (#2634, #2643 review): a module that cannot see enough now
-  // defers, and `eq_mint_deferred_into` builds the helper against the
-  // concatenated program -- the whole program. So narrowing the context changes
-  // the EXECUTION PATH, and a module that would have synthesized a differing
-  // helper under exact context can defer instead and receive the
-  // whole-program one, turning the comparison green over a real difference.
+  // The approximation is NOT one-sided: it can hide a difference as well as
+  // manufacture one, so do not restore an "only manufactures" claim here.
+  // Narrowing a module's context changes the EXECUTION PATH, not just the
+  // inputs -- a module that cannot see enough defers, and
+  // `eq_mint_deferred_into` builds the helper at the link against the
+  // concatenated program, which is the whole program. A module that would have
+  // synthesized a DIFFERING helper under exact context receives the
+  // whole-program one instead, green over a real difference.
   // `prelude_module_oracle_test.vibe` relies on exactly that to make a module
   // defer on demand.
   //
-  // What the oracle's zero therefore supports is "the LINKED program equals the
-  // whole-program one" -- the question a per-module driver has -- and not
-  // "every module synthesized faithfully". `SYNTH deferred=` / `minted=`
-  // separate the two by counting how much of the green is the link's work.
+  // So the oracle's zero supports "the LINKED program equals the whole-program
+  // one" -- the question a per-module driver has -- and not "every module
+  // synthesized faithfully". `SYNTH deferred=` / `minted=` separate the two by
+  // counting how much of the green is the link's work.
   // Measured on the compiler's own CLI closure, and the transitivity was very
   // much load-bearing -- 32017 reachable pairs against 1415 one-hop ones, 22x
   // wider. Under it the split read `missing=1 content=4 invisible_split=2`;

--- a/lib/@vibe/compiler/entry/compiler/file_compile/file_compile.vibe
+++ b/lib/@vibe/compiler/entry/compiler/file_compile/file_compile.vibe
@@ -73,6 +73,7 @@ import @vibe/compiler/codegen/common_base {
 import @vibe/compiler/codegen/wasi {
   compile_wasi_module_impl_with_typed_offsets,
   compile_wasi_module_no_dce_impl_with_typed_offsets,
+  compile_wasi_module_rc_cached_impl_with_prov,
   compile_wasi_module_rc_cached_impl_with_typed_offsets,
   compile_wasi_module_rc_impl_with_typed_offsets,
   compile_wasi_module_rc_shadow_impl_with_typed_offsets,
@@ -1513,6 +1514,45 @@ fn body_cache_guards_equal(a: CodegenBodyCache, b: CodegenBodyCache) -> Bool {
   Array::length(a.guard_meta) == 5 && bcc_int_lists_equal(a.guard_meta, b.guard_meta) && bcc_string_lists_equal(a.guard_synth_names, b.guard_synth_names) && bcc_int_lists_equal(a.guard_synth_stmts, b.guard_synth_stmts) && bcc_string_lists_equal(a.guard_import_names, b.guard_import_names) && bcc_string_lists_equal(a.guard_borrow_names, b.guard_borrow_names) && bcc_int_lists_equal(a.guard_borrow_masks, b.guard_borrow_masks) && bcc_string_lists_equal(a.guard_unmangled_names, b.guard_unmangled_names)
 }
 
+/// #2575 item 2: the ordinary lane's statement-to-module map, as a `DbgProv`.
+///
+/// This is the input `prelude_run_per_module` needs and no production compile
+/// could give it: `effect_lowering_prelude` takes only the merged statement
+/// array, so nothing downstream can split it by module.
+///
+/// It costs an expansion and no new merge work. `file_counts[i]` is how many
+/// merged top-level statements flat file `i` contributed, in merge order --
+/// `build_grouped_merged_stmts_counted` already produces it because the
+/// codegen body cache needs the same table -- so the per-statement ids are a
+/// run-length decode of something this lane holds either way.
+///
+/// `file_nls` is deliberately EMPTY. The per-file newline tables are the
+/// expensive half of the break lane's provenance (one offset array per source,
+/// rebased) and exist to map a LINE; a per-module prelude needs only which
+/// module a statement came from.
+///
+/// Alignment holds across `elaborate_heap_params`, which runs between this and
+/// the owner scan that reads it: that pass pushes exactly one statement per
+/// input statement, so the count and order it hands on are the merge's.
+/// `linked_compile_prov_inert_test.vibe` pins that, because an edit there
+/// would silently misalign every id rather than fail.
+fn ordinary_lane_dbg_prov(file_paths: Array[String], file_counts: Array[Int]) -> DbgProv {
+  let files = array_empty()
+  let stmt_file_id = array_empty()
+  let mut i = 0
+  while i < Array::length(file_paths) && i < Array::length(file_counts) {
+    Array::push(files, path_basename(Array::get(file_paths, i)))
+    let n = Array::get(file_counts, i)
+    let mut k = 0
+    while k < n {
+      Array::push(stmt_file_id, i)
+      k = k + 1
+    }
+    i = i + 1
+  }
+  DbgProv::{ files: files, file_nls: array_empty(), stmt_file_id: stmt_file_id }
+}
+
 export fn compile_file_fs_mode_rc_body_cached(entry_path: String, entry_name: String, cache_mode: String) -> Bytes with Exception + Fs {
   let source_groups = collect_source_groups_fs(entry_path)
   let next_db = prepare_file_fs_from_source_groups_persistent_cached(db_new(), entry_path, source_groups)
@@ -1521,6 +1561,10 @@ export fn compile_file_fs_mode_rc_body_cached(entry_path: String, entry_name: St
   let (float_offsets, tl_rels, tl_pluses, int_offsets, bool_offsets) = split_typed_lowering_offsets(union_module_typed_lowering_with_clones(file_paths, file_bases, clone_float_offsets))
   let (eq_offsets, eq_keys) = union_module_typed_eq_rows(file_paths, file_bases)
   let merged_stmts = rewrite_string_binops_stmts(merged_stmts_raw, tl_rels, tl_pluses, typed_lowering_binop_anchor)
+  // #2575 item 2. The binop rewrite above preserves the statement count (it
+  // rewrites in place), so the map built from the merge's counts still indexes
+  // `merged_stmts`.
+  let lane_prov = ordinary_lane_dbg_prov(file_paths, file_counts)
   // The key is independent of source CONTENT (the point is to hit after an
   // edit) but scoped to the entry PATH: two roots that share a conventional
   // entry name (`run`, `main`) must not share one artifact slot, or their
@@ -1532,7 +1576,7 @@ export fn compile_file_fs_mode_rc_body_cached(entry_path: String, entry_name: St
   }
   if cache_mode == "verify" {
     let fresh_out = codegen_body_cache_new()
-    let fresh = compile_wasi_module_rc_cached_impl_with_typed_offsets(merged_stmts, entry_name, codegen_body_cache_new(), fresh_out, float_offsets, int_offsets, bool_offsets, eq_offsets, eq_keys)
+    let fresh = compile_wasi_module_rc_cached_impl_with_prov(merged_stmts, entry_name, codegen_body_cache_new(), fresh_out, lane_prov, float_offsets, int_offsets, bool_offsets, eq_offsets, eq_keys)
     if Array::length(cache_in.fn_indices) > 0 && body_cache_guards_equal(cache_in, fresh_out) {
       // Guard drift (an edit flipped a whole-program fact the guards pin)
       // is an EXPECTED cache miss, checked above against the fresh
@@ -1544,7 +1588,7 @@ export fn compile_file_fs_mode_rc_body_cached(entry_path: String, entry_name: St
       // replay/sliced gates prove that recompile is byte-identical to the
       // first, so any difference here is attributable to the persisted
       // bodies being replayed.
-      let replayed = compile_wasi_module_rc_cached_impl_with_typed_offsets(merged_stmts, entry_name, cache_in, codegen_body_cache_new(), float_offsets, int_offsets, bool_offsets, eq_offsets, eq_keys)
+      let replayed = compile_wasi_module_rc_cached_impl_with_prov(merged_stmts, entry_name, cache_in, codegen_body_cache_new(), lane_prov, float_offsets, int_offsets, bool_offsets, eq_offsets, eq_keys)
       let fresh_n = Bytes::length(fresh)
       let rn = Bytes::length(replayed)
       if fresh_n != rn {
@@ -1573,7 +1617,7 @@ export fn compile_file_fs_mode_rc_body_cached(entry_path: String, entry_name: St
     fresh
   } else {
     let cache_out = codegen_body_cache_new()
-    let bytes = compile_wasi_module_rc_cached_impl_with_typed_offsets(merged_stmts, entry_name, cache_in, cache_out, float_offsets, int_offsets, bool_offsets, eq_offsets, eq_keys)
+    let bytes = compile_wasi_module_rc_cached_impl_with_prov(merged_stmts, entry_name, cache_in, cache_out, lane_prov, float_offsets, int_offsets, bool_offsets, eq_offsets, eq_keys)
     // Replayed entries are not re-recorded, so the refreshed artifact is
     // the new harvest plus the entries it replayed -- but ONLY when the
     // cache was actually consumed (its guards match the new harvest's).

--- a/lib/@vibe/compiler/entry/compiler/file_compile/file_compile.vibe
+++ b/lib/@vibe/compiler/entry/compiler/file_compile/file_compile.vibe
@@ -817,9 +817,25 @@ fn oracle_import_closure(source_groups: Array[(String, Array[(String, String)])]
   // Closing only across re-export edges would be the exact rule, and the
   // loader's header scan does not distinguish them: it returns a module's deps
   // and its export NAMES, with no record of which deps a dep re-exports. So
-  // this takes the safe side instead. Direct-only is an UNDER-approximation,
-  // and an under-approximation can only manufacture a difference, never hide
-  // one -- the same reason `unresolved` is reported rather than swallowed.
+  // this takes the safe side instead: direct-only is an UNDER-approximation,
+  // and `unresolved` is reported rather than swallowed for the same reason.
+  //
+  // This used to add "and an under-approximation can only manufacture a
+  // difference, never hide one". That held when a module which could not build
+  // a helper produced a `missing` row, and STOPPED holding when the link
+  // learned to MINT (#2634, #2643 review): a module that cannot see enough now
+  // defers, and `eq_mint_deferred_into` builds the helper against the
+  // concatenated program -- the whole program. So narrowing the context changes
+  // the EXECUTION PATH, and a module that would have synthesized a differing
+  // helper under exact context can defer instead and receive the
+  // whole-program one, turning the comparison green over a real difference.
+  // `prelude_module_oracle_test.vibe` relies on exactly that to make a module
+  // defer on demand.
+  //
+  // What the oracle's zero therefore supports is "the LINKED program equals the
+  // whole-program one" -- the question a per-module driver has -- and not
+  // "every module synthesized faithfully". `SYNTH deferred=` / `minted=`
+  // separate the two by counting how much of the green is the link's work.
   // Measured on the compiler's own CLI closure, and the transitivity was very
   // much load-bearing -- 32017 reachable pairs against 1415 one-hop ones, 22x
   // wider. Under it the split read `missing=1 content=4 invisible_split=2`;

--- a/lib/@vibe/compiler/normalize/desugar_trait_dict.vibe
+++ b/lib/@vibe/compiler/normalize/desugar_trait_dict.vibe
@@ -21172,6 +21172,30 @@ export fn eq_mint_deferred_into(stmts: Array[Stmt]) -> Int {
   Array::length(stmts) - before
 }
 
+/// #2642 review (Codex P2): clear what a LANE recorded, at that lane's
+/// boundary.
+///
+/// These three arrays are process-global and nothing cleared them, while their
+/// own doc comments said "since the last reset". The other synthesis registries
+/// (`dtd_arr_eq_needed_keys`, `dtd_map_eq_needed_keys`,
+/// `dtd_eq_specializations`) are reset by `dtd_run` on every call, so they
+/// describe one run; a caller that wants the union over several modules unions
+/// the per-run lists itself. These cannot do that, because `eq_mint_deferred_into`
+/// reads the REGISTRY at the link and so needs it to accumulate across the
+/// modules of one split run -- which also means every earlier program's
+/// deferrals were still in it. A second oracle report in the same process
+/// therefore replayed the first program's instantiations against the second
+/// program's statements, and `deferred` / `minted` depended on test order.
+///
+/// So the reset is at the lane boundary rather than per run: the whole-program
+/// entry (`desugar_trait_dicts_with_typed_eq`, one program per call) and the
+/// per-module driver, before its first module.
+export fn eq_deferred_reset() -> Unit {
+  Array::truncate(dtd_eq_deferred_requests, 0)
+  Array::truncate(dtd_eq_deferred_types, 0)
+  Array::truncate(dtd_eq_typed_refusals, 0)
+}
+
 export fn eq_deferred_requests_list() -> Array[String] {
   let out = empty_str_array()
   let mut i = 0
@@ -21246,6 +21270,11 @@ export fn desugar_trait_dicts_with_typed_eq(stmts: Array[Stmt], typed_eq_offsets
   Array::set(dtd_own_limit, 0, 0 - 1)
   Array::set(dtd_ctx_len, 0, 0)
   Array::set(dlh_module_tag, 0, "")
+  // One program per call, so this call's deferrals and refusals are this
+  // program's. The per-module entry deliberately does NOT reset: its caller
+  // wants the union across the modules of one split run, and resets once at
+  // that boundary (#2642 review, Codex P2).
+  eq_deferred_reset()
   dtd_run(stmts, typed_eq_offsets, typed_eq_keys)
 }
 

--- a/lib/@vibe/compiler/normalize/index.vpkg
+++ b/lib/@vibe/compiler/normalize/index.vpkg
@@ -75,6 +75,7 @@ fn hoisted_lambda_owner_key(name: String) -> Option[String]
 fn eq_synthesis_requests_list() -> Array[String]
 fn eq_typed_refusals_list() -> Array[String]
 fn eq_deferred_requests_list() -> Array[String]
+fn eq_deferred_reset() -> Unit
 fn eq_mint_deferred_into(stmts: Array[Stmt]) -> Int
 fn eq_invisible_nominals_reset() -> Unit
 fn eq_invisible_nominals_list() -> Array[String]

--- a/lib/@vibe/compiler/tests/linked_compile_prov_inert_test.vibe
+++ b/lib/@vibe/compiler/tests/linked_compile_prov_inert_test.vibe
@@ -1,0 +1,114 @@
+import @vibe/compiler/codegen/common_base {
+  DbgProv, codegen_body_cache_new, empty_dbg_prov
+}
+
+import @vibe/compiler/codegen/wasi {
+  compile_wasi_module_rc_cached_impl_with_prov, compile_wasi_module_rc_cached_impl_with_typed_offsets
+}
+
+import @vibe/compiler/core {
+  Stmt
+}
+
+import @vibe/compiler/syntax {
+  lex, parse_program
+}
+
+// #2575 item 2: the ordinary lane now carries the merged program's
+// statement-to-module map to codegen. `prelude_run_per_module` is measured
+// exact and cannot be CALLED by a production compile, because
+// `effect_lowering_prelude` takes only the merged statement array -- nothing
+// downstream can split it by module. Carrying the map is the prerequisite.
+//
+// Carrying it must change nothing until something reads it, and "must change
+// nothing" has exactly one honest test: compile the same program both ways and
+// compare the BYTES.
+//
+// WHAT THIS TEST DOES NOT COVER, measured rather than assumed. The owner-key
+// scan in `compile_wasi_module_linked_impl_with_typed_offsets` was gated on
+// `Array::length(prov.stmt_file_id) > 0` -- a PROXY for the break lane,
+// correct only while the break lane was the only caller filling provenance.
+// Filling it here would have switched that scan on for every ordinary compile
+// (one `hoisted_lambda_owner_of_stmt` plus two pushes per top-level statement,
+// ~9.9k of them on the compiler's own closure) with the arrays never read, so
+// the guard now tests `debug_break`. Reverting it to the proxy and re-running
+// this file still PASSES: the scan fills arrays nothing consumes, so it is
+// pure COST and byte-inert. The guard is therefore not pinned here and cannot
+// be -- where it shows up is the perf report's selfcompile allocation row.
+
+fn program_stmts(src: String) -> Array[Stmt] with Exception {
+  parse_program(lex(src))
+}
+
+/// The checker's typed-lowering tables, empty: this lane compiles a parsed
+/// program directly, so there are no offsets to thread. Named rather than
+/// spelled `[]` five times per call, which the formatter breaks across lines.
+fn no_ints() -> Array[Int] {
+  []
+}
+
+fn no_keys() -> Array[String] {
+  []
+}
+
+fn rc_plain(stmts: Array[Stmt]) -> Bytes with Exception {
+  compile_wasi_module_rc_cached_impl_with_typed_offsets(stmts, "main", codegen_body_cache_new(), codegen_body_cache_new(), no_ints(), no_ints(), no_ints(), no_ints(), no_keys())
+}
+
+fn rc_with_prov(stmts: Array[Stmt], prov: DbgProv) -> Bytes with Exception {
+  compile_wasi_module_rc_cached_impl_with_prov(stmts, "main", codegen_body_cache_new(), codegen_body_cache_new(), prov, no_ints(), no_ints(), no_ints(), no_ints(), no_keys())
+}
+
+fn src_two_modules() -> String {
+  "fn helper(n: Int) -> Int {\n  n + 1\n}\n\nstruct Pt {\n  x: Int;\n  y: Int\n} derive (Eq)\n\nfn main() -> Int {\n  let a = Pt::{ x: helper(1), y: 2 }\n  let b = Pt::{ x: 2, y: 2 }\n  if a == b {\n    helper(10)\n  } else {\n    0\n  }\n}\n"
+}
+
+/// A map shaped like the one `ordinary_lane_dbg_prov` builds: every statement
+/// attributed to one of two modules, split down the middle.
+fn two_module_prov(n: Int) -> DbgProv {
+  let ids: Array[Int] = []
+  let mut i = 0
+  while i < n {
+    Array::push(ids, if i < n / 2 {
+      0
+    } else {
+      1
+    })
+    i = i + 1
+  }
+  DbgProv::{ files: ["a.vibe", "b.vibe"], file_nls: [], stmt_file_id: ids }
+}
+
+test "carrying the statement-to-module map does not change a byte of the output" {
+  let stmts = program_stmts(src_two_modules())
+  let without = rc_plain(stmts)
+  let with_map = rc_with_prov(program_stmts(src_two_modules()), two_module_prov(Array::length(stmts)))
+  // Same length AND same bytes. Length alone would pass on a module that
+  // differed only in a function's contents, which is exactly what a wrongly
+  // enabled owner scan or a misread file id would produce.
+  inspect(Bytes::length(with_map) == Bytes::length(without), content = "true")
+  let mut i = 0
+  let mut first_diff = 0 - 1
+  while i < Bytes::length(without) && i < Bytes::length(with_map) {
+    if Bytes::get(with_map, i) != Bytes::get(without, i) && first_diff < 0 {
+      first_diff = i
+    } else {
+      ()
+    }
+    i = i + 1
+  }
+  inspect(first_diff, content = "-1")
+  // And the compile is not vacuously empty -- an entry that produced nothing
+  // would compare equal to itself and prove nothing.
+  inspect(Bytes::length(without) > 0, content = "true")
+}
+
+test "an empty map and a full one are the same compile" {
+  // The wrapper passes `empty_dbg_prov()`, so this pins that the two entries
+  // agree when the map carries nothing: a difference here would mean the new
+  // parameter changed the compile by existing rather than by its contents.
+  let stmts = program_stmts(src_two_modules())
+  let via_wrapper = rc_plain(stmts)
+  let via_empty = rc_with_prov(program_stmts(src_two_modules()), empty_dbg_prov())
+  inspect(Bytes::length(via_empty) == Bytes::length(via_wrapper), content = "true")
+}

--- a/lib/@vibe/compiler/tests/prelude_module_oracle_test.vibe
+++ b/lib/@vibe/compiler/tests/prelude_module_oracle_test.vibe
@@ -582,3 +582,45 @@ test "the analyses refuse to answer where production would have run late DCE fir
   // a guard that suppressed the columns unconditionally could not pass this.
   inspect(String::trim(analysis_line_of(prelude_module_full_oracle_report_fs(main_path, "__no_entry__"))), content = "ANALYSIS dce_entry=0 borrow_ret=9/8:-1:main+0: borrow_fns=0/1:-0:+1:head_of_exp__tmp_vibe_dce_gate_helper_vibe borrow_masks=0/1:-0:+1:head_of_exp__tmp_vibe_dce_gate_helper_vibe#1 view_ret=2/1:-1:main+0:")
 }
+
+// #2642 review (Codex P2): `dtd_eq_deferred_requests`, `dtd_eq_deferred_types`
+// and `dtd_eq_typed_refusals` are process-global and nothing cleared them,
+// while their own doc comments said "since the last reset". They cannot be
+// reset per run like the other synthesis registries, because
+// `eq_mint_deferred_into` reads the REGISTRY at the link and needs the union
+// over one split run's modules -- which is also why every EARLIER program's
+// deferrals were still in it. So the reset is at the lane boundary:
+// `desugar_trait_dicts_with_typed_eq` (one program per call) and the per-module
+// driver, before its first module.
+//
+// Two reports, one process, and the first one defers. A re-export chain is what
+// makes it defer: `Box` reaches the module through `export ./b.vibe { Box }`,
+// so the module NAMES the type and cannot see its declaration -- the context is
+// each module's direct imports reduced to their exported form, and a re-export
+// boundary is not a declaration. That is the same shape as the `opaque` contract
+// in #2631, without needing a package on disk.
+//
+// Red-tested by removing both reset calls: the second report then reads
+// `typed_refused=1 deferred=1` -- the FIRST program's `Box[Int]`, carried into
+// a program that has no `Box` at all. `minted` stays 0 there because the link's
+// mint finds nothing to build it from, which is the point: the counters
+// describe a program that is not the one being measured.
+test "a report's deferrals are its own, not the previous report's" {
+  let b = "/tmp/vibe_defer_reset_b.vibe"
+  let c = "/tmp/vibe_defer_reset_c.vibe"
+  let a = "/tmp/vibe_defer_reset_a.vibe"
+  Fs::write_file(b, "export struct Box[T] {\n  v: T\n}\n\nexport fn make_box(n: Int) -> Box[Int] {\n  Box::{ v: n }\n}\n")
+  Fs::write_file(c, "export ./vibe_defer_reset_b.vibe {\n  Box, make_box\n}\n")
+  Fs::write_file(a, "import ./vibe_defer_reset_c.vibe {\n  make_box\n}\n\ntest \"t\" {\n  let p = make_box(1)\n  let q = make_box(1)\n  inspect(p == q, content = \"true\")\n}\n")
+  // The deferring program, and the line that says so: one request the whole
+  // program makes and the split does not, one row the typed channel refused,
+  // and the link minting the helper from the deferral.
+  inspect(String::trim(synth_line_of(prelude_module_full_oracle_report_fs(a, "__no_entry__"))), content = "SYNTH requests=1/0:-spec:A1_N3_BoxN3_Int+ typed_refused=0/1:-+A66_111_120_LN73_110_116_ZR deferred=1 minted=1 indirect=0")
+  // A second program in the same process, which defers nothing. Every column
+  // is zero, including the two the first report left behind.
+  let dep2 = "/tmp/vibe_defer_reset_dep2.vibe"
+  let main2 = "/tmp/vibe_defer_reset_main2.vibe"
+  Fs::write_file(dep2, "export fn twice(n: Int) -> Int {\n  n * 2\n}\n")
+  Fs::write_file(main2, "import ./vibe_defer_reset_dep2.vibe {\n  twice\n}\n\ntest \"t\" {\n  inspect(twice(2), content = \"4\")\n}\n")
+  inspect(String::trim(synth_line_of(prelude_module_full_oracle_report_fs(main2, "__no_entry__"))), content = "SYNTH requests=0 typed_refused=0 deferred=0 minted=0 indirect=0")
+}

--- a/scripts/bench_report.mjs
+++ b/scripts/bench_report.mjs
@@ -238,18 +238,32 @@ if (missingReps.length) {
 // This is what makes one-row-per-tier safe: the report stays small when
 // everything is flat, and a regression in a series nobody chose to render
 // still arrives by name.
+// Keys from BOTH snapshots, current first, baseline's extras after. Iterating
+// `cur` alone means a series the current run did not produce at all is never
+// visited: `bench_metrics.sh` records nothing for a binary-size sample that
+// failed to compile or a tracked bench that parsed no row, so the series simply
+// vanishes rather than going null, and a scan over `cur` would then report the
+// rest as clean. Same class as the null-value case below, one level up -- an
+// absent KEY instead of an absent VALUE (#2643 review, Codex P2).
+const unionKeys = (a, b) => {
+  const out = Object.keys(a || {});
+  for (const k of Object.keys(b || {})) if (!(k in (a || {}))) out.push(k);
+  return out;
+};
+
 function* allMetrics() {
   yield ["selfcompile heap", "selfcompile.heap_ptr_bytes", cur.selfcompile?.heap_ptr_bytes, base?.selfcompile?.heap_ptr_bytes];
   for (const k of ["stage2_wasm", "cli_adapter_bundle", "compiler_sources_bundle", "module_source"]) {
     yield [k, `sizes.${k}`, cur.sizes?.[k], base?.sizes?.[k]];
   }
-  for (const [name, v] of Object.entries(cur.sizes?.samples || {})) {
-    yield [`sample ${name}`, `sizes.samples.${name}`, v, base?.sizes?.samples?.[name]];
+  for (const name of unionKeys(cur.sizes?.samples, base?.sizes?.samples)) {
+    yield [`sample ${name}`, `sizes.samples.${name}`, cur.sizes?.samples?.[name], base?.sizes?.samples?.[name]];
   }
-  for (const [label, v] of Object.entries(cur.benches || {})) {
-    yield [`B/op ${label}`, `benches.${label}`, v?.bytes_per_op, base?.benches?.[label]?.bytes_per_op];
+  for (const label of unionKeys(cur.benches, base?.benches)) {
+    yield [`B/op ${label}`, `benches.${label}`, cur.benches?.[label]?.bytes_per_op, base?.benches?.[label]?.bytes_per_op];
   }
-  for (const [name, s] of Object.entries(execCur?.scenarios || {})) {
+  for (const name of unionKeys(execCur?.scenarios, execBase?.scenarios)) {
+    const s = execCur?.scenarios?.[name] || {};
     const b = execBase?.scenarios?.[name];
     if (!wasmtimeChanged) {
       yield [`${name} fuel`, `exec.${name}.linear.fuel`, s.linear?.fuel, b?.linear?.fuel];

--- a/scripts/bench_report.mjs
+++ b/scripts/bench_report.mjs
@@ -3,8 +3,8 @@
 //
 //   node scripts/bench_report.mjs current.json [baseline.json] [coverage.json]
 //
-// FOUR sections, in this order: coverage, then one per SIZE TIER -- 大 the
-// compiler itself, 中 a real program, 小 a micro case -- with the axes
+// FOUR sections, in this order: coverage, then one per SIZE TIER -- Large the
+// compiler itself, Medium a real program, Small a micro case -- with the axes
 // (memory, code size, benchmark) as columns. One representative row per tier.
 //
 // The shape is deliberate. The report used to render every tracked series:
@@ -59,10 +59,10 @@ const cov = readJsonMaybe(covPath);
 // of these is a deliberate edit, and the drift line below still covers
 // everything that is not named here.
 //
-//   大  the compiler compiling itself -- the only workload at this scale
-//   中  expr_eval: the corpus's heaviest by fuel (~2.5x the next), an
-//       evaluator loop, so the most sensitive to a codegen regression
-//   小  fib / fib30: the smallest thing that still allocates nothing
+//   Large   the compiler compiling itself -- the only workload at this scale
+//   Medium  expr_eval: the corpus's heaviest by fuel (~2.5x the next), an
+//           evaluator loop, so the most sensitive to a codegen regression
+//   Small   fib / fib30: the smallest thing that still allocates nothing
 const REPRESENTATIVE = {
   largeBench: "parser_bench.vibe::parse_checker_vibe",
   medium: "expr_eval",
@@ -168,8 +168,8 @@ const wasmtimeChanged = !!(execBase?.scenarios && execCur?.wasmtime && execBase.
 const rendered = new Set();
 const show = (key) => { rendered.add(key); return true; };
 
-// --- 大: the compiler itself -------------------------------------------------
-lines.push("#### 大 — the compiler itself");
+// --- Large: the compiler itself -------------------------------------------------
+lines.push("#### Large — the compiler itself");
 lines.push("");
 lines.push("| subject | memory | code | bench (B/op) |");
 lines.push("|---|---:|---:|---:|");
@@ -181,11 +181,11 @@ lines.push(`| selfcompile | ${cell(fmtBytes, cur.selfcompile?.heap_ptr_bytes, ba
   `${cell(fmtBytes, cur.benches?.[REPRESENTATIVE.largeBench]?.bytes_per_op, base?.benches?.[REPRESENTATIVE.largeBench]?.bytes_per_op)} |`);
 lines.push("");
 
-// --- 中: a real program ------------------------------------------------------
+// --- Medium: a real program ------------------------------------------------------
 const medName = REPRESENTATIVE.medium;
 const medCur = execCur?.scenarios?.[medName];
 const medBase = execBase?.scenarios?.[medName];
-lines.push(`#### 中 — a real program (\`${medName}\`, bench/exec)`);
+lines.push(`#### Medium — a real program (\`${medName}\`, bench/exec)`);
 lines.push("");
 lines.push("| scenario | heap | code | fuel |");
 lines.push("|---|---:|---:|---:|");
@@ -197,8 +197,8 @@ lines.push(`| ${medName} | ${cell(fmtBytes, medCur?.linear?.heap_bytes, medBase?
   `${cell(fmtCount, medCur?.linear?.fuel, medBase?.linear?.fuel, !wasmtimeChanged)} |`);
 lines.push("");
 
-// --- 小: micro ---------------------------------------------------------------
-lines.push("#### 小 — micro");
+// --- Small: micro ---------------------------------------------------------------
+lines.push("#### Small — micro");
 lines.push("");
 lines.push("| case | code | B/op |");
 lines.push("|---|---:|---:|");

--- a/scripts/bench_report.mjs
+++ b/scripts/bench_report.mjs
@@ -208,17 +208,28 @@ lines.push(`| ${REPRESENTATIVE.smallSample} | ${cell(fmtBytes, cur.sizes?.sample
   `${cell(fmtBytes, cur.benches?.[REPRESENTATIVE.smallBench]?.bytes_per_op, base?.benches?.[REPRESENTATIVE.smallBench]?.bytes_per_op)} |`);
 lines.push("");
 
-// A representative the snapshot does not carry renders "–", which reads like
-// "no change" at a glance. Say it instead: a missing representative means the
-// report is measuring less than its headings claim.
+// A representative with no VALUE renders "– (–)", which reads like "no change"
+// at a glance. Say it instead: the row's heading promises a number, so a blank
+// one means the report is measuring less than it claims.
+//
+// Checked per CELL, not per object. A scenario can be present and `ok` while
+// the metric inside it is null -- `bench_metrics.sh` scrapes fuel and memory
+// out of the runner's stderr, so a runner that ran fine but printed no
+// `vibe::fuel` line stores null under an `ok` status (#2643 review, Codex P2).
 const missingReps = [];
-if (cur.selfcompile?.heap_ptr_bytes == null) missingReps.push("selfcompile heap");
-if (cur.benches?.[REPRESENTATIVE.largeBench] == null) missingReps.push(REPRESENTATIVE.largeBench);
-if (execCur?.scenarios && medCur == null) missingReps.push(`exec scenario ${medName}`);
-if (cur.sizes?.samples && cur.sizes.samples[REPRESENTATIVE.smallSample] == null) missingReps.push(`sample ${REPRESENTATIVE.smallSample}`);
-if (cur.benches && Object.keys(cur.benches).length && cur.benches[REPRESENTATIVE.smallBench] == null) missingReps.push(REPRESENTATIVE.smallBench);
+const repCell = (label, v) => { if (v == null) missingReps.push(label); };
+repCell("selfcompile heap", cur.selfcompile?.heap_ptr_bytes);
+repCell("stage2.wasm", cur.sizes?.stage2_wasm);
+repCell(`B/op ${REPRESENTATIVE.largeBench}`, cur.benches?.[REPRESENTATIVE.largeBench]?.bytes_per_op);
+if (execCur?.scenarios) {
+  repCell(`${medName} heap`, medCur?.linear?.heap_bytes);
+  repCell(`${medName} wasm`, medCur?.linear?.wasm_bytes);
+  if (!wasmtimeChanged) repCell(`${medName} fuel`, medCur?.linear?.fuel);
+}
+repCell(`sample ${REPRESENTATIVE.smallSample}`, cur.sizes?.samples?.[REPRESENTATIVE.smallSample]);
+repCell(`B/op ${REPRESENTATIVE.smallBench}`, cur.benches?.[REPRESENTATIVE.smallBench]?.bytes_per_op);
 if (missingReps.length) {
-  lines.push(`> ⚠️ representative missing from this snapshot: ${missingReps.join(", ")} — the row above is blank, not flat`);
+  lines.push(`> ⚠️ no value in this snapshot for: ${missingReps.join(" · ")} — the cell above is blank, not flat`);
   lines.push("");
 }
 
@@ -251,16 +262,35 @@ function* allMetrics() {
   }
 }
 const drifted = [];
+const unmeasured = [];
+let compared = 0;
 for (const [label, key, c, b] of allMetrics()) {
   if (rendered.has(key)) continue;
+  // The baseline had a number and this run does not. That is lost
+  // instrumentation, not agreement -- `pctOf` returns null for it, and
+  // counting that as a clean scan is exactly how "nothing moved" and "nothing
+  // was checked" come to look alike (#2643 review, Codex P2).
+  if (c == null && b != null) { unmeasured.push(label); continue; }
   const pct = pctOf(c, b);
-  if (pct != null && Math.abs(pct) >= 2) drifted.push(`${label} ${fmtPct(pct)}`);
+  if (pct == null) continue;
+  compared += 1;
+  if (Math.abs(pct) >= 2) drifted.push(`${label} ${fmtPct(pct)}`);
 }
 if (drifted.length) {
   lines.push(`> drift outside the rows above (±2% threshold, ${drifted.length}): ${drifted.join(" · ")}`);
   lines.push("");
+} else if (compared) {
+  lines.push(`> no drift ≥±2% in the ${compared} other tracked series compared`);
+  lines.push("");
 } else if (base) {
-  lines.push("> no drift ≥±2% in any other tracked series");
+  // Zero comparable series is its own answer, and dropping the line here would
+  // reintroduce the ambiguity this scan exists to remove: a reader cannot tell
+  // an absent line from a clean one.
+  lines.push("> no other tracked series to compare");
+  lines.push("");
+}
+if (unmeasured.length) {
+  lines.push(`> ⚠️ measured on the baseline, absent here (${unmeasured.length}): ${unmeasured.join(" · ")} — instrumentation gap, not agreement`);
   lines.push("");
 }
 

--- a/scripts/bench_report.mjs
+++ b/scripts/bench_report.mjs
@@ -3,16 +3,32 @@
 //
 //   node scripts/bench_report.mjs current.json [baseline.json] [coverage.json]
 //
-// The report renders DETERMINISTIC metrics only (heap, sizes, bytes/op, exec
-// fuel/memory/parity): any change is real, >±2% gets a warning emoji. The
-// snapshots also carry advisory wall-time readings (wall_ms, ns_p50) and the
-// runner calibration record — those stay in the bench-data history for
+// FOUR sections, in this order: coverage, then one per SIZE TIER -- 大 the
+// compiler itself, 中 a real program, 小 a micro case -- with the axes
+// (memory, code size, benchmark) as columns. One representative row per tier.
+//
+// The shape is deliberate. The report used to render every tracked series:
+// 5 deterministic rows + 5 sample sizes + 15 B/op rows + 9 exec scenarios
+// across two tables + coverage, ~50 rows, of which ~48 read `±0` on an
+// ordinary PR. A reader -- human or LLM -- cannot find the one row that moved
+// in that, so the report was skipped rather than read, which is worse than a
+// smaller report that is actually looked at.
+//
+// Cutting to one row per tier would create a blind spot on its own, so it does
+// not: `driftOutsideRows` below re-checks EVERY tracked metric, rendered or
+// not, and names the ones past the ±2% threshold. Flat runs stay small; a
+// regression in an unrendered series still shows up by name.
+//
+// Deltas are rendered INSIDE each cell rather than in one trailing Δ column:
+// with three metric columns per row, a single Δ cannot say which metric moved.
+//
+// Snapshots also carry advisory wall-time readings (wall_ms, ns_p50) and the
+// runner calibration record -- those stay in the bench-data history for
 // offline analysis but are deliberately NOT rendered: shared-runner speed
 // swings every wall row ±15-40% on unrelated PRs (see the #1207/#1209
-// postmortems and bench/perf/README.md "Runner normalization"), which made
-// the section noise for human AND LLM readers alike. Never exits non-zero on
-// regressions: this is a report, the blocking gate for allocation is ci.yml's
-// KPI heap step.
+// postmortems and bench/perf/README.md "Runner normalization"). Never exits
+// non-zero on regressions: this is a report, the blocking gate for allocation
+// is ci.yml's KPI heap step.
 import { readFileSync, existsSync } from "node:fs";
 
 const [curPath, basePath, covPath] = process.argv.slice(2);
@@ -36,8 +52,26 @@ const base = readJsonMaybe(basePath);
 // the first main run lands one.
 const cov = readJsonMaybe(covPath);
 
-// Human-readable units for table cells. Rounding here loses no signal: the Δ
-// column is computed from the raw values, so "any drift is real" still reads
+// The representative of each tier, BY NAME. Fixed rather than computed (say,
+// "the scenario with the most fuel"), because a series whose subject changes
+// when the data changes is not a series: the row would silently start
+// describing a different program and its Δ would be meaningless. Changing one
+// of these is a deliberate edit, and the drift line below still covers
+// everything that is not named here.
+//
+//   大  the compiler compiling itself -- the only workload at this scale
+//   中  expr_eval: the corpus's heaviest by fuel (~2.5x the next), an
+//       evaluator loop, so the most sensitive to a codegen regression
+//   小  fib / fib30: the smallest thing that still allocates nothing
+const REPRESENTATIVE = {
+  largeBench: "parser_bench.vibe::parse_checker_vibe",
+  medium: "expr_eval",
+  smallSample: "fib",
+  smallBench: "pure_bench.vibe::fib30",
+};
+
+// Human-readable units for table cells. Rounding here loses no signal: the
+// delta is computed from the raw values, so "any drift is real" still reads
 // off the percentage even when two close values render the same.
 const nice = (v) => v >= 100 ? v.toFixed(0) : v >= 10 ? v.toFixed(1) : v.toFixed(2);
 const fmtBytes = (n) => {
@@ -58,14 +92,25 @@ const fmtCount = (n) => {
   return `${nice(v)}${units[i]}`;
 };
 
-function delta(curV, baseV) {
-  if (baseV == null || curV == null) return " | –";
-  if (baseV === curV) return " | ±0";
-  const pct = baseV === 0 ? 100 : ((curV - baseV) / baseV) * 100;
-  const sign = pct > 0 ? "+" : "";
+const pctOf = (curV, baseV) => {
+  if (baseV == null || curV == null) return null;
+  if (baseV === curV) return 0;
+  return baseV === 0 ? 100 : ((curV - baseV) / baseV) * 100;
+};
+const fmtPct = (pct) => {
+  if (pct == null) return "–";
+  if (pct === 0) return "±0";
   const flag = Math.abs(pct) >= 2 ? (pct > 0 ? " ⚠️" : " 🎉") : "";
-  return ` | ${sign}${pct.toFixed(2)}%${flag}`;
-}
+  // A real change that rounds to 0.00 must not print as `-0.00%`, which reads
+  // as "zero, but negative" -- the values DID differ and two decimals cannot
+  // show it. Say that instead of rendering a signed zero.
+  if (Math.abs(pct) < 0.005) return `${pct > 0 ? "+" : "−"}<0.01%`;
+  return `${pct > 0 ? "+" : ""}${pct.toFixed(2)}%${flag}`;
+};
+// One cell: the value with its own delta. `comparable=false` renders the value
+// with a "–" delta (fuel across a wasmtime cost-table change).
+const cell = (fmt, curV, baseV, comparable = true) =>
+  `${fmt(curV)} (${comparable ? fmtPct(pctOf(curV, baseV)) : "–"})`;
 
 const lines = [];
 lines.push("<!-- vibe-perf-report -->");
@@ -75,98 +120,16 @@ lines.push(`current: \`${(cur.commit || "?").slice(0, 9)}\`` +
   (base ? ` / baseline (main): \`${(base.commit || "?").slice(0, 9)}\` (${(base.date || "").slice(0, 10)})` : " / baseline: _none yet_"));
 lines.push("");
 
-lines.push("#### Deterministic (allocation & size — any drift is real)");
-lines.push("");
-lines.push("| metric | current | baseline | Δ |");
-lines.push("|---|---:|---:|---|");
-const detRows = [
-  ["selfcompile heap_ptr_bytes", cur.selfcompile?.heap_ptr_bytes, base?.selfcompile?.heap_ptr_bytes],
-  ["stage2.wasm bytes", cur.sizes?.stage2_wasm, base?.sizes?.stage2_wasm],
-  ["cli_adapter_bundle bytes", cur.sizes?.cli_adapter_bundle, base?.sizes?.cli_adapter_bundle],
-  ["compiler_sources_bundle bytes", cur.sizes?.compiler_sources_bundle, base?.sizes?.compiler_sources_bundle],
-  ["flat module source bytes", cur.sizes?.module_source, base?.sizes?.module_source],
-];
-for (const [name, c, b] of detRows) lines.push(`| ${name} | ${fmtBytes(c)} | ${fmtBytes(b)}${delta(c, b)} |`);
-for (const [name, c] of Object.entries(cur.sizes?.samples || {})) {
-  const b = base?.sizes?.samples?.[name];
-  lines.push(`| sample wasm: ${name} | ${fmtBytes(c)} | ${fmtBytes(b)}${delta(c, b)} |`);
-}
-for (const [label, v] of Object.entries(cur.benches || {})) {
-  const b = base?.benches?.[label]?.bytes_per_op;
-  lines.push(`| B/op: ${label} | ${fmtBytes(v.bytes_per_op)} | ${fmtBytes(b)}${delta(v.bytes_per_op, b)} |`);
-}
-lines.push("");
-
-// Program execution: fuel (deterministic instruction-count proxy), memory and
-// linear-vs-wasm-gc comparison over the general-program corpus (bench/exec/).
-// Fuel readings are only comparable when both snapshots metered on the same
-// wasmtime version — the per-instruction cost table lives in wasmtime.
-const execCur = cur.exec;
-const execBase = base?.exec;
-if (execCur?.scenarios && Object.keys(execCur.scenarios).length) {
-  lines.push("#### Program execution (deterministic — fuel, memory, linear vs wasm-gc)");
-  lines.push("");
-  let fuelComparable = true;
-  if (execBase?.scenarios && execCur.wasmtime && execBase.wasmtime &&
-      execCur.wasmtime !== execBase.wasmtime) {
-    fuelComparable = false;
-    lines.push(`> fuel not comparable to baseline: wasmtime ${execBase.wasmtime} → ${execCur.wasmtime} (per-instruction cost table changed) — fuel Δ omitted`);
-    lines.push("");
-  }
-  const ratio = (g, l) => (g != null && l != null && l > 0) ? `${(g / l).toFixed(2)}×` : "–";
-  lines.push("| scenario | fuel (linear) | Δ | fuel (gc) | Δ | gc÷linear |");
-  lines.push("|---|---:|---|---:|---|---|");
-  for (const [name, s] of Object.entries(execCur.scenarios)) {
-    const b = execBase?.scenarios?.[name];
-    const dLin = fuelComparable ? delta(s.linear?.fuel, b?.linear?.fuel).replace(" | ", "") : "–";
-    const dGc = fuelComparable ? delta(s.gc?.fuel, b?.gc?.fuel).replace(" | ", "") : "–";
-    lines.push(`| ${name} | ${fmtCount(s.linear?.fuel)} | ${dLin} | ${fmtCount(s.gc?.fuel)} | ${dGc} | ${ratio(s.gc?.fuel, s.linear?.fuel)} |`);
-  }
-  lines.push("");
-  lines.push("| scenario | heap | Δ | committed | Δ | wasm (linear) | Δ | wasm (gc) | Δ |");
-  lines.push("|---|---:|---|---:|---|---:|---|---:|---|");
-  for (const [name, s] of Object.entries(execCur.scenarios)) {
-    const b = execBase?.scenarios?.[name];
-    const d = (c, bb) => delta(c, bb).replace(" | ", "");
-    lines.push(`| ${name} | ${fmtBytes(s.linear?.heap_bytes)} | ${d(s.linear?.heap_bytes, b?.linear?.heap_bytes)} | ${fmtBytes(s.linear?.committed_bytes)} | ${d(s.linear?.committed_bytes, b?.linear?.committed_bytes)} | ${fmtBytes(s.linear?.wasm_bytes)} | ${d(s.linear?.wasm_bytes, b?.linear?.wasm_bytes)} | ${fmtBytes(s.gc?.wasm_bytes)} | ${d(s.gc?.wasm_bytes, b?.gc?.wasm_bytes)} |`);
-  }
-  lines.push("");
-  // Correctness lines: golden (linear vs committed expected output) and
-  // backend parity (gc vs linear stdout). A mismatch is a silent-wrong
-  // candidate — the loudest thing in this report by design.
-  const names = Object.entries(execCur.scenarios);
-  const bad = names.filter(([, s]) => s.output !== "ok" && s.output !== "skipped");
-  const gcGaps = names.filter(([, s]) => s.gc?.status && s.gc.status !== "ok");
-  const linBroken = names.filter(([, s]) => s.linear?.status && s.linear.status !== "ok");
-  if (!bad.length && !linBroken.length) {
-    const ran = names.filter(([, s]) => s.output === "ok").length;
-    lines.push(`> output checks: ${ran}/${names.length} scenarios ✅ (linear = golden; gc = linear where the gc lane runs)` +
-      (gcGaps.length ? ` — ${gcGaps.length} gc-lane gap${gcGaps.length > 1 ? "s" : ""} below` : ""));
-  }
-  for (const [name, s] of linBroken) {
-    lines.push(`> ❌ **${name}: linear ${s.linear.status}** — the corpus program no longer compiles/runs`);
-  }
-  for (const [name, s] of bad) {
-    lines.push(`> ❌ **${name}: ${s.output}** — generated code produced WRONG output (silent-wrong candidate, investigate before merging)`);
-  }
-  for (const [name, s] of gcGaps) {
-    lines.push(`> ⚠️ ${name}: gc ${s.gc.status}${s.gc.detail ? ` — ${s.gc.detail}` : ""}`);
-  }
-  lines.push("");
-  if (execCur.status && execCur.status !== "ok" && execCur.status !== "partial") {
-    lines.push(`> exec scenarios: ${execCur.status}`);
-    lines.push("");
-  }
-}
-
-// Test coverage — the selfhost suite's union rates, measured by ci.yml's
-// main-only coverage-suite job (the suite re-runs the whole test battery
-// instrumented, too expensive per PR). Labeled as main's coverage, never this
-// PR's: implying otherwise would be silently wrong. The Δ column is
-// percentage POINTS vs the previous main measurement (a trend, not a
-// baseline-vs-PR diff).
+// --- coverage ----------------------------------------------------------------
+// First, because it is the only section that answers "is the suite still
+// looking at the code" rather than "did a number move". Measured by ci.yml's
+// main-only coverage-suite job (the suite re-runs the whole battery
+// instrumented, too expensive per PR), so it is labelled as main's coverage
+// and never this PR's: implying otherwise would be silently wrong. The Δ is
+// percentage POINTS against the previous main measurement -- a trend, not a
+// baseline-vs-PR diff.
 if (cov?.function_union && cov?.branch_union) {
-  lines.push("#### Test coverage (selfhost suite — measured on main, not this PR)");
+  lines.push("#### Coverage (selfhost suite — measured on main, not this PR)");
   lines.push("");
   const fmtInt = (n) => n == null ? "–" : n.toLocaleString("en-US");
   const rate = (r) => r == null ? "–" : `${Number(r).toFixed(2)}%`;
@@ -193,10 +156,151 @@ if (cov?.function_union && cov?.branch_union) {
   lines.push("");
 }
 
+// Fuel readings are only comparable when both snapshots metered on the same
+// wasmtime version -- the per-instruction cost table lives in wasmtime.
+const execCur = cur.exec;
+const execBase = base?.exec;
+const wasmtimeChanged = !!(execBase?.scenarios && execCur?.wasmtime && execBase.wasmtime &&
+  execCur.wasmtime !== execBase.wasmtime);
+
+// Tracks which metrics a row already shows, so the drift line does not repeat
+// them.
+const rendered = new Set();
+const show = (key) => { rendered.add(key); return true; };
+
+// --- 大: the compiler itself -------------------------------------------------
+lines.push("#### 大 — the compiler itself");
+lines.push("");
+lines.push("| subject | memory | code | bench (B/op) |");
+lines.push("|---|---:|---:|---:|");
+show("selfcompile.heap_ptr_bytes");
+show("sizes.stage2_wasm");
+show(`benches.${REPRESENTATIVE.largeBench}`);
+lines.push(`| selfcompile | ${cell(fmtBytes, cur.selfcompile?.heap_ptr_bytes, base?.selfcompile?.heap_ptr_bytes)} | ` +
+  `${cell(fmtBytes, cur.sizes?.stage2_wasm, base?.sizes?.stage2_wasm)} | ` +
+  `${cell(fmtBytes, cur.benches?.[REPRESENTATIVE.largeBench]?.bytes_per_op, base?.benches?.[REPRESENTATIVE.largeBench]?.bytes_per_op)} |`);
+lines.push("");
+
+// --- 中: a real program ------------------------------------------------------
+const medName = REPRESENTATIVE.medium;
+const medCur = execCur?.scenarios?.[medName];
+const medBase = execBase?.scenarios?.[medName];
+lines.push(`#### 中 — a real program (\`${medName}\`, bench/exec)`);
+lines.push("");
+lines.push("| scenario | heap | code | fuel |");
+lines.push("|---|---:|---:|---:|");
+show(`exec.${medName}.linear.heap_bytes`);
+show(`exec.${medName}.linear.wasm_bytes`);
+if (!wasmtimeChanged) show(`exec.${medName}.linear.fuel`);
+lines.push(`| ${medName} | ${cell(fmtBytes, medCur?.linear?.heap_bytes, medBase?.linear?.heap_bytes)} | ` +
+  `${cell(fmtBytes, medCur?.linear?.wasm_bytes, medBase?.linear?.wasm_bytes)} | ` +
+  `${cell(fmtCount, medCur?.linear?.fuel, medBase?.linear?.fuel, !wasmtimeChanged)} |`);
+lines.push("");
+
+// --- 小: micro ---------------------------------------------------------------
+lines.push("#### 小 — micro");
+lines.push("");
+lines.push("| case | code | B/op |");
+lines.push("|---|---:|---:|");
+show(`sizes.samples.${REPRESENTATIVE.smallSample}`);
+show(`benches.${REPRESENTATIVE.smallBench}`);
+lines.push(`| ${REPRESENTATIVE.smallSample} | ${cell(fmtBytes, cur.sizes?.samples?.[REPRESENTATIVE.smallSample], base?.sizes?.samples?.[REPRESENTATIVE.smallSample])} | ` +
+  `${cell(fmtBytes, cur.benches?.[REPRESENTATIVE.smallBench]?.bytes_per_op, base?.benches?.[REPRESENTATIVE.smallBench]?.bytes_per_op)} |`);
+lines.push("");
+
+// A representative the snapshot does not carry renders "–", which reads like
+// "no change" at a glance. Say it instead: a missing representative means the
+// report is measuring less than its headings claim.
+const missingReps = [];
+if (cur.selfcompile?.heap_ptr_bytes == null) missingReps.push("selfcompile heap");
+if (cur.benches?.[REPRESENTATIVE.largeBench] == null) missingReps.push(REPRESENTATIVE.largeBench);
+if (execCur?.scenarios && medCur == null) missingReps.push(`exec scenario ${medName}`);
+if (cur.sizes?.samples && cur.sizes.samples[REPRESENTATIVE.smallSample] == null) missingReps.push(`sample ${REPRESENTATIVE.smallSample}`);
+if (cur.benches && Object.keys(cur.benches).length && cur.benches[REPRESENTATIVE.smallBench] == null) missingReps.push(REPRESENTATIVE.smallBench);
+if (missingReps.length) {
+  lines.push(`> ⚠️ representative missing from this snapshot: ${missingReps.join(", ")} — the row above is blank, not flat`);
+  lines.push("");
+}
+
+// --- drift outside the rendered rows ----------------------------------------
+// Every tracked metric, rendered or not, re-checked against the ±2% threshold.
+// This is what makes one-row-per-tier safe: the report stays small when
+// everything is flat, and a regression in a series nobody chose to render
+// still arrives by name.
+function* allMetrics() {
+  yield ["selfcompile heap", "selfcompile.heap_ptr_bytes", cur.selfcompile?.heap_ptr_bytes, base?.selfcompile?.heap_ptr_bytes];
+  for (const k of ["stage2_wasm", "cli_adapter_bundle", "compiler_sources_bundle", "module_source"]) {
+    yield [k, `sizes.${k}`, cur.sizes?.[k], base?.sizes?.[k]];
+  }
+  for (const [name, v] of Object.entries(cur.sizes?.samples || {})) {
+    yield [`sample ${name}`, `sizes.samples.${name}`, v, base?.sizes?.samples?.[name]];
+  }
+  for (const [label, v] of Object.entries(cur.benches || {})) {
+    yield [`B/op ${label}`, `benches.${label}`, v?.bytes_per_op, base?.benches?.[label]?.bytes_per_op];
+  }
+  for (const [name, s] of Object.entries(execCur?.scenarios || {})) {
+    const b = execBase?.scenarios?.[name];
+    if (!wasmtimeChanged) {
+      yield [`${name} fuel`, `exec.${name}.linear.fuel`, s.linear?.fuel, b?.linear?.fuel];
+      yield [`${name} fuel (gc)`, `exec.${name}.gc.fuel`, s.gc?.fuel, b?.gc?.fuel];
+    }
+    yield [`${name} heap`, `exec.${name}.linear.heap_bytes`, s.linear?.heap_bytes, b?.linear?.heap_bytes];
+    yield [`${name} committed`, `exec.${name}.linear.committed_bytes`, s.linear?.committed_bytes, b?.linear?.committed_bytes];
+    yield [`${name} wasm`, `exec.${name}.linear.wasm_bytes`, s.linear?.wasm_bytes, b?.linear?.wasm_bytes];
+    yield [`${name} wasm (gc)`, `exec.${name}.gc.wasm_bytes`, s.gc?.wasm_bytes, b?.gc?.wasm_bytes];
+  }
+}
+const drifted = [];
+for (const [label, key, c, b] of allMetrics()) {
+  if (rendered.has(key)) continue;
+  const pct = pctOf(c, b);
+  if (pct != null && Math.abs(pct) >= 2) drifted.push(`${label} ${fmtPct(pct)}`);
+}
+if (drifted.length) {
+  lines.push(`> drift outside the rows above (±2% threshold, ${drifted.length}): ${drifted.join(" · ")}`);
+  lines.push("");
+} else if (base) {
+  lines.push("> no drift ≥±2% in any other tracked series");
+  lines.push("");
+}
+
+// --- correctness -------------------------------------------------------------
+// Not a perf number, and the loudest thing here by design: golden (linear vs
+// committed expected output) and backend parity (gc vs linear stdout). A
+// mismatch is a silent-wrong candidate, so it survives every cut above.
+if (execCur?.scenarios && Object.keys(execCur.scenarios).length) {
+  if (wasmtimeChanged) {
+    lines.push(`> fuel not comparable to baseline: wasmtime ${execBase.wasmtime} → ${execCur.wasmtime} (per-instruction cost table changed) — fuel Δ omitted`);
+  }
+  const names = Object.entries(execCur.scenarios);
+  const bad = names.filter(([, s]) => s.output !== "ok" && s.output !== "skipped");
+  const gcGaps = names.filter(([, s]) => s.gc?.status && s.gc.status !== "ok");
+  const linBroken = names.filter(([, s]) => s.linear?.status && s.linear.status !== "ok");
+  if (!bad.length && !linBroken.length) {
+    const ran = names.filter(([, s]) => s.output === "ok").length;
+    lines.push(`> output checks: ${ran}/${names.length} scenarios ✅ (linear = golden; gc = linear where the gc lane runs)` +
+      (gcGaps.length ? ` — ${gcGaps.length} gc-lane gap${gcGaps.length > 1 ? "s" : ""} below` : ""));
+  }
+  for (const [name, s] of linBroken) {
+    lines.push(`> ❌ **${name}: linear ${s.linear.status}** — the corpus program no longer compiles/runs`);
+  }
+  for (const [name, s] of bad) {
+    lines.push(`> ❌ **${name}: ${s.output}** — generated code produced WRONG output (silent-wrong candidate, investigate before merging)`);
+  }
+  for (const [name, s] of gcGaps) {
+    lines.push(`> ⚠️ ${name}: gc ${s.gc.status}${s.gc.detail ? ` — ${s.gc.detail}` : ""}`);
+  }
+  lines.push("");
+  if (execCur.status && execCur.status !== "ok" && execCur.status !== "partial") {
+    lines.push(`> exec scenarios: ${execCur.status}`);
+    lines.push("");
+  }
+}
+
 if (cur.micro_status && cur.micro_status !== "ok") {
   lines.push(`> micro benches: ${cur.micro_status}`);
   lines.push("");
 }
-lines.push(`<sub>wall times & runner calibration: recorded in the \`bench-data\` snapshots, not rendered (runner-speed noise — see bench/perf/README.md) · tracked series: bench/perf/tracked_benches.txt · docs: bench/perf/README.md</sub>`);
+lines.push(`<sub>one representative per tier; every other tracked series is re-checked for ±2% drift above · wall times & runner calibration: recorded in the \`bench-data\` snapshots, not rendered (runner-speed noise — see bench/perf/README.md) · tracked series: bench/perf/tracked_benches.txt · docs: bench/perf/README.md</sub>`);
 
 console.log(lines.join("\n"));

--- a/scripts/bench_report.test.mjs
+++ b/scripts/bench_report.test.mjs
@@ -12,7 +12,8 @@ const hashes = {
   bench_sha256: "bench",
 };
 
-// The report renders ONE representative row per size tier (大/中/小) plus
+// The report renders ONE representative row per size tier (Large/Medium/Small)
+// plus
 // coverage. These are the names it renders; a fixture that wants a row to
 // appear has to use them.
 const REP = {
@@ -86,10 +87,10 @@ test("advisory wall-time and calibration data are never rendered", () => {
 
 test("the three tiers render one representative row each, with a per-cell delta", () => {
   const report = render(flatSnapshot("current"), flatSnapshot("baseline"));
-  assert.match(report, /#### 大 — the compiler itself/);
-  assert.match(report, /#### 中 — a real program/);
-  assert.match(report, /#### 小 — micro/);
-  // 大: memory / code / bench, each carrying its OWN delta. A single trailing
+  assert.match(report, /#### Large — the compiler itself/);
+  assert.match(report, /#### Medium — a real program/);
+  assert.match(report, /#### Small — micro/);
+  // Large: memory / code / bench, each carrying its OWN delta. A single trailing
   // Δ column could not say which of the three moved.
   assert.match(report, /\| selfcompile \| 1000 B \(±0\) \| 2\.00 KiB \(±0\) \| 6\.84 KiB \(±0\) \|/);
   assert.match(report, /\| fib \| 648 B \(±0\) \| 0 B \(±0\) \|/);
@@ -208,7 +209,7 @@ const okScenario = {
 };
 const execOf = (scen) => ({ status: "ok", wasmtime: "47.0.2", scenarios: scen });
 
-test("the 中 row reads the representative scenario, and the output check survives the cut", () => {
+test("the Medium row reads the representative scenario, and the output check survives the cut", () => {
   const cur = flatSnapshot("current");
   const base = flatSnapshot("baseline");
   cur.exec = execOf({ [REP.medium]: okScenario, other: okScenario });
@@ -263,7 +264,7 @@ test("coverage leads the report, renders as main's, and degrades when absent", (
     const withCov = run([curP, join(dir, "missing.json"), covP]);
     assert.match(withCov, /#### Coverage \(selfhost suite — measured on main, not this PR\)/);
     // Coverage comes before the tiers.
-    assert.ok(withCov.indexOf("#### Coverage") < withCov.indexOf("#### 大"));
+    assert.ok(withCov.indexOf("#### Coverage") < withCov.indexOf("#### Large"));
     assert.match(withCov, /\| branch union \| 26,442 \| 45,986 \| 57\.50% \| \+0\.43pt 🎉 \|/);
     assert.match(withCov, /\| function union \| 12,950 \| 14,995 \| 86\.36% \| ±0 \|/);
     assert.match(withCov, /cases 582\/582 \(100%\) · measured at `covsha123` \(2026-08-15\)/);

--- a/scripts/bench_report.test.mjs
+++ b/scripts/bench_report.test.mjs
@@ -176,6 +176,24 @@ test("a metric the baseline measured and this run did not is named, not counted 
   assert.doesNotMatch(report, /no drift ≥±2% in any other tracked series$/m);
 });
 
+test("a series the baseline had and this run omits ENTIRELY is named too", () => {
+  // One level up from the null-value case: `bench_metrics.sh` records nothing
+  // at all for a size sample that failed to compile or a bench that parsed no
+  // row, so the key vanishes rather than going null. Iterating `cur` alone
+  // would never visit it and would report the rest as clean.
+  const base = flatSnapshot("baseline");
+  const cur = flatSnapshot("current");
+  base.sizes.samples["fizzbuzz"] = 1208;
+  base.benches["parser_bench.vibe::parse_lexer_vibe"] = { bytes_per_op: 737280 };
+  base.exec = execOf({ [REP.medium]: okScenario, gone: okScenario });
+  cur.exec = execOf({ [REP.medium]: okScenario });
+  const report = render(cur, base);
+  assert.match(report, /measured on the baseline, absent here/);
+  assert.match(report, /sample fizzbuzz/);
+  assert.match(report, /B\/op parser_bench\.vibe::parse_lexer_vibe/);
+  assert.match(report, /gone heap/);
+});
+
 test("a representative cell with no value is named even when its scenario is ok", () => {
   const base = flatSnapshot("baseline");
   const cur = flatSnapshot("current");

--- a/scripts/bench_report.test.mjs
+++ b/scripts/bench_report.test.mjs
@@ -38,10 +38,12 @@ const flatSnapshot = (commit) => ({
   commit,
   date: "2026-08-11",
   selfcompile: { heap_ptr_bytes: 1000, wall_ms_median: 100 },
-  sizes: { stage2_wasm: 2048, samples: { [REP.smallSample]: 648 } },
+  sizes: { stage2_wasm: 2048, cli_adapter_bundle: 4096, samples: { [REP.smallSample]: 648 } },
   benches: {
     [REP.largeBench]: { ns_p50: 5000, bytes_per_op: 7000 },
     [REP.smallBench]: { ns_p50: 5000, bytes_per_op: 0 },
+    // A non-representative series, so the drift scan has something to scan.
+    "alloc_bench.vibe::build_100": { ns_p50: 5000, bytes_per_op: 100 },
   },
   calibration: { label: "build_100", ns_p50: 10000, ...hashes },
 });
@@ -125,7 +127,7 @@ test("a representative missing from the snapshot is named, not rendered as flat"
   delete cur.benches[REP.largeBench];
   delete cur.sizes.samples[REP.smallSample];
   const report = render(cur, flatSnapshot("baseline"));
-  assert.match(report, /representative missing from this snapshot/);
+  assert.match(report, /no value in this snapshot for/);
   assert.match(report, new RegExp(REP.largeBench.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")));
   assert.match(report, /sample fib/);
 });
@@ -146,9 +148,46 @@ test("drift in an UNRENDERED series is named rather than hidden by the cut", () 
   assert.match(report, /B\/op alloc_bench\.vibe::build_100 \+100\.00% ⚠️/);
 });
 
-test("a flat run says so instead of leaving the reader to assume it", () => {
+test("a flat run says so, and says how many series it actually compared", () => {
   const report = render(flatSnapshot("current"), flatSnapshot("baseline"));
-  assert.match(report, /no drift ≥±2% in any other tracked series/);
+  assert.match(report, /no drift ≥±2% in the \d+ other tracked series compared/);
+});
+
+// --- lost instrumentation must not read as agreement -------------------------
+
+test("a metric the baseline measured and this run did not is named, not counted clean", () => {
+  // `bench_metrics.sh` scrapes fuel/memory out of the runner's stderr, so a
+  // scenario that RAN FINE but printed no `vibe::fuel` line is stored as null
+  // under an `ok` status. Skipping it (pctOf -> null) and then printing "no
+  // drift" claims a clean scan over something never measured.
+  const base = flatSnapshot("baseline");
+  const cur = flatSnapshot("current");
+  base.exec = execOf({ [REP.medium]: okScenario, other: okScenario });
+  cur.exec = execOf({
+    [REP.medium]: okScenario,
+    other: { ...okScenario, linear: { ...okScenario.linear, fuel: null, heap_bytes: null } },
+  });
+  const report = render(cur, base);
+  assert.match(report, /measured on the baseline, absent here \(2\)/);
+  assert.match(report, /other fuel/);
+  assert.match(report, /other heap/);
+  // and the scan must not describe itself as clean over them
+  assert.doesNotMatch(report, /no drift ≥±2% in any other tracked series$/m);
+});
+
+test("a representative cell with no value is named even when its scenario is ok", () => {
+  const base = flatSnapshot("baseline");
+  const cur = flatSnapshot("current");
+  base.exec = execOf({ [REP.medium]: okScenario });
+  cur.exec = execOf({ [REP.medium]: { ...okScenario, linear: { ...okScenario.linear, fuel: null } } });
+  const report = render(cur, base);
+  assert.match(report, /no value in this snapshot for: expr_eval fuel/);
+});
+
+test("zero comparable series still says so rather than dropping the line", () => {
+  const bare = { commit: "c", selfcompile: { heap_ptr_bytes: 1 }, sizes: {}, benches: {} };
+  const report = render(bare, { commit: "b", date: "2026-08-11", selfcompile: { heap_ptr_bytes: 1 }, sizes: {}, benches: {} });
+  assert.match(report, /no other tracked series to compare/);
 });
 
 test("a rendered representative is not repeated in the drift line", () => {
@@ -157,7 +196,7 @@ test("a rendered representative is not repeated in the drift line", () => {
   cur.selfcompile.heap_ptr_bytes = 1030;
   const report = render(cur, base);
   assert.doesNotMatch(report, /drift outside the rows above/);
-  assert.match(report, /no drift ≥±2% in any other tracked series/);
+  assert.match(report, /no drift ≥±2% in the \d+ other tracked series compared/);
 });
 
 // --- exec corpus -------------------------------------------------------------

--- a/scripts/bench_report.test.mjs
+++ b/scripts/bench_report.test.mjs
@@ -12,195 +12,236 @@ const hashes = {
   bench_sha256: "bench",
 };
 
-// Snapshots deliberately carry advisory wall-time data (wall_ms_median,
-// ns_p50) and a calibration record — the report must keep IGNORING them:
-// they live in the bench-data history only (runner-speed noise, #1207/#1209).
-function renderReport({ factor, currentWall, baselineWall = 100 }) {
+// The report renders ONE representative row per size tier (大/中/小) plus
+// coverage. These are the names it renders; a fixture that wants a row to
+// appear has to use them.
+const REP = {
+  largeBench: "parser_bench.vibe::parse_checker_vibe",
+  medium: "expr_eval",
+  smallSample: "fib",
+  smallBench: "pure_bench.vibe::fib30",
+};
+
+function run(args) {
+  const result = spawnSync(process.execPath, [reportScript.pathname, ...args], { encoding: "utf8" });
+  assert.equal(result.status, 0, result.stderr);
+  return result.stdout;
+}
+
+function withDir(fn) {
   const dir = mkdtempSync(join(tmpdir(), "vibe-bench-report-"));
-  try {
-    const baseline = {
-      commit: "baseline",
-      date: "2026-08-11",
-      selfcompile: { heap_ptr_bytes: 1000, wall_ms_median: baselineWall },
-      sizes: {},
-      benches: { "b.vibe::case": { ns_p50: 5000, bytes_per_op: 64 } },
-      calibration: { label: "build_100", ns_p50: 10000, ...hashes },
-    };
-    const current = {
-      commit: "current",
-      selfcompile: { heap_ptr_bytes: 1000, wall_ms_median: currentWall },
-      sizes: {},
-      benches: { "b.vibe::case": { ns_p50: 9000, bytes_per_op: 64 } },
-      calibration: { label: "build_100", ns_p50: Math.round(factor * 10000), ...hashes },
-    };
-    const currentPath = join(dir, "current.json");
-    const baselinePath = join(dir, "baseline.json");
-    writeFileSync(currentPath, JSON.stringify(current));
-    writeFileSync(baselinePath, JSON.stringify(baseline));
-    const result = spawnSync(process.execPath, [reportScript.pathname, currentPath, baselinePath], {
-      encoding: "utf8",
-    });
-    assert.equal(result.status, 0, result.stderr);
-    return result.stdout;
-  } finally {
-    rmSync(dir, { recursive: true, force: true });
-  }
+  try { return fn(dir); } finally { rmSync(dir, { recursive: true, force: true }); }
+}
+
+// A snapshot whose representatives are all present and all flat.
+const flatSnapshot = (commit) => ({
+  commit,
+  date: "2026-08-11",
+  selfcompile: { heap_ptr_bytes: 1000, wall_ms_median: 100 },
+  sizes: { stage2_wasm: 2048, samples: { [REP.smallSample]: 648 } },
+  benches: {
+    [REP.largeBench]: { ns_p50: 5000, bytes_per_op: 7000 },
+    [REP.smallBench]: { ns_p50: 5000, bytes_per_op: 0 },
+  },
+  calibration: { label: "build_100", ns_p50: 10000, ...hashes },
+});
+
+function render(cur, base, cov) {
+  return withDir((dir) => {
+    const curP = join(dir, "current.json");
+    writeFileSync(curP, JSON.stringify(cur));
+    const args = [curP];
+    if (base !== undefined) {
+      const baseP = join(dir, "baseline.json");
+      writeFileSync(baseP, JSON.stringify(base));
+      args.push(baseP);
+    }
+    if (cov !== undefined) {
+      if (args.length === 1) args.push(join(dir, "missing.json"));
+      const covP = join(dir, "cov.json");
+      writeFileSync(covP, JSON.stringify(cov));
+      args.push(covP);
+    }
+    return run(args);
+  });
 }
 
 test("advisory wall-time and calibration data are never rendered", () => {
   // Wildly different wall readings and an implausible calibration factor must
-  // leave zero trace in the report — no wall rows, no ns/op rows, no
-  // calibration notes, no advisory section at all.
-  for (const args of [
-    { factor: 0.586, currentWall: 80 },
-    { factor: 1.132, currentWall: 500 },
-  ]) {
-    const report = renderReport(args);
-    // The footer legitimately mentions where the unrendered data lives —
-    // exclude it, then require zero advisory traces in the body.
+  // leave zero trace -- no wall rows, no ns/op rows, no calibration notes.
+  for (const [factor, wall] of [[0.586, 80], [1.132, 500]]) {
+    const base = flatSnapshot("baseline");
+    const cur = flatSnapshot("current");
+    cur.selfcompile.wall_ms_median = wall;
+    cur.calibration.ns_p50 = Math.round(factor * 10000);
+    cur.benches[REP.smallBench].ns_p50 = 9000;
+    const report = render(cur, base);
     const body = report.split("\n").filter((l) => !l.startsWith("<sub>")).join("\n");
     assert.doesNotMatch(body, /wall_ms|ns\/op|Advisory|calibration|runner factor|runner mismatch|<details>/);
-    // The deterministic view of the same tracked bench still renders.
-    assert.match(report, /\| B\/op: b\.vibe::case \| 64 B \| 64 B \| ±0 \|/);
-    // The footer says where the unrendered advisory data lives.
     assert.match(report, /wall times & runner calibration: recorded in the `bench-data` snapshots, not rendered/);
   }
 });
 
-test("deterministic rows keep the tight ±2% flag", () => {
-  const dir = mkdtempSync(join(tmpdir(), "vibe-bench-report-det-"));
-  try {
-    const mk = (heap) => ({
-      commit: "x",
-      selfcompile: { heap_ptr_bytes: heap },
-      sizes: {},
-      benches: {},
-    });
-    const currentPath = join(dir, "current.json");
-    const baselinePath = join(dir, "baseline.json");
-    writeFileSync(currentPath, JSON.stringify(mk(1030)));
-    writeFileSync(baselinePath, JSON.stringify(mk(1000)));
-    const result = spawnSync(process.execPath, [reportScript.pathname, currentPath, baselinePath], {
-      encoding: "utf8",
-    });
-    assert.equal(result.status, 0, result.stderr);
-    assert.match(result.stdout, /\| selfcompile heap_ptr_bytes \| 1\.01 KiB \| 1000 B \| \+3\.00% ⚠️ \|/);
-  } finally {
-    rmSync(dir, { recursive: true, force: true });
-  }
+test("the three tiers render one representative row each, with a per-cell delta", () => {
+  const report = render(flatSnapshot("current"), flatSnapshot("baseline"));
+  assert.match(report, /#### 大 — the compiler itself/);
+  assert.match(report, /#### 中 — a real program/);
+  assert.match(report, /#### 小 — micro/);
+  // 大: memory / code / bench, each carrying its OWN delta. A single trailing
+  // Δ column could not say which of the three moved.
+  assert.match(report, /\| selfcompile \| 1000 B \(±0\) \| 2\.00 KiB \(±0\) \| 6\.84 KiB \(±0\) \|/);
+  assert.match(report, /\| fib \| 648 B \(±0\) \| 0 B \(±0\) \|/);
+  // The old per-series dumps are gone.
+  assert.doesNotMatch(report, /Deterministic \(allocation & size/);
+  assert.doesNotMatch(report, /\| B\/op: /);
+  assert.doesNotMatch(report, /\| sample wasm: /);
 });
 
-// --- exec corpus section (deterministic fuel / memory / parity) ---------------
+test("tier rows keep the tight ±2% flag", () => {
+  const base = flatSnapshot("baseline");
+  const cur = flatSnapshot("current");
+  cur.selfcompile.heap_ptr_bytes = 1030;
+  const report = render(cur, base);
+  assert.match(report, /\| selfcompile \| 1\.01 KiB \(\+3\.00% ⚠️\) \|/);
+});
 
-function renderExecReport({ curExec, baseExec }) {
-  const dir = mkdtempSync(join(tmpdir(), "vibe-bench-report-exec-"));
-  try {
-    const shared = {
-      selfcompile: { wall_ms_median: 100 },
-      sizes: {},
-      benches: {},
-      calibration: { label: "build_100", ns_p50: 10000, ...hashes },
-    };
-    const current = { commit: "current", ...shared, exec: curExec };
-    const currentPath = join(dir, "current.json");
-    writeFileSync(currentPath, JSON.stringify(current));
-    const args = [reportScript.pathname, currentPath];
-    if (baseExec !== undefined) {
-      const baseline = { commit: "baseline", date: "2026-08-11", ...shared, exec: baseExec };
-      const baselinePath = join(dir, "baseline.json");
-      writeFileSync(baselinePath, JSON.stringify(baseline));
-      args.push(baselinePath);
-    }
-    const result = spawnSync(process.execPath, args, { encoding: "utf8" });
-    assert.equal(result.status, 0, result.stderr);
-    return result.stdout;
-  } finally {
-    rmSync(dir, { recursive: true, force: true });
-  }
-}
+test("a change too small to round is not printed as a signed zero", () => {
+  // 858783744 -> 858783740 is a real -0.0000005% change. `-0.00%` would read
+  // as "zero, but negative"; the reader cannot tell it from `±0`.
+  const base = flatSnapshot("baseline");
+  const cur = flatSnapshot("current");
+  base.selfcompile.heap_ptr_bytes = 858783744;
+  cur.selfcompile.heap_ptr_bytes = 858783740;
+  const report = render(cur, base);
+  assert.doesNotMatch(report, /-0\.00%/);
+  assert.match(report, /\(−<0\.01%\)/);
+  // And the same value on both sides still reads as a clean zero.
+  const flat = render(flatSnapshot("current"), flatSnapshot("baseline"));
+  assert.match(flat, /\| selfcompile \| 1000 B \(±0\) \|/);
+});
+
+test("a representative missing from the snapshot is named, not rendered as flat", () => {
+  const cur = flatSnapshot("current");
+  delete cur.benches[REP.largeBench];
+  delete cur.sizes.samples[REP.smallSample];
+  const report = render(cur, flatSnapshot("baseline"));
+  assert.match(report, /representative missing from this snapshot/);
+  assert.match(report, new RegExp(REP.largeBench.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")));
+  assert.match(report, /sample fib/);
+});
+
+// --- the drift line: what makes one row per tier safe ------------------------
+
+test("drift in an UNRENDERED series is named rather than hidden by the cut", () => {
+  const base = flatSnapshot("baseline");
+  const cur = flatSnapshot("current");
+  // Neither of these is a rendered representative.
+  cur.sizes.cli_adapter_bundle = 1100;
+  base.sizes.cli_adapter_bundle = 1000;
+  cur.benches["alloc_bench.vibe::build_100"] = { bytes_per_op: 200 };
+  base.benches["alloc_bench.vibe::build_100"] = { bytes_per_op: 100 };
+  const report = render(cur, base);
+  assert.match(report, /drift outside the rows above \(±2% threshold, 2\)/);
+  assert.match(report, /cli_adapter_bundle \+10\.00% ⚠️/);
+  assert.match(report, /B\/op alloc_bench\.vibe::build_100 \+100\.00% ⚠️/);
+});
+
+test("a flat run says so instead of leaving the reader to assume it", () => {
+  const report = render(flatSnapshot("current"), flatSnapshot("baseline"));
+  assert.match(report, /no drift ≥±2% in any other tracked series/);
+});
+
+test("a rendered representative is not repeated in the drift line", () => {
+  const base = flatSnapshot("baseline");
+  const cur = flatSnapshot("current");
+  cur.selfcompile.heap_ptr_bytes = 1030;
+  const report = render(cur, base);
+  assert.doesNotMatch(report, /drift outside the rows above/);
+  assert.match(report, /no drift ≥±2% in any other tracked series/);
+});
+
+// --- exec corpus -------------------------------------------------------------
 
 const okScenario = {
   linear: { status: "ok", fuel: 1000000, heap_bytes: 4096, committed_bytes: 65536, wasm_bytes: 5000 },
   gc: { status: "ok", fuel: 800000, wasm_bytes: 6000, detail: null },
   output: "ok",
 };
+const execOf = (scen) => ({ status: "ok", wasmtime: "47.0.2", scenarios: scen });
 
-test("exec section renders fuel deltas, gc ratio, and the all-ok output line", () => {
-  const cur = { status: "ok", wasmtime: "47.0.2", scenarios: { demo: okScenario } };
-  const base = { status: "ok", wasmtime: "47.0.2", scenarios: {
-    demo: { ...okScenario, linear: { ...okScenario.linear, fuel: 900000 } },
-  } };
-  const report = renderExecReport({ curExec: cur, baseExec: base });
-  assert.match(report, /Program execution \(deterministic/);
-  assert.match(report, /\| demo \| 1\.00M \| \+11\.11% ⚠️ \| 800k \| ±0 \| 0\.80× \|/);
-  assert.match(report, /\| demo \| 4\.00 KiB \| ±0 \| 64\.0 KiB \| ±0 \| 4\.88 KiB \| ±0 \| 5\.86 KiB \| ±0 \|/);
-  assert.match(report, /output checks: 1\/1 scenarios ✅/);
+test("the 中 row reads the representative scenario, and the output check survives the cut", () => {
+  const cur = flatSnapshot("current");
+  const base = flatSnapshot("baseline");
+  cur.exec = execOf({ [REP.medium]: okScenario, other: okScenario });
+  base.exec = execOf({
+    [REP.medium]: { ...okScenario, linear: { ...okScenario.linear, fuel: 900000 } },
+    other: okScenario,
+  });
+  const report = render(cur, base);
+  assert.match(report, /\| expr_eval \| 4\.00 KiB \(±0\) \| 4\.88 KiB \(±0\) \| 1\.00M \(\+11\.11% ⚠️\) \|/);
+  assert.match(report, /output checks: 2\/2 scenarios ✅/);
 });
 
 test("wasmtime version drift omits fuel deltas instead of comparing across cost tables", () => {
-  const cur = { status: "ok", wasmtime: "48.0.0", scenarios: { demo: okScenario } };
-  const base = { status: "ok", wasmtime: "47.0.2", scenarios: { demo: okScenario } };
-  const report = renderExecReport({ curExec: cur, baseExec: base });
+  const cur = flatSnapshot("current");
+  const base = flatSnapshot("baseline");
+  cur.exec = { status: "ok", wasmtime: "48.0.0", scenarios: { [REP.medium]: okScenario } };
+  base.exec = { status: "ok", wasmtime: "47.0.2", scenarios: { [REP.medium]: okScenario } };
+  const report = render(cur, base);
   assert.match(report, /fuel not comparable to baseline: wasmtime 47\.0\.2 → 48\.0\.0/);
-  assert.match(report, /\| demo \| 1\.00M \| – \| 800k \| – \| 0\.80× \|/);
+  assert.match(report, /\| expr_eval \| .* \| .* \| 1\.00M \(–\) \|/);
 });
 
-// --- test-coverage section (bench-data coverage snapshot, main-only) ----------
+test("a parity mismatch is rendered as a loud silent-wrong flag, a gc gap as a note", () => {
+  const cur = flatSnapshot("current");
+  cur.exec = { status: "partial", wasmtime: "47.0.2", scenarios: {
+    bad: { ...okScenario, output: "parity-mismatch" },
+    gap: { linear: okScenario.linear,
+      gc: { status: "compile-failed", fuel: null, wasm_bytes: null, detail: "GC codegen: unknown constructor or function: Array::map" },
+      output: "ok" },
+  } };
+  const report = render(cur);
+  assert.match(report, /❌ \*\*bad: parity-mismatch\*\* — generated code produced WRONG output/);
+  assert.match(report, /⚠️ gap: gc compile-failed — GC codegen: unknown constructor or function: Array::map/);
+  assert.doesNotMatch(report, /output checks: .* ✅/);
+});
 
-test("coverage snapshot renders as main's coverage with a pt trend, absent when no snapshot", () => {
-  const dir = mkdtempSync(join(tmpdir(), "vibe-bench-report-cov-"));
-  try {
+// --- coverage ----------------------------------------------------------------
+
+test("coverage leads the report, renders as main's, and degrades when absent", () => {
+  withDir((dir) => {
     const minimal = { commit: "x", selfcompile: {}, sizes: {}, benches: {} };
-    const currentPath = join(dir, "current.json");
-    writeFileSync(currentPath, JSON.stringify(minimal));
-    const covPath = join(dir, "coverage_latest.json");
-    writeFileSync(covPath, JSON.stringify({
+    const curP = join(dir, "current.json");
+    writeFileSync(curP, JSON.stringify(minimal));
+    const covP = join(dir, "coverage_latest.json");
+    writeFileSync(covP, JSON.stringify({
       schema: 1, commit: "covsha1234", date: "2026-08-15T12:00:00Z",
       function_union: { hit: 12950, total: 14995, rate: 86.36 },
       branch_union: { hit: 26442, total: 45986, rate: 57.5, exact: false },
       entries_total: 582, entries_passed: 582, case_rate: 100,
       prev: { commit: "old", date: "2026-08-14T00:00:00Z", function_union_rate: 86.36, branch_union_rate: 57.07 },
     }));
-    const withCov = spawnSync(process.execPath,
-      [reportScript.pathname, currentPath, join(dir, "missing.json"), covPath], { encoding: "utf8" });
-    assert.equal(withCov.status, 0, withCov.stderr);
-    assert.match(withCov.stdout, /#### Test coverage \(selfhost suite — measured on main, not this PR\)/);
-    assert.match(withCov.stdout, /\| branch union \| 26,442 \| 45,986 \| 57\.50% \| \+0\.43pt 🎉 \|/);
-    assert.match(withCov.stdout, /\| function union \| 12,950 \| 14,995 \| 86\.36% \| ±0 \|/);
-    assert.match(withCov.stdout, /cases 582\/582 \(100%\) · measured at `covsha123` \(2026-08-15\)/);
-    assert.match(withCov.stdout, /branch union is a LOWER BOUND/);
+    const withCov = run([curP, join(dir, "missing.json"), covP]);
+    assert.match(withCov, /#### Coverage \(selfhost suite — measured on main, not this PR\)/);
+    // Coverage comes before the tiers.
+    assert.ok(withCov.indexOf("#### Coverage") < withCov.indexOf("#### 大"));
+    assert.match(withCov, /\| branch union \| 26,442 \| 45,986 \| 57\.50% \| \+0\.43pt 🎉 \|/);
+    assert.match(withCov, /\| function union \| 12,950 \| 14,995 \| 86\.36% \| ±0 \|/);
+    assert.match(withCov, /cases 582\/582 \(100%\) · measured at `covsha123` \(2026-08-15\)/);
+    assert.match(withCov, /branch union is a LOWER BOUND/);
 
-    const withoutCov = spawnSync(process.execPath,
-      [reportScript.pathname, currentPath], { encoding: "utf8" });
-    assert.equal(withoutCov.status, 0, withoutCov.stderr);
-    assert.doesNotMatch(withoutCov.stdout, /Test coverage/);
+    const withoutCov = run([curP]);
+    assert.doesNotMatch(withoutCov, /Coverage/);
 
     // A 0-byte optional file (how `git show missing > file` leaves things in
     // the perf workflow) must degrade like an absent one, not crash the
-    // report — the first #1883 CI run died exactly here.
+    // report -- the first #1883 CI run died exactly here.
     const emptyBase = join(dir, "empty_base.json");
     const emptyCov = join(dir, "empty_cov.json");
     writeFileSync(emptyBase, "");
     writeFileSync(emptyCov, "");
-    const withEmpty = spawnSync(process.execPath,
-      [reportScript.pathname, currentPath, emptyBase, emptyCov], { encoding: "utf8" });
-    assert.equal(withEmpty.status, 0, withEmpty.stderr);
-    assert.doesNotMatch(withEmpty.stdout, /Test coverage/);
-    assert.match(withEmpty.stdout, /baseline: _none yet_/);
-  } finally {
-    rmSync(dir, { recursive: true, force: true });
-  }
-});
-
-test("a parity mismatch is rendered as a loud silent-wrong flag, a gc gap as a note", () => {
-  const cur = { status: "partial", wasmtime: "47.0.2", scenarios: {
-    bad: { ...okScenario, output: "parity-mismatch" },
-    gap: { linear: okScenario.linear,
-      gc: { status: "compile-failed", fuel: null, wasm_bytes: null, detail: "GC codegen: unknown constructor or function: Array::map" },
-      output: "ok" },
-  } };
-  const report = renderExecReport({ curExec: cur });
-  assert.match(report, /❌ \*\*bad: parity-mismatch\*\* — generated code produced WRONG output/);
-  assert.match(report, /⚠️ gap: gc compile-failed — GC codegen: unknown constructor or function: Array::map/);
-  assert.doesNotMatch(report, /output checks: .* ✅/);
+    const withEmpty = run([curP, emptyBase, emptyCov]);
+    assert.doesNotMatch(withEmpty, /Coverage/);
+    assert.match(withEmpty, /baseline: _none yet_/);
+  });
 });


### PR DESCRIPTION
#2642 merged at `e7550df`, four minutes before this commit reached the branch — so its Codex review findings are fixed here rather than there. (I resolved those threads on #2642 after the merge; the fixes were on the branch but not in the merge, which is what this PR corrects.)

## P1 — the doc narrated the path it abandoned

`docs/incremental-build.md` carried a four-row table of context rules with three marked as corrections, then prose explaining how each failed. `AGENTS.md:234-236` is explicit: rewrite the document as the final state, leave the abandoned path in `git log`.

What the table encoded that is **not** history survives as prose — a context rule can miss in either direction, and the two failures look different:

- **too wide** → the module gets declarations a real compile does not expose (a dependency's private imports), so a green means less than it looks;
- **too narrow** → the comparison *manufactures* a difference that is not there.

The three abandoned rows and their intermediate measurements are in `git log` now.

## P2 — the two lanes sampled the validators at different points

`lc_collect_validator_diags` collected both validators at one call: **before pass 0** on the whole lane, **after pass 4** on the split lane. Production runs them at two points and neither is that one — `zero_alloc_check` is the first thing `effect_lowering_prelude` does, and `lc_validate_stdin_provider_stmts` runs after `unbox_tuple_loop_params` (pass 5), once the merged AST carries canonical import value names. So the two lanes were reading different programs, and `DIAGS validators` could differ for the sample point rather than for what a module can see.

Now two functions at production's two points, on both lanes.

**Stated as alignment, not as a caught bug.** I could not build a program that distinguishes the points. Three shapes probed through the oracle, each a two-file program:

| probe | old points | new points |
|---|---|---|
| `#zero_alloc` fn beside a lambda-hoisting fn | `validators=1` | `validators=1` |
| `#zero_alloc` fn beside a `derive (Eq)` struct | `validators=1` | `validators=1` |
| `#zero_alloc` fn whose own body compares two structs | `validators=0` | `validators=0` |

The change still lands — matching production's order is what the oracle is for and it costs nothing — but the code comment says plainly that nothing here is pinned by a program that tells the points apart.

## P2 — the deferral registries were never cleared

`dtd_eq_deferred_requests`, `dtd_eq_deferred_types` and `dtd_eq_typed_refusals` are process-global, nothing truncated them anywhere in the tree, and their own doc comments said *"since the last reset"*.

They cannot be reset per run like the other synthesis registries, because `eq_mint_deferred_into` reads the **registry** at the link and needs the union over one split run's modules — which is exactly why every *earlier program's* deferrals were still in it. So `eq_deferred_reset` is called at the two **lane** boundaries instead: `desugar_trait_dicts_with_typed_eq` (one program per call) and the per-module driver, before its first module.

**Red-tested**, and building the fixture was the work. A re-export chain is what makes a module defer: `Box` reaches it through `export ./b.vibe { Box }`, so the module *names* the type and cannot see its declaration — the same shape as the `opaque` contract in #2631, without a package on disk. That program reads:

```
SYNTH requests=1/0:-spec:A1_N3_BoxN3_Int+ typed_refused=0/1 deferred=1 minted=1
```

With both resets removed, a second report in the same process then reads `typed_refused=1 deferred=1` — the first program's `Box[Int]`, carried into a program that has no `Box` at all. `minted` stays 0 there because the link's mint finds nothing to build it from, which is the point: the counters describe a program that is not the one being measured.

## Verification

- 39 tests across the four affected files pass on this head: `prelude_module_oracle_test.vibe`, `linked_compile_test.vibe`, `desugar_trait_dicts_module_test.vibe`, `break_lane_synthesized_provenance_test.vibe`.
- `scripts/compiler_gate.sh` is running locally on this head; I will report the result here and fix anything it finds.
- The commit is a clean replay onto the post-merge `main` (identical tree, `b3412794`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CCUq2wJKeDzguGzmx78HkZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01CCUq2wJKeDzguGzmx78HkZ)_