### PR TITLE
gates: the #2305 lane must be told WHICH compiler it is questioning

### DIFF
--- a/tests/gates/lib.sh
+++ b/tests/gates/lib.sh
@@ -90,3 +90,32 @@ gate_resolve_stage2() {
   fi
   export VIBE_STAGE2_WASM="$stage2_wasm"
 }
+
+# gate_split_cli_cache_is_current <cache_dir> <stage2_wasm>
+#
+# Was the split CLI core in <cache_dir> built from THIS stage2? Answers 0 for
+# yes; for anything else it REMOVES the directory and answers 1, so a caller
+# that ignores the status still cannot reuse a mismatched artifact.
+#
+# Identity is `cmp` against a copy of the stage2 kept beside the build, not a
+# hash and not a timestamp. `sha256sum` dies on this container's glibc
+# mismatch under the task runner, and a gate must not fail for a reason
+# unrelated to what it checks (#2252); mtime and size are proxies for
+# identity, and trusting a proxy is what every failure this guards against
+# had in common.
+#
+# Lives here rather than inline in the lane so it can be tested with
+# fabricated inputs -- a copy of the decision inside a test would be another
+# proxy, agreeing with itself.
+gate_split_cli_cache_is_current() {
+  _gscc_dir="$1"
+  _gscc_stage2="$2"
+  if [ -s "$_gscc_dir/index_stage1.wasm" ] && \
+     [ -s "$_gscc_dir/base_stage2.wasm" ] && \
+     [ -s "$_gscc_stage2" ] && \
+     cmp -s "$_gscc_dir/base_stage2.wasm" "$_gscc_stage2"; then
+    return 0
+  fi
+  rm -rf "$_gscc_dir"
+  return 1
+}

--- a/tests/gates/lib_test.sh
+++ b/tests/gates/lib_test.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+# Self-test for the helpers in tests/gates/lib.sh.
+#
+# `gate_split_cli_cache_is_current` decides WHICH compiler the #2305 lane
+# questions. It got one because the thing it replaced -- "reuse whatever is at
+# _build/bench/selfhost_cli_core/index_stage1.wasm" -- produced a false RED
+# twice in one session on a reused workspace, and the same mechanism produces
+# a false GREEN just as easily.
+set -euo pipefail
+
+GATES_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck disable=SC1090
+source "$GATES_DIR/lib.sh"
+
+WORK="$(mktemp -d "${TMPDIR:-/tmp}/vibe_gates_lib_test.XXXXXX")"
+trap 'rm -rf "$WORK"' EXIT
+
+passed=0
+failed=0
+ok()  { echo "ok: $1"; passed=$((passed + 1)); }
+bad() { echo "FAIL: $1" >&2; failed=$((failed + 1)); }
+
+# Two distinct "stage2" artifacts. Content, not names: the helper compares
+# bytes, so the test must too.
+printf 'stage2-A' > "$WORK/a.wasm"
+printf 'stage2-B' > "$WORK/b.wasm"
+
+fresh_cache() {
+  rm -rf "$WORK/cache"; mkdir -p "$WORK/cache"
+  printf 'cli' > "$WORK/cache/index_stage1.wasm"
+  cp "$1" "$WORK/cache/base_stage2.wasm"
+}
+
+# 1. built from THIS stage2 -> reuse, and the cache survives.
+fresh_cache "$WORK/a.wasm"
+if gate_split_cli_cache_is_current "$WORK/cache" "$WORK/a.wasm"; then
+  if [ -s "$WORK/cache/index_stage1.wasm" ]; then
+    ok "a cache built from this stage2 is reused"
+  else
+    bad "answered current but removed the cache"
+  fi
+else
+  bad "a cache built from this stage2 was rejected"
+fi
+
+# 2. built from a DIFFERENT stage2 -> refuse, and the cache is GONE. Removing
+#    it is the half that matters: a caller that ignores the status still
+#    cannot reuse a mismatched artifact.
+fresh_cache "$WORK/b.wasm"
+if gate_split_cli_cache_is_current "$WORK/cache" "$WORK/a.wasm"; then
+  bad "a cache built from another stage2 was accepted"
+elif [ -e "$WORK/cache" ]; then
+  bad "rejected a mismatched cache but left it in place"
+else
+  ok "a cache built from another stage2 is rejected AND removed"
+fi
+
+# 3. same SIZE, different bytes. Size and mtime are the proxies this helper
+#    exists to avoid; without a content compare this case passes wrongly.
+fresh_cache "$WORK/a.wasm"
+printf 'stage2-C' > "$WORK/c.wasm"
+if [ "$(wc -c < "$WORK/a.wasm")" != "$(wc -c < "$WORK/c.wasm")" ]; then
+  bad "the same-size case is not set up: a and c differ in length"
+elif gate_split_cli_cache_is_current "$WORK/cache" "$WORK/c.wasm"; then
+  bad "a same-size, different-content stage2 was accepted"
+else
+  ok "identity is content, not size"
+fi
+
+# 4. no provenance record at all (what every pre-existing cache looks like)
+#    -> refuse. Otherwise the first run after this lands trusts a directory
+#    whose origin nobody knows.
+rm -rf "$WORK/cache"; mkdir -p "$WORK/cache"
+printf 'cli' > "$WORK/cache/index_stage1.wasm"
+if gate_split_cli_cache_is_current "$WORK/cache" "$WORK/a.wasm"; then
+  bad "a cache with no provenance record was accepted"
+else
+  ok "a cache with no provenance record is rejected"
+fi
+
+# 5. a missing stage2 -> refuse rather than treat absence as a match.
+fresh_cache "$WORK/a.wasm"
+if gate_split_cli_cache_is_current "$WORK/cache" "$WORK/nonexistent.wasm"; then
+  bad "a missing stage2 was treated as a match"
+else
+  ok "a missing stage2 is rejected"
+fi
+
+echo "----"
+echo "passed: $passed, failed: $failed"
+[ "$failed" -eq 0 ]

