### PR TITLE
Prebuilt runner release assets, `vibe self update <version>`, and `install/install.sh --version` (#2678)

### DIFF
--- a/.github/workflows/cli-install.yml
+++ b/.github/workflows/cli-install.yml
@@ -24,6 +24,7 @@ on:
       - "runtime/vibe"
       - "install/**"
       - "tests/integration/install/**"
+      - "scripts/build_release_assets.sh"
       - "scripts/build_cli_wasm.sh"
       - "scripts/ensure_seed.sh"
       - "scripts/ensure_generated.sh"
@@ -79,6 +80,7 @@ on:
       - "runtime/vibe"
       - "install/**"
       - "tests/integration/install/**"
+      - "scripts/build_release_assets.sh"
       - "scripts/build_cli_wasm.sh"
       - "scripts/ensure_seed.sh"
       - "scripts/ensure_generated.sh"
@@ -248,6 +250,7 @@ jobs:
               # install slice + LSP/host-abi/bench (need a fresh compiler) + name
               # section + located diagnostics.
               bash tests/integration/install/curl_bootstrap_test.sh
+              bash tests/integration/install/release_install_test.sh
               bash tests/integration/install/install_test.sh
               bash scripts/test_vibe_root.sh
               export VIBE_HOME="$RUNNER_TEMP/vibe-home"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,51 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  # One prebuilt `viberun` per target, built natively (docs/toolchain-layout.md
+  # section 3, #2678). x86_64 macOS rides along while GitHub still hosts an
+  # Intel runner; its job may fail without failing the release.
+  runners:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+          - os: ubuntu-24.04-arm
+            target: aarch64-unknown-linux-gnu
+          - os: macos-latest
+            target: aarch64-apple-darwin
+          - os: macos-15-intel
+            target: x86_64-apple-darwin
+    runs-on: ${{ matrix.os }}
+    continue-on-error: ${{ matrix.target == 'x86_64-apple-darwin' }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Build runner
+        run: |
+          set -euo pipefail
+          host="$(rustc -vV | sed -n 's/^host: //p')"
+          [ "$host" = "${{ matrix.target }}" ] || { echo "runner host $host is not ${{ matrix.target }}" >&2; exit 1; }
+          cargo build --release --manifest-path runtime/viberun/Cargo.toml
+
+      - name: Package runner
+        run: |
+          set -euo pipefail
+          mkdir -p dist/release/runners
+          tar -czf "dist/release/runners/viberun-${GITHUB_REF_NAME}-${{ matrix.target }}.tar.gz" \
+            -C runtime/viberun/target/release viberun
+
+      - name: Upload runner
+        uses: actions/upload-artifact@v6
+        with:
+          name: viberun-${{ matrix.target }}
+          path: dist/release/runners/viberun-*.tar.gz
+          if-no-files-found: error
+
   github-release:
+    needs: runners
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -25,6 +69,13 @@ jobs:
       # needed, just the node wasm runner.
       - name: Ensure seed artifact
         run: bash scripts/ensure_seed.sh
+
+      - name: Download runner tarballs
+        uses: actions/download-artifact@v6
+        with:
+          pattern: viberun-*
+          path: dist/release/runners
+          merge-multiple: true
 
       - name: Build release assets
         run: bash scripts/build_release_assets.sh "${GITHUB_REF_NAME}"
@@ -43,3 +94,28 @@ jobs:
             dist/release/${{ github.ref_name }}/*
           fail_on_unmatched_files: true
           generate_release_notes: true
+
+  # The published release installs the way a user installs it
+  # (docs/toolchain-layout.md section 9, #2678): the curl entry point in
+  # release mode, on a fresh machine, with nothing but bash, curl and tar --
+  # then the installed toolchain compiles and runs a program.
+  release-install:
+    needs: github-release
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Install the published release
+        run: |
+          set -euo pipefail
+          export VIBE_HOME="$RUNNER_TEMP/vibe-home"
+          cat install/install.sh | bash -s -- --version "${GITHUB_REF_NAME#v}" --no-modify-path
+          "$VIBE_HOME/bin/vibe" version
+          printf 'fn main allows Console {\n  println("42")\n}\n' > "$RUNNER_TEMP/hello.vibex"
+          out="$(cd "$RUNNER_TEMP" && "$VIBE_HOME/bin/vibe" run hello.vibex)"
+          [ "$out" = "42" ] || { echo "installed release printed '$out'" >&2; exit 1; }

--- a/Taskfile.pkl
+++ b/Taskfile.pkl
@@ -1024,7 +1024,8 @@ local testVibeRootSmoke = new Task {
 local testVibeTest = scriptTask("test-vibe-test", "scripts/vibe_test_smoke.sh")
 local testReleaseInstall = new Task {
   name = "test-release-install"
-  description = "release install and update against a synthetic file:// release: install.sh --version with bash+curl+tar, vibe self update, tampered assets refused (#2678)"
+  description =
+    "release install and update against a synthetic file:// release: install.sh --version with bash+curl+tar, vibe self update, tampered assets refused (#2678)"
   cmd = "bash tests/integration/install/release_install_test.sh"
   inputs {
     "tests/integration/install/release_install_test.sh"

--- a/Taskfile.pkl
+++ b/Taskfile.pkl
@@ -1022,6 +1022,18 @@ local testVibeRootSmoke = new Task {
   }
 }
 local testVibeTest = scriptTask("test-vibe-test", "scripts/vibe_test_smoke.sh")
+local testReleaseInstall = new Task {
+  name = "test-release-install"
+  description = "release install and update against a synthetic file:// release: install.sh --version with bash+curl+tar, vibe self update, tampered assets refused (#2678)"
+  cmd = "bash tests/integration/install/release_install_test.sh"
+  inputs {
+    "tests/integration/install/release_install_test.sh"
+    "install/install.sh"
+    "runtime/vibe"
+    "scripts/vibe_pkg.sh"
+    "scripts/parallel_warm_pool.sh"
+  }
+}
 local testEnsureSeed = scriptTask("test-ensure-seed", "scripts/ensure_seed_test.sh")
 local testVibeFmt = scriptTask("test-vibe-fmt", "scripts/vibe_fmt_smoke.sh")
 // #2271: `vibe fmt` reported a file as unformatted when the FORMATTER ENTRY
@@ -2045,6 +2057,7 @@ tasks {
   testVibeRun
   testInstallHelloSmoke
   testVibeRootSmoke
+  testReleaseInstall
   testUncaughtExceptionExit
   testVibeTest
   testEnsureSeed

--- a/docs/cli-commands.md
+++ b/docs/cli-commands.md
@@ -314,7 +314,8 @@ There is no `vibe init`; scaffolding is `vibe new`.
 | `context-pack [--out FILE]` | Cheatsheet + verified golden examples as one file (#820) |
 | `lsp` | Start the stdio LSP server |
 | `toolchain list\|default <name>\|remove <name>` | Installed toolchains with the default marked; select the default; delete one, never the default (#2677) |
-| `self update [--cli-wasm <path>]` | Refresh the compiler wasm and rebuild the `.cwasm` |
+| `self update [<version>\|latest] [--no-default] [--force]` | Install a release toolchain: download into `$VIBE_HOME/cache/downloads/<tag>/`, verify every asset against `release-manifest.json`, precompile, rename into `toolchains/<version>/` and make it the default (#2678) |
+| `self update --cli-wasm <path>` | Refresh the current toolchain's compiler wasm and rebuild its `.cwasm` |
 | `self uninstall [--purge]` | Remove `toolchains/`, `bin/`, `env` and `toolchain` under `$VIBE_HOME` (and the installer's rc line); `--purge` also `cache/`, `lib/`, `log/` |
 | `version` | Print the toolchain's version from its `manifest.json`, then the runner and compiler paths |
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -6,19 +6,34 @@ is AOT-compiled to a host-specific `vibe-cli.cwasm` so the compiler is not
 re-JITed on every command. See `docs/release-roadmap.md` (テーマ1) for the
 rationale behind this split.
 
-## Quick install (curl)
+## Quick install (release)
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/mizchi/vibe-lang/main/install/install.sh | bash -s -- --version X.Y.Z
+```
+
+Installs the published release `vX.Y.Z` (or `latest`) into
+`$VIBE_HOME/toolchains/X.Y.Z/` with nothing but bash, curl (or wget), tar and
+sha256sum (or shasum): the release's runner for this machine, its compiler
+wasm and its toolchain bundle are downloaded into
+`$VIBE_HOME/cache/downloads/vX.Y.Z/`, verified against the release's
+`release-manifest.json`, unpacked into a staging directory and precompiled,
+and only then renamed into place (#2678). `VIBE_INSTALL_VERSION` selects the
+version from the environment; `VIBE_RELEASE_URL` overrides the download base.
+
+## Quick install (from source)
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/mizchi/vibe-lang/main/install/install.sh | bash
 ```
 
-Outside a checkout, the installer initializes a temporary repository and
+Without `--version`, the installer initializes a temporary repository and
 shallow-fetches the exact branch, tag, or reachable commit selected by
-`VIBE_INSTALL_REF` from `VIBE_INSTALL_REPO`, then safely reinvokes the matching
-`install/install.sh` from the detached checkout. Requirements: `git`, `bash`,
-`cargo` (unless `--runner` supplies a prebuilt runner), and Node.js for the
-default compiler seed acquisition/build path. Node.js is optional only when
-`--cli-wasm PATH` supplies an existing compiler wasm.
+`--ref` / `VIBE_INSTALL_REF` from `VIBE_INSTALL_REPO`, then safely reinvokes
+the matching `install/install.sh` from the detached checkout. Requirements:
+`git`, `bash`, `cargo` (unless `--runner` supplies a prebuilt runner), and
+Node.js for the default compiler seed acquisition/build path. Node.js is
+optional only when `--cli-wasm PATH` supplies an existing compiler wasm.
 
 ## Quick install (from a checkout)
 
@@ -149,6 +164,8 @@ vibe context-pack [--out FILE]        emit cheatsheet + verified golden examples
 vibe version                          print toolchain versions (from manifest.json)
 vibe toolchain list|default <name>|remove <name>
                                       installed toolchains / pick the default / delete one
+vibe self update [<version>|latest] [--no-default] [--force]
+                                      install a release toolchain and make it the default
 vibe self update --cli-wasm <path>    refresh compiler wasm + rebuild .cwasm
 vibe self uninstall [--purge]         remove the install (--purge: caches, shared packages, log too)
 vibe help                             usage
@@ -251,17 +268,33 @@ references are AST-accurate (scope-aware binding occurrences). Remaining
 precision work (call-site / expression-node spans) is tracked as span-arc in
 [docs/release-roadmap.md](release-roadmap.md) テーマ4.
 
-## Updating the compiler independently of the runner
+## Updating
 
-The runner and the compiler wasm version independently. To move the compiler
-forward (e.g. to a newer compiler build) without rebuilding the runner:
+```bash
+vibe self update latest            # install the newest release and make it the default
+vibe self update 0.2.0             # a specific release
+vibe self update 0.2.0 --no-default
+vibe self update 0.2.0 --force     # reinstall over an existing toolchains/0.2.0/
+```
+
+A release is resolved through its `release-manifest.json` (`latest` through
+the newest release's), every asset is downloaded into
+`$VIBE_HOME/cache/downloads/<tag>/` and verified against that manifest, the
+toolchain is assembled and precompiled in a staging directory, and only then
+renamed into `toolchains/<version>/`. A mismatch stops before anything is
+moved. The previous toolchain stays installed: `vibe toolchain default
+<name>` switches back, `vibe toolchain remove <name>` deletes it.
+
+The runner and the compiler wasm also version independently. To move only the
+compiler of the current toolchain forward without a release:
 
 ```bash
 vibe self update --cli-wasm path/to/new/vibe-cli.wasm
 ```
 
 This copies the new compiler wasm into place and rebuilds the host-specific
-`vibe-cli.cwasm` against the installed runner.
+`vibe-cli.cwasm` against the installed runner; it is the one edit ever made
+inside an installed toolchain directory.
 
 ## Uninstalling
 

--- a/docs/release-notes-0.1.0.md
+++ b/docs/release-notes-0.1.0.md
@@ -86,7 +86,11 @@ read, and every feature below is one the compiler itself depends on.
   rest of the 26 `@vibe/*` and 18 `@vibex/*` packages in the tree are the
   compiler's own dependencies, not part of the install.
 - `install/install.sh` is the curl entry point and is smoke-tested on multiple
-  operating systems by the `cli-install` workflow.
+  operating systems by the `cli-install` workflow. A release installs with
+  bash, curl and tar only (`--version X.Y.Z`, and `vibe self update` from an
+  installed toolchain: prebuilt runners ship per target, every asset is
+  verified against the release manifest before it is moved into place,
+  #2678); only an install from a checkout needs git, cargo and Node.js.
 
 ## Tooling
 

--- a/docs/toolchain-layout.md
+++ b/docs/toolchain-layout.md
@@ -20,7 +20,8 @@ Phases, in dependency order:
    stdlib, toolchain manifest, `vibe toolchain`, environment variables —
    **implemented**
 4. [#2678](https://github.com/mizchi/vibe-lang/issues/2678) — prebuilt runner
-   release assets, `vibe self update <version>`, release install path
+   release assets, `vibe self update <version>`, release install path —
+   **implemented**
 
 ## 1. What this replaces (measured 2026-09-11)
 
@@ -328,7 +329,7 @@ Two modes, one entry point:
 
 | mode | selector | requirements | what it does |
 | --- | --- | --- | --- |
-| release | `--version X.Y.Z` (or `VIBE_INSTALL_VERSION`); the default of the curl entry point once #2678 lands | bash, curl or wget, tar | download the assets of section 3, verify against the manifest, unpack into `toolchains/<version>/`, precompile, write `manifest.json` |
+| release | `--version X.Y.Z` or `--version latest` (or `VIBE_INSTALL_VERSION`); the bare curl entry point stays in checkout mode until a release is published | bash, curl or wget, tar, sha256sum or shasum | download the assets of section 3, verify against the manifest, unpack into `toolchains/<version>/`, precompile, write `manifest.json` |
 | checkout | `--ref <ref>` (or `VIBE_INSTALL_REF`), or running inside a checkout | git, cargo, Node.js (Node.js not needed with `--cli-wasm`) | build the runner and the compiler from the checkout, as today |
 
 Both modes: install into a staging directory and rename, so a failed install

--- a/install/install.sh
+++ b/install/install.sh
@@ -3,9 +3,18 @@
 #
 #   curl -fsSL https://raw.githubusercontent.com/mizchi/vibe-lang/main/install/install.sh | bash
 #
-# With no checkout, this script fetches VIBE_INSTALL_REPO at VIBE_INSTALL_REF
-# into a temporary directory and safely reinvokes the matching installer from
-# that checkout. When run from a checkout, it installs that checkout directly.
+# Two modes (docs/toolchain-layout.md section 9, #2678):
+#
+#   release   `--version X.Y.Z` (or `latest`, or VIBE_INSTALL_VERSION):
+#             download the release's assets, verify them against its
+#             release-manifest.json, unpack into toolchains/<version>/ and
+#             precompile. Needs bash, curl or wget, tar, and sha256sum or
+#             shasum -- no git, cargo or Node.js.
+#   checkout  `--ref REF` (or VIBE_INSTALL_REF), or running inside a
+#             checkout: with no checkout, fetch VIBE_INSTALL_REPO at the ref
+#             into a temporary directory and safely reinvoke the matching
+#             installer from it; from a checkout, install that checkout
+#             directly. Builds the runner and the compiler.
 #
 # The installed rustup-style layout under VIBE_HOME (default ~/.vibe) is:
 #
@@ -22,16 +31,20 @@
 # #2677): installing a second one never touches the first.
 #
 # Usage:
+#   bash install/install.sh --version X.Y.Z [--prefix DIR] [--bin-dir DIR]
+#       [--no-link] [--no-modify-path] [--set-default]
 #   bash install/install.sh [--repo URL] [--ref REF] [--prefix DIR]
 #       [--runner PATH] [--cli-wasm PATH] [--bin-dir DIR] [--no-link]
 #       [--no-modify-path] [--toolchain NAME] [--set-default] [--no-stdlib]
 #
 # Curl arguments follow `bash -s --`, for example:
-#   curl -fsSL URL | bash -s -- --ref v0.1.0 --no-modify-path
+#   curl -fsSL URL | bash -s -- --version 0.1.0 --no-modify-path
 #
-# Env overrides: VIBE_INSTALL_REPO, VIBE_INSTALL_REF, VIBE_HOME, VIBE_BIN_DIR.
-# Requirements: git and bash; Node.js unless --cli-wasm supplies the compiler;
-# cargo unless --runner points to a prebuilt runner.
+# Env overrides: VIBE_INSTALL_VERSION, VIBE_INSTALL_REPO, VIBE_INSTALL_REF,
+# VIBE_RELEASE_URL, VIBE_HOME, VIBE_BIN_DIR.
+# Requirements (release mode): bash, curl or wget, tar, sha256sum or shasum.
+# Requirements (checkout mode): git and bash; Node.js unless --cli-wasm
+# supplies the compiler; cargo unless --runner points to a prebuilt runner.
 set -euo pipefail
 
 usage() {
@@ -39,10 +52,16 @@ usage() {
 vibe installer
 
 Usage:
+  bash install/install.sh --version X.Y.Z [install options]
   bash install/install.sh [--repo URL] [--ref REF] [install options]
+  curl -fsSL URL | bash -s -- --version X.Y.Z [install options]
   curl -fsSL URL | bash -s -- [--repo URL] [--ref REF] [install options]
 
-Bootstrap options:
+Release mode (bash, curl or wget, tar, sha256sum or shasum):
+  --version X.Y.Z|latest install a published release (or VIBE_INSTALL_VERSION);
+                         VIBE_RELEASE_URL overrides the download base
+
+Bootstrap options (checkout mode: git, cargo, Node.js):
   --repo URL             source repository (or VIBE_INSTALL_REPO)
   --ref REF              source ref and default toolchain name (or VIBE_INSTALL_REF)
 
@@ -58,13 +77,254 @@ Install options:
   --no-stdlib            do not install standard library packages
 
 Requirements:
-  Git and Bash; Node.js unless --cli-wasm supplies the compiler; Cargo unless
-  --runner supplies a prebuilt viberun executable.
+  Release mode: Bash, curl or wget, tar, sha256sum or shasum.
+  Checkout mode: Git and Bash; Node.js unless --cli-wasm supplies the
+  compiler; Cargo unless --runner supplies a prebuilt viberun executable.
 USAGE
 }
 
 bootstrap_die() { echo "[vibe-installer] error: $*" >&2; exit 1; }
 bootstrap_say() { echo "[vibe-installer] $*"; }
+say() { echo "[install] $*"; }
+die() { echo "[install] error: $*" >&2; exit 1; }
+
+# --- shared by both modes ----------------------------------------------------
+# A pre-#755 flat install (bin/viberun next to lib/vibe-cli.wasm) cannot host
+# toolchains: its launcher and stdlib would shadow theirs. Refuse rather than
+# mix the two layouts (docs/toolchain-layout.md section 2, #2677).
+refuse_flat_home() {
+  if [ -f "$VIBE_HOME/lib/vibe-cli.wasm" ] || [ -x "$VIBE_HOME/bin/viberun" ]; then
+    die "$VIBE_HOME holds a flat pre-#755 install (lib/vibe-cli.wasm, bin/viberun), which is no longer supported; remove it, or choose another --prefix, and run install/install.sh again"
+  fi
+}
+
+# The dispatcher: a few lines of shell rewritten by the newest installer
+# (rustup-style, #755) that select a toolchain and exec its launcher.
+# Selection order: $VIBE_TOOLCHAIN env > $VIBE_HOME/toolchain file > the
+# single installed toolchain. `vibe toolchain default` rewrites the file. Its
+# whole contract is to keep executing any older toolchain's launcher with
+# VIBE_HOME exported (docs/toolchain-layout.md section 3).
+write_dispatcher() {
+  mkdir -p "$VIBE_HOME/bin"
+  cat > "$VIBE_HOME/bin/vibe" <<'DISPATCH'
+#!/usr/bin/env bash
+# vibe dispatcher (rustup-style, #755): selects a toolchain and execs its
+# launcher. Selection order: $VIBE_TOOLCHAIN env > $VIBE_HOME/toolchain file
+# > the single installed toolchain. Managed by the installer;
+# `vibe toolchain default` rewrites the default file.
+set -euo pipefail
+_src="${BASH_SOURCE[0]}"
+while [ -L "$_src" ]; do
+  _dir="$(cd -P "$(dirname "$_src")" && pwd)"
+  _src="$(readlink "$_src")"
+  case "$_src" in /*) ;; *) _src="$_dir/$_src" ;; esac
+done
+_self_dir="$(cd -P "$(dirname "$_src")" && pwd)"
+VIBE_HOME="${VIBE_HOME:-$(dirname "$_self_dir")}"
+tc="${VIBE_TOOLCHAIN:-}"
+if [ -z "$tc" ] && [ -f "$VIBE_HOME/toolchain" ]; then
+  tc="$(head -n 1 "$VIBE_HOME/toolchain" | tr -d '[:space:]')"
+fi
+if [ -z "$tc" ]; then
+  count=0
+  only=""
+  for d in "$VIBE_HOME/toolchains"/*/; do
+    [ -d "$d" ] || continue
+    count=$((count + 1))
+    only="$(basename "$d")"
+  done
+  if [ "$count" = "1" ]; then
+    tc="$only"
+  else
+    echo "vibe: no default toolchain (set \$VIBE_TOOLCHAIN or write $VIBE_HOME/toolchain)" >&2
+    exit 1
+  fi
+fi
+case "$tc" in
+  ""|.|..|*[!A-Za-z0-9._-]*)
+    echo "vibe: invalid toolchain name '$tc'" >&2
+    exit 1
+    ;;
+esac
+launcher="$VIBE_HOME/toolchains/$tc/bin/vibe"
+[ -x "$launcher" ] || { echo "vibe: toolchain '$tc' is not installed ($launcher)" >&2; exit 1; }
+export VIBE_HOME
+exec "$launcher" "$@"
+DISPATCH
+  chmod 0755 "$VIBE_HOME/bin/vibe"
+  say "dispatcher -> $VIBE_HOME/bin/vibe"
+}
+
+# write_default_toolchain <name> <set-default 0|1>: the default file, written
+# when asked for or when there is none yet.
+write_default_toolchain() {
+  if [ "$2" = "1" ] || [ ! -f "$VIBE_HOME/toolchain" ]; then
+    printf '%s\n' "$1" > "$VIBE_HOME/toolchain"
+    say "default toolchain -> $1"
+  fi
+}
+
+# PATH setup: $VIBE_HOME/bin (the dispatcher) is THE PATH entry. Write the
+# sourceable env file (rustup's ~/.cargo/env pattern) and -- for a
+# default-prefix install only -- wire it into the shell rc files. A custom
+# --prefix (tests, throwaway installs) never touches the user's rc files.
+# Emit one POSIX-shell single-quoted word. Prefixes may contain whitespace,
+# quotes, command substitutions, or newlines; sourcing the generated file must
+# always treat those bytes as path data rather than shell syntax.
+shell_quote() {
+  printf "'"
+  printf '%s' "$1" | sed "s/'/'\\\\''/g"
+  printf "'"
+}
+# write_env_and_path <modify-path 0|1> <link 0|1> <bin-dir>
+write_env_and_path() {
+  local do_modify_path="$1" do_link="$2" bin_dir="$3" env_line modified rc
+  {
+    cat <<'ENV_HEAD'
+#!/bin/sh
+# vibe shell setup: prepends the vibe dispatcher dir to PATH.
+# Wired into your shell rc by the installer.
+_vibe_bin=
+ENV_HEAD
+    printf '_vibe_bin='
+    shell_quote "$VIBE_HOME/bin"
+    printf '\n'
+    cat <<'ENV_TAIL'
+case ":${PATH}:" in
+  *:"${_vibe_bin}":*) ;;
+  *) PATH="${_vibe_bin}:${PATH}"; export PATH ;;
+esac
+unset _vibe_bin
+ENV_TAIL
+  } > "$VIBE_HOME/env"
+  chmod 0644 "$VIBE_HOME/env"
+  say "env file -> $VIBE_HOME/env"
+
+  if [ "$do_modify_path" = "1" ] && [ "$VIBE_HOME" = "$HOME/.vibe" ]; then
+    env_line=". \"\$HOME/.vibe/env\""
+    modified=""
+    for rc in "$HOME/.profile" "$HOME/.bashrc" "$HOME/.zshrc"; do
+      [ -f "$rc" ] || continue
+      if ! grep -qsF '.vibe/env' "$rc"; then
+        printf '\n%s\n' "$env_line" >> "$rc"
+        modified="$modified $(basename "$rc")"
+      fi
+    done
+    if [ -n "$modified" ]; then
+      say "PATH: added '. \$HOME/.vibe/env' to:$modified"
+      say "restart your shell or run: . \"\$HOME/.vibe/env\""
+    else
+      say "PATH: shell rc files already source ~/.vibe/env (or none found)"
+    fi
+  else
+    case ":$PATH:" in
+      *":$VIBE_HOME/bin:"*) ;;
+      *) say "PATH: add $VIBE_HOME/bin to PATH (e.g. . \"$VIBE_HOME/env\")" ;;
+    esac
+  fi
+
+  # Optional extra symlink dir (test harness / packaging), opt-in only.
+  if [ "$do_link" = "1" ] && [ -n "$bin_dir" ]; then
+    mkdir -p "$bin_dir"
+    ln -sf "$VIBE_HOME/bin/vibe" "$bin_dir/vibe"
+    say "linked $bin_dir/vibe -> $VIBE_HOME/bin/vibe"
+  fi
+}
+
+# --- release mode --------------------------------------------------------------
+# The launcher owns the download/verify/stage/precompile logic
+# (`vibe self update`, runtime/vibe). Release mode fetches the release's
+# manifest and toolchain bundle into the download cache, verifies the bundle,
+# extracts the launcher from it and hands over; then writes the dispatcher,
+# the default marker and the env file exactly as a checkout install does.
+release_sha256() {
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "$1" | sed 's/ .*//'
+  elif command -v shasum >/dev/null 2>&1; then
+    shasum -a 256 "$1" | sed 's/ .*//'
+  else
+    bootstrap_die "sha256sum or shasum is required to verify the release assets"
+  fi
+}
+release_fetch() {
+  if command -v curl >/dev/null 2>&1; then
+    curl -fsSL "$1" -o "$2"
+  elif command -v wget >/dev/null 2>&1; then
+    wget -q -O "$2" "$1"
+  else
+    bootstrap_die "curl or wget is required to download $1"
+  fi
+}
+release_field() { sed -n "s/^  \"$2\": \"\([^\"]*\)\",\{0,1\}\$/\1/p" "$1" | sed -n '1p'; }
+release_asset_sha() { sed -n "s/^    \"$2\": \"\([0-9a-f]*\)\",\{0,1\}\$/\1/p" "$1" | sed -n '1p'; }
+release_work=""
+release_install() {
+  local want="$1"; shift
+  local bin_dir="${VIBE_BIN_DIR:-}" do_link=1 do_modify_path=1 set_default=0
+  local base="${VIBE_RELEASE_URL:-https://github.com/mizchi/vibe-lang/releases/download}"
+  local version tag dl manifest tc_name want_sha
+  VIBE_HOME="${VIBE_HOME:-$HOME/.vibe}"
+  while [ "$#" -gt 0 ]; do
+    case "$1" in
+      --prefix) VIBE_HOME="$2"; shift 2 ;;
+      --bin-dir) bin_dir="$2"; shift 2 ;;
+      --no-link) do_link=0; shift ;;
+      --no-modify-path) do_modify_path=0; shift ;;
+      --set-default) set_default=1; shift ;;
+      --toolchain|--runner|--cli-wasm|--no-stdlib)
+        bootstrap_die "$1 applies to a checkout install; a release install is named by its version and ships its runner, compiler and stdlib" ;;
+      -h|--help) usage; exit 0 ;;
+      *) bootstrap_die "unknown argument: $1" ;;
+    esac
+  done
+  command -v tar >/dev/null 2>&1 || bootstrap_die "tar is required"
+  refuse_flat_home
+  if [ "$want" = "latest" ]; then
+    dl="$VIBE_HOME/cache/downloads/latest"
+    mkdir -p "$dl"
+    release_fetch "${base%/download}/latest/download/release-manifest.json" "$dl/release-manifest.json" \
+      || bootstrap_die "cannot fetch the latest release manifest from ${base%/download}/latest/download/"
+    version="$(release_field "$dl/release-manifest.json" version)"
+    [ -n "$version" ] || bootstrap_die "the latest release manifest names no version"
+    bootstrap_say "latest release is $version"
+  else
+    version="${want#v}"
+  fi
+  case "$version" in
+    ""|.|..|*[!A-Za-z0-9._-]*) bootstrap_die "invalid version '$version'" ;;
+  esac
+  tag="v$version"
+  dl="$VIBE_HOME/cache/downloads/$tag"
+  mkdir -p "$dl"
+  manifest="$dl/release-manifest.json"
+  release_fetch "$base/$tag/release-manifest.json" "$manifest" \
+    || bootstrap_die "cannot fetch $base/$tag/release-manifest.json (is $version a published release?)"
+  tc_name="$(release_field "$manifest" toolchain)"
+  [ -n "$tc_name" ] || bootstrap_die "the release manifest lists no toolchain bundle"
+  want_sha="$(release_asset_sha "$manifest" "$tc_name")"
+  [ -n "$want_sha" ] || bootstrap_die "the release manifest has no sha256 for $tc_name"
+  if ! { [ -f "$dl/$tc_name" ] && [ "$(release_sha256 "$dl/$tc_name")" = "$want_sha" ]; }; then
+    bootstrap_say "downloading $tc_name"
+    release_fetch "$base/$tag/$tc_name" "$dl/$tc_name.part" || { rm -f "$dl/$tc_name.part"; bootstrap_die "download failed: $base/$tag/$tc_name"; }
+    mv "$dl/$tc_name.part" "$dl/$tc_name"
+  fi
+  if [ "$(release_sha256 "$dl/$tc_name")" != "$want_sha" ]; then
+    rm -f "$dl/$tc_name"
+    bootstrap_die "$tc_name does not match the release manifest; nothing was installed"
+  fi
+  # A global, not a local: the EXIT trap runs after this function returned.
+  release_work="$(mktemp -d "${TMPDIR:-/tmp}/vibe-install-XXXXXX")"
+  trap 'rm -rf -- "${release_work:-}"' EXIT
+  tar -xzf "$dl/$tc_name" -C "$release_work" bin/vibe || bootstrap_die "the toolchain bundle has no bin/vibe"
+  bootstrap_say "installing toolchain '$version' with the release's launcher..."
+  VIBE_HOME="$VIBE_HOME" VIBE_RELEASE_URL="$base" bash "$release_work/bin/vibe" self update "$version" --no-default \
+    || bootstrap_die "release install failed"
+  export VIBE_HOME
+  write_dispatcher
+  write_default_toolchain "$version" "$set_default"
+  write_env_and_path "$do_modify_path" "$do_link" "$bin_dir"
+  say "done. try: vibe version"
+}
 
 # The private root argument is emitted only by the bootstrap half below. It
 # makes reinvocation explicit and avoids trusting BASH_SOURCE after curl|bash.
