### PR TITLE
#2638: the borrow-returning fixpoint decomposes as link-driven rounds

### DIFF
--- a/lib/@vibe/compiler/codegen/wasi/linked_compile.vibe
+++ b/lib/@vibe/compiler/codegen/wasi/linked_compile.vibe
@@ -68,6 +68,8 @@ import @vibe/compiler/normalize {
 
 import @vibe/compiler/perceus {
   PerceusAction,
+  borrow_ret_link_parts,
+  borrow_ret_shadow_mask,
   build_perceus_plan,
   build_perceus_plan_pinned_split,
   build_perceus_plan_with_params,
@@ -5465,6 +5467,9 @@ fn prelude_run_per_module(c: Array[Stmt], c_file_id: Array[Int], file_count: Int
     lc_concat_into(st.an_local_names, part_local_names)
     lc_concat_ints_into(st.an_local_masks, part_local_masks)
     compute_borrow_disqualifiers(part, st.an_valued, st.an_nonident_fns, st.an_nonident_pos)
+    // #2638: and this module's half of the borrow-returning SEED. The whole
+    // program's is the OR, so it publishes like the disqualifiers above.
+    Array::push(st.an_bret_shadow, borrow_ret_shadow_mask(part))
     fi = fi + 1
   }
   // #2638 PHASE B. Round 0 for the whole program is linkable now, from what
@@ -5487,6 +5492,23 @@ fn prelude_run_per_module(c: Array[Stmt], c_file_id: Array[Int], file_count: Int
   }
   let ph_r01mask = lc_fresh_int_array()
   let ph_r01 = borrow_round1_link_parts(parts, ph_r0, ph_r0mask, st.an_valued, st.an_nonident_fns, st.an_nonident_pos, an_exclude, ph_shadow, ph_r01mask)
+  // #2638: and the borrow-returning set, as a fixpoint over the MODULES. This
+  // one genuinely iterates at the link -- whether a module can classify `f`
+  // depends on a callee in another module having entered the set, which is
+  // only known after that module's round.
+  let mut ph_bshadow = 0
+  let mut bsi = 0
+  while bsi < Array::length(st.an_bret_shadow) {
+    ph_bshadow = ph_bshadow|Array::get(st.an_bret_shadow, bsi)
+    bsi = bsi + 1
+  }
+  let mut apx = 0
+  while apx < Array::length(parts) {
+    Array::push(st.an_parts, Array::get(parts, apx))
+    apx = apx + 1
+  }
+  Array::push(st.an_bret_seed, ph_bshadow)
+  lc_concat_into(st.an_bret_link, sorted_names_of(borrow_ret_link_parts(parts, ph_bshadow)))
   lc_concat_into(st.an_r01_names, ph_r01)
   lc_concat_ints_into(st.an_r01_masks, ph_r01mask)
   // ASSEMBLY (#2575 item 2 step 3). Concatenating the modules is the obvious
@@ -5666,6 +5688,16 @@ struct PreludeSplitStats {
   an_nonident_pos: Array[Int];
   // #2638: each module's source-shadow bits, a union like the two above.
   an_shadow: Array[Int];
+  // #2638: the same for the borrow-RETURNING seed, and that analysis' linked
+  // answer (a fixpoint the link drives across the modules).
+  an_bret_shadow: Array[Int];
+  // The OR the split lane actually seeded with, so the caller can compare it
+  // against the whole program's instead of assuming they agree.
+  an_bret_seed: Array[Int];
+  // The module parts themselves, so the caller can run its own controls
+  // against the SAME statements the split lane answered from.
+  an_parts: Array[Array[Stmt]];
+  an_bret_link: Array[String];
   // #2638 phase B's ANSWER: the program's round 0 and round 1, linked from
   // the modules' published facts plus each module's own bodies. Filled by
   // `prelude_run_per_module`, which is where the parts live.
@@ -5698,6 +5730,10 @@ fn prelude_split_stats_new() -> PreludeSplitStats {
     an_nonident_fns: lc_fresh_string_array(),
     an_nonident_pos: lc_fresh_int_array(),
     an_shadow: lc_fresh_int_array(),
+    an_bret_shadow: lc_fresh_int_array(),
+    an_bret_seed: lc_fresh_int_array(),
+    an_parts: [],
+    an_bret_link: lc_fresh_string_array(),
     an_r01_names: lc_fresh_string_array(),
     an_r01_masks: lc_fresh_int_array(),
     counts: [0, 0, 0]
@@ -5806,6 +5842,15 @@ export fn prelude_module_full_oracle_line(a: Array[Stmt], c: Array[Stmt], c_file
   //     direction is reachable and it is the unsound one.
   let an_exclude = lc_analysis_exclude(entry_name)
   let an_bret_w = sorted_names_of(compute_borrow_returning_names(a))
+  // #2638 CONTROL. The same link, handed the whole program as a SINGLE part.
+  // If this is a bare count the link's iteration is exact and any residue in
+  // `link_bret` comes from the parts being different statements -- not from
+  // the fixpoint failing to decompose. Without it the two causes are
+  // indistinguishable, and "the analysis does not decompose" is the more
+  // interesting and more wrong of the two.
+  let an_bret_one: Array[Array[Stmt]] = []
+  Array::push(an_bret_one, a)
+  let an_bret_self = sorted_names_of(borrow_ret_link_parts(an_bret_one, borrow_ret_shadow_mask(a)))
   let an_bmask_w = lc_fresh_int_array()
   let an_bfns_w = compute_borrow_param_user_fns(a, an_exclude, an_bmask_w)
   // #2638: round 0 ALONE for the whole program. The reference the link below
@@ -5843,6 +5888,36 @@ export fn prelude_module_full_oracle_line(a: Array[Stmt], c: Array[Stmt], c_file
   let an_r0_link = borrow_round0_link(st.an_local_names, st.an_local_masks, st.an_valued, st.an_nonident_fns, st.an_nonident_pos, an_exclude, an_r0mask_link)
   // #2638 phase B's answer, computed by the split lane itself (it owns the
   // module parts) and only READ here for the comparison.
+  // #2638 SECOND CONTROL. The link over the ASSEMBLED program -- what the
+  // split lane actually produces after folding the modules' 167 duplicate
+  // declarations. Between this and `link_bret_self` the residue in
+  // `link_bret` is attributed: if this is a bare count, splitting the rounds
+  // across 365 parts is what costs it; if it carries the same residue, the
+  // parts' STATEMENTS do, and the fixpoint is exonerated either way only by
+  // saying which.
+  // #2638 THIRD CONTROL. The parts CONCATENATED into one part -- same
+  // statements as `link_bret` sees, same duplicates, but ONE round structure
+  // instead of 365. Against `link_bret_asm` (the same statements FOLDED) this
+  // says whether the residue is the 167 duplicate declarations or the
+  // splitting of the rounds. Two arguments predicted different answers here,
+  // so it is measured rather than reasoned.
+  let an_bret_cat: Array[Stmt] = []
+  let mut bci = 0
+  while bci < Array::length(st.an_parts) {
+    let bp = Array::get(st.an_parts, bci)
+    let mut bcj = 0
+    while bcj < Array::length(bp) {
+      Array::push(an_bret_cat, Array::get(bp, bcj))
+      bcj = bcj + 1
+    }
+    bci = bci + 1
+  }
+  let an_bret_cat_one: Array[Array[Stmt]] = []
+  Array::push(an_bret_cat_one, an_bret_cat)
+  let an_bret_catr = sorted_names_of(borrow_ret_link_parts(an_bret_cat_one, borrow_ret_shadow_mask(an_bret_cat)))
+  let an_bret_asm_one: Array[Array[Stmt]] = []
+  Array::push(an_bret_asm_one, linked)
+  let an_bret_asm = sorted_names_of(borrow_ret_link_parts(an_bret_asm_one, borrow_ret_shadow_mask(linked)))
   let an_r01_link = st.an_r01_names
   let an_r01mask_link = st.an_r01_masks
   let an_pairs_u = st.an_pairs
@@ -5910,9 +5985,12 @@ export fn prelude_module_full_oracle_line(a: Array[Stmt], c: Array[Stmt], c_file
     "0"
   })
   let an_cols = if an_dce_entry {
-    " borrow_ret=unmeasured borrow_fns=unmeasured borrow_masks=unmeasured view_ret=unmeasured link_round0=unmeasured link_round0_masks=unmeasured link_round0_occ=unmeasured link_round01=unmeasured link_round01_masks=unmeasured link_round01_occ=unmeasured"
+    " borrow_ret=unmeasured borrow_fns=unmeasured borrow_masks=unmeasured view_ret=unmeasured link_round0=unmeasured link_round0_masks=unmeasured link_round0_occ=unmeasured link_round01=unmeasured link_round01_masks=unmeasured link_round01_occ=unmeasured link_bret=unmeasured link_bret_occ=unmeasured link_bret_self=unmeasured link_bret_asm=unmeasured link_bret_seed=unmeasured link_bret_cat=unmeasured"
   } else {
-    String::concat(String::concat(String::concat(" borrow_ret=", lc_set_cmp_counted(an_bret_w, an_bret_u)), String::concat(" borrow_fns=", lc_set_cmp_counted(an_bfns_w, an_bfns_u))), String::concat(String::concat(" borrow_masks=", lc_set_cmp_counted(lc_name_mask_pairs(an_bfns_w, an_bmask_w), an_pairs_u)), String::concat(String::concat(" view_ret=", lc_set_cmp_counted(an_view_w, an_view_u)), String::concat(String::concat(" link_round0=", lc_set_cmp_counted(an_r0_w, an_r0_link)), String::concat(String::concat(" link_round0_masks=", lc_set_cmp_counted(lc_name_mask_pairs(an_r0_w, an_r0mask_w), lc_name_mask_pairs(an_r0_link, an_r0mask_link))), String::concat(String::concat(" link_round0_occ=", lc_multiset_first_diff(an_r0_w, an_r0_link)), String::concat(String::concat(" link_round01=", lc_set_cmp_counted(an_bfns_w, an_r01_link)), String::concat(String::concat(" link_round01_masks=", lc_set_cmp_counted(lc_name_mask_pairs(an_bfns_w, an_bmask_w), lc_name_mask_pairs(an_r01_link, an_r01mask_link))), String::concat(" link_round01_occ=", lc_multiset_first_diff(an_bfns_w, an_r01_link))))))))))
+    String::concat(String::concat(String::concat(" borrow_ret=", lc_set_cmp_counted(an_bret_w, an_bret_u)), String::concat(" borrow_fns=", lc_set_cmp_counted(an_bfns_w, an_bfns_u))), String::concat(String::concat(" borrow_masks=", lc_set_cmp_counted(lc_name_mask_pairs(an_bfns_w, an_bmask_w), an_pairs_u)), String::concat(String::concat(" view_ret=", lc_set_cmp_counted(an_view_w, an_view_u)), String::concat(String::concat(" link_round0=", lc_set_cmp_counted(an_r0_w, an_r0_link)), String::concat(String::concat(" link_round0_masks=", lc_set_cmp_counted(lc_name_mask_pairs(an_r0_w, an_r0mask_w), lc_name_mask_pairs(an_r0_link, an_r0mask_link))), String::concat(String::concat(" link_round0_occ=", lc_multiset_first_diff(an_r0_w, an_r0_link)), String::concat(String::concat(" link_round01=", lc_set_cmp_counted(an_bfns_w, an_r01_link)), String::concat(String::concat(" link_round01_masks=", lc_set_cmp_counted(lc_name_mask_pairs(an_bfns_w, an_bmask_w), lc_name_mask_pairs(an_r01_link, an_r01mask_link))), String::concat(String::concat(" link_round01_occ=", lc_multiset_first_diff(an_bfns_w, an_r01_link)), String::concat(String::concat(" link_bret=", lc_set_cmp_counted(an_bret_w, st.an_bret_link)), String::concat(String::concat(" link_bret_occ=", lc_multiset_first_diff(an_bret_w, st.an_bret_link)), String::concat(String::concat(" link_bret_self=", lc_set_cmp_counted(an_bret_w, an_bret_self)), String::concat(String::concat(" link_bret_asm=", lc_set_cmp_counted(an_bret_w, an_bret_asm)), String::concat(String::concat(" link_bret_seed=", String::concat(Int::to_string(match Array::length(st.an_bret_seed) {
+      0 => 0 - 1,
+      _ => Array::get(st.an_bret_seed, 0)
+    }), String::concat("/", Int::to_string(borrow_ret_shadow_mask(a))))), String::concat(" link_bret_cat=", lc_set_cmp_counted(an_bret_w, an_bret_catr))))))))))))))))
   }
   let an_line = String::concat(String::concat(an_head, an_cols), "\n")
   let line = String::concat(String::concat(head, mid), tail)

--- a/lib/@vibe/compiler/perceus/index.vpkg
+++ b/lib/@vibe/compiler/perceus/index.vpkg
@@ -76,6 +76,8 @@ fn reuse_arm_has_ctor_site(e: Expr, arity: Int) -> Bool
 
 // --- program-wide name scans (threaded into every function's plan)
 fn compute_borrow_returning_names(stmts: Array[Stmt]) -> Array[String]
+fn borrow_ret_shadow_mask(stmts: Array[Stmt]) -> Int
+fn borrow_ret_link_parts(parts: Array[Array[Stmt]], shadow_mask: Int) -> Array[String]
 fn compute_scalar_returning_names(stmts: Array[Stmt]) -> Array[String]
 fn compute_heap_returning(stmts: Array[Stmt]) -> Array[String]
 

--- a/lib/@vibe/compiler/perceus/perceus.vibe
+++ b/lib/@vibe/compiler/perceus/perceus.vibe
@@ -972,6 +972,73 @@ fn strip_wrappers_for_borrow_ret(e: Expr) -> Expr {
 /// The two Map iterator accessors have source-ownership guards in both linear
 /// and GC codegen. If source binds either exact name, its body -- not the
 /// compiler intrinsic -- determines whether the result is borrowed.
+/// #2638: ONE ROUND of the borrow-returning fixpoint over `stmts`, against
+/// the set decided so far. Returns whether it added anything.
+///
+/// The fixpoint is MONOTONE -- `known` only grows and the loop runs to
+/// quiescence -- so the least fixed point does not depend on the order bodies
+/// are visited in. That is what lets the link drive the rounds across modules:
+/// each round it asks every module what IT can add given the current set, and
+/// unions the answers. A module reads only its own bodies plus that set, and
+/// the answer is the whole program's because the modules partition it.
+///
+/// One implementation serves both the whole-program pass and the per-module
+/// lane, so `tail_is_borrow_ret_safe` is not re-stated anywhere.
+fn bret_round(stmts: Array[Stmt], known: Array[String], known_set: MutSet[String]) -> Bool {
+  let mut changed = false
+  let mut i = 0
+  while i < Array::length(stmts) {
+    match Array::get(stmts, i) {
+      SLet(_, _, name, _, value) =>
+      if !MutSet::has(known_set, name) {
+        match value {
+          EFn(_, _, _, _, _, body) => {
+            // A function is borrow-returning only if its (wrapper-stripped)
+            // top-level shape is itself a call/if/match reaching a known
+            // borrow-return name on every branch -- a BARE identifier tail
+            // at the *top level* (an identity-like function) is NOT eligible
+            // here even though tail_is_borrow_ret_safe accepts a bare ident
+            // as a safe fallback *inside* an if/match branch (e.g. peek's
+            // `else TEof`). This keeps `let f = (x) -> T { x }` (a genuine
+            // passthrough of a normally-owned argument) from being
+            // misclassified as a Array::get-style borrowed view.
+            let top = strip_wrappers_for_borrow_ret(body)
+            let eligible_shape = match top {
+              ECall(_, _, _) => true,
+              EIf(_, _, _) => true,
+              EMatch(_, _) => true,
+              _ => false
+            }
+            if eligible_shape {
+              // #1915: the spine bindings resolve bare ident branch tails
+              // to the values they name (see tail_is_borrow_ret_safe).
+              let sp_names: Array[String] = []
+              let sp_vals: Array[Expr] = []
+              let sp_excluded: Array[String] = []
+              let _ = collect_spine_let_vals(body, sp_names, sp_vals, sp_excluded)
+              if tail_is_borrow_ret_safe(known_set, top, sp_names, sp_vals, sp_excluded) {
+                Array::push(known, name)
+                MutSet::add(known_set, name)
+                changed = true
+              } else {
+                ()
+              }
+            } else {
+              ()
+            }
+          },
+          _ => ()
+        }
+      } else {
+        ()
+      },
+      _ => ()
+    }
+    i = i + 1
+  }
+  changed
+}
+
 /// Return a two-bit mask in one statement scan: bit 0 is the checked accessor,
 /// bit 1 is the unchecked accessor. This runs on every linked compile, so do
 /// not scan the compiler-sized statement array once per builtin seed.
@@ -1034,56 +1101,62 @@ export fn compute_borrow_returning_names(stmts: Array[Stmt]) -> Array[String] {
   }
   let mut changed = true
   while changed {
+    changed = bret_round(stmts, known, known_set)
+  }
+  known
+}
+
+/// #2638: this module's half of the borrow-returning SEED -- the two bits
+/// saying whether the program's own source shadows a shadowable borrow-ret
+/// builtin. The whole program's answer is the OR, so a module publishes its
+/// bits like any other body-local fact.
+export fn borrow_ret_shadow_mask(stmts: Array[Stmt]) -> Int {
+  source_owned_shadowable_borrow_mask(stmts)
+}
+
+/// #2638: THE BORROW-RETURNING LINK. The whole program's borrow-returning set,
+/// run as a fixpoint over the MODULES rather than over one statement array.
+///
+/// Each round asks every module what it can add given the set decided so far,
+/// and the round repeats until no module adds anything. A module reads only
+/// its own bodies and that set -- it never sees another module's statements --
+/// and the result is the whole program's because the modules partition it and
+/// the fixpoint is monotone (least fixed point, independent of visit order).
+///
+/// This is the shape #2638 calls "the module collects, the link decides", and
+/// unlike the borrow-param analysis it genuinely needs the ITERATION at the
+/// link: whether a module can classify `f` depends on whether a callee in
+/// another module entered the set, which is only known after that module's
+/// round.
+///
+/// `shadow_mask` is the OR of what the modules published, so the seed is the
+/// program's and not any one module's.
+export fn borrow_ret_link_parts(parts: Array[Array[Stmt]], shadow_mask: Int) -> Array[String] {
+  let builtin_names = borrow_ret_builtin_names()
+  let known: Array[String] = []
+  let known_set = MutSet::new_string()
+  let mut seed_i = 0
+  while seed_i < Array::length(builtin_names) {
+    let builtin_name = Array::get(builtin_names, seed_i)
+    if !source_owns_shadowable_borrow_builtin(shadow_mask, builtin_name) {
+      Array::push(known, builtin_name)
+      MutSet::add(known_set, builtin_name)
+    } else {
+      ()
+    }
+    seed_i = seed_i + 1
+  }
+  let mut changed = true
+  while changed {
     changed = false
-    let mut i = 0
-    while i < Array::length(stmts) {
-      match Array::get(stmts, i) {
-        SLet(_, _, name, _, value) =>
-        if !MutSet::has(known_set, name) {
-          match value {
-            EFn(_, _, _, _, _, body) => {
-              // A function is borrow-returning only if its (wrapper-stripped)
-              // top-level shape is itself a call/if/match reaching a known
-              // borrow-return name on every branch -- a BARE identifier tail
-              // at the *top level* (an identity-like function) is NOT eligible
-              // here even though tail_is_borrow_ret_safe accepts a bare ident
-              // as a safe fallback *inside* an if/match branch (e.g. peek's
-              // `else TEof`). This keeps `let f = (x) -> T { x }` (a genuine
-              // passthrough of a normally-owned argument) from being
-              // misclassified as a Array::get-style borrowed view.
-              let top = strip_wrappers_for_borrow_ret(body)
-              let eligible_shape = match top {
-                ECall(_, _, _) => true,
-                EIf(_, _, _) => true,
-                EMatch(_, _) => true,
-                _ => false
-              }
-              if eligible_shape {
-                // #1915: the spine bindings resolve bare ident branch tails
-                // to the values they name (see tail_is_borrow_ret_safe).
-                let sp_names: Array[String] = []
-                let sp_vals: Array[Expr] = []
-                let sp_excluded: Array[String] = []
-                let _ = collect_spine_let_vals(body, sp_names, sp_vals, sp_excluded)
-                if tail_is_borrow_ret_safe(known_set, top, sp_names, sp_vals, sp_excluded) {
-                  Array::push(known, name)
-                  MutSet::add(known_set, name)
-                  changed = true
-                } else {
-                  ()
-                }
-              } else {
-                ()
-              }
-            },
-            _ => ()
-          }
-        } else {
-          ()
-        },
-        _ => ()
+    let mut pi = 0
+    while pi < Array::length(parts) {
+      if bret_round(Array::get(parts, pi), known, known_set) {
+        changed = true
+      } else {
+        ()
       }
-      i = i + 1
+      pi = pi + 1
     }
   }
   known

--- a/lib/@vibe/compiler/tests/prelude_module_oracle_test.vibe
+++ b/lib/@vibe/compiler/tests/prelude_module_oracle_test.vibe
@@ -420,6 +420,34 @@ test "the whole prelude per module reproduces the whole-program prelude" {
   // against a stand-in, so `2767` is the same 2767 the `borrow_fns` row above
   // reports for the whole-program lane.
   //
+  // #2638: `borrow_ret` is the FIXPOINT, and it decomposes too -- as rounds
+  // the LINK drives. Each round asks every module what it can add given the
+  // set so far; it repeats until no module adds anything. On the closure that
+  // takes `borrow_ret`'s 15 missing down to 4, with 0 extra:
+  //
+  //   borrow_ret=379/364:-15:MutSortedSet::delete+0:
+  //   link_bret=379/375:-4:resolve_checked_path_fs_...+0:
+  //
+  // The residue is ATTRIBUTED rather than guessed, by three controls that cost
+  // one column each. Two of my own arguments about it were wrong and the
+  // columns are what said so:
+  //
+  //   link_bret_self=379                 the rule over the merged program: exact
+  //   link_bret_seed=0/0                 both lanes seed identically
+  //   link_bret_cat=379/375:-4:...       the parts CONCATENATED, one round
+  //   link_bret_asm=379                  the same statements FOLDED: exact
+  //
+  // `cat` equals `link_bret`, so splitting the rounds across 365 modules costs
+  // NOTHING -- the fixpoint decomposes. `asm` is exact on the same statements
+  // once the assembly folds them, so the 4 are lost to the 167 DUPLICATE
+  // declarations the modules emit (`FULL split=10286 linked=10119 folded=167`).
+  //
+  // That is worth stating plainly because it is new: duplicates are inert for
+  // the borrow-PARAM analysis -- `link_round01_occ` reports one and the answer
+  // is still exact -- and they are NOT inert for a fixpoint. Whatever fixes
+  // `copies` (#2575) is what closes this column, not more work on the
+  // analysis.
+  //
   // So all 89 of `borrow_fns`' unsound extras are gone, and so are its 168
   // conservative misses. The 89 were callees whose disqualifying call site
   // lives in another module, and the union of `nonident` is a fact a module
@@ -435,7 +463,7 @@ test "the whole prelude per module reproduces the whole-program prelude" {
   // twice across the modules, because a program-level helper is synthesized
   // once per module that needs it. That is the `copies` shape this oracle
   // already counts, and the link folds it by key elsewhere.
-  inspect(String::trim(analysis_line_of(report)), content = "ANALYSIS dce_entry=0 borrow_ret=7 borrow_fns=0 borrow_masks=0 view_ret=2/1:-1:helper_use_exp__tmp_vibe_full_oracle_helper_vibe+0: link_round0=0 link_round0_masks=0 link_round0_occ= link_round01=0 link_round01_masks=0 link_round01_occ=")
+  inspect(String::trim(analysis_line_of(report)), content = "ANALYSIS dce_entry=0 borrow_ret=7 borrow_fns=0 borrow_masks=0 view_ret=2/1:-1:helper_use_exp__tmp_vibe_full_oracle_helper_vibe+0: link_round0=0 link_round0_masks=0 link_round0_occ= link_round01=0 link_round01_masks=0 link_round01_occ= link_bret=7 link_bret_occ= link_bret_self=7 link_bret_asm=7 link_bret_seed=0/0 link_bret_cat=7")
   // `missing=0 extra=0 content=0` is the property: every declaration the
   // whole-program prelude produced is produced by the module that owns it,
   // with the same body. `copies` is what remains after the link, and
@@ -608,7 +636,7 @@ test "the may_return and borrow analyses do not decompose per module, in both di
   // business: a tail call across the import, whose classification needs the
   // callee's round-0 mask. Round 0 is what this column covers, and the
   // remaining `-1:via` says exactly where the next slice is.
-  inspect(String::trim(analysis_line_of(report)), content = "ANALYSIS dce_entry=0 borrow_ret=10/9:-1:via+0: borrow_fns=2/2:-1:via+1:head_of_exp__tmp_vibe_analysis_oracle_helper_vibe borrow_masks=2/2:-1:via#1+1:head_of_exp__tmp_vibe_analysis_oracle_helper_vibe#1 view_ret=3/2:-1:via+0: link_round0=1 link_round0_masks=1 link_round0_occ= link_round01=2 link_round01_masks=2 link_round01_occ=")
+  inspect(String::trim(analysis_line_of(report)), content = "ANALYSIS dce_entry=0 borrow_ret=10/9:-1:via+0: borrow_fns=2/2:-1:via+1:head_of_exp__tmp_vibe_analysis_oracle_helper_vibe borrow_masks=2/2:-1:via#1+1:head_of_exp__tmp_vibe_analysis_oracle_helper_vibe#1 view_ret=3/2:-1:via+0: link_round0=1 link_round0_masks=1 link_round0_occ= link_round01=2 link_round01_masks=2 link_round01_occ= link_bret=10 link_bret_occ= link_bret_self=10 link_bret_asm=10 link_bret_seed=0/0 link_bret_cat=10")
   // The prelude itself still agrees on this program, so the difference above
   // is the analyses' and not a per-module prelude that already diverged.
   let lines = String::split(report, "\n")
@@ -635,14 +663,14 @@ test "the analyses refuse to answer where production would have run late DCE fir
   let main_path = "/tmp/vibe_dce_gate_main.vibe"
   Fs::write_file(helper_path, "export fn head_of(xs: Array[Int]) -> Int {\n  Array::get(xs, 0)\n}\n")
   Fs::write_file(main_path, "import ./vibe_dce_gate_helper.vibe {\n  head_of\n}\n\nfn main() -> Int {\n  head_of([1, 2, 3])\n}\n")
-  inspect(String::trim(analysis_line_of(prelude_module_full_oracle_report_fs(main_path, "main"))), content = "ANALYSIS dce_entry=1 borrow_ret=unmeasured borrow_fns=unmeasured borrow_masks=unmeasured view_ret=unmeasured link_round0=unmeasured link_round0_masks=unmeasured link_round0_occ=unmeasured link_round01=unmeasured link_round01_masks=unmeasured link_round01_occ=unmeasured")
+  inspect(String::trim(analysis_line_of(prelude_module_full_oracle_report_fs(main_path, "main"))), content = "ANALYSIS dce_entry=1 borrow_ret=unmeasured borrow_fns=unmeasured borrow_masks=unmeasured view_ret=unmeasured link_round0=unmeasured link_round0_masks=unmeasured link_round0_occ=unmeasured link_round01=unmeasured link_round01_masks=unmeasured link_round01_occ=unmeasured link_bret=unmeasured link_bret_occ=unmeasured link_bret_self=unmeasured link_bret_asm=unmeasured link_bret_seed=unmeasured link_bret_cat=unmeasured")
   // The control. `__no_entry__` is a name no program defines, so production
   // would not have run either transform and the sample point is its own. The
   // counts are live here rather than merely present -- this program shows the
   // unsound direction too (`+1:head_of_exp__...`, qualified by its own module
   // and disqualified by the whole program through the call site in `main`), so
   // a guard that suppressed the columns unconditionally could not pass this.
-  inspect(String::trim(analysis_line_of(prelude_module_full_oracle_report_fs(main_path, "__no_entry__"))), content = "ANALYSIS dce_entry=0 borrow_ret=9/8:-1:main+0: borrow_fns=0/1:-0:+1:head_of_exp__tmp_vibe_dce_gate_helper_vibe borrow_masks=0/1:-0:+1:head_of_exp__tmp_vibe_dce_gate_helper_vibe#1 view_ret=2/1:-1:main+0: link_round0=0 link_round0_masks=0 link_round0_occ= link_round01=0 link_round01_masks=0 link_round01_occ=")
+  inspect(String::trim(analysis_line_of(prelude_module_full_oracle_report_fs(main_path, "__no_entry__"))), content = "ANALYSIS dce_entry=0 borrow_ret=9/8:-1:main+0: borrow_fns=0/1:-0:+1:head_of_exp__tmp_vibe_dce_gate_helper_vibe borrow_masks=0/1:-0:+1:head_of_exp__tmp_vibe_dce_gate_helper_vibe#1 view_ret=2/1:-1:main+0: link_round0=0 link_round0_masks=0 link_round0_occ= link_round01=0 link_round01_masks=0 link_round01_occ= link_bret=9 link_bret_occ= link_bret_self=9 link_bret_asm=9 link_bret_seed=0/0 link_bret_cat=9")
 }
 
 // #2642 review (Codex P2): `dtd_eq_deferred_requests`, `dtd_eq_deferred_types`


### PR DESCRIPTION
Blocks #2575 item 4. Third slice of #2638, after #2666 (round 0) and #2672 (round 1).

`compute_borrow_returning_names` is a **real fixpoint** (`while changed`), unlike the borrow-param analysis. It decomposes as rounds the *link* drives: each round asks every module what it can add given the set decided so far, and repeats until no module adds anything. A module reads only its own bodies plus that set. The seed's source-shadow bits are a union, so a module publishes its two bits and the link ORs them.

`bret_round` is extracted from the existing loop, so the whole-program pass and the per-module lane run one implementation.

## Measurement

Compiler's own CLI closure — 15 missing down to **4**, with 0 extra:

```
borrow_ret=379/364:-15:MutSortedSet::delete+0:
link_bret=379/375:-4:resolve_checked_path_fs_...+0:
```

## The residue is attributed, not guessed

Three controls, one column each:

| column | what it runs | result |
|---|---|---|
| `link_bret_self` | the rule over the merged program | **379** — exact |
| `link_bret_seed` | both lanes' seed masks | **0/0** — identical |
| `link_bret_cat` | the parts **concatenated**, one round | `379/375:-4:…` |
| `link_bret_asm` | the same statements **folded** | **379** — exact |

`cat` equals `link_bret`, so **splitting the rounds across 365 modules costs nothing** — the fixpoint does decompose. `asm` is exact on the same statements once the assembly folds them, so the 4 are lost to the **167 duplicate declarations** the modules emit (`FULL split=10286 linked=10119 folded=167`).

That is a new fact, and the reason the controls earn their columns: duplicates are **inert** for the borrow-param analysis — `link_round01_occ` reports one and the answer is still exact — and they are **not inert** for a fixpoint. What closes this column is whatever fixes `copies` (#2575), not more work on the analysis.

Two of my own arguments about this residue were wrong. I predicted the seed; `link_bret_seed=0/0` killed it. I then predicted round-splitting; `link_bret_cat` killed that too. Each control exists because a prediction failed, which is why they are pinned rather than deleted once they had served.

## Verification

| check | result |
|---|---|
| output equivalence | `lib/@vibe/cli/entry.vibe` with a stage2 built before and after, 3 runs each, ABBA-interleaved, isolated `VIBE_BUILD_CACHE_DIR` — **6/6 identical sha256** (`df770b3b…`, 39,635,202 bytes) |
| `scripts/compiler_gate.sh` | `[compiler-gate] ok` — 63 suites, **0 failed** |
| `prelude_module_oracle_test.vibe` | 9 tests pass |
| `vibe check` / `vibe_fmt --check` | clean on all four files |

Production cost is unchanged: the split lane is reached only with `use_split` true, and every production caller passes false.

## Still open

`compute_may_return_view_fns` — the callee-edge worklist — is untouched. `view_ret=2141/1956:-185:HashSet::size+0:`. It is the same fixpoint shape as this one, so the link-driven rounds should carry over; I have not measured that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NAeZzkckdAwtQiubBFpdmM

---
_Generated by [Claude Code](https://claude.ai/code/session_01NAeZzkckdAwtQiubBFpdmM)_