### PR TITLE
#2638: the residue is the link-only passes, not the duplicate declarations

### DIFF
--- a/lib/@vibe/compiler/codegen/wasi/linked_compile.vibe
+++ b/lib/@vibe/compiler/codegen/wasi/linked_compile.vibe
@@ -5609,6 +5609,17 @@ fn prelude_run_per_module(c: Array[Stmt], c_file_id: Array[Int], file_count: Int
   // is the measurement's ANSWER, and stopping at the first would say "some
   // module disagrees" without saying how many or about what. Production keeps
   // the throw.
+  // #2638 FOURTH CONTROL, and the one that settles what the other three left
+  // open. `trial` is the parts concatenated WITH passes 12-16 and the mint
+  // applied, but BEFORE the fold; `linked` is the same thing folded. So
+  // `trial` vs `linked` isolates the FOLD, and `trial` vs the raw parts
+  // isolates the LINK-ONLY PASSES. Measured because the obvious reading of the
+  // first three controls -- that the duplicates cost the residue -- turned out
+  // to be wrong: filtering the parts to what the fold keeps changed nothing.
+  let an_bret_trial_one: Array[Array[Stmt]] = []
+  Array::push(an_bret_trial_one, trial)
+  lc_concat_into(st.an_bret_trial, sorted_names_of(borrow_ret_link_parts(an_bret_trial_one, borrow_ret_shadow_mask(trial))))
+  lc_concat_into(st.an_view_trial, sorted_names_of(may_return_view_link_parts(an_bret_trial_one, mrv_declared_fn_names(trial))))
   let (linked, collisions0) = link_fold_duplicate_definitions_report(trial, synth_keys, render)
   lc_union_into(st.collisions, collisions0)
   // #2388 (Codex round on #2623): a definition key that still repeats in the
@@ -5702,6 +5713,10 @@ struct PreludeSplitStats {
   // The OR the split lane actually seeded with, so the caller can compare it
   // against the whole program's instead of assuming they agree.
   an_bret_seed: Array[Int];
+  // #2638: the two fixpoints over `trial` -- concatenated, link-passes applied,
+  // NOT folded. Isolates the fold from the link-only passes.
+  an_bret_trial: Array[String];
+  an_view_trial: Array[String];
   // #2638: the modules' declared fn names (a union), and the may-return-view
   // set the link computed from them.
   an_mrv_names: Array[String];
@@ -5744,6 +5759,8 @@ fn prelude_split_stats_new() -> PreludeSplitStats {
     an_shadow: lc_fresh_int_array(),
     an_bret_shadow: lc_fresh_int_array(),
     an_bret_seed: lc_fresh_int_array(),
+    an_bret_trial: lc_fresh_string_array(),
+    an_view_trial: lc_fresh_string_array(),
     an_mrv_names: lc_fresh_string_array(),
     an_view_link: lc_fresh_string_array(),
     an_parts: [],
@@ -6009,12 +6026,12 @@ export fn prelude_module_full_oracle_line(a: Array[Stmt], c: Array[Stmt], c_file
     "0"
   })
   let an_cols = if an_dce_entry {
-    " borrow_ret=unmeasured borrow_fns=unmeasured borrow_masks=unmeasured view_ret=unmeasured link_round0=unmeasured link_round0_masks=unmeasured link_round0_occ=unmeasured link_round01=unmeasured link_round01_masks=unmeasured link_round01_occ=unmeasured link_bret=unmeasured link_bret_occ=unmeasured link_bret_self=unmeasured link_bret_asm=unmeasured link_bret_seed=unmeasured link_bret_cat=unmeasured link_view=unmeasured link_view_self=unmeasured link_view_asm=unmeasured"
+    " borrow_ret=unmeasured borrow_fns=unmeasured borrow_masks=unmeasured view_ret=unmeasured link_round0=unmeasured link_round0_masks=unmeasured link_round0_occ=unmeasured link_round01=unmeasured link_round01_masks=unmeasured link_round01_occ=unmeasured link_bret=unmeasured link_bret_occ=unmeasured link_bret_self=unmeasured link_bret_asm=unmeasured link_bret_seed=unmeasured link_bret_cat=unmeasured link_view=unmeasured link_view_self=unmeasured link_view_asm=unmeasured link_bret_trial=unmeasured link_view_trial=unmeasured"
   } else {
     String::concat(String::concat(String::concat(" borrow_ret=", lc_set_cmp_counted(an_bret_w, an_bret_u)), String::concat(" borrow_fns=", lc_set_cmp_counted(an_bfns_w, an_bfns_u))), String::concat(String::concat(" borrow_masks=", lc_set_cmp_counted(lc_name_mask_pairs(an_bfns_w, an_bmask_w), an_pairs_u)), String::concat(String::concat(" view_ret=", lc_set_cmp_counted(an_view_w, an_view_u)), String::concat(String::concat(" link_round0=", lc_set_cmp_counted(an_r0_w, an_r0_link)), String::concat(String::concat(" link_round0_masks=", lc_set_cmp_counted(lc_name_mask_pairs(an_r0_w, an_r0mask_w), lc_name_mask_pairs(an_r0_link, an_r0mask_link))), String::concat(String::concat(" link_round0_occ=", lc_multiset_first_diff(an_r0_w, an_r0_link)), String::concat(String::concat(" link_round01=", lc_set_cmp_counted(an_bfns_w, an_r01_link)), String::concat(String::concat(" link_round01_masks=", lc_set_cmp_counted(lc_name_mask_pairs(an_bfns_w, an_bmask_w), lc_name_mask_pairs(an_r01_link, an_r01mask_link))), String::concat(String::concat(" link_round01_occ=", lc_multiset_first_diff(an_bfns_w, an_r01_link)), String::concat(String::concat(" link_bret=", lc_set_cmp_counted(an_bret_w, st.an_bret_link)), String::concat(String::concat(" link_bret_occ=", lc_multiset_first_diff(an_bret_w, st.an_bret_link)), String::concat(String::concat(" link_bret_self=", lc_set_cmp_counted(an_bret_w, an_bret_self)), String::concat(String::concat(" link_bret_asm=", lc_set_cmp_counted(an_bret_w, an_bret_asm)), String::concat(String::concat(" link_bret_seed=", String::concat(Int::to_string(match Array::length(st.an_bret_seed) {
       0 => 0 - 1,
       _ => Array::get(st.an_bret_seed, 0)
-    }), String::concat("/", Int::to_string(borrow_ret_shadow_mask(a))))), String::concat(String::concat(" link_bret_cat=", lc_set_cmp_counted(an_bret_w, an_bret_catr)), String::concat(String::concat(" link_view=", lc_set_cmp_counted(an_view_w, st.an_view_link)), String::concat(String::concat(" link_view_self=", lc_set_cmp_counted(an_view_w, an_view_self)), String::concat(" link_view_asm=", lc_set_cmp_counted(an_view_w, an_view_asm)))))))))))))))))))
+    }), String::concat("/", Int::to_string(borrow_ret_shadow_mask(a))))), String::concat(String::concat(" link_bret_cat=", lc_set_cmp_counted(an_bret_w, an_bret_catr)), String::concat(String::concat(" link_view=", lc_set_cmp_counted(an_view_w, st.an_view_link)), String::concat(String::concat(" link_view_self=", lc_set_cmp_counted(an_view_w, an_view_self)), String::concat(String::concat(" link_view_asm=", lc_set_cmp_counted(an_view_w, an_view_asm)), String::concat(String::concat(" link_bret_trial=", lc_set_cmp_counted(an_bret_w, st.an_bret_trial)), String::concat(" link_view_trial=", lc_set_cmp_counted(an_view_w, st.an_view_trial)))))))))))))))))))))
   }
   let an_line = String::concat(String::concat(an_head, an_cols), "\n")
   let line = String::concat(String::concat(head, mid), tail)