@@ -78,6 +338,7 @@ if [ "${1:-}" = "--__vibe-install-root" ]; then
 else
   REPO="${VIBE_INSTALL_REPO:-https://github.com/mizchi/vibe-lang}"
   REF="${VIBE_INSTALL_REF:-main}"
+  WANT_VERSION="${VIBE_INSTALL_VERSION:-}"
   passthrough=()
   while [ "$#" -gt 0 ]; do
     case "$1" in
@@ -87,11 +348,19 @@ else
       --ref)
         [ "$#" -ge 2 ] || bootstrap_die "--ref requires a value"
         REF="$2"; shift 2 ;;
+      --version)
+        [ "$#" -ge 2 ] || bootstrap_die "--version requires a value"
+        WANT_VERSION="$2"; shift 2 ;;
       --) shift; passthrough+=("$@"); break ;;
       -h|--help) usage; exit 0 ;;
       *) passthrough+=("$1"); shift ;;
     esac
   done
+
+  if [ -n "$WANT_VERSION" ]; then
+    release_install "$WANT_VERSION" ${passthrough[@]+"${passthrough[@]}"}
+    exit $?
+  fi
 
   SRC_DIR=""
   script_source="${BASH_SOURCE[0]:-}"
@@ -177,9 +446,6 @@ done
 CLI_WASM_EXPLICIT=0
 [ -n "$CLI_WASM_SRC" ] && CLI_WASM_EXPLICIT=1
 
