### PR TITLE
#2638: the may-return-view fixpoint decomposes too — all four analyses linked

### DIFF
--- a/lib/@vibe/compiler/codegen/common_analysis/common_analysis.vibe
+++ b/lib/@vibe/compiler/codegen/common_analysis/common_analysis.vibe
@@ -4401,6 +4401,38 @@ fn mrv_fresh(e: Expr, fresh_names: MutMap[String, Int], tainted: MutMap[String, 
   }
 }
 
+/// #2638: is THIS function view-returning, given the set decided so far?
+///
+/// The one cross-function read is `view_seen` (through `mrv_fresh`), plus
+/// `user_fns_srt` to tell a user-fn call from a builtin. Everything else is
+/// the function's own body and parameters.
+///
+/// Extracted because the whole-program driver and the per-module lane run
+/// DIFFERENT drivers and must not diverge on the DECISION. The worklist
+/// (#2386) re-walks a function only when one of its callees enters the set,
+/// through a reverse index over the whole program -- an index a module cannot
+/// hold, since the caller and the callee may live in different modules. The
+/// link therefore runs plain ROUNDS instead, which converge to the same set
+/// because the fixpoint is monotone. So what is shared here is the
+/// classification, not the loop around it; claiming one implementation serves
+/// both drivers would be false.
+///
+/// `bound` and `callees` are the caller's scratch rows: `bound` is truncated
+/// here, `callees` is appended to and read by a caller that maintains a
+/// reverse index (the worklist does; the round driver does not need one).
+fn mrv_classify_one(body: Expr, fps: Array[(String, Option[TypeExpr])], fresh_names: MutMap[String, Int], tainted: MutMap[String, Int], bound: Array[String], gen: Int, user_fns_srt: Array[String], view_seen: MutSet[String], callees: Array[String]) -> Bool {
+  Array::truncate(bound, 0)
+  let mut pi = 0
+  while pi < Array::length(fps) {
+    let (pn, _) = Array::get(fps, pi)
+    Array::push(bound, pn)
+    pi = pi + 1
+  }
+  let ret_view = [0]
+  let tail_fresh = mrv_fresh(body, fresh_names, tainted, bound, gen, user_fns_srt, view_seen, ret_view, callees)
+  !tail_fresh || Array::get(ret_view, 0) == 1
+}
+
 /// ADR-0092 borrow-inference: top-level functions whose RETURN VALUE may be
 /// an unowned interior view (a borrow-returning builtin result, a match
 /// payload, a global, a parameter, or anything reaching a return position
@@ -4472,17 +4504,8 @@ export fn compute_may_return_view_fns(stmts: Array[Stmt]) -> Array[String] {
       ()
     } else {
       gen = gen + 1
-      Array::truncate(bound, 0)
-      let fps = Array::get(fn_params, fi)
-      let mut pi = 0
-      while pi < Array::length(fps) {
-        let (pn, _) = Array::get(fps, pi)
-        Array::push(bound, pn)
-        pi = pi + 1
-      }
-      let ret_view = [0]
       let callees = array_empty()
-      let tail_fresh = mrv_fresh(Array::get(fn_bodies, fi), fresh_names, tainted, bound, gen, user_fns_srt, view_seen, ret_view, callees)
+      let is_view = mrv_classify_one(Array::get(fn_bodies, fi), Array::get(fn_params, fi), fresh_names, tainted, bound, gen, user_fns_srt, view_seen, callees)
       // Reverse edges from this walk (recorded once; later walks of the
       // same body see the same callees, so re-recording would only add
       // duplicate callers, which the `queued` mark absorbs anyway).
@@ -4495,7 +4518,7 @@ export fn compute_may_return_view_fns(stmts: Array[Stmt]) -> Array[String] {
         }
         ki = ki + 1
       }
