### PR TITLE
ci: the gate lanes build in-job again — the shared build cost more wall time than it saved

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -971,6 +971,24 @@ jobs:
           key: seed-artifact-${{ hashFiles('bootstrap/seed.json') }}
       - name: Ensure seed artifact
         run: bash scripts/ensure_seed.sh
+      - name: Provision PyYAML for the gates that parse the workflows
+        # DECLARED, NOT ASSUMED (Codex reviews of #2646 and #2648, and the
+        # #2252 rule that a gate must not assume the environment it runs in).
+        # check_pkfire_pin.sh and test_ci_compiler_gate_layout.sh both PARSE
+        # the workflows rather than scanning them, so both need a YAML parser.
+        #
+        # FIRST IN THE JOB, not next to the gate that prompted it. This step
+        # sat at position 18 while the layout gate ran at position 8, so on a
+        # runner without a preinstalled PyYAML the job died before its own
+        # declared dependency was installed. I had checked that the step was
+        # in the same JOB and not that it came FIRST -- presence instead of
+        # order, which is the bug check_ci_seed_cache.sh exists to catch.
+        # ubuntu-latest happens to ship PyYAML today -- measured: the gate and
+        # its 12 cases passed on run 34586469800 -- but "happens to ship" is
+        # how a gate ends up failing for a reason unrelated to its subject,
+        # which is how gates end up excused instead of fixed. Installing it
+        # here costs seconds and removes the assumption.
+        run: python3 -m pip install --quiet --disable-pip-version-check pyyaml
       - name: architecture-debt lint self-test
         run: bash scripts/lint_architecture_debt_test.sh
       - name: architecture-debt lint
@@ -999,16 +1017,6 @@ jobs:
         run: bash scripts/check_portable_boundary_test.sh
       - name: portable-boundary gate
         run: bash scripts/check_portable_boundary.sh
-      - name: Provision PyYAML for the pkfire pin gate
-        # DECLARED, NOT ASSUMED (Codex review of #2646, and the #2252 rule that
-        # a gate must not assume the environment it runs in). The gate parses
-        # the workflows rather than scanning them, so it needs a YAML parser.
-        # ubuntu-latest happens to ship PyYAML today -- measured: the gate and
-        # its 12 cases passed on run 34586469800 -- but "happens to ship" is
-        # how a gate ends up failing for a reason unrelated to its subject,
-        # which is how gates end up excused instead of fixed. Installing it
-        # here costs seconds and removes the assumption.
-        run: python3 -m pip install --quiet --disable-pip-version-check pyyaml
       - name: pkfire pin gate self-test
         run: bash scripts/check_pkfire_pin_test.sh
       - name: pkfire pin gate

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -802,7 +802,28 @@ jobs:
   # ci-required requires this matrix, and an empty/unknown lane fails
   # the dispatcher rather than running nothing.
   compiler-gate-lanes:
-    needs: [compiler-build]
+    # NO `needs: [compiler-build]`, DELIBERATELY, AND THE LANES BUILD IN-JOB.
+    # This reverses #2641 for these three jobs only, on the measurement #2641
+    # could not make until main ran a compiler-touching change through the new
+    # layout (run 34583809863, 9793f25d, compiler-build genuinely cold at 168s):
+    #
+    #   old layout, compiler-touching (run 34578957960)   858s wall
+    #   new layout, compiler-touching (run 34583809863)   959s wall
+    #
+    # "Build once" cut JOB time hard (7879s -> 4971s) and lost WALL time on the
+    # path that matters most for compiler work, for two reasons that stack:
+    #
+    #   1. 30 jobs sat behind this dependency, released in a burst, and reached
+    #      only 11 concurrent where the old layout reached 18 -- median job
+    #      start 365s against 3s. compiler-gate (late) began at 489s.
+    #   2. A consumer downloads stage2 but never compiles anything on the way,
+    #      so it never warms the source-fingerprinted header cache for itself.
+    #      The late lane took 466s against 341s of the same work before.
+    #
+    # Building here costs one compiler build per lane in CPU and buys back both:
+    # the lanes start at t=0, and the flatten plus seed -> stage1 -> stage2 they
+    # run leaves the header cache warm for the fixtures that follow. The short
+    # jobs keep using compiler-build, where not building is pure win.
     name: compiler-gate (${{ matrix.lane }})
     runs-on: ubuntu-latest
     strategy:
