### PR TITLE
docs(perceus-reuse): the ownership accounting's cost on the compiler's own self-compile (#2671)

### DIFF
--- a/docs/perceus-reuse.md
+++ b/docs/perceus-reuse.md
@@ -379,6 +379,14 @@ caller keeps its; such a program never sees the unique path for that name,
 which is the honest price of shadowing an intrinsic with a source
 definition the planner reads.
 
+What the accounting costs the compiler itself (30 `Array::map` sites,
+the RC-built compiler compiling the flat compiler source, viberun fuel,
+same input): 1,178,199,286,771 → 1,177,029,188,108 instructions (−0.10%),
+1,837,225,668 → 1,835,120,428 B allocated (−0.11%), the RC-built stage2
+4,882,987 → 4,889,652 B (+0.14%). The bump lane's bytes are untouched; its
+`selfcompile_kpi` heap high-water moves 875,863,464 → 875,211,600 B (−0.07%,
+the #2680 inference).
+
 Pinned by `tests/hof_rc_ownership_test.vibe` (bump / RC / RC-shadow
 agreement on every builtin, shared and unique sources, a capturing closure
 used by three maps, a source-level `Array::map` shadowing the intrinsic),


### PR DESCRIPTION
One docs commit that landed on the branch after #2673 was merged (the merge took the branch at 045db6c; this was pushed minutes later), rebased onto main.

It adds the measured cost of the #2671 ownership accounting to the `docs/perceus-reuse.md` section that describes it. RC-built compiler compiling the flat compiler source (viberun fuel, same input, cold):

| | pre-fix | post-fix |
|---|---:|---:|
| instructions | 1,178,199,286,771 | 1,177,029,188,108 (−0.10%) |
| allocated | 1,837,225,668 B | 1,835,120,428 B (−0.11%) |
| RC-built stage2 | 4,882,987 B | 4,889,652 B (+0.14%) |

The bump lane's bytes are untouched by the fix; its `selfcompile_kpi` heap high-water moves 875,863,464 → 875,211,600 B (−0.07%, the #2680 inference). Documentation only; no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ASfkaC6HgSCSydTZcKSF2M

---
_Generated by [Claude Code](https://claude.ai/code/session_01ASfkaC6HgSCSydTZcKSF2M)_