-      if !tail_fresh || Array::get(ret_view, 0) == 1 {
+      if is_view {
         Array::push(view_set, fname)
         MutSet::add(view_seen, fname)
         match MutMap::get(callers_of, fname) {
@@ -4519,6 +4542,96 @@ export fn compute_may_return_view_fns(stmts: Array[Stmt]) -> Array[String] {
       }
     }
     wi = wi + 1
+  }
+  view_set
+}
+
+/// #2638: this module's own top-level function NAMES. `mrv_fresh` needs the
+/// whole program's set to tell a user-fn call from a builtin, and that set is
+/// a union -- so a module publishes its half. Body-free: one pass over the
+/// declaration forms.
+export fn mrv_declared_fn_names(stmts: Array[Stmt]) -> Array[String] {
+  let out = array_empty()
+  let mut i = 0
+  while i < Array::length(stmts) {
+    match Array::get(stmts, i) {
+      SLet(_, _, fname, _, fval) => match fval {
+        EFn(_, _, _, _, _, _) => Array::push(out, fname),
+        _ => ()
+      },
+      _ => ()
+    }
+    i = i + 1
+  }
+  out
+}
+
+/// #2638: ONE ROUND of the may-return-view fixpoint over `stmts`, against the
+/// set decided so far. Returns whether it added anything.
+fn mrv_round(stmts: Array[Stmt], user_fns_srt: Array[String], view_set: Array[String], view_seen: MutSet[String], fresh_names: MutMap[String, Int], tainted: MutMap[String, Int], bound: Array[String], gen_cell: Array[Int]) -> Bool {
+  let mut changed = false
+  let mut i = 0
+  while i < Array::length(stmts) {
+    match Array::get(stmts, i) {
+      SLet(_, _, fname, _, fval) => match fval {
+        EFn(_, _, fps, _, _, fbody) =>
+        if MutSet::has(view_seen, fname) {
+          ()
+        } else {
+          Array::set(gen_cell, 0, Array::get(gen_cell, 0) + 1)
+          let callees = array_empty()
+          if mrv_classify_one(fbody, fps, fresh_names, tainted, bound, Array::get(gen_cell, 0), user_fns_srt, view_seen, callees) {
+            Array::push(view_set, fname)
+            MutSet::add(view_seen, fname)
+            changed = true
+          } else {
+            ()
+          }
+        },
+        _ => ()
+      },
+      _ => ()
+    }
+    i = i + 1
+  }
+  changed
+}
+
+/// #2638: THE MAY-RETURN-VIEW LINK. The whole program's view set, as rounds
+/// the link drives across the modules.
+///
+/// Each round asks every module what it can add given the set so far, and
+/// repeats until no module adds anything. A module reads only its own bodies,
+/// that set, and `user_fn_names` -- the union the modules published.
+///
+/// ROUNDS, not the worklist: #2386 replaced rounds with a callee-edge worklist
+/// keyed on a reverse index over the whole program, and that index is exactly
+/// the cross-module edge (a caller in one module must be re-walked when a
+/// callee in another enters the set). A module cannot hold it. Rounds converge
+/// to the same set because the fixpoint is monotone, so the answer is
+/// unchanged and only the driver is. The whole-program pass keeps its
+/// worklist; this costs the rounds #2386 measured at ~0.32 s warm on the
+/// compiler closure, and it is paid on the oracle lane alone.
+export fn may_return_view_link_parts(parts: Array[Array[Stmt]], user_fn_names: Array[String]) -> Array[String] {
+  let user_fns_srt = sorted_names_of(user_fn_names)
+  let view_set = array_empty()
+  let view_seen = MutSet::new_string()
+  let fresh_names: MutMap[String, Int] = MutMap::new_string()
+  let tainted: MutMap[String, Int] = MutMap::new_string()
+  let bound = array_empty()
+  let gen_cell = [0]
+  let mut changed = true
+  while changed {
+    changed = false
+    let mut pi = 0
+    while pi < Array::length(parts) {
+      if mrv_round(Array::get(parts, pi), user_fns_srt, view_set, view_seen, fresh_names, tainted, bound, gen_cell) {
+        changed = true
+      } else {
+        ()
+      }
+      pi = pi + 1
+    }
   }
   view_set
 }

