### PR TITLE
perceus: where reuse pays (measured), the Array HOF ownership fix, and a linear + inference (#2389, #2671, #2680)

### DIFF
--- a/docs/perceus-reuse.md
+++ b/docs/perceus-reuse.md
@@ -333,11 +333,50 @@ the lever is the retain traffic -- borrowed reads the inference cannot
 prove (every `Array::get` result passed on, every pattern field consumed
 through a container it does not own) -- and the code shape that produces
 unique inputs (a consuming `map` / a move out of a container) which the
-compiler's own style does not use. Note in passing, found while measuring
-(not fixed here): the RC `Array::map` lowering never releases its input
-array -- 84 B leaked per call on a two-element array (measured
-`measure_heap.mjs`, 20,000 iterations: 1,680,188 B vs 376 B for the
-equivalent index loop).
+compiler's own style does not use.
+
+### The HOF lowerings own what they are handed (#2671)
+
+Measuring the forest shape exposed that the RC lowerings of the Array
+higher-order builtins (`map` / `filter` / `fold` / `iter_eager` / `any` /
+`all` / `find` / `reverse` / `concat`) did no ownership accounting at all.
+Each consumes its array argument (the planner counts the position as
+owning) and calls a callback that OWNS its parameter, so the lane owes the
+callback one reference per element handed over and owes the array one
+release. The lowerings did neither: `Array::map` over an array the caller
+still held handed each element to the rebuilding callback without a
+retain, the callback found the block unique, the reuse fusion fired, and
+the CALLER's array was rewritten in place -- silently wrong (bump 1280400,
+RC 1286800 on the same program); `filter` / `fold` / a capturing `map`
+freed elements the array still listed (the shadow lane's dup-of-freed);
+`find`'s `Some(t)` and `reverse` read freed payloads; and no shell was
+ever released (84 B per `map` call on a two-element array).
+
+Fixed in the lowerings (`compile_call.vibe`, `cc_hof_*`): one rc-word test
+per array decides the path. UNIQUE -- the elements are moved out with no
+retain (a rebuilding callback sees a unique block and fuses), a rejected
+element is released by the lowering, and the shell is freed with its
+length zeroed so the walk skips the moved elements. SHARED -- every element
+handed over is retained first and the array is dropped normally at the
+end. The predicates (`any` / `all` / `find`) never move an element: retain
+per call, walking drop at the end; `concat` retains what it copies and
+releases both inputs; the callback reference is released after the loop
+either way. Two staged-`None` leaks fell out of the same measurement:
+`find` and `MapBuilder::get` initialise their result slot with a 16-byte
+nullary block and overwrote it on a hit.
+
+Pinned by `tests/hof_rc_ownership_test.vibe` (bump / RC / RC-shadow
+agreement on every builtin, shared and unique sources, a capturing closure
+used by three maps), the HOF shapes of `fixtures/rc_reclaim_leak_test.vibe`
+(the shell release, under the 2,000-byte bound) and shape 10 of
+`fixtures/rc_shadow_regression_test.vibe`. Three neighbours found on the
+way are filed, not fixed here: an unannotated lambda parameter consumed
+three times is released early (#2681, P0), an owned call result passed
+straight into a borrowed argument position is never released (#2682), and
+a `MapBuilder` is never reclaimed (#2683). A fourth, in the compiler rather
+than the lane, is fixed on the same branch: a bound `+` chain of 24
+operands ran the compiler out of memory because the trait-dict operand
+inference walked each operand twice per node (#2680).
 
 Pinned by `tests/perceus_reuse_plan_test.vibe` (plan rows, blocker
 semantics, ineligible shapes, the anywhere-consumer and held-bind rows),

--- a/docs/perceus-reuse.md
+++ b/docs/perceus-reuse.md
@@ -365,9 +365,24 @@ either way. Two staged-`None` leaks fell out of the same measurement:
 `find` and `MapBuilder::get` initialise their result slot with a 16-byte
 nullary block and overwrote it on a hit.
 
+One more rule, found by the book's collections chapter: the lowering owns
+an argument only where the PLANNER planned an owning position. `@vibe/builtin`
+declares `let Array::map = ..` as a borrow-only loop, so a program that
+imports the package (the book does, for `trait Iterator`) plans every
+`Array::map(xs, f)` call as a borrow -- no dup, the caller expects `xs`
+back -- while the ladder still intercepts the name and consumes. The first
+cut moved the array out from under the caller (`Array::push(xs, 4)` after
+a map answered length 1). `cc_hof_retain_arg` now also retains an argument
+whose position the planner classified as borrowed
+(`md_borrow_mask_of`), so the lowering holds a reference of its own and the
+caller keeps its; such a program never sees the unique path for that name,
+which is the honest price of shadowing an intrinsic with a source
+definition the planner reads.
+
 Pinned by `tests/hof_rc_ownership_test.vibe` (bump / RC / RC-shadow
 agreement on every builtin, shared and unique sources, a capturing closure
-used by three maps), the HOF shapes of `fixtures/rc_reclaim_leak_test.vibe`
+used by three maps, a source-level `Array::map` shadowing the intrinsic),
+the HOF shapes of `fixtures/rc_reclaim_leak_test.vibe`
 (the shell release, under the 2,000-byte bound) and shape 10 of
 `fixtures/rc_shadow_regression_test.vibe`. Three neighbours found on the
 way are filed, not fixed here: an unannotated lambda parameter consumed
@@ -377,6 +392,44 @@ a `MapBuilder` is never reclaimed (#2683). A fourth, in the compiler rather
 than the lane, is fixed on the same branch: a bound `+` chain of 24
 operands ran the compiler out of memory because the trait-dict operand
 inference walked each operand twice per node (#2680).
+
+### An FBIP-shaped rewrite of one pass, measured (2026-09-11)
+
+The question behind #2389 was whether the compiler's own code could be
+moved toward the shape reuse rewards. One pass was rewritten to find out:
+`lift_match_scrutinees` (`normalize/normalize.vibe`), whose arms are
+already same-shape constructor rebuilds and whose child arrays were rebuilt
+with `for` comprehensions -- a comprehension reads each element through a
+borrow, so everything below an array boundary was shared and allocated
+fresh. The comprehensions became consuming `Array::map` helpers
+(`lms_exprs` / `lms_arms` / `lms_named`, closures capturing the counter),
+which after the ownership fix above move the elements out of a unique
+array. Measured on the flat-source RC-lane self-compile through two
+counter-instrumented RC-built compilers (the same input, cold, viberun
+fuel):
+
+| | fuel | allocated | output | staged | unique |
+|---|---:|---:|---|---:|---:|
+| before | 1,177,116,818,175 | 1,836,094,292 B | 4,978,430 B | 3,970,084 | 826 |
+| after | 1,177,155,083,233 (+0.003%) | 1,836,094,276 B | byte-identical | 3,970,084 | 826 |
+
+Neutral, and the counters say why: not one more uniqueness test passed.
+The pass never receives a unique tree. Its root is `get_slet_expr(pb_stmt)`
+-- a field of a statement the statement array still owns -- run through
+`uniquify_shadowed_bindings`, which hands back every unchanged subtree
+as is (structure sharing, by design), so a moving map finds shared arrays
+all the way down and takes the retaining path, exactly as the comprehension
+did. Uniqueness has to be produced upstream, by a pipeline that transfers
+its statement array from pass to pass (`let stmts = pass(stmts)`) instead
+of mutating it in place through borrowed reads (`pass(stmts)`, every desugar
+today), and that is a change to the pipeline's ownership, not to any one
+pass. The rewrite is not landed: it buys nothing yet, costs one closure
+block per array-bearing node, and under the committed seed -- whose
+`Array::map` still hands the callback elements the shared tree owns -- the
+FS-lane test harness traps in `expr_contains_exceptions` reading a freed
+node (the flat self-compile happens to produce identical bytes, the freed
+nodes not being reused before they are read). It is attached to the PR
+for the record.
 
 Pinned by `tests/perceus_reuse_plan_test.vibe` (plan rows, blocker
 semantics, ineligible shapes, the anywhere-consumer and held-bind rows),

--- a/docs/perceus-reuse.md
+++ b/docs/perceus-reuse.md
@@ -280,6 +280,65 @@ the RC lane's wall time is made of, and reuse buys allocation traffic, not
 wall. The lever for the ≤1.2× target is elsewhere (dup/drop traffic, the
 RC entry sequences), as the issue's last measurement already concluded.
 
+### Where reuse pays, and why the self-compile does not see it (2026-09-11)
+
+`bench/exec/tree_rebuild.vibe` is the pattern: a unique tree rebuilt by
+`match` through the shapes the tiers distinguish. Measured under viberun
+fuel (deterministic instruction cost; `VIBE_FUEL=1`) per shape, one
+variant per shape run in isolation, 12 rounds over depth-11 trees, with
+three compilers -- reuse disabled entirely (both tiers return -1, a
+scratch build), the branch base (slices 1-2), and this slice:
+
+| shape (rebuilds per round) | reuse off | branch base | this slice | rebuild allocation |
+|---|---:|---:|---:|---|
+| `only_tail`: constructor tail (3) | 18.31M / rebuild | 3.59M | 3.59M | 0 B (114,664 = the build alone) |
+| `only_shared`: same rebuild, source kept alive (3) | 18.92M | 9.43M | 9.43M | one fresh tree per shared rebuild |
+| `only_mirror`: constructor in an `if` branch (3) | 18.85M | 19.34M | 4.40M | 229,328 → 114,672 B |
+| `only_clamp`: one branch at another size (2) | 9.55M | 9.82M | 3.69M | token released on that path |
+| `only_weigh`: held bind, right spine only (3) | 1.86M | 1.86M | 1.82M | dominated by the `checksum` reads |
+
+A fused rebuild costs ~5x fewer instructions than the normal path
+(bind-time dups, recursive drop, free-list push, alloc, header init) and
+allocates nothing; a staged arm whose test fails costs the normal path plus
+the test (`only_mirror` on the branch base, +2.6%). The container shape
+decides everything (8 depth-8 trees, 12 rounds, 3 rebuild passes):
+
+| container shape | reuse off | fused | note |
+|---|---:|---:|---|
+| `only_chain8`: unique chains, no container | 69.9M | 25.8M | the reference |
+| `only_forest`: `Array::map(arr, incr)` | 74.8M | 30.7M | the element reaches the callback without a retain, so it is unique |
+| `only_forest_loop`: `Array::push(out, incr(Array::get(arr, i)))` | 74.9M | 77.8M | `Array::get` is a borrowed view; the owned argument position retains it, every root is shared, nothing reuses, the staging is pure cost |
+
+The compiler itself is written in the third shape: its sources hold 30
+`Array::map` calls against 43,587 `Array::get`, 11,523 index `while`
+loops and 8,418 `Array::set` (statements rewritten in place, `match
+Array::get(stmts, i)` 7,684 times). A pass receives its tree as a
+pattern-bound field of a statement that the statement array still owns,
+so the root of every rebuild is shared, the shared path dups the children,
+and the whole cascade below it allocates fresh. Measured on the RC-built
+compiler compiling the full closure (viberun fuel, cold isolated cache):
+reuse on vs the reuse-disabled build is **+0.38%** instructions
+(175.26G vs 174.60G) and +0.25% allocation -- the staging runs, the
+uniqueness test fails, and the fallback costs a little. Counted with a
+scratch build whose staging code increments a memory counter (verified on
+the exec shapes: the unique chains and the `Array::map` forest hit 147,168
+of 147,168, the index loop 0 of 147,168): the full-closure self-compile
+stages **2,637,481** uniqueness tests and **1,078** pass (0.04%).
+
+The profile of the same compile (`scripts/profile_compile.sh`, names
+build) puts the RC lane's cost where reuse cannot reach: `__rt_rc_dup`
+33.2% of CPU, `__rt_rc_drop` 3.1%, `__rt_rc_alloc` 3.1%. Even a perfect
+allocation-free compiler would move the ADR-0092 ratio by a few percent;
+the lever is the retain traffic -- borrowed reads the inference cannot
+prove (every `Array::get` result passed on, every pattern field consumed
+through a container it does not own) -- and the code shape that produces
+unique inputs (a consuming `map` / a move out of a container) which the
+compiler's own style does not use. Note in passing, found while measuring
+(not fixed here): the RC `Array::map` lowering never releases its input
+array -- 84 B leaked per call on a two-element array (measured
+`measure_heap.mjs`, 20,000 iterations: 1,680,188 B vs 376 B for the
+equivalent index loop).
+
 Pinned by `tests/perceus_reuse_plan_test.vibe` (plan rows, blocker
 semantics, ineligible shapes, the anywhere-consumer and held-bind rows),
 `tests/perceus_reuse_e2e_test.vibe` (bump/RC output agreement on the unique

--- a/fixtures/rc_reclaim_leak_test.vibe
+++ b/fixtures/rc_reclaim_leak_test.vibe
@@ -158,6 +158,39 @@ let hold = (t: Tree) -> Tree {
   }
 }
 
+// #2671 HOF ownership guards. Each Array higher-order lowering (map /
+// filter / fold / any / all / find / reverse / concat) consumes the array it
+// is handed and owns the callback reference, so on the RC lane it must
+// release the shell exactly once -- emptied on the unique path (elements
+// moved out), walked on the shared path (elements retained as they are
+// handed over) -- and drop the callback after the loop. Before the fix no
+// lowering released anything: one shell per call (plus the callback block
+// for a capturing closure) leaked, scaling heap_used with N.
+let incr_tree = (t: Tree) -> Tree {
+  match t {
+    Leaf(v) => Leaf(v + 1),
+    Node(l, r) => {
+      let l2 = incr_tree(l)
+      let r2 = incr_tree(r)
+      Node(l2, r2)
+    }
+  }
+}
+
+let is_leaf = (t: Tree) -> Bool {
+  match t {
+    Leaf(_) => true,
+    Node(_, _) => false
+  }
+}
+
+let is_node = (t: Tree) -> Bool {
+  match t {
+    Leaf(_) => false,
+    Node(_, _) => true
+  }
+}
+
 let main = () -> Int {
   let mut total = 0
   let mut i = 0
@@ -221,7 +254,52 @@ let main = () -> Int {
     // sumtri(w) = 2i + 1, sumt(h) = 3i + 1.
     let w = widen0(N2(L(i), L(i + 1)), 0)
     let h = hold(Node(Leaf(i), Leaf(i + 1)))
+    // #2671 (see incr_tree / is_leaf / is_node above). `ta` stays live
+    // across every call, so each lowering takes the SHARED path; the
+    // map-of-map and the literal-fed filter take the UNIQUE path (elements
+    // moved out, the rejected Node discarded, the emptied shell released).
+    // Per iteration: sumt(ta1) = 2i+1, sumt(hm21) = 2i+5, |hf| = |hf2| = 1,
+    // hfold = 3i+1, hfind = 2i+1, sumt(hrev0) = 2i+1, |hcat| = 4,
+    // hany + hall = 1 -- 11i + 16 in all. Accumulated in a second statement:
+    // a `+` chain of 24 or more operands under a binding is compiled in
+    // exponential time by desugar_trait_dict's operand-type inference and
+    // runs the compiler out of memory (see the `dtd_binop_builtin_operand_type`
+    // note there).
+    let ta: Array[Tree] = [
+      Leaf(i),
+      Node(Leaf(i), Leaf(i + 1))
+    ]
+    let hm = Array::map(ta, incr_tree)
+    let hm2 = Array::map(hm, incr_tree)
+    let hf = Array::filter(ta, is_leaf)
+    let hf2 = Array::filter([
+      Leaf(i),
+      Node(Leaf(i), Leaf(i + 1))
+    ], is_leaf)
+    let hfold = Array::fold(ta, 0, (acc: Int, t: Tree) -> Int {
+      acc + sumt(t)
+    })
+    let hfind = match Array::find(ta, is_node) {
+      Some(t) => sumt(t),
+      None => 0
+    }
+    let hrev = Array::reverse(ta)
+    let hcat = Array::concat(ta, hrev)
+    let hany = if Array::any(ta, is_node) {
+      1
+    } else {
+      0
+    }
+    let hall = if Array::all(ta, is_node) {
+      1
+    } else {
+      0
+    }
+    let ta1 = Array::get(ta, 1)
+    let hm21 = Array::get(hm2, 1)
+    let hrev0 = Array::get(hrev, 0)
     total = total + t.0 + t.1 + c + sumt(tr) + first + ignored + inlined + blen + looped + Array::length(built) + Array::length(built_if) + sumtri(w) + sumt(h)
+    total = total + sumt(ta1) + sumt(hm21) + Array::length(hf) + Array::length(hf2) + hfold + hfind + sumt(hrev0) + Array::length(hcat) + hany + hall
     i = i + 1
   }
   total

--- a/fixtures/rc_shadow_regression_test.vibe
+++ b/fixtures/rc_shadow_regression_test.vibe
@@ -178,6 +178,36 @@ fn shape9_optional(x?: Array[Int]) -> Int {
   Array::length(x)
 }
 
+// Shape 10 (#2671): the Array higher-order lowerings over a SHARED array
+// of heap elements. Every callback OWNS its parameter, so each lowering
+// must retain what it hands over (or move it out of a unique array) and
+// release the array exactly once. Before the fix the callbacks consumed
+// elements the array still listed: filter / fold / a capturing map trapped
+// on a dup of a freed value, find's `Some(t)` payload and reverse on a drop
+// of a freed value. The map callback rebuilds its TFn (a reuse arm), which
+// on a unique block fires in place -- hence the source array is read last.
+// The parameter is annotated on purpose: an UNANNOTATED lambda parameter
+// consumed three or more times is released early (#2681, a separate,
+// pre-existing accounting bug this shape is not about).
+let shape10 = (tys: Array[Ty]) -> Int {
+  let kept = Array::filter(tys, (t) -> use_ty(t) == 1)
+  let folded = Array::fold(tys, 0, (acc, t) -> acc + use_ty(t))
+  let found = match Array::find(tys, (t) -> use_ty(t) == 1) {
+    Some(t) => use_ty(t) + 1,
+    None => 0
+  }
+  let rev = Array::reverse(tys)
+  let mapped = Array::map(tys, (t) -> match t {
+    TFn(ps, r) => TFn(ps, r),
+    _ => TInt
+  })
+  let cat = Array::concat(tys, rev)
+  let r1 = Array::get(rev, 1)
+  let m1 = Array::get(mapped, 1)
+  let t1 = Array::get(tys, 1)
+  Array::length(kept) + folded + found + use_ty(r1) + Array::length(mapped) + use_ty(m1) + Array::length(cat) + use_ty(t1)
+}
+
 let main = () -> Int {
   let names = ["a", "b", "c"]
   let effs = [[TInt], [TFn([TInt], TInt)], [TInt]]
@@ -204,6 +234,7 @@ let main = () -> Int {
     acc = acc + shape6(k)
     acc = acc + shape7()
     acc = acc + shape8(k)
+    acc = acc + shape10(tys)
     let borrowed = [10, 20, 30, 40]
     acc = acc + shape9_labeled(x=borrowed)
     acc = acc + Array::length(borrowed)

--- a/lib/@vibe/compiler/codegen/expr/compile_call.vibe
+++ b/lib/@vibe/compiler/codegen/expr/compile_call.vibe
@@ -1465,10 +1465,20 @@ fn cc_retain_stored_arg(buf: Bytes, carg: Expr, local_names: Array[String], nl: 
 /// bytes are untouched.
 ///
 /// The generic owning-position retain (cc_retain_stored_arg's rule) for an
-/// argument already sitting in `local_idx`.
-fn cc_hof_retain_arg(buf: Bytes, carg: Expr, local_idx: Int, ctx: CompileCtx) -> Unit with Exception {
+/// argument already sitting in `local_idx`, plus one rule of its own: when
+/// the PLANNER classified position `pos` of this callee as BORROWED, the
+/// caller passed its reference without a dup and expects it back intact,
+/// so the lowering takes a reference of its own here. That happens when
+/// the program carries a source definition of the same name -- `@vibe/builtin`
+/// declares `let Array::map = ..` as a borrow-only loop, so every program
+/// that imports the package plans its `Array::map(xs, f)` calls as borrows
+/// while this ladder still intercepts the name and consumes. Without the
+/// retain the array was moved out from under the caller (the book's
+/// `Array::push(xs, 4)` after a map answered length 1).
+fn cc_hof_retain_arg(buf: Bytes, carg: Expr, local_idx: Int, fname: String, pos: Int, ctx: CompileCtx) -> Unit with Exception {
   let is_loop_borrow = ctx.enable_rc && cc_is_loop_borrowed_ident(carg, ctx)
-  if ctx.enable_rc && (cc_is_projection(carg) || cc_is_borrow_ret_call(carg, ctx) || is_loop_borrow) {
+  let planner_borrows = ctx.enable_rc && cc_bmask_has(md_borrow_mask_of(fname, ctx.borrow_param_user, ctx.borrow_param_mask), pos)
+  if ctx.enable_rc && (cc_is_projection(carg) || cc_is_borrow_ret_call(carg, ctx) || is_loop_borrow || planner_borrows) {
     if is_loop_borrow {
       Array::push(ctx.loop_consumed_names, get_eident_name(carg))
     } else {
@@ -4007,8 +4017,8 @@ fn compile_call_core(buf: Bytes, callee: Expr, args: Array[Expr], local_names: A
       Array::push(local_names, "__map_uniq")
       emit_local_set(buf, fn_l)
       emit_local_set(buf, arr_l)
-      cc_hof_retain_arg(buf, Array::get(args, 0), arr_l, ctx)
-      cc_hof_retain_arg(buf, Array::get(args, 1), fn_l, ctx)
+      cc_hof_retain_arg(buf, Array::get(args, 0), arr_l, fname, 0, ctx)
+      cc_hof_retain_arg(buf, Array::get(args, 1), fn_l, fname, 1, ctx)
       cc_hof_unique_test(buf, arr_l, uniq_l, ctx)
       emit_call(buf, arr_new_fi)
       emit_local_set(buf, res_l)
@@ -4073,8 +4083,8 @@ fn compile_call_core(buf: Bytes, callee: Expr, args: Array[Expr], local_names: A
       Array::push(local_names, "__filter_uniq")
       emit_local_set(buf, fn_l)
       emit_local_set(buf, arr_l)
-      cc_hof_retain_arg(buf, Array::get(args, 0), arr_l, ctx)
-      cc_hof_retain_arg(buf, Array::get(args, 1), fn_l, ctx)
+      cc_hof_retain_arg(buf, Array::get(args, 0), arr_l, fname, 0, ctx)
+      cc_hof_retain_arg(buf, Array::get(args, 1), fn_l, fname, 1, ctx)
       cc_hof_unique_test(buf, arr_l, uniq_l, ctx)
       emit_call(buf, arr_new_fi)
       emit_local_set(buf, res_l)
@@ -4144,9 +4154,9 @@ fn compile_call_core(buf: Bytes, callee: Expr, args: Array[Expr], local_names: A
       emit_local_set(buf, fn_l)
       emit_local_set(buf, acc_l)
       emit_local_set(buf, arr_l)
-      cc_hof_retain_arg(buf, Array::get(args, 0), arr_l, ctx)
-      cc_hof_retain_arg(buf, Array::get(args, 1), acc_l, ctx)
-      cc_hof_retain_arg(buf, Array::get(args, 2), fn_l, ctx)
+      cc_hof_retain_arg(buf, Array::get(args, 0), arr_l, fname, 0, ctx)
+      cc_hof_retain_arg(buf, Array::get(args, 1), acc_l, fname, 1, ctx)
+      cc_hof_retain_arg(buf, Array::get(args, 2), fn_l, fname, 2, ctx)
       cc_hof_unique_test(buf, arr_l, uniq_l, ctx)
       emit_local_get(buf, arr_l)
       emit_call(buf, arr_len_fi)
@@ -4203,8 +4213,8 @@ fn compile_call_core(buf: Bytes, callee: Expr, args: Array[Expr], local_names: A
       Array::push(local_names, "__iter_uniq")
       emit_local_set(buf, fn_l)
       emit_local_set(buf, arr_l)
-      cc_hof_retain_arg(buf, Array::get(args, 0), arr_l, ctx)
-      cc_hof_retain_arg(buf, Array::get(args, 1), fn_l, ctx)
+      cc_hof_retain_arg(buf, Array::get(args, 0), arr_l, fname, 0, ctx)
+      cc_hof_retain_arg(buf, Array::get(args, 1), fn_l, fname, 1, ctx)
       cc_hof_unique_test(buf, arr_l, uniq_l, ctx)
       emit_local_get(buf, arr_l)
       emit_call(buf, arr_len_fi)
@@ -4256,7 +4266,7 @@ fn compile_call_core(buf: Bytes, callee: Expr, args: Array[Expr], local_names: A
       Array::push(local_names, "__rev_elem")
       Array::push(local_names, "__rev_uniq")
       emit_local_set(buf, arr_l)
-      cc_hof_retain_arg(buf, Array::get(args, 0), arr_l, ctx)
+      cc_hof_retain_arg(buf, Array::get(args, 0), arr_l, fname, 0, ctx)
       cc_hof_unique_test(buf, arr_l, uniq_l, ctx)
       emit_call(buf, arr_new_fi)
       emit_local_set(buf, res_l)
@@ -4313,8 +4323,8 @@ fn compile_call_core(buf: Bytes, callee: Expr, args: Array[Expr], local_names: A
       Array::push(local_names, "__cat_elem")
       emit_local_set(buf, b_l)
       emit_local_set(buf, a_l)
-      cc_hof_retain_arg(buf, Array::get(args, 0), a_l, ctx)
-      cc_hof_retain_arg(buf, Array::get(args, 1), b_l, ctx)
+      cc_hof_retain_arg(buf, Array::get(args, 0), a_l, fname, 0, ctx)
+      cc_hof_retain_arg(buf, Array::get(args, 1), b_l, fname, 1, ctx)
       emit_call(buf, arr_new_fi)
       emit_local_set(buf, res_l)
       emit_local_get(buf, a_l)
@@ -4453,8 +4463,8 @@ fn compile_call_core(buf: Bytes, callee: Expr, args: Array[Expr], local_names: A
       Array::push(local_names, "__any_elem")
       emit_local_set(buf, fn_l)
       emit_local_set(buf, arr_l)
-      cc_hof_retain_arg(buf, Array::get(args, 0), arr_l, ctx)
-      cc_hof_retain_arg(buf, Array::get(args, 1), fn_l, ctx)
+      cc_hof_retain_arg(buf, Array::get(args, 0), arr_l, fname, 0, ctx)
+      cc_hof_retain_arg(buf, Array::get(args, 1), fn_l, fname, 1, ctx)
       emit_local_get(buf, arr_l)
       emit_call(buf, arr_len_fi)
       emit_local_set(buf, len_l)
@@ -4528,8 +4538,8 @@ fn compile_call_core(buf: Bytes, callee: Expr, args: Array[Expr], local_names: A
       Array::push(local_names, "__all_elem")
       emit_local_set(buf, fn_l)
       emit_local_set(buf, arr_l)
-      cc_hof_retain_arg(buf, Array::get(args, 0), arr_l, ctx)
-      cc_hof_retain_arg(buf, Array::get(args, 1), fn_l, ctx)
+      cc_hof_retain_arg(buf, Array::get(args, 0), arr_l, fname, 0, ctx)
+      cc_hof_retain_arg(buf, Array::get(args, 1), fn_l, fname, 1, ctx)
       emit_local_get(buf, arr_l)
       emit_call(buf, arr_len_fi)
       emit_local_set(buf, len_l)
@@ -4617,8 +4627,8 @@ fn compile_call_core(buf: Bytes, callee: Expr, args: Array[Expr], local_names: A
       let mut nl2 = nl + 8
       emit_local_set(buf, fn_l)
       emit_local_set(buf, arr_l)
-      cc_hof_retain_arg(buf, Array::get(args, 0), arr_l, ctx)
-      cc_hof_retain_arg(buf, Array::get(args, 1), fn_l, ctx)
+      cc_hof_retain_arg(buf, Array::get(args, 0), arr_l, fname, 0, ctx)
+      cc_hof_retain_arg(buf, Array::get(args, 1), fn_l, fname, 1, ctx)
       emit_local_get(buf, arr_l)
       emit_call(buf, arr_len_fi)
       emit_local_set(buf, len_l)

--- a/lib/@vibe/compiler/codegen/expr/compile_call.vibe
+++ b/lib/@vibe/compiler/codegen/expr/compile_call.vibe
@@ -1435,6 +1435,171 @@ fn cc_retain_stored_arg(buf: Bytes, carg: Expr, local_names: Array[String], nl: 
   }
 }
 
+/// #2671: ownership for the inline lowerings that read an array's elements
+/// (Array::map / filter / fold / iter_eager / any / all / find / reverse /
+/// concat). Each consumes its array argument -- the planner counts the
+/// position as owning, so the caller's reference arrives here -- and the
+/// closure-taking ones call a callback that OWNS its parameter (a lambda
+/// always does; a top-level fn used as a value is excluded from the borrow
+/// classification, compute_borrow_param_user_fns). The RC lane therefore
+/// owes the callback one reference per element it hands over and owes the
+/// array exactly one release. The lowerings used to do neither: the
+/// callback consumed an element the array still listed (a use-after-free
+/// the shadow lane catches), a rebuilding callback found the element unique
+/// and rewrote the CALLER's array in place (silently wrong: bump 128004000,
+/// RC 128068000 on the same program), and the shell was never freed (84 B
+/// per call on a two-element array).
+///
+/// Two paths, decided once per array by its rc word (cc_hof_unique_test):
+/// UNIQUE -- the elements are moved out with no retain (a rebuilding
+/// callback then sees a unique block and the reuse fusion fires), and the
+/// shell is released with its length zeroed so rc_drop frees it and its
+/// grown buffer without walking the moved elements (cc_hof_release_moved);
+/// SHARED -- every element handed over is retained first (cc_hof_give), the
+/// other owner's view stays intact, and the array reference is dropped
+/// normally at the end. A lowering that never moves an element (the
+/// predicates any / all / find) retains every element it hands over and
+/// drops the array normally (cc_hof_release_walking). The callback
+/// reference is released after the loop either way -- a bare fn value is
+/// even and rc_drop ignores it. Every emission is RC-only; the bump lane's
+/// bytes are untouched.
+///
+/// The generic owning-position retain (cc_retain_stored_arg's rule) for an
+/// argument already sitting in `local_idx`.
+fn cc_hof_retain_arg(buf: Bytes, carg: Expr, local_idx: Int, ctx: CompileCtx) -> Unit with Exception {
+  let is_loop_borrow = ctx.enable_rc && cc_is_loop_borrowed_ident(carg, ctx)
+  if ctx.enable_rc && (cc_is_projection(carg) || cc_is_borrow_ret_call(carg, ctx) || is_loop_borrow) {
+    if is_loop_borrow {
+      Array::push(ctx.loop_consumed_names, get_eident_name(carg))
+    } else {
+      ()
+    }
+    emit_rc_dup_guarded(buf, local_idx, ctx.rc_shadow, ctx.rc_dup_func_idx)
+  } else {
+    ()
+  }
+}
+
+/// uniq_l := 1 when the array block's rc word is exactly `1 | (5 << 24)`
+/// (one owner, class 5), else 0. A saturated (immortal) word lands on the
+/// shared path, where every step is a plain retain / release.
+fn cc_hof_unique_test(buf: Bytes, arr_l: Int, uniq_l: Int, ctx: CompileCtx) -> Unit {
+  if ctx.enable_rc {
+    emit_local_get(buf, arr_l)
+    emit_i64_const(buf, -2)
+    emit_i64_and(buf)
+    emit_i32_wrap_i64(buf)
+    emit_i32_const(buf, 4)
+    emit_i32_sub(buf)
+    emit_i32_load(buf, 2, 0)
+    emit_i32_const(buf, 83886081)
+    emit_i32_eq(buf)
+    emit_i64_extend_i32_u(buf)
+    emit_local_set(buf, uniq_l)
+  } else {
+    ()
+  }
+}
+
+/// Hand `elem_l` over to something that will own it (a consuming callback,
+/// the result array): on the shared path retain it first; on the unique
+/// path it moves.
+fn cc_hof_give(buf: Bytes, elem_l: Int, uniq_l: Int, ctx: CompileCtx) -> Unit {
+  if ctx.enable_rc {
+    emit_local_get(buf, uniq_l)
+    emit_i64_eqz(buf)
+    emit_if_void(buf)
+    emit_rc_dup_guarded(buf, elem_l, ctx.rc_shadow, ctx.rc_dup_func_idx)
+    emit_end(buf)
+  } else {
+    ()
+  }
+}
+
+/// The unique path's release of an element the lowering is NOT handing over
+/// (Array::filter's rejected element): the array's reference to it is spent
+/// here, since the shell is freed without walking its elements.
+fn cc_hof_discard(buf: Bytes, elem_l: Int, uniq_l: Int, ctx: CompileCtx) -> Unit {
+  if ctx.enable_rc && ctx.rc_drop_func_idx >= 0 {
+    emit_local_get(buf, uniq_l)
+    emit_i64_eqz(buf)
+    emit_i32_eqz(buf)
+    emit_if_void(buf)
+    emit_local_get(buf, elem_l)
+    emit_call(buf, ctx.rc_drop_func_idx)
+    emit_end(buf)
+  } else {
+    ()
+  }
+}
+
+/// Release the callback reference (`fn_l` < 0: no callback).
+fn cc_hof_release_fn(buf: Bytes, fn_l: Int, ctx: CompileCtx) -> Unit {
+  if ctx.enable_rc && ctx.rc_drop_func_idx >= 0 && fn_l >= 0 {
+    emit_local_get(buf, fn_l)
+    emit_call(buf, ctx.rc_drop_func_idx)
+  } else {
+    ()
+  }
+}
+
+/// Release an array whose elements were moved out on the unique path: zero
+/// its length first so rc_drop frees the shell (and a grown buffer) without
+/// walking them; on the shared path the drop is the ordinary decrement.
+fn cc_hof_release_moved(buf: Bytes, arr_l: Int, uniq_l: Int, fn_l: Int, ctx: CompileCtx) -> Unit {
+  if ctx.enable_rc && ctx.rc_drop_func_idx >= 0 {
+    emit_local_get(buf, uniq_l)
+    emit_i64_eqz(buf)
+    emit_i32_eqz(buf)
+    emit_if_void(buf)
+    emit_local_get(buf, arr_l)
+    emit_i64_const(buf, -2)
+    emit_i64_and(buf)
+    emit_i32_wrap_i64(buf)
+    emit_i32_const(buf, 0)
+    emit_i32_store(buf, 2, 4)
+    emit_end(buf)
+    emit_local_get(buf, arr_l)
+    emit_call(buf, ctx.rc_drop_func_idx)
+    cc_hof_release_fn(buf, fn_l, ctx)
+  } else {
+    ()
+  }
+}
+
+/// Release an array none of whose elements were moved (the predicates): the
+/// ordinary drop walks and releases them.
+fn cc_hof_release_walking(buf: Bytes, arr_l: Int, fn_l: Int, ctx: CompileCtx) -> Unit {
+  if ctx.enable_rc && ctx.rc_drop_func_idx >= 0 {
+    emit_local_get(buf, arr_l)
+    emit_call(buf, ctx.rc_drop_func_idx)
+    cc_hof_release_fn(buf, fn_l, ctx)
+  } else {
+    ()
+  }
+}
+
+/// Release the value a result slot holds before it is overwritten (the
+/// `None` a search lowering stages before its loop).
+fn cc_hof_release_slot(buf: Bytes, slot_l: Int, ctx: CompileCtx) -> Unit {
+  if ctx.enable_rc && ctx.rc_drop_func_idx >= 0 {
+    emit_local_get(buf, slot_l)
+    emit_call(buf, ctx.rc_drop_func_idx)
+  } else {
+    ()
+  }
+}
+
+/// A predicate owns its parameter but the array keeps its element: retain
+/// before the call, unconditionally.
+fn cc_hof_lend(buf: Bytes, elem_l: Int, ctx: CompileCtx) -> Unit {
+  if ctx.enable_rc {
+    emit_rc_dup_guarded(buf, elem_l, ctx.rc_shadow, ctx.rc_dup_func_idx)
+  } else {
+    ()
+  }
+}
+
 /// #664/#678: is `e` statically a known integer that must NOT be run through
 /// `__to_string`'s string-pointer heuristic (which misreads a large int as an
 /// empty string)? An Int literal, a bitwise/shift/mod expression (those
@@ -3830,6 +3995,7 @@ fn compile_call_core(buf: Bytes, callee: Expr, args: Array[Expr], local_names: A
       let slot_l = nl + 5
       let env_l = nl + 6
       let elem_l = nl + 7
+      let uniq_l = nl + 8
       Array::push(local_names, "__map_arr")
       Array::push(local_names, "__map_fn")
       Array::push(local_names, "__map_res")
@@ -3838,8 +4004,12 @@ fn compile_call_core(buf: Bytes, callee: Expr, args: Array[Expr], local_names: A
       Array::push(local_names, "__map_slot")
       Array::push(local_names, "__map_env")
       Array::push(local_names, "__map_elem")
+      Array::push(local_names, "__map_uniq")
       emit_local_set(buf, fn_l)
       emit_local_set(buf, arr_l)
+      cc_hof_retain_arg(buf, Array::get(args, 0), arr_l, ctx)
+      cc_hof_retain_arg(buf, Array::get(args, 1), fn_l, ctx)
+      cc_hof_unique_test(buf, arr_l, uniq_l, ctx)
       emit_call(buf, arr_new_fi)
       emit_local_set(buf, res_l)
       emit_local_get(buf, arr_l)
@@ -3858,6 +4028,7 @@ fn compile_call_core(buf: Bytes, callee: Expr, args: Array[Expr], local_names: A
       emit_local_get(buf, i_l)
       emit_call(buf, arr_get_fi)
       emit_local_set(buf, elem_l)
+      cc_hof_give(buf, elem_l, uniq_l, ctx)
       emit_local_get(buf, elem_l)
       emit_closure_call_tail(buf, env_l, slot_l, 9, 1)
       emit_local_set(buf, elem_l)
@@ -3871,8 +4042,9 @@ fn compile_call_core(buf: Bytes, callee: Expr, args: Array[Expr], local_names: A
       emit_br(buf, 0)
       emit_end(buf)
       emit_end(buf)
+      cc_hof_release_moved(buf, arr_l, uniq_l, fn_l, ctx)
       emit_local_get(buf, res_l)
-      nl + 8
+      nl + 9
     }
     else if fname == "Array::filter" {
       let (arr_new_fi, _, _) = resolve_func(ctx.func_table, "array_new")
@@ -3889,6 +4061,7 @@ fn compile_call_core(buf: Bytes, callee: Expr, args: Array[Expr], local_names: A
       let slot_l = nl + 5
       let env_l = nl + 6
       let elem_l = nl + 7
+      let uniq_l = nl + 8
       Array::push(local_names, "__filter_arr")
       Array::push(local_names, "__filter_fn")
       Array::push(local_names, "__filter_res")
@@ -3897,8 +4070,12 @@ fn compile_call_core(buf: Bytes, callee: Expr, args: Array[Expr], local_names: A
       Array::push(local_names, "__filter_slot")
       Array::push(local_names, "__filter_env")
       Array::push(local_names, "__filter_elem")
+      Array::push(local_names, "__filter_uniq")
       emit_local_set(buf, fn_l)
       emit_local_set(buf, arr_l)
+      cc_hof_retain_arg(buf, Array::get(args, 0), arr_l, ctx)
+      cc_hof_retain_arg(buf, Array::get(args, 1), fn_l, ctx)
+      cc_hof_unique_test(buf, arr_l, uniq_l, ctx)
       emit_call(buf, arr_new_fi)
       emit_local_set(buf, res_l)
       emit_local_get(buf, arr_l)
@@ -3917,13 +4094,17 @@ fn compile_call_core(buf: Bytes, callee: Expr, args: Array[Expr], local_names: A
       emit_local_get(buf, i_l)
       emit_call(buf, arr_get_fi)
       emit_local_set(buf, elem_l)
+      cc_hof_lend(buf, elem_l, ctx)
       emit_local_get(buf, elem_l)
       emit_closure_call_tail(buf, env_l, slot_l, 9, 1)
       emit_i32_wrap_i64(buf)
       emit_if_void(buf)
+      cc_hof_give(buf, elem_l, uniq_l, ctx)
       emit_local_get(buf, res_l)
       emit_local_get(buf, elem_l)
       emit_call(buf, arr_push_fi)
+      emit_else(buf)
+      cc_hof_discard(buf, elem_l, uniq_l, ctx)
       emit_end(buf)
       emit_local_get(buf, i_l)
       emit_index_one(buf, ctx)
@@ -3932,8 +4113,9 @@ fn compile_call_core(buf: Bytes, callee: Expr, args: Array[Expr], local_names: A
       emit_br(buf, 0)
       emit_end(buf)
       emit_end(buf)
+      cc_hof_release_moved(buf, arr_l, uniq_l, fn_l, ctx)
       emit_local_get(buf, res_l)
-      nl + 8
+      nl + 9
     }
     else if fname == "Array::fold" {
       let (arr_len_fi, _, _) = resolve_func(ctx.func_table, "Array::length")
@@ -3948,6 +4130,8 @@ fn compile_call_core(buf: Bytes, callee: Expr, args: Array[Expr], local_names: A
       let i_l = nl + 4
       let slot_l = nl + 5
       let env_l = nl + 6
+      let elem_l = nl + 7
+      let uniq_l = nl + 8
       Array::push(local_names, "__fold_arr")
       Array::push(local_names, "__fold_acc")
       Array::push(local_names, "__fold_fn")
@@ -3955,9 +4139,15 @@ fn compile_call_core(buf: Bytes, callee: Expr, args: Array[Expr], local_names: A
       Array::push(local_names, "__fold_i")
       Array::push(local_names, "__fold_slot")
       Array::push(local_names, "__fold_env")
+      Array::push(local_names, "__fold_elem")
+      Array::push(local_names, "__fold_uniq")
       emit_local_set(buf, fn_l)
       emit_local_set(buf, acc_l)
       emit_local_set(buf, arr_l)
+      cc_hof_retain_arg(buf, Array::get(args, 0), arr_l, ctx)
+      cc_hof_retain_arg(buf, Array::get(args, 1), acc_l, ctx)
+      cc_hof_retain_arg(buf, Array::get(args, 2), fn_l, ctx)
+      cc_hof_unique_test(buf, arr_l, uniq_l, ctx)
       emit_local_get(buf, arr_l)
       emit_call(buf, arr_len_fi)
       emit_local_set(buf, len_l)
@@ -3970,10 +4160,13 @@ fn compile_call_core(buf: Bytes, callee: Expr, args: Array[Expr], local_names: A
       emit_local_get(buf, len_l)
       emit_i64_ge_s(buf)
       emit_br_if(buf, 1)
-      emit_local_get(buf, acc_l)
       emit_local_get(buf, arr_l)
       emit_local_get(buf, i_l)
       emit_call(buf, arr_get_fi)
+      emit_local_set(buf, elem_l)
+      cc_hof_give(buf, elem_l, uniq_l, ctx)
+      emit_local_get(buf, acc_l)
+      emit_local_get(buf, elem_l)
       emit_closure_call_tail(buf, env_l, slot_l, 9, 2)
       emit_local_set(buf, acc_l)
       emit_local_get(buf, i_l)
@@ -3983,8 +4176,9 @@ fn compile_call_core(buf: Bytes, callee: Expr, args: Array[Expr], local_names: A
       emit_br(buf, 0)
       emit_end(buf)
       emit_end(buf)
+      cc_hof_release_moved(buf, arr_l, uniq_l, fn_l, ctx)
       emit_local_get(buf, acc_l)
-      nl + 7
+      nl + 9
     }
     else if !prefer_bound_call && fname == "Array::iter_eager" {
       let (arr_len_fi, _, _) = resolve_func(ctx.func_table, "Array::length")
@@ -3997,14 +4191,21 @@ fn compile_call_core(buf: Bytes, callee: Expr, args: Array[Expr], local_names: A
       let i_l = nl + 3
       let slot_l = nl + 4
       let env_l = nl + 5
+      let elem_l = nl + 6
+      let uniq_l = nl + 7
       Array::push(local_names, "__iter_arr")
       Array::push(local_names, "__iter_fn")
       Array::push(local_names, "__iter_len")
       Array::push(local_names, "__iter_i")
       Array::push(local_names, "__iter_slot")
       Array::push(local_names, "__iter_env")
+      Array::push(local_names, "__iter_elem")
+      Array::push(local_names, "__iter_uniq")
       emit_local_set(buf, fn_l)
       emit_local_set(buf, arr_l)
+      cc_hof_retain_arg(buf, Array::get(args, 0), arr_l, ctx)
+      cc_hof_retain_arg(buf, Array::get(args, 1), fn_l, ctx)
+      cc_hof_unique_test(buf, arr_l, uniq_l, ctx)
       emit_local_get(buf, arr_l)
       emit_call(buf, arr_len_fi)
       emit_local_set(buf, len_l)
@@ -4020,6 +4221,9 @@ fn compile_call_core(buf: Bytes, callee: Expr, args: Array[Expr], local_names: A
       emit_local_get(buf, arr_l)
       emit_local_get(buf, i_l)
       emit_call(buf, arr_get_fi)
+      emit_local_set(buf, elem_l)
+      cc_hof_give(buf, elem_l, uniq_l, ctx)
+      emit_local_get(buf, elem_l)
       emit_closure_call_tail(buf, env_l, slot_l, 9, 1)
       emit_drop(buf)
       emit_local_get(buf, i_l)
@@ -4029,8 +4233,9 @@ fn compile_call_core(buf: Bytes, callee: Expr, args: Array[Expr], local_names: A
       emit_br(buf, 0)
       emit_end(buf)
       emit_end(buf)
+      cc_hof_release_moved(buf, arr_l, uniq_l, fn_l, ctx)
       emit_local_get(buf, i_l)
-      nl + 6
+      nl + 8
     }
     else if fname == "Array::reverse" {
       let (arr_new_fi, _, _) = resolve_func(ctx.func_table, "array_new")
@@ -4042,11 +4247,17 @@ fn compile_call_core(buf: Bytes, callee: Expr, args: Array[Expr], local_names: A
       let res_l = nl + 1
       let len_l = nl + 2
       let i_l = nl + 3
+      let elem_l = nl + 4
+      let uniq_l = nl + 5
       Array::push(local_names, "__rev_arr")
       Array::push(local_names, "__rev_res")
       Array::push(local_names, "__rev_len")
       Array::push(local_names, "__rev_i")
+      Array::push(local_names, "__rev_elem")
+      Array::push(local_names, "__rev_uniq")
       emit_local_set(buf, arr_l)
+      cc_hof_retain_arg(buf, Array::get(args, 0), arr_l, ctx)
+      cc_hof_unique_test(buf, arr_l, uniq_l, ctx)
       emit_call(buf, arr_new_fi)
       emit_local_set(buf, res_l)
       emit_local_get(buf, arr_l)
@@ -4062,10 +4273,13 @@ fn compile_call_core(buf: Bytes, callee: Expr, args: Array[Expr], local_names: A
       emit_i64_const(buf, 0)
       emit_i64_lt_s(buf)
       emit_br_if(buf, 1)
-      emit_local_get(buf, res_l)
       emit_local_get(buf, arr_l)
       emit_local_get(buf, i_l)
       emit_call(buf, arr_get_fi)
+      emit_local_set(buf, elem_l)
+      cc_hof_give(buf, elem_l, uniq_l, ctx)
+      emit_local_get(buf, res_l)
+      emit_local_get(buf, elem_l)
       emit_call(buf, arr_push_fi)
       emit_local_get(buf, i_l)
       emit_index_one(buf, ctx)
@@ -4074,8 +4288,9 @@ fn compile_call_core(buf: Bytes, callee: Expr, args: Array[Expr], local_names: A
       emit_br(buf, 0)
       emit_end(buf)
       emit_end(buf)
+      cc_hof_release_moved(buf, arr_l, uniq_l, 0 - 1, ctx)
       emit_local_get(buf, res_l)
-      nl + 4
+      nl + 6
     }
     else if fname == "Array::concat" {
       let (arr_new_fi, _, _) = resolve_func(ctx.func_table, "array_new")
@@ -4098,6 +4313,8 @@ fn compile_call_core(buf: Bytes, callee: Expr, args: Array[Expr], local_names: A
       Array::push(local_names, "__cat_elem")
       emit_local_set(buf, b_l)
       emit_local_set(buf, a_l)
+      cc_hof_retain_arg(buf, Array::get(args, 0), a_l, ctx)
+      cc_hof_retain_arg(buf, Array::get(args, 1), b_l, ctx)
       emit_call(buf, arr_new_fi)
       emit_local_set(buf, res_l)
       emit_local_get(buf, a_l)
@@ -4208,6 +4425,8 @@ fn compile_call_core(buf: Bytes, callee: Expr, args: Array[Expr], local_names: A
       emit_br(buf, 0)
       emit_end(buf)
       emit_end(buf)
+      cc_hof_release_walking(buf, a_l, 0 - 1, ctx)
+      cc_hof_release_walking(buf, b_l, 0 - 1, ctx)
       emit_local_get(buf, res_l)
       nl + 6
     }
@@ -4223,6 +4442,7 @@ fn compile_call_core(buf: Bytes, callee: Expr, args: Array[Expr], local_names: A
       let slot_l = nl + 4
       let env_l = nl + 5
       let res_l = nl + 6
+      let elem_l = nl + 7
       Array::push(local_names, "__any_arr")
       Array::push(local_names, "__any_fn")
       Array::push(local_names, "__any_len")
@@ -4230,8 +4450,11 @@ fn compile_call_core(buf: Bytes, callee: Expr, args: Array[Expr], local_names: A
       Array::push(local_names, "__any_slot")
       Array::push(local_names, "__any_env")
       Array::push(local_names, "__any_res")
+      Array::push(local_names, "__any_elem")
       emit_local_set(buf, fn_l)
       emit_local_set(buf, arr_l)
+      cc_hof_retain_arg(buf, Array::get(args, 0), arr_l, ctx)
+      cc_hof_retain_arg(buf, Array::get(args, 1), fn_l, ctx)
       emit_local_get(buf, arr_l)
       emit_call(buf, arr_len_fi)
       emit_local_set(buf, len_l)
@@ -4249,6 +4472,9 @@ fn compile_call_core(buf: Bytes, callee: Expr, args: Array[Expr], local_names: A
       emit_local_get(buf, arr_l)
       emit_local_get(buf, i_l)
       emit_call(buf, arr_get_fi)
+      emit_local_set(buf, elem_l)
+      cc_hof_lend(buf, elem_l, ctx)
+      emit_local_get(buf, elem_l)
       emit_closure_call_tail(buf, env_l, slot_l, 9, 1)
       emit_i32_wrap_i64(buf)
       emit_if_void(buf)
@@ -4263,6 +4489,7 @@ fn compile_call_core(buf: Bytes, callee: Expr, args: Array[Expr], local_names: A
       emit_br(buf, 0)
       emit_end(buf)
       emit_end(buf)
+      cc_hof_release_walking(buf, arr_l, fn_l, ctx)
       emit_local_get(buf, res_l)
       // Under RC a Bool is a TAGGED scalar (n << 1: true=2, false=0); res_l holds
       // a raw 0/1 built from i64 consts, so tag it here. Without this the raw
@@ -4276,7 +4503,7 @@ fn compile_call_core(buf: Bytes, callee: Expr, args: Array[Expr], local_names: A
       } else {
         ()
       }
-      nl + 7
+      nl + 8
     }
     else if fname == "Array::all" {
       let (arr_len_fi, _, _) = resolve_func(ctx.func_table, "Array::length")
@@ -4290,6 +4517,7 @@ fn compile_call_core(buf: Bytes, callee: Expr, args: Array[Expr], local_names: A
       let slot_l = nl + 4
       let env_l = nl + 5
       let res_l = nl + 6
+      let elem_l = nl + 7
       Array::push(local_names, "__all_arr")
       Array::push(local_names, "__all_fn")
       Array::push(local_names, "__all_len")
@@ -4297,8 +4525,11 @@ fn compile_call_core(buf: Bytes, callee: Expr, args: Array[Expr], local_names: A
       Array::push(local_names, "__all_slot")
       Array::push(local_names, "__all_env")
       Array::push(local_names, "__all_res")
+      Array::push(local_names, "__all_elem")
       emit_local_set(buf, fn_l)
       emit_local_set(buf, arr_l)
+      cc_hof_retain_arg(buf, Array::get(args, 0), arr_l, ctx)
+      cc_hof_retain_arg(buf, Array::get(args, 1), fn_l, ctx)
       emit_local_get(buf, arr_l)
       emit_call(buf, arr_len_fi)
       emit_local_set(buf, len_l)
@@ -4316,6 +4547,9 @@ fn compile_call_core(buf: Bytes, callee: Expr, args: Array[Expr], local_names: A
       emit_local_get(buf, arr_l)
       emit_local_get(buf, i_l)
       emit_call(buf, arr_get_fi)
+      emit_local_set(buf, elem_l)
+      cc_hof_lend(buf, elem_l, ctx)
+      emit_local_get(buf, elem_l)
       emit_closure_call_tail(buf, env_l, slot_l, 9, 1)
       emit_i32_wrap_i64(buf)
       emit_i64_extend_i32_s(buf)
@@ -4332,6 +4566,7 @@ fn compile_call_core(buf: Bytes, callee: Expr, args: Array[Expr], local_names: A
       emit_br(buf, 0)
       emit_end(buf)
       emit_end(buf)
+      cc_hof_release_walking(buf, arr_l, fn_l, ctx)
       emit_local_get(buf, res_l)
       // Under RC a Bool is a TAGGED scalar (n << 1); tag the raw 0/1 result so it
       // matches tagged Bool literals (see Array::any above). #776/hof_test.
@@ -4341,7 +4576,7 @@ fn compile_call_core(buf: Bytes, callee: Expr, args: Array[Expr], local_names: A
       } else {
         ()
       }
-      nl + 7
+      nl + 8
     }
     else if fname == "Array::find" {
       // #1065: `res_l` holds an `Option[T]`, NOT a raw scalar (unlike
@@ -4382,6 +4617,8 @@ fn compile_call_core(buf: Bytes, callee: Expr, args: Array[Expr], local_names: A
       let mut nl2 = nl + 8
       emit_local_set(buf, fn_l)
       emit_local_set(buf, arr_l)
+      cc_hof_retain_arg(buf, Array::get(args, 0), arr_l, ctx)
+      cc_hof_retain_arg(buf, Array::get(args, 1), fn_l, ctx)
       emit_local_get(buf, arr_l)
       emit_call(buf, arr_len_fi)
       emit_local_set(buf, len_l)
@@ -4400,11 +4637,20 @@ fn compile_call_core(buf: Bytes, callee: Expr, args: Array[Expr], local_names: A
       emit_local_get(buf, i_l)
       emit_call(buf, arr_get_fi)
       emit_local_set(buf, elem_l)
+      cc_hof_lend(buf, elem_l, ctx)
       emit_local_get(buf, elem_l)
       emit_closure_call_tail(buf, env_l, slot_l, 9, 1)
       emit_i32_wrap_i64(buf)
       emit_if_void(buf)
+      // The Some takes a reference of its own; the array keeps its element
+      // until the walking release below.
+      cc_hof_lend(buf, elem_l, ctx)
       nl2 = ce(buf, ECall(EIdent("Some", -1), [EIdent("__find_elem", -1)], -1), local_names, nl2, ctx, ld)
+      // The `None` staged in res_l before the loop is a 16-byte nullary
+      // block on the RC lane; overwriting it with the Some leaked it on
+      // every hit (measured 16 B per call, payload- and callback-
+      // independent). Release it first.
+      cc_hof_release_slot(buf, res_l, ctx)
       emit_local_set(buf, res_l)
       emit_br(buf, 2)
       emit_end(buf)
@@ -4415,6 +4661,7 @@ fn compile_call_core(buf: Bytes, callee: Expr, args: Array[Expr], local_names: A
       emit_br(buf, 0)
       emit_end(buf)
       emit_end(buf)
+      cc_hof_release_walking(buf, arr_l, fn_l, ctx)
       emit_local_get(buf, res_l)
       nl2
     }
@@ -5457,6 +5704,9 @@ fn compile_call_core(buf: Bytes, callee: Expr, args: Array[Expr], local_names: A
         ()
       }
       nl2 = ce(buf, ECall(EIdent("Some", -1), [EIdent("__mbg_val", -1)], -1), local_names, nl2, ctx, ld)
+      // Same staged-`None` leak as Array::find's hit path (#2671): the
+      // nullary block res_l holds is released before the Some replaces it.
+      cc_hof_release_slot(buf, res_l, ctx)
       emit_local_set(buf, res_l)
       emit_br(buf, 2)
       emit_end(buf)

--- a/lib/@vibe/compiler/normalize/desugar_trait_dict.vibe
+++ b/lib/@vibe/compiler/normalize/desugar_trait_dict.vibe
@@ -2395,6 +2395,13 @@ fn dtd_tuple_index_of(field: String) -> Option[Int] {
 fn dtd_binop_builtin_operand_type(bl: Expr, br: Expr, struct_sets: Array[(String, Array[String])], var_types: Array[(String, String)], fn_returns: Array[(String, String)]) -> Option[String] {
   let lt = dtd_type_name_or_empty(bl, struct_sets, var_types, fn_returns)
   let rt = dtd_type_name_or_empty(br, struct_sets, var_types, fn_returns)
+  dtd_builtin_arith_agreement(lt, rt)
+}
+
+/// The operand-type test of dtd_binop_builtin_operand_type on two ALREADY
+/// inferred operand names, so a caller that has both in hand (the `+` arm of
+/// infer_arg_type_name) does not infer them a second time (#2680).
+fn dtd_builtin_arith_agreement(lt: String, rt: String) -> Option[String] {
   if lt == rt && dtd_is_builtin_arith_type(lt) {
     Some(lt)
   } else {
@@ -2431,19 +2438,20 @@ fn infer_arg_type_name(arg: Expr, struct_sets: Array[(String, Array[String])], v
     // types the concat rewrite below and lets a `let u = a + "x"` binding
     // record u -> String for downstream `u + ...`. Other `+` operands stay
     // None (no behavior change for numeric/unknown).
+    // Each operand is inferred ONCE. The String test used to infer both
+    // operands and then hand them to dtd_binop_builtin_operand_type, which
+    // inferred both again -- four walks per `+` node, two of each child, so
+    // a left-nested chain cost 2^n walks: `let y = x + x + ... ` with 23
+    // operands compiled in 5.3 s and 24 ran the compiler out of memory
+    // (#2680). The tail position and an unbound chain never reach this
+    // inference, which is why only the bound spelling crashed.
     EBinOp(bop, bl, br, _) => if bop == "+" {
-      let lstr = match infer_arg_type_name(bl, struct_sets, var_types, fn_returns) {
-        Some(t) => t == "String",
-        None => false
-      }
-      let rstr = match infer_arg_type_name(br, struct_sets, var_types, fn_returns) {
-        Some(t) => t == "String",
-        None => false
-      }
-      if lstr || rstr {
+      let lt = dtd_type_name_or_empty(bl, struct_sets, var_types, fn_returns)
+      let rt = dtd_type_name_or_empty(br, struct_sets, var_types, fn_returns)
+      if lt == "String" || rt == "String" {
         Some("String")
       } else {
-        dtd_binop_builtin_operand_type(bl, br, struct_sets, var_types, fn_returns)
+        dtd_builtin_arith_agreement(lt, rt)
       }
     } else if bop == "-" || bop == "*" || bop == "/" {
       dtd_binop_builtin_operand_type(bl, br, struct_sets, var_types, fn_returns)

--- a/lib/@vibe/compiler/tests/codegen_test_support.vibe
+++ b/lib/@vibe/compiler/tests/codegen_test_support.vibe
@@ -5,7 +5,7 @@ import @vibe/core {
 }
 
 import @vibe/compiler/codegen {
-  compile_module, compile_wasi_module, compile_wasi_module_rc
+  compile_module, compile_wasi_module, compile_wasi_module_rc, compile_wasi_module_rc_shadow
 }
 
 import @vibe/compiler/codegen/gc {
@@ -47,6 +47,17 @@ export fn compile_wasi_rc(source: String, entry: String) -> Bytes with Exception
   let tokens = lex(source)
   let stmts = parse_program(tokens)
   compile_wasi_module_rc(stmts, entry)
+}
+
+/// RC-mode compile with the shadow-liveness instrumentation (VIBE_RC=shadow,
+/// #715): the program traps at the FIRST dup-of-freed or drop-of-freed
+/// instead of running on a corrupted free list. An e2e test runs the same
+/// source through this lane and asserts the normal lane's value comes out,
+/// so an RC accounting regression fails at the faulting operation.
+export fn compile_wasi_rc_shadow(source: String, entry: String) -> Bytes with Exception {
+  let tokens = lex(source)
+  let stmts = parse_program(tokens)
+  compile_wasi_module_rc_shadow(stmts, entry)
 }
 
 export fn compile_source(source: String) -> Bytes with Exception {

--- a/lib/@vibe/compiler/tests/dtd_binop_chain_linear_test.vibe
+++ b/lib/@vibe/compiler/tests/dtd_binop_chain_linear_test.vibe
@@ -1,0 +1,25 @@
+//# Imports
+
+// #2680: `infer_arg_type_name`'s `+` arm inferred each operand twice (once
+// for the String test, once more inside dtd_binop_builtin_operand_type),
+// so a left-nested `+` chain under a binding cost 2^n operand walks: 23
+// operands compiled in 5.3 s and 24 ran the compiler out of memory. The
+// arm now infers each operand once. Forty operands would be 2^40 walks on
+// the old code -- this test does not finish there -- and one pass here.
+
+import @vibe/compiler/syntax {
+  lex, parse_program
+}
+
+import @vibe/compiler/codegen {
+  desugar_trait_dicts
+}
+
+//# Tests
+
+test "a 40-operand + chain under a let desugars in one pass (#2680)" {
+  let src = "let main = () -> Int {\n  let x = 1\n  let y = x + x + x + x + x + x + x + x + x + x + x + x + x + x + x + x + x + x + x + x + x + x + x + x + x + x + x + x + x + x + x + x + x + x + x + x + x + x + x + x\n  let mut total = 0\n  total = total + y + x + x + x + x + x + x + x + x + x + x + x + x + x + x + x + x + x + x + x + x + x + x + x + x + x + x + x + x + x + x + x + x + x + x + x + x + x + x + x + x\n  total\n}\n"
+  let stmts = parse_program(lex(src))
+  desugar_trait_dicts(stmts)
+  inspect(Array::length(stmts), content = "1")
+}

--- a/lib/@vibe/compiler/tests/hof_rc_ownership_test.vibe
+++ b/lib/@vibe/compiler/tests/hof_rc_ownership_test.vibe
@@ -132,3 +132,17 @@ test "filter, fold and map chained on one shared array" {
   let src = String::concat(tree_prelude(), "let main = () -> Int {\n  let mut total = 0\n  let mut i = 0\n  while i < 200 {\n    let arr: Array[Tree] = [Leaf(i), Node(Leaf(i), Leaf(i + 1)), Leaf(3)]\n    let kept = Array::filter(arr, big)\n    let folded = Array::fold(arr, 0, (acc: Int, t: Tree) -> Int { (acc + checksum(t, 0)) % 1000000007 })\n    let mapped = Array::map(kept, incr)\n    total = (total + checksum(Array::get(arr, 1), 0) + Array::length(kept) + folded + Array::length(mapped)) % 1000000007\n    i = i + 1\n  }\n  total\n}\n")
   assert_lanes_agree(src, "combined", "1295214")
 }
+
+test "a source-level Array::map (as @vibe/builtin declares one) keeps the caller's array" {
+  // `@vibe/builtin/array.vibe` declares `let Array::map = ..` as a
+  // borrow-only loop. The planner classifies that definition's first
+  // parameter as borrowed, so a program carrying it plans every
+  // `Array::map(xs, f)` call as a borrow (no dup), while this ladder still
+  // intercepts the name and consumes: the array was moved out from under
+  // the caller and `Array::push(xs, 4)` after the map answered length 1
+  // (the book's collections chapter, through `import @vibe/builtin`). The
+  // lowering now retains an argument the planner classified as borrowed.
+  // Per iteration 2i + 44; 48600 in all. The old RC lane answered 42600.
+  let src = "let Array::map = [A, B](xs: Array[A], f: (x: A) -> B) -> Array[B] {\n  let len = Array::length(xs)\n  let out = ArrayBuilder::new()\n  let mut i = 0\n  while i < len {\n    ArrayBuilder::push(out, f(Array::get(xs, i)))\n    i = i + 1\n  }\n  ArrayBuilder::freeze(out)\n}\nlet main = () -> Int {\n  let mut total = 0\n  let mut i = 0\n  while i < 200 {\n    let xs = [i, i + 1, i + 2]\n    let doubled = Array::map(xs, (x: Int) -> Int { x * 2 })\n    Array::push(xs, 4)\n    total = total + Array::length(xs) * 10 + Array::get(doubled, 2)\n    i = i + 1\n  }\n  total\n}\n"
+  assert_lanes_agree(src, "source_shadowed_map", "48600")
+}

--- a/lib/@vibe/compiler/tests/hof_rc_ownership_test.vibe
+++ b/lib/@vibe/compiler/tests/hof_rc_ownership_test.vibe
@@ -1,0 +1,134 @@
+//# Imports
+
+// #2671: ownership in the RC lowerings of the Array higher-order builtins
+// (map / filter / fold / iter_eager / any / all / find / reverse / concat).
+// Each consumes its array argument and calls a callback that OWNS its
+// parameter, so the RC lane owes the callback one reference per element
+// it hands over and owes the array exactly one release. The lowerings
+// used to do neither: a rebuilding callback found a SHARED element unique
+// and rewrote the caller's array in place (silently wrong), a consuming
+// callback freed an element the array still listed (use-after-free), and
+// the shell was never released (a leak per call).
+//
+// Every program runs through the bump lane, the RC lane and the RC
+// shadow-liveness lane (VIBE_RC=shadow: traps at the FIRST dup-of-freed or
+// drop-of-freed) of THIS checkout's codegen, under wasmtime; the printed
+// entry return value is the oracle (codegen_heap_e2e_test's convention).
+// The bump lane's value is pinned as a literal so a lane that answers
+// differently fails on its own line. The per-call leak is pinned by the
+// gate's reclamation guard (fixtures/rc_reclaim_leak_test.vibe).
+
+import ./codegen_test_support.vibe {
+  compile_wasi, compile_wasi_rc, compile_wasi_rc_shadow
+}
+
+//# Functions
+
+fn run_value(bytes: Bytes, label: String) -> String with Fs + Process {
+  let path = String::concat("/tmp/_hof_rc_", String::concat(label, ".wasm"))
+  Fs::write_bytes(path, bytes)
+  let out = sh_lines(String::concat("wasmtime run -W exceptions=y --invoke main ", String::concat(path, " 0 2>/dev/null")))
+  if Array::length(out) > 0 {
+    Array::get(out, 0)
+  } else {
+    "<no output>"
+  }
+}
+
+fn assert_lanes_agree(src: String, label: String, expected: String) -> Int with Exception + Fs + Process + Stdout {
+  let bump = run_value(compile_wasi(src, "main"), String::concat(label, "_bump"))
+  let rc = run_value(compile_wasi_rc(src, "main"), String::concat(label, "_rc"))
+  let shadow = run_value(compile_wasi_rc_shadow(src, "main"), String::concat(label, "_shadow"))
+  inspect(bump, content = expected)
+  inspect(rc, content = expected)
+  inspect(shadow, content = expected)
+  0
+}
+
+/// A small enum tree, a rebuilding map callback (`incr`'s Node arm is a
+/// wide reuse arm: it fires in place when the block is unique), a
+/// borrow-classified checksum and a predicate over it.
+fn tree_prelude() -> String {
+  "enum Tree {\n  Leaf(Int);\n  Node(Tree, Tree)\n}\nfn incr(t: Tree) -> Tree {\n  match t {\n    Leaf(v) => Leaf(v + 1),\n    Node(l, r) => {\n      let l2 = incr(l)\n      let r2 = incr(r)\n      Node(l2, r2)\n    }\n  }\n}\nfn checksum(t: Tree, acc: Int) -> Int {\n  match t {\n    Leaf(v) => (acc * 31 + v) % 1000000007,\n    Node(l, r) => checksum(r, checksum(l, acc))\n  }\n}\nfn big(t: Tree) -> Bool {\n  checksum(t, 0) > 40\n}\n"
+}
+
+test "Array::map over a shared array leaves the source intact (#2671)" {
+  // The headline of #2671: `arr` stays live across the map, so its Node
+  // element is SHARED. The rebuilding callback (incr's Node arm is a wide
+  // reuse arm) used to find that block unique -- the lowering handed the
+  // element over without a retain -- and rewrote the caller's array in
+  // place: RC answered 1286800 (every source Node incremented) where the
+  // bump lane answers 1280400.
+  let src = String::concat(tree_prelude(), "let main = () -> Int {\n  let mut total = 0\n  let mut i = 0\n  while i < 200 {\n    let arr: Array[Tree] = [Leaf(i), Node(Leaf(i), Leaf(i + 1))]\n    let out = Array::map(arr, incr)\n    total = (total + checksum(Array::get(arr, 1), 0) + checksum(Array::get(out, 1), 0)) % 1000000007\n    i = i + 1\n  }\n  total\n}\n")
+  assert_lanes_agree(src, "map_shared", "1280400")
+}
+
+test "Array::map over unique arrays moves the elements and reuses in place" {
+  // Fresh literals and map results are unique: the elements move out with
+  // no retain, the rebuilding callback sees a unique block and the reuse
+  // fusion fires, and the emptied shell is released without a walk.
+  let src = String::concat(tree_prelude(), "let main = () -> Int {\n  let mut total = 0\n  let mut i = 0\n  while i < 200 {\n    let out = Array::map([Leaf(i), Node(Leaf(i), Leaf(i + 1))], incr)\n    let out2 = Array::map(Array::map(out, incr), incr)\n    total = (total + checksum(Array::get(out2, 1), 0) + checksum(Array::get(out2, 0), 0)) % 1000000007\n    i = i + 1\n  }\n  total\n}\n")
+  assert_lanes_agree(src, "map_unique", "676700")
+}
+
+test "Array::filter: kept elements are given, rejected ones released" {
+  // Shared source: the predicate borrows (lend), a kept element is retained
+  // for the result. Unique source: a kept element moves, a REJECTED element
+  // is the lowering's to release (cc_hof_discard), since the shell is freed
+  // without walking. Before the fix the shadow lane trapped on a dup of a
+  // freed value (the predicate consumed an element the array still listed).
+  let src = String::concat(tree_prelude(), "let main = () -> Int {\n  let mut total = 0\n  let mut i = 0\n  while i < 200 {\n    let arr: Array[Tree] = [Leaf(i), Node(Leaf(i), Leaf(i + 1)), Leaf(3)]\n    let kept = Array::filter(arr, big)\n    let kept_unique = Array::filter([Leaf(i), Node(Leaf(i), Leaf(i + 1)), Leaf(3)], big)\n    let mut ks = 0\n    let mut k = 0\n    while k < Array::length(kept) {\n      ks = (ks + checksum(Array::get(kept, k), 0)) % 1000000007\n      k = k + 1\n    }\n    total = (total + checksum(Array::get(arr, 1), 0) + Array::length(kept) + Array::length(kept_unique) + ks) % 1000000007\n    i = i + 1\n  }\n  total\n}\n")
+  assert_lanes_agree(src, "filter_shared", "1293760")
+}
+
+test "Array::fold hands each element to a consuming callback exactly once" {
+  // RC agreed by luck before the fix (nothing read the freed blocks in
+  // time); the shadow lane trapped on a dup of a freed value.
+  let src = String::concat(tree_prelude(), "let main = () -> Int {\n  let mut total = 0\n  let mut i = 0\n  while i < 200 {\n    let arr: Array[Tree] = [Leaf(i), Node(Leaf(i), Leaf(i + 1)), Leaf(3)]\n    let folded = Array::fold(arr, 0, (acc: Int, t: Tree) -> Int { (acc + checksum(t, 0)) % 1000000007 })\n    let folded_unique = Array::fold([Leaf(i), Node(Leaf(i), Leaf(i + 1))], 0, (acc: Int, t: Tree) -> Int { (acc + checksum(t, 0)) % 1000000007 })\n    total = (total + checksum(Array::get(arr, 1), 0) + folded + folded_unique) % 1000000007\n    i = i + 1\n  }\n  total\n}\n")
+  assert_lanes_agree(src, "fold_shared", "1951400")
+}
+
+test "Array::any / all / find lend elements and keep the array whole" {
+  // The predicates never move an element: each is retained before the
+  // owning callback call, and Some(found) takes a reference of its own.
+  // Before the fix a `Some(t) => checksum(t, 0)` arm read a freed payload
+  // (RC trapped; shadow: drop of freed value).
+  let src = String::concat(tree_prelude(), "let main = () -> Int {\n  let mut total = 0\n  let mut i = 0\n  while i < 200 {\n    let arr: Array[Tree] = [Leaf(i), Node(Leaf(i), Leaf(i + 1)), Leaf(3)]\n    let a = if Array::any(arr, big) { 1 } else { 0 }\n    let b = if Array::all(arr, big) { 10 } else { 0 }\n    let c = match Array::find(arr, big) {\n      Some(t) => checksum(t, 0),\n      None => 100\n    }\n    let d = match Array::find([Leaf(i), Node(Leaf(i), Leaf(i + 1))], big) {\n      Some(t) => checksum(t, 0),\n      None => 1000\n    }\n    total = (total + checksum(Array::get(arr, 1), 0) + a + b + c + d) % 1000000007\n    i = i + 1\n  }\n  total\n}\n")
+  assert_lanes_agree(src, "predicates_shared", "730052")
+}
+
+test "Array::iter_eager consumes the array it walks" {
+  // `Iterator::iter` over an Array devirtualizes to this compiler-only
+  // name; the codegen lane here takes it directly (no checker).
+  let src = String::concat(tree_prelude(), "let main = () -> Int {\n  let mut total = 0\n  let mut i = 0\n  while i < 200 {\n    let arr: Array[Tree] = [Leaf(i), Node(Leaf(i), Leaf(i + 1)), Leaf(3)]\n    let mut acc = 0\n    Array::iter_eager(arr, (t: Tree) -> Unit { acc = (acc + checksum(t, 0)) % 1000000007 })\n    Array::iter_eager([Leaf(i), Node(Leaf(i), Leaf(i + 1))], (t: Tree) -> Unit { acc = (acc + checksum(t, 0)) % 1000000007 })\n    total = (total + checksum(Array::get(arr, 1), 0) + acc) % 1000000007\n    i = i + 1\n  }\n  total\n}\n")
+  assert_lanes_agree(src, "iter_shared", "1951400")
+}
+
+test "Array::reverse moves or retains its elements by the rc word of the array" {
+  // No callback: unique input is moved element by element, a shared input
+  // is retained element by element and dropped normally at the end.
+  let src = String::concat(tree_prelude(), "let main = () -> Int {\n  let mut total = 0\n  let mut i = 0\n  while i < 200 {\n    let arr: Array[Tree] = [Leaf(i), Node(Leaf(i), Leaf(i + 1)), Leaf(3)]\n    let rv = Array::reverse(arr)\n    let rv2 = Array::reverse(Array::map(arr, incr))\n    total = (total + checksum(Array::get(arr, 1), 0) + checksum(Array::get(rv, 0), 0) + checksum(Array::get(rv2, 2), 0)) % 1000000007\n    i = i + 1\n  }\n  total\n}\n")
+  assert_lanes_agree(src, "reverse_shared", "657700")
+}
+
+test "Array::concat retains the elements it copies and releases both inputs" {
+  // concat already retained each copied element; it never released its
+  // two consumed inputs (84 B per call on a two-element array). The
+  // release is the ordinary walking drop.
+  let src = String::concat(tree_prelude(), "let main = () -> Int {\n  let mut total = 0\n  let mut i = 0\n  while i < 200 {\n    let arr: Array[Tree] = [Leaf(i), Node(Leaf(i), Leaf(i + 1))]\n    let arr2: Array[Tree] = [Leaf(3)]\n    let cat = Array::concat(arr, arr2)\n    let cat2 = Array::concat(Array::map(arr, incr), cat)\n    total = (total + checksum(Array::get(arr, 1), 0) + checksum(Array::get(arr2, 0), 0) + checksum(Array::get(cat, 2), 0) + checksum(Array::get(cat2, 4), 0) + Array::length(cat2)) % 1000000007\n    i = i + 1\n  }\n  total\n}\n")
+  assert_lanes_agree(src, "concat_shared", "639800")
+}
+
+test "a captured closure used by three maps is released by each lowering" {
+  // `f` captures `k`, so it is a real closure block; every lowering owns
+  // the callback reference it was handed and drops it after the loop (a
+  // bare fn value is even and rc_drop ignores it).
+  let src = String::concat(tree_prelude(), "let main = () -> Int {\n  let mut total = 0\n  let mut i = 0\n  while i < 200 {\n    let k = i % 5\n    let f = (t: Tree) -> Tree { match t { Leaf(v) => Leaf(v + k), Node(l, r) => Node(incr(l), r) } }\n    let arr: Array[Tree] = [Leaf(i), Node(Leaf(i), Leaf(i + 1))]\n    let m1 = Array::map(arr, f)\n    let m2 = Array::map(m1, f)\n    let m3 = Array::map(arr, f)\n    total = (total + checksum(Array::get(arr, 1), 0) + checksum(Array::get(m1, 1), 0) + checksum(Array::get(m2, 1), 0) + checksum(Array::get(m3, 0), 0)) % 1000000007\n    i = i + 1\n  }\n  total\n}\n")
+  assert_lanes_agree(src, "closure_reused", "1949900")
+}
+
+test "filter, fold and map chained on one shared array" {
+  // The program that crashed on the RC lane before the fix.
+  let src = String::concat(tree_prelude(), "let main = () -> Int {\n  let mut total = 0\n  let mut i = 0\n  while i < 200 {\n    let arr: Array[Tree] = [Leaf(i), Node(Leaf(i), Leaf(i + 1)), Leaf(3)]\n    let kept = Array::filter(arr, big)\n    let folded = Array::fold(arr, 0, (acc: Int, t: Tree) -> Int { (acc + checksum(t, 0)) % 1000000007 })\n    let mapped = Array::map(kept, incr)\n    total = (total + checksum(Array::get(arr, 1), 0) + Array::length(kept) + folded + Array::length(mapped)) % 1000000007\n    i = i + 1\n  }\n  total\n}\n")
+  assert_lanes_agree(src, "combined", "1295214")
+}

--- a/tests/gates/mid/run.sh
+++ b/tests/gates/mid/run.sh
@@ -396,7 +396,7 @@ if [ "$sh_out" != "42" ]; then
   exit 1
 fi
 echo "[compiler-gate] RC user-shadowed builtin name ok (#1746)"
-echo "[compiler-gate] 40d/40 RC reclamation leak guard (tuple+cell+closure+enum+loop-consume+builder-return+hof-shell)"
+echo "[compiler-gate] 40d/40 RC reclamation leak guard (tuple+cell+closure+enum+loop-consume+builder-return)"
 lkdir="_build/_gate_rc_leak"
 rm -rf "$lkdir"; mkdir -p "$lkdir"
 VIBE_RC=1 VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \

--- a/tests/gates/mid/run.sh
+++ b/tests/gates/mid/run.sh
@@ -396,7 +396,7 @@ if [ "$sh_out" != "42" ]; then
   exit 1
 fi
 echo "[compiler-gate] RC user-shadowed builtin name ok (#1746)"
-echo "[compiler-gate] 40d/40 RC reclamation leak guard (tuple+cell+closure+enum+loop-consume+builder-return)"
+echo "[compiler-gate] 40d/40 RC reclamation leak guard (tuple+cell+closure+enum+loop-consume+builder-return+hof-shell)"
 lkdir="_build/_gate_rc_leak"
 rm -rf "$lkdir"; mkdir -p "$lkdir"
 VIBE_RC=1 VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
@@ -413,8 +413,8 @@ lk_result="$(printf '%s' "$lk_json" | sed -n 's/.*"result":\([0-9]*\).*/\1/p')"
 if [ -z "$lk_used" ]; then
   echo "[compiler-gate] FAIL: could not measure rc_reclaim_leak heap ($lk_json)" >&2; exit 1
 fi
-if [ "$lk_result" != "4200390000" ]; then
-  echo "[compiler-gate] FAIL: rc_reclaim_leak wrong result $lk_result (want 4200390000)" >&2; exit 1
+if [ "$lk_result" != "6400600000" ]; then
+  echo "[compiler-gate] FAIL: rc_reclaim_leak wrong result $lk_result (want 6400600000)" >&2; exit 1
 fi
 if [ "$lk_used" -ge 2000 ]; then
   echo "[compiler-gate] FAIL: rc_reclaim_leak heap_used=$lk_used >= 2000 (RC reclamation regressed; ~800000 == full leak)" >&2; exit 1
@@ -445,12 +445,12 @@ if [ ! -s "$shdir/shadow.wasm" ]; then
   exit 1
 fi
 sh_out="$(VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh "$shdir/shadow.wasm" 2>&1 | tail -1)"
-if [ "$sh_out" != "25297489" ]; then
-  echo "[compiler-gate] FAIL: rc_shadow_regression got '$sh_out' (want 25297489). A trap here means an RC dup/drop accounting regression touched a freed block -- see fixtures/rc_shadow_regression_test.vibe for which shapes are covered and issue #715 for the debugging methodology." >&2
+if [ "$sh_out" != "25377489" ]; then
+  echo "[compiler-gate] FAIL: rc_shadow_regression got '$sh_out' (want 25377489). A trap here means an RC dup/drop accounting regression touched a freed block -- see fixtures/rc_shadow_regression_test.vibe for which shapes are covered and issue #715 for the debugging methodology." >&2
   exit 1
 fi
 rm -rf "$shdir"
-echo "[compiler-gate] RC shadow-liveness regression guard ok (25297489)"
+echo "[compiler-gate] RC shadow-liveness regression guard ok (25377489)"
 
 # 40f1a. #2427: the shadow table must not overlap the heap it describes.
 #        40f above proves the marks catch a real dup/drop-of-freed; this


### PR DESCRIPTION
Follow-up to #2667 (merged). Six commits: the measurement record, the `+`-chain inference fix (#2680), the Array HOF ownership fix in two steps (#2671), a gate-registry title fix, and the cost numbers.

## Measured: where reuse pays, and why the self-compile does not see it

`docs/perceus-reuse.md` gains the numbers behind the flat KPI:

- `bench/exec/tree_rebuild.vibe` under viberun fuel against a reuse-disabled scratch compiler: a fused rebuild costs ~5x fewer instructions than the normal path (18.3M → 3.6M per rebuild for the constructor-tail shape, 18.9M → 4.4M for the branch shape) and allocates nothing.
- The container shape decides everything: unique chains 69.9M → 25.8M, `Array::map` forest 74.8M → 30.7M, the index loop `Array::push(out, incr(Array::get(arr, i)))` 74.9M → 77.8M (worse). Counted: the first two hit 147,168 of 147,168 uniqueness tests, the loop 0 of 147,168.
- The compiler is written in the loop shape (30 `Array::map` against 43,587 `Array::get`, 11,523 index loops, 8,418 `Array::set`). Its full-closure self-compile stages 2,637,481 uniqueness tests and 1,078 pass (0.04%); the CPU profile puts the RC lane's cost in `__rt_rc_dup` (33.2%).

## The Array HOF lowerings own what they are handed (#2671)

The RC lowerings of `Array::map` / `filter` / `fold` / `iter_eager` / `any` / `all` / `find` / `reverse` / `concat` did no ownership accounting. Each consumes its array argument and calls a callback that owns its parameter, so the lane owes the callback one reference per element handed over and owes the array one release. The lowerings did neither:

| before | now |
|---|---|
| `map` over an array the caller still held handed elements to the rebuilding callback without a retain; the reuse fusion rewrote the caller's array in place (bump 1280400, RC 1286800 on the same program) | one rc-word test per array: UNIQUE moves the elements out (the callback sees a unique block and fuses) and frees the emptied shell; SHARED retains per element and drops the array normally |
| `filter` / `fold` / a capturing `map` freed elements the array still listed (shadow: dup of freed value) | the predicates retain per call and drop the array walking; `filter` releases a rejected element itself |
| `find`'s `Some(t)` and `reverse` read freed payloads | retained before the hand-over; `concat` retains what it copies and releases both inputs |
| no shell released (84 B per `map` call); `find` / `MapBuilder::get` leaked the staged `None` on every hit (16 B) | released; the staged slot is dropped before the `Some` replaces it |
| a program importing `@vibe/builtin` (the book, for `trait Iterator`) plans `Array::map(xs, f)` as a borrow, because the package declares a source-level `let Array::map` that only borrows, while the ladder intercepts the name and consumed — `Array::push(xs, 4)` after a map answered length 1 (caught by the docs gate on the first cut) | the lowering retains an argument whose position the planner classified as borrowed (`md_borrow_mask_of`), so the caller keeps its reference |

Pinned three ways: `hof_rc_ownership_test.vibe` runs every builtin over shared and unique sources through the bump, RC and RC-shadow lanes of the checkout's codegen and asserts the bump value on all three (11 shapes; red on the old lowering); `fixtures/rc_reclaim_leak_test.vibe` gains the HOF shapes under its 2,000-byte bound (total 6400600000); `fixtures/rc_shadow_regression_test.vibe` gains shape 10 (25377489). The bump lane's bytes are untouched. The book doctest (130 blocks) passes against the rebuilt stage2.

Cost, measured on the compiler itself (it has 30 `Array::map` call sites): the RC-built compiler's flat-source self-compile goes from 1,178,199,286,771 to 1,177,029,188,108 instructions (viberun fuel, −0.10%) and from 1,837,225,668 to 1,835,120,428 B allocated (−0.11%); the RC-built stage2 grows 4,882,987 → 4,889,652 B (+0.14%). The bump lane's `selfcompile_kpi` heap high-water moves 875,863,464 → 875,211,600 B (−0.07%, the #2680 inference).

Found on the way and filed, not fixed here: #2681 (an unannotated lambda parameter consumed three times is released early, P0), #2682 (an owned call result in a borrowed argument position is never released), #2683 (a `MapBuilder` is never reclaimed).

## `desugar_trait_dict`: linear `+` operand inference (#2680)

`infer_arg_type_name`'s `+` arm inferred both operands twice per node, so a bound chain cost 2^n walks: 23 operands compiled in 5.3 s, 24 ran the compiler out of memory. Each operand is now inferred once; `dtd_binop_chain_linear_test.vibe` pins a 40-operand chain (red within seconds on the old code).

## An FBIP-shaped rewrite of one pass, measured and not landed

`lift_match_scrutinees` was rewritten to rebuild its child arrays with consuming `Array::map` helpers instead of `for` comprehensions and measured on the flat-source RC self-compile through counter-instrumented compilers: fuel 1,177,116,818,175 → 1,177,155,083,233 (+0.003%), allocation 1,836,094,292 → 1,836,094,276 B, output byte-identical, uniqueness tests staged 3,970,084 → 3,970,084, passed 826 → 826. Neutral, and the counters say why: the pass never receives a unique tree (its root is a statement-owned field run through `uniquify_shadowed_bindings`' structure sharing). Uniqueness has to be produced by a pipeline that transfers its statement array from pass to pass, not by any one pass; the rewrite is kept out of the tree (it also traps under the committed seed's pre-fix `Array::map` in the FS-lane test harness). The patch is in the comment below for the record; the analysis is in `docs/perceus-reuse.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ASfkaC6HgSCSydTZcKSF2M