-say() { echo "[install] $*"; }
-die() { echo "[install] error: $*" >&2; exit 1; }
-
 # The seed wasm is a fetched/build cache rather than a tracked checkout file.
 # Both fresh compilation and seed acquisition use the Node bootstrap runner, so
 # do not pretend a default install can continue without Node. An explicitly
@@ -197,12 +463,7 @@ validate_toolchain_name() {
 }
 
 validate_toolchain_name "$TOOLCHAIN"
-# A pre-#755 flat install (bin/viberun next to lib/vibe-cli.wasm) cannot host
-# toolchains: its launcher and stdlib would shadow theirs. Refuse rather than
-# mix the two layouts (docs/toolchain-layout.md section 2, #2677).
-if [ -f "$VIBE_HOME/lib/vibe-cli.wasm" ] || [ -x "$VIBE_HOME/bin/viberun" ]; then
-  die "$VIBE_HOME holds a flat pre-#755 install (lib/vibe-cli.wasm, bin/viberun), which is no longer supported; remove it, or choose another --prefix, and run install/install.sh again"
-fi
+refuse_flat_home
 TC_DIR="$VIBE_HOME/toolchains/$TOOLCHAIN"
 mkdir -p "$TC_DIR/bin" "$TC_DIR/lib" "$VIBE_HOME/bin" "$VIBE_HOME/lib"
 