--- a/lib/@vibe/compiler/codegen/common_analysis/index.vpkg
+++ b/lib/@vibe/compiler/codegen/common_analysis/index.vpkg
@@ -63,6 +63,8 @@ fn borrow_round1_link_parts(parts: Array[Array[Stmt]], round0_names: Array[Strin
 fn bmask_max_param() -> Int
 fn bmask_has(mask: Int, i: Int) -> Bool
 fn compute_may_return_view_fns(stmts: Array[Stmt]) -> Array[String]
+fn mrv_declared_fn_names(stmts: Array[Stmt]) -> Array[String]
+fn may_return_view_link_parts(parts: Array[Array[Stmt]], user_fn_names: Array[String]) -> Array[String]
 fn count_lambda_sites_expr(expr: Expr, user_fn_names: Array[String]) -> Int
 fn packed_lines_to_array_expr(raw_call: Expr, tmp_name: String) -> Expr
 fn region_array_value_copy(value: Expr, tmp: String) -> Expr

--- a/lib/@vibe/compiler/codegen/wasi/linked_compile.vibe
+++ b/lib/@vibe/compiler/codegen/wasi/linked_compile.vibe
@@ -181,7 +181,9 @@ import @vibe/compiler/codegen/common_analysis {
   emit_closure_resolve,
   emit_i64_extend_i32_u,
   is_mut_captured_in,
+  may_return_view_link_parts,
   md_is_borrow_arg0_call,
+  mrv_declared_fn_names,
   scope_tail_proj_root,
   stmts_contain_exceptions,
   unique_typed_lowering_offsets_in_stmts,
@@ -5470,6 +5472,9 @@ fn prelude_run_per_module(c: Array[Stmt], c_file_id: Array[Int], file_count: Int
     // #2638: and this module's half of the borrow-returning SEED. The whole
     // program's is the OR, so it publishes like the disqualifiers above.
     Array::push(st.an_bret_shadow, borrow_ret_shadow_mask(part))
+    // #2638: and its own top-level fn NAMES -- `mrv_fresh` needs the program's
+    // set to tell a user-fn call from a builtin, and that set is a union.
+    lc_concat_into(st.an_mrv_names, mrv_declared_fn_names(part))
     fi = fi + 1
   }
   // #2638 PHASE B. Round 0 for the whole program is linkable now, from what
@@ -5509,6 +5514,9 @@ fn prelude_run_per_module(c: Array[Stmt], c_file_id: Array[Int], file_count: Int
   }
   Array::push(st.an_bret_seed, ph_bshadow)
   lc_concat_into(st.an_bret_link, sorted_names_of(borrow_ret_link_parts(parts, ph_bshadow)))
+  // #2638: and the may-return-view set, the last of the four. Same link-driven
+  // rounds; the whole-program pass keeps its worklist (see the link's doc).
+  lc_concat_into(st.an_view_link, sorted_names_of(may_return_view_link_parts(parts, st.an_mrv_names)))
   lc_concat_into(st.an_r01_names, ph_r01)
   lc_concat_ints_into(st.an_r01_masks, ph_r01mask)
   // ASSEMBLY (#2575 item 2 step 3). Concatenating the modules is the obvious
@@ -5694,6 +5702,10 @@ struct PreludeSplitStats {
   // The OR the split lane actually seeded with, so the caller can compare it
   // against the whole program's instead of assuming they agree.
   an_bret_seed: Array[Int];
+  // #2638: the modules' declared fn names (a union), and the may-return-view
+  // set the link computed from them.
+  an_mrv_names: Array[String];
+  an_view_link: Array[String];
   // The module parts themselves, so the caller can run its own controls
   // against the SAME statements the split lane answered from.
   an_parts: Array[Array[Stmt]];
@@ -5732,6 +5744,8 @@ fn prelude_split_stats_new() -> PreludeSplitStats {
     an_shadow: lc_fresh_int_array(),
     an_bret_shadow: lc_fresh_int_array(),
     an_bret_seed: lc_fresh_int_array(),
+    an_mrv_names: lc_fresh_string_array(),
+    an_view_link: lc_fresh_string_array(),
     an_parts: [],
     an_bret_link: lc_fresh_string_array(),
     an_r01_names: lc_fresh_string_array(),
@@ -5848,6 +5862,13 @@ export fn prelude_module_full_oracle_line(a: Array[Stmt], c: Array[Stmt], c_file
   // the fixpoint failing to decompose. Without it the two causes are
   // indistinguishable, and "the analysis does not decompose" is the more
   // interesting and more wrong of the two.
+  // #2638: the same two controls for the view set -- the rule over the merged
+  // program, and over the split lane's ASSEMBLED output. `bret` needed them to
+  // tell a decomposition failure from a statement difference, and there is no
+  // reason to believe this analysis differs without measuring it.
+  let an_view_one: Array[Array[Stmt]] = []
+  Array::push(an_view_one, a)
+  let an_view_self = sorted_names_of(may_return_view_link_parts(an_view_one, mrv_declared_fn_names(a)))
   let an_bret_one: Array[Array[Stmt]] = []
   Array::push(an_bret_one, a)
   let an_bret_self = sorted_names_of(borrow_ret_link_parts(an_bret_one, borrow_ret_shadow_mask(a)))
@@ -5915,6 +5936,9 @@ export fn prelude_module_full_oracle_line(a: Array[Stmt], c: Array[Stmt], c_file
   let an_bret_cat_one: Array[Array[Stmt]] = []
   Array::push(an_bret_cat_one, an_bret_cat)
   let an_bret_catr = sorted_names_of(borrow_ret_link_parts(an_bret_cat_one, borrow_ret_shadow_mask(an_bret_cat)))
+  let an_view_asm_one: Array[Array[Stmt]] = []
+  Array::push(an_view_asm_one, linked)
+  let an_view_asm = sorted_names_of(may_return_view_link_parts(an_view_asm_one, mrv_declared_fn_names(linked)))
   let an_bret_asm_one: Array[Array[Stmt]] = []
   Array::push(an_bret_asm_one, linked)
   let an_bret_asm = sorted_names_of(borrow_ret_link_parts(an_bret_asm_one, borrow_ret_shadow_mask(linked)))
@@ -5985,12 +6009,12 @@ export fn prelude_module_full_oracle_line(a: Array[Stmt], c: Array[Stmt], c_file
     "0"
   })
   let an_cols = if an_dce_entry {
-    " borrow_ret=unmeasured borrow_fns=unmeasured borrow_masks=unmeasured view_ret=unmeasured link_round0=unmeasured link_round0_masks=unmeasured link_round0_occ=unmeasured link_round01=unmeasured link_round01_masks=unmeasured link_round01_occ=unmeasured link_bret=unmeasured link_bret_occ=unmeasured link_bret_self=unmeasured link_bret_asm=unmeasured link_bret_seed=unmeasured link_bret_cat=unmeasured"
+    " borrow_ret=unmeasured borrow_fns=unmeasured borrow_masks=unmeasured view_ret=unmeasured link_round0=unmeasured link_round0_masks=unmeasured link_round0_occ=unmeasured link_round01=unmeasured link_round01_masks=unmeasured link_round01_occ=unmeasured link_bret=unmeasured link_bret_occ=unmeasured link_bret_self=unmeasured link_bret_asm=unmeasured link_bret_seed=unmeasured link_bret_cat=unmeasured link_view=unmeasured link_view_self=unmeasured link_view_asm=unmeasured"
   } else {
     String::concat(String::concat(String::concat(" borrow_ret=", lc_set_cmp_counted(an_bret_w, an_bret_u)), String::concat(" borrow_fns=", lc_set_cmp_counted(an_bfns_w, an_bfns_u))), String::concat(String::concat(" borrow_masks=", lc_set_cmp_counted(lc_name_mask_pairs(an_bfns_w, an_bmask_w), an_pairs_u)), String::concat(String::concat(" view_ret=", lc_set_cmp_counted(an_view_w, an_view_u)), String::concat(String::concat(" link_round0=", lc_set_cmp_counted(an_r0_w, an_r0_link)), String::concat(String::concat(" link_round0_masks=", lc_set_cmp_counted(lc_name_mask_pairs(an_r0_w, an_r0mask_w), lc_name_mask_pairs(an_r0_link, an_r0mask_link))), String::concat(String::concat(" link_round0_occ=", lc_multiset_first_diff(an_r0_w, an_r0_link)), String::concat(String::concat(" link_round01=", lc_set_cmp_counted(an_bfns_w, an_r01_link)), String::concat(String::concat(" link_round01_masks=", lc_set_cmp_counted(lc_name_mask_pairs(an_bfns_w, an_bmask_w), lc_name_mask_pairs(an_r01_link, an_r01mask_link))), String::concat(String::concat(" link_round01_occ=", lc_multiset_first_diff(an_bfns_w, an_r01_link)), String::concat(String::concat(" link_bret=", lc_set_cmp_counted(an_bret_w, st.an_bret_link)), String::concat(String::concat(" link_bret_occ=", lc_multiset_first_diff(an_bret_w, st.an_bret_link)), String::concat(String::concat(" link_bret_self=", lc_set_cmp_counted(an_bret_w, an_bret_self)), String::concat(String::concat(" link_bret_asm=", lc_set_cmp_counted(an_bret_w, an_bret_asm)), String::concat(String::concat(" link_bret_seed=", String::concat(Int::to_string(match Array::length(st.an_bret_seed) {
       0 => 0 - 1,
       _ => Array::get(st.an_bret_seed, 0)
-    }), String::concat("/", Int::to_string(borrow_ret_shadow_mask(a))))), String::concat(" link_bret_cat=", lc_set_cmp_counted(an_bret_w, an_bret_catr))))))))))))))))
+    }), String::concat("/", Int::to_string(borrow_ret_shadow_mask(a))))), String::concat(String::concat(" link_bret_cat=", lc_set_cmp_counted(an_bret_w, an_bret_catr)), String::concat(String::concat(" link_view=", lc_set_cmp_counted(an_view_w, st.an_view_link)), String::concat(String::concat(" link_view_self=", lc_set_cmp_counted(an_view_w, an_view_self)), String::concat(" link_view_asm=", lc_set_cmp_counted(an_view_w, an_view_asm)))))))))))))))))))
   }
   let an_line = String::concat(String::concat(an_head, an_cols), "\n")
   let line = String::concat(String::concat(head, mid), tail)