--- a/lib/@vibe/compiler/tests/prelude_module_oracle_test.vibe
+++ b/lib/@vibe/compiler/tests/prelude_module_oracle_test.vibe
@@ -428,19 +428,40 @@ test "the whole prelude per module reproduces the whole-program prelude" {
   //   borrow_ret=381/365:-16:MutSortedSet::delete+0:
   //   link_bret=381/377:-4:resolve_checked_path_fs_...+0:
   //
-  // The residue is ATTRIBUTED rather than guessed, by three controls that cost
-  // one column each. Two of my own arguments about it were wrong and the
-  // columns are what said so:
+  // The residue is ATTRIBUTED rather than guessed, by controls that cost one
+  // column each. THREE of my arguments about it were wrong in turn, and the
+  // columns are what said so each time -- which is why they are pinned rather
+  // than deleted once they had served:
   //
-  //   link_bret_self=381                 the rule over the merged program: exact
-  //   link_bret_seed=0/0                 both lanes seed identically
-  //   link_bret_cat=381/377:-4:...       the parts CONCATENATED, one round
-  //   link_bret_asm=381                  the same statements FOLDED: exact
+  //   link_bret_self=381             the rule over the merged program: exact
+  //   link_bret_seed=0/0             both lanes seed identically
+  //   link_bret_cat=381/377:-4:...   the parts CONCATENATED, one round
+  //   link_bret_asm=381              concatenated + link passes + FOLDED: exact
+  //   link_bret_trial=381            concatenated + link passes, NOT folded: exact
   //
-  // `cat` equals `link_bret`, so splitting the rounds across 365 modules costs
-  // NOTHING -- the fixpoint decomposes. `asm` is exact on the same statements
-  // once the assembly folds them, so the 4 are lost to the 167 DUPLICATE
-  // declarations the modules emit (`FULL split=10286 linked=10119 folded=167`).
+  // Read them as a 2x2 over (link-only passes applied?) x (folded?):
+  //
+  //                     not folded          folded
+  //   no link passes    -4  (cat)           -4   (measured: parts filtered
+  //                                              to what the fold keeps)
+  //   link passes       EXACT (trial)       EXACT (asm)
+  //
+  // So the FOLD IS IRRELEVANT and the residue is the LINK-ONLY PASSES (12-16)
+  // plus the mint. `cat` equals `link_bret`, so splitting the rounds across
+  // 365 modules costs nothing either -- the fixpoint itself decomposes, and
+  // what it is missing is statements no module has yet been given.
+  //
+  // The folded column is the one that had to be built to be believed: this
+  // comment previously said the 167 duplicates (`FULL split=10286
+  // linked=10119 folded=167`) cost the 4, on the strength of `asm` alone.
+  // Filtering each part to exactly what the fold keeps changed NOTHING, and
+  // `trial` then showed why -- `asm` differs from `cat` in two ways at once,
+  // and it was the other one. That machinery is not in the tree: it earned its
+  // measurement, not its keep.
+  //
+  // This puts the residue in #2633's territory (passes that decide from a
+  // union over the whole program and run once at the link), not #2575's
+  // `copies`.
   //
   // #2638: `view_ret` is the LAST of the four, and the same rounds close it:
   //
@@ -448,10 +469,11 @@ test "the whole prelude per module reproduces the whole-program prelude" {
   //   link_view=2144/2137:-7:diag_fail_fast_...+0:
   //   link_view_self=2144   link_view_asm=2144
   //
-  // 186 missing down to 7, 0 extra, and BOTH controls exact -- so the 7 are
-  // the same duplicate-declaration residue as `link_bret`'s 4, measured rather
-  // than assumed to be the same cause. On the two-file repro `link_view=3` is
-  // a bare count where `view_ret=3/2:-1:via+0:`.
+  // 186 missing down to 7, 0 extra, and `link_view_self` / `link_view_asm` /
+  // `link_view_trial` all exact -- the SAME 2x2 as `borrow_ret` above, so the
+  // 7 have the same cause as its 4: the link-only passes, not the duplicates.
+  // Measured on this analysis rather than assumed to carry over. On the
+  // two-file repro `link_view=3` is a bare count where `view_ret=3/2:-1:via+0:`.
   //
   // This one keeps TWO drivers on purpose. #2386 replaced rounds with a
   // callee-edge worklist keyed on a reverse index over the whole program, and
@@ -463,11 +485,9 @@ test "the whole prelude per module reproduces the whole-program prelude" {
   // implementation serves both" here would be false, and the comment on that
   // function says so.
   //
-  // That is worth stating plainly because it is new: duplicates are inert for
-  // the borrow-PARAM analysis -- `link_round01_occ` reports one and the answer
-  // is still exact -- and they are NOT inert for a fixpoint. Whatever fixes
-  // `copies` (#2575) is what closes this column, not more work on the
-  // analysis.
+  // What `link_round01_occ` reports is a duplicate too, and it is harmless
+  // there for the same reason it turned out to be harmless here: membership is
+  // unaffected. Nothing in these four columns is a duplicate problem.
   //
   // So all 89 of `borrow_fns`' unsound extras are gone, and so are its 168
   // conservative misses. The 89 were callees whose disqualifying call site
@@ -484,7 +504,7 @@ test "the whole prelude per module reproduces the whole-program prelude" {
   // twice across the modules, because a program-level helper is synthesized
   // once per module that needs it. That is the `copies` shape this oracle
   // already counts, and the link folds it by key elsewhere.
-  inspect(String::trim(analysis_line_of(report)), content = "ANALYSIS dce_entry=0 borrow_ret=7 borrow_fns=0 borrow_masks=0 view_ret=2/1:-1:helper_use_exp__tmp_vibe_full_oracle_helper_vibe+0: link_round0=0 link_round0_masks=0 link_round0_occ= link_round01=0 link_round01_masks=0 link_round01_occ= link_bret=7 link_bret_occ= link_bret_self=7 link_bret_asm=7 link_bret_seed=0/0 link_bret_cat=7 link_view=2/1:-1:helper_use_exp__tmp_vibe_full_oracle_helper_vibe+0: link_view_self=2 link_view_asm=2")
+  inspect(String::trim(analysis_line_of(report)), content = "ANALYSIS dce_entry=0 borrow_ret=7 borrow_fns=0 borrow_masks=0 view_ret=2/1:-1:helper_use_exp__tmp_vibe_full_oracle_helper_vibe+0: link_round0=0 link_round0_masks=0 link_round0_occ= link_round01=0 link_round01_masks=0 link_round01_occ= link_bret=7 link_bret_occ= link_bret_self=7 link_bret_asm=7 link_bret_seed=0/0 link_bret_cat=7 link_view=2/1:-1:helper_use_exp__tmp_vibe_full_oracle_helper_vibe+0: link_view_self=2 link_view_asm=2 link_bret_trial=7 link_view_trial=2")
   // `missing=0 extra=0 content=0` is the property: every declaration the
   // whole-program prelude produced is produced by the module that owns it,
   // with the same body. `copies` is what remains after the link, and
@@ -657,7 +677,7 @@ test "the may_return and borrow analyses do not decompose per module, in both di
   // business: a tail call across the import, whose classification needs the
   // callee's round-0 mask. Round 0 is what this column covers, and the
   // remaining `-1:via` says exactly where the next slice is.
-  inspect(String::trim(analysis_line_of(report)), content = "ANALYSIS dce_entry=0 borrow_ret=10/9:-1:via+0: borrow_fns=2/2:-1:via+1:head_of_exp__tmp_vibe_analysis_oracle_helper_vibe borrow_masks=2/2:-1:via#1+1:head_of_exp__tmp_vibe_analysis_oracle_helper_vibe#1 view_ret=3/2:-1:via+0: link_round0=1 link_round0_masks=1 link_round0_occ= link_round01=2 link_round01_masks=2 link_round01_occ= link_bret=10 link_bret_occ= link_bret_self=10 link_bret_asm=10 link_bret_seed=0/0 link_bret_cat=10 link_view=3 link_view_self=3 link_view_asm=3")
+  inspect(String::trim(analysis_line_of(report)), content = "ANALYSIS dce_entry=0 borrow_ret=10/9:-1:via+0: borrow_fns=2/2:-1:via+1:head_of_exp__tmp_vibe_analysis_oracle_helper_vibe borrow_masks=2/2:-1:via#1+1:head_of_exp__tmp_vibe_analysis_oracle_helper_vibe#1 view_ret=3/2:-1:via+0: link_round0=1 link_round0_masks=1 link_round0_occ= link_round01=2 link_round01_masks=2 link_round01_occ= link_bret=10 link_bret_occ= link_bret_self=10 link_bret_asm=10 link_bret_seed=0/0 link_bret_cat=10 link_view=3 link_view_self=3 link_view_asm=3 link_bret_trial=10 link_view_trial=3")
   // The prelude itself still agrees on this program, so the difference above
   // is the analyses' and not a per-module prelude that already diverged.
   let lines = String::split(report, "\n")
@@ -684,14 +704,14 @@ test "the analyses refuse to answer where production would have run late DCE fir
   let main_path = "/tmp/vibe_dce_gate_main.vibe"
   Fs::write_file(helper_path, "export fn head_of(xs: Array[Int]) -> Int {\n  Array::get(xs, 0)\n}\n")
   Fs::write_file(main_path, "import ./vibe_dce_gate_helper.vibe {\n  head_of\n}\n\nfn main() -> Int {\n  head_of([1, 2, 3])\n}\n")
-  inspect(String::trim(analysis_line_of(prelude_module_full_oracle_report_fs(main_path, "main"))), content = "ANALYSIS dce_entry=1 borrow_ret=unmeasured borrow_fns=unmeasured borrow_masks=unmeasured view_ret=unmeasured link_round0=unmeasured link_round0_masks=unmeasured link_round0_occ=unmeasured link_round01=unmeasured link_round01_masks=unmeasured link_round01_occ=unmeasured link_bret=unmeasured link_bret_occ=unmeasured link_bret_self=unmeasured link_bret_asm=unmeasured link_bret_seed=unmeasured link_bret_cat=unmeasured link_view=unmeasured link_view_self=unmeasured link_view_asm=unmeasured")
+  inspect(String::trim(analysis_line_of(prelude_module_full_oracle_report_fs(main_path, "main"))), content = "ANALYSIS dce_entry=1 borrow_ret=unmeasured borrow_fns=unmeasured borrow_masks=unmeasured view_ret=unmeasured link_round0=unmeasured link_round0_masks=unmeasured link_round0_occ=unmeasured link_round01=unmeasured link_round01_masks=unmeasured link_round01_occ=unmeasured link_bret=unmeasured link_bret_occ=unmeasured link_bret_self=unmeasured link_bret_asm=unmeasured link_bret_seed=unmeasured link_bret_cat=unmeasured link_view=unmeasured link_view_self=unmeasured link_view_asm=unmeasured link_bret_trial=unmeasured link_view_trial=unmeasured")
   // The control. `__no_entry__` is a name no program defines, so production
   // would not have run either transform and the sample point is its own. The
   // counts are live here rather than merely present -- this program shows the
   // unsound direction too (`+1:head_of_exp__...`, qualified by its own module
   // and disqualified by the whole program through the call site in `main`), so
   // a guard that suppressed the columns unconditionally could not pass this.
-  inspect(String::trim(analysis_line_of(prelude_module_full_oracle_report_fs(main_path, "__no_entry__"))), content = "ANALYSIS dce_entry=0 borrow_ret=9/8:-1:main+0: borrow_fns=0/1:-0:+1:head_of_exp__tmp_vibe_dce_gate_helper_vibe borrow_masks=0/1:-0:+1:head_of_exp__tmp_vibe_dce_gate_helper_vibe#1 view_ret=2/1:-1:main+0: link_round0=0 link_round0_masks=0 link_round0_occ= link_round01=0 link_round01_masks=0 link_round01_occ= link_bret=9 link_bret_occ= link_bret_self=9 link_bret_asm=9 link_bret_seed=0/0 link_bret_cat=9 link_view=2 link_view_self=2 link_view_asm=2")
+  inspect(String::trim(analysis_line_of(prelude_module_full_oracle_report_fs(main_path, "__no_entry__"))), content = "ANALYSIS dce_entry=0 borrow_ret=9/8:-1:main+0: borrow_fns=0/1:-0:+1:head_of_exp__tmp_vibe_dce_gate_helper_vibe borrow_masks=0/1:-0:+1:head_of_exp__tmp_vibe_dce_gate_helper_vibe#1 view_ret=2/1:-1:main+0: link_round0=0 link_round0_masks=0 link_round0_occ= link_round01=0 link_round01_masks=0 link_round01_occ= link_bret=9 link_bret_occ= link_bret_self=9 link_bret_asm=9 link_bret_seed=0/0 link_bret_cat=9 link_view=2 link_view_self=2 link_view_asm=2 link_bret_trial=9 link_view_trial=2")
 }
 
 // #2642 review (Codex P2): `dtd_eq_deferred_requests`, `dtd_eq_deferred_types`


### PR DESCRIPTION
A correction to #2685 / #2687, with the control that forces it. Oracle only — no production code is touched and the four analyses are unchanged.

## What was wrong

#2685 concluded that `link_bret`'s 4 missing names (and #2687's `link_view` 7) were lost to the **167 duplicate declarations** the modules emit. That rested on `link_bret_asm` being exact — the same statements *folded*. It was the wrong reading: `asm` differs from `cat` in **two** ways at once, the fold **and** the link-only passes, and it was the other one.

## I built the fix that conclusion implied, and it changed nothing

Filter each part to exactly the statements the fold keeps (a multiset claim against `linked`, so it cannot drift from the fold's own choice), then run the per-module rounds over that. Result: still `-4` and `-7`. Unchanged.

That machinery is **not** in this commit. It earned its measurement, not its keep.

## The control that settles it

`link_bret_trial` / `link_view_trial` run over `trial` — the parts concatenated **with** passes 12–16 and the mint applied, but **before** the fold. Both are exact (`381`, `2145`).

| | not folded | folded |
|---|---|---|
| **no link passes** | `-4` (`cat`) | `-4` (measured, not shipped) |
| **link passes** | **exact** (`trial`) | **exact** (`asm`) |

So the **fold is irrelevant**, and the residue is the **link-only passes plus the mint** — statements no module has been given yet. That puts it in #2633's territory (passes that decide from a union over the whole program and run once at the link), not #2575's `copies`.

The fixpoints themselves still decompose: `cat` equals the per-module answer, so splitting the rounds across 365 modules costs nothing.

## Why this is worth a PR rather than a quiet edit

The wrong cause is currently asserted in a merged commit message, a merged PR body, a test comment and two issue comments. This fixes the test comment — the copy a future reader will actually hit — and records the 2×2 so the next person does not re-derive it. The issue comments are corrected separately.

This is the fourth time on #2638 that a prediction about this residue was wrong and a column said so (seed → no; round-splitting → no; duplicates → no). That is the argument for keeping all of them pinned rather than deleting a control once it has served.

## Verification

| check | result |
|---|---|
| `scripts/compiler_gate.sh` | `[compiler-gate] ok` — 63 suites, **0 failed** |
| `prelude_module_oracle_test.vibe` | 9 tests pass |
| `vibe check` / `vibe_fmt --check` | clean on both files |

No output-equivalence run: the diff touches only the oracle path (`prelude_module_full_oracle_line` and its stats struct), which production never reaches — `use_split` is false at every production caller.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NAeZzkckdAwtQiubBFpdmM

---
_Generated by [Claude Code](https://claude.ai/code/session_01NAeZzkckdAwtQiubBFpdmM)_