@@ -338,57 +599,8 @@ wasmtime_ver="$("$TC_DIR/bin/viberun" --version 2>/dev/null | sed -n '1p' || tru
 say "manifest -> $TC_DIR/manifest.json"
 
 # 5. dispatcher + default toolchain ----------------------------------------
-cat > "$VIBE_HOME/bin/vibe" <<'DISPATCH'
-#!/usr/bin/env bash
-# vibe dispatcher (rustup-style, #755): selects a toolchain and execs its
-# launcher. Selection order: $VIBE_TOOLCHAIN env > $VIBE_HOME/toolchain file
-# > the single installed toolchain. Managed by the installer; a future
-# `vibe toolchain` selector rewrites the default file.
-set -euo pipefail
-_src="${BASH_SOURCE[0]}"
-while [ -L "$_src" ]; do
-  _dir="$(cd -P "$(dirname "$_src")" && pwd)"
-  _src="$(readlink "$_src")"
-  case "$_src" in /*) ;; *) _src="$_dir/$_src" ;; esac
-done
-_self_dir="$(cd -P "$(dirname "$_src")" && pwd)"
-VIBE_HOME="${VIBE_HOME:-$(dirname "$_self_dir")}"
-tc="${VIBE_TOOLCHAIN:-}"
-if [ -z "$tc" ] && [ -f "$VIBE_HOME/toolchain" ]; then
-  tc="$(head -n 1 "$VIBE_HOME/toolchain" | tr -d '[:space:]')"
-fi
-if [ -z "$tc" ]; then
-  count=0
-  only=""
-  for d in "$VIBE_HOME/toolchains"/*/; do
-    [ -d "$d" ] || continue
-    count=$((count + 1))
-    only="$(basename "$d")"
-  done
-  if [ "$count" = "1" ]; then
-    tc="$only"
-  else
-    echo "vibe: no default toolchain (set \$VIBE_TOOLCHAIN or write $VIBE_HOME/toolchain)" >&2
-    exit 1
-  fi
-fi
-case "$tc" in
-  ""|.|..|*[!A-Za-z0-9._-]*)
-    echo "vibe: invalid toolchain name '$tc'" >&2
-    exit 1
-    ;;
-esac
-launcher="$VIBE_HOME/toolchains/$tc/bin/vibe"
-[ -x "$launcher" ] || { echo "vibe: toolchain '$tc' is not installed ($launcher)" >&2; exit 1; }
-export VIBE_HOME
-exec "$launcher" "$@"
-DISPATCH
-chmod 0755 "$VIBE_HOME/bin/vibe"
-say "dispatcher -> $VIBE_HOME/bin/vibe"
-if [ "$SET_DEFAULT" = "1" ] || [ ! -f "$VIBE_HOME/toolchain" ]; then
-  printf '%s\n' "$TOOLCHAIN" > "$VIBE_HOME/toolchain"
-  say "default toolchain -> $TOOLCHAIN"
-fi
+write_dispatcher
+write_default_toolchain "$TOOLCHAIN" "$SET_DEFAULT"
 
 # 6. stdlib packages (per toolchain, hash-verified) --------------------------
 # The runtime-relevant standard library is materialized into the toolchain's
@@ -433,67 +645,6 @@ if [ "$DO_STDLIB" = "1" ]; then
 fi
 
 # 7. PATH setup --------------------------------------------------------------
-# $VIBE_HOME/bin (the dispatcher) is THE PATH entry. Write the sourceable env
-# file (rustup's ~/.cargo/env pattern) and -- for a default-prefix install
-# only -- wire it into the shell rc files. A custom --prefix (tests, throwaway
-# installs) never touches the user's rc files.
-# Emit one POSIX-shell single-quoted word. Prefixes may contain whitespace,
-# quotes, command substitutions, or newlines; sourcing the generated file must
-# always treat those bytes as path data rather than shell syntax.
-shell_quote() {
-  printf "'"
-  printf '%s' "$1" | sed "s/'/'\\\\''/g"
-  printf "'"
-}
-{
-  cat <<'ENV_HEAD'
-#!/bin/sh
-# vibe shell setup: prepends the vibe dispatcher dir to PATH.
-# Wired into your shell rc by the installer.
-_vibe_bin=
-ENV_HEAD
-  printf '_vibe_bin='
-  shell_quote "$VIBE_HOME/bin"
-  printf '\n'
-  cat <<'ENV_TAIL'
-case ":${PATH}:" in
-  *:"${_vibe_bin}":*) ;;
-  *) PATH="${_vibe_bin}:${PATH}"; export PATH ;;
-esac
-unset _vibe_bin
-ENV_TAIL
-} > "$VIBE_HOME/env"
-chmod 0644 "$VIBE_HOME/env"
-say "env file -> $VIBE_HOME/env"
-
-if [ "$DO_MODIFY_PATH" = "1" ] && [ "$VIBE_HOME" = "$HOME/.vibe" ]; then
-  env_line=". \"\$HOME/.vibe/env\""
-  modified=""
-  for rc in "$HOME/.profile" "$HOME/.bashrc" "$HOME/.zshrc"; do
-    [ -f "$rc" ] || continue
-    if ! grep -qsF '.vibe/env' "$rc"; then
-      printf '\n%s\n' "$env_line" >> "$rc"
-      modified="$modified $(basename "$rc")"
-    fi
-  done
-  if [ -n "$modified" ]; then
-    say "PATH: added '. \$HOME/.vibe/env' to:$modified"
-    say "restart your shell or run: . \"\$HOME/.vibe/env\""
-  else
-    say "PATH: shell rc files already source ~/.vibe/env (or none found)"
-  fi
-else
-  case ":$PATH:" in
-    *":$VIBE_HOME/bin:"*) ;;
-    *) say "PATH: add $VIBE_HOME/bin to PATH (e.g. . \"$VIBE_HOME/env\")" ;;
-  esac
-fi
-
-# Optional extra symlink dir (test harness / packaging), opt-in only.
-if [ "$DO_LINK" = "1" ] && [ -n "$BIN_DIR" ]; then
-  mkdir -p "$BIN_DIR"
-  ln -sf "$VIBE_HOME/bin/vibe" "$BIN_DIR/vibe"
-  say "linked $BIN_DIR/vibe -> $VIBE_HOME/bin/vibe"
-fi
+write_env_and_path "$DO_MODIFY_PATH" "$DO_LINK" "$BIN_DIR"
 
 say "done. try: vibe version"

--- a/runtime/vibe
+++ b/runtime/vibe
@@ -164,7 +164,10 @@
 #   vibe toolchain list                   installed toolchains, the default marked
 #   vibe toolchain default <name>         select the default toolchain
 #   vibe toolchain remove <name>          delete a toolchain (never the default)
-#   vibe self update [--cli-wasm <path>]  refresh compiler wasm + rebuild .cwasm
+#   vibe self update [<version>|latest] [--no-default] [--force]
+#                                         install a release toolchain (download,
+#                                         verify, precompile) and make it default
+#   vibe self update --cli-wasm <path>    refresh compiler wasm + rebuild .cwasm
 #   vibe self uninstall [--purge]         remove toolchains/, bin/, env, toolchain
 #                                         (--purge: cache/, lib/ and log/ too)
 #   vibe help                             this message
@@ -299,6 +302,140 @@ default_toolchain_name() {
 }
 valid_toolchain_name() {
   case "$1" in ""|.|..|*[!A-Za-z0-9._-]*) return 1 ;; *) return 0 ;; esac