--- a/lib/@vibe/compiler/tests/prelude_module_oracle_test.vibe
+++ b/lib/@vibe/compiler/tests/prelude_module_oracle_test.vibe
@@ -381,13 +381,13 @@ test "the whole prelude per module reproduces the whole-program prelude" {
   // On the compiler's own CLI closure (365 modules, measured 2026-09-11 on
   // this change) the same line reads:
   //
-  //   ANALYSIS dce_entry=0 borrow_ret=379/364:-15:MutSortedSet::delete+0:
-  //            borrow_fns=2767/2688:-168:alloc_site_kind_dep_...+89:__arr_equals__N4_Expr
-  //            borrow_masks=2767/2688:-200:agg_expr_of_ident_exp_...#12+121:__arr_equals__N4_Expr#3
-  //            view_ret=2142/1957:-185:HashSet::size+0:
+  //   ANALYSIS dce_entry=0 borrow_ret=381/365:-16:MutSortedSet::delete+0:
+  //            borrow_fns=2772/2693:-168:alloc_site_kind_dep_...+89:__arr_equals__N4_Expr
+  //            borrow_masks=2772/2693:-200:agg_expr_of_ident_exp_...#12+121:__arr_equals__N4_Expr#3
+  //            view_ret=2144/1958:-186:HashSet::size+0:
   //
   // 89 functions take the borrowed ABI from their own module that the whole
-  // program refuses, and the net (2767 - 2688 = 79) hides every one of them
+  // program refuses, and the net (2772 - 2693 = 79) hides every one of them
   // behind the 168 the modules were conservative about. 121 against 89 on the
   // mask row is the other half: 32 functions are in BOTH sets under DIFFERENT
   // masks -- the names agree and the ABI does not, which a name-only
@@ -410,14 +410,14 @@ test "the whole prelude per module reproduces the whole-program prelude" {
   //
   // #2638: and on that same closure the link columns read
   //
-  //   link_round0=2166/2169:-0:+0:   link_round0_occ=__arr_equals__N8_TypeExpr:1/2
-  //   link_round01=2767/2770:-0:+0:  link_round01_occ=__arr_equals__N8_TypeExpr:1/2
+  //   link_round0=2171/2174:-0:+0:   link_round0_occ=__arr_equals__N8_TypeExpr:1/2
+  //   link_round01=2772/2775:-0:+0:  link_round01_occ=__arr_equals__N8_TypeExpr:1/2
   //
   // -- ZERO missing and ZERO extra on both, names and masks alike. The first
   // is round 0 alone, linked from what each module publishes without
   // re-reading a body. The second is the WHOLE analysis: `link_round01` is
   // compared against the shipped `compute_borrow_param_user_fns` itself, not
-  // against a stand-in, so `2767` is the same 2767 the `borrow_fns` row above
+  // against a stand-in, so `2772` is the same 2772 the `borrow_fns` row above
   // reports for the whole-program lane.
   //
   // #2638: `borrow_ret` is the FIXPOINT, and it decomposes too -- as rounds
@@ -425,22 +425,43 @@ test "the whole prelude per module reproduces the whole-program prelude" {
   // set so far; it repeats until no module adds anything. On the closure that
   // takes `borrow_ret`'s 15 missing down to 4, with 0 extra:
   //
-  //   borrow_ret=379/364:-15:MutSortedSet::delete+0:
-  //   link_bret=379/375:-4:resolve_checked_path_fs_...+0:
+  //   borrow_ret=381/365:-16:MutSortedSet::delete+0:
+  //   link_bret=381/377:-4:resolve_checked_path_fs_...+0:
   //
   // The residue is ATTRIBUTED rather than guessed, by three controls that cost
   // one column each. Two of my own arguments about it were wrong and the
   // columns are what said so:
   //
-  //   link_bret_self=379                 the rule over the merged program: exact
+  //   link_bret_self=381                 the rule over the merged program: exact
   //   link_bret_seed=0/0                 both lanes seed identically
-  //   link_bret_cat=379/375:-4:...       the parts CONCATENATED, one round
-  //   link_bret_asm=379                  the same statements FOLDED: exact
+  //   link_bret_cat=381/377:-4:...       the parts CONCATENATED, one round
+  //   link_bret_asm=381                  the same statements FOLDED: exact
   //
   // `cat` equals `link_bret`, so splitting the rounds across 365 modules costs
   // NOTHING -- the fixpoint decomposes. `asm` is exact on the same statements
   // once the assembly folds them, so the 4 are lost to the 167 DUPLICATE
   // declarations the modules emit (`FULL split=10286 linked=10119 folded=167`).
+  //
+  // #2638: `view_ret` is the LAST of the four, and the same rounds close it:
+  //
+  //   view_ret=2144/1958:-186:HashSet::size+0:
+  //   link_view=2144/2137:-7:diag_fail_fast_...+0:
+  //   link_view_self=2144   link_view_asm=2144
+  //
+  // 186 missing down to 7, 0 extra, and BOTH controls exact -- so the 7 are
+  // the same duplicate-declaration residue as `link_bret`'s 4, measured rather
+  // than assumed to be the same cause. On the two-file repro `link_view=3` is
+  // a bare count where `view_ret=3/2:-1:via+0:`.
+  //
+  // This one keeps TWO drivers on purpose. #2386 replaced rounds with a
+  // callee-edge worklist keyed on a reverse index over the whole program, and
+  // that index IS the cross-module edge -- a caller in one module has to be
+  // re-walked when a callee in another enters the set, so no module can hold
+  // it. The link runs rounds instead (same monotone fixpoint, same set, the
+  // ~0.32 s #2386 measured, on the oracle lane only), and what is shared with
+  // the production worklist is `mrv_classify_one`, the DECISION. Saying "one
+  // implementation serves both" here would be false, and the comment on that
+  // function says so.
   //
   // That is worth stating plainly because it is new: duplicates are inert for
   // the borrow-PARAM analysis -- `link_round01_occ` reports one and the answer
@@ -463,7 +484,7 @@ test "the whole prelude per module reproduces the whole-program prelude" {
   // twice across the modules, because a program-level helper is synthesized
   // once per module that needs it. That is the `copies` shape this oracle
   // already counts, and the link folds it by key elsewhere.
-  inspect(String::trim(analysis_line_of(report)), content = "ANALYSIS dce_entry=0 borrow_ret=7 borrow_fns=0 borrow_masks=0 view_ret=2/1:-1:helper_use_exp__tmp_vibe_full_oracle_helper_vibe+0: link_round0=0 link_round0_masks=0 link_round0_occ= link_round01=0 link_round01_masks=0 link_round01_occ= link_bret=7 link_bret_occ= link_bret_self=7 link_bret_asm=7 link_bret_seed=0/0 link_bret_cat=7")
+  inspect(String::trim(analysis_line_of(report)), content = "ANALYSIS dce_entry=0 borrow_ret=7 borrow_fns=0 borrow_masks=0 view_ret=2/1:-1:helper_use_exp__tmp_vibe_full_oracle_helper_vibe+0: link_round0=0 link_round0_masks=0 link_round0_occ= link_round01=0 link_round01_masks=0 link_round01_occ= link_bret=7 link_bret_occ= link_bret_self=7 link_bret_asm=7 link_bret_seed=0/0 link_bret_cat=7 link_view=2/1:-1:helper_use_exp__tmp_vibe_full_oracle_helper_vibe+0: link_view_self=2 link_view_asm=2")
   // `missing=0 extra=0 content=0` is the property: every declaration the
   // whole-program prelude produced is produced by the module that owns it,
   // with the same body. `copies` is what remains after the link, and
@@ -636,7 +657,7 @@ test "the may_return and borrow analyses do not decompose per module, in both di
   // business: a tail call across the import, whose classification needs the
   // callee's round-0 mask. Round 0 is what this column covers, and the
   // remaining `-1:via` says exactly where the next slice is.
-  inspect(String::trim(analysis_line_of(report)), content = "ANALYSIS dce_entry=0 borrow_ret=10/9:-1:via+0: borrow_fns=2/2:-1:via+1:head_of_exp__tmp_vibe_analysis_oracle_helper_vibe borrow_masks=2/2:-1:via#1+1:head_of_exp__tmp_vibe_analysis_oracle_helper_vibe#1 view_ret=3/2:-1:via+0: link_round0=1 link_round0_masks=1 link_round0_occ= link_round01=2 link_round01_masks=2 link_round01_occ= link_bret=10 link_bret_occ= link_bret_self=10 link_bret_asm=10 link_bret_seed=0/0 link_bret_cat=10")
+  inspect(String::trim(analysis_line_of(report)), content = "ANALYSIS dce_entry=0 borrow_ret=10/9:-1:via+0: borrow_fns=2/2:-1:via+1:head_of_exp__tmp_vibe_analysis_oracle_helper_vibe borrow_masks=2/2:-1:via#1+1:head_of_exp__tmp_vibe_analysis_oracle_helper_vibe#1 view_ret=3/2:-1:via+0: link_round0=1 link_round0_masks=1 link_round0_occ= link_round01=2 link_round01_masks=2 link_round01_occ= link_bret=10 link_bret_occ= link_bret_self=10 link_bret_asm=10 link_bret_seed=0/0 link_bret_cat=10 link_view=3 link_view_self=3 link_view_asm=3")
   // The prelude itself still agrees on this program, so the difference above
   // is the analyses' and not a per-module prelude that already diverged.
   let lines = String::split(report, "\n")
@@ -663,14 +684,14 @@ test "the analyses refuse to answer where production would have run late DCE fir
   let main_path = "/tmp/vibe_dce_gate_main.vibe"
   Fs::write_file(helper_path, "export fn head_of(xs: Array[Int]) -> Int {\n  Array::get(xs, 0)\n}\n")
   Fs::write_file(main_path, "import ./vibe_dce_gate_helper.vibe {\n  head_of\n}\n\nfn main() -> Int {\n  head_of([1, 2, 3])\n}\n")
-  inspect(String::trim(analysis_line_of(prelude_module_full_oracle_report_fs(main_path, "main"))), content = "ANALYSIS dce_entry=1 borrow_ret=unmeasured borrow_fns=unmeasured borrow_masks=unmeasured view_ret=unmeasured link_round0=unmeasured link_round0_masks=unmeasured link_round0_occ=unmeasured link_round01=unmeasured link_round01_masks=unmeasured link_round01_occ=unmeasured link_bret=unmeasured link_bret_occ=unmeasured link_bret_self=unmeasured link_bret_asm=unmeasured link_bret_seed=unmeasured link_bret_cat=unmeasured")
+  inspect(String::trim(analysis_line_of(prelude_module_full_oracle_report_fs(main_path, "main"))), content = "ANALYSIS dce_entry=1 borrow_ret=unmeasured borrow_fns=unmeasured borrow_masks=unmeasured view_ret=unmeasured link_round0=unmeasured link_round0_masks=unmeasured link_round0_occ=unmeasured link_round01=unmeasured link_round01_masks=unmeasured link_round01_occ=unmeasured link_bret=unmeasured link_bret_occ=unmeasured link_bret_self=unmeasured link_bret_asm=unmeasured link_bret_seed=unmeasured link_bret_cat=unmeasured link_view=unmeasured link_view_self=unmeasured link_view_asm=unmeasured")
   // The control. `__no_entry__` is a name no program defines, so production
   // would not have run either transform and the sample point is its own. The
   // counts are live here rather than merely present -- this program shows the
   // unsound direction too (`+1:head_of_exp__...`, qualified by its own module
   // and disqualified by the whole program through the call site in `main`), so
   // a guard that suppressed the columns unconditionally could not pass this.
-  inspect(String::trim(analysis_line_of(prelude_module_full_oracle_report_fs(main_path, "__no_entry__"))), content = "ANALYSIS dce_entry=0 borrow_ret=9/8:-1:main+0: borrow_fns=0/1:-0:+1:head_of_exp__tmp_vibe_dce_gate_helper_vibe borrow_masks=0/1:-0:+1:head_of_exp__tmp_vibe_dce_gate_helper_vibe#1 view_ret=2/1:-1:main+0: link_round0=0 link_round0_masks=0 link_round0_occ= link_round01=0 link_round01_masks=0 link_round01_occ= link_bret=9 link_bret_occ= link_bret_self=9 link_bret_asm=9 link_bret_seed=0/0 link_bret_cat=9")
+  inspect(String::trim(analysis_line_of(prelude_module_full_oracle_report_fs(main_path, "__no_entry__"))), content = "ANALYSIS dce_entry=0 borrow_ret=9/8:-1:main+0: borrow_fns=0/1:-0:+1:head_of_exp__tmp_vibe_dce_gate_helper_vibe borrow_masks=0/1:-0:+1:head_of_exp__tmp_vibe_dce_gate_helper_vibe#1 view_ret=2/1:-1:main+0: link_round0=0 link_round0_masks=0 link_round0_occ= link_round01=0 link_round01_masks=0 link_round01_occ= link_bret=9 link_bret_occ= link_bret_self=9 link_bret_asm=9 link_bret_seed=0/0 link_bret_cat=9 link_view=2 link_view_self=2 link_view_asm=2")
 }
 
 // #2642 review (Codex P2): `dtd_eq_deferred_requests`, `dtd_eq_deferred_types`


### PR DESCRIPTION
Blocks #2575 item 4. Fourth and last analysis of #2638, after #2666, #2672 and #2685.

`compute_may_return_view_fns` closes the `view_ret` column the same way #2685 closed `borrow_ret`: rounds the **link** drives, each asking every module what it can add given the set decided so far.

## Measurement

Compiler's own CLI closure — 186 missing down to **7**, with 0 extra:

```
view_ret=2144/1958:-186:HashSet::size+0:
link_view=2144/2137:-7:diag_fail_fast_...+0:
link_view_self=2144   link_view_asm=2144
```

Both controls are exact, so the 7 are the **same duplicate-declaration residue** as `link_bret`'s 4 — measured here rather than assumed to carry over from the other fixpoint. On the two-file repro `link_view=3` is a bare count where `view_ret=3/2:-1:via+0:`.

## Two drivers, on purpose

#2386 replaced whole-program rounds with a callee-edge worklist keyed on a reverse index over the program — and that index **is** the cross-module edge: a caller in one module has to be re-walked when a callee in another enters the set, so no module can hold it. The link runs rounds instead: same monotone fixpoint, same set, at the ~0.32 s #2386 measured, and on the oracle lane only.

So what is shared with the production worklist is `mrv_classify_one`, the **decision** — not the loop around it. Claiming "one implementation serves both drivers" would be false here, unlike in the previous three slices, and both the function's doc and the test comment say so.

## Where the four columns stand

| column | union lane | link |
|---|---|---|
| `borrow_fns` | −168 / +89 | **0 / 0** (bare) |
| `borrow_masks` | −200 / +121 | **0 / 0** |
| `borrow_ret` | −16 / +0 | −4 / +0 |
| `view_ret` | −186 / +0 | −7 / +0 |

Every remaining miss is attributed to the modules' **duplicate declarations**, which the assembly folds and the analyses do not: `link_bret_asm` and `link_view_asm` are both exact on those same statements once folded. What closes the last two columns is whatever fixes `copies` (#2575), not more work on the analyses.

The unsound direction — a module qualifying something the whole program disqualifies, which is what this issue was filed about — is **0 in every column**.

## Verification

| check | result |
|---|---|
| output equivalence | `lib/@vibe/cli/entry.vibe` with a stage2 built before and after, 3 runs each, ABBA-interleaved, isolated `VIBE_BUILD_CACHE_DIR` — **6/6 identical sha256** (`d539ffb5…`, 40,014,437 bytes) |
| `scripts/compiler_gate.sh` | `[compiler-gate] ok` — 63 suites, **0 failed** |
| `prelude_module_oracle_test.vibe` | 9 tests pass |
| `vibe check` / `vibe_fmt --check` | clean on all four files |

Production cost is unchanged: the split lane is reached only with `use_split` true, and every production caller passes false.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NAeZzkckdAwtQiubBFpdmM

---
_Generated by [Claude Code](https://claude.ai/code/session_01NAeZzkckdAwtQiubBFpdmM)_