### PR TITLE
checker: the contract-head check keys on ARITY, not on the name alone (#2659 follow-up)

### DIFF
--- a/fixtures/contract_generic_head_shadowed_formal.vibe
+++ b/fixtures/contract_generic_head_shadowed_formal.vibe
@@ -1,0 +1,25 @@
+/// #2640 review: a type formal may be NAMED `MutSet` -- shadowing is legal and
+/// these names are not reserved. A bare shadowed formal resolves to
+/// `CtNamed("MutSet", [])`, the same representation the contract head has, so
+/// the head check keys on ARITY and this stays as tolerated as the identical
+/// declaration spelled `T`.
+///
+/// A PIN, not a discriminating test: measured, this compiles and runs to 42
+/// against a stage2 built WITHOUT the arity guard too. Seven shapes were tried
+/// to find a program where the unguarded classification changes the answer and
+/// none diverged, so the guard closes a mechanism that is real in the source
+/// rather than a failure that was reproduced.
+struct Cell[MutSet] {
+  value: MutSet
+}
+
+//# Functions
+
+fn read(c: Cell[Int]) -> Int {
+  c.value
+}
+
+export let main = () -> Int {
+  let c = Cell::{ value: 1 }
+  read(c) + 41
+}

--- a/fixtures/err_type_mutmap_from_mutset.vibe
+++ b/fixtures/err_type_mutmap_from_mutset.vibe
@@ -1,0 +1,24 @@
+// #2640: the two contract heads must also be certain AGAINST EACH OTHER. They
+// get separate kinds rather than sharing one -- sharing would make
+// `MutMap[K, V]` and `MutSet[T]` equal to `head_differ`, leaving only
+// `nominal_head_conflict` between them, and a row that never exercises the
+// pair would not notice which one was doing the work.
+
+import @vibe/core {
+  struct MutMap, struct MutSet
+}
+
+//# Functions
+
+fn takes_map(m: MutMap[String, Int]) -> Bool {
+  MutMap::has(m, "x")
+}
+
+export let main = () -> Int {
+  let s: MutSet[String] = MutSet::new_string()
+  if takes_map(s) {
+    1
+  } else {
+    0
+  }
+}

--- a/lib/@vibe/compiler/checker/checker.vibe
+++ b/lib/@vibe/compiler/checker/checker.vibe
@@ -4618,7 +4618,7 @@ fn head_kind(t: Type) -> Int {
     // builtin receiver checks (`Array::get(record { a: 1 }, 0)` etc.) pass
     // and codegen reads the record layout as the wrong representation.
     CtRecord(_) => 14,
-    CtNamed(name, _) => if name == "MutList" {
+    CtNamed(name, nargs) => if name == "MutList" {
       15
     } else if name == "Attempt" {
       // #1961 / ADR-0088: `perform?` yields `Attempt[T, E]`, a compiler-owned
@@ -4655,7 +4655,7 @@ fn head_kind(t: Type) -> Int {
       // Array sites needed it. Here both directions need a head, so the head is
       // where it belongs.
       18
-    } else if name == "MutMap" {
+    } else if name == "MutMap" && Array::length(nargs) > 0 {
       // #2640: `@vibe/core`'s collections are declared BODYLESS in its
       // contract (`type MutMap[K, V]`, `type MutSet[T]`), so a consumer sees
       // them as `CtNamed` and they landed in the tolerated `0` bucket --
@@ -4670,12 +4670,29 @@ fn head_kind(t: Type) -> Int {
       //
       // Same treatment as MutList / Attempt / Map / FrozenArray above, for the
       // same reason: their runtime representation is compiler-owned, so a
-      // certain head is what the check needs. This is an allow-list and that
-      // is a proxy for the property (a `CtNamed` that is a declared nominal
-      // rather than a type parameter in scope); the general fix needs the
-      // scope `head_kind` does not have, and is the same root as #2631/#2634.
+      // certain head is what the check needs.
+      //
+      // APPLIED ONLY, and that is the load-bearing half (Codex review on
+      // #2644's successor). A type formal may be NAMED `MutSet`: shadowing is
+      // legal, these names are not reserved, and
+      // `resolve_type_expr_core_shadowed` gives a bare shadowed formal
+      // `CtNamed(name, [])` -- the same representation. Classifying by the
+      // string alone would make `struct Cell[MutSet] { value: MutSet }`
+      // behave differently from the identical declaration spelled `T`, whose
+      // tolerance is what the `0` bucket exists for. An APPLIED occurrence is
+      // not that case: the contract declares both heads WITH parameters
+      // (`type MutMap[K, V]`, `type MutSet[T]`), and a shadowed formal with
+      // arity resolves to `CtApplied`, not here. So the arity is the property
+      // and the name is not asked to carry it alone.
+      //
+      // The four entries above are unguarded and carry the same latent
+      // exposure; narrowing them is a separate change with its own
+      // measurement, not a drive-by.
       19
-    } else if name == "MutSet" {
+    } else if name == "MutSet" && Array::length(nargs) > 0 {
+      // Its own kind, not MutMap's: sharing one would make `MutMap[K, V]` and
+      // `MutSet[T]` equal to `head_differ`, and then only `nominal_head_conflict`
+      // stands between them. Two heads, two kinds.
       20
     } else {
       0

--- a/tests/gates/late/run.sh
+++ b/tests/gates/late/run.sh
@@ -964,6 +964,10 @@ send_check_reject "err_type_ord_marker_bound_struct.vibe" 'no impl `Ord` for `To
 # head would leave the other open and this row would not notice.
 send_check_reject "err_type_mutset_from_array.vibe" 'expected MutSet[String], got Array[String]' "cgenhead"
 send_check_reject "err_type_array_from_mutset.vibe" 'expected Array[String], got MutSet[String]' "cgenhead2"
+# And against EACH OTHER: the two heads get separate kinds, so this pair is
+# caught by `head_differ` rather than falling through to
+# `nominal_head_conflict`. A shared kind would pass every other row here.
+send_check_reject "err_type_mutmap_from_mutset.vibe" 'expected MutMap[String, Int], got MutSet[String]' "cgenhead3"
 # The control, and the reason the two rows above cannot pass by rejecting the
 # type outright: the same heads used correctly -- including a function
 # polymorphic over the element, which is what the `0` bucket exists for --
@@ -983,6 +987,34 @@ cgenok_out="$(VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runne
 # a run that merely exits 0 would pass while returning anything.
 if [ "$(printf '%s' "$cgenok_out" | tail -1)" != "42" ]; then
   echo "[compiler-gate] FAIL: contract_generic_head_ok got '$cgenok_out' (want 42)" >&2
+  exit 1
+fi
+# The SHADOWING pin (Codex review): a type formal may be NAMED `MutSet` --
+# shadowing is legal, these names are not reserved, and a bare shadowed formal
+# resolves to `CtNamed("MutSet", [])`, the same representation the contract
+# head has. The head check keys on ARITY so the string is never asked to carry
+# that distinction alone.
+#
+# This row is a PIN, not a discriminating test, and the difference is worth
+# stating: measured, it compiles and runs to 42 against a stage2 built WITHOUT
+# the arity guard as well. Seven shapes were tried to find a program where the
+# unguarded classification changes the answer -- a bare formal field, an
+# un-instantiated struct literal, an anonymous record against a uniquely
+# matched struct, a bare-struct annotation -- and none diverged from the same
+# declaration spelled `T`. So the guard is a narrowing that costs nothing and
+# closes a mechanism that is real in `resolve_type_expr_core_shadowed`, and
+# this row holds the behaviour still rather than proving it.
+VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
+  bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
+  fixtures/contract_generic_head_shadowed_formal.vibe "$senddir/cgenshadow.wasm" main >/dev/null 2>&1 || true
+if [ ! -s "$senddir/cgenshadow.wasm" ]; then
+  echo "[compiler-gate] FAIL: a type formal named MutSet no longer compiles -- the #2640 head check classifies shadowed formals" >&2
+  cat "$senddir/cgenshadow.wasm.diag" 2>/dev/null >&2 || true
+  exit 1
+fi
+cgenshadow_out="$(VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh --invoke _start "$senddir/cgenshadow.wasm" 2>&1)" || cgenshadow_out="<run failed> $cgenshadow_out"
+if [ "$(printf '%s' "$cgenshadow_out" | tail -1)" != "42" ]; then
+  echo "[compiler-gate] FAIL: contract_generic_head_shadowed_formal got '$cgenshadow_out' (want 42)" >&2
   exit 1
 fi
 # #1090 review: bounds are enforced on the IMPORT (check_program_with_env /


### PR DESCRIPTION
A Codex finding on #2659 that arrived after it was merged.

## What was wrong

A type formal may be **named** `MutSet`. Shadowing is legal, these names are not reserved, and `resolve_type_expr_core_shadowed` gives a bare shadowed formal the same representation the contract head has:

```vibe
TyName(name) => if type_expr_name_is_shadowed(shadow, name) {
  CtNamed(name, array_empty())        // core/types.vibe:3014
```

So classifying by the string alone would let

```vibe
struct Cell[MutSet] { value: MutSet }
```

behave differently from the identical declaration spelled `T`, whose tolerance is the whole point of `head_kind`'s `0` bucket. The repo's own comment two functions over already says this representation *"is INDISTINGUISHABLE from an [in-scope formal]"*.

## The fix

Key on **arity**. A shadowed formal that *has* arity resolves to `CtApplied` (core/types.vibe:3038), not to this arm, and the contract declares both heads **with** parameters (`type MutMap[K, V]`, `type MutSet[T]`) — so an applied `CtNamed("MutSet", [..])` cannot be a shadowed formal. `Array::length(nargs) > 0` separates the two exactly, and the name is never asked to carry the distinction alone.

`MutSet` also gets its own kind rather than sharing `MutMap`'s: sharing would make `MutMap[K, V]` and `MutSet[T]` equal to `head_differ`, leaving only `nominal_head_conflict` between them. `fixtures/err_type_mutmap_from_mutset.vibe` is the row for that pair, and it is rejected.

## What is proven, and what is only pinned

**I could not reproduce the divergence**, and the new shadowing row is labelled accordingly rather than presented as a red test. Seven shapes, each against a stage2 with and without the guard, and against the same declaration spelled `T`:

| shape | guarded | unguarded | `T` spelling |
|---|---|---|---|
| `struct Cell[MutSet] { value: MutSet }` + `Cell::{ value: 1 }` (un-instantiated literal) | compiles | compiles | compiles |
| `record { value: 1 }` against a uniquely matched `Cell[Int]` | compiles | compiles | compiles |
| `record { value: 1 }` against a bare `Cell` annotation | rejected | same | same |
| `let c = record { value: 1 }` then `c.value` | compiles | compiles | compiles |
| `Holder::{ slot: 1 }` through `fn read(h: Holder[Int])` | compiles | compiles | compiles |
| `Cell[Int]` annotation + struct literal | compiles | compiles | compiles |
| `fn adopt[T](s: MutSet[T], x: T)` | compiles | compiles | — |

So `fixtures/contract_generic_head_shadowed_formal.vibe` compiles and runs to 42 against **both** builds. It is a **pin**, and the gate comment and the fixture doc say so in those words — this repo's rule is that a mutation matching nothing passes while proving nothing, and recording the gap beats dressing it up. The guard stands on the representation argument, not on a reproduction: it is a narrowing that costs nothing and closes the mechanism at its source.

The four entries above this one (`MutList`, `Attempt`, `Map`, `FrozenArray`) are **unguarded** and carry the same latent exposure. Narrowing them is a separate change with its own measurement, and the comment says so at the site.

## Measured, with a stage2 built from this change

```
Array[String]  -> MutSet[String]          rejected
MutSet[String] -> Array[String]           rejected
Array[String]  -> MutMap[String, Int]     rejected
MutSet[String] -> MutMap[String, Int]     rejected   (new row)
Int            -> MutSet[String]          rejected
Array[String]  -> StringSet               rejected
Array[String]  -> Bar (imported struct)   rejected
Array[String]  -> Array[Int]              rejected
struct Cell[MutSet] { value: MutSet }     COMPILES, = the `T` spelling
contract_generic_head_ok.vibe             COMPILES, runs to 42
```

## Verification

- `bash scripts/compiler_gate.sh` → `[compiler-gate] ok` (stage2==stage3 fixpoint holds), re-run after rebasing onto `0ebddad` since #2647 landed 239 files in between.
- `bash tests/gates/late/run.sh` → exit 0.
- `bash scripts/vibe_fmt.sh --check` clean.

Refs #2659, #2640.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NAeZzkckdAwtQiubBFpdmM

---
_Generated by [Claude Code](https://claude.ai/code/session_01NAeZzkckdAwtQiubBFpdmM)_