+}
+
+# --- release install (docs/toolchain-layout.md section 3, #2678) ------------
+# `vibe self update <version>` fetches a release's assets from
+# $VIBE_RELEASE_URL (default: this repository's GitHub releases; tests point
+# it at a file:// directory), verifies every byte against
+# release-manifest.json BEFORE anything is moved, unpacks into a staging
+# directory under toolchains/, precompiles, writes manifest.json and renames
+# into toolchains/<version>/. Needs curl or wget, tar, and sha256sum or
+# shasum -- no git, cargo or Node.js.
+VIBE_RELEASE_URL_DEFAULT="https://github.com/mizchi/vibe-lang/releases/download"
+release_fetch() { # release_fetch <url> <out>
+  if command -v curl >/dev/null 2>&1; then
+    curl -fsSL "$1" -o "$2"
+  elif command -v wget >/dev/null 2>&1; then
+    wget -q -O "$2" "$1"
+  else
+    die "vibe self update: curl or wget is required to download $1"
+  fi
+}
+release_target() {
+  local os arch
+  os="$(uname -s)"
+  arch="$(uname -m)"
+  case "$arch" in arm64|aarch64) arch="aarch64" ;; x86_64|amd64) arch="x86_64" ;; esac
+  case "$os" in
+    Linux) printf '%s-unknown-linux-gnu' "$arch" ;;
+    Darwin) printf '%s-apple-darwin' "$arch" ;;
+    *) die "vibe self update: no prebuilt runner for $os/$arch; install from a checkout instead (install/install.sh --ref <ref>)" ;;
+  esac
+}
+# The release manifest is read with sed: top-level `"key": "value"` lines sit
+# at two spaces, the `assets` (name -> sha256) and `runners` (target -> asset)
+# entries at four, the shape scripts/build_release_assets.sh writes.
+release_manifest_field() { sed -n "s/^  \"$2\": \"\([^\"]*\)\",\{0,1\}\$/\1/p" "$1" | sed -n '1p'; }
+release_manifest_asset() { sed -n "s/^    \"$2\": \"\([0-9a-f]*\)\",\{0,1\}\$/\1/p" "$1" | sed -n '1p'; }
+release_manifest_runner() { sed -n "s/^    \"$2\": \"\([^\"]*\)\",\{0,1\}\$/\1/p" "$1" | sed -n '1p'; }
+release_manifest_targets() { sed -n '/^  "runners": {/,/^  }/p' "$1" | sed -n 's/^    "\([^"]*\)".*/\1/p' | tr '\n' ' '; }
+json_safe() { printf '%s' "$1" | tr -d '"\\\n'; }
+# write_toolchain_manifest <dir> <version> <toolchain> <source> <ref> <commit> <wasmtime>
+# The same one-`"key": "value"`-per-line shape install/install.sh writes for a
+# checkout install, so `vibe version` and `vibe toolchain list` read both.
+write_toolchain_manifest() {
+  local dir="$1" version="$2" name="$3" source="$4" ref="$5" commit="$6" wasmtime="$7"
+  {
+    printf '{\n'
+    printf '  "version": "%s",\n' "$(json_safe "$version")"
+    printf '  "toolchain": "%s",\n' "$(json_safe "$name")"
+    printf '  "source": "%s",\n' "$(json_safe "$source")"
+    printf '  "ref": "%s",\n' "$(json_safe "$ref")"
+    printf '  "commit": "%s",\n' "$(json_safe "$commit")"
+    printf '  "installed_at": "%s",\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || true)"
+    printf '  "runner_sha256": "%s",\n' "$(_sha256_file "$dir/bin/viberun" 2>/dev/null || true)"
+    printf '  "compiler_sha256": "%s",\n' "$(_sha256_file "$dir/lib/vibe-cli.wasm" 2>/dev/null || true)"
+    printf '  "wasmtime": "%s"\n' "$(json_safe "$wasmtime")"
+    printf '}\n'
+  } > "$dir/manifest.json"
+}
+# install_release_toolchain <version|latest> <set-default 0|1> <force 0|1>
+install_release_toolchain() {
+  local want="$1" set_default="$2" force="$3"
+  local base="${VIBE_RELEASE_URL:-$VIBE_RELEASE_URL_DEFAULT}"
+  local dl tag version manifest target runner_name tc_name wasm_name asset sha want_sha staging
+  command -v tar >/dev/null 2>&1 || die "vibe self update: tar is required"
+  command -v sha256sum >/dev/null 2>&1 || command -v shasum >/dev/null 2>&1 \
+    || die "vibe self update: sha256sum or shasum is required to verify the release assets"
+  if [ "$want" = "latest" ]; then
+    dl="$VIBE_HOME/cache/downloads/latest"
+    mkdir -p "$dl"
+    release_fetch "${base%/download}/latest/download/release-manifest.json" "$dl/release-manifest.json" \
+      || die "vibe self update: cannot fetch the latest release manifest from ${base%/download}/latest/download/"
+    version="$(release_manifest_field "$dl/release-manifest.json" version)"
+    [ -n "$version" ] || die "vibe self update: the latest release manifest names no version"
+    echo "vibe: latest release is $version"
+  else
+    version="${want#v}"
+  fi
+  valid_toolchain_name "$version" || die "vibe self update: invalid version '$version'"
+  tag="v$version"
+  if [ -e "$VIBE_HOME/toolchains/$version" ] && [ "$force" != 1 ]; then
+    die "toolchain '$version' is already installed at $VIBE_HOME/toolchains/$version (\`vibe self update $version --force\` reinstalls it, \`vibe toolchain default $version\` selects it)"
+  fi
+  dl="$VIBE_HOME/cache/downloads/$tag"
+  mkdir -p "$dl"
+  manifest="$dl/release-manifest.json"
+  release_fetch "$base/$tag/release-manifest.json" "$manifest" \
+    || die "vibe self update: cannot fetch $base/$tag/release-manifest.json (is $version a published release?)"
+  [ "$(release_manifest_field "$manifest" version)" = "$version" ] \
+    || die "vibe self update: the manifest at $base/$tag names version '$(release_manifest_field "$manifest" version)', not $version"
+  target="$(release_target)"
+  runner_name="$(release_manifest_runner "$manifest" "$target")"
+  [ -n "$runner_name" ] || die "vibe self update: release $tag ships no runner for $target (it ships: $(release_manifest_targets "$manifest")); install from a checkout instead (install/install.sh --ref $tag)"
+  tc_name="$(release_manifest_field "$manifest" toolchain)"
+  wasm_name="$(release_manifest_field "$manifest" compiler_wasm)"
+  [ -n "$tc_name" ] && [ -n "$wasm_name" ] || die "vibe self update: the release manifest lists no toolchain bundle or compiler wasm"
+  # Every asset is downloaded and verified before toolchains/ is touched; a
+  # cached copy that still matches the manifest is reused.
+  for asset in "$runner_name" "$tc_name" "$wasm_name"; do
+    want_sha="$(release_manifest_asset "$manifest" "$asset")"
+    [ -n "$want_sha" ] || die "vibe self update: the release manifest has no sha256 for $asset"
+    if [ -f "$dl/$asset" ] && [ "$(_sha256_file "$dl/$asset")" = "$want_sha" ]; then
+      echo "vibe: $asset (cached)"
+    else
+      echo "vibe: downloading $asset"
+      release_fetch "$base/$tag/$asset" "$dl/$asset.part" || { rm -f "$dl/$asset.part"; die "vibe self update: download failed: $base/$tag/$asset"; }
+      mv "$dl/$asset.part" "$dl/$asset"
+    fi
+    sha="$(_sha256_file "$dl/$asset")"
+    if [ "$sha" != "$want_sha" ]; then
+      rm -f "$dl/$asset"
+      die "vibe self update: $asset does not match the release manifest (sha256 $sha, manifest $want_sha); nothing was installed"
+    fi
+  done
+  staging="$VIBE_HOME/toolchains/.staging-$version-$$"
+  rm -rf "$staging"
+  mkdir -p "$staging/bin" "$staging/lib"
+  tar -xzf "$dl/$tc_name" -C "$staging" || { rm -rf "$staging"; die "vibe self update: cannot unpack $tc_name"; }
+  tar -xzf "$dl/$runner_name" -C "$staging/bin" || { rm -rf "$staging"; die "vibe self update: cannot unpack $runner_name"; }
+  [ -f "$staging/bin/viberun" ] && [ -f "$staging/bin/vibe" ] \
+    || { rm -rf "$staging"; die "vibe self update: the release assets did not contain bin/viberun and bin/vibe"; }
+  chmod 0755 "$staging/bin/viberun" "$staging/bin/vibe"
+  cp "$dl/$wasm_name" "$staging/lib/vibe-cli.wasm"
+  echo "vibe: AOT-compiling the host-specific .cwasm"
+  "$staging/bin/viberun" --precompile "$staging/lib/vibe-cli.wasm" -o "$staging/lib/vibe-cli.cwasm" \
+    || { rm -rf "$staging"; die "vibe self update: viberun --precompile failed"; }
+  write_toolchain_manifest "$staging" "$version" "$version" "release" "$tag" \
+    "$(release_manifest_field "$manifest" commit)" "$(release_manifest_field "$manifest" wasmtime)"
+  rm -rf "$VIBE_HOME/toolchains/$version"
+  mv "$staging" "$VIBE_HOME/toolchains/$version"
+  echo "vibe: installed toolchain $version -> $VIBE_HOME/toolchains/$version"
+  if [ "$set_default" = 1 ]; then
+    printf '%s\n' "$version" > "$VIBE_HOME/toolchain"
+    echo "vibe: default toolchain -> $version"
+  fi
 }
 
 # --- semver constraint resolution for `vibe add` -----------------------------
@@ -471,9 +608,14 @@ manifest_add_pin() {
 # missing/unbuilt runner. `vibe symbols --legend|--help|-h` is the same:
 # a static KIND table / usage, no wasm (#1944). Every other subcommand
 # still requires the runner.
+# `self update <version>` (#2678) runs the runner it DOWNLOADS, never this
+# toolchain's; `self uninstall`, `toolchain`, `root`, `clean` and `new` touch
+# no wasm either -- so a launcher extracted from a release bundle into a
+# directory that holds no runner yet (install/install.sh --version) can drive
+# the release install.
 need_runner=1
 case "${1:-help}" in
-  context-pack) need_runner=0 ;;
+  context-pack|self|toolchain|root|clean|new|help|--help|-h|version|--version|-V) need_runner=0 ;;
   symbols)
     case "${2:-}" in
       --legend|--help|-h) need_runner=0 ;;
@@ -3456,21 +3598,39 @@ EOF
     sub="${1:-}"; shift || true
     case "$sub" in
       update)
+        # vibe self update [<version>|latest] [--no-default] [--force]
+        #   install a release toolchain (docs/toolchain-layout.md section 3,
+        #   #2678) and make it the default
+        # vibe self update --cli-wasm <path>
+        #   swap the compiler wasm of THIS toolchain and rebuild its .cwasm
+        #   (offline; the one in-place edit of a toolchain directory)
         new_wasm=""
+        want=""
+        set_default=1
+        force=0
         while [ "$#" -gt 0 ]; do
           case "$1" in
-            --cli-wasm) new_wasm="$2"; shift 2 ;;
-            *) die "unknown self update flag: $1" ;;
+            --cli-wasm) new_wasm="${2:-}"; shift 2 ;;
+            --no-default) set_default=0; shift ;;
+            --force) force=1; shift ;;
+            -*) die "unknown self update flag: $1" ;;
+            *)
+              [ -z "$want" ] || die "usage: vibe self update [<version>|latest] [--no-default] [--force]"
+              want="$1"; shift ;;
           esac
         done
