### PR TITLE
The #2510 memory KPI, measured: the per-module prelude costs a flat ~117 MB and recovers none of it

### DIFF
--- a/docs/incremental-build.md
+++ b/docs/incremental-build.md
@@ -539,6 +539,56 @@ into a build where indices moved — the stored form or the cache key has to
 account for index assignment. That constraint came out of this measurement; no
 amount of comparing declarations would have produced it.
 
+#### And what it costs in ALLOCATION — the #2510 criterion-5 KPI (2026-09-11)
+
+The section above bounds the split's cost in wall time. The KPI #2510 actually
+states is about memory: *the live set is bounded by the edited module plus
+interfaces.* That had never been measured. It is now, by
+`scripts/prelude_split_memory.sh` (protocol in its header) driving
+`scripts/prelude_split_memory.vibex`.
+
+Corpus: the compiler's own closure (`codegen_lexer_test.vibe`, 190 resolved
+files, a split the lane really builds — 191 modules, 4728 statements mapped,
+asserted per run so no row can be vacuous). `cache_mode = "off"`, one lane per
+process, a fresh `VIBE_BUILD_CACHE_DIR` per lane. `heap_delta` is
+`Profiler::heap_bytes`, a bump pointer, so it is **bytes allocated across the
+compile, not bytes live at its end** — the allocator never frees, and no
+instrument here can report a live set. N=1 per cell because the figure is
+deterministic: every row below reproduced to the byte across separate runs.
+
+| lane | cold | after a one-module edit | unchanged (warm) |
+|---|---:|---:|---:|
+| whole-program | 821,534,940 | 765,264,132 | 510,478,340 |
+| per-module (split) | 938,747,492 | 882,476,684 | 627,625,364 |
+| **split − whole** | **+117,212,552** | **+117,212,552** | **+117,147,024** |
+
+**The split costs a flat ~117 MB and recovers none of it** — +14.3% cold,
++15.3% on the edit it exists for, +22.9% warm. The two left-hand deltas are
+equal *to the byte*, which is the shape of the cost: one interface context
+built per module, paid once per module, independent of what changed. The
+emitted wasm is byte-identical in every row (4,025,394), so this is a price for
+decomposition, not a behavior difference.
+
+**So criterion 5 is not met, and the split alone cannot meet it.** A one-module
+edit rebuild costs 765 MB against a cold 821 MB — 93% of a cold build — so
+almost nothing is being reused across processes to begin with. Nothing persists
+a module's prelude: there is no per-module prelude artifact anywhere under
+`lib/@vibe/compiler/cache/`, so a new process re-runs all 191 module preludes
+whatever changed, and the split adds its ~117 MB on top of that.
+
+That re-orders the remaining work. The per-file binary AST (#2510's fourth
+bullet) is not the last item on the list; it is the **prerequisite that makes
+the split pay for itself**. Until a per-module artifact survives the process,
+turning the split on is a straight loss, which is why it stays behind its
+`use_split` argument rather than becoming the default.
+
+One measurement note, because it nearly produced a false result. The first run
+of this experiment edited `cache/header_codec.vibe`, which is **not** in this
+corpus's closure, and every "leaf-edited" row came back byte-identical to the
+unchanged row — a vacuous experiment that read as a finding. The script now
+resolves the closure with the compiler's own `vibe deps` and refuses a leaf
+that is not in it.
+
 #### What the split path still costs a caller
 
 Codegen emits functions in statement order, so switching lanes permutes the

--- a/lib/@vibe/compiler/ast_binary.vibe
+++ b/lib/@vibe/compiler/ast_binary.vibe
@@ -306,6 +306,34 @@ export fn ast_binary_read_header(r: AstBinaryReader) -> (Bool, Int) {
   }
 }
 
+//# The checked twin of `ast_binary_read_header`, for a decoder reading
+//# UNTRUSTED bytes (#2647 Codex round 13). The raw one parses the version
+//# with `ast_binary_read_varint`, which has no range guard at all: its
+//# `shift` grows without bound and `(b & 127) << shift` wraps silently, so
+//# a corrupt blob carrying the right magic could present a version this
+//# build then accepted. Every other field `ast_binary_read_module` reads
+//# goes through the `_checked` family; the version had no reason to be the
+//# exception.
+//#
+//# `ast_binary_read_header` stays exactly as it was -- raw and checked
+//# twins are how every other primitive in this file is spelled, and the
+//# raw one is what a caller that already trusts its bytes wants.
+export fn ast_binary_read_header_checked(r: AstBinaryReader) -> (Bool, Int) with Exception {
+  if ast_binary_reader_remaining(r) < 4 {
+    (false, 0)
+  } else {
+    let v = ast_binary_read_byte_checked(r)
+    let a = ast_binary_read_byte_checked(r)
+    let s = ast_binary_read_byte_checked(r)
+    let t = ast_binary_read_byte_checked(r)
+    if v != AST_BINARY_MAGIC_V || a != AST_BINARY_MAGIC_A || s != AST_BINARY_MAGIC_S || t != AST_BINARY_MAGIC_T {
+      (false, 0)
+    } else {
+      (true, ast_binary_read_varint_checked(r))
+    }
+  }
+}
+
 //# Checked reads ===
 //#
 //# The primitives above answer for WELL-FORMED input. These report the