--- a/tests/gates/mid/run.sh
+++ b/tests/gates/mid/run.sh
@@ -2889,7 +2889,34 @@ echo "[compiler-gate] self-discharging owner's closure-typed parameter ok (285)"
 # redundant with the cold one: a port that only passes the cold case is
 # silently permissive, which is worse than no gate.
 echo "[compiler-gate] 114/114 the ADR-0068 gate exists in the split CLI, cold and warm (#2305)"
-sc_cli="${VIBE_SPLIT_CLI_WASM:-_build/bench/selfhost_cli_core/index_stage1.wasm}"
+# WHICH compiler is this gate asking? The answer used to be "whatever
+# `_build/bench/selfhost_cli_core/index_stage1.wasm` happens to hold", with no
+# link to the stage2 the rest of the lane exercises. That path is written by
+# other tooling, so on a reused workspace this gate silently questioned a CLI
+# built from different sources -- twice in one session, and both times the
+# result said nothing about the tree under test:
+#
+#   - an artifact predating the `allows` landing could not parse the gate's
+#     OWN fixture, and answered `expected { but got ident` instead of the
+#     ADR-0068 diagnostic: a false RED;
+#   - the same mechanism can as easily produce a false GREEN, which is the
+#     dangerous direction -- a stale CLI that still refuses correctly while
+#     the current sources no longer do.
+#
+# CLAUDE.md states the rule this broke: a gate that asks the compiler a
+# question has to be TOLD which compiler, and the ones that pick for
+# themselves all pick the same wrong way.
+#
+# `VIBE_SPLIT_CLI_WASM` still overrides, because a caller naming an artifact
+# explicitly has taken responsibility for its provenance.
+sc_cache_dir="_build/_gate_split_cli_core"
+sc_cli="${VIBE_SPLIT_CLI_WASM:-}"
+if [ -z "$sc_cli" ]; then
+  sc_cli="$sc_cache_dir/index_stage1.wasm"
+  if gate_split_cli_cache_is_current "$ROOT_DIR/$sc_cache_dir" "$stage2_wasm"; then
+    echo "[compiler-gate] 114/114 reusing the split CLI core built from THIS stage2 (#2305)"
+  fi
+fi
 if [ ! -s "$ROOT_DIR/$sc_cli" ] && [ ! -s "$sc_cli" ]; then
   # BUILD it rather than skip (Codex review on #2313). The first version of
   # this section skipped when no split CLI core was present -- and `ci.yml`
@@ -2917,6 +2944,9 @@ if [ ! -s "$ROOT_DIR/$sc_cli" ] && [ ! -s "$sc_cli" ]; then
     echo "[compiler-gate] FAIL: split CLI core build produced no artifact for the #2305 gate" >&2
     exit 1
   fi