-        [ -n "$new_wasm" ] || die "usage: vibe self update --cli-wasm <path-to-vibe-cli.wasm>"
-        [ -f "$new_wasm" ] || die "not found: $new_wasm"
-        mkdir -p "$(dirname "$CLI_WASM")"
-        cp -f "$new_wasm" "$CLI_WASM"
-        echo "vibe: updated compiler wasm -> $CLI_WASM"
-        # Rebuild the host-specific AOT artifact against this runner.
-        "$RUNNER" --precompile "$CLI_WASM" -o "$CLI_CWASM"
-        echo "vibe: rebuilt AOT compiler -> $CLI_CWASM"
+        if [ -n "$new_wasm" ]; then
+          [ -z "$want" ] || die "vibe self update: --cli-wasm swaps the compiler of the current toolchain and takes no version"
+          [ -f "$new_wasm" ] || die "not found: $new_wasm"
+          mkdir -p "$(dirname "$CLI_WASM")"
+          cp -f "$new_wasm" "$CLI_WASM"
+          echo "vibe: updated compiler wasm -> $CLI_WASM"
+          # Rebuild the host-specific AOT artifact against this runner.
+          "$RUNNER" --precompile "$CLI_WASM" -o "$CLI_CWASM"
+          echo "vibe: rebuilt AOT compiler -> $CLI_CWASM"
+        else
+          install_release_toolchain "${want:-latest}" "$set_default" "$force"
+        fi
         ;;
       uninstall)
         # vibe self uninstall [--purge]  (docs/toolchain-layout.md section 3,
@@ -3506,7 +3666,7 @@ EOF
           echo "vibe: kept $VIBE_HOME/{cache,lib,log} (vibe self uninstall --purge removes them too)"
         fi
         ;;
-      *) die "usage: vibe self update --cli-wasm <path> | vibe self uninstall [--purge]" ;;
+      *) die "usage: vibe self update [<version>|latest] [--no-default] [--force] | vibe self update --cli-wasm <path> | vibe self uninstall [--purge]" ;;
     esac
     ;;
   root)

--- a/scripts/build_release_assets.sh
+++ b/scripts/build_release_assets.sh
@@ -54,33 +54,141 @@ compiler_fragment="$OUT_DIR/.compiler-manifest-fragment.json"
   echo "release-assets: compiler manifest fragment not produced: $compiler_fragment" >&2; exit 1; }
 
 commit_sha="$(git -C "$PROJECT_ROOT" rev-parse HEAD 2>/dev/null || true)"
-node - "$compiler_fragment" "$OUT_DIR/$MANIFEST_NAME" "$TAG" "$VERSION" "$commit_sha" \
-  "$WASM_NAME" "$MODSRC_NAME" "$SEED_JSON_NAME" <<'NODE'
-const fs = require("node:fs");
-const [fragmentPath, outPath, tag, version, commit, wasmName, modsrcName, seedJsonName] =
-  process.argv.slice(2);
-const compiler = JSON.parse(fs.readFileSync(fragmentPath, "utf8"));
-const manifest = {
-  tag,
-  version,
-  commit,
-  artifacts: [wasmName, modsrcName, seedJsonName],
-  compiler,
-};
-fs.writeFileSync(outPath, `${JSON.stringify(manifest, null, 2)}\n`);
-NODE
-rm -f "$compiler_fragment"
 
