### PR TITLE
#2638: round 1 too — the whole borrow-param analysis decomposes in two phases

### DIFF
--- a/lib/@vibe/compiler/codegen/common_analysis/common_analysis.vibe
+++ b/lib/@vibe/compiler/codegen/common_analysis/common_analysis.vibe
@@ -3675,6 +3675,92 @@ fn bp_round0_scan(stmts: Array[Stmt], nonident: MutMap[String, Int], valued_set:
   source_shadow_mask
 }
 
+/// #2638: round 1 of ADR-0092's borrow inference -- the ONE bounded
+/// transitive round, over the COMPLETE round-0 snapshot it is handed.
+///
+/// Round 1 reads `round0_names` / `round0_masks` and never its own updates,
+/// and it only ever ADDS bits to the mask of the function it is scanning. So
+/// the module that DECLARES `f` computes `f`'s round-1 mask in full, given
+/// that snapshot -- which is what lets the per-module lane run this same scan
+/// against the LINKED round-0 table and the link merely overlay the results.
+/// One implementation serves both, so that is a fact about this code and not
+/// a claim about two loops that look alike.
+///
+/// Appends to `names` and updates `masks` in place.
+fn bp_round1_scan(stmts: Array[Stmt], round0_names: Array[String], round0_masks: Array[Int], nonident: MutMap[String, Int], valued_set: MutSet[String], excluded_set: MutSet[String], names: Array[String], masks: MutMap[String, Int]) -> Unit {
+  // Scratch rows reused across bodies; each use truncates first.
+  let bp_names: Array[String] = []
+  let bp_hits: Array[Int] = []
+  let mut si = 0
+  // One transitive step captures most of the useful wrapper chains while
+  // keeping the analysis bounded. Read only the complete round-0 snapshot;
+  // updates land in `masks` for the final result and never feed this round.
+  si = 0
+  while si < Array::length(stmts) {
+    match Array::get(stmts, si) {
+      SLet(_, _, fname, _, fval) => match fval {
+        EFn(_, _, fps, _, _, fbody) => if !MutSet::has(valued_set, fname) && !MutSet::has(excluded_set, fname) && bp_calls_round0_borrow(fbody, round0_names) {
+          let owned_bits = match MutMap::get(nonident, fname) {
+            Some(m) => m,
+            None => 0
+          }
+          let prev_mask = match MutMap::get(masks, fname) {
+            Some(m) => m,
+            None => 0
+          }
+          let mut mask = prev_mask
+          let body_masks = md_shadow_zeroed_bmasks(fbody, round0_names, round0_masks)
+          let mut pi = 0
+          let np = Array::length(fps)
+          let lim = if np < bmask_max_param() {
+            np
+          } else {
+            bmask_max_param()
+          }
+          Array::truncate(bp_names, 0)
+          Array::truncate(bp_hits, 0)
+          while pi < lim {
+            let (praw, _) = Array::get(fps, pi)
+            let pn = bp_param_base_name(praw)
+            Array::push(bp_names, pn)
+            Array::push(bp_hits, if !bmask_has(mask, pi) && pn != "" && !bmask_has(owned_bits, pi) {
+              0
+            } else {
+              1
+            })
+            pi = pi + 1
+          }
+          md_consumed_any(fbody, bp_names, round0_names, body_masks, bp_hits)
+          pi = 0
+          while pi < lim {
+            if Array::get(bp_hits, pi) == 0 && !is_mut_captured_in(fbody, Array::get(bp_names, pi)) {
+              mask = mask|(1<<pi)
+            } else {
+              ()
+            }
+            pi = pi + 1
+          }
+          if mask != prev_mask {
+            if prev_mask == 0 {
+              Array::push(names, fname)
+            } else {
+              ()
+            }
+            MutMap::set(masks, fname, mask)
+          } else {
+            ()
+          }
+        } else {
+          ()
+        },
+        _ => ()
+      },
+      _ => ()
+    }
+    si = si + 1
+  }
+}
+
 /// ADR-0092 borrow-inference: for every top-level fn, which of its
 /// parameters are only ever READ. Each such position's ABI flips to
 /// borrowed, program-wide and in lockstep: the caller's plan counts an