+  # The provenance record the reuse check above reads. Written only after the
+  # build succeeded, so a half-built cache is never mistaken for a match.
+  cp "$stage2_wasm" "$ROOT_DIR/$sc_built/base_stage2.wasm"
 fi
 if true; then
   case "$sc_cli" in /*) sc_abs="$sc_cli" ;; *) sc_abs="$ROOT_DIR/$sc_cli" ;; esac

--- a/tests/gates/selftests/run.sh
+++ b/tests/gates/selftests/run.sh
@@ -39,4 +39,9 @@ gate_resolve_stage2
 echo "[compiler-gate] selftests: every gate self-test, serially"
 bash "$ROOT_DIR/scripts/check_gate_self_tests.sh"
 bash "$ROOT_DIR/scripts/check_gate_self_tests_test.sh"
+# The gate LIBRARY's own helpers. check_gate_self_tests.sh discovers companions
+# by globbing scripts/, so anything under tests/gates/ is invisible to it --
+# and `gate_split_cli_cache_is_current` decides WHICH compiler the #2305 lane
+# questions, which is exactly the kind of answer that must not go unchecked.
+bash "$ROOT_DIR/tests/gates/lib_test.sh"
 echo "[compiler-gate] gate self-tests ok (#2248)"


### PR DESCRIPTION
Restarted from `main` at `0bd7801`. **This PR is now one commit** — see "What this PR used to be" at the bottom for why it shrank.

## The problem

`tests/gates/mid/run.sh` picked its split CLI like this:

```sh
sc_cli="${VIBE_SPLIT_CLI_WASM:-_build/bench/selfhost_cli_core/index_stage1.wasm}"
```

That path is written by other tooling and has **no link to the `stage2_wasm` the rest of the lane exercises**. On a fresh CI runner it does not exist and the lane builds its own, which is why CI never noticed. On a reused workspace the lane silently questions a CLI built from different sources — twice in one session here:

- an artifact predating the `allows` landing could not parse the lane's **own fixture**, and answered `expected { but got ident` instead of the ADR-0068 diagnostic. A false RED that cost a full gate run before I traced it;
- the same mechanism produces a **false GREEN** just as easily — a stale CLI still refusing correctly while the current sources no longer do — and that direction is the one nobody investigates.

CLAUDE.md already states the rule this broke:

> a gate that asks the compiler a question has to be told WHICH compiler, and the ones that pick for themselves all pick the same wrong way.

## The fix

The cached build is keyed on the stage2 it was built **from**: a copy kept beside it, compared with `cmp`.

- **Not a hash.** `sha256sum` dies on this container's nix-vs-system glibc mismatch under the task runner, and a gate must not fail for a reason unrelated to what it checks (#2252).
- **Not mtime or size.** Those are proxies for identity, and trusting a proxy is what every one of these failures had in common.
- `VIBE_SPLIT_CLI_WASM` still overrides — a caller naming an artifact explicitly has taken responsibility for its provenance.

The decision lives in `tests/gates/lib.sh` rather than inline, so it can be tested with fabricated inputs. A copy of it inside a test would be another proxy, agreeing with itself.

## Verification

`tests/gates/lib_test.sh` — 5 cases, all passing:

| case | why |
|---|---|
| built from this stage2 → reused | the happy path |
| built from another → rejected **and removed** | a caller ignoring the status still must not reuse it |
| same size, different content | the proxy this exists to avoid |
| no provenance record | what every pre-existing cache looks like |
| missing stage2 | absence is not a match |

Red-tested by swapping `cmp` for a size comparison — the same-size case fails, and only that one.

`check_gate_self_tests.sh` discovers companions by globbing `scripts/`, so nothing under `tests/gates/` is visible to it; the selftests lane runs this one explicitly. `check_gate_portability.sh` passes.

Also verified end to end before the branch was reduced: `scripts/compiler_gate.sh` reached `GATE_EXIT=0` with the #2305 lane building its own split CLI rather than reusing a stale one.

---

## What this PR used to be, and why it shrank

It opened carrying a bootstrap bump and a `__Vfp_` parser fix. While it was open, **#2654/#2663 landed the same ground independently** during the release, and better in two of three places. Recording it so the overlap is legible rather than mysterious:

| what I had | what `main` has now |
|---|---|
| `parse_generated_source()` ambient so the bootstrap can re-parse its own `__Vfp_` spellings | `reads_compiler_spelled_type_params()` — same shape, same file, already in |
| `BUILTIN_SHADOW_FORCE_FALLBACK` replacing case 8's "the seed is old" premise | `BUILTIN_SHADOW_NO_BATCH` — same idea, and its case 9 is **stronger** than my 8b: it checks the fallback still *detects and names* a shadow, where mine only checked a clean tree is accepted |
| a bump to `seed/f64-bits-lohi-2026-09-11` | `seed/entry-allows-2026-09-11`, newer — **mine would have reverted it** |

The bump commit is dropped for exactly that reason. #2662 is closed as fixed by `main`.

One thing that survives from the dropped work, because it is now answered: **#2510 criterion 4 is unblocked.** `Double::from_i64_bits_lohi` was the blocker — `ast_binary.vibe`'s decoder needs it and the old seed answered `unknown name`. Probed against `main`'s current seed: it compiles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CCUq2wJKeDzguGzmx78HkZ