@@ -829,8 +850,34 @@ jobs:
           dir="wasmtime-${WASMTIME_VERSION}-x86_64-linux"
           curl -sSL --fail --retry 5 --retry-delay 2 --retry-all-errors "https://github.com/bytecodealliance/wasmtime/releases/download/${WASMTIME_VERSION}/${dir}.tar.xz" | tar -xJ
           echo "$PWD/$dir" >> "$GITHUB_PATH"
-      - name: Use the compiler built once for this run
-        uses: ./.github/actions/use-compiler-build
+      - name: Generated compiler artifacts (fingerprint)
+        id: genfp
+        run: echo "fp=$(bash scripts/ensure_generated.sh --print-fingerprint)" >> "$GITHUB_OUTPUT"
+      - name: Cache generated compiler artifacts
+        uses: actions/cache@v4
+        with:
+          path: |
+            lib/@vibe/compiler/compiler_sources_bundle.vibe
+            lib/@vibe/compiler/cli_adapter_bundle.vibe
+            lib/@vibe/compiler/selfbuild_runtime_entry_bundle.vibe
+            lib/@vibe/compiler/_cli_adapter_module_source.vibe
+            lib/@vibe/compiler/cache/codegen_fingerprint.vibe
+            lib/@vibe/compiler/.generated.stamp
+            lib/@vibe/compiler/.generated.inputs
+          key: gen-v1-${{ steps.genfp.outputs.fp }}
+      - name: Ensure generated compiler artifacts
+        run: bash scripts/ensure_generated.sh
+      - name: Cache stage2 (keyed on seed + flat module source)
+        id: stage2-cache
+        uses: actions/cache@v4
+        with:
+          path: _build/_ci_shard_gen
+          key: stage2-v2-${{ steps.genfp.outputs.fp }}-${{ hashFiles('scripts/generations.sh', 'scripts/wasm_vibe_host_runner.js') }}
+      - name: Build stage2 from committed flat module source
+        if: steps.stage2-cache.outputs.cache-hit != 'true'
+        run: |
+          VIBE_PREBUILT_MODULE_SOURCE=lib/@vibe/compiler/_cli_adapter_module_source.vibe \
+            bash scripts/generations.sh build --out-dir _build/_ci_shard_gen
       - name: Compiler-gate lane ${{ matrix.lane }}
         env:
           COMPILER_GATE_LANE: ${{ matrix.lane }}

--- a/scripts/test_ci_compiler_gate_layout.sh
+++ b/scripts/test_ci_compiler_gate_layout.sh
@@ -209,4 +209,61 @@ if ! grep -qF 'bash scripts/generations.sh build' <<<"$lanes_block"; then
   exit 1
 fi
 
+# A GATE THAT PARSES YAML MUST HAVE ITS PARSER INSTALLED FIRST.
+#
+# Twice this session the same shape: the dependency was in the right JOB and
+# not in the right ORDER. check_ci_seed_cache.sh exists because of it for the
+# seed; this is the same bug for PyYAML. The layout gate ran at step 8 while
+# the provisioning step sat at 18, so on a runner without a preinstalled
+# PyYAML the required structural-lint job died before installing its own
+# declared dependency -- and "the hosted image happens to ship it" is exactly
+# the assumption #2252 forbids.
+#
+# Presence is not order, so this checks order.
+if ! python3 - "$workflow" <<'PYEOF'
+import sys
+try:
+    import yaml
+except ImportError:
+    sys.stderr.write("[ci-compiler-gate-layout] FAIL: PyYAML is required to read the job graph.\n")
+    sys.exit(1)
+
+PARSING_GATES = ("test_ci_compiler_gate_layout.sh", "check_pkfire_pin.sh", "check_pkfire_pin_test.sh")
+
+with open(sys.argv[1], encoding="utf-8") as fh:
+    doc = yaml.safe_load(fh)
+
+rc = 0
+for job_id, job in (doc.get("jobs") or {}).items():
+    if not isinstance(job, dict):
+        continue
+    steps = job.get("steps") or []
+    provision = None
+    for n, step in enumerate(steps):
+        if isinstance(step, dict) and "pyyaml" in str(step.get("run", "")).lower():
+            provision = n
+            break
+    for n, step in enumerate(steps):
+        if not isinstance(step, dict):
+            continue
+        run = str(step.get("run", ""))
+        gate = next((g for g in PARSING_GATES if g in run), None)
+        if gate is None:
+            continue
+        if provision is None:
+            print(f"[ci-compiler-gate-layout] {job_id} runs {gate} but never provisions PyYAML",
+                  file=sys.stderr)
+            rc = 1
+        elif provision > n:
+            print(f"[ci-compiler-gate-layout] {job_id} runs {gate} at step {n} but provisions "
+                  f"PyYAML at step {provision} -- the gate dies before its dependency is installed",
+                  file=sys.stderr)
+            rc = 1
+sys.exit(rc)
+PYEOF
+then
+  echo "  Move the PyYAML step ahead of every gate that parses the workflows." >&2
+  exit 1
+fi
+
 echo "[ci-compiler-gate-layout] ok"

