### PR TITLE
#2638: round 0 of the borrow inference decomposes, measured by a link

### DIFF
--- a/lib/@vibe/compiler/codegen/common_analysis/common_analysis.vibe
+++ b/lib/@vibe/compiler/codegen/common_analysis/common_analysis.vibe
@@ -3528,63 +3528,10 @@ fn bp_calls_round0_borrow_arms(arms: Array[(Pat, Expr)], round0_names: Array[Str
   found
 }
 
-/// ADR-0092 borrow-inference: for every top-level fn, which of its
-/// parameters are only ever READ. Each such position's ABI flips to
-/// borrowed, program-wide and in lockstep: the caller's plan counts an
-/// ident argument there as a free borrow (no transfer dup) and the callee's
-/// plan-site drop for that param is skipped (linked_compile).
-///
-/// Slice 1 (#1282) inferred position 0 only. This is the per-position
-/// generalization: a fn that consumes param0 but only reads param1 now gets
-/// param1 borrowed, and a fn all of whose params are read-only gets all of
-/// them. **Bit 0 of the result is exactly slice 1's set** -- same
-/// eligibility test, same disqualifiers -- which is what makes
-/// `mask & 1` a byte-identity differential against the previous compiler.
-///
-/// Eligibility is decided per position, all conservative:
-///   - the fn is a top-level `SLet` + `EFn`, and the position is < arity
-///     and < bmask_max_param()
-///   - that param's consume count in the body is 0 (only borrow-position
-///     uses: projections, borrow-arg0 builtin calls -- md_consume_count)
-///   - that param is not mut-captured by an inner closure
-///   - the fn body does not shadow it (a rebinding would make the consume
-///     count unreliable) -- approximated by md_consume_count only, which
-///     counts ANY bare mention; a shadowed rebind's value read would count
-///     as a consume and disqualify the position
-///   - no call anywhere passes a NON-IDENT argument at that position
-///     (ca_collect_nonident_args -- a fresh temp at a borrowed position has
-///     no owner left to release it)
-/// Whole-fn disqualifiers, which zero the mask outright:
-///   - the fn name is used as a VALUE anywhere in the program (indirect
-///     call sites cannot consult this set)
-///   - the caller passes it in `exclude` (the program entry and the
-///     conventional entry names: the host invokes them without consulting
-///     the set either)
-///
-/// Round 0 uses `md_consume_count` without a user borrow set and exactly
-/// preserves the original conservative result. One bounded transitive round
-/// then reads that immutable snapshot through `md_consume_count_pre`; it never
-/// consumes masks being decided in the same round. Only bodies that actually
-/// call a round-0 borrowed function are revisited. A local callee shadow zeros
-/// that function's mask before counting, preserving the owned-call fallback.
-/// This deliberately stops after one extra layer: deeper closure is a possible
-/// future worklist extension, while every intermediate result stays sound.
-///
-/// Returns the SORTED name array and fills `out_masks` aligned to it, so a
-/// single `bsearch_leftmost` on the names indexes straight into the masks.
-/// Ordinary entries have a non-zero inferred borrow mask. A source definition
-/// that shadows a compiler-owned accessor is retained with an authoritative
-/// zero mask when it consumes every parameter. Sorting and alignment happen
-/// here together -- a caller that sorted the names itself would silently
-/// misattribute every mask.
-export fn compute_borrow_param_user_fns(stmts: Array[Stmt], exclude: Array[String], out_masks: Array[Int]) -> Array[String] {
-  let valued = array_empty()
-  let _ = ca_walk_stmts_valued(stmts, valued)
-  let nonident_fns = array_empty()
-  let nonident_pos = array_empty()
-  let _ = ca_walk_stmts_nonident_args(stmts, nonident_fns, nonident_pos)
-  // Fold the (callee, position) pairs into one mask per callee of the
-  // positions that must STAY owned, so both rounds share the same index.
+/// #2638: the (callee, position) pairs folded into one mask per callee, the
+/// way `compute_borrow_param_user_fns` folds them. Shared so a module's
+/// published facts and the whole program's are built by one function.
+fn bp_fold_nonident(nonident_fns: Array[String], nonident_pos: Array[Int]) -> MutMap[String, Int] {
   let nonident: MutMap[String, Int] = MutMap::new_string()
   let mut ni = 0
   while ni < Array::length(nonident_fns) {
@@ -3601,23 +3548,52 @@ export fn compute_borrow_param_user_fns(stmts: Array[Stmt], exclude: Array[Strin
     }
     ni = ni + 1
   }
-  // #2386: membership only -- a set instead of two sorted copies queried by
-  // binary search per function (sorting `valued` was 0.09 s of a warm
-  // compiler-closure compile; the analysis never reads the order).
-  let valued_set: MutSet[String] = MutSet::new_string()
-  let mut vsi = 0
-  while vsi < Array::length(valued) {
-    MutSet::add(valued_set, Array::get(valued, vsi))
-    vsi = vsi + 1
+  nonident
+}
+
+/// #2638: membership over a name list. #2386's rationale applies -- the
+/// analysis never reads the order.
+fn bp_name_set(names: Array[String]) -> MutSet[String] {
+  let s: MutSet[String] = MutSet::new_string()
+  let mut i = 0
+  while i < Array::length(names) {
+    MutSet::add(s, Array::get(names, i))
+    i = i + 1
   }
-  let excluded_set: MutSet[String] = MutSet::new_string()
-  let mut esi = 0
-  while esi < Array::length(exclude) {
-    MutSet::add(excluded_set, Array::get(exclude, esi))
-    esi = esi + 1
+  s
+}
+
+/// #2638: the result shape every entry point here returns -- the SORTED names
+/// with `out_masks` filled aligned to them, so one `bsearch_leftmost` on the
+/// names indexes straight into the masks. Shared because a caller that sorted
+/// the names itself would silently misattribute every mask.
+fn bp_sorted_with_masks(names: Array[String], masks: MutMap[String, Int], out_masks: Array[Int]) -> Array[String] {
+  let names_srt = sorted_names_of(names)
+  let mut oi = 0
+  while oi < Array::length(names_srt) {
+    Array::push(out_masks, match MutMap::get(masks, Array::get(names_srt, oi)) {
+      Some(m) => m,
+      None => 0
+    })
+    oi = oi + 1
   }
-  let names = array_empty()
-  let masks: MutMap[String, Int] = MutMap::new_string()
+  names_srt
+}
+
+/// #2638: round 0 of ADR-0092's borrow inference, with the two facts that are
+/// UNIONS OVER THE WHOLE PROGRAM taken as parameters instead of derived here:
+/// the per-callee `nonident` disqualifier mask, and the names used as a VALUE.
+/// Everything else it reads is body-local.
+///
+/// One implementation serves three callers -- the production pass (which
+/// derives both unions from the merged program), the whole-program round-0
+/// reference, and a module publishing its body-local half with both unions
+/// EMPTY. That is what makes `round0 = local & ~owned_bits` a fact about this
+/// code rather than a claim about two loops that look alike.
+///
+/// Returns the source-shadow bits observed; appends to `names` and fills
+/// `masks`.
+fn bp_round0_scan(stmts: Array[Stmt], nonident: MutMap[String, Int], valued_set: MutSet[String], excluded_set: MutSet[String], names: Array[String], masks: MutMap[String, Int]) -> Int {
   // #2386: both rounds ask "is this parameter consumed anywhere in the
   // body?" through ONE md_consumed_any walk per body instead of one
   // md_consume_count walk per parameter. The rows are reused across bodies;
@@ -3627,10 +3603,6 @@ export fn compute_borrow_param_user_fns(stmts: Array[Stmt], exclude: Array[Strin
   let bp_hits: Array[Int] = []
   let bp_no_fns: Array[String] = []
   let bp_no_masks: Array[Int] = []
-  // Source-owned compiler intrinsics need an authoritative entry even when
-  // their inferred mask is zero. Keep this as two scalar bits and collect it
-  // during the analysis' existing statement pass: no extra compiler-sized
-  // scan or per-function allocation is added.
   let mut source_shadow_mask = 0
   let mut si = 0
   while si < Array::length(stmts) {
@@ -3700,6 +3672,83 @@ export fn compute_borrow_param_user_fns(stmts: Array[Stmt], exclude: Array[Strin
     }
     si = si + 1
   }
+  source_shadow_mask
+}
+
+/// ADR-0092 borrow-inference: for every top-level fn, which of its
+/// parameters are only ever READ. Each such position's ABI flips to
+/// borrowed, program-wide and in lockstep: the caller's plan counts an
+/// ident argument there as a free borrow (no transfer dup) and the callee's
+/// plan-site drop for that param is skipped (linked_compile).
+///
+/// Slice 1 (#1282) inferred position 0 only. This is the per-position
+/// generalization: a fn that consumes param0 but only reads param1 now gets
+/// param1 borrowed, and a fn all of whose params are read-only gets all of
+/// them. **Bit 0 of the result is exactly slice 1's set** -- same
+/// eligibility test, same disqualifiers -- which is what makes
+/// `mask & 1` a byte-identity differential against the previous compiler.
+///
+/// Eligibility is decided per position, all conservative:
+///   - the fn is a top-level `SLet` + `EFn`, and the position is < arity
+///     and < bmask_max_param()
+///   - that param's consume count in the body is 0 (only borrow-position
+///     uses: projections, borrow-arg0 builtin calls -- md_consume_count)
+///   - that param is not mut-captured by an inner closure
+///   - the fn body does not shadow it (a rebinding would make the consume
+///     count unreliable) -- approximated by md_consume_count only, which
+///     counts ANY bare mention; a shadowed rebind's value read would count
+///     as a consume and disqualify the position
+///   - no call anywhere passes a NON-IDENT argument at that position
+///     (ca_collect_nonident_args -- a fresh temp at a borrowed position has
+///     no owner left to release it)
+/// Whole-fn disqualifiers, which zero the mask outright:
+///   - the fn name is used as a VALUE anywhere in the program (indirect
+///     call sites cannot consult this set)
+///   - the caller passes it in `exclude` (the program entry and the
+///     conventional entry names: the host invokes them without consulting
+///     the set either)
+///
+/// Round 0 uses `md_consume_count` without a user borrow set and exactly
+/// preserves the original conservative result. One bounded transitive round
+/// then reads that immutable snapshot through `md_consume_count_pre`; it never
+/// consumes masks being decided in the same round. Only bodies that actually
+/// call a round-0 borrowed function are revisited. A local callee shadow zeros
+/// that function's mask before counting, preserving the owned-call fallback.
+/// This deliberately stops after one extra layer: deeper closure is a possible
+/// future worklist extension, while every intermediate result stays sound.
+///
+/// Returns the SORTED name array and fills `out_masks` aligned to it, so a
+/// single `bsearch_leftmost` on the names indexes straight into the masks.
+/// Ordinary entries have a non-zero inferred borrow mask. A source definition
+/// that shadows a compiler-owned accessor is retained with an authoritative
+/// zero mask when it consumes every parameter. Sorting and alignment happen
+/// here together -- a caller that sorted the names itself would silently
+/// misattribute every mask.
+export fn compute_borrow_param_user_fns(stmts: Array[Stmt], exclude: Array[String], out_masks: Array[Int]) -> Array[String] {
+  let valued = array_empty()
+  let _ = ca_walk_stmts_valued(stmts, valued)
+  let nonident_fns = array_empty()
+  let nonident_pos = array_empty()
+  let _ = ca_walk_stmts_nonident_args(stmts, nonident_fns, nonident_pos)
+  // Fold the (callee, position) pairs into one mask per callee of the
+  // positions that must STAY owned, so both rounds share the same index.
+  let nonident = bp_fold_nonident(nonident_fns, nonident_pos)
+  // #2386: membership only -- a set instead of two sorted copies queried by
+  // binary search per function (sorting `valued` was 0.09 s of a warm
+  // compiler-closure compile; the analysis never reads the order).
+  let valued_set = bp_name_set(valued)
+  let excluded_set = bp_name_set(exclude)
+  let names = array_empty()
+  let masks: MutMap[String, Int] = MutMap::new_string()
+  // Round 0, factored out so the per-module lane runs the SAME scan with the
+  // two program-wide unions empty (#2638).
+  let source_shadow_mask = bp_round0_scan(stmts, nonident, valued_set, excluded_set, names, masks)
+  // Round 1 keeps its own scratch rows and its own cursor: round 0's live
+  // inside the scan now, and `bp_no_fns` / `bp_no_masks` were only ever
+  // round 0's.
+  let bp_names: Array[String] = []
+  let bp_hits: Array[Int] = []
+  let mut si = 0
   let round0_names = sorted_names_of(names)
   let round0_masks: Array[Int] = []
   let mut rmi = 0
@@ -3802,16 +3851,95 @@ export fn compute_borrow_param_user_fns(stmts: Array[Stmt], exclude: Array[Strin
   } else {
     ()
   }
-  let names_srt = sorted_names_of(names)
-  let mut oi = 0
-  while oi < Array::length(names_srt) {
-    Array::push(out_masks, match MutMap::get(masks, Array::get(names_srt, oi)) {
-      Some(m) => m,
-      None => 0
-    })
-    oi = oi + 1
+  bp_sorted_with_masks(names, masks, out_masks)
+}
+
+/// #2638: the facts about THIS statement list that ADR-0092's borrow
+/// inference reads as a UNION over the whole program -- the names used as a
+/// VALUE, and the (callee, position) pairs a call site here disqualifies.
+///
+/// A module can compute both from its own statements and neither can be
+/// completed without every other module's, which is the whole asymmetry: the
+/// 88 functions a per-module run qualifies that the whole program refuses are
+/// callees whose disqualifying call site lives in another module.
+export fn compute_borrow_disqualifiers(stmts: Array[Stmt], out_valued: Array[String], out_nonident_fns: Array[String], out_nonident_pos: Array[Int]) -> Unit {
+  let _ = ca_walk_stmts_valued(stmts, out_valued)
+  let _ = ca_walk_stmts_nonident_args(stmts, out_nonident_fns, out_nonident_pos)
+}
+
+/// #2638: round 0 alone, over the whole program -- the reference the
+/// per-module link is measured against. `compute_borrow_param_user_fns` is
+/// this plus one bounded transitive round, and that round is the half that
+/// still needs callee edges to cross a module boundary.
+export fn compute_borrow_param_user_fns_round0(stmts: Array[Stmt], exclude: Array[String], out_masks: Array[Int]) -> Array[String] {
+  let valued = array_empty()
+  let nonident_fns = array_empty()
+  let nonident_pos = array_empty()
+  compute_borrow_disqualifiers(stmts, valued, nonident_fns, nonident_pos)
+  let names = array_empty()
+  let masks: MutMap[String, Int] = MutMap::new_string()
+  let _ = bp_round0_scan(stmts, bp_fold_nonident(nonident_fns, nonident_pos), bp_name_set(valued), bp_name_set(exclude), names, masks)
+  bp_sorted_with_masks(names, masks, out_masks)
+}
+
+/// #2638: what a MODULE can publish -- the same scan with both program-wide
+/// unions EMPTY, so every mask is the body-local answer and nothing has been
+/// disqualified yet. The link removes what the unions say.
+export fn compute_borrow_param_local_masks(stmts: Array[Stmt], out_masks: Array[Int]) -> Array[String] {
+  let names = array_empty()
+  let masks: MutMap[String, Int] = MutMap::new_string()
+  let empty_nonident: MutMap[String, Int] = MutMap::new_string()
+  let empty_valued: MutSet[String] = MutSet::new_string()
+  let empty_excluded: MutSet[String] = MutSet::new_string()
+  let _ = bp_round0_scan(stmts, empty_nonident, empty_valued, empty_excluded, names, masks)
+  bp_sorted_with_masks(names, masks, out_masks)
+}
+
+/// #2638: THE LINK. Round 0 for the whole program, from the modules'
+/// body-local masks and the UNION of their disqualifiers, without re-reading
+/// a single body.
+///
+///   round0(f) = local(f) & ~owned_bits(f),  dropped when f is used as a
+///   value anywhere, when the caller excludes it, or when the mask is empty
+///
+/// That factorisation is the claim, and `bp_round0_scan` is why it holds: the
+/// scan pre-marks a position `owned_bits` disqualifies so the walk never asks
+/// about it, which skips work for that position but cannot change the answer
+/// for the ones it does ask. The oracle checks the claim against the
+/// whole-program reference rather than trusting this paragraph.
+///
+/// A name is NOT deduplicated here. A program may declare one twice, the
+/// whole-program scan pushes each occurrence and lets the last mask win, and
+/// `sorted_names_of` keeps both -- so the link mirrors that rather than
+/// tidying it, or the two answers would differ on exactly the programs the
+/// oracle's `dup_defs` counter exists for.
+export fn borrow_round0_link(local_names: Array[String], local_masks: Array[Int], valued: Array[String], nonident_fns: Array[String], nonident_pos: Array[Int], exclude: Array[String], out_masks: Array[Int]) -> Array[String] {
+  let nonident = bp_fold_nonident(nonident_fns, nonident_pos)
+  let valued_set = bp_name_set(valued)
+  let excluded_set = bp_name_set(exclude)
+  let names = array_empty()
+  let masks: MutMap[String, Int] = MutMap::new_string()
+  let mut i = 0
+  while i < Array::length(local_names) {
+    let nm = Array::get(local_names, i)
+    if MutSet::has(valued_set, nm) || MutSet::has(excluded_set, nm) {
+      ()
+    } else {
+      let owned_bits = match MutMap::get(nonident, nm) {
+        Some(m) => m,
+        None => 0
+      }
+      let mask = Array::get(local_masks, i)&(~owned_bits)
+      if mask != 0 {
+        Array::push(names, nm)
+        MutMap::set(masks, nm, mask)
+      } else {
+        ()
+      }
+    }
+    i = i + 1
   }
-  names_srt
+  bp_sorted_with_masks(names, masks, out_masks)
 }
 
 //# ADR-0092 borrow-inference: may-return-view analysis

--- a/lib/@vibe/compiler/codegen/common_analysis/index.vpkg
+++ b/lib/@vibe/compiler/codegen/common_analysis/index.vpkg
@@ -55,6 +55,10 @@ fn zero_alloc_check(stmts: Array[Stmt]) -> String
 fn zero_alloc_fn_summaries(stmts: Array[Stmt]) -> Array[(String, String, String)]
 fn typed_operator_alloc_kind(expr: Expr, names: Array[String], kinds: Array[String]) -> String
 fn compute_borrow_param_user_fns(stmts: Array[Stmt], exclude: Array[String], out_masks: Array[Int]) -> Array[String]
+fn compute_borrow_param_user_fns_round0(stmts: Array[Stmt], exclude: Array[String], out_masks: Array[Int]) -> Array[String]
+fn compute_borrow_param_local_masks(stmts: Array[Stmt], out_masks: Array[Int]) -> Array[String]
+fn compute_borrow_disqualifiers(stmts: Array[Stmt], out_valued: Array[String], out_nonident_fns: Array[String], out_nonident_pos: Array[Int]) -> Unit
+fn borrow_round0_link(local_names: Array[String], local_masks: Array[Int], valued: Array[String], nonident_fns: Array[String], nonident_pos: Array[Int], exclude: Array[String], out_masks: Array[Int]) -> Array[String]
 fn bmask_max_param() -> Int
 fn bmask_has(mask: Int, i: Int) -> Bool
 fn compute_may_return_view_fns(stmts: Array[Stmt]) -> Array[String]

--- a/lib/@vibe/compiler/codegen/wasi/linked_compile.vibe
+++ b/lib/@vibe/compiler/codegen/wasi/linked_compile.vibe
@@ -164,9 +164,13 @@ import @vibe/compiler/codegen/builtin_bodies {
 
 import @vibe/compiler/codegen/common_analysis {
   bmask_has,
+  borrow_round0_link,
   collect_free_vars,
   collect_strings_stmts,
+  compute_borrow_disqualifiers,
+  compute_borrow_param_local_masks,
   compute_borrow_param_user_fns,
+  compute_borrow_param_user_fns_round0,
   compute_float_returning_names,
   compute_may_return_view_fns,
   count_lambda_sites_expr,
@@ -679,6 +683,26 @@ fn lc_union_into(dst: Array[String], src: Array[String]) -> Unit {
   }
 }
 
+/// #2638: append every entry, DUPLICATES INCLUDED. `lc_union_into` is the
+/// wrong tool for the link's inputs: the local masks are parallel arrays, and
+/// a program may declare one name twice -- the whole-program scan pushes each
+/// occurrence, so the link has to see each one too.
+fn lc_concat_into(dst: Array[String], src: Array[String]) -> Unit {
+  let mut i = 0
+  while i < Array::length(src) {
+    Array::push(dst, Array::get(src, i))
+    i = i + 1
+  }
+}
+
+fn lc_concat_ints_into(dst: Array[Int], src: Array[Int]) -> Unit {
+  let mut i = 0
+  while i < Array::length(src) {
+    Array::push(dst, Array::get(src, i))
+    i = i + 1
+  }
+}
+
 fn lc_str_array_has(xs: Array[String], n: String) -> Bool {
   let mut i = 0
   let mut found = false
@@ -800,6 +824,69 @@ fn lc_set_cmp_counted(whole: Array[String], union: Array[String]) -> String {
   } else {
     String::concat(String::concat(Int::to_string(Array::length(whole)), String::concat("/", Int::to_string(Array::length(union)))), String::concat(String::concat(String::concat(":-", Int::to_string(missing)), String::concat(":", first_missing)), String::concat(String::concat("+", Int::to_string(extra)), String::concat(":", first_extra))))
   }
+}
+
+/// #2638: the first name whose OCCURRENCE COUNT differs between two lists,
+/// as `<name>:<whole>/<link>`, or "" when the two are the same multiset.
+///
+/// `lc_set_cmp_counted` compares MEMBERSHIP, so a name present in both lists a
+/// different number of times reads as `-0:+0:` with the sizes apart -- which
+/// is exactly what the link produces, because a per-module run synthesizes a
+/// program-level helper once per module that needs it and the whole-program
+/// run emits it once. Naming the multiset difference is what turns that gap
+/// from an unexplained three into a fact.
+fn lc_multiset_first_diff(whole: Array[String], link: Array[String]) -> String {
+  let seen: MutMap[String, Int] = MutMap::new_string()
+  let mut out = ""
+  let mut i = 0
+  while i < Array::length(whole) {
+    let n = Array::get(whole, i)
+    if MutMap::has(seen, n) {
+      ()
+    } else {
+      MutMap::set(seen, n, 1)
+      let wn = lc_count_occurrences(whole, n)
+      let ln = lc_count_occurrences(link, n)
+      if wn != ln && out == "" {
+        out = String::concat(n, String::concat(":", String::concat(Int::to_string(wn), String::concat("/", Int::to_string(ln)))))
+      } else {
+        ()
+      }
+    }
+    i = i + 1
+  }
+  let mut j = 0
+  while j < Array::length(link) {
+    let n = Array::get(link, j)
+    if MutMap::has(seen, n) {
+      ()
+    } else {
+      MutMap::set(seen, n, 1)
+      let wn = lc_count_occurrences(whole, n)
+      let ln = lc_count_occurrences(link, n)
+      if wn != ln && out == "" {
+        out = String::concat(n, String::concat(":", String::concat(Int::to_string(wn), String::concat("/", Int::to_string(ln)))))
+      } else {
+        ()
+      }
+    }
+    j = j + 1
+  }
+  out
+}
+
+fn lc_count_occurrences(xs: Array[String], n: String) -> Int {
+  let mut c = 0
+  let mut i = 0
+  while i < Array::length(xs) {
+    if Array::get(xs, i) == n {
+      c = c + 1
+    } else {
+      ()
+    }
+    i = i + 1
+  }
+  c
 }
 
 /// #2575 item 4: the borrow analysis answers with a NAME and a per-position
@@ -5365,6 +5452,16 @@ fn prelude_run_per_module(c: Array[Stmt], c_file_id: Array[Int], file_count: Int
     lc_union_into(st.an_bfns, part_bfns)
     lc_union_into(st.an_pairs, lc_name_mask_pairs(part_bfns, part_bmask))
     lc_union_into(st.an_view, sorted_names_of(compute_may_return_view_fns(part)))
+    // #2638: and what this module would PUBLISH. Its body-local round-0 masks
+    // are computed with both program-wide unions empty, so nothing here is
+    // disqualified yet; its own half of those unions goes alongside. No body
+    // of another module is read on this path, which is what makes the link's
+    // answer below a per-module driver's answer rather than a re-run.
+    let part_local_masks = lc_fresh_int_array()
+    let part_local_names = compute_borrow_param_local_masks(part, part_local_masks)
+    lc_concat_into(st.an_local_names, part_local_names)
+    lc_concat_ints_into(st.an_local_masks, part_local_masks)
+    compute_borrow_disqualifiers(part, st.an_valued, st.an_nonident_fns, st.an_nonident_pos)
     fi = fi + 1
   }
   // ASSEMBLY (#2575 item 2 step 3). Concatenating the modules is the obvious
@@ -5531,6 +5628,17 @@ struct PreludeSplitStats {
   an_bfns: Array[String];
   an_pairs: Array[String];
   an_view: Array[String];
+  // #2638: what a per-module driver would PUBLISH rather than answer -- each
+  // module's body-local round-0 masks, and its half of the two facts the
+  // borrow inference reads as a union over the whole program. The link
+  // (`borrow_round0_link`) turns these into round 0 for the program without
+  // re-reading a body, and the caller compares that against the whole-program
+  // reference. Concatenated, not unioned: the masks are parallel arrays.
+  an_local_names: Array[String];
+  an_local_masks: Array[Int];
+  an_valued: Array[String];
+  an_nonident_fns: Array[String];
+  an_nonident_pos: Array[Int];
   counts: Array[Int]
 }
 
@@ -5552,6 +5660,11 @@ fn prelude_split_stats_new() -> PreludeSplitStats {
     an_bfns: lc_fresh_string_array(),
     an_pairs: lc_fresh_string_array(),
     an_view: lc_fresh_string_array(),
+    an_local_names: lc_fresh_string_array(),
+    an_local_masks: lc_fresh_int_array(),
+    an_valued: lc_fresh_string_array(),
+    an_nonident_fns: lc_fresh_string_array(),
+    an_nonident_pos: lc_fresh_int_array(),
     counts: [0, 0, 0]
   }
 }
@@ -5660,6 +5773,11 @@ export fn prelude_module_full_oracle_line(a: Array[Stmt], c: Array[Stmt], c_file
   let an_bret_w = sorted_names_of(compute_borrow_returning_names(a))
   let an_bmask_w = lc_fresh_int_array()
   let an_bfns_w = compute_borrow_param_user_fns(a, an_exclude, an_bmask_w)
+  // #2638: round 0 ALONE for the whole program. The reference the link below
+  // is measured against -- the split lane never sees this, it sees only what
+  // each module published.
+  let an_r0mask_w = lc_fresh_int_array()
+  let an_r0_w = compute_borrow_param_user_fns_round0(a, an_exclude, an_r0mask_w)
   let an_view_w = sorted_names_of(compute_may_return_view_fns(a))
   let whole_invisible = eq_invisible_nominals_list()
   eq_invisible_nominals_reset()
@@ -5680,6 +5798,14 @@ export fn prelude_module_full_oracle_line(a: Array[Stmt], c: Array[Stmt], c_file
   // order.
   let an_bret_u = st.an_bret
   let an_bfns_u = st.an_bfns
+  // #2638: THE LINK. Round 0 for the whole program from the modules'
+  // published facts -- their body-local masks and the union of their
+  // disqualifiers -- with no body of any module re-read. If this equals the
+  // whole-program reference, round 0 decomposes, and the 88 functions a
+  // per-module run qualifies that the whole program refuses are exactly what
+  // the union of `nonident` removes.
+  let an_r0mask_link = lc_fresh_int_array()
+  let an_r0_link = borrow_round0_link(st.an_local_names, st.an_local_masks, st.an_valued, st.an_nonident_fns, st.an_nonident_pos, an_exclude, an_r0mask_link)
   let an_pairs_u = st.an_pairs
   let an_view_u = st.an_view
   let collisions = st.collisions
@@ -5745,9 +5871,9 @@ export fn prelude_module_full_oracle_line(a: Array[Stmt], c: Array[Stmt], c_file
     "0"
   })
   let an_cols = if an_dce_entry {
-    " borrow_ret=unmeasured borrow_fns=unmeasured borrow_masks=unmeasured view_ret=unmeasured"
+    " borrow_ret=unmeasured borrow_fns=unmeasured borrow_masks=unmeasured view_ret=unmeasured link_round0=unmeasured link_round0_masks=unmeasured link_round0_occ=unmeasured"
   } else {
-    String::concat(String::concat(String::concat(" borrow_ret=", lc_set_cmp_counted(an_bret_w, an_bret_u)), String::concat(" borrow_fns=", lc_set_cmp_counted(an_bfns_w, an_bfns_u))), String::concat(String::concat(" borrow_masks=", lc_set_cmp_counted(lc_name_mask_pairs(an_bfns_w, an_bmask_w), an_pairs_u)), String::concat(" view_ret=", lc_set_cmp_counted(an_view_w, an_view_u))))
+    String::concat(String::concat(String::concat(" borrow_ret=", lc_set_cmp_counted(an_bret_w, an_bret_u)), String::concat(" borrow_fns=", lc_set_cmp_counted(an_bfns_w, an_bfns_u))), String::concat(String::concat(" borrow_masks=", lc_set_cmp_counted(lc_name_mask_pairs(an_bfns_w, an_bmask_w), an_pairs_u)), String::concat(String::concat(" view_ret=", lc_set_cmp_counted(an_view_w, an_view_u)), String::concat(String::concat(" link_round0=", lc_set_cmp_counted(an_r0_w, an_r0_link)), String::concat(String::concat(" link_round0_masks=", lc_set_cmp_counted(lc_name_mask_pairs(an_r0_w, an_r0mask_w), lc_name_mask_pairs(an_r0_link, an_r0mask_link))), String::concat(" link_round0_occ=", lc_multiset_first_diff(an_r0_w, an_r0_link)))))))
   }
   let an_line = String::concat(String::concat(an_head, an_cols), "\n")
   let line = String::concat(String::concat(head, mid), tail)

--- a/lib/@vibe/compiler/tests/prelude_module_oracle_test.vibe
+++ b/lib/@vibe/compiler/tests/prelude_module_oracle_test.vibe
@@ -381,17 +381,22 @@ test "the whole prelude per module reproduces the whole-program prelude" {
   // On the compiler's own CLI closure (365 modules, measured 2026-09-11 on
   // this change) the same line reads:
   //
-  //   ANALYSIS dce_entry=0 borrow_ret=378/363:-15:MutSortedSet::delete+0:
-  //            borrow_fns=2706/2627:-167:alloc_site_kind_dep_...+88:__arr_equals__N4_Expr
-  //            borrow_masks=2706/2627:-197:agg_expr_of_ident_exp_...#12+118:__arr_equals__N4_Expr#3
-  //            view_ret=2123/1943:-180:HashSet::size+0:
+  //   ANALYSIS dce_entry=0 borrow_ret=379/364:-15:MutSortedSet::delete+0:
+  //            borrow_fns=2764/2685:-168:alloc_site_kind_dep_...+89:__arr_equals__N4_Expr
+  //            borrow_masks=2764/2685:-199:agg_expr_of_ident_exp_...#12+120:__arr_equals__N4_Expr#3
+  //            view_ret=2142/1957:-185:HashSet::size+0:
   //
-  // 88 functions take the borrowed ABI from their own module that the whole
-  // program refuses, and the net (2706 - 2627 = 79) hides every one of them
-  // behind the 167 the modules were conservative about. 118 against 88 on the
-  // mask row is the other half: 30 functions are in BOTH sets under DIFFERENT
+  // 89 functions take the borrowed ABI from their own module that the whole
+  // program refuses, and the net (2764 - 2685 = 79) hides every one of them
+  // behind the 168 the modules were conservative about. 120 against 89 on the
+  // mask row is the other half: 31 functions are in BOTH sets under DIFFERENT
   // masks -- the names agree and the ABI does not, which a name-only
   // comparison reports as agreement.
+  //
+  // Every count in this paragraph is the CORPUS's, and the corpus is the
+  // compiler's own sources: they move whenever `lib/` does, so read a
+  // different number here as a bigger compiler and not as a regression. The
+  // ones that carry a claim are the ZEROS below, which do not move.
   //
   // `dce_entry=0`, so these are the sets WITHOUT late DCE: the oracle runs
   // that closure under `__no_entry__`. A `vibe build` of the same closure
@@ -402,7 +407,25 @@ test "the whole prelude per module reproduces the whole-program prelude" {
   // `stmts` in the block above predates this change and is not re-measured
   // here: the corpus is the compiler's own closure, so the code doing the
   // measuring is inside what is being measured, and adding it moves the count.
-  inspect(String::trim(analysis_line_of(report)), content = "ANALYSIS dce_entry=0 borrow_ret=7 borrow_fns=0 borrow_masks=0 view_ret=2/1:-1:helper_use_exp__tmp_vibe_full_oracle_helper_vibe+0:")
+  //
+  // #2638: and on that same closure the link column reads
+  //
+  //   link_round0=2162/2165:-0:+0: link_round0_occ=__arr_equals__N8_TypeExpr:1/2
+  //
+  // -- ZERO missing and ZERO extra. Round 0 for the whole program, computed
+  // by a link from what each module publishes and without re-reading a single
+  // body, is the whole-program answer. In particular all 89 of `borrow_fns`'
+  // unsound extras are gone: every one was a callee whose disqualifying call
+  // site lives in another module, and the union of `nonident` is a fact a
+  // module can publish.
+  //
+  // The three-entry size gap is NOT a membership difference, and
+  // `link_round0_occ` names it rather than leaving it as an unexplained
+  // three: `__arr_equals__N8_TypeExpr` occurs once in the whole program and
+  // twice across the modules, because a program-level helper is synthesized
+  // once per module that needs it. That is the `copies` shape this oracle
+  // already counts, and the link folds it by key elsewhere.
+  inspect(String::trim(analysis_line_of(report)), content = "ANALYSIS dce_entry=0 borrow_ret=7 borrow_fns=0 borrow_masks=0 view_ret=2/1:-1:helper_use_exp__tmp_vibe_full_oracle_helper_vibe+0: link_round0=0 link_round0_masks=0 link_round0_occ=")
   // `missing=0 extra=0 content=0` is the property: every declaration the
   // whole-program prelude produced is produced by the module that owns it,
   // with the same body. `copies` is what remains after the link, and
@@ -558,7 +581,24 @@ test "the may_return and borrow analyses do not decompose per module, in both di
   // stripped: the name a module mints is what a link folds by, so a
   // measurement that matched on the bare name would be answering a question
   // the link does not ask.
-  inspect(String::trim(analysis_line_of(report)), content = "ANALYSIS dce_entry=0 borrow_ret=10/9:-1:via+0: borrow_fns=2/2:-1:via+1:head_of_exp__tmp_vibe_analysis_oracle_helper_vibe borrow_masks=2/2:-1:via#1+1:head_of_exp__tmp_vibe_analysis_oracle_helper_vibe#1 view_ret=3/2:-1:via+0:")
+  // #2638: and the same line shows the FIX for the unsound half, on the same
+  // four functions. `borrow_fns=2/2:-1:via+1:head_of_exp__...` is the union
+  // lane -- each module answering alone and the answers merged. `link_round0`
+  // is a BARE COUNT: round 0 computed by a link from what each module
+  // PUBLISHES (its body-local masks, and its half of the two facts the
+  // inference reads as a program-wide union) equals the whole program's round
+  // 0 exactly, `head_of` included.
+  //
+  // That is the whole claim of the fix in four functions: the module never
+  // qualified `head_of` on its own account, it qualified it because it could
+  // not see `main`'s non-ident call site -- and the union of the
+  // disqualifiers is a fact a module can publish.
+  //
+  // `via` is still missing from `borrow_fns` because that is round ONE's
+  // business: a tail call across the import, whose classification needs the
+  // callee's round-0 mask. Round 0 is what this column covers, and the
+  // remaining `-1:via` says exactly where the next slice is.
+  inspect(String::trim(analysis_line_of(report)), content = "ANALYSIS dce_entry=0 borrow_ret=10/9:-1:via+0: borrow_fns=2/2:-1:via+1:head_of_exp__tmp_vibe_analysis_oracle_helper_vibe borrow_masks=2/2:-1:via#1+1:head_of_exp__tmp_vibe_analysis_oracle_helper_vibe#1 view_ret=3/2:-1:via+0: link_round0=1 link_round0_masks=1 link_round0_occ=")
   // The prelude itself still agrees on this program, so the difference above
   // is the analyses' and not a per-module prelude that already diverged.
   let lines = String::split(report, "\n")
@@ -585,14 +625,14 @@ test "the analyses refuse to answer where production would have run late DCE fir
   let main_path = "/tmp/vibe_dce_gate_main.vibe"
   Fs::write_file(helper_path, "export fn head_of(xs: Array[Int]) -> Int {\n  Array::get(xs, 0)\n}\n")
   Fs::write_file(main_path, "import ./vibe_dce_gate_helper.vibe {\n  head_of\n}\n\nfn main() -> Int {\n  head_of([1, 2, 3])\n}\n")
-  inspect(String::trim(analysis_line_of(prelude_module_full_oracle_report_fs(main_path, "main"))), content = "ANALYSIS dce_entry=1 borrow_ret=unmeasured borrow_fns=unmeasured borrow_masks=unmeasured view_ret=unmeasured")
+  inspect(String::trim(analysis_line_of(prelude_module_full_oracle_report_fs(main_path, "main"))), content = "ANALYSIS dce_entry=1 borrow_ret=unmeasured borrow_fns=unmeasured borrow_masks=unmeasured view_ret=unmeasured link_round0=unmeasured link_round0_masks=unmeasured link_round0_occ=unmeasured")
   // The control. `__no_entry__` is a name no program defines, so production
   // would not have run either transform and the sample point is its own. The
   // counts are live here rather than merely present -- this program shows the
   // unsound direction too (`+1:head_of_exp__...`, qualified by its own module
   // and disqualified by the whole program through the call site in `main`), so
   // a guard that suppressed the columns unconditionally could not pass this.
-  inspect(String::trim(analysis_line_of(prelude_module_full_oracle_report_fs(main_path, "__no_entry__"))), content = "ANALYSIS dce_entry=0 borrow_ret=9/8:-1:main+0: borrow_fns=0/1:-0:+1:head_of_exp__tmp_vibe_dce_gate_helper_vibe borrow_masks=0/1:-0:+1:head_of_exp__tmp_vibe_dce_gate_helper_vibe#1 view_ret=2/1:-1:main+0:")
+  inspect(String::trim(analysis_line_of(prelude_module_full_oracle_report_fs(main_path, "__no_entry__"))), content = "ANALYSIS dce_entry=0 borrow_ret=9/8:-1:main+0: borrow_fns=0/1:-0:+1:head_of_exp__tmp_vibe_dce_gate_helper_vibe borrow_masks=0/1:-0:+1:head_of_exp__tmp_vibe_dce_gate_helper_vibe#1 view_ret=2/1:-1:main+0: link_round0=0 link_round0_masks=0 link_round0_occ=")
 }
 
 // #2642 review (Codex P2): `dtd_eq_deferred_requests`, `dtd_eq_deferred_types`


### PR DESCRIPTION
Blocks #2575 item 4. First half of #2638.

## What this does

ADR-0092's `compute_borrow_param_user_fns` is **round 0 plus one bounded transitive round** (the correction recorded in [#2638's comment](https://github.com/mizchi/vibe-lang/issues/2638#issuecomment-5630374437)). This slice takes round 0: it factors the scan out so one implementation serves three callers, and adds a **link** that rebuilds round 0 for the whole program from what each module publishes — without re-reading a single body.

The factorisation:

```
round0(f) = local(f) & ~owned_bits(f)
```

dropped when `f` is used as a value anywhere, when the caller excludes it, or when the mask is empty. `local` is body-local; `owned_bits` (from `ca_collect_nonident_args`) and the valued set are unions over the whole program.

`bp_round0_scan` is *why* it holds rather than merely looking true: the scan pre-marks a position `owned_bits` disqualifies so the walk never asks about it, which skips work for that position but cannot change the answer for the ones it does ask. The production pass, the whole-program round-0 reference, and a module's body-local publish all run that same scan, so the three cannot drift apart.

## Measurement

The compiler's own CLI closure, 365 modules:

```
ANALYSIS dce_entry=0
  borrow_ret=379/364:-15:MutSortedSet::delete+0:
  borrow_fns=2764/2685:-168:alloc_site_kind_dep_...+89:__arr_equals__N4_Expr
  borrow_masks=2764/2685:-199:agg_expr_of_ident_exp_...#12+120:__arr_equals__N4_Expr#3
  view_ret=2142/1957:-185:HashSet::size+0:
  link_round0=2162/2165:-0:+0:
  link_round0_masks=2162/2165:-0:+0:
  link_round0_occ=__arr_equals__N8_TypeExpr:1/2
```

**Zero missing, zero extra.** Every one of `borrow_fns`' **89 unsound extras** is gone — each was a callee whose disqualifying call site lives in another module, and the union of `nonident` is a fact a module can publish. That is the direction the issue calls unsound rather than merely slow.

On the two-file repro the union lane still reads `borrow_fns=2/2:-1:via+1:head_of_exp__...` while `link_round0=1` is a **bare count** — the fix in four functions.

### The three-entry size gap is named, not waved at

It is an *occurrence* difference, not a membership one. `lc_set_cmp_counted` compares membership, so a name present in both lists a different number of times reads `-0:+0:` with the sizes apart. The new `link_round0_occ` column reports the first name whose count differs: `__arr_equals__N8_TypeExpr` occurs once in the whole program and twice across the modules, because a program-level helper is synthesized once per module that needs it.

For the same reason the link's inputs are **concatenated, not unioned** (`lc_concat_into`): the masks are parallel arrays, and a duplicated declaration must survive because the whole-program scan pushes each occurrence and `sorted_names_of` keeps both.

## Scope and cost

- **Production output is unchanged.** Compiled `lib/@vibe/cli/entry.vibe` with a stage2 built before and after, three runs each, ABBA-interleaved, isolated `VIBE_BUILD_CACHE_DIR` per run: all six outputs are the same sha256 (`564a67fa…`, 39,471,293 bytes).
- **The new per-module accumulation costs nothing in production.** The split lane is reached only with `use_split` true, and every production caller passes false (`file_compile.vibe:1813`); today that is the oracle and its tests.

## Verification

| check | result |
|---|---|
| `scripts/compiler_gate.sh` | `[compiler-gate] ok`, every suite 0 failed |
| `prelude_module_oracle_test.vibe` | 9 tests pass (seed and rebased candidate stage2) |
| `prelude_split_bytes_test` + `prelude_split_fs_lane_test` | 23 tests pass |
| `vibe check` / `vibe_fmt --check` | clean on all four files |
| output equivalence | 6/6 identical sha256 |

## What is left

The issue stays open. Round **one** and the two real fixpoints (`compute_borrow_returning_names`, `compute_may_return_view_fns`) still need per-callee edge summaries before the `ANALYSIS` line reads a bare count in every column. The repro's remaining `-1:via` — a tail call across the import, needing the callee's round-0 mask — names exactly where the next slice is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NAeZzkckdAwtQiubBFpdmM

---
_Generated by [Claude Code](https://claude.ai/code/session_01NAeZzkckdAwtQiubBFpdmM)_