@@ -3743,89 +3829,12 @@ export fn compute_borrow_param_user_fns(stmts: Array[Stmt], exclude: Array[Strin
   // Round 0, factored out so the per-module lane runs the SAME scan with the
   // two program-wide unions empty (#2638).
   let source_shadow_mask = bp_round0_scan(stmts, nonident, valued_set, excluded_set, names, masks)
-  // Round 1 keeps its own scratch rows and its own cursor: round 0's live
-  // inside the scan now, and `bp_no_fns` / `bp_no_masks` were only ever
-  // round 0's.
-  let bp_names: Array[String] = []
-  let bp_hits: Array[Int] = []
-  let mut si = 0
-  let round0_names = sorted_names_of(names)
+  // Round 1, factored out the same way (#2638). The snapshot it reads is
+  // built here and handed in, because the per-module lane is handed the
+  // LINKED round-0 table instead of building one from its own module.
   let round0_masks: Array[Int] = []
-  let mut rmi = 0
-  while rmi < Array::length(round0_names) {
-    Array::push(round0_masks, match MutMap::get(masks, Array::get(round0_names, rmi)) {
-      Some(m) => m,
-      None => 0
-    })
-    rmi = rmi + 1
-  }
-  // One transitive step captures most of the useful wrapper chains while
-  // keeping the analysis bounded. Read only the complete round-0 snapshot;
-  // updates land in `masks` for the final result and never feed this round.
-  si = 0
-  while si < Array::length(stmts) {
-    match Array::get(stmts, si) {
-      SLet(_, _, fname, _, fval) => match fval {
-        EFn(_, _, fps, _, _, fbody) => if !MutSet::has(valued_set, fname) && !MutSet::has(excluded_set, fname) && bp_calls_round0_borrow(fbody, round0_names) {
-          let owned_bits = match MutMap::get(nonident, fname) {
-            Some(m) => m,
-            None => 0
-          }
-          let prev_mask = match MutMap::get(masks, fname) {
-            Some(m) => m,
-            None => 0
-          }
-          let mut mask = prev_mask
-          let body_masks = md_shadow_zeroed_bmasks(fbody, round0_names, round0_masks)
-          let mut pi = 0
-          let np = Array::length(fps)
-          let lim = if np < bmask_max_param() {
-            np
-          } else {
-            bmask_max_param()
-          }
-          Array::truncate(bp_names, 0)
-          Array::truncate(bp_hits, 0)
-          while pi < lim {
-            let (praw, _) = Array::get(fps, pi)
-            let pn = bp_param_base_name(praw)
-            Array::push(bp_names, pn)
-            Array::push(bp_hits, if !bmask_has(mask, pi) && pn != "" && !bmask_has(owned_bits, pi) {
-              0
-            } else {
-              1
-            })
-            pi = pi + 1
-          }
-          md_consumed_any(fbody, bp_names, round0_names, body_masks, bp_hits)
-          pi = 0
-          while pi < lim {
-            if Array::get(bp_hits, pi) == 0 && !is_mut_captured_in(fbody, Array::get(bp_names, pi)) {
-              mask = mask|(1<<pi)
-            } else {
-              ()
-            }
-            pi = pi + 1
-          }
-          if mask != prev_mask {
-            if prev_mask == 0 {
-              Array::push(names, fname)
-            } else {
-              ()
-            }
-            MutMap::set(masks, fname, mask)
-          } else {
-            ()
-          }
-        } else {
-          ()
-        },
-        _ => ()
-      },
-      _ => ()
-    }
-    si = si + 1
-  }
+  let round0_names = bp_sorted_with_masks(names, masks, round0_masks)
+  bp_round1_scan(stmts, round0_names, round0_masks, nonident, valued_set, excluded_set, names, masks)
   // A zero-mask entry is an ownership override, not a borrowed ABI. Callers
   // distinguish it by looking up the aligned mask instead of testing name
   // membership alone.
@@ -3885,13 +3894,20 @@ export fn compute_borrow_param_user_fns_round0(stmts: Array[Stmt], exclude: Arra
 /// #2638: what a MODULE can publish -- the same scan with both program-wide
 /// unions EMPTY, so every mask is the body-local answer and nothing has been
 /// disqualified yet. The link removes what the unions say.
-export fn compute_borrow_param_local_masks(stmts: Array[Stmt], out_masks: Array[Int]) -> Array[String] {
+export fn compute_borrow_param_local_masks(stmts: Array[Stmt], out_masks: Array[Int], out_shadow: Array[Int]) -> Array[String] {
   let names = array_empty()
   let masks: MutMap[String, Int] = MutMap::new_string()
   let empty_nonident: MutMap[String, Int] = MutMap::new_string()
   let empty_valued: MutSet[String] = MutSet::new_string()
   let empty_excluded: MutSet[String] = MutSet::new_string()
-  let _ = bp_round0_scan(stmts, empty_nonident, empty_valued, empty_excluded, names, masks)
+  // The source-shadow bits are this module's half of a UNION (the program
+  // shadows a compiler-owned accessor if ANY module does), so a module
+  // publishes them exactly like its other body-local facts and the link ORs
+  // them. Without this the link cannot reproduce the two zero-mask rows
+  // `compute_borrow_param_user_fns` appends, and the comparison would have to
+  // leave the tail off BOTH sides -- which hides whether the tail was empty or
+  // merely unmeasured.
+  Array::push(out_shadow, bp_round0_scan(stmts, empty_nonident, empty_valued, empty_excluded, names, masks))
   bp_sorted_with_masks(names, masks, out_masks)
 }
 
@@ -3938,6 +3954,138 @@ export fn borrow_round0_link(local_names: Array[String], local_masks: Array[Int]
       }
     }
     i = i + 1
+  }
+  bp_sorted_with_masks(names, masks, out_masks)
+}
+
+/// #2638: what a MODULE answers for round 1, given the LINKED round-0 table
+/// and the program-wide structures PREPARED ONCE by the caller.
+///
+/// This is the second phase of the protocol and the reason round 1 needs one:
+/// a module cannot build the round-0 table (round 0's disqualifiers are a
+/// union over the program), but once it is handed that table it can run round
+/// 1 on its own bodies alone, because the scan reads the snapshot and never
+/// another function's round-1 result.
+///
+/// The prepared arguments are why this takes them instead of deriving them:
+/// `nonident` is folded from EVERY call site in the program, and rebuilding it
+/// per module ran the compiler's own closure out of memory (365 folds of the
+/// whole program's pairs). A real driver ships these tables to a module once
+/// for the same reason.
+///
+/// The seed is this module's own slice of `r0`, one entry per DECLARATION
+/// rather than per table row. Round 0 pushed one row per qualifying
+/// declaration, so a name two modules both declare gets one seed in each and
+/// the link ends up with the number of copies the whole-program scan produced,
+/// instead of each module claiming both.
+fn bp_round1_local_prepared(stmts: Array[Stmt], round0_names: Array[String], round0_masks: Array[Int], r0: MutMap[String, Int], nonident: MutMap[String, Int], valued_set: MutSet[String], excluded_set: MutSet[String], out_names: Array[String], out_masks: Array[Int]) -> Unit {
+  let names = array_empty()
+  let masks: MutMap[String, Int] = MutMap::new_string()
+  let mut si = 0
+  while si < Array::length(stmts) {
+    match Array::get(stmts, si) {
+      SLet(_, _, fname, _, fval) => match fval {
+        EFn(_, _, _, _, _, _) => match MutMap::get(r0, fname) {
+          Some(m) => {
+            Array::push(names, fname)
+            MutMap::set(masks, fname, m)
+          },
+          None => ()
+        },
+        _ => ()
+      },
+      _ => ()
+    }
+    si = si + 1
+  }
+  bp_round1_scan(stmts, round0_names, round0_masks, nonident, valued_set, excluded_set, names, masks)
+  let part_masks: Array[Int] = []
+  let part_names = bp_sorted_with_masks(names, masks, part_masks)
+  let mut oi = 0
+  while oi < Array::length(part_names) {
+    Array::push(out_names, Array::get(part_names, oi))
+    Array::push(out_masks, Array::get(part_masks, oi))
+    oi = oi + 1
+  }
+}
+
+/// #2638: PHASE B, whole. The program's round 0 AND round 1, from the linked
+/// round-0 table plus each module's own bodies -- an OVERLAY, not a fixpoint.
+///
+/// Every module in `parts` answers round 1 for the functions IT declares,
+/// reading only its own statements and the shared tables. Round 1 raises only
+/// the mask of the function it is scanning, and that function is declared by
+/// exactly one module, so the owning module's answer is final and the link
+/// merely overlays it. A name the round-0 table does not carry is pushed for
+/// the same reason the whole-program scan pushes it: its `prev_mask` was 0 and
+/// round 1 raised it.
+///
+/// Modules are visited in order, so a name two modules declare resolves
+/// last-wins exactly as the whole-program scan's single `masks` map does.
+///
+/// The program-wide folds happen ONCE here rather than per module. That is not
+/// a convenience: per module they cost 365 folds of every call site in the
+/// program and exhausted memory on the compiler's own closure.
+export fn borrow_round1_link_parts(parts: Array[Array[Stmt]], round0_names: Array[String], round0_masks: Array[Int], valued: Array[String], nonident_fns: Array[String], nonident_pos: Array[Int], exclude: Array[String], shadow: Int, out_masks: Array[Int]) -> Array[String] {
+  let nonident = bp_fold_nonident(nonident_fns, nonident_pos)
+  let valued_set = bp_name_set(valued)
+  let excluded_set = bp_name_set(exclude)
+  let r0: MutMap[String, Int] = MutMap::new_string()
+  let mut ri = 0
+  while ri < Array::length(round0_names) {
+    MutMap::set(r0, Array::get(round0_names, ri), Array::get(round0_masks, ri))
+    ri = ri + 1
+  }
+  let delta_names = array_empty()
+  let delta_masks: Array[Int] = []
+  let mut pi = 0
+  while pi < Array::length(parts) {
+    bp_round1_local_prepared(Array::get(parts, pi), round0_names, round0_masks, r0, nonident, valued_set, excluded_set, delta_names, delta_masks)
+    pi = pi + 1
+  }
+  let masks: MutMap[String, Int] = MutMap::new_string()
+  let names = array_empty()
+  let mut i = 0
+  while i < Array::length(round0_names) {
+    let nm = Array::get(round0_names, i)
+    Array::push(names, nm)
+    MutMap::set(masks, nm, Array::get(round0_masks, i))
+    i = i + 1
+  }
+  let mut j = 0
+  while j < Array::length(delta_names) {
+    let nm = Array::get(delta_names, j)
+    match MutMap::get(masks, nm) {
+      Some(_) => (),
+      None => Array::push(names, nm)
+    }
+    MutMap::set(masks, nm, Array::get(delta_masks, j))
+    j = j + 1
+  }
+  // The same tail `compute_borrow_param_user_fns` appends, from the OR of what
+  // the modules published. A zero-mask entry is an ownership override, not a
+  // borrowed ABI.
+  if (shadow&1) != 0 {
+    match MutMap::get(masks, "Map::iter_get") {
+      Some(_) => (),
+      None => {
+        Array::push(names, "Map::iter_get")
+        MutMap::set(masks, "Map::iter_get", 0)
+      }
+    }
+  } else {
+    ()
+  }
+  if (shadow&2) != 0 {
+    match MutMap::get(masks, "Map::__iter_get_unchecked") {
+      Some(_) => (),
+      None => {
+        Array::push(names, "Map::__iter_get_unchecked")
+        MutMap::set(masks, "Map::__iter_get_unchecked", 0)
+      }
+    }
+  } else {
+    ()
   }
   bp_sorted_with_masks(names, masks, out_masks)
 }

--- a/lib/@vibe/compiler/codegen/common_analysis/index.vpkg
+++ b/lib/@vibe/compiler/codegen/common_analysis/index.vpkg
@@ -56,9 +56,10 @@ fn zero_alloc_fn_summaries(stmts: Array[Stmt]) -> Array[(String, String, String)
 fn typed_operator_alloc_kind(expr: Expr, names: Array[String], kinds: Array[String]) -> String
 fn compute_borrow_param_user_fns(stmts: Array[Stmt], exclude: Array[String], out_masks: Array[Int]) -> Array[String]
 fn compute_borrow_param_user_fns_round0(stmts: Array[Stmt], exclude: Array[String], out_masks: Array[Int]) -> Array[String]
-fn compute_borrow_param_local_masks(stmts: Array[Stmt], out_masks: Array[Int]) -> Array[String]
+fn compute_borrow_param_local_masks(stmts: Array[Stmt], out_masks: Array[Int], out_shadow: Array[Int]) -> Array[String]
 fn compute_borrow_disqualifiers(stmts: Array[Stmt], out_valued: Array[String], out_nonident_fns: Array[String], out_nonident_pos: Array[Int]) -> Unit
 fn borrow_round0_link(local_names: Array[String], local_masks: Array[Int], valued: Array[String], nonident_fns: Array[String], nonident_pos: Array[Int], exclude: Array[String], out_masks: Array[Int]) -> Array[String]
+fn borrow_round1_link_parts(parts: Array[Array[Stmt]], round0_names: Array[String], round0_masks: Array[Int], valued: Array[String], nonident_fns: Array[String], nonident_pos: Array[Int], exclude: Array[String], shadow: Int, out_masks: Array[Int]) -> Array[String]
 fn bmask_max_param() -> Int
 fn bmask_has(mask: Int, i: Int) -> Bool
 fn compute_may_return_view_fns(stmts: Array[Stmt]) -> Array[String]

--- a/lib/@vibe/compiler/codegen/wasi/linked_compile.vibe
+++ b/lib/@vibe/compiler/codegen/wasi/linked_compile.vibe
@@ -165,6 +165,7 @@ import @vibe/compiler/codegen/builtin_bodies {
 import @vibe/compiler/codegen/common_analysis {
   bmask_has,
   borrow_round0_link,
+  borrow_round1_link_parts,
   collect_free_vars,
   collect_strings_stmts,
   compute_borrow_disqualifiers,
@@ -5458,12 +5459,36 @@ fn prelude_run_per_module(c: Array[Stmt], c_file_id: Array[Int], file_count: Int
     // of another module is read on this path, which is what makes the link's
     // answer below a per-module driver's answer rather than a re-run.
     let part_local_masks = lc_fresh_int_array()
-    let part_local_names = compute_borrow_param_local_masks(part, part_local_masks)
+    let part_shadow = lc_fresh_int_array()
+    let part_local_names = compute_borrow_param_local_masks(part, part_local_masks, part_shadow)
+    lc_concat_ints_into(st.an_shadow, part_shadow)
     lc_concat_into(st.an_local_names, part_local_names)
     lc_concat_ints_into(st.an_local_masks, part_local_masks)
     compute_borrow_disqualifiers(part, st.an_valued, st.an_nonident_fns, st.an_nonident_pos)
     fi = fi + 1
   }
+  // #2638 PHASE B. Round 0 for the whole program is linkable now, from what
+  // the loop above published -- so hand that table BACK to every module and
+  // let each answer ROUND 1 for its own declarations. Two phases and no
+  // fixpoint, which is the protocol a per-module driver would actually run
+  // rather than a re-derivation of the whole-program pass.
+  //
+  // The link, not a module, owns round 0: a module cannot build it, because
+  // round 0's disqualifiers are a union over the program. Round 1 is the
+  // opposite -- given the table it is a map over bodies, since the scan reads
+  // the snapshot and never another function's round-1 result.
+  let ph_r0mask = lc_fresh_int_array()
+  let ph_r0 = borrow_round0_link(st.an_local_names, st.an_local_masks, st.an_valued, st.an_nonident_fns, st.an_nonident_pos, an_exclude, ph_r0mask)
+  let mut ph_shadow = 0
+  let mut shi = 0
+  while shi < Array::length(st.an_shadow) {
+    ph_shadow = ph_shadow|Array::get(st.an_shadow, shi)
+    shi = shi + 1
+  }
+  let ph_r01mask = lc_fresh_int_array()
+  let ph_r01 = borrow_round1_link_parts(parts, ph_r0, ph_r0mask, st.an_valued, st.an_nonident_fns, st.an_nonident_pos, an_exclude, ph_shadow, ph_r01mask)
+  lc_concat_into(st.an_r01_names, ph_r01)
+  lc_concat_ints_into(st.an_r01_masks, ph_r01mask)
   // ASSEMBLY (#2575 item 2 step 3). Concatenating the modules is the obvious
   // thing and produces the whole program's declarations in a DIFFERENT ORDER:
   // a module's appended helpers close that module, so they precede the next
@@ -5639,6 +5664,13 @@ struct PreludeSplitStats {
   an_valued: Array[String];
   an_nonident_fns: Array[String];
   an_nonident_pos: Array[Int];
+  // #2638: each module's source-shadow bits, a union like the two above.
+  an_shadow: Array[Int];
+  // #2638 phase B's ANSWER: the program's round 0 and round 1, linked from
+  // the modules' published facts plus each module's own bodies. Filled by
+  // `prelude_run_per_module`, which is where the parts live.
+  an_r01_names: Array[String];
+  an_r01_masks: Array[Int];
   counts: Array[Int]
 }
 
@@ -5665,6 +5697,9 @@ fn prelude_split_stats_new() -> PreludeSplitStats {
     an_valued: lc_fresh_string_array(),
     an_nonident_fns: lc_fresh_string_array(),
     an_nonident_pos: lc_fresh_int_array(),
+    an_shadow: lc_fresh_int_array(),
+    an_r01_names: lc_fresh_string_array(),
+    an_r01_masks: lc_fresh_int_array(),
     counts: [0, 0, 0]
   }
 }
@@ -5806,6 +5841,10 @@ export fn prelude_module_full_oracle_line(a: Array[Stmt], c: Array[Stmt], c_file
   // the union of `nonident` removes.
   let an_r0mask_link = lc_fresh_int_array()
   let an_r0_link = borrow_round0_link(st.an_local_names, st.an_local_masks, st.an_valued, st.an_nonident_fns, st.an_nonident_pos, an_exclude, an_r0mask_link)
+  // #2638 phase B's answer, computed by the split lane itself (it owns the
+  // module parts) and only READ here for the comparison.
+  let an_r01_link = st.an_r01_names
+  let an_r01mask_link = st.an_r01_masks
   let an_pairs_u = st.an_pairs
   let an_view_u = st.an_view
   let collisions = st.collisions
@@ -5871,9 +5910,9 @@ export fn prelude_module_full_oracle_line(a: Array[Stmt], c: Array[Stmt], c_file
     "0"
   })
   let an_cols = if an_dce_entry {
-    " borrow_ret=unmeasured borrow_fns=unmeasured borrow_masks=unmeasured view_ret=unmeasured link_round0=unmeasured link_round0_masks=unmeasured link_round0_occ=unmeasured"
+    " borrow_ret=unmeasured borrow_fns=unmeasured borrow_masks=unmeasured view_ret=unmeasured link_round0=unmeasured link_round0_masks=unmeasured link_round0_occ=unmeasured link_round01=unmeasured link_round01_masks=unmeasured link_round01_occ=unmeasured"
   } else {
-    String::concat(String::concat(String::concat(" borrow_ret=", lc_set_cmp_counted(an_bret_w, an_bret_u)), String::concat(" borrow_fns=", lc_set_cmp_counted(an_bfns_w, an_bfns_u))), String::concat(String::concat(" borrow_masks=", lc_set_cmp_counted(lc_name_mask_pairs(an_bfns_w, an_bmask_w), an_pairs_u)), String::concat(String::concat(" view_ret=", lc_set_cmp_counted(an_view_w, an_view_u)), String::concat(String::concat(" link_round0=", lc_set_cmp_counted(an_r0_w, an_r0_link)), String::concat(String::concat(" link_round0_masks=", lc_set_cmp_counted(lc_name_mask_pairs(an_r0_w, an_r0mask_w), lc_name_mask_pairs(an_r0_link, an_r0mask_link))), String::concat(" link_round0_occ=", lc_multiset_first_diff(an_r0_w, an_r0_link)))))))
+    String::concat(String::concat(String::concat(" borrow_ret=", lc_set_cmp_counted(an_bret_w, an_bret_u)), String::concat(" borrow_fns=", lc_set_cmp_counted(an_bfns_w, an_bfns_u))), String::concat(String::concat(" borrow_masks=", lc_set_cmp_counted(lc_name_mask_pairs(an_bfns_w, an_bmask_w), an_pairs_u)), String::concat(String::concat(" view_ret=", lc_set_cmp_counted(an_view_w, an_view_u)), String::concat(String::concat(" link_round0=", lc_set_cmp_counted(an_r0_w, an_r0_link)), String::concat(String::concat(" link_round0_masks=", lc_set_cmp_counted(lc_name_mask_pairs(an_r0_w, an_r0mask_w), lc_name_mask_pairs(an_r0_link, an_r0mask_link))), String::concat(String::concat(" link_round0_occ=", lc_multiset_first_diff(an_r0_w, an_r0_link)), String::concat(String::concat(" link_round01=", lc_set_cmp_counted(an_bfns_w, an_r01_link)), String::concat(String::concat(" link_round01_masks=", lc_set_cmp_counted(lc_name_mask_pairs(an_bfns_w, an_bmask_w), lc_name_mask_pairs(an_r01_link, an_r01mask_link))), String::concat(" link_round01_occ=", lc_multiset_first_diff(an_bfns_w, an_r01_link))))))))))
   }
   let an_line = String::concat(String::concat(an_head, an_cols), "\n")
   let line = String::concat(String::concat(head, mid), tail)

--- a/lib/@vibe/compiler/tests/prelude_module_oracle_test.vibe
+++ b/lib/@vibe/compiler/tests/prelude_module_oracle_test.vibe
@@ -382,14 +382,14 @@ test "the whole prelude per module reproduces the whole-program prelude" {
   // this change) the same line reads:
   //
   //   ANALYSIS dce_entry=0 borrow_ret=379/364:-15:MutSortedSet::delete+0:
-  //            borrow_fns=2764/2685:-168:alloc_site_kind_dep_...+89:__arr_equals__N4_Expr
-  //            borrow_masks=2764/2685:-199:agg_expr_of_ident_exp_...#12+120:__arr_equals__N4_Expr#3
+  //            borrow_fns=2767/2688:-168:alloc_site_kind_dep_...+89:__arr_equals__N4_Expr
+  //            borrow_masks=2767/2688:-200:agg_expr_of_ident_exp_...#12+121:__arr_equals__N4_Expr#3
   //            view_ret=2142/1957:-185:HashSet::size+0:
   //
   // 89 functions take the borrowed ABI from their own module that the whole
-  // program refuses, and the net (2764 - 2685 = 79) hides every one of them
-  // behind the 168 the modules were conservative about. 120 against 89 on the
-  // mask row is the other half: 31 functions are in BOTH sets under DIFFERENT
+  // program refuses, and the net (2767 - 2688 = 79) hides every one of them
+  // behind the 168 the modules were conservative about. 121 against 89 on the
+  // mask row is the other half: 32 functions are in BOTH sets under DIFFERENT
   // masks -- the names agree and the ABI does not, which a name-only
   // comparison reports as agreement.
   //
@@ -408,16 +408,26 @@ test "the whole prelude per module reproduces the whole-program prelude" {
   // here: the corpus is the compiler's own closure, so the code doing the
   // measuring is inside what is being measured, and adding it moves the count.
   //
-  // #2638: and on that same closure the link column reads
+  // #2638: and on that same closure the link columns read
   //
-  //   link_round0=2162/2165:-0:+0: link_round0_occ=__arr_equals__N8_TypeExpr:1/2
+  //   link_round0=2166/2169:-0:+0:   link_round0_occ=__arr_equals__N8_TypeExpr:1/2
+  //   link_round01=2767/2770:-0:+0:  link_round01_occ=__arr_equals__N8_TypeExpr:1/2
   //
-  // -- ZERO missing and ZERO extra. Round 0 for the whole program, computed
-  // by a link from what each module publishes and without re-reading a single
-  // body, is the whole-program answer. In particular all 89 of `borrow_fns`'
-  // unsound extras are gone: every one was a callee whose disqualifying call
-  // site lives in another module, and the union of `nonident` is a fact a
-  // module can publish.
+  // -- ZERO missing and ZERO extra on both, names and masks alike. The first
+  // is round 0 alone, linked from what each module publishes without
+  // re-reading a body. The second is the WHOLE analysis: `link_round01` is
+  // compared against the shipped `compute_borrow_param_user_fns` itself, not
+  // against a stand-in, so `2767` is the same 2767 the `borrow_fns` row above
+  // reports for the whole-program lane.
+  //
+  // So all 89 of `borrow_fns`' unsound extras are gone, and so are its 168
+  // conservative misses. The 89 were callees whose disqualifying call site
+  // lives in another module, and the union of `nonident` is a fact a module
+  // can publish. The 168 needed round ONE, which is why the link runs in two
+  // phases: the link owns round 0 (a module cannot build it), then hands the
+  // table back and each module answers round 1 for its own declarations. No
+  // fixpoint -- round 1 reads the snapshot and never another function's
+  // round-1 result, so the owning module's answer is final.
   //
   // The three-entry size gap is NOT a membership difference, and
   // `link_round0_occ` names it rather than leaving it as an unexplained
@@ -425,7 +435,7 @@ test "the whole prelude per module reproduces the whole-program prelude" {
   // twice across the modules, because a program-level helper is synthesized
   // once per module that needs it. That is the `copies` shape this oracle
   // already counts, and the link folds it by key elsewhere.
-  inspect(String::trim(analysis_line_of(report)), content = "ANALYSIS dce_entry=0 borrow_ret=7 borrow_fns=0 borrow_masks=0 view_ret=2/1:-1:helper_use_exp__tmp_vibe_full_oracle_helper_vibe+0: link_round0=0 link_round0_masks=0 link_round0_occ=")
+  inspect(String::trim(analysis_line_of(report)), content = "ANALYSIS dce_entry=0 borrow_ret=7 borrow_fns=0 borrow_masks=0 view_ret=2/1:-1:helper_use_exp__tmp_vibe_full_oracle_helper_vibe+0: link_round0=0 link_round0_masks=0 link_round0_occ= link_round01=0 link_round01_masks=0 link_round01_occ=")
   // `missing=0 extra=0 content=0` is the property: every declaration the
   // whole-program prelude produced is produced by the module that owns it,
   // with the same body. `copies` is what remains after the link, and
@@ -598,7 +608,7 @@ test "the may_return and borrow analyses do not decompose per module, in both di
   // business: a tail call across the import, whose classification needs the
   // callee's round-0 mask. Round 0 is what this column covers, and the
   // remaining `-1:via` says exactly where the next slice is.
-  inspect(String::trim(analysis_line_of(report)), content = "ANALYSIS dce_entry=0 borrow_ret=10/9:-1:via+0: borrow_fns=2/2:-1:via+1:head_of_exp__tmp_vibe_analysis_oracle_helper_vibe borrow_masks=2/2:-1:via#1+1:head_of_exp__tmp_vibe_analysis_oracle_helper_vibe#1 view_ret=3/2:-1:via+0: link_round0=1 link_round0_masks=1 link_round0_occ=")
+  inspect(String::trim(analysis_line_of(report)), content = "ANALYSIS dce_entry=0 borrow_ret=10/9:-1:via+0: borrow_fns=2/2:-1:via+1:head_of_exp__tmp_vibe_analysis_oracle_helper_vibe borrow_masks=2/2:-1:via#1+1:head_of_exp__tmp_vibe_analysis_oracle_helper_vibe#1 view_ret=3/2:-1:via+0: link_round0=1 link_round0_masks=1 link_round0_occ= link_round01=2 link_round01_masks=2 link_round01_occ=")
   // The prelude itself still agrees on this program, so the difference above
   // is the analyses' and not a per-module prelude that already diverged.
   let lines = String::split(report, "\n")
@@ -625,14 +635,14 @@ test "the analyses refuse to answer where production would have run late DCE fir
   let main_path = "/tmp/vibe_dce_gate_main.vibe"
   Fs::write_file(helper_path, "export fn head_of(xs: Array[Int]) -> Int {\n  Array::get(xs, 0)\n}\n")
   Fs::write_file(main_path, "import ./vibe_dce_gate_helper.vibe {\n  head_of\n}\n\nfn main() -> Int {\n  head_of([1, 2, 3])\n}\n")
-  inspect(String::trim(analysis_line_of(prelude_module_full_oracle_report_fs(main_path, "main"))), content = "ANALYSIS dce_entry=1 borrow_ret=unmeasured borrow_fns=unmeasured borrow_masks=unmeasured view_ret=unmeasured link_round0=unmeasured link_round0_masks=unmeasured link_round0_occ=unmeasured")
+  inspect(String::trim(analysis_line_of(prelude_module_full_oracle_report_fs(main_path, "main"))), content = "ANALYSIS dce_entry=1 borrow_ret=unmeasured borrow_fns=unmeasured borrow_masks=unmeasured view_ret=unmeasured link_round0=unmeasured link_round0_masks=unmeasured link_round0_occ=unmeasured link_round01=unmeasured link_round01_masks=unmeasured link_round01_occ=unmeasured")
   // The control. `__no_entry__` is a name no program defines, so production
   // would not have run either transform and the sample point is its own. The
   // counts are live here rather than merely present -- this program shows the
   // unsound direction too (`+1:head_of_exp__...`, qualified by its own module
   // and disqualified by the whole program through the call site in `main`), so
   // a guard that suppressed the columns unconditionally could not pass this.
-  inspect(String::trim(analysis_line_of(prelude_module_full_oracle_report_fs(main_path, "__no_entry__"))), content = "ANALYSIS dce_entry=0 borrow_ret=9/8:-1:main+0: borrow_fns=0/1:-0:+1:head_of_exp__tmp_vibe_dce_gate_helper_vibe borrow_masks=0/1:-0:+1:head_of_exp__tmp_vibe_dce_gate_helper_vibe#1 view_ret=2/1:-1:main+0: link_round0=0 link_round0_masks=0 link_round0_occ=")
+  inspect(String::trim(analysis_line_of(prelude_module_full_oracle_report_fs(main_path, "__no_entry__"))), content = "ANALYSIS dce_entry=0 borrow_ret=9/8:-1:main+0: borrow_fns=0/1:-0:+1:head_of_exp__tmp_vibe_dce_gate_helper_vibe borrow_masks=0/1:-0:+1:head_of_exp__tmp_vibe_dce_gate_helper_vibe#1 view_ret=2/1:-1:main+0: link_round0=0 link_round0_masks=0 link_round0_occ= link_round01=0 link_round01_masks=0 link_round01_occ=")
 }
 
 // #2642 review (Codex P2): `dtd_eq_deferred_requests`, `dtd_eq_deferred_types`


### PR DESCRIPTION
Blocks #2575 item 4. Second half of #2638, on top of #2666.

With this, the `borrow_fns` / `borrow_masks` columns the issue was opened about read a **bare count**.

## The shape

Round 1 is the *one bounded transitive round* — not a fixpoint, per [the issue's own correction](https://github.com/mizchi/vibe-lang/issues/2638#issuecomment-5630374437). It reads the complete round-0 snapshot and never its own updates, and it only ever raises the mask of the function it is scanning. That function is declared by exactly one module, so **given the table, the owning module's answer is final**. Round 1 therefore decomposes as a map over bodies, and the protocol is two phases with no fixpoint:

| | who | what |
|---|---|---|
| **phase A** | each module | publishes its body-local round-0 masks, its half of the two program-wide unions, and its source-shadow bits |
| **link** | the link | round 0 for the program — a module *cannot* build this, the disqualifiers are a union over the program |
| **phase B** | each module | the table goes back; each answers round 1 for its own declarations |
| **link** | the link | overlays the answers |

`bp_round1_scan` is extracted the way `bp_round0_scan` was in #2666, so the production pass and the per-module lane run the same scan and cannot drift.

## Measurement

Compiler's own CLI closure, 365 modules:

```
borrow_fns=2767/2688:-168:alloc_site_kind_dep_...+89:__arr_equals__N4_Expr
borrow_masks=2767/2688:-200:agg_expr_of_ident_exp_...#12+121:...#3

link_round0=2166/2169:-0:+0:    link_round0_masks=2166/2169:-0:+0:
link_round01=2767/2770:-0:+0:   link_round01_masks=2767/2770:-0:+0:
link_round01_occ=__arr_equals__N8_TypeExpr:1/2
```

**Zero missing, zero extra — on names and on masks.** All 89 unsound extras are gone (#2666's result) and so are the 168 conservative misses, which are what needed round 1.

On the two-file repro, `link_round01=2` is a bare count where the union lane still reads `borrow_fns=2/2:-1:via+1:head_of_exp__...`. `via` — the tail call across the import — is round 1's case, and the link now classifies it.

### Compared against the shipped function, not a stand-in

`link_round01` is compared against `compute_borrow_param_user_fns` itself, so the `2767` above is the same 2767 the `borrow_fns` row reports. My first cut compared against a tail-less reference that omitted the two source-shadow zero rows from *both* sides — which would have left it unmeasurable whether the tail was empty or merely omitted, and an equal count with different membership is exactly what this oracle exists to catch. So a module now publishes its source-shadow bits (from `bp_round0_scan`'s return value — it is a union like the other two) and the link ORs them and appends the same tail.

The remaining 3-entry size gap is the occurrence artifact #2666 named, not a membership difference: `__arr_equals__N8_TypeExpr` is a program-level helper synthesized once per module that needs it.

## What measurement forced

The program-wide folds are prepared **once** for all modules, not per module. Per module they cost 365 folds of every call site in the program and ran the compiler's own closure out of memory:

```
trap: RuntimeError: memory access out of bounds
  at insert_raw ... at rehash ... at bp_fold_nonident
  at compute_borrow_param_round1_local
```

A real driver ships those tables to a module once for the same reason, so the restructure is the right shape rather than merely cheaper.

## Verification

| check | result |
|---|---|
| output equivalence | `lib/@vibe/cli/entry.vibe` compiled with a stage2 built before and after, 3 runs each, ABBA-interleaved, isolated `VIBE_BUILD_CACHE_DIR` per run — **6/6 identical sha256** (`e860df0f…`, 39,544,650 bytes) |
| `scripts/compiler_gate.sh` | `[compiler-gate] ok` — 63 suites, **0 failed** |
| `prelude_module_oracle_test.vibe` | 9 tests pass |
| `vibe check` / `vibe_fmt --check` | clean on all four files |

Production cost is unchanged: the split lane is reached only with `use_split` true, and every production caller passes false (`file_compile.vibe:1813`).

## Still open

#2638 stays open. The two remaining analyses are **real fixpoints** and neither is addressed here:

- `compute_borrow_returning_names` — a `while changed` loop
- `compute_may_return_view_fns` — a callee-edge worklist that re-walks a function when one of its callees enters the set

`borrow_ret=379/364:-15` and `view_ret=2142/1957:-185` still differ in both directions. Those two close over the union and need the fixpoint at the link, which is a different mechanism from the two-phase overlay that suffices here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NAeZzkckdAwtQiubBFpdmM

---
_Generated by [Claude Code](https://claude.ai/code/session_01NAeZzkckdAwtQiubBFpdmM)_