--- a/scripts/test_ci_compiler_gate_layout.sh
+++ b/scripts/test_ci_compiler_gate_layout.sh
@@ -92,34 +92,84 @@ require_stage2_builder_wasmtime compiler-build
 # orders them, so the two halves are required together: a job carrying the
 # composite action must declare the dependency, and a job declaring the
 # dependency must actually use the action.
-consumers="$(grep -n 'uses: ./.github/actions/use-compiler-build' "$workflow" | cut -d: -f1)"
-if [ -z "$consumers" ]; then
+# ASK THE YAML WHICH JOBS DEPEND ON compiler-build (Codex review of #2648).
+#
+# This used to test `^    needs:.*compiler-build`, which only sees the flow
+# form. The block form is equally valid and equally binding:
+#
+#     needs:
+#       - compiler-build
+#
+# and the regex does not match it, so a routine reformat could restore the
+# serialization regression with this gate still printing ok -- verified, it
+# did. That is the same mistake scripts/check_pkfire_pin.sh took four rounds
+# to stop making: a lexical approximation of a structural question. One round
+# is enough here.
+#
+# PyYAML is provisioned in the structural-lint job, which is where this gate
+# runs, and a missing parser is fatal rather than a pass.
+deps="$(python3 - "$workflow" <<'PYEOF' || echo "__PYFAIL__"
+import sys
+try:
+    import yaml
+except ImportError:
+    sys.stderr.write(
+        "[ci-compiler-gate-layout] FAIL: PyYAML is required to read the job graph.\n"
+        "  Install it with: python3 -m pip install pyyaml\n"
+    )
+    sys.exit(1)
+
+with open(sys.argv[1], encoding="utf-8") as fh:
+    doc = yaml.safe_load(fh)
+
+for job_id, job in (doc.get("jobs") or {}).items():
+    if not isinstance(job, dict):
+        continue
+    needs = job.get("needs")
+    if needs is None:
+        needs = []
+    elif isinstance(needs, str):          # `needs: compiler-build`
+        needs = [needs]
+    uses = any(
+        isinstance(step, dict)
+        and str(step.get("uses", "")).strip() == "./.github/actions/use-compiler-build"
+        for step in (job.get("steps") or [])
+    )
+    print(f"{job_id}\t{'yes' if 'compiler-build' in needs else 'no'}\t{'yes' if uses else 'no'}")
+PYEOF
+)"
+if [ "$deps" = "__PYFAIL__" ]; then
+  echo "[ci-compiler-gate-layout] FAIL: could not read the job graph (see above)" >&2
+  exit 1
+fi
+
+# THE COMPILER IS BUILT ONCE (#2645). A job that consumes it must say so, or
+# actions/download-artifact races the producer and fails on a run where the
+# scheduler happens to start them together. `needs:` is the only thing that
+# orders them, so the two halves are required together: a job carrying the
+# composite action must declare the dependency, and a job declaring the
+# dependency must actually use the action.
+if ! awk -F'\t' '$3=="yes"{found=1} END{exit !found}' <<<"$deps"; then
   echo "[ci-compiler-gate-layout] no job uses ./.github/actions/use-compiler-build" >&2
   echo "  The shared compiler build is how every gate job gets a stage2." >&2
   exit 1
 fi
