### PR TITLE
codegen: size the name sets for the map's LOAD FACTOR, not its entry count (#2644 follow-up)

### DIFF
--- a/lib/@vibe/compiler/codegen/common_base/inline_direct_perform.vibe
+++ b/lib/@vibe/compiler/codegen/common_base/inline_direct_perform.vibe
@@ -4861,11 +4861,14 @@ fn edp_needing_names_tab(fn_defs: Array[(Int, Bool, Bool, String, Option[TypeExp
 /// #2386: the membership side of a name array, for a query that asks per
 /// call node rather than per name.
 fn edp_name_set(names: Array[String]) -> MutSet[String] {
-  // Pre-sized because the size is known. It is NOT where the cost is: measured
-  // on `selfcompile_kpi`, pre-sizing moved heap_ptr by 42 KB of the +1.68 MB
-  // these tables cost, so the growth reallocations were a guess and the
-  // entries themselves are the bill.
-  let s: MutSet[String] = MutSet::with_capacity(hash_string, eq_string, Array::length(names))
+  // Sized for the map's LOAD FACTOR, not for the entry count. `MutMap::set`
+  // rehashes to 2x when `(size + tombs + 1) * 10 > cap * 7`, so a capacity of
+  // exactly `n` still rebuilds the table at insertion `0.7n` and lands at
+  // `2n` slots -- which is why passing `n` measured the same as letting it
+  // grow from 16 (42 KB apart on `selfcompile_kpi`: 2700 + 5400 slots against
+  // 16 + 32 + ... + 4096). `ceil(10n/7)` is the smallest capacity at which the
+  // last insertion does not trip that test (Codex review on #2644).
+  let s: MutSet[String] = MutSet::with_capacity(hash_string, eq_string, Array::length(names) * 10 / 7 + 1)
   let mut i = 0
   while i < Array::length(names) {
     MutSet::add(s, Array::get(names, i))


### PR DESCRIPTION
A Codex finding on #2644 that arrived after it was merged. One line plus its comment; halves that change's only cost.

## What was wrong

`MutMap::set` rehashes to 2× when `(size + tombs + 1) * 10 > cap * 7`. So `MutSet::with_capacity(…, n)` does **not** build the table once: it rebuilds at insertion `0.7n` and lands at `2n` slots.

That also explains a number #2644 measured and I misread. Its comment said pre-sizing was worth only 42 KB, so "the growth reallocations were a guess and the entries are the bill". The real reason the two were within 42 KB:

| | slots allocated |
|---|---|
| `MutSet::new_string()`, grown from 16 | 16 + 32 + … + 4096 = 8176 |
| `with_capacity(2700)` | 2700 + 5400 = 8100 |

The same total, by coincidence. I recorded the coincidence as a finding.

## The fix

`ceil(10n/7)`, spelled `n * 10 / 7 + 1` — the smallest capacity at which the last insertion does not trip the test, so the table is built once.

Checked rather than assumed, since a non-power-of-two capacity would be a problem in many table implementations: `home_of` is `h % cap` and `find_index` / `insert_raw` probe linearly from it. Nothing here requires a power of two.

## Measured

`selfcompile_kpi` heap_ptr_bytes, same baseline:

| capacity | Δ |
|---|---:|
| `n` (what #2644 shipped) | +1.67 MB (+0.195%) |
| `ceil(10n/7)` | **+0.81 MB (+0.094%)** |

Output equivalence unchanged: compiling `lib/@vibe/cli/entry.vibe` with the baseline stage2 and with this one gives a byte-identical 39 MB wasm (`sha256 f45fd2a4fc…`).

A third ABBA round on the final artifact, N=3, fresh cache dir per run:

```
warm  base 16212 17581 17544   cand 12827 12935 12529   median -26.9%
```

Pooling all nine pairs across #2644's three rounds, warm median 16115 → 12923 = **−19.8%**, with per-round medians of −16.6%, −11.9% and −26.9%. The spread is the machine, not the change.

## Verification

- `bash scripts/compiler_gate.sh` → `[compiler-gate] ok` (stage2==stage3 fixpoint holds).
- `bash scripts/vibe_fmt.sh --check` clean; `vibe check` clean.

Refs #2644, #2386.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NAeZzkckdAwtQiubBFpdmM

---
_Generated by [Claude Code](https://claude.ai/code/session_01NAeZzkckdAwtQiubBFpdmM)_