### PR TITLE
release notes: the pinned seed is published, so the known gap is gone (#2655)

### DIFF
--- a/docs/release-notes-0.1.0.md
+++ b/docs/release-notes-0.1.0.md
@@ -144,12 +144,6 @@ the edit that fixes them rather than an internal pass name.
 
 ## Known gaps
 
-- **The pinned seed must be published.** `bootstrap/seed.json` pins
-  `seed/entry-allows-2026-09-11` (#2654); its release is dispatched by hand
-  (`seed-release.yml`). Until it exists a cold checkout rebuilds the seed
-  from its source commit, which fetches `seed/cfg-spans-emission-2026-09-04`
-  and so needs that release published first (#2655). Publishing both closes
-  it.
 - **The Japanese book is a translation of all 20 chapters**, checked for
   identical program output by `pkf run check-tutorial-translation-parity`;
   English (`book/en/`) is canonical.


### PR DESCRIPTION
Follow-up to #2663 (docs only, one bullet).

The 0.1.0 "Known gaps" list still said the pinned seed must be published. Both releases now exist with the pinned hashes: `seed/cfg-spans-emission-2026-09-04` (`3acf3c3f…`, seed-release run 26) and `seed/entry-allows-2026-09-11` (`00f50229…`, run 27), and `bash scripts/ensure_seed.sh` at the merged head fetches and verifies the seed with no rebuild fallback (CI's `Ensure seed artifact` step takes the plain fetch). The bullet described the window inside the bump, which closed with #2663, so it is deleted rather than reworded; roadmap item 8 ("The seed is fetchable") is now simply met.

Refs #2655.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019vCFHoPYJxzou2BsMeWU1S

---
_Generated by [Claude Code](https://claude.ai/code/session_019vCFHoPYJxzou2BsMeWU1S)_