@@ -326,9 +354,13 @@ export fn ast_binary_read_byte_checked(r: AstBinaryReader) -> Int with Exception
 export fn ast_binary_read_varint_checked(r: AstBinaryReader) -> Int with Exception {
   let mut result = 0
   let mut shift = 0
+  let mut bytes_read = 0
+  let mut last_payload = 0
   let mut more = true
   while more {
     let b = ast_binary_read_byte_checked(r)
+    bytes_read = bytes_read + 1
+    last_payload = b&127
     // A vibe `Int` is 63-bit, so bits 0..62 are all that can be represented:
     // nine bytes' worth. A tenth byte shifts its payload into positions that
     // WRAP rather than raise (#2647 Codex round 12) -- ULEB128 for 2^64
@@ -347,6 +379,20 @@ export fn ast_binary_read_varint_checked(r: AstBinaryReader) -> Int with Excepti
     } else {
       shift = shift + 7
     }
+  }
+  // CANONICAL form only: a multi-byte encoding whose last group is empty
+  // says nothing the shorter encoding does not (#2647 Codex round 13).
+  // `ast_binary_write_varint` never emits one -- it stops as soon as the
+  // remaining value is zero -- so this rejects only input no encoder of
+  // this format produces.
+  //
+  // The range guard above does NOT cover it, which is the point: the
+  // padding groups are EMPTY, so `(b & 127) != 0` never fires, and a
+  // version field spelled `0x81 0x00` decodes as 1 and is accepted as
+  // supported. One spelling per value is what stops two implementations
+  // from disagreeing about the same bytes.
+  if bytes_read > 1 && last_payload == 0 {
+    throw("ast_binary: varint is not in canonical form")
   }
   result
 }