-(
-  cd "$OUT_DIR"
+sha256_file() {
   # Probe by RUNNING it, not by `command -v`: a nix-shim `sha256sum` that is on
   # PATH but dies on a glibc mismatch passes an existence check and then fails
   # every call, so the fallback never engages and the caller dies instead.
   if sha256sum </dev/null >/dev/null 2>&1; then
-    sha256sum "$WASM_NAME" "$MODSRC_NAME" "$SEED_JSON_NAME" "$MANIFEST_NAME" \
+    sha256sum "$1" | cut -d' ' -f1
+  elif shasum -a 256 </dev/null >/dev/null 2>&1; then
+    shasum -a 256 "$1" | awk '{print $1}'
+  else
+    echo "release-assets: sha256sum or shasum is required" >&2
+    exit 1
+  fi
+}
+
+# --- toolchain bundle (docs/toolchain-layout.md section 3, #2678) -----------
+# The platform-independent part of toolchains/<name>/: the launcher, the pkg
+# and warm-pool scripts, the LSP scripts, the context pack, and the stdlib
+# packages `install/install.sh` materializes in checkout mode, with their
+# package hashes computed by the compiler this release ships (the node host
+# runner, no viberun needed). A release install unpacks this next to the
+# runner tarball for the host and the compiler wasm.
+TOOLCHAIN_NAME="vibe-toolchain-$TAG.tar.gz"
+tc_stage="$OUT_DIR/.toolchain"
+rm -rf "$tc_stage"
+mkdir -p "$tc_stage/bin" "$tc_stage/lib"
+install -m 0755 "$PROJECT_ROOT/runtime/vibe" "$tc_stage/bin/vibe"
+install -m 0644 "$PROJECT_ROOT/scripts/vibe_pkg.sh" "$tc_stage/lib/vibe_pkg.sh"
+install -m 0644 "$PROJECT_ROOT/scripts/parallel_warm_pool.sh" "$tc_stage/lib/parallel_warm_pool.sh"
+for js in lsp_server.js symbol_index.js graph_query.js; do
+  [ -f "$PROJECT_ROOT/clients/js/$js" ] && install -m 0644 "$PROJECT_ROOT/clients/js/$js" "$tc_stage/lib/$js"
+done
+bash "$PROJECT_ROOT/scripts/gen_context_pack.sh" "$PROJECT_ROOT" > "$tc_stage/lib/context-pack.md"
+: > "$tc_stage/stdlib-hashes.tsv"
+for pkg in @vibe/core @vibe/ast @vibe/parser @vibe/builtin @vibe/console @vibe/wit_runtime; do
+  src="$PROJECT_ROOT/lib/$pkg"
+  [ -f "$src/index.vpkg" ] || { echo "release-assets: stdlib package missing: $src" >&2; exit 1; }
+  dest="$tc_stage/lib/$pkg"
+  mkdir -p "$dest"
+  cp "$src/index.vpkg" "$dest/"
+  for f in "$src"/*.vibe; do
+    [ -e "$f" ] || continue
+    case "$(basename "$f")" in
+      *_test.vibe|*_bench.vibe) ;;
+      *) cp "$f" "$dest/" ;;
+    esac
+  done
+  hash_out="$OUT_DIR/.hash.out"
+  rm -f "$hash_out" "$hash_out.diag"
+  VIBE_HASH=1 VIBE_PREOPEN_DIR="$PROJECT_ROOT" \
+    bash "$SCRIPT_DIR/run_wasm_vibe_host_runner.sh" --invoke cli_main "$OUT_DIR/$WASM_NAME" \
+      "$src/index.vpkg" "$hash_out" __no_entry__ >/dev/null 2>&1 || true
+  pkg_hash="$(awk '/^package /{print $2}' "$hash_out" 2>/dev/null || true)"
+  [ -n "$pkg_hash" ] || { cat "$hash_out.diag" >&2 2>/dev/null || true; echo "release-assets: package hash failed for $pkg" >&2; exit 1; }
+  printf '%s\t%s\n' "$pkg" "$pkg_hash" >> "$tc_stage/stdlib-hashes.tsv"
+  rm -f "$hash_out" "$hash_out.diag"
+done
+( cd "$tc_stage" && tar -czf "$OUT_DIR/$TOOLCHAIN_NAME" bin lib stdlib-hashes.tsv )
+rm -rf "$tc_stage"
+
+# --- runner tarballs -----------------------------------------------------
+# One prebuilt `viberun` per target, built natively by the release workflow's
+# matrix and dropped into $VIBE_RELEASE_RUNNERS_DIR as
+# viberun-<tag>-<target>.tar.gz (each holding one executable, `viberun`).
+# A local run of this script with no runners dir produces a manifest with
+# no runners, which `vibe self update` refuses for the host with a clear
+# message.
+RUNNERS_DIR="${VIBE_RELEASE_RUNNERS_DIR:-$PROJECT_ROOT/dist/release/runners}"
+runner_names=()
+runner_targets=()
+if [ -d "$RUNNERS_DIR" ]; then
+  for f in "$RUNNERS_DIR"/viberun-"$TAG"-*.tar.gz; do
+    [ -f "$f" ] || continue
+    name="$(basename "$f")"
+    target="${name#viberun-$TAG-}"
+    target="${target%.tar.gz}"
+    cp "$f" "$OUT_DIR/$name"
+    runner_names+=("$name")
+    runner_targets+=("$target")
+  done
+fi
+wasmtime_version="$(sed -n 's/^wasmtime = { version = "\([^"]*\)".*$/\1/p' "$PROJECT_ROOT/runtime/viberun/Cargo.toml" | head -1)"
+
+# --- release manifest ------------------------------------------------------
+# Every shipped asset with its sha256 (`assets`), the runner per target, and
+# the wasmtime version the runners embed: what `vibe self update` and
+# `install/install.sh --version` verify every downloaded byte against before
+# anything is moved into toolchains/.
+asset_lines="$OUT_DIR/.assets.tsv"
+: > "$asset_lines"
+for name in "$WASM_NAME" "$MODSRC_NAME" "$SEED_JSON_NAME" "$TOOLCHAIN_NAME" ${runner_names[@]+"${runner_names[@]}"}; do
+  printf '%s\t%s\n' "$name" "$(sha256_file "$OUT_DIR/$name")" >> "$asset_lines"
+done
+runner_lines="$OUT_DIR/.runners.tsv"
+: > "$runner_lines"
+i=0
+while [ "$i" -lt "${#runner_names[@]}" ]; do
+  printf '%s\t%s\n' "${runner_targets[$i]}" "${runner_names[$i]}" >> "$runner_lines"
+  i=$((i + 1))
+done
+node - "$compiler_fragment" "$OUT_DIR/$MANIFEST_NAME" "$TAG" "$VERSION" "$commit_sha" \
+  "$WASM_NAME" "$MODSRC_NAME" "$SEED_JSON_NAME" "$TOOLCHAIN_NAME" "$wasmtime_version" \
+  "$asset_lines" "$runner_lines" <<'NODE'
+const fs = require("node:fs");
+const [fragmentPath, outPath, tag, version, commit, wasmName, modsrcName, seedJsonName,
+  toolchainName, wasmtime, assetLines, runnerLines] = process.argv.slice(2);
+const compiler = JSON.parse(fs.readFileSync(fragmentPath, "utf8"));
+const tsv = (p) => fs.readFileSync(p, "utf8").split("\n").filter(Boolean).map((l) => l.split("\t"));
+const assets = {};
+for (const [name, sha] of tsv(assetLines)) assets[name] = sha;
+const runners = {};
+for (const [target, name] of tsv(runnerLines)) runners[target] = name;
+const manifest = {
+  tag,
+  version,
+  commit,
+  wasmtime,
+  compiler_wasm: wasmName,
+  toolchain: toolchainName,
+  runners,
+  assets,
+  artifacts: [wasmName, modsrcName, seedJsonName, toolchainName, ...Object.values(runners)],
+  compiler,
+};
+fs.writeFileSync(outPath, `${JSON.stringify(manifest, null, 2)}\n`);
+NODE
+rm -f "$compiler_fragment" "$asset_lines" "$runner_lines"
+
+(
+  cd "$OUT_DIR"
+  if sha256sum </dev/null >/dev/null 2>&1; then
+    sha256sum "$WASM_NAME" "$MODSRC_NAME" "$SEED_JSON_NAME" "$TOOLCHAIN_NAME" ${runner_names[@]+"${runner_names[@]}"} "$MANIFEST_NAME" \
       > "$CHECKSUM_NAME"
   else
-    shasum -a 256 "$WASM_NAME" "$MODSRC_NAME" "$SEED_JSON_NAME" "$MANIFEST_NAME" \
+    shasum -a 256 "$WASM_NAME" "$MODSRC_NAME" "$SEED_JSON_NAME" "$TOOLCHAIN_NAME" ${runner_names[@]+"${runner_names[@]}"} "$MANIFEST_NAME" \
       > "$CHECKSUM_NAME"
   fi
 )
@@ -90,5 +198,8 @@ printf '  %s\n' \
   "$OUT_DIR/$WASM_NAME" \
   "$OUT_DIR/$MODSRC_NAME" \
   "$OUT_DIR/$SEED_JSON_NAME" \
+  "$OUT_DIR/$TOOLCHAIN_NAME"
+for name in ${runner_names[@]+"${runner_names[@]}"}; do printf '  %s\n' "$OUT_DIR/$name"; done
+printf '  %s\n' \
   "$OUT_DIR/$MANIFEST_NAME" \
   "$OUT_DIR/$CHECKSUM_NAME"

--- a/tests/integration/install/release_install_test.sh
+++ b/tests/integration/install/release_install_test.sh
@@ -1,0 +1,188 @@
+#!/usr/bin/env bash
+# Network-free regression for the release install path (#2678,
+# docs/toolchain-layout.md section 3): a synthetic release directory served
+# over file:// stands in for GitHub releases, a fake `viberun` stands in for
+# the prebuilt runner (it only knows --precompile and --version), and the
+# toolchain bundle is built from this checkout's launcher. What is proven:
+#   * `install/install.sh --version X.Y.Z` installs with a PATH that holds
+#     bash, curl, tar and the POSIX utilities the scripts use -- no git, no
+#     cargo, no node;
+#   * `vibe self update <version>|latest` installs a toolchain and switches
+#     the default; `--no-default` does not; `--force` reinstalls; an installed
+#     version is refused without it;
+#   * an asset that does not match the release manifest is refused before
+#     anything is moved into toolchains/ (no staging leftovers, the default
+#     untouched), for the runner tarball and for the toolchain bundle;
+#   * a release with no runner for this host names the targets it ships.
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+mkdir -p "$WORK/tmp" "$WORK/fakehome"
+
+pass=0
+fail=0
+check() { # check <desc> <expected> <actual>
+  if [ "$2" = "$3" ]; then
+    echo "ok: $1"
+    pass=$((pass + 1))
+  else
+    echo "FAIL: $1 (expected '$2', got '$3')" >&2
+    fail=$((fail + 1))
+  fi
+}
+sha256() {
+  if command -v sha256sum >/dev/null 2>&1; then sha256sum "$1" | cut -d' ' -f1; else shasum -a 256 "$1" | awk '{print $1}'; fi
+}
+# The same host -> target mapping the launcher uses.
+os="$(uname -s)"; arch="$(uname -m)"
+case "$arch" in arm64|aarch64) arch=aarch64 ;; x86_64|amd64) arch=x86_64 ;; esac
+case "$os" in Linux) TARGET="$arch-unknown-linux-gnu" ;; Darwin) TARGET="$arch-apple-darwin" ;; *) echo "unsupported host $os" >&2; exit 1 ;; esac
+
+REL="$WORK/release"
+RELEASE_URL="file://$REL/download"
+
+# write_manifest <dir> <version> <runner-target>: the shape
+# scripts/build_release_assets.sh writes (top-level keys at two spaces, the
+# `runners` and `assets` entries at four).
+write_manifest() {
+  local d="$1" version="$2" rtarget="$3" tag="v$2"
+  {
+    printf '{\n'
+    printf '  "tag": "%s",\n' "$tag"
+    printf '  "version": "%s",\n' "$version"
+    printf '  "commit": "0123456789abcdef0123456789abcdef01234567",\n'
+    printf '  "wasmtime": "fake",\n'
+    printf '  "compiler_wasm": "vibe-compiler-%s.wasm",\n' "$tag"
+    printf '  "toolchain": "vibe-toolchain-%s.tar.gz",\n' "$tag"
+    printf '  "runners": {\n'
+    printf '    "%s": "viberun-%s-%s.tar.gz"\n' "$rtarget" "$tag" "$rtarget"
+    printf '  },\n'
+    printf '  "assets": {\n'
+    printf '    "vibe-compiler-%s.wasm": "%s",\n' "$tag" "$(sha256 "$d/vibe-compiler-$tag.wasm")"
+    printf '    "vibe-toolchain-%s.tar.gz": "%s",\n' "$tag" "$(sha256 "$d/vibe-toolchain-$tag.tar.gz")"
+    printf '    "viberun-%s-%s.tar.gz": "%s"\n' "$tag" "$rtarget" "$(sha256 "$d/viberun-$tag-$rtarget.tar.gz")"
+    printf '  }\n'
+    printf '}\n'
+  } > "$d/release-manifest.json"
+}
+
+# mk_release <version> [latest] [runner-target]
+mk_release() {
+  local version="$1" tag="v$1" latest="${2:-}" rtarget="${3:-$TARGET}" d stage
+  d="$REL/download/$tag"
+  stage="$WORK/stage-$version"
+  rm -rf "$stage"
+  mkdir -p "$d" "$stage/runner" "$stage/tc/bin" "$stage/tc/lib/@vibe/console"
+  cat > "$stage/runner/viberun" <<RUNNER
+#!/usr/bin/env bash
+set -euo pipefail
+case "\${1:-}" in --version) echo "viberun fake $version"; exit 0 ;; esac
+out=""
+while [ "\$#" -gt 0 ]; do
+  case "\$1" in -o) out="\$2"; shift 2 ;; *) shift ;; esac
+done
+[ -n "\$out" ] || { echo "fake runner: missing -o" >&2; exit 2; }
+printf 'fake-cwasm %s\n' "$version" > "\$out"
+RUNNER
+  chmod +x "$stage/runner/viberun"
+  tar -czf "$d/viberun-$tag-$rtarget.tar.gz" -C "$stage/runner" viberun
+  install -m 0755 "$ROOT_DIR/runtime/vibe" "$stage/tc/bin/vibe"
+  cp "$ROOT_DIR/scripts/vibe_pkg.sh" "$ROOT_DIR/scripts/parallel_warm_pool.sh" "$stage/tc/lib/"
+  cp "$ROOT_DIR/lib/@vibe/console/index.vpkg" "$stage/tc/lib/@vibe/console/"
+  printf '@vibe/console\tpkg:sha1:0000000000000000000000000000000000000000\n' > "$stage/tc/stdlib-hashes.tsv"
+  printf 'context pack of release %s\n' "$version" > "$stage/tc/lib/context-pack.md"
+  tar -czf "$d/vibe-toolchain-$tag.tar.gz" -C "$stage/tc" bin lib stdlib-hashes.tsv
+  printf 'fake-wasm %s\n' "$version" > "$d/vibe-compiler-$tag.wasm"
+  write_manifest "$d" "$version" "$rtarget"
+  if [ "$latest" = latest ]; then
+    mkdir -p "$REL/latest/download"
+    cp "$d/release-manifest.json" "$REL/latest/download/release-manifest.json"
+  fi
+}
+
+mk_release 0.9.9
+mk_release 1.0.0 latest
+
+# A PATH with bash, curl, tar and the POSIX utilities the scripts use, and
+# nothing that builds: no git, no cargo, no node.
+lean="$WORK/lean-bin"
+mkdir -p "$lean"
+for cmd in bash curl tar gzip sha256sum shasum sed mkdir mv rm cp chmod uname tr cut date cat dirname basename readlink ln grep head awk mktemp env; do
+  p="$(command -v "$cmd" 2>/dev/null || true)"
+  [ -n "$p" ] && ln -s "$p" "$lean/$cmd"
+done
+for forbidden in git cargo node; do
+  [ ! -e "$lean/$forbidden" ] || { echo "FAIL: $forbidden must not be on the lean PATH" >&2; exit 1; }
+done
+
+home="$WORK/home"
+( cd "$WORK" && env -i PATH="$lean" HOME="$WORK/fakehome" TMPDIR="$WORK/tmp" \
+    VIBE_HOME="$home" VIBE_BIN_DIR="$WORK/bin" VIBE_RELEASE_URL="$RELEASE_URL" \
+    bash "$ROOT_DIR/install/install.sh" --version 0.9.9 --no-modify-path ) > "$WORK/install.log" 2>&1 && rc=0 || rc=$?
+check "install.sh --version installs with bash, curl and tar" "0" "$rc"
+[ "$rc" = 0 ] || sed 's/^/  | /' "$WORK/install.log" >&2
+tc="$home/toolchains/0.9.9"
+check "release install lays out the toolchain" "yes" "$([ -x "$tc/bin/vibe" ] && [ -x "$tc/bin/viberun" ] && [ -s "$tc/lib/vibe-cli.wasm" ] && [ -s "$tc/lib/vibe-cli.cwasm" ] && [ -f "$tc/lib/vibe_pkg.sh" ] && [ -f "$tc/lib/@vibe/console/index.vpkg" ] && [ -f "$tc/lib/context-pack.md" ] && echo yes || echo no)"
+check "release install writes the manifest" "yes" "$(grep -q '"source": "release"' "$tc/manifest.json" && grep -q '"version": "0.9.9"' "$tc/manifest.json" && grep -q '"ref": "v0.9.9"' "$tc/manifest.json" && grep -q '"commit": "0123456789abcdef0123456789abcdef01234567"' "$tc/manifest.json" && echo yes || echo no)"
+check "release install writes the dispatcher, env and default" "yes" "$([ -x "$home/bin/vibe" ] && [ -f "$home/env" ] && [ "$(cat "$home/toolchain")" = 0.9.9 ] && [ -L "$WORK/bin/vibe" ] && echo yes || echo no)"
+check "the assets stay in the download cache" "yes" "$([ -f "$home/cache/downloads/v0.9.9/release-manifest.json" ] && [ -f "$home/cache/downloads/v0.9.9/vibe-toolchain-v0.9.9.tar.gz" ] && [ -f "$home/cache/downloads/v0.9.9/viberun-v0.9.9-$TARGET.tar.gz" ] && echo yes || echo no)"
+check "no staging directory is left behind" "yes" "$([ -z "$(ls -d "$home/toolchains"/.staging-* 2>/dev/null)" ] && echo yes || echo no)"
+VIBE="$home/bin/vibe"
+version_line="$("$VIBE" version 2>/dev/null | sed -n '1p')"
+check "vibe version reports the release" "yes" "$(printf '%s\n' "$version_line" | grep -qF 'vibe 0.9.9 (toolchain 0.9.9: release v0.9.9@0123456789ab' && echo yes || echo no)"
+
+# self update latest -> 1.0.0, and it becomes the default.
+VIBE_RELEASE_URL="$RELEASE_URL" "$VIBE" self update latest > "$WORK/update1.log" 2>&1 && rc=0 || rc=$?
+check "vibe self update latest exit" "0" "$rc"
+[ "$rc" = 0 ] || sed 's/^/  | /' "$WORK/update1.log" >&2
+check "self update latest resolved 1.0.0 and switched the default" "yes" "$([ -f "$home/toolchains/1.0.0/manifest.json" ] && [ "$(cat "$home/toolchain")" = 1.0.0 ] && grep -q 'latest release is 1.0.0' "$WORK/update1.log" && echo yes || echo no)"
+list_out="$("$VIBE" toolchain list 2>/dev/null || true)"
+check "vibe toolchain list shows both, the new one default" "yes" "$(printf '%s\n' "$list_out" | grep -qE '^\* 1\.0\.0[[:space:]]' && printf '%s\n' "$list_out" | grep -qE '^  0\.9\.9[[:space:]]' && echo yes || echo no)"
+
+# An installed version is refused without --force; --force reinstalls.
+VIBE_RELEASE_URL="$RELEASE_URL" "$VIBE" self update 1.0.0 > "$WORK/update2.log" 2>&1 && rc=0 || rc=$?
+check "self update of an installed version is refused" "yes" "$([ "$rc" != 0 ] && grep -q -- '--force' "$WORK/update2.log" && [ -f "$home/toolchains/1.0.0/manifest.json" ] && echo yes || echo no)"
+VIBE_RELEASE_URL="$RELEASE_URL" "$VIBE" self update 1.0.0 --force > "$WORK/update3.log" 2>&1 && rc=0 || rc=$?
+check "self update --force reinstalls" "yes" "$([ "$rc" = 0 ] && [ -f "$home/toolchains/1.0.0/manifest.json" ] && echo yes || echo no)"
+
+# --no-default installs without switching.
+VIBE_RELEASE_URL="$RELEASE_URL" "$VIBE" self update 0.9.9 --force --no-default > "$WORK/update4.log" 2>&1 && rc=0 || rc=$?
+check "self update --no-default keeps the default" "yes" "$([ "$rc" = 0 ] && [ "$(cat "$home/toolchain")" = 1.0.0 ] && echo yes || echo no)"
+
+# A tampered runner tarball is refused before anything is moved.
+mk_release 1.0.1
+printf 'tamper\n' >> "$REL/download/v1.0.1/viberun-v1.0.1-$TARGET.tar.gz"
+VIBE_RELEASE_URL="$RELEASE_URL" "$VIBE" self update 1.0.1 > "$WORK/update5.log" 2>&1 && rc=0 || rc=$?
+check "a tampered runner tarball is refused" "yes" "$([ "$rc" != 0 ] && grep -q 'does not match the release manifest' "$WORK/update5.log" && echo yes || echo no)"
+check "a refused update moves nothing into toolchains/" "yes" "$([ ! -e "$home/toolchains/1.0.1" ] && [ -z "$(ls -d "$home/toolchains"/.staging-* 2>/dev/null)" ] && [ "$(cat "$home/toolchain")" = 1.0.0 ] && echo yes || echo no)"
+check "the mismatching download is dropped from the cache" "yes" "$([ ! -e "$home/cache/downloads/v1.0.1/viberun-v1.0.1-$TARGET.tar.gz" ] && echo yes || echo no)"
+
+# A tampered toolchain bundle is refused by the installer's own check too.
+mk_release 1.0.2
+printf 'tamper\n' >> "$REL/download/v1.0.2/vibe-toolchain-v1.0.2.tar.gz"
+home2="$WORK/home2"
+( cd "$WORK" && env -i PATH="$lean" HOME="$WORK/fakehome" TMPDIR="$WORK/tmp" VIBE_HOME="$home2" VIBE_RELEASE_URL="$RELEASE_URL" \
+    bash "$ROOT_DIR/install/install.sh" --version 1.0.2 --no-modify-path --no-link ) > "$WORK/install2.log" 2>&1 && rc=0 || rc=$?
+check "install.sh refuses a tampered toolchain bundle" "yes" "$([ "$rc" != 0 ] && grep -q 'does not match the release manifest' "$WORK/install2.log" && [ ! -e "$home2/toolchains" ] && [ ! -e "$home2/bin" ] && echo yes || echo no)"
+
+# A release with no runner for this host names the targets it ships.
+mk_release 1.0.3 "" nonexistent-target
+VIBE_RELEASE_URL="$RELEASE_URL" "$VIBE" self update 1.0.3 > "$WORK/update6.log" 2>&1 && rc=0 || rc=$?
+check "a release without a runner for this host is refused, naming the targets" "yes" "$([ "$rc" != 0 ] && grep -q "ships no runner for $TARGET" "$WORK/update6.log" && grep -q 'nonexistent-target' "$WORK/update6.log" && [ ! -e "$home/toolchains/1.0.3" ] && echo yes || echo no)"
+
+# An unknown version is refused with the URL that was tried.
+VIBE_RELEASE_URL="$RELEASE_URL" "$VIBE" self update 7.7.7 > "$WORK/update7.log" 2>&1 && rc=0 || rc=$?
+check "an unpublished version is refused" "yes" "$([ "$rc" != 0 ] && grep -q 'is 7.7.7 a published release' "$WORK/update7.log" && echo yes || echo no)"
+
+# A flat home is refused by release mode as well.
+flat="$WORK/flat"
+mkdir -p "$flat/bin" "$flat/lib"
+printf 'fake\n' > "$flat/lib/vibe-cli.wasm"
+( cd "$WORK" && env -i PATH="$lean" HOME="$WORK/fakehome" TMPDIR="$WORK/tmp" VIBE_HOME="$flat" VIBE_RELEASE_URL="$RELEASE_URL" \
+    bash "$ROOT_DIR/install/install.sh" --version 0.9.9 --no-modify-path --no-link ) > "$WORK/install3.log" 2>&1 && rc=0 || rc=$?
+check "install.sh --version refuses a flat-layout VIBE_HOME" "yes" "$([ "$rc" != 0 ] && grep -q 'flat' "$WORK/install3.log" && [ ! -e "$flat/toolchains" ] && echo yes || echo no)"
+
+echo "[test] $pass passed, $fail failed"
+[ "$fail" -eq 0 ] || exit 1


### PR DESCRIPTION
Closes #2678 (phase 4 of #2674; contract: `docs/toolchain-layout.md` sections 3 and 9, ADR-0111).

## What changes

**Before:** a release published the compiler wasm, its module source, the seed json, a manifest and checksums, and no runner binary, so installing needed git, cargo and Node.js, and the only update path was `vibe self update --cli-wasm <local path>`.

**Release assets** (`scripts/build_release_assets.sh`, `release.yml`). A `runners` matrix builds `viberun` natively per target (`x86_64-unknown-linux-gnu`, `aarch64-unknown-linux-gnu`, `aarch64-apple-darwin`, and `x86_64-apple-darwin` while GitHub hosts an Intel runner; that leg may fail without failing the release) and uploads `viberun-<tag>-<target>.tar.gz`. The release job downloads them and adds `vibe-toolchain-<tag>.tar.gz`, the platform-independent part of a toolchain directory: launcher, `vibe_pkg.sh`, `parallel_warm_pool.sh`, the LSP scripts, the context pack, and the six user-facing stdlib packages with their package hashes (computed by the release's own compiler through the node host runner). `release-manifest.json` lists every asset with its sha256, the runner per target, the toolchain bundle, the compiler wasm and the wasmtime version the runners embed. After publishing, a `release-install` job installs the published release on ubuntu and macOS through the curl entry point and runs a program with it.

**Launcher.** `vibe self update [<version>|latest] [--no-default] [--force]` resolves the tag (`latest` through the newest release's manifest), downloads the runner for this host, the toolchain bundle and the compiler wasm into `$VIBE_HOME/cache/downloads/<tag>/`, verifies each against the manifest before anything is moved (a mismatch drops the download and stops), unpacks into a staging directory under `toolchains/`, runs `viberun --precompile`, writes `manifest.json` (source `release`), renames into `toolchains/<version>/` and makes it the default unless `--no-default`. An installed version is refused without `--force`; a release with no runner for this host names the targets it ships. `VIBE_RELEASE_URL` overrides the download base. `--cli-wasm <path>` stays the offline compiler swap. Verbs that run no wasm (`self`, `toolchain`, `root`, `clean`, `new`, `version`, `help`) no longer require a runner at startup, which lets a launcher extracted from a release bundle drive the install.

**Installer.** `--version X.Y.Z|latest` (or `VIBE_INSTALL_VERSION`) is the release mode: fetch the manifest and the toolchain bundle into the download cache, verify the bundle, extract the release's launcher from it and hand over to its `self update` (one implementation of download/verify/stage), then write the dispatcher, the default marker and the env file as a checkout install does. Those writers and the flat-home refusal are now functions shared by both modes. The bare curl entry point stays in checkout mode until a release is published.

## Tests

`tests/integration/install/release_install_test.sh` (also `pkf run test-release-install`, and in the cli-install `install` group) builds a synthetic release directory served over `file://` (manifest, tarballs, a fake runner that only knows `--precompile`) and asserts: `install.sh --version` installs with a PATH of bash, curl, tar and POSIX utilities and no git, cargo or node; `vibe version` reports the release; `self update latest` installs and switches, `--no-default` does not, `--force` reinstalls, an installed version is refused; a tampered runner tarball and a tampered toolchain bundle are refused before anything moves into `toolchains/` (no staging leftovers, the default untouched, the mismatching download dropped); a release without a runner for this host names its targets; an unpublished version and a flat-layout home are refused.

## Docs

`docs/install.md` (release install, from-source install, updating), `docs/cli-commands.md`, the release notes' install requirements, `docs/toolchain-layout.md` marks phase 4 implemented. Folding that contract file into `install.md` and moving ADR-0111 to `accepted` is the epic's close-out, after this lands.

## Verification

`release_install_test.sh` (20/20), `install_test.sh` (92/92), `curl_bootstrap_test.sh`, `scripts/test_vibe_root.sh`, the toolchain-bundle section of the asset builder run against the built compiler wasm (91 entries, six stdlib hashes), the doc gates (path citations, commands, classification, book links), selector precedence, gate portability and self-tests, task inputs, CI seed cache. The runner matrix and the post-publish install job run on the next `v*` tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019vCFHoPYJxzou2BsMeWU1S

---
_Generated by [Claude Code](https://claude.ai/code/session_019vCFHoPYJxzou2BsMeWU1S)_