-for job in $(awk '
-  /^jobs:[[:space:]]*$/ { in_jobs = 1; next }
-  /^[A-Za-z0-9_-]+:/ { if (!/^jobs:/) in_jobs = 0 }
-  in_jobs && /^  [A-Za-z0-9_-]+:[[:space:]]*$/ { job = $1; sub(/:$/, "", job); print job }
-' "$workflow"); do
-  block="$(sed -n "/^  ${job}:\$/,/^  [a-zA-Z0-9_-]*:\$/p" "$workflow")"
-  uses_shared=0
-  needs_shared=0
-  grep -qF 'uses: ./.github/actions/use-compiler-build' <<<"$block" && uses_shared=1
-  grep -qE '^    needs:.*compiler-build' <<<"$block" && needs_shared=1
-  if [ "$uses_shared" = 1 ] && [ "$needs_shared" = 0 ]; then
+while IFS="$(printf '\t')" read -r job needs_shared uses_shared; do
+  [ -n "${job:-}" ] || continue
+  if [ "$uses_shared" = yes ] && [ "$needs_shared" = no ]; then
     echo "[ci-compiler-gate-layout] ${job} downloads the shared compiler build without 'needs: [compiler-build]'" >&2
     echo "  Add it to the job -- download-artifact cannot wait on its own." >&2
     exit 1
   fi
-  if [ "$needs_shared" = 1 ] && [ "$uses_shared" = 0 ] && [ "$job" != "ci-required" ]; then
+  if [ "$needs_shared" = yes ] && [ "$uses_shared" = no ] && [ "$job" != "ci-required" ]; then
     echo "[ci-compiler-gate-layout] ${job} declares 'needs: [compiler-build]' but never uses it" >&2
     echo "  Either add '- uses: ./.github/actions/use-compiler-build' or drop the dependency;" >&2
     echo "  waiting ~200s for an artifact the job ignores is pure latency." >&2
     exit 1
   fi
-done
+done <<EOF
+$deps
+EOF
 
 # THE LANES MUST NOT WAIT FOR compiler-build.
 #
@@ -139,7 +189,12 @@ if [ -z "$lanes_block" ]; then
   echo "[ci-compiler-gate-layout] FAIL: no compiler-gate-lanes job found -- the scan did not run" >&2
   exit 1
 fi
-if grep -qE '^    needs:.*compiler-build' <<<"$lanes_block"; then
+lanes_needs="$(awk -F'\t' '$1=="compiler-gate-lanes"{print $2}' <<<"$deps")"
+if [ -z "$lanes_needs" ]; then
+  echo "[ci-compiler-gate-layout] FAIL: compiler-gate-lanes is not in the job graph" >&2
+  exit 1
+fi
+if [ "$lanes_needs" = yes ]; then
   echo "[ci-compiler-gate-layout] compiler-gate-lanes declares 'needs: [compiler-build]'" >&2
   echo "  The lanes build in-job on purpose: they are the critical path, and" >&2
   echo "  waiting for the shared build measured 959s against 858s on main" >&2

--- a/scripts/test_ci_compiler_gate_layout.sh
+++ b/scripts/test_ci_compiler_gate_layout.sh
@@ -121,4 +121,37 @@ for job in $(awk '
   fi
 done
 
+# THE LANES MUST NOT WAIT FOR compiler-build.
+#
+# Measured on main, compiler-touching runs: the old layout (every job building
+# in-job, starting at t=0) finished in 858s; the shared-build layout finished in
+# 959s, because 30 jobs released in a burst behind this dependency reached only
+# 11 concurrent against 18 before -- median job start 365s against 3s -- and
+# compiler-gate (late) began at 489s and then ran 466s instead of 341s, having
+# never warmed its own header cache.
+#
+# So compiler-gate-lanes builds in-job on purpose. Re-adding the dependency
+# would restore that regression SILENTLY: CI would still be green, only slower,
+# which is the kind of change nobody notices for weeks. The decision is pinned
+# here rather than left in a comment.
+lanes_block="$(sed -n '/^  compiler-gate-lanes:$/,/^  [a-zA-Z0-9_-]*:$/p' "$workflow")"
+if [ -z "$lanes_block" ]; then
+  echo "[ci-compiler-gate-layout] FAIL: no compiler-gate-lanes job found -- the scan did not run" >&2
+  exit 1
+fi
+if grep -qE '^    needs:.*compiler-build' <<<"$lanes_block"; then
+  echo "[ci-compiler-gate-layout] compiler-gate-lanes declares 'needs: [compiler-build]'" >&2
+  echo "  The lanes build in-job on purpose: they are the critical path, and" >&2
+  echo "  waiting for the shared build measured 959s against 858s on main" >&2
+  echo "  (runs 34583809863 vs 34578957960). Drop the dependency." >&2
+  exit 1
+fi
+# ...and it must still be the job that BUILDS, not one that silently stopped.
+if ! grep -qF 'bash scripts/generations.sh build' <<<"$lanes_block"; then
+  echo "[ci-compiler-gate-layout] compiler-gate-lanes no longer builds stage2 in-job" >&2
+  echo "  Without the build the lanes run against no compiler at all, and the" >&2
+  echo "  header cache they exist to warm stays cold." >&2
+  exit 1
+fi
+
 echo "[ci-compiler-gate-layout] ok"


### PR DESCRIPTION
#2641 made every gate job download one shared compiler build. That was right for **job time** and wrong for the **critical path** — and the measurement that shows it could not be taken until main ran a compiler-touching change through the new layout. Every earlier number in #2641 and #2645 landed on a cache-hit path, which I flagged each time as not the case that matters.

Main run [34583809863](https://github.com/mizchi/vibe-lang/actions/runs/34583809863) (`9793f25d`, a codegen change, `compiler-build` genuinely **cold at 168s**) is finally that run.

## The number

| run | layout | compiler-build | wall | job time |
|---|---|---:|---:|---:|
| [34567587111](https://github.com/mizchi/vibe-lang/actions/runs/34567587111) | old | in-job ×14 | 893s | 7879s |
| [34578957960](https://github.com/mizchi/vibe-lang/actions/runs/34578957960) | old | in-job, **compiler-touching** | **858s** | — |
| [34580632266](https://github.com/mizchi/vibe-lang/actions/runs/34580632266) | new | 19s (cache hit) | 613s | 4921s |
| [34583809863](https://github.com/mizchi/vibe-lang/actions/runs/34583809863) | new | **168s (cold)** | **959s** | 4971s |

"Build once" cut job time hard (7879s → 4971s) and **lost ~100s of wall clock on the path that matters most for compiler work**.

## Why, measured

| | old | new |
|---|---:|---:|
| jobs that ran | 21 | 36 |
| peak concurrency | 18 | **11** |
| median job start | 3s | **365s** |

Two costs stack:

1. **30 jobs sat behind `needs: [compiler-build]`**, released in a burst, and reached only 11 concurrent where the old layout reached 18. `compiler-gate (late)` began at **489s**.
2. **A consumer compiles nothing on the way**, so it never warms the source-fingerprinted header cache for itself. The late lane took **466s against 341s** for the same work before — the cost I wrote down when landing #2641 and could not yet price.

## The change

`compiler-gate-lanes` builds in-job again. The three lanes start at t=0, and the flatten plus seed → stage1 → stage2 they run leaves the header cache warm for the fixtures that follow.

**Scoped to the lanes on purpose.** They are the critical path; the short jobs are not, and they keep the shared build, where not building is pure win and the wait is short. Paying three extra compiler builds in CPU to remove ~395s of wall clock from the longest job is the trade the numbers support — this is not a revert of #2641.

## Pinned, because this regression returns silently

CI would stay green and only get slower, which nobody notices for weeks. `test_ci_compiler_gate_layout.sh` now rejects `needs: [compiler-build]` on the lanes — citing both run ids in the message — and also rejects the lanes *losing* their in-job build, since without it they run against no compiler and warm nothing.

Red-tested, and **the first attempt was wrong in the way this repository keeps warning about**: my mutation landed in the `compiler-build` job instead of the lanes, so the gate "failed" while proving nothing about the new rule. Redone block-scoped, with the mutation verified in place before the gate is asked. The case that matters is a **full revert** — re-adding both `needs:` and the download — because the pre-existing symmetric rule accepts that happily and only the new rule catches it.

## What this does not do

It does not reach 5 minutes. The remaining shape is ~215s of serial bootstrap inside the longest lane plus ~341s of lane work; `tests/gates/late/run.sh` is 9437 lines of straight-line bash with no section boundary to shard on, so splitting it is its own change. Projected wall clock here is ~560s against 955s, to be confirmed against the next compiler-touching main run rather than claimed now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0133gZewqUBf9KhEhj87t7ny

---
_Generated by [Claude Code](https://claude.ai/code/session_0133gZewqUBf9KhEhj87t7ny)_