@@ -597,11 +643,24 @@ export fn ast_binary_read_svarint_checked(r: AstBinaryReader) -> Int with Except
   let mut more = true
   while more {
     let b = ast_binary_read_byte_checked(r)
-    // Same 63-bit limit as the unsigned reader, with the sign taken into
-    // account: past bit 62 a byte can only be repeating the sign, so its
-    // payload must be all-zero (non-negative) or all-one (negative). Anything
-    // else is a value this `Int` cannot hold, and shifting it in wraps.
-    if shift >= 63 && (b&127) != 0 && (b&127) != 127 {
+    // Past bit 62 a byte can only repeat the sign ALREADY ACCUMULATED in
+    // bit 62 -- 127 when that bit is set, 0 when it is not.
+    //
+    // Accepting either value unconditionally was the hole (#2647 Codex
+    // round 13). With bit 62 clear, a final 127 is admitted, its payload
+    // shifts into positions a 63-bit `Int` does not have and wraps away,
+    // and `shift` then reaches 70 -- so the sign-extension arm below is
+    // SKIPPED and the decoder answers 0. Measured on nine 0x80 bytes then
+    // 0x7f: 0, for a value the format cannot hold. svarint carries `EInt`
+    // and `PInt` literals and the byte-offset slots on `EIdent` / `ELet` /
+    // `ELetMut` / `ECall` / `EBinOp` / `EDot`, so that is a changed literal
+    // or a diagnostic pointing at the wrong place, not a miss.
+    let sign_pad = if (result>>62)&1 == 1 {
+      127
+    } else {
+      0
+    }
+    if shift >= 63 && (b&127) != sign_pad {
       throw("ast_binary: svarint exceeds the representable Int range")
     }
     if shift >= 70 {
@@ -1858,7 +1917,7 @@ export fn ast_binary_write_module(buf: Bytes, stmts: Array[Stmt]) -> Unit {
 }
 
 export fn ast_binary_read_module(r: AstBinaryReader) -> Array[Stmt] with Exception {
-  let (ok, version) = ast_binary_read_header(r)
+  let (ok, version) = ast_binary_read_header_checked(r)
   if ok {
     ()
   } else {

--- a/lib/@vibe/compiler/index.vpkg
+++ b/lib/@vibe/compiler/index.vpkg
@@ -383,6 +383,7 @@ fn ast_binary_read_string(r: AstBinaryReader) -> String
 fn ast_binary_read_optstr(r: AstBinaryReader) -> Option[String]
 fn ast_binary_read_span(r: AstBinaryReader) -> (Int, Int)
 fn ast_binary_read_header(r: AstBinaryReader) -> (Bool, Int)
+fn ast_binary_read_header_checked(r: AstBinaryReader) -> (Bool, Int) with Exception
 fn ast_binary_read_byte_checked(r: AstBinaryReader) -> Int with Exception
 fn ast_binary_read_varint_checked(r: AstBinaryReader) -> Int with Exception
 fn ast_binary_read_string_checked(r: AstBinaryReader) -> String with Exception

--- a/lib/@vibe/compiler/tests/ast_binary_parse_equivalence_test.vibe
+++ b/lib/@vibe/compiler/tests/ast_binary_parse_equivalence_test.vibe
@@ -1,0 +1,138 @@
+//# Imports
+
+import ../ast_binary.vibe {
+  ast_binary_read_module, ast_binary_reader_new, ast_binary_reader_remaining, ast_binary_write_module
+}
+
+import @vibe/compiler/syntax {
+  lex, parse_program, print_stmt
+}
+
+import @vibe/ast {
+  Stmt
+}
+
+import @vibe/compiler/contract {
+  extract_require_pins, parse_contract_program
+}
+
+//# Functions
+
+fn rendered(stmts: Array[Stmt]) -> String {
+  let out = StringBuilder::new()
+  let mut i = 0
+  while i < Array::length(stmts) {
+    StringBuilder::push(out, print_stmt(Array::get(stmts, i)))
+    StringBuilder::push(out, "\n")
+    i = i + 1
+  }
+  StringBuilder::freeze(out)
+}
+
+/// Parse -> encode -> decode -> render, against parse -> render.
+///
+/// This is the question the 44 round-trip tests do NOT answer. Those compare
+/// the codec with itself -- encode, decode, re-encode, same bytes -- so they
+/// are blind to anything the codec drops CONSISTENTLY: a writer that discards
+/// a field encodes nothing for it, decodes to `None`, and re-encodes to the
+/// same bytes. They are also limited to the ASTs someone thought to build by
+/// hand.
+///
+/// Comparing against the PARSER closes both. The left side never goes near
+/// the codec, so a dropped field has nothing to hide behind; and real
+/// compiler sources carry shapes no fixture author would think to write.
+///
+/// Measured, on `ast_binary_write_stmt`'s `SLet` arm writing `None` for the
+/// type annotation instead of `ty`:
+///
+///   ast_binary_stmt_test.vibe               ok    (9 tests, all blind)
+///   this file                               FAIL  (on the real sources)
+///
+/// Two limits, stated rather than left to be discovered:
+///
+///   - `print_stmt` is a RENDERER, so this is a necessary and not a
+///     sufficient condition. A field it does not print, this cannot see.
+///   - A wire format that departs from docs/ast_binary_abi.md while its own
+///     reader inverts it EXACTLY passes this unharmed, because both sides
+///     end at the same AST. That was the shape of the double-encoding string
+///     writer (#2647 rounds 11-12), and what catches that is the
+///     canonical-byte assertion in ast_binary_type_expr_test.vibe, which
+///     pins the bytes on the wire rather than the round trip.
+///
+/// So this does not replace either of the other two kinds. It covers the one
+/// they leave open.
+fn survives(src: String) -> Bool with Exception {
+  survives_stmts(parse_program(lex(src)))
+}
+
+fn survives_stmts(parsed: Array[Stmt]) -> Bool with Exception {
+  let buf = Bytes::new()
+  ast_binary_write_module(buf, parsed)
+  let r = ast_binary_reader_new(buf)
+  let back = handle {
+    ast_binary_read_module(r)
+  } with { Exception::Throw(_) => [] }
+  Array::length(back) == Array::length(parsed) &&
+  rendered(back) == rendered(parsed) &&
+  ast_binary_reader_remaining(r) == 0
+}
+
+fn survives_file(path: String) -> Bool with Exception + Fs {
+  survives(Fs::read_file(path))
+}
+
+/// A `.vpkg` needs BOTH of the loader's two departures from an ordinary
+/// source, or it does not parse at all: the header is not vibe syntax
+/// (`name = @vibe/ast`), so the directives are blanked to spaces first (byte
+/// length preserved, so offsets never shift), and the declarations below it
+/// are BODYLESS, which `parse_program` rejects outright -- `expected { but
+/// got fn`. `parse_contract_program` is the grammar the contract lane uses.
+fn survives_contract(path: String) -> Bool with Exception + Fs {
+  let (_pins, blanked) = extract_require_pins(Fs::read_file(path))
+  let (_decls, _opaques, stmts) = parse_contract_program(lex(blanked))
+  survives_stmts(stmts)
+}
+
+//# Misc — the codec against the PARSER, not against itself
+
+test "a decoded AST renders identically to a parsed one, on real sources" {
+  // Real compiler sources rather than hand-written fixtures: they carry
+  // constructs nobody would think to write a fixture for.
+  assert(survives_file("lib/@vibe/compiler/ast_binary.vibe"))
+  assert(survives_file("lib/@vibe/builtin/bool.vibe"))
+  assert(survives_file("lib/@vibe/compiler/cache/header_codec.vibe"))
+  // A contract: bodyless declarations, a Stmt shape no implementation file has.
+  assert(survives_contract("lib/@vibe/ast/index.vpkg"))
+}
+
+test "a decoded AST renders identically on the shapes a fixture would miss" {
+  // Non-ASCII in identifiers and literals -- the case the double-encoding
+  // string writer got wrong while every round trip agreed.
+  assert(survives("fn f() -> String {\n  \"日本語 café 😀\"\n}\n"))
+  // A lambda-valued binding: the one shape whose `ret` slot is genuinely
+  // None, since a bare `fn` demands a return annotation.
+  assert(survives("let f = () -> {\n  1\n}\n"))
+  // The same slots populated: exported, a bounded type formal, an annotated
+  // return, and an effect row.
+  assert(survives("export fn g[T: Eq](a: T, b: T) -> Bool with Exception {\n  a == b\n}\n"))
+  // Float literals, which carry the f64 pattern as the lo/hi varint pair.
+  assert(survives("let a = 1.5\n\nlet b = 0.0 - 2.25\n"))
+  // A named struct pattern. Field SHORTHAND is the only spelling the parser
+  // accepts here -- `parser_base.vibe` pushes `(fname, PBind(fname))` for
+  // every field, so `P::{ x: 0, y: b }` is `expected => but got int`. The
+  // sub-pattern slot `PStruct` carries is reached by destructuring instead,
+  // which is the next case; the round-trip tests build the rest by hand.
+  assert(survives("struct P {\n  x: Int;\n  y: Int\n}\n\nfn h(p: P) -> Int {\n  match p {\n    P::{ x, y } => x + y\n  }\n}\n"))
+  // Destructuring: a nested tuple pattern, so the sub-patterns are not all
+  // plain binders.
+  assert(survives("let ((a, b), c) = ((1, 2), 3)\n"))
+  // An or-pattern, a literal arm and a wildcard.
+  assert(survives("fn k(v: Int) -> Int {\n  match v {\n    1 | 2 => 0\n    _ => 1\n  }\n}\n"))
+  // An effect declaration: the operation is a CamelCase constructor, not a
+  // function, so it is its own Stmt shape.
+  assert(survives("export effect Log {\n  Emit(String) -> Unit\n}\n"))
+  // An import with an alias and a re-export: two distinct Stmt tags that a
+  // file-at-a-time cache has to tell apart.
+  assert(survives("import ./dep.vibe {\n  a as b\n}\n"))
+  assert(survives("export ./dep.vibe {\n  a, b\n}\n"))
+}

--- a/lib/@vibe/compiler/tests/ast_binary_test.vibe
+++ b/lib/@vibe/compiler/tests/ast_binary_test.vibe
@@ -6,7 +6,30 @@ import ../ast_binary.vibe {
   ast_binary_write_optstr, ast_binary_write_span, ast_binary_write_header,
   ast_binary_reader_new, ast_binary_read_byte, ast_binary_read_varint, ast_binary_read_svarint,
   ast_binary_read_bool, ast_binary_read_string, ast_binary_read_optstr, ast_binary_read_span,
-  ast_binary_read_header
+  ast_binary_read_header, ast_binary_read_header_checked, ast_binary_read_module,
+  ast_binary_read_svarint_checked, ast_binary_read_varint_checked
+}
+
+//# Functions
+
+/// Assert the MESSAGE, not merely that something was refused: a decoder that
+/// threw for the wrong reason would pass a bare "it refused" check.
+fn svarint_outcome(raw: Array[Int]) -> String {
+  handle {
+    __to_string(ast_binary_read_svarint_checked(ast_binary_reader_new(Bytes::from_array(raw))))
+  } with { Exception::Throw(msg) => msg }
+}
+
+fn varint_outcome(raw: Array[Int]) -> String {
+  handle {
+    __to_string(ast_binary_read_varint_checked(ast_binary_reader_new(Bytes::from_array(raw))))
+  } with { Exception::Throw(msg) => msg }
+}
+
+fn module_outcome(raw: Array[Int]) -> String {
+  handle {
+    __to_string(Array::length(ast_binary_read_module(ast_binary_reader_new(Bytes::from_array(raw)))))
+  } with { Exception::Throw(msg) => msg }
 }
 
 //# Misc — parity tests against docs/ast_binary_abi.md
@@ -232,10 +255,12 @@ test "ast_binary: header bad magic rejected" {
   }
 }
 
-//# Cross-impl parity: this byte sequence MUST be produced by the
-//# MoonBit `serialize_module_binary(Module { stmts: [] })` —
-//# header (5 bytes) + array_count varint(0) (1 byte) = 6 bytes
-//# total: 'v','A','S','T', version=1, count=0.
+//# The empty module's bytes, pinned so any implementation of
+//# docs/ast_binary_abi.md can be checked against them: header (5 bytes) +
+//# array_count varint(0) (1 byte) = 6 total, 'v','A','S','T', version=1,
+//# count=0. This used to cite the MoonBit host's `serialize_module_binary`
+//# as the producer; that host was retired in #594, so the citation named
+//# something that no longer exists.
 test "ast_binary: empty-module canonical bytes" {
   let expected = Bytes::new()
   Bytes::push(expected, AST_BINARY_MAGIC_V)
@@ -254,4 +279,58 @@ test "ast_binary: empty-module canonical bytes" {
     assert(Bytes::get(actual, i) == Bytes::get(expected, i))
     i = i + 1
   }
+}
+
+//# Misc — what a CORRUPT blob must not be able to say (#2647 Codex round 13)
+
+test "ast_binary: svarint padding must repeat the sign already accumulated" {
+  // Nine 0x80 bytes then 0x7f. The range guard used to admit a final 127
+  // whatever the accumulated sign was; its payload then shifted into
+  // positions a 63-bit `Int` does not have, `shift` reached 70, and the
+  // sign-extension arm was skipped -- so this answered 0 for a value the
+  // format cannot represent. Measured before the fix: "0".
+  assert_eq(svarint_outcome([128, 128, 128, 128, 128, 128, 128, 128, 128, 127]), "ast_binary: svarint exceeds the representable Int range")
+  // The control at the boundary, so the guard cannot pass by refusing
+  // everything long: -2^62 IS representable, and its canonical encoding is
+  // eight 0x80 bytes then 0x40 -- nine bytes reaching bit 62.
+  assert_eq(svarint_outcome([128, 128, 128, 128, 128, 128, 128, 128, 64]), "-4611686018427387904")
+  // And the ordinary short forms still decode.
+  assert_eq(svarint_outcome([127]), "-1")
+  assert_eq(svarint_outcome([1]), "1")
+}
+
+test "ast_binary: a varint must be in canonical form" {
+  // `0x81 0x00` is 1 spelled in two bytes. The RANGE guard cannot see it --
+  // the padding group is empty, so `(b & 127) != 0` never fires -- which is
+  // why reading the version through the checked reader alone would not have
+  // closed this.
+  assert_eq(varint_outcome([129, 0]), "ast_binary: varint is not in canonical form")
+  // Canonical multi-byte encodings are untouched: 128 is [0x80, 0x01].
+  assert_eq(varint_outcome([128, 1]), "128")
+  // A single 0x00 is the canonical encoding of 0, not a padded anything.
+  assert_eq(varint_outcome([0]), "0")
+  assert_eq(varint_outcome([1]), "1")
+}
+
+test "ast_binary: the module decoder reads its version through the checked reader" {
+  // Magic + version 1 + count 0 -- the empty module, accepted.
+  assert_eq(module_outcome([118, 65, 83, 84, 1, 0]), "0")
+  // Magic + a PADDED version 1 + count 0. The raw header reader answers
+  // `version == 1` and the blob used to decode as an empty AST -- a wrong
+  // answer rather than a cache miss.
+  assert_eq(module_outcome([118, 65, 83, 84, 129, 0, 0]), "ast_binary: varint is not in canonical form")
+  // An unsupported version is still reported as one.
+  assert_eq(module_outcome([118, 65, 83, 84, 2, 0]), "ast_binary: unsupported version 2")
+  // Bad magic is still bad magic.
+  assert_eq(module_outcome([0, 0, 0, 0, 1, 0]), "ast_binary: bad magic")
+}
+
+test "ast_binary: the checked header twin answers like the raw one on good input" {
+  let buf = Bytes::new()
+  ast_binary_write_header(buf)
+  let (ok, v) = handle {
+    ast_binary_read_header_checked(ast_binary_reader_new(buf))
+  } with { Exception::Throw(_msg) => (false, 0) }
+  assert(ok)
+  assert(v == AST_BINARY_VERSION)
 }

--- a/scripts/prelude_split_memory.sh
+++ b/scripts/prelude_split_memory.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+# #2510 criterion 5: what the per-module prelude (#2575 item 2) costs in
+# allocation, measured on the compiler's own closure.
+#
+#   bash scripts/prelude_split_memory.sh [corpus] [leaf]
+#
+# This is a MEASUREMENT, not a gate: it prints numbers and always exits 0, so
+# there is no pass/fail property for a `_test.sh` to red-test. That is also why
+# it is not named `check_*` / `*_gate` -- scripts/check_gate_self_tests.sh's
+# ratchet is for scripts that make a claim, and this one only reports.
+#
+# The protocol is the one .claude/skills/compiler-perf-profiling insists on,
+# because without it the numbers lie (#2393/#2394):
+#
+#   - ONE lane per process, each with its OWN VIBE_BUILD_CACHE_DIR. Two lanes
+#     in one process would let the first warm every persistent cache the
+#     second reads; the skill measures that asymmetry at ~8.0s/1.46GB cold vs
+#     ~4.7s/727MB warm, larger than anything being compared here.
+#   - three temperatures per lane: cold (fresh cache), after a ONE-MODULE
+#     edit (the scenario the split exists for), and unchanged-warm.
+#   - `heap_delta` comes from `Profiler::heap_bytes`, a BUMP pointer, so it is
+#     bytes ALLOCATED across the compile, not bytes live at the end. N=1 per
+#     cell is enough BECAUSE of that: the figure is deterministic for a given
+#     input and cache state, and reproduced to the byte across runs. Wall time
+#     would need N>=3; this does not report wall.
+#
+# The leaf must really be in the corpus's import closure. It is checked here,
+# because the first run of this measurement edited a file that was NOT, and
+# every "leaf-edited" number came back byte-identical to the unchanged-warm
+# one -- a vacuous experiment that looked like a result.
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+CORPUS="${1:-lib/@vibe/compiler/tests/codegen_lexer_test.vibe}"
+LEAF="${2:-lib/@vibe/core/defaults.vibe}"
+
+for f in "$CORPUS" "$LEAF"; do
+  if [ ! -f "$f" ]; then
+    echo "prelude_split_memory.sh: not found: $f" >&2
+    exit 2
+  fi
+done
+
+cli="${VIBE_PRELUDE_SPLIT_CLI_WASM:-}"
+if [ -z "$cli" ]; then
+  cli="$(ls -d _build/selfhost/generations/*/ 2>/dev/null | tail -1)stage2.wasm"
+fi
+if [ ! -f "$cli" ]; then
+  echo "prelude_split_memory.sh: no compiler wasm; set VIBE_PRELUDE_SPLIT_CLI_WASM" >&2
+  exit 2
+fi
+
+tmp_dir="$(mktemp -d "${TMPDIR:-/tmp}/vibe_prelude_split.XXXXXX")"
+trap 'cp "$tmp_dir/leaf.orig" "$LEAF" 2>/dev/null || true; rm -rf "$tmp_dir"' EXIT
+
+# The closure the build actually reads, from the compiler itself -- the same
+# query `pkf run test-affected` uses, so it cannot drift from what is compiled.
+closure="$tmp_dir/closure.txt"
+VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_IMPORT_ABI=raw VIBE_DEPS=1 \
+  bash "$ROOT_DIR/scripts/run_wasm_vibe_host_runner.sh" \
+  --invoke cli_main "$cli" "$CORPUS" "$closure" __no_entry__ >/dev/null 2>&1 || true
+if [ ! -s "$closure" ]; then
+  echo "prelude_split_memory.sh: could not resolve the closure of $CORPUS" >&2
+  exit 2
+fi
+if ! grep -qx -- "$LEAF" "$closure"; then
+  echo "prelude_split_memory.sh: $LEAF is NOT in the import closure of $CORPUS." >&2
+  echo "  Editing it would change nothing, and every leaf-edited row would" >&2
+  echo "  come back equal to the unchanged one -- a vacuous measurement." >&2
+  exit 2
+fi
+echo "[prelude-split-memory] corpus=$CORPUS closure=$(grep -c . "$closure") leaf=$LEAF"
+
+cp "$LEAF" "$tmp_dir/leaf.orig"
+
+run_one() {
+  local lane="$1" cache_dir="$2" label="$3"
+  local line
+  line="$(VIBE_BUILD_CACHE_DIR="$cache_dir" VIBE_PREOPEN_DIR="$ROOT_DIR" \
+    bash "$ROOT_DIR/scripts/vibe_run.sh" scripts/prelude_split_memory.vibex \
+    -- "$CORPUS" __no_entry__ "$lane" 2>&1 | grep 'prelude-split-memory' || true)"
+  if [ -z "$line" ]; then
+    echo "[prelude-split-memory] $label $lane: no measurement line" >&2
+    exit 1
+  fi
+  printf '%-13s %s\n' "$label" "$line"
+}
+
+for lane in whole split; do
+  cache_dir="$tmp_dir/cache_$lane"
+  mkdir -p "$cache_dir"
+  run_one "$lane" "$cache_dir" "cold"
+  printf '\n// prelude_split_memory.sh measurement touch\n' >> "$LEAF"
+  run_one "$lane" "$cache_dir" "leaf-edited"
+  cp "$tmp_dir/leaf.orig" "$LEAF"
+  run_one "$lane" "$cache_dir" "unchanged"
+done

--- a/scripts/prelude_split_memory.vibex
+++ b/scripts/prelude_split_memory.vibex
@@ -1,0 +1,71 @@
+// #2510 criterion 5: what the per-module prelude costs in allocation, on a
+// real closure rather than a two-file toy.
+//
+// Compiles ONE root through the ordinary RC lane with the prelude split
+// either off or on, and prints the bump-heap delta for that compile.
+//
+//   vibe run scripts/prelude_split_memory.vibex -- <root.vibe> <entry> whole|split
+//
+// One lane per process, deliberately. Running both in one process would let
+// the first compile warm every persistent cache the second reads, and the
+// skill's own measured figure for that asymmetry (cold ~8.0s/1.46GB vs warm
+// ~4.7s/727MB) is larger than anything this is trying to see. The caller
+// gives each process its own VIBE_BUILD_CACHE_DIR; scripts/prelude_split_memory.sh
+// does that, alternates the order, and takes medians.
+//
+// `Profiler::heap_bytes` is a BUMP pointer, so a delta is bytes ALLOCATED in
+// the region, not bytes live at its end -- the allocator never frees. Report
+// it as allocation volume and nothing else: "the live set is bounded by the
+// edited module" is not a claim this instrument can make.
+
+import @vibe/compiler/entry/compiler/file_compile {
+  compile_file_fs_mode_rc_body_cached, compile_file_fs_mode_rc_body_cached_split, ordinary_lane_split_shape
+}
+
+fn arg_at(i: Int, fallback: String) -> String with Env {
+  if i < Env::args_len() {
+    Env::args_get(i)
+  } else {
+    fallback
+  }
+}
+
+fn field(out: StringBuilder, name: String, value: String) -> Unit {
+  StringBuilder::push(out, name)
+  StringBuilder::push(out, value)
+}
+
+fn measure(root: String, entry: String, lane: String) -> Unit with Exception + Fs + Profiler::heap_bytes + Stdout {
+  // Report the split SHAPE before compiling. A run that reports one module
+  // measured nothing about a split: the lane fell back to the whole-program
+  // prelude, and the two lanes are then the same code. This is the same
+  // non-vacuity guard prelude_split_fs_lane_test.vibe carries, and it has to
+  // be here too -- a number is not evidence if the thing it names did not run.
+  let (modules, mapped) = ordinary_lane_split_shape(root)
+  let before = Profiler::heap_bytes()
+  let bytes = if lane == "split" {
+    compile_file_fs_mode_rc_body_cached_split(root, entry, "off", true)
+  } else {
+    compile_file_fs_mode_rc_body_cached(root, entry, "off")
+  }
+  let after = Profiler::heap_bytes()
+  // One line, fixed field order, greppable -- the CLI contract in CLAUDE.md.
+  let out = StringBuilder::new()
+  field(out, "prelude-split-memory lane=", lane)
+  field(out, " modules=", __to_string(modules))
+  field(out, " mapped=", __to_string(mapped))
+  field(out, " heap_delta=", __to_string(after - before))
+  field(out, " wasm_bytes=", __to_string(Bytes::length(bytes)))
+  println(StringBuilder::freeze(out))
+}
+
+fn main() -> Unit with Env + Exception + Fs + Profiler::heap_bytes + Stdout {
+  let root = arg_at(0, "")
+  let entry = arg_at(1, "main")
+  let lane = arg_at(2, "whole")
+  if String::length(root) == 0 {
+    println("usage: prelude_split_memory.vibex <root.vibe> <entry> whole|split")
+  } else {
+    measure(root, entry, lane)
+  }
+}


### PR DESCRIPTION
Follow-up to #2647 (merged at `0ebddad`). Same branch, restarted from `main`.

Two things #2510 lists as "done when" had never been checked. This checks both, and one of them comes back negative in a way that re-orders the remaining work.

## 1. The codec, held against the PARSER instead of against itself

44 round-trip tests prove `encode → decode → re-encode` gives the same bytes. That is blind to a field the writer drops **consistently**: nothing is written, the reader yields `None`, the re-encode matches. It is also limited to the ASTs someone thought to build by hand.

A cache needs the other assurance — that a decoded AST is the one the compiler would have parsed. So: parse real compiler sources, encode, decode, and compare `print_stmt` renderings against the parse that never went near the codec.

Red-tested, `ast_binary_write_stmt`'s `SLet` arm writing `None` for the type annotation instead of `ty`:

| | result |
|---|---|
| `ast_binary_stmt_test.vibe` | ok — 9 tests, all blind |
| this file | **FAIL**, on the real sources |

Two things it found about the lanes it exercises, now recorded in the file rather than rediscovered:

- a **`.vpkg` needs BOTH** of the loader's departures from an ordinary source or it does not parse at all. The header is not vibe syntax, so directives are blanked to spaces first (`extract_require_pins`, byte length preserved); the declarations below it are bodyless, which `parse_program` rejects outright — `expected { but got fn`. `parse_contract_program` is that lane's grammar.
- a **named struct pattern accepts field shorthand only**. `parser_base` pushes `(fname, PBind(fname))` for every field, so `P::{ x: 0 }` is `expected => but got int`. The sub-pattern slot `PStruct` carries is reached by destructuring instead.

The limits are stated in the file too, because this does not replace the other two kinds of test. `print_stmt` is a renderer, so a field it does not print is a field this cannot see; and a wire format that departs from the ABI while its own reader inverts it exactly passes unharmed — which was the shape of the double-encoding string writer, and is why the canonical-byte assertions stay.

## 2. The criterion-5 memory KPI — measured, and not met

#2510's fifth criterion is a memory claim: *the live set bounded by the edited module plus interfaces.* The wall-time section next to it bounds the split's cost at +5.3%; nothing said what it costs in **allocation**.

`scripts/prelude_split_memory.vibex` compiles one root through the ordinary RC lane with the split off or on and prints the bump-heap delta. `scripts/prelude_split_memory.sh` runs the protocol the perf skill requires: one lane per process, a fresh `VIBE_BUILD_CACHE_DIR` per lane, three temperatures.

Compiler's own closure, 190 resolved files, a split the lane really builds (191 modules / 4728 statements, asserted per run so no row can be vacuous):

| lane | cold | after a one-module edit | unchanged |
|---|---:|---:|---:|
| whole-program | 821,534,940 | 765,264,132 | 510,478,340 |
| per-module (split) | 938,747,492 | 882,476,684 | 627,625,364 |
| **split − whole** | **+117,212,552** | **+117,212,552** | **+117,147,024** |

**The split costs a flat ~117 MB and recovers none of it** — +14.3% cold, +15.3% on the edit it exists for, +22.9% warm. The first two deltas are equal *to the byte*, which is the shape of the cost: one interface context per module, paid per module, independent of what changed. Emitted wasm is byte-identical in every row (4,025,394), so this is the price of decomposition and not a behavior difference.

`heap_delta` is `Profiler::heap_bytes`, a bump pointer — bytes **allocated** across the compile, not bytes live at its end. No instrument here can report a live set, and the doc says so rather than implying otherwise. N=1 per cell because the figure is deterministic; every row reproduced to the byte across separate runs.

### Why, and what it changes

A one-module edit rebuild costs **93% of a cold build**, so almost nothing survives the process to begin with. Nothing persists a module's prelude — there is no per-module prelude artifact anywhere under `lib/@vibe/compiler/cache/` — so a new process re-runs all 191 module preludes whatever changed, and the split adds its ~117 MB on top.

So the per-file binary AST is **not the last bullet on #2510's list; it is the prerequisite that makes the split pay for itself.** Until a per-module artifact survives the process, turning the split on is a straight loss, which is why it stays behind its `use_split` argument rather than becoming the default.

### One measurement note

The first run of this experiment edited `cache/header_codec.vibe`, which is **not** in this corpus's closure, and every "leaf-edited" row came back byte-identical to the unchanged row — a vacuous experiment that read as a finding. The script now resolves the closure with the compiler's own `vibe deps` and refuses a leaf that is not in it. The `.vibex` carries the matching guard: it asserts the split shape before compiling, because a run reporting one module measured nothing about a split.

Neither script is named `check_*` / `*_gate`, and neither has a `_test.sh`: they print numbers and always exit 0, so there is no pass/fail property to red-test. `scripts/check_gate_portability.sh` passes on the shell driver.

## Verification

- `ast_binary_parse_equivalence_test.vibe` **green on this base, which is the interesting part**: `main` moved 34 commits ahead and changed `parser_base.vibe` by 224 lines and `printer.vibe` by 92 — exactly what the test exercises — and the codec still reproduces what the parser produces.
- The whole codec + split family re-run on this base: **52 tests, 6 files, 0 failed** (`ast_binary_{,type_expr_,pat_,expr_,stmt_}test`, `prelude_split_fs_lane_test`).
- The measurement protocol re-run end to end from the committed script; the table above is its output.

## Known blocker, not addressed here

Wiring the cache (criterion 4) needs `ast_binary.vibe` inside a seed-compiled package, and its decoder calls `Double::from_i64_bits_lohi` — added in `11f7cef`, **after** the pinned seed `fe58fa8`. Probed both ways: `Double::to_i64_bits_lo`/`_hi` (the write side) compile under the committed seed; `from_i64_bits_lohi` does not. Moving the file into `lib/@vibe/compiler/cache/` therefore fails the seed build outright, and that move is reverted on this branch. Per `docs/bootstrap.md` the fix is a **bootstrap bump**, which publishes a release — left for a decision rather than taken unilaterally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CCUq2wJKeDzguGzmx78HkZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01CCUq2wJKeDzguGzmx78HkZ)_