### PR TITLE
Fix the 419 remaining `2>/dev/null >&2` diag-swallowing redirections; guard it in the portability gate (#2688)

### DIFF
--- a/scripts/build_compile_only.sh
+++ b/scripts/build_compile_only.sh
@@ -114,11 +114,11 @@ if ! (
       "$COMPILER" "$MODULE_SOURCE" "$OUT" cli_main_compile_only >"$STEM.compile.log" 2>&1
 ); then
   echo "build_compile_only: compile failed:" >&2
-  cat "$OUT.diag" 2>/dev/null >&2 || true
+  cat "$OUT.diag" >&2 2>/dev/null || true
   tail -40 "$STEM.compile.log" >&2
   exit 1
 fi
-[ -s "$OUT" ] || { echo "build_compile_only: no output: $OUT" >&2; cat "$OUT.diag" 2>/dev/null >&2 || true; exit 1; }
+[ -s "$OUT" ] || { echo "build_compile_only: no output: $OUT" >&2; cat "$OUT.diag" >&2 2>/dev/null || true; exit 1; }
 # A non-empty file is not a compiler: a hijacked verb writes text there. The
 # output must start with the wasm magic.
 if [ "$(head -c 4 "$OUT" | od -An -tx1 | tr -d ' \n')" != "0061736d" ]; then

--- a/scripts/check_cheatsheet_signatures.sh
+++ b/scripts/check_cheatsheet_signatures.sh
@@ -111,7 +111,7 @@ env VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   "$PROBE" "$WORK/probe.wasm" main >/dev/null 2>&1 || true
 if [ ! -s "$WORK/probe.wasm" ]; then
   echo "cheatsheet-signatures: FAIL: the probe did not compile" >&2
-  head -3 "$WORK/probe.wasm.diag" 2>/dev/null >&2 || true
+  head -3 "$WORK/probe.wasm.diag" >&2 2>/dev/null || true
   exit 1
 fi
 # The probe's exit status is load-bearing, so it is NOT discarded. If it emits
@@ -125,7 +125,7 @@ env VIBE_PREOPEN_DIR="$ROOT_DIR" CHEATSHEET_SIG_INPUT="_build/_cheatsheet_sig/pa
   > "$WORK/actual.tsv" 2>"$WORK/probe.err" || probe_rc=$?
 if [ "$probe_rc" -ne 0 ]; then
   echo "cheatsheet-signatures: FAIL: the probe exited $probe_rc after emitting $(grep -c '' "$WORK/actual.tsv" 2>/dev/null || echo 0) of $pair_count rows" >&2
-  head -3 "$WORK/probe.err" 2>/dev/null >&2 || true
+  head -3 "$WORK/probe.err" >&2 2>/dev/null || true
   exit 1
 fi
 if [ ! -s "$WORK/actual.tsv" ]; then

--- a/scripts/check_compile_only_lanes_test.sh
+++ b/scripts/check_compile_only_lanes_test.sh
@@ -109,7 +109,7 @@ LEAK="$TMP/leak.wasm"
 env $(sed -n '/^VIBE_SELECTOR_ORDER="/,/"$/p' "$ROOT_DIR/runtime/vibe" | tr -d '"' | sed 's/^VIBE_SELECTOR_ORDER=//' | sed 's/\(VIBE_[A-Z_]*\)/-u \1/g') \
   -u VIBE_RC VIBE_WASM_NAMES=1 VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$STAGE2" "$LEAK_SRC" "$LEAK" main >"$TMP/leak.build.log" 2>&1 || true
-[ -s "$LEAK" ] || { echo "check_compile_only_lanes_test: FAIL (leak): probe did not compile" >&2; cat "$LEAK.diag" 2>/dev/null >&2; exit 1; }
+[ -s "$LEAK" ] || { echo "check_compile_only_lanes_test: FAIL (leak): probe did not compile" >&2; cat "$LEAK.diag" >&2 2>/dev/null; exit 1; }
 node scripts/wasm_func_sizes.mjs "$LEAK" --top 1000000 | grep -q 'compile_file_fs_mode_gc' \
   || { echo "check_compile_only_lanes_test: FAIL (leak): the probe's name section lacks compile_file_fs_mode_gc, so the mutation did not hit" >&2; exit 1; }
 expect_fail leak "still defines functions of a dropped lane" --scan-only "$LEAK"

--- a/scripts/check_gate_portability.sh
+++ b/scripts/check_gate_portability.sh
@@ -23,6 +23,17 @@
 #      formatter entry points, so `pkf run fmt` and `bash scripts/
 #      check_vibe_fmt.sh` did not run on a supported contributor platform.
 #
+#   4. `cmd 2>/dev/null >&2` sends the message to /dev/null, not to stderr
+#      (#2688). Redirections apply left to right: `2>/dev/null` points stderr
+#      at /dev/null, then `>&2` dups stdout onto THAT -- so a sidecar the
+#      caller meant to surface (`cat "$out.diag" 2>/dev/null >&2`) is
+#      discarded and only the generic failure line ("... did not compile")
+#      shows. The fix is the reverse order, `>&2 2>/dev/null`. This is a
+#      correctness defect rather than a portability one, but it is lexical and
+#      shares the machinery, and it had reached 419 sites across runtime,
+#      scripts, tests and install, so it is scanned across every directory the
+#      idiom reached, not just scripts/.
+#
 # All are lexical, so all are decidable from the text.
 set -euo pipefail
 
@@ -147,10 +158,55 @@ findings="$(
   ' "${scan_files[@]}"
 )"
 
+# 4. The diag-swallowing redirection `2>/dev/null >&2` (#2688), scanned across
+#    every directory the idiom reached -- not just scripts/, because the
+#    launcher (runtime/), the gate runners (tests/gates/) and the installer
+#    (install/) all cat a `.diag` sidecar on a failure path. `*.mjs` too: the
+#    same order is just as broken inside a shell string handed to a node child
+#    process. Same self-exclusion and whole-line-comment skip as above, so the
+#    one comment that documents the historical bug (install_test.sh) is not a
+#    finding.
+diag_scan_files=()
+for d in runtime scripts tests install .github .claude; do
+  [ -d "$ROOT/$d" ] || continue
+  while IFS= read -r f; do
+    case "$(basename "$f")" in "$SELF" | "$SELF_TEST") continue ;; esac
+    diag_scan_files+=("$f")
+  done < <(find "$ROOT/$d" -type f \( -name '*.sh' -o -name '*.mjs' \))
+done
+
+if [ "${#diag_scan_files[@]}" -gt 0 ]; then
+  diag_findings="$(
+    awk -v root="$ROOT/" '
+      FNR == 1 { rel = FILENAME; sub("^" root, "", rel) }
+
+      # Whole-line comments (sh # or mjs //) carry no behaviour, and one of
+      # them deliberately shows the broken form to document the bug.
+      /^[[:space:]]*(#|\/\/)/ { next }
+
+      # `2>/dev/null` then `>&2` (or the `1>&2` synonym), any run of blanks
+      # between. The reverse order `>&2 2>/dev/null` and the correct
+      # discard-both `>/dev/null 2>&1` both have a different token order and do
+      # not match.
+      /2>[[:space:]]*\/dev\/null[[:space:]]+1?>&2/ {
+        printf "  %s:%d: `2>/dev/null >&2` sends the message to /dev/null (redirections apply left to right) -- write `>&2 2>/dev/null` so the content reaches stderr and only the missing-file error is dropped (#2688)\n", rel, FNR
+      }
+    ' "${diag_scan_files[@]}"
+  )"
+  if [ -n "$diag_findings" ]; then
+    if [ -n "$findings" ]; then
+      findings="$findings
+$diag_findings"
+    else
+      findings="$diag_findings"
+    fi
+  fi
+fi
+
 if [ -n "$findings" ]; then
   echo "[gate-portability] FAIL: gates that cannot run, or patterns that do not mean what they say:" >&2
   printf '%s\n' "$findings" >&2
   exit 1
 fi
 
-echo "[gate-portability] ok (no ripgrep dependency; no bash 4 mapfile; no bare sed -i; no uninterpreted \\t in grep patterns)"
+echo "[gate-portability] ok (no ripgrep dependency; no bash 4 mapfile; no bare sed -i; no uninterpreted \\t in grep patterns; no 2>/dev/null >&2 diag-swallow)"

--- a/scripts/check_gate_portability_test.sh
+++ b/scripts/check_gate_portability_test.sh
@@ -183,4 +183,31 @@ if VIBE_GATE_PORTABILITY_ROOT="$TMP_ROOT/nowhere" bash "$CHECK" >"$TMP_ROOT/out"
 fi
 ok "a missing scan directory fails rather than passing vacuously"
 
+# --- red 7: the diag-swallowing redirection `2>/dev/null >&2` (#2688). The
+# redirections apply left to right, so `2>/dev/null` points stderr at
+# /dev/null and `>&2` then dups stdout onto that -- the sidecar goes to
+# /dev/null and only the caller's generic line shows.
+reset_tree
+printf '%s\n' 'cat "$out.diag" 2>/dev/null >&2 || true' >> "$TMP_ROOT/scripts/clean.sh"
+grep -qF 'cat "$out.diag" 2>/dev/null >&2' "$TMP_ROOT/scripts/clean.sh" || fail "fixture 7 did not land"
+run && { cat "$TMP_ROOT/out" >&2; fail "the 2>/dev/null >&2 diag-swallow was accepted"; }
+grep -qF 'sends the message to /dev/null' "$TMP_ROOT/out" || { cat "$TMP_ROOT/out" >&2; fail "diag-swallow finding did not name the reason"; }
+ok "the 2>/dev/null >&2 diag-swallowing redirection is rejected"
+
+# --- green guard for 7: the corrected order must pass, or the rule could be
+# satisfied by rejecting every redirection to stderr.
+reset_tree
+printf '%s\n' 'cat "$out.diag" >&2 2>/dev/null || true' >> "$TMP_ROOT/scripts/clean.sh"
+printf '%s\n' 'foo >/dev/null 2>&1 || true' >> "$TMP_ROOT/scripts/clean.sh"
+run || { cat "$TMP_ROOT/out" >&2; fail "the corrected >&2 2>/dev/null form (or >/dev/null 2>&1) was rejected"; }
+ok "the corrected >&2 2>/dev/null form and the discard-both >/dev/null 2>&1 both pass"
+
+# --- red 7b: the checker must not flag the idiom in a whole-line comment. One
+# such comment documents the historical bug in install_test.sh, and rewriting
+# it to the correct order would make the sentence false.
+reset_tree
+printf '%s\n' '# cat "$x.diag" 2>/dev/null >&2 sent the message to /dev/null (historical, #2688)' >> "$TMP_ROOT/scripts/clean.sh"
+run || { cat "$TMP_ROOT/out" >&2; fail "a comment documenting the 2>/dev/null >&2 bug was rejected"; }
+ok "the 2>/dev/null >&2 idiom in a whole-line comment is not a finding"
+
 echo "[gate-portability-test] ok"

--- a/scripts/compiler_differential.sh
+++ b/scripts/compiler_differential.sh
@@ -89,7 +89,7 @@ for spec in "${inputs[@]}"; do
     # than a skip: an input that compares nothing must not look like
     # agreement. (This is how bench/binary_size got its `=main` entries.)
     echo "[differential] FAIL: $input compiled by NEITHER build (wrong entry '$entry'?)" >&2
-    cat "$new_out.diag" 2>/dev/null >&2 || true
+    cat "$new_out.diag" >&2 2>/dev/null || true
     status=1
     continue
   fi

--- a/scripts/coverage_unittests.sh
+++ b/scripts/coverage_unittests.sh
@@ -59,10 +59,10 @@ for f in lib/@vibe/compiler/*_test.vibe; do
     VIBE_PREOPEN_DIR="$ROOT" VIBE_IMPORT_ABI=raw \
     bash "$RUNNER" --invoke cli_main "$COMPILER_COV" \
     "$COMPILER_ENTRY" "$d/src.vibe" cov_driver_main >"$d/expose.log" 2>&1 || true
-  [ -s "$d/src.vibe" ] || { echo "[ut:$base] exact-path exposure failed" >&2; cat "$d/src.vibe.diag" 2>/dev/null >&2 || tail -3 "$d/expose.log" >&2; exit 1; }
+  [ -s "$d/src.vibe" ] || { echo "[ut:$base] exact-path exposure failed" >&2; cat "$d/src.vibe.diag" >&2 2>/dev/null || tail -3 "$d/expose.log" >&2; exit 1; }
   compile_status=0
   coverage_driver_compile_with_retries "$d" cov_driver_main || compile_status=$?
-  [ "$compile_status" = 0 ] || { echo "[ut:$base] compile failed (status $compile_status)" >&2; cat "$d/m.wasm.diag" 2>/dev/null >&2 || tail -3 "$d/compile.log" >&2; exit 1; }
+  [ "$compile_status" = 0 ] || { echo "[ut:$base] compile failed (status $compile_status)" >&2; cat "$d/m.wasm.diag" >&2 2>/dev/null || tail -3 "$d/compile.log" >&2; exit 1; }
   cov="$d/cov.json"
   VIBE_COV_OUT="$cov" VIBE_COV_RAW=1 VIBE_PREOPEN_DIR="$ROOT" bash "$RUNNER" --invoke _start "$d/m.wasm" >"$d/run.log" 2>&1 || {
     echo "[ut:$base] execution failed" >&2; tail -5 "$d/run.log" >&2; exit 1

--- a/scripts/dep_order_oracle.sh
+++ b/scripts/dep_order_oracle.sh
@@ -88,7 +88,7 @@ for seed in $SEEDS; do
     "$STAGE2" "$INPUT" "$out" "$ENTRY" >/dev/null 2>&1 || true
   if [ ! -s "$out" ]; then
     echo "[dep-order-oracle] FAIL: seed=$seed did not compile $INPUT" >&2
-    cat "$out.diag" 2>/dev/null >&2 || true
+    cat "$out.diag" >&2 2>/dev/null || true
     exit 1
   fi
   size="$(wc -c < "$out")"

--- a/scripts/size_ratchet.sh
+++ b/scripts/size_ratchet.sh
@@ -42,7 +42,7 @@ for src in bench/binary_size/*.vibe; do
     "$src" "$out" main >/dev/null 2>&1 || true
   if [ ! -s "$out" ]; then
     echo "[size-ratchet] FAIL: binary_size sample did not compile: $src" >&2
-    cat "$out.diag" 2>/dev/null >&2 || true
+    cat "$out.diag" >&2 2>/dev/null || true
     exit 1
   fi
   printf '%s %s\n' "$name" "$(wc -c < "$out")" >> "$measured"

--- a/scripts/test_http_body_read_probe_gate.sh
+++ b/scripts/test_http_body_read_probe_gate.sh
@@ -351,7 +351,7 @@ VIBE_PREOPEN_DIR="$PROJECT_ROOT" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   "$EMITTER_COMPILER" "$OUT_DIR/emit.vibe" "$OUT_DIR/emit.wasm" main >/dev/null 2>&1 || true
 if [ ! -s "$OUT_DIR/emit.wasm" ]; then
   echo "[body-read-probe] FAILED: the emitter program did not compile" >&2
-  cat "$OUT_DIR/emit.wasm.diag" 2>/dev/null >&2 || true
+  cat "$OUT_DIR/emit.wasm.diag" >&2 2>/dev/null || true
   exit 1
 fi
 VIBE_PREOPEN_DIR="$PROJECT_ROOT" bash "$PROJECT_ROOT/scripts/run_wasm_vibe_host_runner.sh" \

--- a/scripts/test_serve_async_lift_gate.sh
+++ b/scripts/test_serve_async_lift_gate.sh
@@ -117,7 +117,7 @@ VIBE_PREOPEN_DIR="$PROJECT_ROOT" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   "$CLI_WASM" "$OUT_DIR/emit.vibe" "$OUT_DIR/emit.wasm" main >/dev/null 2>&1 || true
 if [ ! -s "$OUT_DIR/emit.wasm" ]; then
   echo "[serve-async] FAILED: the componentizer program did not compile" >&2
-  cat "$OUT_DIR/emit.wasm.diag" 2>/dev/null >&2 || true
+  cat "$OUT_DIR/emit.wasm.diag" >&2 2>/dev/null || true
   exit 1
 fi
 VIBE_PREOPEN_DIR="$PROJECT_ROOT" bash "$SCRIPT_DIR/run_wasm_vibe_host_runner.sh" \

--- a/scripts/test_serve_body_stream_gate.sh
+++ b/scripts/test_serve_body_stream_gate.sh
@@ -142,7 +142,7 @@ env VIBE_SERVE_COMPONENT=1 VIBE_PREOPEN_DIR="$PROJECT_ROOT" VIBE_IMPORT_ABI=raw 
   "${UNUSED_BODY_SRC#"$PROJECT_ROOT"/}" "${UNUSED_BODY_COMPONENT#"$PROJECT_ROOT"/}" main >/dev/null 2>&1 || true
 if [ ! -s "$UNUSED_BODY_COMPONENT" ]; then
   echo "[serve-body] FAILED: a signature-selected stream handler with an unused body did not componentize" >&2
-  cat "$UNUSED_BODY_COMPONENT.diag" 2>/dev/null >&2 || true
+  cat "$UNUSED_BODY_COMPONENT.diag" >&2 2>/dev/null || true
   exit 1
 fi
 wasm-tools validate --features all "$UNUSED_BODY_COMPONENT" >/dev/null
@@ -172,7 +172,7 @@ env VIBE_RC=0 VIBE_PREOPEN_DIR="$PROJECT_ROOT" VIBE_IMPORT_ABI=raw \
   "${ORDINARY_STREAM_SRC#"$PROJECT_ROOT"/}" "${ORDINARY_STREAM_CORE#"$PROJECT_ROOT"/}" __no_entry__ >/dev/null 2>&1 || true
 if [ ! -s "$ORDINARY_STREAM_CORE" ]; then
   echo "[serve-body] FAILED: the ordinary HostStream export did not compile" >&2
-  cat "$ORDINARY_STREAM_CORE.diag" 2>/dev/null >&2 || true
+  cat "$ORDINARY_STREAM_CORE.diag" >&2 2>/dev/null || true
   exit 1
 fi
 if LC_ALL=C grep -a -q 'vibe.tagmode' "$ORDINARY_STREAM_CORE"; then
@@ -194,7 +194,7 @@ serve_handler() {
     "${src#"$PROJECT_ROOT"/}" "${component#"$PROJECT_ROOT"/}" main >/dev/null 2>&1 || true
   if [ ! -s "$component" ]; then
     echo "[serve-body] FAILED: the serve path produced no component for $tag" >&2
-    cat "$component.diag" 2>/dev/null >&2 || true
+    cat "$component.diag" >&2 2>/dev/null || true
     exit 1
   fi
   wasm-tools validate --features all "$component" >/dev/null
@@ -418,7 +418,7 @@ env VIBE_SERVE_COMPONENT=1 VIBE_PREOPEN_DIR="$PROJECT_ROOT" VIBE_IMPORT_ABI=raw 
   "${CLOSE_SRC#"$PROJECT_ROOT"/}" "${CLOSE_COMPONENT#"$PROJECT_ROOT"/}" main >/dev/null 2>&1 || true
 if [ ! -s "$CLOSE_COMPONENT" ]; then
   echo "[serve-body] FAILED: an early-closing handler did not componentize" >&2
-  cat "$CLOSE_COMPONENT.diag" 2>/dev/null >&2 || true
+  cat "$CLOSE_COMPONENT.diag" >&2 2>/dev/null || true
   exit 1
 fi
 CLOSE_CORE_WIT="$(wasm-tools print "$CLOSE_COMPONENT")"

--- a/scripts/test_wasi_http_p3_full_gate.sh
+++ b/scripts/test_wasi_http_p3_full_gate.sh
@@ -81,7 +81,7 @@ env VIBE_SERVE_COMPONENT=1 VIBE_PREOPEN_DIR="$PROJECT_ROOT" VIBE_IMPORT_ABI=raw 
   "${HANDLER_SRC#"$PROJECT_ROOT"/}" "${COMPONENT#"$PROJECT_ROOT"/}" main >/dev/null 2>&1 || true
 if [ ! -s "$COMPONENT" ]; then
   echo "[http-full-gate] FAIL: handler componentization produced nothing" >&2
-  cat "$COMPONENT.diag" 2>/dev/null >&2 || true
+  cat "$COMPONENT.diag" >&2 2>/dev/null || true
   exit 1
 fi
 wasm-tools validate --features all "$COMPONENT" >/dev/null

--- a/tests/gates/early/run.sh
+++ b/tests/gates/early/run.sh
@@ -618,7 +618,7 @@ VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   "$cdir/ok.vibe" "$cdir/ok.wasm" _start >/dev/null 2>&1 || true
 if [ ! -s "$cdir/ok.wasm" ]; then
   echo "[compiler-gate] FAIL: contract package import did not compile (#729)" >&2
-  cat "$cdir/ok.wasm.diag" 2>/dev/null >&2; exit 1
+  cat "$cdir/ok.wasm.diag" >&2 2>/dev/null; exit 1
 fi
 if [ -s "$cdir/ok.wasm.diag" ]; then
   echo "[compiler-gate] FAIL: cold contract compile left a stale .diag beside a valid wasm (#749 first-pass ingestion failure)" >&2
@@ -633,7 +633,7 @@ if VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
 fi
 if ! grep -q "package boundary" "$cdir/bad.wasm.diag" 2>/dev/null; then
   echo "[compiler-gate] FAIL: boundary rejection lacks the expected diagnostic (#729)" >&2
-  cat "$cdir/bad.wasm.diag" 2>/dev/null >&2; exit 1
+  cat "$cdir/bad.wasm.diag" >&2 2>/dev/null; exit 1
 fi
 rm -rf "$cdir"
 echo "[compiler-gate] contract package + boundary regression ok"
@@ -657,7 +657,7 @@ VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   "$gsdir/ok.vibe" "$gsdir/ok.wasm" _start >/dev/null 2>&1 || true
 if [ ! -s "$gsdir/ok.wasm" ]; then
   echo "[compiler-gate] FAIL: contract-correct 'type Box[T]' arity was rejected (over-reject)" >&2
-  cat "$gsdir/ok.wasm.diag" 2>/dev/null >&2; exit 1
+  cat "$gsdir/ok.wasm.diag" >&2 2>/dev/null; exit 1
 fi
 printf 'version 0.0.1\nimport ./box.vibe {}\ntype Box\nfn Box::wrap[T](v: T) -> Box[T]\n' > "$gsdir/pkg/index.vibei"
 if VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
@@ -668,7 +668,7 @@ if VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
 fi
 if ! grep -q "arity mismatch" "$gsdir/bad.wasm.diag" 2>/dev/null; then
   echo "[compiler-gate] FAIL: struct arity mismatch rejection lacks the expected diagnostic" >&2
-  cat "$gsdir/bad.wasm.diag" 2>/dev/null >&2; exit 1
+  cat "$gsdir/bad.wasm.diag" >&2 2>/dev/null; exit 1
 fi
 rm -rf "$gsdir"
 echo "[compiler-gate] generic-struct contract arity regression ok"
@@ -688,7 +688,7 @@ VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   "$stdir/ok.vibe" "$stdir/ok.wasm" _start >/dev/null 2>&1 || true
 if [ ! -s "$stdir/ok.wasm" ]; then
   echo "[compiler-gate] FAIL: explicit struct type args (#886) did not compile" >&2
-  cat "$stdir/ok.wasm.diag" 2>/dev/null >&2; exit 1
+  cat "$stdir/ok.wasm.diag" >&2 2>/dev/null; exit 1
 fi
 if ! VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh --invoke _start "$stdir/ok.wasm" >/dev/null 2>&1; then
   echo "[compiler-gate] FAIL: explicit struct type args (#886) compiled but trapped at runtime" >&2; exit 1
@@ -702,7 +702,7 @@ if VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
 fi
 if ! grep -q "expects 1 type argument(s), got 2" "$stdir/arity.wasm.diag" 2>/dev/null; then
   echo "[compiler-gate] FAIL: type-arg arity rejection lacks the expected diagnostic (#886)" >&2
-  cat "$stdir/arity.wasm.diag" 2>/dev/null >&2; exit 1
+  cat "$stdir/arity.wasm.diag" >&2 2>/dev/null; exit 1
 fi
 printf 'struct Pair[T] {\n  a: T;\n  b: T\n}\n\nexport let _start: () -> Unit with Stdout = () -> {\n  let p = Pair[String]::{ a: 1, b: 2 }\n  assert_eq(p.a, "x")\n}\n' > "$stdir/pin.vibe"
 if VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
@@ -713,7 +713,7 @@ if VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
 fi
 if ! grep -q "struct field type mismatch for a" "$stdir/pin.wasm.diag" 2>/dev/null; then
   echo "[compiler-gate] FAIL: pinned-arg field mismatch rejection lacks the expected diagnostic (#886)" >&2
-  cat "$stdir/pin.wasm.diag" 2>/dev/null >&2; exit 1
+  cat "$stdir/pin.wasm.diag" >&2 2>/dev/null; exit 1
 fi
 rm -rf "$stdir"
 echo "[compiler-gate] explicit struct type args (#886) ok"
@@ -741,7 +741,7 @@ VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   "$xpdir/ok.vibe" "$xpdir/ok.wasm" _start >/dev/null 2>&1 || true
 if [ ! -s "$xpdir/ok.wasm" ]; then
   echo "[compiler-gate] FAIL: .vibei contract's cross-package directory import (../pkgb) did not resolve (#842)" >&2
-  cat "$xpdir/ok.wasm.diag" 2>/dev/null >&2; exit 1
+  cat "$xpdir/ok.wasm.diag" >&2 2>/dev/null; exit 1
 fi
 xpres="$(VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh --invoke _start "$xpdir/ok.wasm" 2>/dev/null | tr -dc '0-9')"
 rm -rf "$xpdir"
@@ -770,7 +770,7 @@ VIBE_HASH=1 VIBE_PREOPEN_DIR="$ROOT_DIR" \
 pin="$(grep '^package ' "$cdir2/hash.out" 2>/dev/null | cut -d' ' -f2)"
 if [ -z "$pin" ]; then
   echo "[compiler-gate] FAIL: vibe hash produced no package pin (#730)" >&2
-  cat "$cdir2/hash.out.diag" 2>/dev/null >&2; exit 1
+  cat "$cdir2/hash.out.diag" >&2 2>/dev/null; exit 1
 fi
 printf 'require @gate/d2pkg 1.0.0 = %s\n\nimport @gate/d2pkg { triple }\nexport let _start: () -> Int = () -> { triple(14) }\n' "$pin" > "$cdir2/ok.vibe"
 VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
@@ -778,7 +778,7 @@ VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   "$cdir2/ok.vibe" "$cdir2/ok.wasm" _start >/dev/null 2>&1 || true
 if [ ! -s "$cdir2/ok.wasm" ]; then
   echo "[compiler-gate] FAIL: pinned store import did not compile (#730)" >&2
-  cat "$cdir2/ok.wasm.diag" 2>/dev/null >&2; exit 1
+  cat "$cdir2/ok.wasm.diag" >&2 2>/dev/null; exit 1
 fi
 # #2227: check must agree with the build lane it just exercised -- the same
 # require-pin head used to be a parse error on the check lane. A clean check
@@ -800,7 +800,7 @@ VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   "$cdir2/ok_pin.vibex" "$cdir2/ok_pin.wasm" main >/dev/null 2>&1 || true
 if [ ! -s "$cdir2/ok_pin.wasm" ]; then
   echo "[compiler-gate] FAIL: a .vibex with a require-pin head did not compile (#2227)" >&2
-  cat "$cdir2/ok_pin.wasm.diag" 2>/dev/null >&2; exit 1
+  cat "$cdir2/ok_pin.wasm.diag" >&2 2>/dev/null; exit 1
 fi
 printf 'require @gate/d2pkg 1.0.0 = #pkg:sha1:0000000000000000000000000000000000000000\n\nimport @gate/d2pkg { triple }\nexport let _start: () -> Int = () -> { triple(14) }\n' > "$cdir2/bad.vibe"
 if VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
@@ -811,7 +811,7 @@ if VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
 fi
 if ! grep -q "pin mismatch" "$cdir2/bad.wasm.diag" 2>/dev/null; then
   echo "[compiler-gate] FAIL: pin rejection lacks the expected diagnostic (#730)" >&2
-  cat "$cdir2/bad.wasm.diag" 2>/dev/null >&2; exit 1
+  cat "$cdir2/bad.wasm.diag" >&2 2>/dev/null; exit 1
 fi
 # D-3: an unpinned require refuses to build; VIBE_FILL_PINS completes it
 # offline from the store; the filled source builds; the fill is idempotent.
@@ -827,21 +827,21 @@ VIBE_FILL_PINS=1 VIBE_PREOPEN_DIR="$ROOT_DIR" \
   "$cdir2/unpinned.vibe" "$cdir2/filled.vibe" __no_entry__ >/dev/null 2>&1 || true
 if ! grep -q "= #pkg:sha1:" "$cdir2/filled.vibe" 2>/dev/null; then
   echo "[compiler-gate] FAIL: VIBE_FILL_PINS did not insert the pin (#730 D-3)" >&2
-  cat "$cdir2/filled.vibe.diag" 2>/dev/null >&2; exit 1
+  cat "$cdir2/filled.vibe.diag" >&2 2>/dev/null; exit 1
 fi
 VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
   "$cdir2/filled.vibe" "$cdir2/filled.wasm" _start >/dev/null 2>&1 || true
 if [ ! -s "$cdir2/filled.wasm" ]; then
   echo "[compiler-gate] FAIL: pin-filled source did not compile (#730 D-3)" >&2
-  cat "$cdir2/filled.wasm.diag" 2>/dev/null >&2; exit 1
+  cat "$cdir2/filled.wasm.diag" >&2 2>/dev/null; exit 1
 fi
 VIBE_NORMALIZE=1 VIBE_PREOPEN_DIR="$ROOT_DIR" \
   bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
   "$cdir2/filled.vibe" "$cdir2/norm.vibe" >/dev/null 2>&1 || true
 if ! head -1 "$cdir2/norm.vibe" 2>/dev/null | grep -q "^require @gate/d2pkg 1.0.0 = #pkg:sha1:"; then
   echo "[compiler-gate] FAIL: normalize did not re-emit the require pin line (#730 D-3)" >&2
-  head -3 "$cdir2/norm.vibe" 2>/dev/null >&2; exit 1
+  head -3 "$cdir2/norm.vibe" >&2 2>/dev/null; exit 1
 fi
 rm -rf ".vibe/store/@gate" "$cdir2"
 echo "[compiler-gate] content-addressed store regression ok"
@@ -865,7 +865,7 @@ VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   "$ldir/ok.vibe" "$ldir/ok.wasm" _start >/dev/null 2>&1 || true
 if [ ! -s "$ldir/ok.wasm" ]; then
   echo "[compiler-gate] FAIL: unpinned lib/ package import did not compile (#751)" >&2
-  cat "$ldir/ok.wasm.diag" 2>/dev/null >&2; exit 1
+  cat "$ldir/ok.wasm.diag" >&2 2>/dev/null; exit 1
 fi
 printf 'require @gate751/greet 1.0.0 = #pkg:sha1:0000000000000000000000000000000000000000\n\nimport @gate751/greet { greet_n }\nexport let _start: () -> Int = () -> { greet_n(40) }\n' > "$ldir/bad.vibe"
 if VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
@@ -876,7 +876,7 @@ if VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
 fi
 if ! grep -q "pin mismatch" "$ldir/bad.wasm.diag" 2>/dev/null; then
   echo "[compiler-gate] FAIL: lib/ pin rejection lacks the expected diagnostic (#751)" >&2
-  cat "$ldir/bad.wasm.diag" 2>/dev/null >&2; exit 1
+  cat "$ldir/bad.wasm.diag" >&2 2>/dev/null; exit 1
 fi
 rm -rf "lib/@gate751" "$ldir"
 echo "[compiler-gate] workspace lib/ package resolution ok"
@@ -914,7 +914,7 @@ VIBE_LIB="$xroot/does-not-exist:$xroot" VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COM
   "$xdir/ext.vibe" "$xdir/ext.wasm" _start >/dev/null 2>&1 || true
 if [ ! -s "$xdir/ext.wasm" ]; then
   echo "[compiler-gate] FAIL: VIBE_LIB root resolution did not compile (#751)" >&2
-  cat "$xdir/ext.wasm.diag" 2>/dev/null >&2; exit 1
+  cat "$xdir/ext.wasm.diag" >&2 2>/dev/null; exit 1
 fi
 ext_out="$(VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh --invoke _start "$xdir/ext.wasm" 2>/dev/null | tail -1)"
 if [ "$ext_out" != "42" ]; then
@@ -930,7 +930,7 @@ VIBE_LIB="$xroot/does-not-exist:$xroot" VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COM
   "$xdir/ws.vibe" "$xdir/ws.wasm" _start >/dev/null 2>&1 || true
 if [ ! -s "$xdir/ws.wasm" ]; then
   echo "[compiler-gate] FAIL: workspace-precedence consumer did not compile (#751)" >&2
-  cat "$xdir/ws.wasm.diag" 2>/dev/null >&2; exit 1
+  cat "$xdir/ws.wasm.diag" >&2 2>/dev/null; exit 1
 fi
 ws_out="$(VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh --invoke _start "$xdir/ws.wasm" 2>/dev/null | tail -1)"
 if [ "$ws_out" != "43" ]; then
@@ -946,7 +946,7 @@ if VIBE_REQUIRE_PINS=1 VIBE_LIB="$xroot" VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_CO
 fi
 if ! grep -q "pin required" "$xdir/frz.wasm.diag" 2>/dev/null; then
   echo "[compiler-gate] FAIL: freeze rejection lacks the expected diagnostic (#751)" >&2
-  cat "$xdir/frz.wasm.diag" 2>/dev/null >&2; exit 1
+  cat "$xdir/frz.wasm.diag" >&2 2>/dev/null; exit 1
 fi
 # (5) #758 review (P1): a resolved graph cached under one environment must
 #     NOT replay under another — the SAME consumer content is compiled
@@ -961,7 +961,7 @@ VIBE_LIB="$xroot" VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI
   "$xdir/replay.vibe" "$xdir/replay1.wasm" _start >/dev/null 2>&1 || true
 if [ ! -s "$xdir/replay1.wasm" ]; then
   echo "[compiler-gate] FAIL: replay warm-up compile failed (#758)" >&2
-  cat "$xdir/replay1.wasm.diag" 2>/dev/null >&2; exit 1
+  cat "$xdir/replay1.wasm.diag" >&2 2>/dev/null; exit 1
 fi
 if VIBE_LIB="$xroot/does-not-exist" VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
@@ -977,7 +977,7 @@ if VIBE_REQUIRE_PINS=1 VIBE_LIB="$xroot" VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_CO
 fi
 if ! grep -q "pin required" "$xdir/replay3.wasm.diag" 2>/dev/null; then
   echo "[compiler-gate] FAIL: freeze-under-warm-cache rejection lacks the expected diagnostic (#758)" >&2
-  cat "$xdir/replay3.wasm.diag" 2>/dev/null >&2; exit 1
+  cat "$xdir/replay3.wasm.diag" >&2 2>/dev/null; exit 1
 fi
 rm -rf "$xdir" "$xroot"
 echo "[compiler-gate] VIBE_LIB external roots + freeze ok"
@@ -1013,7 +1013,7 @@ VIBE_HOME="$jhome" VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_AB
   "$jdir/use.vibe" "$jdir/use.wasm" _start >/dev/null 2>&1 || true
 if [ ! -s "$jdir/use.wasm" ]; then
   echo "[compiler-gate] FAIL: materialized package did not resolve via VIBE_HOME default root (#754)" >&2
-  cat "$jdir/use.wasm.diag" 2>/dev/null >&2; exit 1
+  cat "$jdir/use.wasm.diag" >&2 2>/dev/null; exit 1
 fi
 juse_out="$(VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh --invoke _start "$jdir/use.wasm" 2>/dev/null | tail -1)"
 if [ "$juse_out" != "44" ]; then
@@ -1031,7 +1031,7 @@ VIBE_REQUIRE_PINS=1 VIBE_HOME="$jhome" VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMP
   "$jdir/pinned.vibe" "$jdir/pinned.wasm" _start >/dev/null 2>&1 || true
 if [ ! -s "$jdir/pinned.wasm" ]; then
   echo "[compiler-gate] FAIL: pinned store build under VIBE_REQUIRE_PINS=1 failed (#754)" >&2
-  cat "$jdir/pinned.wasm.diag" 2>/dev/null >&2; exit 1
+  cat "$jdir/pinned.wasm.diag" >&2 2>/dev/null; exit 1
 fi
 # same-version republish with different content must be rejected
 printf 'export fn quad(x: Int) -> Int { x * 5 }\n' > "$jsrc/impl.vibe"
@@ -1151,7 +1151,7 @@ if ! VIBE_HOME="$lhome805" VIBE_PKG_CLI_WASM="$stage2_wasm" bash scripts/vibe_pk
 fi
 if ! awk -F'\t' '$1 == "0" && $2 == "publish" && $3 == "@gate805/logx@1.0.0"' "$lhome805/log/records.tsv" 2>/dev/null | grep -q .; then
   echo "[compiler-gate] FAIL: publish did not append a transparency-log record (#805)" >&2
-  cat "$lhome805/log/records.tsv" 2>/dev/null >&2; exit 1
+  cat "$lhome805/log/records.tsv" >&2 2>/dev/null; exit 1
 fi
 if [ ! -s "$lhome805/log/head" ]; then
   echo "[compiler-gate] FAIL: publish did not write a merkle head (#805)" >&2; exit 1
@@ -1267,7 +1267,7 @@ VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   "$edir/ok.vibe" "$edir/ok.wasm" _start >/dev/null 2>&1 || true
 if [ ! -s "$edir/ok.wasm" ]; then
   echo "[compiler-gate] FAIL: satisfied where-contract program did not compile (#731)" >&2
-  cat "$edir/ok.wasm.diag" 2>/dev/null >&2; exit 1
+  cat "$edir/ok.wasm.diag" >&2 2>/dev/null; exit 1
 fi
 ok_out="$(VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh --invoke _start "$edir/ok.wasm" 2>/dev/null | tail -1)"
 if [ "$ok_out" != "42" ]; then
@@ -1280,7 +1280,7 @@ VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   "$edir/viol.vibe" "$edir/viol.wasm" _start >/dev/null 2>&1 || true
 if [ ! -s "$edir/viol.wasm" ]; then
   echo "[compiler-gate] FAIL: where-contract program did not compile (#731)" >&2
-  cat "$edir/viol.wasm.diag" 2>/dev/null >&2; exit 1
+  cat "$edir/viol.wasm.diag" >&2 2>/dev/null; exit 1
 fi
 if VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh --invoke _start "$edir/viol.wasm" >/dev/null 2>&1; then
   echo "[compiler-gate] FAIL: violated requires clause did not trap (#731)" >&2; exit 1
@@ -1292,7 +1292,7 @@ VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   "$edir/viol_ens.vibe" "$edir/viol_ens.wasm" _start >/dev/null 2>&1 || true
 if [ ! -s "$edir/viol_ens.wasm" ]; then
   echo "[compiler-gate] FAIL: ensures-contract program did not compile (#731)" >&2
-  cat "$edir/viol_ens.wasm.diag" 2>/dev/null >&2; exit 1
+  cat "$edir/viol_ens.wasm.diag" >&2 2>/dev/null; exit 1
 fi
 if VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh --invoke _start "$edir/viol_ens.wasm" >/dev/null 2>&1; then
   echo "[compiler-gate] FAIL: violated ensures clause did not trap (#731)" >&2; exit 1
@@ -1304,14 +1304,14 @@ VIBE_PUBLISH_CHECK=1 VIBE_PUBLISH_PREV="$edir/prev.vibei" VIBE_PUBLISH_PREV_VERS
   "$edir/next.vibei" "$edir/pub.out" __no_entry__ >/dev/null 2>&1 || true
 if ! grep -q "^ok" "$edir/pub.out" 2>/dev/null; then
   echo "[compiler-gate] FAIL: honest minor bump was rejected (#732)" >&2
-  cat "$edir/pub.out.diag" 2>/dev/null >&2; exit 1
+  cat "$edir/pub.out.diag" >&2 2>/dev/null; exit 1
 fi
 VIBE_PUBLISH_CHECK=1 VIBE_PUBLISH_PREV="$edir/prev.vibei" VIBE_PUBLISH_PREV_VERSION=1.0.0 VIBE_PUBLISH_VERSION=1.0.1 \
   VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
   "$edir/next.vibei" "$edir/pub2.out" __no_entry__ >/dev/null 2>&1 || true
 if ! grep -q "requires minor" "$edir/pub2.out.diag" 2>/dev/null; then
   echo "[compiler-gate] FAIL: dishonest patch claim was not rejected (#732)" >&2
-  cat "$edir/pub2.out" "$edir/pub2.out.diag" 2>/dev/null >&2; exit 1
+  cat "$edir/pub2.out" "$edir/pub2.out.diag" >&2 2>/dev/null; exit 1
 fi
 rm -rf "$edir"
 echo "[compiler-gate] where-contract + publish gate regression ok"
@@ -1361,7 +1361,7 @@ VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   "$cdir6f/consumer.vibe" "$cdir6f/consumer.wasm" _start >/dev/null 2>&1 || true
 if [ ! -s "$cdir6f/consumer.wasm" ]; then
   echo "[compiler-gate] FAIL: pinned @vibe/core consumer did not compile" >&2
-  cat "$cdir6f/consumer.wasm.diag" 2>/dev/null >&2; exit 1
+  cat "$cdir6f/consumer.wasm.diag" >&2 2>/dev/null; exit 1
 fi
 if ! VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh --invoke _start "$cdir6f/consumer.wasm" >/dev/null 2>&1; then
   echo "[compiler-gate] FAIL: @vibe/core consumer trapped at runtime" >&2; exit 1
@@ -1669,7 +1669,7 @@ VIBE_COVERAGE=1 VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_IMPORT_ABI=raw \
   "$tldir/bool_render.vibe" "$tldir/cov.wasm" _start >/dev/null 2>&1 || true
 if [ ! -s "$tldir/cov.wasm" ]; then
   echo "[compiler-gate] FAIL: coverage build of the #2469 probe produced no wasm" >&2
-  cat "$tldir/cov.wasm.diag" 2>/dev/null >&2 || true
+  cat "$tldir/cov.wasm.diag" >&2 2>/dev/null || true
   exit 1
 fi
 tl_cov_out="$(VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh \
@@ -1731,7 +1731,7 @@ VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   "$mbtdir/mbt.vibe" "$mbtdir/mbt.wasm" _start >/dev/null 2>&1 || true
 if [ ! -s "$mbtdir/mbt.wasm" ]; then
   echo "[compiler-gate] FAIL: trait dict-passing program did not compile" >&2
-  cat "$mbtdir/mbt.wasm.diag" 2>/dev/null >&2; exit 1
+  cat "$mbtdir/mbt.wasm.diag" >&2 2>/dev/null; exit 1
 fi
 mbt_out="$(VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh \
   --invoke _start "$mbtdir/mbt.wasm" 2>/dev/null | tr -dc '0-9')"
@@ -1774,7 +1774,7 @@ VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   "$mgdir/mg.vibe" "$mgdir/mg.wasm" _start >/dev/null 2>&1 || true
 if [ ! -s "$mgdir/mg.wasm" ]; then
   echo "[compiler-gate] FAIL: rank-1 trait-method generic program did not compile" >&2
-  cat "$mgdir/mg.wasm.diag" 2>/dev/null >&2; exit 1
+  cat "$mgdir/mg.wasm.diag" >&2 2>/dev/null; exit 1
 fi
 mg_out="$(VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh \
   --invoke _start "$mgdir/mg.wasm" 2>/dev/null | tr -dc '0-9')"
@@ -1806,7 +1806,7 @@ VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   fixtures/trait_bound_ufcs_method.vibe "$ufcsdir/ufcs.wasm" __no_entry__ >/dev/null 2>&1 || true
 if [ ! -s "$ufcsdir/ufcs.wasm" ]; then
   echo "[compiler-gate] FAIL: UFCS-on-bounded-tparam program did not compile" >&2
-  cat "$ufcsdir/ufcs.wasm.diag" 2>/dev/null >&2; exit 1
+  cat "$ufcsdir/ufcs.wasm.diag" >&2 2>/dev/null; exit 1
 fi
 if ! ufcs_out="$(VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh \
   --invoke _start "$ufcsdir/ufcs.wasm" 2>&1)"; then
@@ -1839,7 +1839,7 @@ VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   "$drvdir/drv.vibe" "$drvdir/drv.wasm" _start >/dev/null 2>&1 || true
 if [ ! -s "$drvdir/drv.wasm" ]; then
   echo "[compiler-gate] FAIL: derive program did not compile" >&2
-  cat "$drvdir/drv.wasm.diag" 2>/dev/null >&2; exit 1
+  cat "$drvdir/drv.wasm.diag" >&2 2>/dev/null; exit 1
 fi
 drv_out="$(VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh \
   --invoke _start "$drvdir/drv.wasm" 2>/dev/null | tr -dc '0-9-')"
@@ -1879,7 +1879,7 @@ run_test_block_fixtures() {
       "$fx" "$fxout" __no_entry__ >/dev/null 2>&1 || true
     if [ ! -s "$fxout" ]; then
       echo "[compiler-gate] FAIL: $fx did not compile ($label)" >&2
-      cat "$fxout.diag" 2>/dev/null >&2; exit 1
+      cat "$fxout.diag" >&2 2>/dev/null; exit 1
     fi
     if ! VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh \
         --invoke _start "$fxout" >/dev/null 2>&1; then
@@ -1909,7 +1909,7 @@ run_test_block_fixtures_gc() {
       "$fx" "$fxout" __no_entry__ >/dev/null 2>&1 || true
     if [ ! -s "$fxout" ]; then
       echo "[compiler-gate] FAIL: $fx did not compile on the gc lane ($label)" >&2
-      cat "$fxout.diag" 2>/dev/null >&2; exit 1
+      cat "$fxout.diag" >&2 2>/dev/null; exit 1
     fi
     if ! VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh \
         --invoke _start "$fxout" >/dev/null 2>&1; then
@@ -1941,7 +1941,7 @@ run_test_block_fixtures_rc() {
       "$fx" "$fxout" __no_entry__ >/dev/null 2>&1 || true
     if [ ! -s "$fxout" ]; then
       echo "[compiler-gate] FAIL: $fx did not compile on the RC lane ($label)" >&2
-      cat "$fxout.diag" 2>/dev/null >&2; exit 1
+      cat "$fxout.diag" >&2 2>/dev/null; exit 1
     fi
     if ! VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh \
         --invoke _start "$fxout" >/dev/null 2>&1; then
@@ -2030,12 +2030,12 @@ for eqrefuse_src in fixtures/structural_eq_untyped_empty_*_refused.vibe fixtures
   fi
   if ! grep -qF 'structural `==` cannot be decided here' "$eqrefuse_wasm.diag" 2>/dev/null; then
     echo "[compiler-gate] FAIL: $eqrefuse_src was refused without the #2475 message" >&2
-    cat "$eqrefuse_wasm.diag" 2>/dev/null >&2
+    cat "$eqrefuse_wasm.diag" >&2 2>/dev/null
     exit 1
   fi
   if ! grep -qE 'Annotate|rename the declared type' "$eqrefuse_wasm.diag" 2>/dev/null; then
     echo "[compiler-gate] FAIL: $eqrefuse_src refusal does not name an edit" >&2
-    cat "$eqrefuse_wasm.diag" 2>/dev/null >&2
+    cat "$eqrefuse_wasm.diag" >&2 2>/dev/null
     exit 1
   fi
 done
@@ -2070,7 +2070,7 @@ bs_check() { # <src> <tag>
 bs_check "$bsdir/shadow_fn.vibe" shadow_fn
 if ! grep -qF 'rename `String::index_of`' "$bsdir/shadow_fn.out" 2>/dev/null; then
   echo "[compiler-gate] FAIL: a qualified fn definition of a builtin name was not reported (#2378)" >&2
-  cat "$bsdir/shadow_fn.out" "$bsdir/shadow_fn.out.diag" 2>/dev/null >&2; exit 1
+  cat "$bsdir/shadow_fn.out" "$bsdir/shadow_fn.out.diag" >&2 2>/dev/null; exit 1
 fi
 if ! grep -qE 'never import it' "$bsdir/shadow_fn.out" 2>/dev/null; then
   echo "[compiler-gate] FAIL: the #2378 report does not say why the name is program-wide" >&2
@@ -2096,7 +2096,7 @@ printf 'import ./xdep.vibe { unrelated_helper }\n\nexport fn run() -> Int {\n  u
 bs_check "$bsdir/xmain.vibe" xmain
 if ! grep -qF 'rename `String::index_of`' "$bsdir/xmain.out" 2>/dev/null; then
   echo "[compiler-gate] FAIL: checking the ENTRY did not report a dependency's builtin override (#2378)" >&2
-  cat "$bsdir/xmain.out" "$bsdir/xmain.out.diag" 2>/dev/null >&2; exit 1
+  cat "$bsdir/xmain.out" "$bsdir/xmain.out.diag" >&2 2>/dev/null; exit 1
 fi
 if ! grep -qF 'xdep.vibe' "$bsdir/xmain.out" 2>/dev/null; then
   echo "[compiler-gate] FAIL: the cross-file report does not name the file to edit (#2378)" >&2
@@ -2117,7 +2117,7 @@ for eqtrap_src in fixtures/structural_eq_generic_enum_*_trap.vibe; do
     "$eqtrap_src" "$eqtrap_wasm" _start >/dev/null 2>&1 || true
   if [ ! -s "$eqtrap_wasm" ]; then
     echo "[compiler-gate] FAIL: $eqtrap_src did not compile" >&2
-    cat "$eqtrap_wasm.diag" 2>/dev/null >&2
+    cat "$eqtrap_wasm.diag" >&2 2>/dev/null
     exit 1
   fi
   if VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh \
@@ -2151,7 +2151,7 @@ if [ -s "$eqrej_wasm" ]; then
 fi
 if ! grep -qF 'compares two values of type `Array[T]`, but the type parameter `T` has no `Eq` bound' "$eqrej_wasm.diag" 2>/dev/null; then
   echo "[compiler-gate] FAIL: $eqrej_src was refused for another reason than the missing Eq bound (#2474)" >&2
-  cat "$eqrej_wasm.diag" 2>/dev/null >&2
+  cat "$eqrej_wasm.diag" >&2 2>/dev/null
   exit 1
 fi
 rm -rf "$eqrejdir"
@@ -2183,7 +2183,7 @@ for eqtyped_src in fixtures/structural_eq_untyped_empty_*_typed.vibe fixtures/st
     "$eqtyped_src" "$eqtyped_wasm" _start >/dev/null 2>&1 || true
   if [ ! -s "$eqtyped_wasm" ]; then
     echo "[compiler-gate] FAIL: $eqtyped_src did not compile" >&2
-    cat "$eqtyped_wasm.diag" 2>/dev/null >&2
+    cat "$eqtyped_wasm.diag" >&2 2>/dev/null
     exit 1
   fi
   if ! VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh \
@@ -2219,7 +2219,7 @@ for hetero_src in fixtures/empty_array_hetero_*_reject.vibe; do
   # fixture broken some other way (syntax, missing name) cannot green this.
   if ! grep -q "type mismatch" "$hetero_wasm.diag" 2>/dev/null; then
     echo "[compiler-gate] FAIL: $hetero_src was rejected without the expected type mismatch diagnostic" >&2
-    cat "$hetero_wasm.diag" 2>/dev/null >&2
+    cat "$hetero_wasm.diag" >&2 2>/dev/null
     exit 1
   fi
 done
@@ -2239,7 +2239,7 @@ VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   fixtures/structural_eq_nonregular_generic_trap.vibe "$nonregular_wasm" _start >/dev/null 2>&1 || true
 if [ ! -s "$nonregular_wasm" ]; then
   echo "[compiler-gate] FAIL: non-regular generic equality did not compile" >&2
-  cat "$nonregular_wasm.diag" 2>/dev/null >&2
+  cat "$nonregular_wasm.diag" >&2 2>/dev/null
   exit 1
 fi
 if VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh \
@@ -2284,7 +2284,7 @@ VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   "$eqansdir/a.vibe" "$eqansdir/a.wasm" _start >/dev/null 2>&1 || true
 if [ ! -s "$eqansdir/a.wasm" ]; then
   echo "[compiler-gate] FAIL: untyped-empty answer probe did not compile" >&2
-  cat "$eqansdir/a.wasm.diag" 2>/dev/null >&2
+  cat "$eqansdir/a.wasm.diag" >&2 2>/dev/null
   exit 1
 fi
 if ! VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh \
@@ -2444,7 +2444,7 @@ VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   "$itdir/iter.vibe" "$itdir/iter.wasm" _start >/dev/null 2>&1 || true
 if [ ! -s "$itdir/iter.wasm" ]; then
   echo "[compiler-gate] FAIL: Iterator trait program did not compile" >&2
-  cat "$itdir/iter.wasm.diag" 2>/dev/null >&2; exit 1
+  cat "$itdir/iter.wasm.diag" >&2 2>/dev/null; exit 1
 fi
 it_out="$(VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh \
   --invoke _start "$itdir/iter.wasm" 2>/dev/null | tr -dc '0-9-')"
@@ -2515,7 +2515,7 @@ VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   "$lcdir/lc.vibe" "$lcdir/lc.wasm" _start >/dev/null 2>&1 || true
 if [ ! -s "$lcdir/lc.wasm" ]; then
   echo "[compiler-gate] FAIL: lazy combinators program did not compile" >&2
-  cat "$lcdir/lc.wasm.diag" 2>/dev/null >&2; exit 1
+  cat "$lcdir/lc.wasm.diag" >&2 2>/dev/null; exit 1
 fi
 lc_out="$(VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh \
   --invoke _start "$lcdir/lc.wasm" 2>/dev/null | tr -dc '0-9-')"
@@ -2626,7 +2626,7 @@ VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   "$fadir/fa.vibe" "$fadir/fa.wasm" _start >/dev/null 2>&1 || true
 if [ ! -s "$fadir/fa.wasm" ]; then
   echo "[compiler-gate] FAIL: async for-loop program did not compile" >&2
-  cat "$fadir/fa.wasm.diag" 2>/dev/null >&2; exit 1
+  cat "$fadir/fa.wasm.diag" >&2 2>/dev/null; exit 1
 fi
 fa_out="$(VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh \
   --invoke _start "$fadir/fa.wasm" 2>/dev/null | tr -dc '0-9-')"
@@ -2683,7 +2683,7 @@ VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   "$eidir/pos.vibe" "$eidir/pos.wasm" _start >/dev/null 2>&1 || true
 if [ ! -s "$eidir/pos.wasm" ]; then
   echo "[compiler-gate] FAIL: element-type positive program did not compile" >&2
-  cat "$eidir/pos.wasm.diag" 2>/dev/null >&2; exit 1
+  cat "$eidir/pos.wasm.diag" >&2 2>/dev/null; exit 1
 fi
 ei_out="$(VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh \
   --invoke _start "$eidir/pos.wasm" 2>/dev/null | tr -dc '0-9-')"
@@ -2710,7 +2710,7 @@ if [ -s "$eidir/neg.wasm" ]; then
 fi
 if ! grep -q "type mismatch in '+'" "$eidir/neg.wasm.diag" 2>/dev/null; then
   echo "[compiler-gate] FAIL: element-type negative rejected for the wrong reason" >&2
-  cat "$eidir/neg.wasm.diag" 2>/dev/null >&2; exit 1
+  cat "$eidir/neg.wasm.diag" >&2 2>/dev/null; exit 1
 fi
 rm -rf "$eidir"
 echo "[compiler-gate] cross-import trait-iterator element-type regression ok"
@@ -2732,7 +2732,7 @@ for suite in lib/@vibe/builtin/lazy_iter_test.vibe lib/@vibe/builtin/async_iter_
     "$suite" "$out" __no_entry__ >/dev/null 2>&1 || true
   if [ ! -s "$out" ]; then
     echo "[compiler-gate] FAIL: $suite did not compile" >&2
-    cat "$out.diag" 2>/dev/null >&2; exit 1
+    cat "$out.diag" >&2 2>/dev/null; exit 1
   fi
   if ! VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh \
       --invoke _start "$out" >/dev/null 2>&1; then
@@ -2768,7 +2768,7 @@ VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   "$gidir/pos.vibe" "$gidir/pos.wasm" _start >/dev/null 2>&1 || true
 if [ ! -s "$gidir/pos.wasm" ]; then
   echo "[compiler-gate] FAIL: generic-impl positive program did not compile" >&2
-  cat "$gidir/pos.wasm.diag" 2>/dev/null >&2; exit 1
+  cat "$gidir/pos.wasm.diag" >&2 2>/dev/null; exit 1
 fi
 gi_out="$(VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh \
   --invoke _start "$gidir/pos.wasm" 2>/dev/null | tr -dc '0-9-')"
@@ -2822,7 +2822,7 @@ VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   "$gjdir/pos.vibe" "$gjdir/pos.wasm" _start >/dev/null 2>&1 || true
 if [ ! -s "$gjdir/pos.wasm" ]; then
   echo "[compiler-gate] FAIL: dict-of-dict positive program did not compile" >&2
-  cat "$gjdir/pos.wasm.diag" 2>/dev/null >&2; exit 1
+  cat "$gjdir/pos.wasm.diag" >&2 2>/dev/null; exit 1
 fi
 gj_out="$(VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh \
   --invoke _start "$gjdir/pos.wasm" 2>/dev/null | tr -dc '0-9-')"
@@ -3049,11 +3049,11 @@ fi
 # not the callee `leaf`.
 if ! grep -qF "effect row mismatch for 'mid': missing { Fs }" "$pfdir/bad_transitive.wasm.diag" 2>/dev/null; then
   echo "[compiler-gate] FAIL: transitive reject lacks the effect-row set-difference diagnostic (#639)" >&2
-  cat "$pfdir/bad_transitive.wasm.diag" 2>/dev/null >&2; exit 1
+  cat "$pfdir/bad_transitive.wasm.diag" >&2 2>/dev/null; exit 1
 fi
 if ! grep -qF "hint: declare 'fn mid(...) -> T with Fs'" "$pfdir/bad_transitive.wasm.diag" 2>/dev/null; then
   echo "[compiler-gate] FAIL: no-row reject lacks the declare-form fix-it hint (#639)" >&2
-  cat "$pfdir/bad_transitive.wasm.diag" 2>/dev/null >&2; exit 1
+  cat "$pfdir/bad_transitive.wasm.diag" >&2 2>/dev/null; exit 1
 fi
 # #639: a caller that already declares a row gets the add-form hint carrying
 # the sorted union (existing row preserved, missing effect appended).
@@ -3080,11 +3080,11 @@ fi
 # because the canonical name is what gets printed either way.
 if ! grep -qF "effect row mismatch for 'mid': missing { Fs } (declared { Exception }, requires { Exception, Fs })" "$pfdir/bad_row_single.wasm.diag" 2>/dev/null; then
   echo "[compiler-gate] FAIL: partial-row reject lacks the declared-vs-required diff (#639)" >&2
-  cat "$pfdir/bad_row_single.wasm.diag" 2>/dev/null >&2; exit 1
+  cat "$pfdir/bad_row_single.wasm.diag" >&2 2>/dev/null; exit 1
 fi
 if ! grep -qF "hint: add 'with Exception + Fs' to 'mid'" "$pfdir/bad_row_single.wasm.diag" 2>/dev/null; then
   echo "[compiler-gate] FAIL: partial-row reject lacks the add-form fix-it hint (#639)" >&2
-  cat "$pfdir/bad_row_single.wasm.diag" 2>/dev/null >&2; exit 1
+  cat "$pfdir/bad_row_single.wasm.diag" >&2 2>/dev/null; exit 1
 fi
 # #639: multiple missing effects at one call site aggregate into ONE sorted
 # set difference (leaf declares "Fs, Env" in reversed order; the diagnostic
@@ -3106,11 +3106,11 @@ if [ -s "$pfdir/bad_row_multi.wasm" ]; then
 fi
 if ! grep -qF "effect row mismatch for 'mid': missing { Env, Fs }" "$pfdir/bad_row_multi.wasm.diag" 2>/dev/null; then
   echo "[compiler-gate] FAIL: multi-effect reject is not an aggregated sorted set difference (#639)" >&2
-  cat "$pfdir/bad_row_multi.wasm.diag" 2>/dev/null >&2; exit 1
+  cat "$pfdir/bad_row_multi.wasm.diag" >&2 2>/dev/null; exit 1
 fi
 if ! grep -qF "hint: declare 'fn mid(...) -> T with Env + Fs'" "$pfdir/bad_row_multi.wasm.diag" 2>/dev/null; then
   echo "[compiler-gate] FAIL: multi-effect reject lacks the sorted fix-it hint (#639)" >&2
-  cat "$pfdir/bad_row_multi.wasm.diag" 2>/dev/null >&2; exit 1
+  cat "$pfdir/bad_row_multi.wasm.diag" >&2 2>/dev/null; exit 1
 fi
 VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
@@ -3608,7 +3608,7 @@ for pp_rc in 0 1; do
     "$ppdir/prints.vibe" "$ppdir/prints.wasm" main >/dev/null 2>&1 || true
   if [ ! -s "$ppdir/prints.wasm" ]; then
     echo "[compiler-gate] FAIL: println/print program did not compile on the FS lane under VIBE_RC=$pp_rc (#929 regressed)" >&2
-    cat "$ppdir/prints.wasm.diag" 2>/dev/null >&2; exit 1
+    cat "$ppdir/prints.wasm.diag" >&2 2>/dev/null; exit 1
   fi
   pp_out="$(bash scripts/run_wasm_vibe_host_runner.sh --invoke _start "$ppdir/prints.wasm" 2>/dev/null | head -n 4 | tr '\n' '|')"
   if [ "$pp_out" != "hello gate|fortytwo|42|A|" ]; then
@@ -3940,7 +3940,7 @@ VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   "$mdir/ok_mut.vibe" "$mdir/ok_mut.wasm" _start >/dev/null 2>&1 || true
 if [ ! -s "$mdir/ok_mut.wasm" ]; then
   echo "[compiler-gate] FAIL: mut-field write did not compile (over-rejects)" >&2
-  cat "$mdir/ok_mut.wasm.diag" 2>/dev/null >&2; exit 1
+  cat "$mdir/ok_mut.wasm.diag" >&2 2>/dev/null; exit 1
 fi
 for bad in bad_nonmut bad_valty; do
   VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
@@ -3997,7 +3997,7 @@ VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   "$cdir/ok.vibe" "$cdir/ok.wasm" _start >/dev/null 2>&1 || true
 if [ ! -s "$cdir/ok.wasm" ]; then
   echo "[compiler-gate] FAIL: well-typed match/array did not compile (over-rejects)" >&2
-  cat "$cdir/ok.wasm.diag" 2>/dev/null >&2; exit 1
+  cat "$cdir/ok.wasm.diag" >&2 2>/dev/null; exit 1
 fi
 for bad in bad_match bad_array bad_arraynest bad_call bad_calloption bad_not bad_forint bad_tuparity; do
   VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
@@ -4033,7 +4033,7 @@ VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   "$mudir/ok.vibe" "$mudir/ok.wasm" _start >/dev/null 2>&1 || true
 if [ ! -s "$mudir/ok.wasm" ]; then
   echo "[compiler-gate] FAIL: well-typed mut/accumulator did not compile (over-rejects)" >&2
-  cat "$mudir/ok.wasm.diag" 2>/dev/null >&2; exit 1
+  cat "$mudir/ok.wasm.diag" >&2 2>/dev/null; exit 1
 fi
 VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
@@ -4071,7 +4071,7 @@ VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   "$mu2dir/ok.vibe" "$mu2dir/ok.wasm" _start >/dev/null 2>&1 || true
 if [ ! -s "$mu2dir/ok.wasm" ]; then
   echo "[compiler-gate] FAIL: legal mut reassignment inside Map::from_pairs value did not compile (over-rejects)" >&2
-  cat "$mu2dir/ok.wasm.diag" 2>/dev/null >&2; exit 1
+  cat "$mu2dir/ok.wasm.diag" >&2 2>/dev/null; exit 1
 fi
 VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
@@ -4109,7 +4109,7 @@ VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   "$pdir/ok.vibe" "$pdir/ok.wasm" _start >/dev/null 2>&1 || true
 if [ ! -s "$pdir/ok.wasm" ]; then
   echo "[compiler-gate] FAIL: well-typed ctor patterns did not compile (over-rejects)" >&2
-  cat "$pdir/ok.wasm.diag" 2>/dev/null >&2; exit 1
+  cat "$pdir/ok.wasm.diag" >&2 2>/dev/null; exit 1
 fi
 for bad in bad_arity bad_scalar; do
   VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
@@ -4191,7 +4191,7 @@ VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   "$idir/ok.vibe" "$idir/ok.wasm" _start >/dev/null 2>&1 || true
 if [ ! -s "$idir/ok.wasm" ]; then
   echo "[compiler-gate] FAIL: well-typed index/tuple did not compile (over-rejects)" >&2
-  cat "$idir/ok.wasm.diag" 2>/dev/null >&2; exit 1
+  cat "$idir/ok.wasm.diag" >&2 2>/dev/null; exit 1
 fi
 for bad in bad_index bad_tuple bad_idxtype bad_idxelem bad_stridx bad_arrget bad_arrpush bad_arrset bad_arrmap bad_arrfold bad_mapparam bad_foldparam bad_arrslice bad_arrconcat bad_arrconcatmix bad_arrpushallmix bad_arrrev; do
   VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
@@ -4229,7 +4229,7 @@ VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   "$gdir/guard.vibe" "$gdir/guard.wasm" _start >/dev/null 2>&1 || true
 if [ ! -s "$gdir/guard.wasm" ]; then
   echo "[compiler-gate] FAIL: guarded match did not compile" >&2
-  cat "$gdir/guard.wasm.diag" 2>/dev/null >&2; exit 1
+  cat "$gdir/guard.wasm.diag" >&2 2>/dev/null; exit 1
 fi
 gres="$(VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh --invoke _start "$gdir/guard.wasm" 2>/dev/null | tr -dc '0-9-')"
 rm -rf "$gdir"
@@ -4263,7 +4263,7 @@ VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   "$xdir/ok.vibe" "$xdir/ok.wasm" _start >/dev/null 2>&1 || true
 if [ ! -s "$xdir/ok.wasm" ]; then
   echo "[compiler-gate] FAIL: exhaustive matches did not compile (over-rejects)" >&2
-  cat "$xdir/ok.wasm.diag" 2>/dev/null >&2; exit 1
+  cat "$xdir/ok.wasm.diag" >&2 2>/dev/null; exit 1
 fi
 VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
@@ -4300,7 +4300,7 @@ VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   "$ldir/ok.vibe" "$ldir/ok.wasm" _start >/dev/null 2>&1 || true
 if [ ! -s "$ldir/ok.wasm" ]; then
   echo "[compiler-gate] FAIL: well-typed literal patterns did not compile (over-rejects)" >&2
-  cat "$ldir/ok.wasm.diag" 2>/dev/null >&2; exit 1
+  cat "$ldir/ok.wasm.diag" >&2 2>/dev/null; exit 1
 fi
 for bad in bad_lit bad_nested; do
   VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
@@ -4339,7 +4339,7 @@ VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   "$bdir/ok.vibe" "$bdir/ok.wasm" _start >/dev/null 2>&1 || true
 if [ ! -s "$bdir/ok.wasm" ]; then
   echo "[compiler-gate] FAIL: well-typed negation/break/continue did not compile (over-rejects)" >&2
-  cat "$bdir/ok.wasm.diag" 2>/dev/null >&2; exit 1
+  cat "$bdir/ok.wasm.diag" >&2 2>/dev/null; exit 1
 fi
 for bad in bad_neg bad_break; do
   VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
@@ -4370,7 +4370,7 @@ VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   "$tdir/ok.vibe" "$tdir/ok.wasm" _start >/dev/null 2>&1 || true
 if [ ! -s "$tdir/ok.wasm" ]; then
   echo "[compiler-gate] FAIL: well-typed tuple destructure did not compile (over-rejects)" >&2
-  cat "$tdir/ok.wasm.diag" 2>/dev/null >&2; exit 1
+  cat "$tdir/ok.wasm.diag" >&2 2>/dev/null; exit 1
 fi
 VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
@@ -4659,7 +4659,7 @@ smoke_check() {
     "$sdir/$nm.vibe" "$sdir/$nm.wasm" _start >/dev/null 2>&1 || true
   if [ ! -s "$sdir/$nm.wasm" ]; then
     echo "[compiler-gate] FAIL: smoke '$nm' did not compile (codegen regression)" >&2
-    cat "$sdir/$nm.wasm.diag" 2>/dev/null >&2; exit 1
+    cat "$sdir/$nm.wasm.diag" >&2 2>/dev/null; exit 1
   fi
   local got
   got="$(VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh --invoke _start "$sdir/$nm.wasm" 2>/dev/null | tr -dc '0-9-')"

--- a/tests/gates/late/run.sh
+++ b/tests/gates/late/run.sh
@@ -43,7 +43,7 @@ VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   "$a69dir/ok_fnmain.vibe" "$a69dir/ok_fnmain.wasm" main >/dev/null 2>&1 || true
 if [ ! -s "$a69dir/ok_fnmain.wasm" ]; then
   echo "[compiler-gate] FAIL: fn main {} sugar did not compile" >&2
-  cat "$a69dir/ok_fnmain.wasm.diag" 2>/dev/null >&2 || true
+  cat "$a69dir/ok_fnmain.wasm.diag" >&2 2>/dev/null || true
   exit 1
 fi
 a69_out="$(VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh \
@@ -66,7 +66,7 @@ VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   "$a69dir/int_main.vibe" "$a69dir/int_main.wasm" main >/dev/null 2>&1 || true
 if [ ! -s "$a69dir/int_main.wasm" ]; then
   echo "[compiler-gate] FAIL: Int-returning let main did not compile" >&2
-  cat "$a69dir/int_main.wasm.diag" 2>/dev/null >&2 || true
+  cat "$a69dir/int_main.wasm.diag" >&2 2>/dev/null || true
   exit 1
 fi
 a69_int_out="$(VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh \
@@ -88,7 +88,7 @@ if [ -s "$a69dir/typo.wasm" ]; then
 fi
 if ! grep -q "not found" "$a69dir/typo.wasm.diag" 2>/dev/null; then
   echo "[compiler-gate] FAIL: entry typo diag missing 'not found' message" >&2
-  cat "$a69dir/typo.wasm.diag" 2>/dev/null >&2 || true
+  cat "$a69dir/typo.wasm.diag" >&2 2>/dev/null || true
   exit 1
 fi
 cat > "$a69dir/toplevel_expr.vibe" <<'EOF'
@@ -142,7 +142,7 @@ VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   "$g830dir/toplevel_record_destr.vibe" "$g830dir/toplevel_record_destr.wasm" _start >/dev/null 2>&1 || true
 if [ ! -s "$g830dir/toplevel_record_destr.wasm" ]; then
   echo "[compiler-gate] FAIL: top-level 'let record { .. } = ..' did not compile (#1281)" >&2
-  cat "$g830dir/toplevel_record_destr.wasm.diag" 2>/dev/null >&2 || true
+  cat "$g830dir/toplevel_record_destr.wasm.diag" >&2 2>/dev/null || true
   exit 1
 fi
 g830_top_out="$(VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh \
@@ -170,7 +170,7 @@ VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   "$g830dir/fnbody_record_destr.vibe" "$g830dir/fnbody_record_destr.wasm" _start >/dev/null 2>&1 || true
 if [ ! -s "$g830dir/fnbody_record_destr.wasm" ]; then
   echo "[compiler-gate] FAIL: function-body 'let record { .. } = ..' did not compile" >&2
-  cat "$g830dir/fnbody_record_destr.wasm.diag" 2>/dev/null >&2 || true
+  cat "$g830dir/fnbody_record_destr.wasm.diag" >&2 2>/dev/null || true
   exit 1
 fi
 g830_out="$(VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh \
@@ -224,7 +224,7 @@ if [ -s "$g844dir/toplevel_narrow.wasm" ]; then
 fi
 if ! grep -q "binding type mismatch" "$g844dir/toplevel_narrow.wasm.diag" 2>/dev/null; then
   echo "[compiler-gate] FAIL: top-level #844 rejection lacks the expected diagnostic" >&2
-  cat "$g844dir/toplevel_narrow.wasm.diag" 2>/dev/null >&2; exit 1
+  cat "$g844dir/toplevel_narrow.wasm.diag" >&2 2>/dev/null; exit 1
 fi
 cat > "$g844dir/local_narrow.vibe" <<'EOF'
 struct Box[T] { v: T }
@@ -245,7 +245,7 @@ if [ -s "$g844dir/local_narrow.wasm" ]; then
 fi
 if ! grep -q "binding type mismatch" "$g844dir/local_narrow.wasm.diag" 2>/dev/null; then
   echo "[compiler-gate] FAIL: local-let #844 rejection lacks the expected diagnostic" >&2
-  cat "$g844dir/local_narrow.wasm.diag" 2>/dev/null >&2; exit 1
+  cat "$g844dir/local_narrow.wasm.diag" >&2 2>/dev/null; exit 1
 fi
 # Positive controls: legitimate bare/explicit generic-struct annotation uses
 # that must NOT be over-rejected by the #844 fix.
@@ -260,7 +260,7 @@ VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   "$g844dir/ok_bare_roundtrip.vibe" "$g844dir/ok_bare_roundtrip.wasm" _start >/dev/null 2>&1 || true
 if [ ! -s "$g844dir/ok_bare_roundtrip.wasm" ]; then
   echo "[compiler-gate] FAIL: bare-to-bare generic-struct annotation round-trip over-rejected (#844 fix too aggressive)" >&2
-  cat "$g844dir/ok_bare_roundtrip.wasm.diag" 2>/dev/null >&2; exit 1
+  cat "$g844dir/ok_bare_roundtrip.wasm.diag" >&2 2>/dev/null; exit 1
 fi
 g844_ok_out="$(VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh \
   --invoke _start "$g844dir/ok_bare_roundtrip.wasm" 2>/dev/null | tr -dc '0-9-')"
@@ -279,7 +279,7 @@ VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   "$g844dir/ok_matching.vibe" "$g844dir/ok_matching.wasm" _start >/dev/null 2>&1 || true
 if [ ! -s "$g844dir/ok_matching.wasm" ]; then
   echo "[compiler-gate] FAIL: explicit matching generic-struct instantiation over-rejected (#844 fix too aggressive)" >&2
-  cat "$g844dir/ok_matching.wasm.diag" 2>/dev/null >&2; exit 1
+  cat "$g844dir/ok_matching.wasm.diag" >&2 2>/dev/null; exit 1
 fi
 g844_ok2_out="$(VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh \
   --invoke _start "$g844dir/ok_matching.wasm" 2>/dev/null | tr -dc '0-9-')"
@@ -335,7 +335,7 @@ if [ -s "$g1078dir/ctor_collision.wasm" ]; then
 fi
 if ! grep -q "constructor name collision" "$g1078dir/ctor_collision.wasm.diag" 2>/dev/null; then
   echo "[compiler-gate] FAIL: ctor-collision diag missing the descriptive #1078 message (still the misleading wrong-declaration mismatch?)" >&2
-  cat "$g1078dir/ctor_collision.wasm.diag" 2>/dev/null >&2 || true
+  cat "$g1078dir/ctor_collision.wasm.diag" >&2 2>/dev/null || true
   exit 1
 fi
 rm -rf "$g1078dir"
@@ -359,7 +359,7 @@ VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   "$g859dir/toplevel_tuple_destr.vibe" "$g859dir/toplevel_tuple_destr.wasm" _start >/dev/null 2>&1 || true
 if [ ! -s "$g859dir/toplevel_tuple_destr.wasm" ]; then
   echo "[compiler-gate] FAIL: top-level 'let (a, b) = ..' did not compile (#1281)" >&2
-  cat "$g859dir/toplevel_tuple_destr.wasm.diag" 2>/dev/null >&2 || true
+  cat "$g859dir/toplevel_tuple_destr.wasm.diag" >&2 2>/dev/null || true
   exit 1
 fi
 g859_out="$(VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh \
@@ -379,7 +379,7 @@ VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   "$g859dir/toplevel_struct_destr.vibe" "$g859dir/toplevel_struct_destr.wasm" _start >/dev/null 2>&1 || true
 if [ ! -s "$g859dir/toplevel_struct_destr.wasm" ]; then
   echo "[compiler-gate] FAIL: top-level 'let Name::{ .. } = ..' did not compile (#1281)" >&2
-  cat "$g859dir/toplevel_struct_destr.wasm.diag" 2>/dev/null >&2 || true
+  cat "$g859dir/toplevel_struct_destr.wasm.diag" >&2 2>/dev/null || true
   exit 1
 fi
 g859_out="$(VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh \
@@ -398,7 +398,7 @@ VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   "$g859dir/toplevel_record_destr.vibe" "$g859dir/toplevel_record_destr.wasm" _start >/dev/null 2>&1 || true
 if [ ! -s "$g859dir/toplevel_record_destr.wasm" ]; then
   echo "[compiler-gate] FAIL: top-level 'let record { .. } = ..' did not compile (#1281)" >&2
-  cat "$g859dir/toplevel_record_destr.wasm.diag" 2>/dev/null >&2 || true
+  cat "$g859dir/toplevel_record_destr.wasm.diag" >&2 2>/dev/null || true
   exit 1
 fi
 g859_out="$(VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh \
@@ -427,7 +427,7 @@ VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   "$g859dir/toplevel_destr_once.vibe" "$g859dir/toplevel_destr_once.wasm" _start >/dev/null 2>&1 || true
 if [ ! -s "$g859dir/toplevel_destr_once.wasm" ]; then
   echo "[compiler-gate] FAIL: top-level destructure of a call did not compile (#1281)" >&2
-  cat "$g859dir/toplevel_destr_once.wasm.diag" 2>/dev/null >&2 || true
+  cat "$g859dir/toplevel_destr_once.wasm.diag" >&2 2>/dev/null || true
   exit 1
 fi
 g859_out="$(VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh \
@@ -452,7 +452,7 @@ if [ -s "$g859dir/toplevel_refutable_destr.wasm" ]; then
 fi
 if ! grep -q "requires an irrefutable pattern" "$g859dir/toplevel_refutable_destr.wasm.diag" 2>/dev/null; then
   echo "[compiler-gate] FAIL: refutable top-level pattern let diag missing the clear #1281 message" >&2
-  cat "$g859dir/toplevel_refutable_destr.wasm.diag" 2>/dev/null >&2 || true
+  cat "$g859dir/toplevel_refutable_destr.wasm.diag" >&2 2>/dev/null || true
   exit 1
 fi
 # The function-body forms (which already worked, per the #859 writeup) must
@@ -473,7 +473,7 @@ VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   "$g859dir/fnbody_tuple_destr.vibe" "$g859dir/fnbody_tuple_destr.wasm" _start >/dev/null 2>&1 || true
 if [ ! -s "$g859dir/fnbody_tuple_destr.wasm" ]; then
   echo "[compiler-gate] FAIL: function-body 'let (a, b) = ..' did not compile" >&2
-  cat "$g859dir/fnbody_tuple_destr.wasm.diag" 2>/dev/null >&2 || true
+  cat "$g859dir/fnbody_tuple_destr.wasm.diag" >&2 2>/dev/null || true
   exit 1
 fi
 g859_out="$(VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh \
@@ -539,7 +539,7 @@ VIBE_CHECK_ERROR_ROW=0 VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_IMPORT_ABI=raw \
   "$g944dir/leak.vibe" "$g944dir/leak_off.wasm" main >/dev/null 2>&1 || true
 if [ ! -s "$g944dir/leak_off.wasm" ]; then
   echo "[compiler-gate] FAIL: VIBE_CHECK_ERROR_ROW=0 opt-out did not restore the old exemption (#944)" >&2
-  cat "$g944dir/leak_off.wasm.diag" 2>/dev/null >&2 || true
+  cat "$g944dir/leak_off.wasm.diag" >&2 2>/dev/null || true
   exit 1
 fi
 rm -f "$g944dir/leak_on.wasm"
@@ -552,7 +552,7 @@ if [ -s "$g944dir/leak_on.wasm" ]; then
 fi
 if ! grep -q "missing { Exception }" "$g944dir/leak_on.wasm.diag" 2>/dev/null; then
   echo "[compiler-gate] FAIL: checked-Error rejection diag missing the row-mismatch message (#944)" >&2
-  cat "$g944dir/leak_on.wasm.diag" 2>/dev/null >&2 || true
+  cat "$g944dir/leak_on.wasm.diag" >&2 2>/dev/null || true
   exit 1
 fi
 rm -f "$g944dir/discharged.wasm"
@@ -561,7 +561,7 @@ VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_IMPORT_ABI=raw \
   "$g944dir/discharged.vibe" "$g944dir/discharged.wasm" main >/dev/null 2>&1 || true
 if [ ! -s "$g944dir/discharged.wasm" ]; then
   echo "[compiler-gate] FAIL: checked-Error mode rejected a handle-with-Error discharge (over-strict, #944)" >&2
-  cat "$g944dir/discharged.wasm.diag" 2>/dev/null >&2 || true
+  cat "$g944dir/discharged.wasm.diag" >&2 2>/dev/null || true
   exit 1
 fi
 g944_out="$(VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh "$g944dir/discharged.wasm" 2>&1 | tail -1)"
@@ -588,7 +588,7 @@ VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_IMPORT_ABI=raw \
   fixtures/entry_error_boundary.vibe "$g944cdir/out.wasm" main >/dev/null 2>&1 || true
 if [ ! -s "$g944cdir/out.wasm" ]; then
   echo "[compiler-gate] FAIL: entry_error_boundary.vibe did not compile (#944 stage C)" >&2
-  cat "$g944cdir/out.wasm.diag" 2>/dev/null >&2 || true
+  cat "$g944cdir/out.wasm.diag" >&2 2>/dev/null || true
   exit 1
 fi
 if VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh --invoke _start "$g944cdir/out.wasm" >"$g944cdir/stdout.txt" 2>"$g944cdir/stderr.txt"; then
@@ -623,7 +623,7 @@ VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_IMPORT_ABI=raw \
   fixtures/err_entry_boundary_typed_payload.vibe "$g944cdir/typed.wasm" main >/dev/null 2>&1 || true
 if [ ! -s "$g944cdir/typed.wasm" ]; then
   echo "[compiler-gate] FAIL: err_entry_boundary_typed_payload.vibe did not compile (#1372 review)" >&2
-  cat "$g944cdir/typed.wasm.diag" 2>/dev/null >&2 || true
+  cat "$g944cdir/typed.wasm.diag" >&2 2>/dev/null || true
   exit 1
 fi
 if VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh --invoke _start "$g944cdir/typed.wasm" >"$g944cdir/typed_stdout.txt" 2>"$g944cdir/typed_stderr.txt"; then
@@ -643,7 +643,7 @@ VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_IMPORT_ABI=raw \
   fixtures/err_entry_boundary_string_payload.vibe "$g944cdir/strp.wasm" main >/dev/null 2>&1 || true
 if [ ! -s "$g944cdir/strp.wasm" ]; then
   echo "[compiler-gate] FAIL: err_entry_boundary_string_payload.vibe did not compile (#1374)" >&2
-  cat "$g944cdir/strp.wasm.diag" 2>/dev/null >&2 || true
+  cat "$g944cdir/strp.wasm.diag" >&2 2>/dev/null || true
   exit 1
 fi
 if VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh --invoke _start "$g944cdir/strp.wasm" >"$g944cdir/strp_stdout.txt" 2>"$g944cdir/strp_stderr.txt"; then
@@ -679,7 +679,7 @@ VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_IMPORT_ABI=raw \
   fixtures/effect_handle_error_nontail.vibe "$g1087dir/out.wasm" __no_entry__ >/dev/null 2>&1 || true
 if [ ! -s "$g1087dir/out.wasm" ]; then
   echo "[compiler-gate] FAIL: effect_handle_error_nontail.vibe did not compile (#1087)" >&2
-  cat "$g1087dir/out.wasm.diag" 2>/dev/null >&2 || true
+  cat "$g1087dir/out.wasm.diag" >&2 2>/dev/null || true
   exit 1
 fi
 if ! g1087_out="$(VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh --invoke _start "$g1087dir/out.wasm" 2>&1)"; then
@@ -734,7 +734,7 @@ VIBE_MISSING_VPKG_SCAN=1 VIBE_PREOPEN_DIR="$ROOT_DIR" \
   "$ROOT_DIR" "$vpkgdir/scan.out" __no_entry__ >/dev/null 2>&1 || true
 if [ ! -s "$vpkgdir/scan.out" ]; then
   echo "[compiler-gate] FAIL: missing-vpkg scan produced no output" >&2
-  cat "$vpkgdir/scan.out.diag" 2>/dev/null >&2
+  cat "$vpkgdir/scan.out.diag" >&2 2>/dev/null
   exit 1
 fi
 if ! grep -q "^ok: no directories missing index.vpkg" "$vpkgdir/scan.out"; then
@@ -776,7 +776,7 @@ VIBE_RC=1 VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   "fixtures/rc_ctor_double_field_match_test.vibe" "$c1062dir/c1062.wasm" __no_entry__ >/dev/null 2>&1 || true
 if [ ! -s "$c1062dir/c1062.wasm" ]; then
   echo "[compiler-gate] FAIL: ctor Double-field match fixture did not compile under RC" >&2
-  cat "$c1062dir/c1062.wasm.diag" 2>/dev/null >&2 || true
+  cat "$c1062dir/c1062.wasm.diag" >&2 2>/dev/null || true
   exit 1
 fi
 if ! VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh \
@@ -848,7 +848,7 @@ VIBE_STDIN_BYTES="$(cat "$lspgatedir/input.bin")" \
   bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" > "$lsp_out" 2>"$lspgatedir/stderr.log"
 if ! grep -q '"id":1,"result"' "$lsp_out" 2>/dev/null && ! grep -q '"id": 1, "result"' "$lsp_out" 2>/dev/null; then
   echo "[compiler-gate] FAIL: self-hosted vibe lsp did not answer initialize" >&2
-  cat "$lspgatedir/stderr.log" 2>/dev/null >&2 || true
+  cat "$lspgatedir/stderr.log" >&2 2>/dev/null || true
   exit 1
 fi
 if ! grep -q '(Int, Int) -> Int' "$lsp_out"; then
@@ -906,7 +906,7 @@ VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   fixtures/send_bound_structural.vibe "$senddir/pos.wasm" __no_entry__ >/dev/null 2>&1 || true
 if [ ! -s "$senddir/pos.wasm" ]; then
   echo "[compiler-gate] FAIL: send_bound_structural.vibe did not compile -- structural Send acceptance regressed" >&2
-  cat "$senddir/pos.wasm.diag" 2>/dev/null >&2 || true
+  cat "$senddir/pos.wasm.diag" >&2 2>/dev/null || true
   exit 1
 fi
 if ! send_pos_out="$(VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh --invoke _start "$senddir/pos.wasm" 2>&1)"; then
@@ -928,7 +928,7 @@ send_check_reject() {
   fi
   if ! grep -qF "$needle" "$senddir/$tag.wasm.diag" 2>/dev/null; then
     echo "[compiler-gate] FAIL: $fixture did not produce the expected diagnostic ($needle)" >&2
-    cat "$senddir/$tag.wasm.diag" 2>/dev/null >&2 || true
+    cat "$senddir/$tag.wasm.diag" >&2 2>/dev/null || true
     exit 1
   fi
 }
@@ -978,7 +978,7 @@ VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   fixtures/contract_generic_head_ok.vibe "$senddir/cgenok.wasm" main >/dev/null 2>&1 || true
 if [ ! -s "$senddir/cgenok.wasm" ]; then
   echo "[compiler-gate] FAIL: contract_generic_head_ok.vibe did not compile -- the #2640 head check over-rejects" >&2
-  cat "$senddir/cgenok.wasm.diag" 2>/dev/null >&2 || true
+  cat "$senddir/cgenok.wasm.diag" >&2 2>/dev/null || true
   exit 1
 fi
 cgenok_out="$(VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh --invoke _start "$senddir/cgenok.wasm" 2>&1)" || cgenok_out="<run failed> $cgenok_out"
@@ -1009,7 +1009,7 @@ VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   fixtures/contract_generic_head_shadowed_formal.vibe "$senddir/cgenshadow.wasm" main >/dev/null 2>&1 || true
 if [ ! -s "$senddir/cgenshadow.wasm" ]; then
   echo "[compiler-gate] FAIL: a type formal named MutSet no longer compiles -- the #2640 head check classifies shadowed formals" >&2
-  cat "$senddir/cgenshadow.wasm.diag" 2>/dev/null >&2 || true
+  cat "$senddir/cgenshadow.wasm.diag" >&2 2>/dev/null || true
   exit 1
 fi
 cgenshadow_out="$(VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh --invoke _start "$senddir/cgenshadow.wasm" 2>&1)" || cgenshadow_out="<run failed> $cgenshadow_out"
@@ -1039,7 +1039,7 @@ if [ -s "$senddir/send_use.wasm" ]; then
 fi
 if ! grep -qF 'no impl `Send` for `Array[Int]`' "$senddir/send_use.wasm.diag" 2>/dev/null; then
   echo "[compiler-gate] FAIL: import-path Send violation did not produce the expected diagnostic" >&2
-  cat "$senddir/send_use.wasm.diag" 2>/dev/null >&2 || true
+  cat "$senddir/send_use.wasm.diag" >&2 2>/dev/null || true
   exit 1
 fi
 rm -rf "$senddir"
@@ -1067,7 +1067,7 @@ VIBE_RC=1 VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   fixtures/rc_branch_loop_mixed_consume_test.vibe "$rc1085dir/src.wasm" __no_entry__ >/dev/null 2>&1 || true
 if [ ! -s "$rc1085dir/src.wasm" ]; then
   echo "[compiler-gate] FAIL: rc_branch_loop_mixed_consume fixture did not compile" >&2
-  cat "$rc1085dir/src.wasm.diag" 2>/dev/null >&2 || true
+  cat "$rc1085dir/src.wasm.diag" >&2 2>/dev/null || true
   exit 1
 fi
 if ! rc1085_out="$(VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh --invoke _start "$rc1085dir/src.wasm" 2>&1)"; then
@@ -1112,7 +1112,7 @@ scps_run_inspect() {
     "fixtures/$fixture" "$scpsdir/$tag.wasm" __no_entry__ >/dev/null 2>&1 || true
   if [ ! -s "$scpsdir/$tag.wasm" ]; then
     echo "[compiler-gate] FAIL: $fixture did not compile -- Phase 3a suspend lowering regressed" >&2
-    cat "$scpsdir/$tag.wasm.diag" 2>/dev/null >&2 || true
+    cat "$scpsdir/$tag.wasm.diag" >&2 2>/dev/null || true
     exit 1
   fi
   if ! scps_out="$(VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh --invoke _start "$scpsdir/$tag.wasm" 2>&1)"; then
@@ -1147,7 +1147,7 @@ VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   "$scpsdir/once.vibe" "$scpsdir/once.wasm" _start >/dev/null 2>&1 || true
 if [ ! -s "$scpsdir/once.wasm" ]; then
   echo "[compiler-gate] FAIL: effect_resume_one_shot_trap.vibe did not compile" >&2
-  cat "$scpsdir/once.wasm.diag" 2>/dev/null >&2 || true
+  cat "$scpsdir/once.wasm.diag" >&2 2>/dev/null || true
   exit 1
 fi
 scps_once_out="$(VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh --invoke _start "$scpsdir/once.wasm" 2>&1 || true)"
@@ -1178,7 +1178,7 @@ scps_check_reject() {
   fi
   if ! grep -qF "$needle" "$scpsdir/$tag.wasm.diag" 2>/dev/null; then
     echo "[compiler-gate] FAIL: $fixture did not produce the expected diagnostic ($needle)" >&2
-    cat "$scpsdir/$tag.wasm.diag" 2>/dev/null >&2 || true
+    cat "$scpsdir/$tag.wasm.diag" >&2 2>/dev/null || true
     exit 1
   fi
 }
@@ -1481,7 +1481,7 @@ VIBE_RC=1 VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   fixtures/rc_match_payload_closure_capture_test.vibe "$rc1097dir/src.wasm" __no_entry__ >/dev/null 2>&1 || true
 if [ ! -s "$rc1097dir/src.wasm" ]; then
   echo "[compiler-gate] FAIL: rc_match_payload_closure_capture fixture did not compile" >&2
-  cat "$rc1097dir/src.wasm.diag" 2>/dev/null >&2 || true
+  cat "$rc1097dir/src.wasm.diag" >&2 2>/dev/null || true
   exit 1
 fi
 if ! rc1097_out="$(VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh --invoke _start "$rc1097dir/src.wasm" 2>&1)"; then
@@ -1509,7 +1509,7 @@ VIBE_RC=1 VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   fixtures/rc_local_container_element_escape.vibe "$rc1272dir/src.wasm" __no_entry__ >/dev/null 2>&1 || true
 if [ ! -s "$rc1272dir/src.wasm" ]; then
   echo "[compiler-gate] FAIL: rc_local_container_element_escape fixture did not compile" >&2
-  cat "$rc1272dir/src.wasm.diag" 2>/dev/null >&2 || true
+  cat "$rc1272dir/src.wasm.diag" >&2 2>/dev/null || true
   exit 1
 fi
 if ! rc1272_out="$(VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh --invoke _start "$rc1272dir/src.wasm" 2>&1)"; then
@@ -1537,7 +1537,7 @@ VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   fixtures/async_await_multi.vibe "$awmdir/src.wasm" __no_entry__ >/dev/null 2>&1 || true
 if [ ! -s "$awmdir/src.wasm" ]; then
   echo "[compiler-gate] FAIL: async_await_multi fixture did not compile" >&2
-  cat "$awmdir/src.wasm.diag" 2>/dev/null >&2 || true
+  cat "$awmdir/src.wasm.diag" >&2 2>/dev/null || true
   exit 1
 fi
 if ! awm_out="$(VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh --invoke _start "$awmdir/src.wasm" 2>&1)"; then
@@ -1562,7 +1562,7 @@ VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   fixtures/async_future_pending.vibe "$fpdir/src.wasm" __no_entry__ >/dev/null 2>&1 || true
 if [ ! -s "$fpdir/src.wasm" ]; then
   echo "[compiler-gate] FAIL: async_future_pending fixture did not compile" >&2
-  cat "$fpdir/src.wasm.diag" 2>/dev/null >&2 || true
+  cat "$fpdir/src.wasm.diag" >&2 2>/dev/null || true
   exit 1
 fi
 if ! fp_out="$(VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh --invoke _start "$fpdir/src.wasm" 2>&1)"; then
@@ -1588,7 +1588,7 @@ VIBE_RC=1 VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   fixtures/rc_closure_owned_capture_escape.vibe "$rcocdir/esc.wasm" _start >/dev/null 2>&1 || true
 if [ ! -s "$rcocdir/esc.wasm" ]; then
   echo "[compiler-gate] FAIL: rc_closure_owned_capture_escape fixture did not compile" >&2
-  cat "$rcocdir/esc.wasm.diag" 2>/dev/null >&2 || true
+  cat "$rcocdir/esc.wasm.diag" >&2 2>/dev/null || true
   exit 1
 fi
 rcoc_out="$(VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh --invoke _start "$rcocdir/esc.wasm" 2>/dev/null | tail -1)"
@@ -1614,7 +1614,7 @@ VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   fixtures/effect_closure_cps_param.vibe "$ccpsdir/param.wasm" _start >/dev/null 2>&1 || true
 if [ ! -s "$ccpsdir/param.wasm" ]; then
   echo "[compiler-gate] FAIL: effect_closure_cps_param fixture did not compile" >&2
-  cat "$ccpsdir/param.wasm.diag" 2>/dev/null >&2 || true
+  cat "$ccpsdir/param.wasm.diag" >&2 2>/dev/null || true
   exit 1
 fi
 ccps_out="$(VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh --invoke _start "$ccpsdir/param.wasm" 2>/dev/null | tail -1)"
@@ -1633,7 +1633,7 @@ if [ -s "$ccpsdir/mixed.wasm" ]; then
 fi
 if ! grep -qF "mixing the step convention" "$ccpsdir/mixed.wasm.diag" 2>/dev/null; then
   echo "[compiler-gate] FAIL: mixed-convention fixture did not produce the expected diagnostic" >&2
-  cat "$ccpsdir/mixed.wasm.diag" 2>/dev/null >&2 || true
+  cat "$ccpsdir/mixed.wasm.diag" >&2 2>/dev/null || true
   exit 1
 fi
 # #1324: ordinary arithmetic on a value bound from a GENERIC suspend-lane
@@ -1648,7 +1648,7 @@ VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   fixtures/effect_closure_cps_generic_operand.vibe "$ccpsdir/genop.wasm" _start >/dev/null 2>&1 || true
 if [ ! -s "$ccpsdir/genop.wasm" ]; then
   echo "[compiler-gate] FAIL: effect_closure_cps_generic_operand did not compile -- a pure desugar helper (__generic_add / __generic_rel_diff / str_lex_diff) sank a suspend-class closure literal again (#1324)" >&2
-  cat "$ccpsdir/genop.wasm.diag" 2>/dev/null >&2 || true
+  cat "$ccpsdir/genop.wasm.diag" >&2 2>/dev/null || true
   exit 1
 fi
 ccps_genop_out="$(VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh --invoke _start "$ccpsdir/genop.wasm" 2>/dev/null | tail -1)"
@@ -1673,7 +1673,7 @@ VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   fixtures/effect_closure_value_evidence_m2.vibe "$tdevdir/m2.wasm" _start >/dev/null 2>&1 || true
 if [ ! -s "$tdevdir/m2.wasm" ]; then
   echo "[compiler-gate] FAIL: effect_closure_value_evidence_m2 fixture did not compile" >&2
-  cat "$tdevdir/m2.wasm.diag" 2>/dev/null >&2 || true
+  cat "$tdevdir/m2.wasm.diag" >&2 2>/dev/null || true
   exit 1
 fi
 tdev_out="$(VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh --invoke _start "$tdevdir/m2.wasm" 2>/dev/null | tail -1)"
@@ -1692,7 +1692,7 @@ if [ -s "$tdevdir/inelig.wasm" ]; then
 fi
 if ! grep -qF "type-directed evidence" "$tdevdir/inelig.wasm.diag" 2>/dev/null; then
   echo "[compiler-gate] FAIL: ineligible closure-value fixture did not produce the expected diagnostic" >&2
-  cat "$tdevdir/inelig.wasm.diag" 2>/dev/null >&2 || true
+  cat "$tdevdir/inelig.wasm.diag" >&2 2>/dev/null || true
   exit 1
 fi
 rm -f "$tdevdir/multi.wasm"
@@ -1701,7 +1701,7 @@ VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   fixtures/effect_closure_value_evidence_multi.vibe "$tdevdir/multi.wasm" _start >/dev/null 2>&1 || true
 if [ ! -s "$tdevdir/multi.wasm" ]; then
   echo "[compiler-gate] FAIL: effect_closure_value_evidence_multi fixture did not compile" >&2
-  cat "$tdevdir/multi.wasm.diag" 2>/dev/null >&2 || true
+  cat "$tdevdir/multi.wasm.diag" >&2 2>/dev/null || true
   exit 1
 fi
 multi_out="$(VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh --invoke _start "$tdevdir/multi.wasm" 2>/dev/null | tail -1)"
@@ -1715,7 +1715,7 @@ VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   fixtures/effect_closure_value_evidence_shadow.vibe "$tdevdir/shadow.wasm" _start >/dev/null 2>&1 || true
 if [ ! -s "$tdevdir/shadow.wasm" ]; then
   echo "[compiler-gate] FAIL: effect_closure_value_evidence_shadow fixture did not compile" >&2
-  cat "$tdevdir/shadow.wasm.diag" 2>/dev/null >&2 || true
+  cat "$tdevdir/shadow.wasm.diag" >&2 2>/dev/null || true
   exit 1
 fi
 shadow_out="$(VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh --invoke _start "$tdevdir/shadow.wasm" 2>/dev/null | tail -1)"
@@ -1748,7 +1748,7 @@ VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   fixtures/effect_vacuous_handle_erased.vibe "$v2dir/vacuous.wasm" __no_entry__ >/dev/null 2>&1 || true
 if [ ! -s "$v2dir/vacuous.wasm" ]; then
   echo "[compiler-gate] FAIL: effect_vacuous_handle_erased fixture did not compile" >&2
-  cat "$v2dir/vacuous.wasm.diag" 2>/dev/null >&2 || true
+  cat "$v2dir/vacuous.wasm.diag" >&2 2>/dev/null || true
   exit 1
 fi
 if ! v2_out="$(VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh --invoke _start "$v2dir/vacuous.wasm" 2>&1)"; then
@@ -1770,7 +1770,7 @@ fi
 # the part most likely to be reworded again.
 if ! grep -qF "cannot be compiled here" "$v2dir/reject.wasm.diag" 2>/dev/null; then
   echo "[compiler-gate] FAIL: replay-removed reject fixture did not produce the expected diagnostic" >&2
-  cat "$v2dir/reject.wasm.diag" 2>/dev/null >&2 || true
+  cat "$v2dir/reject.wasm.diag" >&2 2>/dev/null || true
   exit 1
 fi
 rm -rf "$v2dir"
@@ -1793,7 +1793,7 @@ VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   fixtures/closure_shadowed_inline_builtin.vibe "$csibdir/out.wasm" __no_entry__ >/dev/null 2>&1 || true
 if [ ! -s "$csibdir/out.wasm" ]; then
   echo "[compiler-gate] FAIL: closure_shadowed_inline_builtin.vibe did not compile" >&2
-  cat "$csibdir/out.wasm.diag" 2>/dev/null >&2 || true
+  cat "$csibdir/out.wasm.diag" >&2 2>/dev/null || true
   exit 1
 fi
 if ! csib_out="$(VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh --invoke _start "$csibdir/out.wasm" 2>&1)"; then
@@ -1870,7 +1870,7 @@ VIBE_EMIT_MERGED_SOURCE=1 VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_IMPORT_ABI=raw \
   "$c1078dir/main.vibe" "$c1078dir/merged.vibe" main >/dev/null 2>&1 || true
 if [ ! -s "$c1078dir/merged.vibe" ]; then
   echo "[compiler-gate] FAIL: merge/flatten of the ctor/effect-op collision program failed (#1078)" >&2
-  cat "$c1078dir/merged.vibe.diag" 2>/dev/null >&2 || true
+  cat "$c1078dir/merged.vibe.diag" >&2 2>/dev/null || true
   exit 1
 fi
 VIBE_INTERNAL_TRUSTED_SOURCE=1 VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_IMPORT_ABI=raw \
@@ -1878,7 +1878,7 @@ VIBE_INTERNAL_TRUSTED_SOURCE=1 VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_IMPORT_ABI=raw 
   "$c1078dir/merged.vibe" "$c1078dir/out.wasm" main >/dev/null 2>&1 || true
 if [ ! -s "$c1078dir/out.wasm" ]; then
   echo "[compiler-gate] FAIL: merged ctor/effect-op collision program did not compile -- bare-name resolution picked the wrong declaration (#1078)" >&2
-  cat "$c1078dir/out.wasm.diag" 2>/dev/null >&2 || true
+  cat "$c1078dir/out.wasm.diag" >&2 2>/dev/null || true
   exit 1
 fi
 c1078_out="$(VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh "$c1078dir/out.wasm" 2>&1 | tail -1)"
@@ -1925,7 +1925,7 @@ VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   fixtures/region_ok_basic.vibe "$regiondir/pos.wasm" __no_entry__ >/dev/null 2>&1 || true
 if [ ! -s "$regiondir/pos.wasm" ]; then
   echo "[compiler-gate] FAIL: region_ok_basic.vibe did not compile -- plain non-escaping nursery use regressed" >&2
-  cat "$regiondir/pos.wasm.diag" 2>/dev/null >&2 || true
+  cat "$regiondir/pos.wasm.diag" >&2 2>/dev/null || true
   exit 1
 fi
 if ! region_pos_out="$(VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh --invoke _start "$regiondir/pos.wasm" 2>&1)"; then
@@ -1945,7 +1945,7 @@ if [ -s "$regiondir/neg.wasm" ]; then
 fi
 if ! grep -qF 'region escapes its nursery scope' "$regiondir/neg.wasm.diag" 2>/dev/null; then
   echo "[compiler-gate] FAIL: err_region_escape_return.vibe did not produce the expected diagnostic" >&2
-  cat "$regiondir/neg.wasm.diag" 2>/dev/null >&2 || true
+  cat "$regiondir/neg.wasm.diag" >&2 2>/dev/null || true
   exit 1
 fi
 rm -rf "$regiondir"
@@ -1959,7 +1959,7 @@ VIBE_DEPS_MISSING_SCAN=1 VIBE_PREOPEN_DIR="$ROOT_DIR" \
   "$ROOT_DIR" "$depsdir/scan.out" __no_entry__ >/dev/null 2>&1 || true
 if [ ! -s "$depsdir/scan.out" ]; then
   echo "[compiler-gate] FAIL: deps-missing scan produced no output" >&2
-  cat "$depsdir/scan.out.diag" 2>/dev/null >&2
+  cat "$depsdir/scan.out.diag" >&2 2>/dev/null
   exit 1
 fi
 if ! grep -q "^ok: no missing deps declarations" "$depsdir/scan.out"; then
@@ -1998,7 +1998,7 @@ VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   fixtures/region_ok_spawnable_capture.vibe "$spawnabledir/pos.wasm" __no_entry__ >/dev/null 2>&1 || true
 if [ ! -s "$spawnabledir/pos.wasm" ]; then
   echo "[compiler-gate] FAIL: region_ok_spawnable_capture.vibe did not compile -- same-region Sender capture regressed" >&2
-  cat "$spawnabledir/pos.wasm.diag" 2>/dev/null >&2 || true
+  cat "$spawnabledir/pos.wasm.diag" >&2 2>/dev/null || true
   exit 1
 fi
 if ! spawnable_pos_out="$(VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh --invoke _start "$spawnabledir/pos.wasm" 2>&1)"; then
@@ -2018,7 +2018,7 @@ if [ -s "$spawnabledir/neg_array.wasm" ]; then
 fi
 if ! grep -qF 'no impl `Spawnable` for `Array[Int]`' "$spawnabledir/neg_array.wasm.diag" 2>/dev/null; then
   echo "[compiler-gate] FAIL: err_spawnable_capture_array.vibe did not produce the expected diagnostic" >&2
-  cat "$spawnabledir/neg_array.wasm.diag" 2>/dev/null >&2 || true
+  cat "$spawnabledir/neg_array.wasm.diag" >&2 2>/dev/null || true
   exit 1
 fi
 # #1571: the expectation for this rejection is the diagnostic grep below,
@@ -2033,7 +2033,7 @@ if [ -s "$spawnabledir/neg_cross.wasm" ]; then
 fi
 if ! grep -qF 'no impl `Spawnable`' "$spawnabledir/neg_cross.wasm.diag" 2>/dev/null; then
   echo "[compiler-gate] FAIL: err_spawnable_capture_cross_region.vibe did not produce the expected diagnostic" >&2
-  cat "$spawnabledir/neg_cross.wasm.diag" 2>/dev/null >&2 || true
+  cat "$spawnabledir/neg_cross.wasm.diag" >&2 2>/dev/null || true
   exit 1
 fi
 # #1571: the expectation for this rejection is the diagnostic grep below,
@@ -2048,7 +2048,7 @@ if [ -s "$spawnabledir/neg_letmut.wasm" ]; then
 fi
 if ! grep -qF "no impl \`Spawnable\` for a \`let mut\` binding" "$spawnabledir/neg_letmut.wasm.diag" 2>/dev/null; then
   echo "[compiler-gate] FAIL: err_spawnable_capture_letmut.vibe did not produce the expected diagnostic" >&2
-  cat "$spawnabledir/neg_letmut.wasm.diag" 2>/dev/null >&2 || true
+  cat "$spawnabledir/neg_letmut.wasm.diag" >&2 2>/dev/null || true
   exit 1
 fi
 # #1571: the expectation for this rejection is the diagnostic grep below,
@@ -2063,7 +2063,7 @@ if [ -s "$spawnabledir/neg_letmut_outer.wasm" ]; then
 fi
 if ! grep -qF "no impl \`Spawnable\` for a \`let mut\` binding" "$spawnabledir/neg_letmut_outer.wasm.diag" 2>/dev/null; then
   echo "[compiler-gate] FAIL: err_spawnable_capture_letmut_outer_scope.vibe did not produce the expected diagnostic" >&2
-  cat "$spawnabledir/neg_letmut_outer.wasm.diag" 2>/dev/null >&2 || true
+  cat "$spawnabledir/neg_letmut_outer.wasm.diag" >&2 2>/dev/null || true
   exit 1
 fi
 # Codex review (PR #1152, P1): the whole-program `let mut` capture pass
@@ -2080,7 +2080,7 @@ VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   fixtures/region_ok_spawnable_capture_shadowed_letmut.vibe "$spawnabledir/pos_shadow.wasm" __no_entry__ >/dev/null 2>&1 || true
 if [ ! -s "$spawnabledir/pos_shadow.wasm" ]; then
   echo "[compiler-gate] FAIL: region_ok_spawnable_capture_shadowed_letmut.vibe did not compile -- scope-blind let-mut false positive regressed" >&2
-  cat "$spawnabledir/pos_shadow.wasm.diag" 2>/dev/null >&2 || true
+  cat "$spawnabledir/pos_shadow.wasm.diag" >&2 2>/dev/null || true
   exit 1
 fi
 if ! spawnable_shadow_out="$(VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh --invoke _start "$spawnabledir/pos_shadow.wasm" 2>&1)"; then
@@ -2096,7 +2096,7 @@ fi
 # never reaches this file), so check for THAT rendered form instead.
 if ! grep -qE 'line [0-9]+:[0-9]+-[0-9]+' "$spawnabledir/neg_letmut_outer.wasm.diag" 2>/dev/null; then
   echo "[compiler-gate] FAIL: err_spawnable_capture_letmut_outer_scope.vibe diagnostic lost its located line:col-col source range" >&2
-  cat "$spawnabledir/neg_letmut_outer.wasm.diag" 2>/dev/null >&2 || true
+  cat "$spawnabledir/neg_letmut_outer.wasm.diag" >&2 2>/dev/null || true
   exit 1
 fi
 rm -rf "$spawnabledir"
@@ -2122,7 +2122,7 @@ VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   fixtures/region_ok_taskgroup_sugar.vibe "$taskgroupdir/pos.wasm" __no_entry__ >/dev/null 2>&1 || true
 if [ ! -s "$taskgroupdir/pos.wasm" ]; then
   echo "[compiler-gate] FAIL: region_ok_taskgroup_sugar.vibe did not compile" >&2
-  cat "$taskgroupdir/pos.wasm.diag" 2>/dev/null >&2 || true
+  cat "$taskgroupdir/pos.wasm.diag" >&2 2>/dev/null || true
   exit 1
 fi
 if ! taskgroup_pos_out="$(VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh --invoke _start "$taskgroupdir/pos.wasm" 2>&1)"; then
@@ -2142,7 +2142,7 @@ if [ -s "$taskgroupdir/neg.wasm" ]; then
 fi
 if ! grep -qF 'region escapes its nursery scope' "$taskgroupdir/neg.wasm.diag" 2>/dev/null; then
   echo "[compiler-gate] FAIL: err_taskgroup_sugar_region_escape.vibe did not produce the expected diagnostic" >&2
-  cat "$taskgroupdir/neg.wasm.diag" 2>/dev/null >&2 || true
+  cat "$taskgroupdir/neg.wasm.diag" >&2 2>/dev/null || true
   exit 1
 fi
 rm -rf "$taskgroupdir"
@@ -2180,7 +2180,7 @@ VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   fixtures/region_ok_frozen_array_basic.vibe "$frozenarrdir/basic.wasm" __no_entry__ >/dev/null 2>&1 || true
 if [ ! -s "$frozenarrdir/basic.wasm" ]; then
   echo "[compiler-gate] FAIL: region_ok_frozen_array_basic.vibe did not compile" >&2
-  cat "$frozenarrdir/basic.wasm.diag" 2>/dev/null >&2 || true
+  cat "$frozenarrdir/basic.wasm.diag" >&2 2>/dev/null || true
   exit 1
 fi
 if ! frozenarr_basic_out="$(VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh --invoke _start "$frozenarrdir/basic.wasm" 2>&1)"; then
@@ -2197,7 +2197,7 @@ VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   fixtures/send_bound_frozen_array.vibe "$frozenarrdir/send.wasm" __no_entry__ >/dev/null 2>&1 || true
 if [ ! -s "$frozenarrdir/send.wasm" ]; then
   echo "[compiler-gate] FAIL: send_bound_frozen_array.vibe did not compile -- FrozenArray[Int] Send acceptance regressed" >&2
-  cat "$frozenarrdir/send.wasm.diag" 2>/dev/null >&2 || true
+  cat "$frozenarrdir/send.wasm.diag" >&2 2>/dev/null || true
   exit 1
 fi
 if ! frozenarr_send_out="$(VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh --invoke _start "$frozenarrdir/send.wasm" 2>&1)"; then
@@ -2217,7 +2217,7 @@ if [ -s "$frozenarrdir/neg.wasm" ]; then
 fi
 if ! grep -qF 'no impl `Send` for `FrozenArray[Array[Int]]`' "$frozenarrdir/neg.wasm.diag" 2>/dev/null; then
   echo "[compiler-gate] FAIL: err_type_send_frozen_array_of_array_bound.vibe did not produce the expected diagnostic" >&2
-  cat "$frozenarrdir/neg.wasm.diag" 2>/dev/null >&2 || true
+  cat "$frozenarrdir/neg.wasm.diag" >&2 2>/dev/null || true
   exit 1
 fi
 # #1571: the expected value lives in the fixture now (an `inspect` test
@@ -2228,7 +2228,7 @@ VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   fixtures/region_ok_frozen_array_taskgroup_capture.vibe "$frozenarrdir/capture.wasm" __no_entry__ >/dev/null 2>&1 || true
 if [ ! -s "$frozenarrdir/capture.wasm" ]; then
   echo "[compiler-gate] FAIL: region_ok_frozen_array_taskgroup_capture.vibe did not compile -- FrozenArray Spawnable capture regressed" >&2
-  cat "$frozenarrdir/capture.wasm.diag" 2>/dev/null >&2 || true
+  cat "$frozenarrdir/capture.wasm.diag" >&2 2>/dev/null || true
   exit 1
 fi
 if ! frozenarr_capture_out="$(VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh --invoke _start "$frozenarrdir/capture.wasm" 2>&1)"; then
@@ -2260,7 +2260,7 @@ if [ -s "$eff639dir/no_with.wasm" ]; then
 fi
 if ! grep -qF "missing { Ask::Value } (no 'with' clause, requires { Ask::Value })" "$eff639dir/no_with.wasm.diag" 2>/dev/null; then
   echo "[compiler-gate] FAIL: err_effect_missing_annotation.vibe did not produce the expected diagnostic" >&2
-  cat "$eff639dir/no_with.wasm.diag" 2>/dev/null >&2 || true
+  cat "$eff639dir/no_with.wasm.diag" >&2 2>/dev/null || true
   exit 1
 fi
 cp fixtures/err_effect_handle_partial_discharge.vibe "$eff639dir/partial.vibe"
@@ -2273,7 +2273,7 @@ if [ -s "$eff639dir/partial.wasm" ]; then
 fi
 if ! grep -qF "missing { Fs } (declared { Ask, Ask::Get }, requires { Ask, Ask::Get, Fs })" "$eff639dir/partial.wasm.diag" 2>/dev/null; then
   echo "[compiler-gate] FAIL: err_effect_handle_partial_discharge.vibe did not produce the expected diagnostic" >&2
-  cat "$eff639dir/partial.wasm.diag" 2>/dev/null >&2 || true
+  cat "$eff639dir/partial.wasm.diag" >&2 2>/dev/null || true
   exit 1
 fi
 rm -rf "$eff639dir"
@@ -2296,7 +2296,7 @@ if [ -s "$eff1157dir/x.wasm" ]; then
 fi
 if ! grep -qF "missing { Ask::Get } (no 'with' clause, requires { Ask::Get })" "$eff1157dir/x.wasm.diag" 2>/dev/null; then
   echo "[compiler-gate] FAIL: err_effect_zero_arg_perform_no_parens.vibe did not produce the expected diagnostic" >&2
-  cat "$eff1157dir/x.wasm.diag" 2>/dev/null >&2 || true
+  cat "$eff1157dir/x.wasm.diag" >&2 2>/dev/null || true
   exit 1
 fi
 rm -rf "$eff1157dir"
@@ -2322,12 +2322,12 @@ if [ -s "$eff1161dir/x.wasm" ]; then
 fi
 if ! grep -qF "missing { Ask::Get } (declared { Ask::Other }, requires { Ask::Get, Ask::Other })" "$eff1161dir/x.wasm.diag" 2>/dev/null; then
   echo "[compiler-gate] FAIL: err_effect_op_level_partial_row_bare_perform.vibe did not produce the expected diagnostic" >&2
-  cat "$eff1161dir/x.wasm.diag" 2>/dev/null >&2 || true
+  cat "$eff1161dir/x.wasm.diag" >&2 2>/dev/null || true
   exit 1
 fi
 if ! grep -qF "hint: add 'with Ask::Get + Ask::Other' to 'asks'" "$eff1161dir/x.wasm.diag" 2>/dev/null; then
   echo "[compiler-gate] FAIL: err_effect_op_level_partial_row_bare_perform.vibe did not produce the expected operation-level fix-it hint" >&2
-  cat "$eff1161dir/x.wasm.diag" 2>/dev/null >&2 || true
+  cat "$eff1161dir/x.wasm.diag" >&2 2>/dev/null || true
   exit 1
 fi
 rm -rf "$eff1161dir"
@@ -2433,7 +2433,7 @@ VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   "$c1203dir/main.vibe" "$c1203dir/out.wasm" main >/dev/null 2>&1 || true
 if [ ! -s "$c1203dir/out.wasm" ]; then
   echo "[compiler-gate] FAIL: closure-param/top-level-name collision program did not compile (#1203)" >&2
-  cat "$c1203dir/out.wasm.diag" 2>/dev/null >&2 || true
+  cat "$c1203dir/out.wasm.diag" >&2 2>/dev/null || true
   exit 1
 fi
 c1203_out="$(VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh "$c1203dir/out.wasm" 2>&1 | tail -1)"
@@ -2485,7 +2485,7 @@ VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   "$c1203bdir/main.vibe" "$c1203bdir/out.wasm" main >/dev/null 2>&1 || true
 if [ ! -s "$c1203bdir/out.wasm" ]; then
   echo "[compiler-gate] FAIL: write-only closure capture / top-level-name collision program did not compile (#1203 follow-up) -- #1212 review regressed" >&2
-  cat "$c1203bdir/out.wasm.diag" 2>/dev/null >&2 || true
+  cat "$c1203bdir/out.wasm.diag" >&2 2>/dev/null || true
   exit 1
 fi
 c1203b_out="$(VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh "$c1203bdir/out.wasm" 2>&1 | tail -1)"
@@ -2720,7 +2720,7 @@ for bag_be in gc linear; do
     "fixtures/gc_bytes_append_grow.vibe" "$bagdir/$bag_be.wasm" main >/dev/null 2>&1 || true
   if [ ! -s "$bagdir/$bag_be.wasm" ]; then
     echo "[compiler-gate] FAIL: gc_bytes_append_grow.vibe did not compile on the $bag_be backend" >&2
-    cat "$bagdir/$bag_be.wasm.diag" 2>/dev/null >&2 || true
+    cat "$bagdir/$bag_be.wasm.diag" >&2 2>/dev/null || true
     exit 1
   fi
   bag_out="$(VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh "$bagdir/$bag_be.wasm" 2>&1 | tail -1)"
@@ -2773,13 +2773,13 @@ run_diag_collect() {
 diag_default_lines="$(run_diag_collect default)"
 if [ "$diag_default_lines" != "1" ]; then
   echo "[compiler-gate] FAIL: the default walk reported $diag_default_lines diagnostic lines (want 1) -- fail-fast is supposed to be unchanged without VIBE_DIAGNOSTICS_ALL" >&2
-  cat "$dcolldir/default.wasm.diag" 2>/dev/null >&2 || true
+  cat "$dcolldir/default.wasm.diag" >&2 2>/dev/null || true
   exit 1
 fi
 diag_all_lines="$(run_diag_collect all VIBE_DIAGNOSTICS_ALL=1)"
 if [ "$diag_all_lines" != "2" ]; then
   echo "[compiler-gate] FAIL: VIBE_DIAGNOSTICS_ALL=1 reported $diag_all_lines diagnostic lines (want 2: one per independent bad leaf, none for the blocked importer)" >&2
-  cat "$dcolldir/all.wasm.diag" 2>/dev/null >&2 || true
+  cat "$dcolldir/all.wasm.diag" >&2 2>/dev/null || true
   exit 1
 fi
 if [ "$(sed -n 1p "$dcolldir/all.wasm.diag" | grep -c 'alpha\.vibe')" != "1" ] || \
@@ -2823,7 +2823,7 @@ VIBE_DIAGNOSTICS_ALL=1 VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPOR
   "$dcolldir/src/main.vibe" "$dcolldir/ok.wasm" _start >/dev/null 2>&1 || true
 if [ ! -s "$dcolldir/ok.wasm" ]; then
   echo "[compiler-gate] FAIL: a clean project failed to compile with VIBE_DIAGNOSTICS_ALL=1" >&2
-  cat "$dcolldir/ok.wasm.diag" 2>/dev/null >&2 || true
+  cat "$dcolldir/ok.wasm.diag" >&2 2>/dev/null || true
   exit 1
 fi
 diag_ok_out="$(VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh "$dcolldir/ok.wasm" 2>&1 | tail -1)"
@@ -2859,7 +2859,7 @@ VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   fixtures/region_arena_ok.vibe "$r90dir/pos.wasm" __no_entry__ >/dev/null 2>&1 || true
 if [ ! -s "$r90dir/pos.wasm" ]; then
   echo "[compiler-gate] FAIL: region_arena_ok.vibe did not compile -- ADR-0090 region/MutList slice regressed" >&2
-  cat "$r90dir/pos.wasm.diag" 2>/dev/null >&2 || true
+  cat "$r90dir/pos.wasm.diag" >&2 2>/dev/null || true
   exit 1
 fi
 if ! r90_pos_out="$(VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh --invoke _start "$r90dir/pos.wasm" 2>&1)"; then
@@ -2877,7 +2877,7 @@ if [ -s "$r90dir/neg.wasm" ]; then
 fi
 if ! grep -qF 'region escapes its scope' "$r90dir/neg.wasm.diag" 2>/dev/null; then
   echo "[compiler-gate] FAIL: err_region_escape_return_value.vibe did not produce the expected diagnostic" >&2
-  cat "$r90dir/neg.wasm.diag" 2>/dev/null >&2 || true
+  cat "$r90dir/neg.wasm.diag" >&2 2>/dev/null || true
   exit 1
 fi
 # #1274 Codex P1: the token is unforgeable -- MutList::empty with a
@@ -2892,7 +2892,7 @@ if [ -s "$r90dir/forged.wasm" ]; then
 fi
 if ! grep -qF 'region token' "$r90dir/forged.wasm.diag" 2>/dev/null; then
   echo "[compiler-gate] FAIL: err_region_token_forged.vibe did not produce the expected diagnostic" >&2
-  cat "$r90dir/forged.wasm.diag" 2>/dev/null >&2 || true
+  cat "$r90dir/forged.wasm.diag" >&2 2>/dev/null || true
   exit 1
 fi
 # #1725: the return-position check above scans the region body's RESULT TYPE
@@ -2909,7 +2909,7 @@ if [ -s "$r90dir/cap.wasm" ]; then
 fi
 if ! grep -qF 'region escapes its scope' "$r90dir/cap.wasm.diag" 2>/dev/null; then
   echo "[compiler-gate] FAIL: err_region_escape_closure_capture.vibe did not produce the expected diagnostic" >&2
-  cat "$r90dir/cap.wasm.diag" 2>/dev/null >&2 || true
+  cat "$r90dir/cap.wasm.diag" >&2 2>/dev/null || true
   exit 1
 fi
 # The sharper negative: the escaping closure holds the region TOKEN, with no
@@ -2923,7 +2923,7 @@ if [ -s "$r90dir/tok.wasm" ]; then
 fi
 if ! grep -qF 'region escapes its scope' "$r90dir/tok.wasm.diag" 2>/dev/null; then
   echo "[compiler-gate] FAIL: err_region_escape_token_capture.vibe did not produce the expected diagnostic" >&2
-  cat "$r90dir/tok.wasm.diag" 2>/dev/null >&2 || true
+  cat "$r90dir/tok.wasm.diag" >&2 2>/dev/null || true
   exit 1
 fi
 # #1938: capture provenance is part of the checked function type, not a
@@ -3004,7 +3004,7 @@ for r90_fixture in \
   fi
   if ! grep -qF 'region escapes its scope' "$r90dir/${r90_escape}.wasm.diag" 2>/dev/null; then
     echo "[compiler-gate] FAIL: $r90_fixture did not produce the expected diagnostic (#1938)" >&2
-    cat "$r90dir/${r90_escape}.wasm.diag" 2>/dev/null >&2 || true
+    cat "$r90dir/${r90_escape}.wasm.diag" >&2 2>/dev/null || true
     exit 1
   fi
 done
@@ -3018,7 +3018,7 @@ VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   fixtures/region_ok_closure_local.vibe "$r90dir/caplocal.wasm" __no_entry__ >/dev/null 2>&1 || true
 if [ ! -s "$r90dir/caplocal.wasm" ]; then
   echo "[compiler-gate] FAIL: region_ok_closure_local.vibe did not compile -- the #1725 capture check is over-approximating" >&2
-  cat "$r90dir/caplocal.wasm.diag" 2>/dev/null >&2 || true
+  cat "$r90dir/caplocal.wasm.diag" >&2 2>/dev/null || true
   exit 1
 fi
 if ! r90_cap_out="$(VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh --invoke _start "$r90dir/caplocal.wasm" 2>&1)"; then
@@ -3030,7 +3030,7 @@ VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   fixtures/region_ok_capture_provenance.vibe "$r90dir/provenance_ok.wasm" __no_entry__ >/dev/null 2>&1 || true
 if [ ! -s "$r90dir/provenance_ok.wasm" ]; then
   echo "[compiler-gate] FAIL: region_ok_capture_provenance.vibe did not compile -- capture provenance over-approximated (#1938)" >&2
-  cat "$r90dir/provenance_ok.wasm.diag" 2>/dev/null >&2 || true
+  cat "$r90dir/provenance_ok.wasm.diag" >&2 2>/dev/null || true
   exit 1
 fi
 if ! VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh --invoke _start "$r90dir/provenance_ok.wasm" >/dev/null 2>&1; then
@@ -3048,7 +3048,7 @@ VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   fixtures/region_ok_freeze_copies_out.vibe "$r90dir/copyout.wasm" __no_entry__ >/dev/null 2>&1 || true
 if [ ! -s "$r90dir/copyout.wasm" ]; then
   echo "[compiler-gate] FAIL: region_ok_freeze_copies_out.vibe did not compile" >&2
-  cat "$r90dir/copyout.wasm.diag" 2>/dev/null >&2 || true
+  cat "$r90dir/copyout.wasm.diag" >&2 2>/dev/null || true
   exit 1
 fi
 if ! r90_copy_out="$(VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh --invoke _start "$r90dir/copyout.wasm" 2>&1)"; then
@@ -3067,7 +3067,7 @@ for r90_rc in 1 0; do
     fixtures/region_arena_release_ok.vibe "$r90dir/release.wasm" __no_entry__ >/dev/null 2>&1 || true
   if [ ! -s "$r90dir/release.wasm" ]; then
     echo "[compiler-gate] FAIL: region_arena_release_ok.vibe did not compile (VIBE_RC=$r90_rc)" >&2
-    cat "$r90dir/release.wasm.diag" 2>/dev/null >&2 || true
+    cat "$r90dir/release.wasm.diag" >&2 2>/dev/null || true
     exit 1
   fi
   if ! r90_rel_out="$(VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh --invoke _start "$r90dir/release.wasm" 2>&1)"; then
@@ -3090,7 +3090,7 @@ VIBE_RC=0 VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   fixtures/region_arena_bounded.vibe "$r90dir/bounded.wasm" __no_entry__ >/dev/null 2>&1 || true
 if [ ! -s "$r90dir/bounded.wasm" ]; then
   echo "[compiler-gate] FAIL: region_arena_bounded.vibe did not compile" >&2
-  cat "$r90dir/bounded.wasm.diag" 2>/dev/null >&2 || true
+  cat "$r90dir/bounded.wasm.diag" >&2 2>/dev/null || true
   exit 1
 fi
 if ! r90_bounded_out="$(VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh --invoke _start "$r90dir/bounded.wasm" 2>&1)"; then
@@ -3116,7 +3116,7 @@ VIBE_RC=0 VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   fixtures/region_throw_unwind_test.vibe "$r90dir/unwind.wasm" __no_entry__ >/dev/null 2>&1 || true
 if [ ! -s "$r90dir/unwind.wasm" ]; then
   echo "[compiler-gate] FAIL: region_throw_unwind_test.vibe did not compile" >&2
-  cat "$r90dir/unwind.wasm.diag" 2>/dev/null >&2 || true
+  cat "$r90dir/unwind.wasm.diag" >&2 2>/dev/null || true
   exit 1
 fi
 if ! r90_unwind_out="$(VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh --invoke _start "$r90dir/unwind.wasm" 2>&1)"; then
@@ -3151,7 +3151,7 @@ for r90_cyc_n in 200 800; do
     "$r90dir/cycles_$r90_cyc_n.vibe" "$r90dir/cycles_$r90_cyc_n.wasm" __no_entry__ >/dev/null 2>&1 || true
   if [ ! -s "$r90dir/cycles_$r90_cyc_n.wasm" ]; then
     echo "[compiler-gate] FAIL: region_arena_cycles.vibe ($r90_cyc_n) did not compile" >&2
-    cat "$r90dir/cycles_$r90_cyc_n.wasm.diag" 2>/dev/null >&2 || true
+    cat "$r90dir/cycles_$r90_cyc_n.wasm.diag" >&2 2>/dev/null || true
     exit 1
   fi
   if ! VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh --invoke _start "$r90dir/cycles_$r90_cyc_n.wasm" >/dev/null 2>&1; then
@@ -3181,7 +3181,7 @@ VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   fixtures/region_bytes_ok.vibe "$r90dir/bpos.wasm" __no_entry__ >/dev/null 2>&1 || true
 if [ ! -s "$r90dir/bpos.wasm" ]; then
   echo "[compiler-gate] FAIL: region_bytes_ok.vibe did not compile -- ADR-0090 MutBytes slice regressed" >&2
-  cat "$r90dir/bpos.wasm.diag" 2>/dev/null >&2 || true
+  cat "$r90dir/bpos.wasm.diag" >&2 2>/dev/null || true
   exit 1
 fi
 if ! VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh --invoke _start "$r90dir/bpos.wasm" >/dev/null 2>&1; then
@@ -3200,7 +3200,7 @@ for r90b_neg in err_region_bytes_token_forged:'region token' err_region_bytes_es
   fi
   if ! grep -qF "$r90b_needle" "$r90dir/bneg.wasm.diag" 2>/dev/null; then
     echo "[compiler-gate] FAIL: $r90b_fixture.vibe did not produce the expected diagnostic ('$r90b_needle')" >&2
-    cat "$r90dir/bneg.wasm.diag" 2>/dev/null >&2 || true
+    cat "$r90dir/bneg.wasm.diag" >&2 2>/dev/null || true
     exit 1
   fi
   rm -f "$r90dir/bneg.wasm" "$r90dir/bneg.wasm.diag"
@@ -3211,7 +3211,7 @@ VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
 if [ ! -s "$r90dir/bcopy.wasm" ] \
   || ! VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh --invoke _start "$r90dir/bcopy.wasm" >/dev/null 2>&1; then
   echo "[compiler-gate] FAIL: region_bytes_ok_copy_out.vibe failed -- MutBytes::to_bytes must COPY (an alias sees the post-snapshot push)" >&2
-  cat "$r90dir/bcopy.wasm.diag" 2>/dev/null >&2 || true
+  cat "$r90dir/bcopy.wasm.diag" >&2 2>/dev/null || true
   exit 1
 fi
 VIBE_RC=0 VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
@@ -3219,7 +3219,7 @@ VIBE_RC=0 VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   fixtures/region_bytes_arena_bounded.vibe "$r90dir/bbounded.wasm" __no_entry__ >/dev/null 2>&1 || true
 if [ ! -s "$r90dir/bbounded.wasm" ]; then
   echo "[compiler-gate] FAIL: region_bytes_arena_bounded.vibe did not compile" >&2
-  cat "$r90dir/bbounded.wasm.diag" 2>/dev/null >&2 || true
+  cat "$r90dir/bbounded.wasm.diag" >&2 2>/dev/null || true
   exit 1
 fi
 if ! VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh --invoke _start "$r90dir/bbounded.wasm" >/dev/null 2>&1; then
@@ -3250,7 +3250,7 @@ for r90_consume_rc in 1 0; do
   if [ ! -s "$r90dir/consume.wasm" ] \
     || ! VIBE_RC="$r90_consume_rc" VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh --invoke _start "$r90dir/consume.wasm" >/dev/null 2>&1; then
     echo "[compiler-gate] FAIL: region_ok_consume_in_region.vibe failed under VIBE_RC=$r90_consume_rc -- MutList::get/length in-region reads regressed" >&2
-    cat "$r90dir/consume.wasm.diag" 2>/dev/null >&2 || true
+    cat "$r90dir/consume.wasm.diag" >&2 2>/dev/null || true
     exit 1
   fi
   rm -f "$r90dir/consume.wasm"
@@ -3266,7 +3266,7 @@ VIBE_RC=0 VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
 if [ ! -s "$r90dir/nested.wasm" ] \
   || ! VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh --invoke _start "$r90dir/nested.wasm" >/dev/null 2>&1; then
   echo "[compiler-gate] FAIL: region_arena_nested_regrow_ok.vibe failed -- an outer buffer regrown inside a nested region was rewound/overwritten" >&2
-  cat "$r90dir/nested.wasm.diag" 2>/dev/null >&2 || true
+  cat "$r90dir/nested.wasm.diag" >&2 2>/dev/null || true
   exit 1
 fi
 echo "[compiler-gate] nested-region regrow guard ok (MutList + MutBytes)"
@@ -3296,7 +3296,7 @@ VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   fixtures/zero_alloc_ok.vibe "$za91dir/pos.wasm" __no_entry__ >/dev/null 2>&1 || true
 if [ ! -s "$za91dir/pos.wasm" ]; then
   echo "[compiler-gate] FAIL: zero_alloc_ok.vibe did not compile -- ADR-0091 #zero_alloc slice regressed" >&2
-  cat "$za91dir/pos.wasm.diag" 2>/dev/null >&2 || true
+  cat "$za91dir/pos.wasm.diag" >&2 2>/dev/null || true
   exit 1
 fi
 if ! za91_pos_out="$(VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh --invoke _start "$za91dir/pos.wasm" 2>&1)"; then
@@ -3314,7 +3314,7 @@ if [ -s "$za91dir/neg.wasm" ]; then
 fi
 if ! grep -qF 'zero_alloc' "$za91dir/neg.wasm.diag" 2>/dev/null; then
   echo "[compiler-gate] FAIL: err_zero_alloc_ctor.vibe did not produce the expected diagnostic" >&2
-  cat "$za91dir/neg.wasm.diag" 2>/dev/null >&2 || true
+  cat "$za91dir/neg.wasm.diag" >&2 2>/dev/null || true
   exit 1
 fi
 # #1274 Codex P1: a param shadowing a clean top-level fn is an indirect
@@ -3329,7 +3329,7 @@ if [ -s "$za91dir/shadowed.wasm" ]; then
 fi
 if ! grep -qF 'zero_alloc' "$za91dir/shadowed.wasm.diag" 2>/dev/null; then
   echo "[compiler-gate] FAIL: err_zero_alloc_shadowed_call.vibe did not produce the expected diagnostic" >&2
-  cat "$za91dir/shadowed.wasm.diag" 2>/dev/null >&2 || true
+  cat "$za91dir/shadowed.wasm.diag" >&2 2>/dev/null || true
   exit 1
 fi
 # #1838: typed operators can allocate even when their operands are variables.
@@ -3347,7 +3347,7 @@ for za_typed in double_operator string_operator shadowed_operator; do
   fi
   if ! grep -qF 'zero_alloc' "$za91dir/${za_typed}.wasm.diag" 2>/dev/null; then
     echo "[compiler-gate] FAIL: err_zero_alloc_${za_typed}.vibe did not produce the expected diagnostic" >&2
-    cat "$za91dir/${za_typed}.wasm.diag" 2>/dev/null >&2 || true
+    cat "$za91dir/${za_typed}.wasm.diag" >&2 2>/dev/null || true
     exit 1
   fi
 done
@@ -3374,7 +3374,7 @@ for za_n in 200 800; do
     "$za91mdir/measured_$za_n.vibe" "$za91mdir/measured_$za_n.wasm" __no_entry__ >/dev/null 2>&1 || true
   if [ ! -s "$za91mdir/measured_$za_n.wasm" ]; then
     echo "[compiler-gate] FAIL: zero_alloc_measured.vibe ($za_n) did not compile -- the #zero_alloc check rejected a fn the measurement says is clean" >&2
-    cat "$za91mdir/measured_$za_n.wasm.diag" 2>/dev/null >&2 || true
+    cat "$za91mdir/measured_$za_n.wasm.diag" >&2 2>/dev/null || true
     exit 1
   fi
   if ! VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh --invoke _start "$za91mdir/measured_$za_n.wasm" >/dev/null 2>&1; then
@@ -3414,7 +3414,7 @@ VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   "$asb89dir/pos.vibe" "$asb89dir/pos.wasm" main >/dev/null 2>&1 || true
 if [ ! -s "$asb89dir/pos.wasm" ]; then
   echo "[compiler-gate] FAIL: async_sleep_boundary_test.vibe did not compile -- ADR-0089 D1 sleep boundary regressed" >&2
-  cat "$asb89dir/pos.wasm.diag" 2>/dev/null >&2 || true
+  cat "$asb89dir/pos.wasm.diag" >&2 2>/dev/null || true
   exit 1
 fi
 asb89_pos_out="$(VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh --invoke main "$asb89dir/pos.wasm" 2>/dev/null | tail -1)"
@@ -3437,7 +3437,7 @@ fi
 if ! grep -qF 'mixing the step convention' "$asb89dir/neg.wasm.diag" 2>/dev/null \
    && ! grep -qF 'hand the step object back as the value' "$asb89dir/neg.wasm.diag" 2>/dev/null; then
   echo "[compiler-gate] FAIL: err_async_boundary_mixed_convention.vibe did not produce the expected diagnostic" >&2
-  cat "$asb89dir/neg.wasm.diag" 2>/dev/null >&2 || true
+  cat "$asb89dir/neg.wasm.diag" >&2 2>/dev/null || true
   exit 1
 fi
 # #1342: the same guard must be POSITION-INDEPENDENT and must key on the
@@ -3458,7 +3458,7 @@ if [ -s "$asb89dir/negop.wasm" ]; then
 fi
 if ! grep -qF 'mixing the step convention' "$asb89dir/negop.wasm.diag" 2>/dev/null; then
   echo "[compiler-gate] FAIL: err_async_boundary_mixed_operand.vibe did not produce the mixing diagnostic" >&2
-  cat "$asb89dir/negop.wasm.diag" 2>/dev/null >&2 || true
+  cat "$asb89dir/negop.wasm.diag" >&2 2>/dev/null || true
   exit 1
 fi
 cp fixtures/async_boundary_user_sleep_test.vibe "$asb89dir/usersleep.vibe"
@@ -3467,7 +3467,7 @@ VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   "$asb89dir/usersleep.vibe" "$asb89dir/usersleep.wasm" main >/dev/null 2>&1 || true
 if [ ! -s "$asb89dir/usersleep.wasm" ]; then
   echo "[compiler-gate] FAIL: async_boundary_user_sleep_test.vibe was rejected -- the guard fired without an injected boundary (#1342)" >&2
-  cat "$asb89dir/usersleep.wasm.diag" 2>/dev/null >&2 || true
+  cat "$asb89dir/usersleep.wasm.diag" >&2 2>/dev/null || true
   exit 1
 fi
 asb89_us_out="$(VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh --invoke main "$asb89dir/usersleep.wasm" 2>/dev/null | tail -1)"
@@ -3487,7 +3487,7 @@ VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   "$asb89dir/dis.vibe" "$asb89dir/dis.wasm" main >/dev/null 2>&1 || true
 if [ ! -s "$asb89dir/dis.wasm" ]; then
   echo "[compiler-gate] FAIL: async_sleep_handler_discharge_test.vibe did not compile -- handle-with-Async must discharge the builtin row (ADR-0089 D1 increment 2)" >&2
-  cat "$asb89dir/dis.wasm.diag" 2>/dev/null >&2 || true
+  cat "$asb89dir/dis.wasm.diag" >&2 2>/dev/null || true
   exit 1
 fi
 asb89_dis_out="$(VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh --invoke main "$asb89dir/dis.wasm" 2>/dev/null | tail -1)"
@@ -3506,7 +3506,7 @@ VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   "$asb89dir/aw.vibe" "$asb89dir/aw.wasm" main >/dev/null 2>&1 || true
 if [ ! -s "$asb89dir/aw.wasm" ]; then
   echo "[compiler-gate] FAIL: async_await_handler_discharge_test.vibe did not compile -- a pending-future await under a user Async handler must be evidence-eligible (ADR-0089 D1 increment 4)" >&2
-  cat "$asb89dir/aw.wasm.diag" 2>/dev/null >&2 || true
+  cat "$asb89dir/aw.wasm.diag" >&2 2>/dev/null || true
   exit 1
 fi
 asb89_aw_out="$(VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh --invoke main "$asb89dir/aw.wasm" 2>/dev/null | tail -1)"
@@ -3523,7 +3523,7 @@ VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   "$asb89dir/mx.vibe" "$asb89dir/mx.wasm" main >/dev/null 2>&1 || true
 if [ ! -s "$asb89dir/mx.wasm" ]; then
   echo "[compiler-gate] FAIL: async_sleep_mixed_scope_test.vibe did not compile -- scoped retargeting must not strand performs (Codex P1 on #1312)" >&2
-  cat "$asb89dir/mx.wasm.diag" 2>/dev/null >&2 || true
+  cat "$asb89dir/mx.wasm.diag" >&2 2>/dev/null || true
   exit 1
 fi
 asb89_mx_out="$(VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh --invoke main "$asb89dir/mx.wasm" 2>/dev/null | tail -1)"
@@ -3544,7 +3544,7 @@ VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   "$asb89dir/fr.vibe" "$asb89dir/fr.wasm" main >/dev/null 2>&1 || true
 if [ ! -s "$asb89dir/fr.wasm" ]; then
   echo "[compiler-gate] FAIL: async_future_boundary_resolved_test.vibe did not compile -- Future cell primitives must be evidence-inert (ADR-0089 D2)" >&2
-  cat "$asb89dir/fr.wasm.diag" 2>/dev/null >&2 || true
+  cat "$asb89dir/fr.wasm.diag" >&2 2>/dev/null || true
   exit 1
 fi
 asb89_fr_out="$(VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh --invoke main "$asb89dir/fr.wasm" 2>/dev/null | tail -1)"
@@ -3563,7 +3563,7 @@ VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   "$asb89dir/fd.vibe" "$asb89dir/fd.wasm" main >/dev/null 2>&1 || true
 if [ ! -s "$asb89dir/fd.wasm" ]; then
   echo "[compiler-gate] FAIL: async_future_boundary_deadlock_test.vibe did not compile (ADR-0089 D2 -- the deadlock case must compile and trap at runtime)" >&2
-  cat "$asb89dir/fd.wasm.diag" 2>/dev/null >&2 || true
+  cat "$asb89dir/fd.wasm.diag" >&2 2>/dev/null || true
   exit 1
 fi
 asb89_fd_out="$(timeout 30 bash -c "VIBE_PREOPEN_DIR='$ROOT_DIR' bash scripts/run_wasm_vibe_host_runner.sh --invoke main '$asb89dir/fd.wasm' 2>&1" || true)"
@@ -3619,7 +3619,7 @@ rm -f "$nhf37dir/nested.wasm" "$nhf37dir/nested.wasm.diag"
 VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_IMPORT_ABI=raw   bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm"   "$nhf37dir/nested.vibe" "$nhf37dir/nested.wasm" run >/dev/null 2>&1 || true
 if [ ! -s "$nhf37dir/nested.wasm" ]; then
   echo "[compiler-gate] FAIL: host_future_named nested in a record literal did not compile (#1337)" >&2
-  cat "$nhf37dir/nested.wasm.diag" 2>/dev/null >&2 || true
+  cat "$nhf37dir/nested.wasm.diag" >&2 2>/dev/null || true
   exit 1
 fi
 if ! grep -q "price" "$nhf37dir/nested.wasm"; then
@@ -3639,7 +3639,7 @@ rm -f "$nhf37dir/shadowed.wasm" "$nhf37dir/shadowed.wasm.diag"
 VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw   bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm"   "$nhf37dir/shadowed.vibe" "$nhf37dir/shadowed.wasm" _start >/dev/null 2>&1 || true
 if [ ! -s "$nhf37dir/shadowed.wasm" ]; then
   echo "[compiler-gate] FAIL: a shadowed host_future_named did not compile (#1337)" >&2
-  cat "$nhf37dir/shadowed.wasm.diag" 2>/dev/null >&2 || true
+  cat "$nhf37dir/shadowed.wasm.diag" >&2 2>/dev/null || true
   exit 1
 fi
 if grep -q 'host_future_get\$price' "$nhf37dir/shadowed.wasm"; then
@@ -3677,7 +3677,7 @@ VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   fixtures/effect_generic_row_instantiation.vibe "$g1340dir/pos.wasm" __no_entry__ >/dev/null 2>&1 || true
 if [ ! -s "$g1340dir/pos.wasm" ]; then
   echo "[compiler-gate] FAIL: effect_generic_row_instantiation.vibe did not compile (with State[Int] row grammar or generic registration regressed)" >&2
-  cat "$g1340dir/pos.wasm.diag" 2>/dev/null >&2 || true
+  cat "$g1340dir/pos.wasm.diag" >&2 2>/dev/null || true
   exit 1
 fi
 if ! g1340_out="$(VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh --invoke _start "$g1340dir/pos.wasm" 2>&1)"; then
@@ -3697,7 +3697,7 @@ if [ -s "$g1340dir/arity.wasm" ]; then
 fi
 if ! grep -q "perform State::Get expects 0 argument(s), got 3" "$g1340dir/arity.wasm.diag" 2>/dev/null; then
   echo "[compiler-gate] FAIL: err_generic_effect_perform_arity.vibe did not produce the arity diagnostic" >&2
-  cat "$g1340dir/arity.wasm.diag" 2>/dev/null >&2 || true
+  cat "$g1340dir/arity.wasm.diag" >&2 2>/dev/null || true
   exit 1
 fi
 # #1571: the expectation for this rejection is the diagnostic grep below,
@@ -3712,7 +3712,7 @@ if [ -s "$g1340dir/rowtarg.wasm" ]; then
 fi
 if ! grep -q "effect Log declares no type parameters" "$g1340dir/rowtarg.wasm.diag" 2>/dev/null; then
   echo "[compiler-gate] FAIL: err_generic_effect_row_targ.vibe did not produce the row-instantiation diagnostic" >&2
-  cat "$g1340dir/rowtarg.wasm.diag" 2>/dev/null >&2 || true
+  cat "$g1340dir/rowtarg.wasm.diag" >&2 2>/dev/null || true
   exit 1
 fi
 rm -rf "$g1340dir"
@@ -3742,7 +3742,7 @@ VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   fixtures/effect_builtin_operation_row.vibe "$opb/pos.wasm" __no_entry__ >/dev/null 2>&1 || true
 if [ ! -s "$opb/pos.wasm" ]; then
   echo "[compiler-gate] FAIL: with Fs::read_file no longer authorizes the Fs::read_file builtin (#1343)" >&2
-  cat "$opb/pos.wasm.diag" 2>/dev/null >&2 || true
+  cat "$opb/pos.wasm.diag" >&2 2>/dev/null || true
   exit 1
 fi
 if ! op_out="$(VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh --invoke _start "$opb/pos.wasm" 2>&1)"; then
@@ -3768,7 +3768,7 @@ if [ -s "$opb/neg.wasm" ]; then
 fi
 if ! grep -q "missing { Fs::write_file }" "$opb/neg.wasm.diag" 2>/dev/null; then
   echo "[compiler-gate] FAIL: the diagnostic must name the missing OPERATION, not the whole effect (ADR-0071/#1343)" >&2
-  cat "$opb/neg.wasm.diag" 2>/dev/null >&2 || true
+  cat "$opb/neg.wasm.diag" >&2 2>/dev/null || true
   exit 1
 fi
 cat > "$opb/bare.vibe" <<'EOF'
@@ -3785,7 +3785,7 @@ VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   "$opb/bare.vibe" "$opb/bare.wasm" main >/dev/null 2>&1 || true
 if [ ! -s "$opb/bare.wasm" ]; then
   echo "[compiler-gate] FAIL: the bare effect row stopped granting all of its operations (#1343 must be a pure widening)" >&2
-  cat "$opb/bare.wasm.diag" 2>/dev/null >&2 || true
+  cat "$opb/bare.wasm.diag" >&2 2>/dev/null || true
   exit 1
 fi
 rm -rf "$opb"
@@ -3811,7 +3811,7 @@ VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   fixtures/effect_async_for_row.vibe "$afdir/pos.wasm" __no_entry__ >/dev/null 2>&1 || true
 if [ ! -s "$afdir/pos.wasm" ]; then
   echo "[compiler-gate] FAIL: effect_async_for_row.vibe did not compile -- a declared `with Async` row must still accept the async for loop (#1358)" >&2
-  cat "$afdir/pos.wasm.diag" 2>/dev/null >&2 || true
+  cat "$afdir/pos.wasm.diag" >&2 2>/dev/null || true
   exit 1
 fi
 if ! af_out="$(VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh --invoke _start "$afdir/pos.wasm" 2>&1)"; then
@@ -3831,7 +3831,7 @@ if [ -s "$afdir/neg.wasm" ]; then
 fi
 if ! grep -q "Countdown::next" "$afdir/neg.wasm.diag" 2>/dev/null; then
   echo "[compiler-gate] FAIL: the async-for diagnostic must name the iterator's next method (#1358)" >&2
-  cat "$afdir/neg.wasm.diag" 2>/dev/null >&2 || true
+  cat "$afdir/neg.wasm.diag" >&2 2>/dev/null || true
   exit 1
 fi
 # Codex review on PR #1364 (P1 x2): two iterand shapes reached the await
@@ -3942,7 +3942,7 @@ if [ -s "$lcdir/neg.wasm" ]; then
 fi
 if ! grep -q "missing { Env }" "$lcdir/neg.wasm.diag" 2>/dev/null; then
   echo "[compiler-gate] FAIL: the local-closure leak must be reported as the caller's missing row label (#1361)" >&2
-  cat "$lcdir/neg.wasm.diag" 2>/dev/null >&2 || true
+  cat "$lcdir/neg.wasm.diag" >&2 2>/dev/null || true
   exit 1
 fi
 cat > "$lcdir/pos.vibe" <<'EOF'
@@ -3958,7 +3958,7 @@ VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   "$lcdir/pos.vibe" "$lcdir/pos.wasm" main >/dev/null 2>&1 || true
 if [ ! -s "$lcdir/pos.wasm" ]; then
   echo "[compiler-gate] FAIL: declaring the local closure's row must satisfy the leak check (#1361)" >&2
-  cat "$lcdir/pos.wasm.diag" 2>/dev/null >&2 || true
+  cat "$lcdir/pos.wasm.diag" >&2 2>/dev/null || true
   exit 1
 fi
 cat > "$lcdir/pure.vibe" <<'EOF'
@@ -3974,7 +3974,7 @@ VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   "$lcdir/pure.vibe" "$lcdir/pure.wasm" main >/dev/null 2>&1 || true
 if [ ! -s "$lcdir/pure.wasm" ]; then
   echo "[compiler-gate] FAIL: a PURE local closure must stay free of any row requirement (#1361 must not over-require)" >&2
-  cat "$lcdir/pure.wasm.diag" 2>/dev/null >&2 || true
+  cat "$lcdir/pure.wasm.diag" >&2 2>/dev/null || true
   exit 1
 fi
 rm -rf "$lcdir"
@@ -4008,7 +4008,7 @@ if [ -s "$hsdir/neg.wasm" ]; then
 fi
 if ! grep -q "can never fire" "$hsdir/neg.wasm.diag" 2>/dev/null; then
   echo "[compiler-gate] FAIL: the dead-handle diagnostic is missing (#1347)" >&2
-  cat "$hsdir/neg.wasm.diag" 2>/dev/null >&2 || true
+  cat "$hsdir/neg.wasm.diag" >&2 2>/dev/null || true
   exit 1
 fi
 cat > "$hsdir/live.vibe" <<'EOF'
@@ -4034,7 +4034,7 @@ VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   "$hsdir/live.vibe" "$hsdir/live.wasm" main >/dev/null 2>&1 || true
 if [ ! -s "$hsdir/live.wasm" ]; then
   echo "[compiler-gate] FAIL: a handle whose body DOES reach the effect must still compile (#1347 must not over-reject)" >&2
-  cat "$hsdir/live.wasm.diag" 2>/dev/null >&2 || true
+  cat "$hsdir/live.wasm.diag" >&2 2>/dev/null || true
   exit 1
 fi
 cat > "$hsdir/param.vibe" <<'EOF'
@@ -4067,7 +4067,7 @@ VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   "$hsdir/param.vibe" "$hsdir/param.wasm" main >/dev/null 2>&1 || true
 if [ ! -s "$hsdir/param.wasm" ]; then
   echo "[compiler-gate] FAIL: a handled body whose only callee is a row-carrying PARAMETER (or annotated local) must compile -- #1347 must consult the #885/#1361 overlay, not just top-level bindings" >&2
-  cat "$hsdir/param.wasm.diag" 2>/dev/null >&2 || true
+  cat "$hsdir/param.wasm.diag" >&2 2>/dev/null || true
   exit 1
 fi
 rm -rf "$hsdir"
@@ -4094,7 +4094,7 @@ if [ -s "$hodir/neg.wasm" ]; then
 fi
 if ! grep -q "Higher-order effects" "$hodir/neg.wasm.diag" 2>/dev/null || ! grep -q "Tracing::Span" "$hodir/neg.wasm.diag" 2>/dev/null; then
   echo "[compiler-gate] FAIL: the diagnostic must name the higher-order OPERATION and the limitation (#1347)" >&2
-  cat "$hodir/neg.wasm.diag" 2>/dev/null >&2 || true
+  cat "$hodir/neg.wasm.diag" >&2 2>/dev/null || true
   exit 1
 fi
 rm -rf "$hodir"
@@ -4121,7 +4121,7 @@ VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   fixtures/exception_typed_row.vibe "$excdir/pos.wasm" __no_entry__ >/dev/null 2>&1 || true
 if [ ! -s "$excdir/pos.wasm" ]; then
   echo "[compiler-gate] FAIL: exception_typed_row.vibe did not compile (Exception[E] rows / kinded handle / erased alias regressed)" >&2
-  cat "$excdir/pos.wasm.diag" 2>/dev/null >&2 || true
+  cat "$excdir/pos.wasm.diag" >&2 2>/dev/null || true
   exit 1
 fi
 if ! exc_out="$(VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh --invoke _start "$excdir/pos.wasm" 2>&1)"; then
@@ -4141,7 +4141,7 @@ if [ -s "$excdir/neg.wasm" ]; then
 fi
 if ! grep -q "missing { Exception\[IoError\] }" "$excdir/neg.wasm.diag" 2>/dev/null; then
   echo "[compiler-gate] FAIL: the diagnostic must name the missing KIND (#1344)" >&2
-  cat "$excdir/neg.wasm.diag" 2>/dev/null >&2 || true
+  cat "$excdir/neg.wasm.diag" >&2 2>/dev/null || true
   exit 1
 fi
 # #1344 follow-up: the same rejection when the payload is a LOCAL binder rather
@@ -4162,7 +4162,7 @@ if [ -s "$excdir/neglocal.wasm" ]; then
 fi
 if ! grep -q "missing { Exception\[IoError\] }" "$excdir/neglocal.wasm.diag" 2>/dev/null; then
   echo "[compiler-gate] FAIL: the local-binder diagnostic must name the missing KIND (#1344 follow-up)" >&2
-  cat "$excdir/neglocal.wasm.diag" 2>/dev/null >&2 || true
+  cat "$excdir/neglocal.wasm.diag" >&2 2>/dev/null || true
   exit 1
 fi
 # The fix-it must be pasteable: the row grammar takes `Eff::Op` and `Eff[T]`
@@ -4194,7 +4194,7 @@ VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   "$excdir/fixit.vibe" "$excdir/fixit.wasm" main >/dev/null 2>&1 || true
 if [ ! -s "$excdir/fixit.wasm" ]; then
   echo "[compiler-gate] FAIL: the row the kind-mismatch hint suggests does not itself compile (#1344)" >&2
-  cat "$excdir/fixit.wasm.diag" 2>/dev/null >&2 || true
+  cat "$excdir/fixit.wasm.diag" >&2 2>/dev/null || true
   exit 1
 fi
 cat > "$excdir/handle.vibe" <<'EOF'
@@ -4227,7 +4227,7 @@ if [ -s "$excdir/handle.wasm" ]; then
 fi
 if ! grep -q "missing { Exception\[IoError\] }" "$excdir/handle.wasm.diag" 2>/dev/null; then
   echo "[compiler-gate] FAIL: a kinded handle must leave the foreign kind in the row (#1344)" >&2
-  cat "$excdir/handle.wasm.diag" 2>/dev/null >&2 || true
+  cat "$excdir/handle.wasm.diag" >&2 2>/dev/null || true
   exit 1
 fi
 rm -rf "$excdir"
@@ -4257,7 +4257,7 @@ VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   fixtures/interp_show_derive.vibe "$showdir/show.wasm" __no_entry__ >/dev/null 2>&1 || true
 if [ ! -s "$showdir/show.wasm" ]; then
   echo "[compiler-gate] FAIL: interp_show_derive.vibe did not compile (#1392)" >&2
-  cat "$showdir/show.wasm.diag" 2>/dev/null >&2 || true
+  cat "$showdir/show.wasm.diag" >&2 2>/dev/null || true
   exit 1
 fi
 if ! show_out="$(VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh --invoke _start "$showdir/show.wasm" 2>&1)"; then
@@ -4295,7 +4295,7 @@ retshow_status=$?
 set -e
 if [ "$retshow_status" -eq 0 ] || [ -s "$retshowdir/missing.wasm" ] || ! grep -q 'cannot interpolate a value of type `Hidden`' "$retshowdir/missing.wasm.diag" 2>/dev/null; then
   echo "[compiler-gate] FAIL: missing renderer function result was not rejected actionably (#1766)" >&2
-  cat "$retshowdir/missing.wasm.diag" 2>/dev/null >&2 || true
+  cat "$retshowdir/missing.wasm.diag" >&2 2>/dev/null || true
   exit 1
 fi
 rm -rf "$retshowdir"
@@ -4343,7 +4343,7 @@ exn_msg_expect() {
     "$exnmsgdir/$name.vibe" "$exnmsgdir/$name.wasm" _start >/dev/null 2>&1 || true
   if [ ! -s "$exnmsgdir/$name.wasm" ]; then
     echo "[compiler-gate] FAIL: $name.vibe did not compile (#1392 slice 3)" >&2
-    cat "$exnmsgdir/$name.wasm.diag" 2>/dev/null >&2 || true
+    cat "$exnmsgdir/$name.wasm.diag" >&2 2>/dev/null || true
     exit 1
   fi
   local got
@@ -4394,7 +4394,7 @@ VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   "$exnmsgdir/handwritten.vibe" "$exnmsgdir/handwritten.wasm" _start >/dev/null 2>&1 || true
 if [ ! -s "$exnmsgdir/handwritten.wasm" ]; then
   echo "[compiler-gate] FAIL: handwritten.vibe did not compile (#1398 review P1)" >&2
-  cat "$exnmsgdir/handwritten.wasm.diag" 2>/dev/null >&2 || true
+  cat "$exnmsgdir/handwritten.wasm.diag" >&2 2>/dev/null || true
   exit 1
 fi
 hw_out="$(VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh --invoke _start "$exnmsgdir/handwritten.wasm" 2>&1)"
@@ -4437,7 +4437,7 @@ VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   fixtures/rc_captured_let_mut.vibe "$refcelldir/cell.wasm" _start >/dev/null 2>&1 || true
 if [ ! -s "$refcelldir/cell.wasm" ]; then
   echo "[compiler-gate] FAIL: rc_captured_let_mut.vibe did not compile under VIBE_RC=1 (#1262)" >&2
-  cat "$refcelldir/cell.wasm.diag" 2>/dev/null >&2 || true
+  cat "$refcelldir/cell.wasm.diag" >&2 2>/dev/null || true
   exit 1
 fi
 if ! VIBE_RC_ASSERT_SIZE0_ONLY=1 python3 scripts/rc_patch_freelist_assert.py \
@@ -4526,7 +4526,7 @@ VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   "fixtures/wit_gen_result.vibe" "$witresdir/fixture.wasm" __no_entry__ >/dev/null 2>&1 || true
 if [ ! -s "$witresdir/fixture.wasm" ]; then
   echo "[compiler-gate] FAIL: fixtures/wit_gen_result.vibe did not FS-compile -- the @vibe/wit_runtime import does not resolve or does not type-check (#1324)" >&2
-  cat "$witresdir/fixture.wasm.diag" 2>/dev/null >&2 || true
+  cat "$witresdir/fixture.wasm.diag" >&2 2>/dev/null || true
   exit 1
 fi
 VIBE_EMIT_WIT=1 VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_IMPORT_ABI=raw \
@@ -4534,7 +4534,7 @@ VIBE_EMIT_WIT=1 VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_IMPORT_ABI=raw \
   "fixtures/wit_gen_result.vibe" "$witresdir/out.wit" main >/dev/null 2>&1 || true
 if [ ! -s "$witresdir/out.wit" ]; then
   echo "[compiler-gate] FAIL: VIBE_EMIT_WIT produced no output for the @vibe/wit_runtime fixture (#1324)" >&2
-  cat "$witresdir/out.wit.diag" 2>/dev/null >&2 || true
+  cat "$witresdir/out.wit.diag" >&2 2>/dev/null || true
   exit 1
 fi
 if ! diff -u "fixtures/wit_gen_result.golden.wit" "$witresdir/out.wit" >&2; then
@@ -4568,7 +4568,7 @@ res_case() {
   if [ "$expect" = "ok" ]; then
     if [ ! -s "$resdir/$rname.wasm" ]; then
       echo "[compiler-gate] FAIL: resource case '$rname' should compile but did not (ADR-0075/#1343)" >&2
-      cat "$resdir/$rname.wasm.diag" 2>/dev/null >&2 || true
+      cat "$resdir/$rname.wasm.diag" >&2 2>/dev/null || true
       exit 1
     fi
   else
@@ -4578,7 +4578,7 @@ res_case() {
     fi
     if [ -n "$rneedle" ] && ! grep -q -- "$rneedle" "$resdir/$rname.wasm.diag" 2>/dev/null; then
       echo "[compiler-gate] FAIL: resource case '$rname' rejected without naming '$rneedle' (ADR-0075/#1343):" >&2
-      cat "$resdir/$rname.wasm.diag" 2>/dev/null >&2 || true
+      cat "$resdir/$rname.wasm.diag" >&2 2>/dev/null || true
       exit 1
     fi
   fi
@@ -4676,7 +4676,7 @@ VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   "$pbdir/pb_test.vibe" "$pbdir/pb.wasm" __no_entry__ >/dev/null 2>&1 || true
 if [ ! -s "$pbdir/pb.wasm" ]; then
   echo "[compiler-gate] FAIL: per-block test fixture did not compile (#819)" >&2
-  cat "$pbdir/pb.wasm.diag" 2>/dev/null >&2 || true
+  cat "$pbdir/pb.wasm.diag" >&2 2>/dev/null || true
   exit 1
 fi
 pbexports="$(node -e '
@@ -4797,7 +4797,7 @@ en_case() {
   if [ "$expect" = "ok" ]; then
     if [ ! -s "$endir/$ename.wasm" ]; then
       echo "[compiler-gate] FAIL: enum-import case '$ename' should compile but did not (#1455)" >&2
-      cat "$endir/$ename.wasm.diag" 2>/dev/null >&2 || true
+      cat "$endir/$ename.wasm.diag" >&2 2>/dev/null || true
       exit 1
     fi
   else
@@ -4807,7 +4807,7 @@ en_case() {
     fi
     if [ -n "$eneedle" ] && ! grep -q -- "$eneedle" "$endir/$ename.wasm.diag" 2>/dev/null; then
       echo "[compiler-gate] FAIL: enum-import case '$ename' rejected without naming '$eneedle' (#1455):" >&2
-      cat "$endir/$ename.wasm.diag" 2>/dev/null >&2 || true
+      cat "$endir/$ename.wasm.diag" >&2 2>/dev/null || true
       exit 1
     fi
   fi
@@ -5028,7 +5028,7 @@ ui_case() {
   if [ "$uexpect" = "ok" ]; then
     if [ ! -s "$uidir/$uname.wasm" ]; then
       echo "[compiler-gate] FAIL: unresolved-import case '$uname' should compile but did not (#1521)" >&2
-      cat "$uidir/$uname.wasm.diag" 2>/dev/null >&2 || true
+      cat "$uidir/$uname.wasm.diag" >&2 2>/dev/null || true
       exit 1
     fi
   else
@@ -5038,7 +5038,7 @@ ui_case() {
     fi
     if ! grep -q "is not exported by" "$uidir/$uname.wasm.diag" 2>/dev/null; then
       echo "[compiler-gate] FAIL: unresolved-import case '$uname' was rejected by something OTHER than the #1521 check" >&2
-      cat "$uidir/$uname.wasm.diag" 2>/dev/null >&2 || true
+      cat "$uidir/$uname.wasm.diag" >&2 2>/dev/null || true
       exit 1
     fi
   fi
@@ -5254,7 +5254,7 @@ VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   "$cgdir/ok.vibe" "$cgdir/ok.wasm" _start >/dev/null 2>&1 || true
 if [ ! -s "$cgdir/ok.wasm" ]; then
   echo "[compiler-gate] FAIL: a correct program hit the unresolved-name path" >&2
-  cat "$cgdir/ok.wasm.diag" 2>/dev/null >&2 || true
+  cat "$cgdir/ok.wasm.diag" >&2 2>/dev/null || true
   exit 1
 fi
 rm -rf "$cgdir"
@@ -5285,7 +5285,7 @@ for dvsrc in "$dvdir"/*.vibe; do
     "$dvsrc" "$dvdir/$dvname.wasm" main >/dev/null 2>&1 || true
   if [ ! -s "$dvdir/$dvname.wasm" ]; then
     echo "[compiler-gate] FAIL: $dvname did not compile in the non-FS lane (#1590)" >&2
-    cat "$dvdir/$dvname.wasm.diag" 2>/dev/null >&2 || true
+    cat "$dvdir/$dvname.wasm.diag" >&2 2>/dev/null || true
     exit 1
   fi
 done
@@ -5341,7 +5341,7 @@ gv_run all.txt VIBE_GREP_PATTERN='$(f:id)($(a:args))'
 for gv_want in 'readit(q)' 'h(1)' 'plain(a)' 'Fs::read_file(p)'; do
   if ! grep -qF "$gv_want" "$gvdir/all.txt"; then
     echo "[compiler-gate] FAIL: vibe grep did not find $gv_want" >&2
-    cat "$gvdir/all.txt" "$gvdir/all.txt.diag" 2>/dev/null >&2 || true
+    cat "$gvdir/all.txt" "$gvdir/all.txt.diag" >&2 2>/dev/null || true
     exit 1
   fi
 done
@@ -5355,7 +5355,7 @@ fi
 gv_run row.txt VIBE_GREP_PATTERN='$(f:id)($(a:args))' VIBE_GREP_WHERE_ROW='$f with Fs'
 if ! grep -qF 'readit(q)' "$gvdir/row.txt" || grep -qF 'plain(a)' "$gvdir/row.txt"; then
   echo "[compiler-gate] FAIL: --where-row '\$f with Fs' kept the wrong sites" >&2
-  cat "$gvdir/row.txt" "$gvdir/row.txt.diag" 2>/dev/null >&2 || true
+  cat "$gvdir/row.txt" "$gvdir/row.txt.diag" >&2 2>/dev/null || true
   exit 1
 fi
 # Resolved-name filter: `h` is an ALIAS for dep.vibe's `helper`, so a text grep
@@ -5363,7 +5363,7 @@ fi
 gv_run alias.txt VIBE_GREP_PATTERN='$(f:id)($(a:args))' VIBE_GREP_WHERE='$f = helper'
 if ! grep -qF 'h(1)' "$gvdir/alias.txt"; then
   echo "[compiler-gate] FAIL: --where '\$f = helper' did not resolve the import alias" >&2
-  cat "$gvdir/alias.txt" "$gvdir/alias.txt.diag" 2>/dev/null >&2 || true
+  cat "$gvdir/alias.txt" "$gvdir/alias.txt.diag" >&2 2>/dev/null || true
   exit 1
 fi
 # A bad pattern is an ERROR on the .diag sidecar, never a plausible-but-wrong
@@ -5371,7 +5371,7 @@ fi
 gv_run bad.txt VIBE_GREP_PATTERN='f($(x:expr))'
 if [ -s "$gvdir/bad.txt" ] || ! grep -q 'unknown metavariable kind' "$gvdir/bad.txt.diag" 2>/dev/null; then
   echo "[compiler-gate] FAIL: a bad grep pattern did not land on the .diag sidecar" >&2
-  cat "$gvdir/bad.txt" "$gvdir/bad.txt.diag" 2>/dev/null >&2 || true
+  cat "$gvdir/bad.txt" "$gvdir/bad.txt.diag" >&2 2>/dev/null || true
   exit 1
 fi
 
@@ -5401,17 +5401,17 @@ VEOF
 gv_run sweep.txt VIBE_GREP_PATTERN='Array::length($(x:exp))' VIBE_GREP_WHERE='$x : Array[Int]'
 if ! grep -qF 'a_sweep_good.vibe' "$gvdir/sweep.txt" || ! grep -qF 'c_sweep_good.vibe' "$gvdir/sweep.txt"; then
   echo "[compiler-gate] FAIL: a broken file aborted the typed grep repo sweep" >&2
-  cat "$gvdir/sweep.txt" "$gvdir/sweep.txt.diag" "$gvdir/sweep.txt.warn" 2>/dev/null >&2 || true
+  cat "$gvdir/sweep.txt" "$gvdir/sweep.txt.diag" "$gvdir/sweep.txt.warn" >&2 2>/dev/null || true
   exit 1
 fi
 if grep -qF 'b_sweep_bad.vibe' "$gvdir/sweep.txt" || [ -s "$gvdir/sweep.txt.diag" ]; then
   echo "[compiler-gate] FAIL: typed grep did not fail closed per broken file" >&2
-  cat "$gvdir/sweep.txt" "$gvdir/sweep.txt.diag" "$gvdir/sweep.txt.warn" 2>/dev/null >&2 || true
+  cat "$gvdir/sweep.txt" "$gvdir/sweep.txt.diag" "$gvdir/sweep.txt.warn" >&2 2>/dev/null || true
   exit 1
 fi
 if [ "$(grep -cF 'b_sweep_bad.vibe' "$gvdir/sweep.txt.warn" 2>/dev/null || true)" -ne 1 ]; then
   echo "[compiler-gate] FAIL: typed grep did not report the skipped file exactly once" >&2
-  cat "$gvdir/sweep.txt.warn" 2>/dev/null >&2 || true
+  cat "$gvdir/sweep.txt.warn" >&2 2>/dev/null || true
   exit 1
 fi
 rm -rf "$gvdir"
@@ -5442,7 +5442,7 @@ VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_IMPORT_ABI=raw \
   "$inspdir/hygiene.vibe" "$inspdir/hygiene.wasm" main >/dev/null 2>&1 || true
 if [ ! -s "$inspdir/hygiene.wasm" ]; then
   echo "[compiler-gate] FAIL: the inspect hygiene sample did not compile" >&2
-  cat "$inspdir/hygiene.wasm.diag" 2>/dev/null >&2 || true
+  cat "$inspdir/hygiene.wasm.diag" >&2 2>/dev/null || true
   exit 1
 fi
 if insp_hyg="$(VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh "$inspdir/hygiene.wasm" 2>&1)"; then
@@ -5459,7 +5459,7 @@ VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_IMPORT_ABI=raw \
   fixtures/inspect_assignop_target_freshness.vibe "$inspdir/assignop.wasm" __no_entry__ >/dev/null 2>&1 || true
 if [ ! -s "$inspdir/assignop.wasm" ]; then
   echo "[compiler-gate] FAIL: inspect EAssignOp target-only freshness fixture did not compile" >&2
-  cat "$inspdir/assignop.wasm.diag" 2>/dev/null >&2 || true
+  cat "$inspdir/assignop.wasm.diag" >&2 2>/dev/null || true
   exit 1
 fi
 if ! VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh \
@@ -5484,7 +5484,7 @@ VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_IMPORT_ABI=raw \
   "$inspdir/shadow_fn.vibe" "$inspdir/shadow_fn.wasm" main >/dev/null 2>&1 || true
 if [ ! -s "$inspdir/shadow_fn.wasm" ]; then
   echo "[compiler-gate] FAIL: a user-declared \`inspect\` did not compile -- the rewrite hijacked the call (#1571 shadow)" >&2
-  cat "$inspdir/shadow_fn.wasm.diag" 2>/dev/null >&2 || true
+  cat "$inspdir/shadow_fn.wasm.diag" >&2 2>/dev/null || true
   exit 1
 fi
 insp_fn_out="$(VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh "$inspdir/shadow_fn.wasm" 2>/dev/null | tail -1)"
@@ -5519,7 +5519,7 @@ VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_IMPORT_ABI=raw \
   "$inspdir/shadow_pat.vibe" "$inspdir/shadow_pat.wasm" main >/dev/null 2>&1 || true
 if [ ! -s "$inspdir/shadow_pat.wasm" ]; then
   echo "[compiler-gate] FAIL: a pattern-bound \`inspect\` did not compile (#1571 shadow, pattern binders)" >&2
-  cat "$inspdir/shadow_pat.wasm.diag" 2>/dev/null >&2 || true
+  cat "$inspdir/shadow_pat.wasm.diag" >&2 2>/dev/null || true
   exit 1
 fi
 insp_pat_out="$(VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh "$inspdir/shadow_pat.wasm" 2>&1)"
@@ -5564,24 +5564,24 @@ diag_n="$(grep -c '^line ' "$chkdir/diag.out" 2>/dev/null || true)"
 [ -n "$diag_n" ] || diag_n=0
 if [ "$chk_n" != "2" ]; then
   echo "[compiler-gate] FAIL: vibe check reported $chk_n parse errors, want 2 -- check_linked_file is dropping diagnostics the recovering parser already collected (#1567)" >&2
-  cat "$chkdir/check.out.diag" 2>/dev/null >&2 || true
+  cat "$chkdir/check.out.diag" >&2 2>/dev/null || true
   exit 1
 fi
 if [ "$diag_n" != "2" ]; then
   echo "[compiler-gate] FAIL: vibe diagnostics reported $diag_n parse errors, want 2 (#1567)" >&2
-  cat "$chkdir/diag.out" 2>/dev/null >&2 || true
+  cat "$chkdir/diag.out" >&2 2>/dev/null || true
   exit 1
 fi
 # Same errors, not merely the same count: both must name line 1 and line 3.
 for want in 'line 1:' 'line 3:'; do
   if ! grep -qF "$want" "$chkdir/check.out.diag" 2>/dev/null; then
     echo "[compiler-gate] FAIL: vibe check's report is missing '$want' (#1567)" >&2
-    cat "$chkdir/check.out.diag" 2>/dev/null >&2 || true
+    cat "$chkdir/check.out.diag" >&2 2>/dev/null || true
     exit 1
   fi
   if ! grep -qF "$want" "$chkdir/diag.out" 2>/dev/null; then
     echo "[compiler-gate] FAIL: vibe diagnostics' report is missing '$want' (#1567)" >&2
-    cat "$chkdir/diag.out" 2>/dev/null >&2 || true
+    cat "$chkdir/diag.out" >&2 2>/dev/null || true
     exit 1
   fi
 done
@@ -5591,7 +5591,7 @@ if ! VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_CHECK_ONLY=1 VIBE_IMPORT_ABI=raw \
   bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
   "$chkdir/clean.vibe" "$chkdir/clean.out" main >/dev/null 2>&1; then
   echo "[compiler-gate] FAIL: vibe check rejected a clean file (#1567)" >&2
-  cat "$chkdir/clean.out.diag" 2>/dev/null >&2 || true
+  cat "$chkdir/clean.out.diag" >&2 2>/dev/null || true
   exit 1
 fi
 rm -rf "$chkdir"
@@ -5624,7 +5624,7 @@ dep_run() {
 dep_run direct.txt lib/@vibe/parser/parser_smoke_test.vibe VIBE_DEPS_DIRECT=1
 if ! grep -qx 'lib/@vibe/ast/index.vpkg' "$depdir/direct.txt"; then
   echo "[compiler-gate] FAIL: vibe deps --direct did not resolve '@vibe/ast' to its index.vpkg (#988)" >&2
-  cat "$depdir/direct.txt" "$depdir/direct.txt.diag" 2>/dev/null >&2 || true
+  cat "$depdir/direct.txt" "$depdir/direct.txt.diag" >&2 2>/dev/null || true
   exit 1
 fi
 
@@ -5635,7 +5635,7 @@ fi
 dep_run closure.txt lib/@vibe/parser/parser_smoke_test.vibe
 if ! grep -qx 'lib/@vibe/ast/ast.vibe' "$depdir/closure.txt"; then
   echo "[compiler-gate] FAIL: vibe deps closure missed the .vpkg sibling impl lib/@vibe/ast/ast.vibe (#988)" >&2
-  cat "$depdir/closure.txt" "$depdir/closure.txt.diag" 2>/dev/null >&2 || true
+  cat "$depdir/closure.txt" "$depdir/closure.txt.diag" >&2 2>/dev/null || true
   exit 1
 fi
 # The closure must cover the direct deps; a closure smaller than one hop means
@@ -5660,7 +5660,7 @@ printf 'import ./does_not_exist.vibe {\n  nope\n}\n\nexport let a = 1\n' > "$dep
 dep_run broken.txt "$depdir/broken.vibe" VIBE_DEPS_DIRECT=1
 if [ -s "$depdir/broken.txt" ] || [ ! -s "$depdir/broken.txt.diag" ]; then
   echo "[compiler-gate] FAIL: an unresolvable import did not land on the .diag sidecar with empty output (#988)" >&2
-  cat "$depdir/broken.txt" "$depdir/broken.txt.diag" 2>/dev/null >&2 || true
+  cat "$depdir/broken.txt" "$depdir/broken.txt.diag" >&2 2>/dev/null || true
   exit 1
 fi
 rm -rf "$depdir"
@@ -5751,7 +5751,7 @@ VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_ALLOCS=1 VIBE_IMPORT_ABI=raw \
   "$alcdir/none.vibe" "$alcdir/none.txt" >/dev/null 2>&1 || true
 if [ -s "$alcdir/none.txt" ] || [ -s "$alcdir/none.txt.diag" ]; then
   echo "[compiler-gate] FAIL: vibe allocs on a function-free file should be empty and clean (#1262)" >&2
-  cat "$alcdir/none.txt" "$alcdir/none.txt.diag" 2>/dev/null >&2 || true
+  cat "$alcdir/none.txt" "$alcdir/none.txt.diag" >&2 2>/dev/null || true
   exit 1
 fi
 rm -rf "$alcdir"
@@ -5782,7 +5782,7 @@ esc_run real_strict.txt "$escdir/real.vibe" 1
 for lane in loose strict; do
   if ! grep -q '^acc ' "$escdir/real_$lane.txt" 2>/dev/null; then
     echo "[compiler-gate] FAIL: vibe escapes ($lane lane) missed a genuine closure capture (#1262)" >&2
-    cat "$escdir/real_$lane.txt" "$escdir/real_$lane.txt.diag" 2>/dev/null >&2 || true
+    cat "$escdir/real_$lane.txt" "$escdir/real_$lane.txt.diag" >&2 2>/dev/null || true
     exit 1
   fi
 done
@@ -5805,7 +5805,7 @@ esc_run shadow_loose.txt "$escdir/shadow.vibe" 0
 esc_run shadow_strict.txt "$escdir/shadow.vibe" 1
 if ! grep -q '^n ' "$escdir/shadow_loose.txt" 2>/dev/null; then
   echo "[compiler-gate] FAIL: the LOWERING escape lane stopped reporting a shadowed name -- it must stay conservative, because codegen really does box that cell (#1262)" >&2
-  cat "$escdir/shadow_loose.txt" "$escdir/shadow_loose.txt.diag" 2>/dev/null >&2 || true
+  cat "$escdir/shadow_loose.txt" "$escdir/shadow_loose.txt.diag" >&2 2>/dev/null || true
   exit 1
 fi
 if [ -s "$escdir/shadow_strict.txt" ]; then
@@ -5823,7 +5823,7 @@ esc_run broken_strict.txt "$escdir/broken.vibe" 1
 for lane in loose strict; do
   if [ -s "$escdir/broken_$lane.txt" ] || [ ! -s "$escdir/broken_$lane.txt.diag" ]; then
     echo "[compiler-gate] FAIL: a broken source did not land on the .diag sidecar with empty output in the $lane escape lane (#1262)" >&2
-    cat "$escdir/broken_$lane.txt" "$escdir/broken_$lane.txt.diag" 2>/dev/null >&2 || true
+    cat "$escdir/broken_$lane.txt" "$escdir/broken_$lane.txt.diag" >&2 2>/dev/null || true
     exit 1
   fi
 done
@@ -5861,7 +5861,7 @@ for spelling in build freeze; do
     "$sbdir/$spelling.vibe" "$sbdir/$spelling.wasm" main >/dev/null 2>&1 || true
   if [ ! -s "$sbdir/$spelling.wasm" ]; then
     echo "[compiler-gate] FAIL: StringBuilder::$spelling did not compile (ADR-0101 (3) / #1262)" >&2
-    cat "$sbdir/$spelling.wasm.diag" 2>/dev/null >&2 || true
+    cat "$sbdir/$spelling.wasm.diag" >&2 2>/dev/null || true
     exit 1
   fi
   sb_out="$(VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh "$sbdir/$spelling.wasm" 2>&1 | tail -1)"
@@ -5916,12 +5916,12 @@ gate_status chk_rc env VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_CHECK_ONLY=1 VIBE_IMPOR
 # failure, which is the one thing this surface must never be.
 if [ "$chk_rc" != "0" ]; then
   echo "[compiler-gate] FAIL: vibe check exited $chk_rc on a file importing @vibe/core -- the second import resolver is back (#1262)" >&2
-  cat "$chkpkgdir/check.out" "$chkpkgdir/check.out.diag" 2>/dev/null >&2 || true
+  cat "$chkpkgdir/check.out" "$chkpkgdir/check.out.diag" >&2 2>/dev/null || true
   exit 1
 fi
 if ! grep -q '^ok$' "$chkpkgdir/check.out" 2>/dev/null; then
   echo "[compiler-gate] FAIL: vibe check on a @scope/pkg importer did not report clean (#1262)" >&2
-  cat "$chkpkgdir/check.out" "$chkpkgdir/check.out.diag" 2>/dev/null >&2 || true
+  cat "$chkpkgdir/check.out" "$chkpkgdir/check.out.diag" >&2 2>/dev/null || true
   exit 1
 fi
 # (b) the deprecated alias must NAME its replacement. This is the half that
@@ -5976,7 +5976,7 @@ VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
 if [ -s "$aliasdir/opaque.wasm" ] \
   || ! grep -qF "expected Token[Int], got Seal[Int]" "$aliasdir/opaque.wasm.diag" 2>/dev/null; then
   echo "[compiler-gate] FAIL: distinct opaque generic contract types stopped being nominal (#1700 control)" >&2
-  cat "$aliasdir/opaque.wasm.diag" 2>/dev/null >&2 || true
+  cat "$aliasdir/opaque.wasm.diag" >&2 2>/dev/null || true
   exit 1
 fi
 rm -rf "$aliasdir"
@@ -6002,7 +6002,7 @@ VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_IMPORT_ABI=raw \
   >/dev/null 2>&1 || true
 if [ ! -s "$fcodir/fco.wasm" ]; then
   echo "[compiler-gate] FAIL: float call-offset fixture did not compile (#2158)" >&2
-  cat "$fcodir/fco.wasm.diag" 2>/dev/null >&2 || true
+  cat "$fcodir/fco.wasm.diag" >&2 2>/dev/null || true
   exit 1
 fi
 if ! VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh \
@@ -6119,7 +6119,7 @@ CDBGEOF
 VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_IMPORT_ABI=raw   bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm"   "$cdbg/oob.vibe" "$cdbg/oob.wasm" main >/dev/null 2>&1 || true
 if [ ! -s "$cdbg/oob.wasm" ]; then
   echo "[compiler-gate] FAIL: crash-debug fixture did not compile (#2199)" >&2
-  cat "$cdbg/oob.wasm.diag" 2>/dev/null >&2 || true
+  cat "$cdbg/oob.wasm.diag" >&2 2>/dev/null || true
   exit 1
 fi
 VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh   --invoke _start "$cdbg/oob.wasm" >"$cdbg/quiet.log" 2>&1 || true
@@ -6243,19 +6243,19 @@ if [ -s "$uwdir/uses.wasm" ]; then
 fi
 if ! grep -qF 'VIBE_UNSTABLE=1' "$uwdir/uses.wasm.diag" 2>/dev/null; then
   echo "[compiler-gate] FAIL: the build rejection did not name the opt-in (#2248)" >&2
-  cat "$uwdir/uses.wasm.diag" 2>/dev/null >&2 || true
+  cat "$uwdir/uses.wasm.diag" >&2 2>/dev/null || true
   exit 1
 fi
 uw_build "$uwdir/uses.vibe" "$uwdir/uses_optin.wasm" VIBE_UNSTABLE=1
 if [ ! -s "$uwdir/uses_optin.wasm" ]; then
   echo "[compiler-gate] FAIL: VIBE_UNSTABLE=1 did not let the build through (#2248)" >&2
-  cat "$uwdir/uses_optin.wasm.diag" 2>/dev/null >&2 || true
+  cat "$uwdir/uses_optin.wasm.diag" >&2 2>/dev/null || true
   exit 1
 fi
 uw_build "$uwdir/plain.vibe" "$uwdir/plain.wasm"
 if [ ! -s "$uwdir/plain.wasm" ]; then
   echo "[compiler-gate] FAIL: a file not importing @vibe/concurrent failed to build (#2248)" >&2
-  cat "$uwdir/plain.wasm.diag" 2>/dev/null >&2 || true
+  cat "$uwdir/plain.wasm.diag" >&2 2>/dev/null || true
   exit 1
 fi
 
@@ -6298,7 +6298,7 @@ UWEOF
 uw_build "$uwdir/comment.vibe" "$uwdir/comment.wasm"
 if ! grep -qF 'line 3:' "$uwdir/comment.wasm.diag" 2>/dev/null; then
   echo "[compiler-gate] FAIL: the opt-in diagnostic named the wrong import line (#2277)" >&2
-  cat "$uwdir/comment.wasm.diag" 2>/dev/null >&2 || true
+  cat "$uwdir/comment.wasm.diag" >&2 2>/dev/null || true
   exit 1
 fi
 
@@ -6328,7 +6328,7 @@ if [ -s "$uwdir/pinned.wasm" ]; then
 fi
 if ! grep -qF 'VIBE_UNSTABLE=1' "$uwdir/pinned.wasm.diag" 2>/dev/null; then
   echo "[compiler-gate] FAIL: a pinned require header silenced the opt-in gate (#2277)" >&2
-  cat "$uwdir/pinned.wasm.diag" 2>/dev/null >&2 || true
+  cat "$uwdir/pinned.wasm.diag" >&2 2>/dev/null || true
   exit 1
 fi
 
@@ -6341,7 +6341,7 @@ printf 'fn helper() -> Int {\n  1\n}\n\nimport\n  @vibe/concurrent { TaskGroup }
 uw_build "$uwdir/multiline.vibe" "$uwdir/multiline.wasm"
 if ! grep -qF 'line 5:' "$uwdir/multiline.wasm.diag" 2>/dev/null; then
   echo "[compiler-gate] FAIL: a multiline import declaration got the wrong line (#2277)" >&2
-  cat "$uwdir/multiline.wasm.diag" 2>/dev/null >&2 || true
+  cat "$uwdir/multiline.wasm.diag" >&2 2>/dev/null || true
   exit 1
 fi
 
@@ -6361,14 +6361,14 @@ rm -f "$uwdir/buffer.out"
 env -u VIBE_UNSTABLE VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_IMPORT_ABI=raw VIBE_DIAGNOSTICS=1   bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm"   "$uwdir/buffer.vibe" "$uwdir/buffer.out" __no_entry__ >/dev/null 2>&1 || true
 if ! grep -qF 'VIBE_UNSTABLE=1' "$uwdir/buffer.out" 2>/dev/null; then
   echo "[compiler-gate] FAIL: the single-file diagnostics lane accepted an unstable import (#2277)" >&2
-  cat "$uwdir/buffer.out" 2>/dev/null >&2 || true
+  cat "$uwdir/buffer.out" >&2 2>/dev/null || true
   exit 1
 fi
 rm -f "$uwdir/buffer.optin.out"
 VIBE_UNSTABLE=1 VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_IMPORT_ABI=raw VIBE_DIAGNOSTICS=1   bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm"   "$uwdir/buffer.vibe" "$uwdir/buffer.optin.out" __no_entry__ >/dev/null 2>&1 || true
 if grep -qF 'VIBE_UNSTABLE=1' "$uwdir/buffer.optin.out" 2>/dev/null; then
   echo "[compiler-gate] FAIL: VIBE_UNSTABLE=1 did not clear the single-file diagnostic (#2277)" >&2
-  cat "$uwdir/buffer.optin.out" 2>/dev/null >&2 || true
+  cat "$uwdir/buffer.optin.out" >&2 2>/dev/null || true
   exit 1
 fi
 # ...and the JSON form of that same buffer lane, which is what the editor
@@ -6381,7 +6381,7 @@ env -u VIBE_UNSTABLE VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_IMPORT_ABI=raw VIBE_DIAGN
   "$uwdir/buffer.vibe" "$uwdir/buffer.json" __no_entry__ >/dev/null 2>&1 || true
 if ! grep -qF 'VIBE_UNSTABLE=1' "$uwdir/buffer.json" 2>/dev/null; then
   echo "[compiler-gate] FAIL: the single-file JSON lane dropped the unstable diagnostic (#2277)" >&2
-  cat "$uwdir/buffer.json" 2>/dev/null >&2 || true
+  cat "$uwdir/buffer.json" >&2 2>/dev/null || true
   exit 1
 fi
 # The JSON form must carry the COLUMN, not just the message. `lsp_parse_diag_line`
@@ -6403,12 +6403,12 @@ env -u VIBE_UNSTABLE VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_IMPORT_ABI=raw VIBE_DIAGN
 # can read -- it parsed "col 3" as a number, failed, and fell back to column 1.
 if ! grep -qF 'line 1:3: set VIBE_UNSTABLE=1' "$uwdir/indented.out" 2>/dev/null; then
   echo "[compiler-gate] FAIL: the text diagnostic lost the column of an indented unstable import (#2277)" >&2
-  cat "$uwdir/indented.out" 2>/dev/null >&2 || true
+  cat "$uwdir/indented.out" >&2 2>/dev/null || true
   exit 1
 fi
 if ! grep -qF '"character":2' "$uwdir/indented.json" 2>/dev/null; then
   echo "[compiler-gate] FAIL: the JSON diagnostic lost the column the text form reported (#2277)" >&2
-  cat "$uwdir/indented.json" 2>/dev/null >&2 || true
+  cat "$uwdir/indented.json" >&2 2>/dev/null || true
   exit 1
 fi
 
@@ -6434,7 +6434,7 @@ if [ -s "$uwdir/serve.component.wasm" ]; then
 fi
 if ! grep -qF 'VIBE_UNSTABLE=1' "$uwdir/serve.component.wasm.diag" 2>/dev/null; then
   echo "[compiler-gate] FAIL: vibe serve refused the handler for the wrong reason (#2277)" >&2
-  cat "$uwdir/serve.component.wasm.diag" 2>/dev/null >&2 || true
+  cat "$uwdir/serve.component.wasm.diag" >&2 2>/dev/null || true
   exit 1
 fi
 rm -f "$uwdir/serve.optin.wasm" "$uwdir/serve.optin.wasm.diag"
@@ -6443,7 +6443,7 @@ VIBE_UNSTABLE=1 VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_IMPORT_ABI=raw VIBE_SERVE_COMP
   "$uwdir/serve.vibe" "$uwdir/serve.optin.wasm" __no_entry__ >/dev/null 2>&1 || true
 if grep -qF 'VIBE_UNSTABLE=1' "$uwdir/serve.optin.wasm.diag" 2>/dev/null; then
   echo "[compiler-gate] FAIL: VIBE_UNSTABLE=1 did not clear the serve gate (#2277)" >&2
-  cat "$uwdir/serve.optin.wasm.diag" 2>/dev/null >&2 || true
+  cat "$uwdir/serve.optin.wasm.diag" >&2 2>/dev/null || true
   exit 1
 fi
 # `export @pkg { .. }` would depend on the package exactly as an import does and
@@ -6475,7 +6475,7 @@ elif grep -qF 'VIBE_UNSTABLE=1' "$uwdir/reexport.wasm.diag" 2>/dev/null; then
   :
 else
   echo "[compiler-gate] FAIL: a package re-export was refused for an unrelated reason -- if it now parses, gate it (#2277)" >&2
-  cat "$uwdir/reexport.wasm.diag" 2>/dev/null >&2 || true
+  cat "$uwdir/reexport.wasm.diag" >&2 2>/dev/null || true
   exit 1
 fi
 # The SINGLE-SOURCE lane is artifact-producing too. `VIBE_TEST_BACKEND=gc` and
@@ -6502,7 +6502,7 @@ if [ -s "$uwdir/bare.wasm" ]; then
 fi
 if ! grep -qF 'VIBE_UNSTABLE=1' "$uwdir/bare.wasm.diag" 2>/dev/null; then
   echo "[compiler-gate] FAIL: the single-source lane refused the file for the wrong reason (#2277)" >&2
-  cat "$uwdir/bare.wasm.diag" 2>/dev/null >&2 || true
+  cat "$uwdir/bare.wasm.diag" >&2 2>/dev/null || true
   exit 1
 fi
 rm -f "$uwdir/bare.optin.wasm" "$uwdir/bare.optin.wasm.diag"
@@ -6511,7 +6511,7 @@ env -u VIBE_FS_COMPILE VIBE_UNSTABLE=1 VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_IMPORT_
   "$uwdir/bare.vibe" "$uwdir/bare.optin.wasm" __no_entry__ >/dev/null 2>&1 || true
 if [ ! -s "$uwdir/bare.optin.wasm" ]; then
   echo "[compiler-gate] FAIL: VIBE_UNSTABLE=1 did not clear the single-source gate (#2277)" >&2
-  cat "$uwdir/bare.optin.wasm.diag" 2>/dev/null >&2 || true
+  cat "$uwdir/bare.optin.wasm.diag" >&2 2>/dev/null || true
   exit 1
 fi
 # ...and an ordinary file on that lane is untouched, so the gate is not simply
@@ -6523,7 +6523,7 @@ env -u VIBE_UNSTABLE -u VIBE_FS_COMPILE VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_IMPORT
   "$uwdir/bare_plain.vibe" "$uwdir/bare_plain.wasm" __no_entry__ >/dev/null 2>&1 || true
 if [ ! -s "$uwdir/bare_plain.wasm" ]; then
   echo "[compiler-gate] FAIL: the single-source gate refused an ordinary file (#2277)" >&2
-  cat "$uwdir/bare_plain.wasm.diag" 2>/dev/null >&2 || true
+  cat "$uwdir/bare_plain.wasm.diag" >&2 2>/dev/null || true
   exit 1
 fi
 # TWO imports of the same package must be located independently. The offset scan
@@ -6545,12 +6545,12 @@ env -u VIBE_UNSTABLE VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_IMPORT_ABI=raw VIBE_DIAGN
   "$uwdir/twice.vibe" "$uwdir/twice.out" __no_entry__ >/dev/null 2>&1 || true
 if ! grep -qF 'line 1:1: set VIBE_UNSTABLE=1' "$uwdir/twice.out" 2>/dev/null; then
   echo "[compiler-gate] FAIL: the first of two unstable imports was not reported at line 1 (#2277)" >&2
-  cat "$uwdir/twice.out" 2>/dev/null >&2 || true
+  cat "$uwdir/twice.out" >&2 2>/dev/null || true
   exit 1
 fi
 if ! grep -qF 'line 3:1: set VIBE_UNSTABLE=1' "$uwdir/twice.out" 2>/dev/null; then
   echo "[compiler-gate] FAIL: the SECOND unstable import was reported at the first one's line (#2277)" >&2
-  cat "$uwdir/twice.out" 2>/dev/null >&2 || true
+  cat "$uwdir/twice.out" >&2 2>/dev/null || true
   exit 1
 fi
 # The import may sit in a SIBLING, and that is the normal shape of a project --
@@ -6588,18 +6588,18 @@ if [ -s "$uwdir/sib/main.wasm" ]; then
 fi
 if ! grep -qF 'VIBE_UNSTABLE=1' "$uwdir/sib/main.wasm.diag" 2>/dev/null; then
   echo "[compiler-gate] FAIL: the sibling import was refused for the wrong reason (#2284)" >&2
-  cat "$uwdir/sib/main.wasm.diag" 2>/dev/null >&2 || true
+  cat "$uwdir/sib/main.wasm.diag" >&2 2>/dev/null || true
   exit 1
 fi
 if ! grep -qF 'worker.vibe' "$uwdir/sib/main.wasm.diag" 2>/dev/null; then
   echo "[compiler-gate] FAIL: the diagnostic named the entry, not the file that spells the import (#2284)" >&2
-  cat "$uwdir/sib/main.wasm.diag" 2>/dev/null >&2 || true
+  cat "$uwdir/sib/main.wasm.diag" >&2 2>/dev/null || true
   exit 1
 fi
 uw_build "$uwdir/sib/main.vibe" "$uwdir/sib/optin.wasm" VIBE_UNSTABLE=1
 if [ ! -s "$uwdir/sib/optin.wasm" ]; then
   echo "[compiler-gate] FAIL: VIBE_UNSTABLE=1 did not let the sibling case build (#2284)" >&2
-  cat "$uwdir/sib/optin.wasm.diag" 2>/dev/null >&2 || true
+  cat "$uwdir/sib/optin.wasm.diag" >&2 2>/dev/null || true
   exit 1
 fi
 # `vibe check` must agree -- the whole point is that the two verbs answer alike.
@@ -6617,7 +6617,7 @@ printf 'import ./dep.vibe {\n  helper\n}\n\nfn main() -> Int {\n  helper()\n}\n'
 uw_build "$uwdir/plain2/main.vibe" "$uwdir/plain2/main.wasm"
 if [ ! -s "$uwdir/plain2/main.wasm" ]; then
   echo "[compiler-gate] FAIL: the closure scan refused an ordinary two-file program (#2284)" >&2
-  cat "$uwdir/plain2/main.wasm.diag" 2>/dev/null >&2 || true
+  cat "$uwdir/plain2/main.wasm.diag" >&2 2>/dev/null || true
   exit 1
 fi
 
@@ -6662,12 +6662,12 @@ if [ -s "$uwdir/srv/c.wasm" ]; then
 fi
 if ! grep -qF 'VIBE_UNSTABLE=1' "$uwdir/srv/c.wasm.diag" 2>/dev/null; then
   echo "[compiler-gate] FAIL: vibe serve refused the handler for the wrong reason -- the gate must outrank the purity check (#2302)" >&2
-  cat "$uwdir/srv/c.wasm.diag" 2>/dev/null >&2 || true
+  cat "$uwdir/srv/c.wasm.diag" >&2 2>/dev/null || true
   exit 1
 fi
 if ! grep -qF 'dep.vibe' "$uwdir/srv/c.wasm.diag" 2>/dev/null; then
   echo "[compiler-gate] FAIL: the serve diagnostic named the handler, not the file that spells the import (#2284)" >&2
-  cat "$uwdir/srv/c.wasm.diag" 2>/dev/null >&2 || true
+  cat "$uwdir/srv/c.wasm.diag" >&2 2>/dev/null || true
   exit 1
 fi
 # With the opt-in the gate stands down -- whatever happens next is not its say.
@@ -6677,7 +6677,7 @@ VIBE_UNSTABLE=1 VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_IMPORT_ABI=raw VIBE_SERVE_COMP
   "$uwdir/srv/h.vibe" "$uwdir/srv/optin.wasm" __no_entry__ >/dev/null 2>&1 || true
 if grep -qF 'VIBE_UNSTABLE=1' "$uwdir/srv/optin.wasm.diag" 2>/dev/null; then
   echo "[compiler-gate] FAIL: VIBE_UNSTABLE=1 did not clear the serve closure gate (#2302)" >&2
-  cat "$uwdir/srv/optin.wasm.diag" 2>/dev/null >&2 || true
+  cat "$uwdir/srv/optin.wasm.diag" >&2 2>/dev/null || true
   exit 1
 fi
 # ...and an ordinary handler is untouched.
@@ -6688,7 +6688,7 @@ env -u VIBE_UNSTABLE VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_IMPORT_ABI=raw VIBE_SERVE
   "$uwdir/srv/plain.vibe" "$uwdir/srv/plain.wasm" __no_entry__ >/dev/null 2>&1 || true
 if [ ! -s "$uwdir/srv/plain.wasm" ]; then
   echo "[compiler-gate] FAIL: the serve closure gate refused an ordinary handler (#2302)" >&2
-  cat "$uwdir/srv/plain.wasm.diag" 2>/dev/null >&2 || true
+  cat "$uwdir/srv/plain.wasm.diag" >&2 2>/dev/null || true
   exit 1
 fi
 
@@ -6818,7 +6818,7 @@ VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_IMPORT_ABI=raw \
   "$asdir/shadow.vibe" "$asdir/shadow.wasm" main >/dev/null 2>&1 || true
 if [ ! -s "$asdir/shadow.wasm" ]; then
   echo "[compiler-gate] FAIL: a program defining its own assert_eq did not compile (#2283)" >&2
-  cat "$asdir/shadow.wasm.diag" 2>/dev/null >&2 || true
+  cat "$asdir/shadow.wasm.diag" >&2 2>/dev/null || true
   exit 1
 fi
 as_out="$(VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh --invoke _start "$asdir/shadow.wasm" 2>&1 || true)"
@@ -6902,7 +6902,7 @@ VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_IMPORT_ABI=raw \
   "$asdir/local.vibe" "$asdir/local.wasm" main >/dev/null 2>&1 || true
 if [ ! -s "$asdir/local.wasm" ]; then
   echo "[compiler-gate] FAIL: a program binding assert_eq locally did not compile (#2285)" >&2
-  cat "$asdir/local.wasm.diag" 2>/dev/null >&2 || true
+  cat "$asdir/local.wasm.diag" >&2 2>/dev/null || true
   exit 1
 fi
 local_out="$(VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh --invoke _start "$asdir/local.wasm" 2>&1 || true)"
@@ -6954,7 +6954,7 @@ VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_IMPORT_ABI=raw \
   "$asdir/lambda.vibe" "$asdir/lambda.wasm" main >/dev/null 2>&1 || true
 if [ ! -s "$asdir/lambda.wasm" ]; then
   echo "[compiler-gate] FAIL: a lambda calling a bare assert did not compile (#1095 guard, #2285)" >&2
-  cat "$asdir/lambda.wasm.diag" 2>/dev/null >&2 || true
+  cat "$asdir/lambda.wasm.diag" >&2 2>/dev/null || true
   exit 1
 fi
 lambda_out="$(VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh --invoke _start "$asdir/lambda.wasm" 2>&1 || true)"
@@ -7109,7 +7109,7 @@ for probe in eq eqf; do
   VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_IMPORT_ABI=raw     bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm"     "$eqdir/$probe.vibe" "$eqdir/$probe.wasm" main >/dev/null 2>&1 || true
   if [ ! -s "$eqdir/$probe.wasm" ]; then
     echo "[compiler-gate] FAIL: the $probe shadow probe did not compile (#2309)" >&2
-    cat "$eqdir/$probe.wasm.diag" 2>/dev/null >&2 || true
+    cat "$eqdir/$probe.wasm.diag" >&2 2>/dev/null || true
     exit 1
   fi
 done
@@ -7144,7 +7144,7 @@ rm -f "$eqdir/builtin.wasm" "$eqdir/builtin.wasm.diag"
 VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_IMPORT_ABI=raw   bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm"   "$eqdir/builtin.vibe" "$eqdir/builtin.wasm" main >/dev/null 2>&1 || true
 if [ ! -s "$eqdir/builtin.wasm" ]; then
   echo "[compiler-gate] FAIL: the unshadowed eq probe did not compile (#2309)" >&2
-  cat "$eqdir/builtin.wasm.diag" 2>/dev/null >&2 || true
+  cat "$eqdir/builtin.wasm.diag" >&2 2>/dev/null || true
   exit 1
 fi
 builtin_out="$(VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh --invoke _start "$eqdir/builtin.wasm" 2>&1 || true)"
@@ -7175,7 +7175,7 @@ VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_IMPORT_ABI=raw \
   "$eqdir/toplevel.vibe" "$eqdir/toplevel.wasm" main >/dev/null 2>&1 || true
 if [ ! -s "$eqdir/toplevel.wasm" ]; then
   echo "[compiler-gate] FAIL: the top-level eq probe did not compile (#2309)" >&2
-  cat "$eqdir/toplevel.wasm.diag" 2>/dev/null >&2 || true
+  cat "$eqdir/toplevel.wasm.diag" >&2 2>/dev/null || true
   exit 1
 fi
 top_out="$(VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh --invoke _start "$eqdir/toplevel.wasm" 2>&1 || true)"
@@ -7204,7 +7204,7 @@ VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_IMPORT_ABI=raw VIBE_FS_COMPILE=1 \
   "$eqdir/withsemver.vibe" "$eqdir/withsemver.wasm" main >/dev/null 2>&1 || true
 if [ ! -s "$eqdir/withsemver.wasm" ]; then
   echo "[compiler-gate] FAIL: the semver+eq probe did not compile (#2309)" >&2
-  cat "$eqdir/withsemver.wasm.diag" 2>/dev/null >&2 || true
+  cat "$eqdir/withsemver.wasm.diag" >&2 2>/dev/null || true
   exit 1
 fi
 sem_out="$(VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh --invoke _start "$eqdir/withsemver.wasm" 2>&1 || true)"
@@ -7271,7 +7271,7 @@ for contract in lib/@vibe/random/index.vpkg; do
   rm -f "$vpdir/out" "$vpdir/out.diag"
   if ! VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_CHECK_ONLY=1 VIBE_IMPORT_ABI=raw     bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm"     "$contract" "$vpdir/out" main >"$vpdir/stdout" 2>&1; then
     echo "[compiler-gate] FAIL: vibe check rejected the working contract $contract (#2280)" >&2
-    cat "$vpdir/out.diag" 2>/dev/null >&2 || true
+    cat "$vpdir/out.diag" >&2 2>/dev/null || true
     cat "$vpdir/stdout" >&2
     exit 1
   fi
@@ -7314,7 +7314,7 @@ if ! VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_CHECK_ONLY=1 VIBE_IMPORT_ABI=raw \
   bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
   "$vpdir/pkg/index.vpkg" "$vpdir/ok.out" main >"$vpdir/ok.stdout" 2>&1; then
   echo "[compiler-gate] FAIL: vibe check rejected a well-formed synthetic contract (#2280)" >&2
-  cat "$vpdir/ok.out.diag" 2>/dev/null >&2 || true
+  cat "$vpdir/ok.out.diag" >&2 2>/dev/null || true
   cat "$vpdir/ok.stdout" >&2
   exit 1
 fi
@@ -7479,7 +7479,7 @@ env -u VIBE_UNSTABLE VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_CHECK_ONLY=1 VIBE_IMPORT_
   "$ihdir/pkg/impl.vibe" "$ihdir/only.out" main >/dev/null 2>&1 || true
 if ! grep -qF 'inherits' "$ihdir/only.out.diag" 2>/dev/null; then
   echo "[compiler-gate] FAIL: a file that only inherits the import no longer says so (#2289)" >&2
-  cat "$ihdir/only.out.diag" 2>/dev/null >&2 || true
+  cat "$ihdir/only.out.diag" >&2 2>/dev/null || true
   exit 1
 fi
 rm -rf "$ihdir"
@@ -7740,7 +7740,7 @@ VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_CHECK_ONLY=1 VIBE_IMPORT_ABI=raw \
   "$tdlabdir/trait.vibe" "$tdlabdir/chk.out" main >/dev/null 2>&1 || true
 if ! grep -qF 'Store::lookup' "$tdlabdir/chk.out.diag" 2>/dev/null; then
   echo "[compiler-gate] FAIL: vibe check no longer names the trait method (#2286)" >&2
-  cat "$tdlabdir/chk.out.diag" 2>/dev/null >&2 || true
+  cat "$tdlabdir/chk.out.diag" >&2 2>/dev/null || true
   exit 1
 fi
 # ...and an INHERITED method names the trait that declares it. `flatten_traits`
@@ -8257,7 +8257,7 @@ generated_hash =
     "$vpbufdir/$dirpos/index.vpkg" "$vpbufdir/$dirpos.imp" main >/dev/null 2>&1 || true
   if ! grep -qF 'unsupported # directive in a contract file: eof' "$vpbufdir/$dirpos.imp.diag" 2>/dev/null; then
     echo "[compiler-gate] FAIL: the import lane no longer reports a '#eof' directive ($dirpos the header) -- repoint this probe (#2316)" >&2
-    cat "$vpbufdir/$dirpos.imp.diag" 2>/dev/null >&2 || true
+    cat "$vpbufdir/$dirpos.imp.diag" >&2 2>/dev/null || true
     exit 1
   fi
   VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_DIAGNOSTICS=1 VIBE_IMPORT_ABI=raw \
@@ -8265,7 +8265,7 @@ generated_hash =
     "$vpbufdir/$dirpos/index.vpkg" "$vpbufdir/$dirpos.buf" main >/dev/null 2>&1 || true
   if ! grep -qF 'unsupported # directive in a contract file: eof' "$vpbufdir/$dirpos.buf" 2>/dev/null; then
     echo "[compiler-gate] FAIL: the buffer lane does not report a '#eof' directive ($dirpos the header) that the import lane refuses (#2316)" >&2
-    cat "$vpbufdir/$dirpos.buf" 2>/dev/null >&2 || true
+    cat "$vpbufdir/$dirpos.buf" >&2 2>/dev/null || true
     exit 1
   fi
   # Anchored on the directive's own '#', not left at 0:0 and not pushed to the
@@ -8273,7 +8273,7 @@ generated_hash =
   # the MESSAGE -- which is the trap that predicate was narrowed to avoid.
   if ! grep -q "^$want_line" "$vpbufdir/$dirpos.buf" 2>/dev/null; then
     echo "[compiler-gate] FAIL: the '#eof' directive ($dirpos the header) is not anchored on its own '#' (expected $want_line) (#2316)" >&2
-    cat "$vpbufdir/$dirpos.buf" 2>/dev/null >&2 || true
+    cat "$vpbufdir/$dirpos.buf" >&2 2>/dev/null || true
     exit 1
   fi
 done
@@ -8288,7 +8288,7 @@ if ! VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_CHECK_ONLY=1 VIBE_IMPORT_ABI=raw \
   bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
   "$vpbufdir/dep/index.vpkg" "$vpbufdir/dep.imp" main >/dev/null 2>&1; then
   echo "[compiler-gate] FAIL: the import lane refuses a '#deprecated' contract -- the control for the probes above is not valid (#2316)" >&2
-  cat "$vpbufdir/dep.imp.diag" 2>/dev/null >&2 || true
+  cat "$vpbufdir/dep.imp.diag" >&2 2>/dev/null || true
   exit 1
 fi
 VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_DIAGNOSTICS=1 VIBE_IMPORT_ABI=raw \
@@ -8340,7 +8340,7 @@ printf '%s\n' "$fwd_cases" | while IFS='|' read -r nm call def; do
   bv="$(cat "$fwddir/$nm.back.verdict")"
   if [ "$fv" != "$bv" ]; then
     echo "[compiler-gate] FAIL: case '$nm' depends on declaration order -- call-first says $fv, definition-first says $bv (#2318)" >&2
-    cat "$fwddir/$nm.fwd.out.diag" 2>/dev/null >&2 || true
+    cat "$fwddir/$nm.fwd.out.diag" >&2 2>/dev/null || true
     exit 1
   fi
   # ...and both must REJECT. Agreeing by accepting everything is the failure
@@ -8370,7 +8370,7 @@ if ! VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_IMPORT_ABI=raw \
   bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
   "$fwddir/ok.vibe" "$fwddir/ok.wasm" main >/dev/null 2>&1; then
   echo "[compiler-gate] FAIL: a CORRECT forward call no longer compiles (#2318)" >&2
-  cat "$fwddir/ok.wasm.diag" 2>/dev/null >&2 || true
+  cat "$fwddir/ok.wasm.diag" >&2 2>/dev/null || true
   exit 1
 fi
 ok_out="$(VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh --invoke _start "$fwddir/ok.wasm" 2>&1 | head -1)"
@@ -8401,7 +8401,7 @@ if ! VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_CHECK_ONLY=1 VIBE_IMPORT_ABI=raw \
   bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
   "$fwddir/opt.vibe" "$fwddir/opt.out" main >/dev/null 2>&1; then
   echo "[compiler-gate] FAIL: omitting an OPTIONAL parameter in a forward call is reported as an error (#2318)" >&2
-  cat "$fwddir/opt.out.diag" 2>/dev/null >&2 || true
+  cat "$fwddir/opt.out.diag" >&2 2>/dev/null || true
   exit 1
 fi
 rm -rf "$fwddir"
@@ -8473,8 +8473,8 @@ for probe in derive decoyderive twoderive multiderive clean; do
   if [ "$probe" = clean ]; then want="clean"; else want="refused"; fi
   if [ "$imp" != "$want" ] || [ "$buf" != "$want" ]; then
     echo "[compiler-gate] FAIL: contract '$probe' -- import lane says $imp, buffer lane says $buf, both should say $want (#2317)" >&2
-    cat "$csdir/$probe.imp.diag" 2>/dev/null >&2 || true
-    cat "$csdir/$probe.buf" 2>/dev/null >&2 || true
+    cat "$csdir/$probe.imp.diag" >&2 2>/dev/null || true
+    cat "$csdir/$probe.buf" >&2 2>/dev/null || true
     exit 1
   fi
 done
@@ -8603,7 +8603,7 @@ for probe in later first; do
     "$clsdir/$probe/index.vpkg" "$clsdir/$probe.imp" main >/dev/null 2>&1 || true
   if ! grep -qF "$cls_msg" "$clsdir/$probe.imp.diag" 2>/dev/null; then
     echo "[compiler-gate] FAIL: the import lane no longer refuses a top-level let in a contract ($probe) -- repoint this probe (#2317)" >&2
-    cat "$clsdir/$probe.imp.diag" 2>/dev/null >&2 || true
+    cat "$clsdir/$probe.imp.diag" >&2 2>/dev/null || true
     exit 1
   fi
   VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_DIAGNOSTICS=1 VIBE_IMPORT_ABI=raw \
@@ -8611,12 +8611,12 @@ for probe in later first; do
     "$clsdir/$probe/index.vpkg" "$clsdir/$probe.buf" main >/dev/null 2>&1 || true
   if ! grep -qF "$cls_msg" "$clsdir/$probe.buf" 2>/dev/null; then
     echo "[compiler-gate] FAIL: the buffer lane does not refuse a top-level let in a contract ($probe) (#2317)" >&2
-    cat "$clsdir/$probe.buf" 2>/dev/null >&2 || true
+    cat "$clsdir/$probe.buf" >&2 2>/dev/null || true
     exit 1
   fi
   if ! grep -q "^$want_line" "$clsdir/$probe.buf" 2>/dev/null; then
     echo "[compiler-gate] FAIL: the unsupported statement ($probe) is not anchored on itself (expected $want_line) (#2317)" >&2
-    cat "$clsdir/$probe.buf" 2>/dev/null >&2 || true
+    cat "$clsdir/$probe.buf" >&2 2>/dev/null || true
     exit 1
   fi
 done
@@ -8627,7 +8627,7 @@ if ! VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_CHECK_ONLY=1 VIBE_IMPORT_ABI=raw \
   bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
   "$clsdir/clean/index.vpkg" "$clsdir/clean.imp" main >/dev/null 2>&1; then
   echo "[compiler-gate] FAIL: the import lane refuses the CLEAN control contract -- the probes above are not valid (#2317)" >&2
-  cat "$clsdir/clean.imp.diag" 2>/dev/null >&2 || true
+  cat "$clsdir/clean.imp.diag" >&2 2>/dev/null || true
   exit 1
 fi
 VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_DIAGNOSTICS=1 VIBE_IMPORT_ABI=raw \
@@ -8708,7 +8708,7 @@ if ! VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_CHECK_ONLY=1 VIBE_IMPORT_ABI=raw \
   bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
   "$dpvdir/clean/index.vpkg" "$dpvdir/clean.out" main >/dev/null 2>&1; then
   echo "[compiler-gate] FAIL: a contract with a KNOWN derive is refused -- the control for the probe above is not valid (#2317)" >&2
-  cat "$dpvdir/clean.out.diag" 2>/dev/null >&2 || true
+  cat "$dpvdir/clean.out.diag" >&2 2>/dev/null || true
   exit 1
 fi
 # The LOCATED case moved to section 123 (#2317). This section asserted that a
@@ -8908,8 +8908,8 @@ for probe in once twice qtwice vtwice; do
   if [ -s "$dupdir/$probe.buf" ]; then buf="refused"; else buf="clean"; fi
   if [ "$imp" != "$want" ] || [ "$buf" != "$want" ]; then
     echo "[compiler-gate] FAIL: contract '$probe' -- import lane says $imp, buffer lane says $buf, both should say $want (#2317)" >&2
-    cat "$dupdir/$probe.imp.diag" 2>/dev/null >&2 || true
-    cat "$dupdir/$probe.buf" 2>/dev/null >&2 || true
+    cat "$dupdir/$probe.imp.diag" >&2 2>/dev/null || true
+    cat "$dupdir/$probe.buf" >&2 2>/dev/null || true
     exit 1
   fi
 done
@@ -8918,12 +8918,12 @@ done
 for lane in imp.diag buf; do
   if ! grep -qF "declares 'plain' more than once" "$dupdir/twice.$lane" 2>/dev/null; then
     echo "[compiler-gate] FAIL: the $lane lane does not name the duplication for a repeated declaration (#2317)" >&2
-    cat "$dupdir/twice.$lane" 2>/dev/null >&2 || true
+    cat "$dupdir/twice.$lane" >&2 2>/dev/null || true
     exit 1
   fi
   if grep -qF 'no implementation file' "$dupdir/twice.$lane" 2>/dev/null; then
     echo "[compiler-gate] FAIL: the $lane lane still blames a missing implementation for a duplicate (#2317)" >&2
-    cat "$dupdir/twice.$lane" 2>/dev/null >&2 || true
+    cat "$dupdir/twice.$lane" >&2 2>/dev/null || true
     exit 1
   fi
 done
@@ -8932,7 +8932,7 @@ done
 # declaration they want to keep.
 if ! grep -q '^line 11:1:' "$dupdir/twice.buf" 2>/dev/null; then
   echo "[compiler-gate] FAIL: the duplicate is not anchored on the repeated declaration (expected line 11) (#2317)" >&2
-  cat "$dupdir/twice.buf" 2>/dev/null >&2 || true
+  cat "$dupdir/twice.buf" >&2 2>/dev/null || true
   exit 1
 fi
 # ...and a FILTERED declaration sharing the duplicate's name does not shift the
@@ -8955,12 +8955,12 @@ VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_DIAGNOSTICS=1 VIBE_IMPORT_ABI=raw \
   "$dupdir/vfiltered/index.vpkg" "$dupdir/vfiltered.buf" main >/dev/null 2>&1 || true
 if ! grep -qF "declares 'version' more than once" "$dupdir/vfiltered.buf" 2>/dev/null; then
   echo "[compiler-gate] FAIL: two effective 'version' declarations beside a filtered one are not reported as a duplicate (#2328)" >&2
-  cat "$dupdir/vfiltered.buf" 2>/dev/null >&2 || true
+  cat "$dupdir/vfiltered.buf" >&2 2>/dev/null || true
   exit 1
 fi
 if ! grep -q '^line 13:1:' "$dupdir/vfiltered.buf" 2>/dev/null; then
   echo "[compiler-gate] FAIL: a filtered declaration sharing the name shifted the duplicate anchor off the repeat (expected line 13) (#2328)" >&2
-  cat "$dupdir/vfiltered.buf" 2>/dev/null >&2 || true
+  cat "$dupdir/vfiltered.buf" >&2 2>/dev/null || true
   exit 1
 fi
 # ...and when a contract has BOTH faults, the two lanes recommend the SAME first
@@ -8986,7 +8986,7 @@ VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_DIAGNOSTICS=1 VIBE_IMPORT_ABI=raw \
 for lane in imp.diag buf; do
   if ! grep -qF 'unsupported statement in a contract file' "$dupdir/both.$lane" 2>/dev/null; then
     echo "[compiler-gate] FAIL: with a duplicate AND an unsupported statement, the $lane lane does not lead with the unsupported statement (#2328)" >&2
-    cat "$dupdir/both.$lane" 2>/dev/null >&2 || true
+    cat "$dupdir/both.$lane" >&2 2>/dev/null || true
     exit 1
   fi
 done
@@ -9068,7 +9068,7 @@ if ! VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_CHECK_ONLY=1 VIBE_IMPORT_ABI=raw \
   bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
   "$mapdir/clean/index.vpkg" "$mapdir/clean.out" main >/dev/null 2>&1; then
   echo "[compiler-gate] FAIL: a contract with a plain transparent struct is refused -- the control is not valid (#2317)" >&2
-  cat "$mapdir/clean.out.diag" 2>/dev/null >&2 || true
+  cat "$mapdir/clean.out.diag" >&2 2>/dev/null || true
   exit 1
 fi
 rm -rf "$mapdir"
@@ -9118,24 +9118,24 @@ done
 for lane in imp.diag buf; do
   if ! grep -qF "unknown type \`Intt\` in field \`x\` of struct \`Bad\`" "$utdir/field.$lane" 2>/dev/null; then
     echo "[compiler-gate] FAIL: the $lane lane does not reject an unknown contract field type (#2317)" >&2
-    cat "$utdir/field.$lane" 2>/dev/null >&2 || true
+    cat "$utdir/field.$lane" >&2 2>/dev/null || true
     exit 1
   fi
   if ! grep -qF "unknown type \`Intt\` in the payload of \`Bad::V\`" "$utdir/payload.$lane" 2>/dev/null; then
     echo "[compiler-gate] FAIL: the $lane lane does not reject an unknown contract payload type (#2317)" >&2
-    cat "$utdir/payload.$lane" 2>/dev/null >&2 || true
+    cat "$utdir/payload.$lane" >&2 2>/dev/null || true
     exit 1
   fi
 done
 if ! grep -q '^line 9:1:' "$utdir/field.buf" 2>/dev/null || ! grep -q '^line 9:1:' "$utdir/payload.buf" 2>/dev/null; then
   echo "[compiler-gate] FAIL: a buffer-lane unknown type is not anchored on its declaration (#2317)" >&2
-  cat "$utdir/field.buf" "$utdir/payload.buf" 2>/dev/null >&2 || true
+  cat "$utdir/field.buf" "$utdir/payload.buf" >&2 2>/dev/null || true
   exit 1
 fi
 for probe in clean local; do
   if [ -s "$utdir/$probe.imp.diag" ] || [ -s "$utdir/$probe.buf" ]; then
     echo "[compiler-gate] FAIL: valid contract '$probe' gained a diagnostic (#2317)" >&2
-    cat "$utdir/$probe.imp.diag" "$utdir/$probe.buf" 2>/dev/null >&2 || true
+    cat "$utdir/$probe.imp.diag" "$utdir/$probe.buf" >&2 2>/dev/null || true
     exit 1
   fi
 done
@@ -9164,7 +9164,7 @@ for pass in cold warm; do
     >/dev/null 2>&1 || true
   if [ ! -s "$ffsdir/$pass.wasm" ]; then
     echo "[compiler-gate] FAIL: FS-lane float call-offset test did not compile ($pass, #2391)" >&2
-    cat "$ffsdir/$pass.wasm.diag" 2>/dev/null >&2 || true
+    cat "$ffsdir/$pass.wasm.diag" >&2 2>/dev/null || true
     exit 1
   fi
 done
@@ -9200,7 +9200,7 @@ VIBE_BUILD_CACHE_DIR="$ffsdir/cache" VIBE_FS_COMPILE=1 VIBE_PREOPEN_DIR="$ROOT_D
   >/dev/null 2>&1 || true
 if [ ! -s "$ffsdir/torn.wasm" ]; then
   echo "[compiler-gate] FAIL: FS-lane float call-offset test did not compile over torn sidecars (#2391)" >&2
-  cat "$ffsdir/torn.wasm.diag" 2>/dev/null >&2 || true
+  cat "$ffsdir/torn.wasm.diag" >&2 2>/dev/null || true
   exit 1
 fi
 if ! cmp -s "$ffsdir/cold.wasm" "$ffsdir/torn.wasm"; then
@@ -9248,7 +9248,7 @@ VIBE_BUILD_CACHE_DIR="$ffsdir/cache" VIBE_FS_COMPILE=1 VIBE_PREOPEN_DIR="$ROOT_D
   >/dev/null 2>&1 || true
 if [ ! -s "$ffsdir/flipped.wasm" ]; then
   echo "[compiler-gate] FAIL: FS-lane float call-offset test did not compile over digit-flipped sidecars (#2391)" >&2
-  cat "$ffsdir/flipped.wasm.diag" 2>/dev/null >&2 || true
+  cat "$ffsdir/flipped.wasm.diag" >&2 2>/dev/null || true
   exit 1
 fi
 if ! cmp -s "$ffsdir/cold.wasm" "$ffsdir/flipped.wasm"; then
@@ -9280,7 +9280,7 @@ VIBE_BUILD_CACHE_DIR="$ffsdir/cache" VIBE_FS_COMPILE=1 VIBE_PREOPEN_DIR="$ROOT_D
   >/dev/null 2>&1 || true
 if [ ! -s "$ffsdir/rowdel.wasm" ]; then
   echo "[compiler-gate] FAIL: FS-lane float call-offset test did not compile over row-deleted sidecars (#2391)" >&2
-  cat "$ffsdir/rowdel.wasm.diag" 2>/dev/null >&2 || true
+  cat "$ffsdir/rowdel.wasm.diag" >&2 2>/dev/null || true
   exit 1
 fi
 if ! cmp -s "$ffsdir/cold.wasm" "$ffsdir/rowdel.wasm"; then
@@ -9310,7 +9310,7 @@ for pass in cold warm; do
     >/dev/null 2>&1 || true
   if [ ! -s "$sbdir/$pass.wasm" ]; then
     echo "[compiler-gate] FAIL: FS-lane String binop channel test did not compile ($pass, #2391)" >&2
-    cat "$sbdir/$pass.wasm.diag" 2>/dev/null >&2 || true
+    cat "$sbdir/$pass.wasm.diag" >&2 2>/dev/null || true
     exit 1
   fi
 done

--- a/tests/gates/mid/run.sh
+++ b/tests/gates/mid/run.sh
@@ -46,7 +46,7 @@ if [ -s "$vdir/v128.wasm" ]; then
 fi
 if ! cat "$vdir/out.txt" "$vdir/v128.wasm.diag" 2>/dev/null | grep -q "unknown name: v128_load"; then
   echo "[compiler-gate] FAIL: v128_load was rejected, but not with 'unknown name' -- the diagnostic must say what is wrong" >&2
-  cat "$vdir/out.txt" "$vdir/v128.wasm.diag" 2>/dev/null >&2 || true
+  cat "$vdir/out.txt" "$vdir/v128.wasm.diag" >&2 2>/dev/null || true
   exit 1
 fi
 rm -rf "$vdir"
@@ -65,7 +65,7 @@ VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   "fixtures/simd_skip_ws_test.vibe" "$swdir/sw.wasm" __no_entry__ >/dev/null 2>&1 || true
 if [ ! -s "$swdir/sw.wasm" ]; then
   echo "[compiler-gate] FAIL: simd_skip_ws test did not compile" >&2
-  cat "$swdir/sw.wasm.diag" 2>/dev/null >&2 || true
+  cat "$swdir/sw.wasm.diag" >&2 2>/dev/null || true
   exit 1
 fi
 if ! VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh \
@@ -86,7 +86,7 @@ VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   "fixtures/simd_scan_string_special_test.vibe" "$sssdir/sss.wasm" __no_entry__ >/dev/null 2>&1 || true
 if [ ! -s "$sssdir/sss.wasm" ]; then
   echo "[compiler-gate] FAIL: SIMD string-special test did not compile" >&2
-  cat "$sssdir/sss.wasm.diag" 2>/dev/null >&2 || true
+  cat "$sssdir/sss.wasm.diag" >&2 2>/dev/null || true
   exit 1
 fi
 if ! VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh \
@@ -107,7 +107,7 @@ VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   "fixtures/simd_scan_line_end_test.vibe" "$sledir/sle.wasm" __no_entry__ >/dev/null 2>&1 || true
 if [ ! -s "$sledir/sle.wasm" ]; then
   echo "[compiler-gate] FAIL: SIMD line-end test did not compile" >&2
-  cat "$sledir/sle.wasm.diag" 2>/dev/null >&2 || true
+  cat "$sledir/sle.wasm.diag" >&2 2>/dev/null || true
   exit 1
 fi
 if ! VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh \
@@ -130,7 +130,7 @@ VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   "fixtures/region_capture_test.vibe" "$rcdir/rc.wasm" __no_entry__ >/dev/null 2>&1 || true
 if [ ! -s "$rcdir/rc.wasm" ]; then
   echo "[compiler-gate] FAIL: region_capture test did not compile" >&2
-  cat "$rcdir/rc.wasm.diag" 2>/dev/null >&2 || true
+  cat "$rcdir/rc.wasm.diag" >&2 2>/dev/null || true
   exit 1
 fi
 if ! VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh \
@@ -182,7 +182,7 @@ MHEOF
     "$mhdir/emit.vibe" "$mhdir/emit.wasm" main >/dev/null 2>&1 || true
   if [ ! -s "$mhdir/emit.wasm" ]; then
     echo "[compiler-gate] FAIL: the memhost-realloc emitter program did not compile" >&2
-    cat "$mhdir/emit.wasm.diag" 2>/dev/null >&2 || true
+    cat "$mhdir/emit.wasm.diag" >&2 2>/dev/null || true
     exit 1
   fi
   VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh \
@@ -247,7 +247,7 @@ ASEOF
     "$asdir/emit.vibe" "$asdir/emit.wasm" main >/dev/null 2>&1 || true
   if [ ! -s "$asdir/emit.wasm" ]; then
     echo "[compiler-gate] FAIL: the async-string component emitter program did not compile" >&2
-    cat "$asdir/emit.wasm.diag" 2>/dev/null >&2 || true
+    cat "$asdir/emit.wasm.diag" >&2 2>/dev/null || true
     exit 1
   fi
   VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh \
@@ -325,7 +325,7 @@ VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   "$hsdir/handler.vibe" "$hsdir/handler.wasm" __no_entry__ >/dev/null 2>&1 || true
 if [ ! -s "$hsdir/handler.wasm" ]; then
   echo "[compiler-gate] FAIL: a HostStream-parameter handler did not compile (#1540)" >&2
-  cat "$hsdir/handler.wasm.diag" 2>/dev/null >&2 || true
+  cat "$hsdir/handler.wasm.diag" >&2 2>/dev/null || true
   exit 1
 fi
 if command -v wasm-tools >/dev/null 2>&1; then
@@ -378,7 +378,7 @@ VIBE_RC=1 VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   "fixtures/rc_user_shadowed_sleep_test.vibe" "$shdir/sh.wasm" main >/dev/null 2>&1 || true
 if [ ! -s "$shdir/sh.wasm" ]; then
   echo "[compiler-gate] FAIL: rc_user_shadowed_sleep fixture did not compile under VIBE_RC" >&2
-  cat "$shdir/sh.wasm.diag" 2>/dev/null >&2 || true
+  cat "$shdir/sh.wasm.diag" >&2 2>/dev/null || true
   exit 1
 fi
 if command -v wasm-tools >/dev/null 2>&1; then
@@ -404,7 +404,7 @@ VIBE_RC=1 VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   "fixtures/rc_reclaim_leak_test.vibe" "$lkdir/rc.wasm" main >/dev/null 2>&1 || true
 if [ ! -s "$lkdir/rc.wasm" ]; then
   echo "[compiler-gate] FAIL: rc_reclaim_leak fixture did not compile under VIBE_RC" >&2
-  cat "$lkdir/rc.wasm.diag" 2>/dev/null >&2 || true
+  cat "$lkdir/rc.wasm.diag" >&2 2>/dev/null || true
   exit 1
 fi
 lk_json="$(node scripts/measure_heap.mjs "$lkdir/rc.wasm" main 2>/dev/null)"
@@ -446,7 +446,7 @@ VIBE_RC=shadow VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=ra
   "fixtures/rc_shadow_regression_test.vibe" "$shdir/shadow.wasm" main >/dev/null 2>&1 || true
 if [ ! -s "$shdir/shadow.wasm" ]; then
   echo "[compiler-gate] FAIL: rc_shadow_regression fixture did not compile under VIBE_RC=shadow" >&2
-  cat "$shdir/shadow.wasm.diag" 2>/dev/null >&2 || true
+  cat "$shdir/shadow.wasm.diag" >&2 2>/dev/null || true
   exit 1
 fi
 sh_out="$(VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh "$shdir/shadow.wasm" 2>&1 | tail -1)"
@@ -478,7 +478,7 @@ VIBE_RC=shadow VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=ra
   "fixtures/rc_shadow_large_heap.vibe" "$lhdir/shadow.wasm" main >/dev/null 2>&1 || true
 if [ ! -s "$lhdir/shadow.wasm" ]; then
   echo "[compiler-gate] FAIL: rc_shadow_large_heap did not compile under VIBE_RC=shadow (#2427)" >&2
-  cat "$lhdir/shadow.wasm.diag" 2>/dev/null >&2 || true
+  cat "$lhdir/shadow.wasm.diag" >&2 2>/dev/null || true
   exit 1
 fi
 lh_out="$(VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_WASM_PRE_GROW_PAGES=40000 \
@@ -524,7 +524,7 @@ VIBE_RC=shadow VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_IMPORT_ABI=raw \
   "$tlsdir/bool_render.vibe" "$tlsdir/shadow.wasm" _start >/dev/null 2>&1 || true
 if [ ! -s "$tlsdir/shadow.wasm" ]; then
   echo "[compiler-gate] FAIL: VIBE_RC=shadow build of the #2469 probe produced no wasm" >&2
-  cat "$tlsdir/shadow.wasm.diag" 2>/dev/null >&2 || true
+  cat "$tlsdir/shadow.wasm.diag" >&2 2>/dev/null || true
   exit 1
 fi
 tls_out="$(VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh \
@@ -565,7 +565,7 @@ do
     "$ca" "$cadir/$ca_base.wasm" __no_entry__ >/dev/null 2>&1 || true
   if [ ! -s "$cadir/$ca_base.wasm" ]; then
     echo "[compiler-gate] FAIL: $ca did not compile under VIBE_RC=shadow (#1986)" >&2
-    cat "$cadir/$ca_base.wasm.diag" 2>/dev/null >&2 || true
+    cat "$cadir/$ca_base.wasm.diag" >&2 2>/dev/null || true
     exit 1
   fi
   if ! VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh \
@@ -646,7 +646,7 @@ VIBE_BACKEND=gc VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_IMPORT_ABI=raw \
   "fixtures/gc_backend_smoke_test.vibe" "$gcdir/smoke.wasm" main >/dev/null 2>&1 || true
 if [ ! -s "$gcdir/smoke.wasm" ]; then
   echo "[compiler-gate] FAIL: gc backend smoke did not compile under VIBE_BACKEND=gc" >&2
-  cat "$gcdir/smoke.wasm.diag" 2>/dev/null >&2 || true
+  cat "$gcdir/smoke.wasm.diag" >&2 2>/dev/null || true
   exit 1
 fi
 gc_out="$(VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh "$gcdir/smoke.wasm" 2>&1 | tail -1)"
@@ -683,7 +683,7 @@ for gccap_lane in linear-rc0 linear-rc1 gc; do
     "fixtures/gc_closure_builtin_capture_test.vibe" "$gccapdir/$gccap_lane.wasm" __no_entry__ >/dev/null 2>&1 || true
   if [ ! -s "$gccapdir/$gccap_lane.wasm" ]; then
     echo "[compiler-gate] FAIL: gc_closure_builtin_capture_test.vibe did not compile on $gccap_lane" >&2
-    cat "$gccapdir/$gccap_lane.wasm.diag" 2>/dev/null >&2 || true
+    cat "$gccapdir/$gccap_lane.wasm.diag" >&2 2>/dev/null || true
     exit 1
   fi
   if ! VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh "$gccapdir/$gccap_lane.wasm" >"$gccapdir/$gccap_lane.out" 2>&1; then
@@ -716,7 +716,7 @@ for gcalias_lane in linear-rc0 linear-rc1 gc; do
     "fixtures/gc_closure_builtin_alias_test.vibe" "$gcaliasdir/$gcalias_lane.wasm" __no_entry__ >/dev/null 2>&1 || true
   if [ ! -s "$gcaliasdir/$gcalias_lane.wasm" ]; then
     echo "[compiler-gate] FAIL: gc_closure_builtin_alias_test.vibe did not compile on $gcalias_lane" >&2
-    cat "$gcaliasdir/$gcalias_lane.wasm.diag" 2>/dev/null >&2 || true
+    cat "$gcaliasdir/$gcalias_lane.wasm.diag" >&2 2>/dev/null || true
     exit 1
   fi
   if ! VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh "$gcaliasdir/$gcalias_lane.wasm" >"$gcaliasdir/$gcalias_lane.out" 2>&1; then
@@ -750,7 +750,7 @@ for gcabi_be in linear gc; do
     "fixtures/gc_host_abi_declaration.vibe" "$gcabidir/$gcabi_be.wasm" main >/dev/null 2>&1 || true
   if [ ! -s "$gcabidir/$gcabi_be.wasm" ]; then
     echo "[compiler-gate] FAIL: gc_host_abi_declaration.vibe did not compile on the $gcabi_be backend (#1814)" >&2
-    cat "$gcabidir/$gcabi_be.wasm.diag" 2>/dev/null >&2 || true
+    cat "$gcabidir/$gcabi_be.wasm.diag" >&2 2>/dev/null || true
     exit 1
   fi
   gcabi_got="$(env -u VIBE_IMPORT_ABI VIBE_PREOPEN_DIR="$ROOT_DIR" \
@@ -800,7 +800,7 @@ for gchb_be in linear gc; do
     "fixtures/gc_host_builtins.vibe" "$gchbdir/$gchb_be.wasm" main >/dev/null 2>&1 || true
   if [ ! -s "$gchbdir/$gchb_be.wasm" ]; then
     echo "[compiler-gate] FAIL: gc_host_builtins.vibe did not compile on the $gchb_be backend (#1262)" >&2
-    cat "$gchbdir/$gchb_be.wasm.diag" 2>/dev/null >&2 || true
+    cat "$gchbdir/$gchb_be.wasm.diag" >&2 2>/dev/null || true
     exit 1
   fi
   gchb_got="$(VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh "$gchbdir/$gchb_be.wasm" 2>&1 | tail -1)"
@@ -833,7 +833,7 @@ env -u VIBE_FS_COMPILE VIBE_BACKEND=gc VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_IMPORT_
   "$gchbdir/rdclosure.vibe" "$gchbdir/rdclosure.wasm" main >/dev/null 2>&1 || true
 if [ ! -s "$gchbdir/rdclosure.wasm" ]; then
   echo "[compiler-gate] FAIL: Fs::readdir inside a closure did not compile on the gc lane -- is it still listed in gc_direct_abi_names()? (#1262)" >&2
-  cat "$gchbdir/rdclosure.wasm.diag" 2>/dev/null >&2 || true
+  cat "$gchbdir/rdclosure.wasm.diag" >&2 2>/dev/null || true
   exit 1
 fi
 gchb_rd="$(VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh "$gchbdir/rdclosure.wasm" 2>&1 | tail -1)"
@@ -869,7 +869,7 @@ for gcrg_be in linear gc; do
     "fixtures/gc_region_arena_free.vibe" "$gcrgdir/$gcrg_be.wasm" __no_entry__ >/dev/null 2>&1 || true
   if [ ! -s "$gcrgdir/$gcrg_be.wasm" ]; then
     echo "[compiler-gate] FAIL: gc_region_arena_free.vibe did not compile on the $gcrg_be backend (#1262)" >&2
-    cat "$gcrgdir/$gcrg_be.wasm.diag" 2>/dev/null >&2 || true
+    cat "$gcrgdir/$gcrg_be.wasm.diag" >&2 2>/dev/null || true
     exit 1
   fi
   if ! VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh "$gcrgdir/$gcrg_be.wasm" >"$gcrgdir/$gcrg_be.out" 2>&1; then
@@ -904,7 +904,7 @@ env -u VIBE_FS_COMPILE VIBE_BACKEND=gc VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_IMPORT_
   "fixtures/region_arena_bounded.vibe" "$gcardir/bounded.wasm" __no_entry__ >/dev/null 2>&1 || true
 if [ ! -s "$gcardir/bounded.wasm" ]; then
   echo "[compiler-gate] FAIL: region_arena_bounded.vibe did not compile on the gc backend (#1262)" >&2
-  cat "$gcardir/bounded.wasm.diag" 2>/dev/null >&2 || true
+  cat "$gcardir/bounded.wasm.diag" >&2 2>/dev/null || true
   exit 1
 fi
 if ! gcar_out="$(VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh --invoke _start "$gcardir/bounded.wasm" 2>&1)"; then
@@ -935,7 +935,7 @@ env -u VIBE_FS_COMPILE VIBE_BACKEND=gc VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_IMPORT_
   "fixtures/region_bytes_arena_bounded.vibe" "$gcardir/bbounded.wasm" __no_entry__ >/dev/null 2>&1 || true
 if [ ! -s "$gcardir/bbounded.wasm" ]; then
   echo "[compiler-gate] FAIL: region_bytes_arena_bounded.vibe did not compile on the gc backend (#1262)" >&2
-  cat "$gcardir/bbounded.wasm.diag" 2>/dev/null >&2 || true
+  cat "$gcardir/bbounded.wasm.diag" >&2 2>/dev/null || true
   exit 1
 fi
 if ! gcarb_out="$(VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh --invoke _start "$gcardir/bbounded.wasm" 2>&1)"; then
@@ -971,7 +971,7 @@ env -u VIBE_FS_COMPILE VIBE_BACKEND=gc VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_IMPORT_
   "fixtures/region_throw_unwind_test.vibe" "$gcarudir/unwind.wasm" main >/dev/null 2>&1 || true
 if [ ! -s "$gcarudir/unwind.wasm" ]; then
   echo "[compiler-gate] FAIL: region_throw_unwind_test.vibe did not compile on the gc backend (#1937)" >&2
-  cat "$gcarudir/unwind.wasm.diag" 2>/dev/null >&2 || true
+  cat "$gcarudir/unwind.wasm.diag" >&2 2>/dev/null || true
   exit 1
 fi
 if ! gcaru_out="$(VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh --invoke _start "$gcarudir/unwind.wasm" 2>&1)"; then
@@ -1009,7 +1009,7 @@ for gcmd_be in linear gc; do
     "fixtures/gc_map_delete.vibe" "$gcmddir/$gcmd_be.snap.wasm" __no_entry__ >/dev/null 2>&1 || true
   if [ ! -s "$gcmddir/$gcmd_be.snap.wasm" ]; then
     echo "[compiler-gate] FAIL: gc_map_delete.vibe did not compile on the $gcmd_be backend (#1262)" >&2
-    cat "$gcmddir/$gcmd_be.snap.wasm.diag" 2>/dev/null >&2 || true
+    cat "$gcmddir/$gcmd_be.snap.wasm.diag" >&2 2>/dev/null || true
     exit 1
   fi
   if ! VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh "$gcmddir/$gcmd_be.snap.wasm" >"$gcmddir/$gcmd_be.snap.out" 2>&1; then
@@ -1056,7 +1056,7 @@ for gcsi_be in linear gc; do
     "fixtures/gc_stdin_int_parse.vibe" "$gcsidir/$gcsi_be.snap.wasm" __no_entry__ >/dev/null 2>&1 || true
   if [ ! -s "$gcsidir/$gcsi_be.snap.wasm" ]; then
     echo "[compiler-gate] FAIL: gc_stdin_int_parse.vibe did not compile on the $gcsi_be backend (#1262)" >&2
-    cat "$gcsidir/$gcsi_be.snap.wasm.diag" 2>/dev/null >&2 || true
+    cat "$gcsidir/$gcsi_be.snap.wasm.diag" >&2 2>/dev/null || true
     exit 1
   fi
   if ! VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh "$gcsidir/$gcsi_be.snap.wasm" >"$gcsidir/$gcsi_be.snap.out" 2>&1; then
@@ -1103,7 +1103,7 @@ for gcpe_be in linear gc; do
     "fixtures/gc_process_exit.vibe" "$gcpedir/$gcpe_be.wasm" main >/dev/null 2>&1 || true
   if [ ! -s "$gcpedir/$gcpe_be.wasm" ]; then
     echo "[compiler-gate] FAIL: gc_process_exit.vibe did not compile on the $gcpe_be backend (#1262)" >&2
-    cat "$gcpedir/$gcpe_be.wasm.diag" 2>/dev/null >&2 || true
+    cat "$gcpedir/$gcpe_be.wasm.diag" >&2 2>/dev/null || true
     exit 1
   fi
   # SUCCESS here is a NON-ZERO status (7), so the exit code is DATA -- read it
@@ -1145,7 +1145,7 @@ for gcss_be in linear gc; do
     "fixtures/gc_sibling_slot_reuse.vibe" "$gcssdir/mixed.$gcss_be.wasm" main >/dev/null 2>&1 || true
   if [ ! -s "$gcssdir/mixed.$gcss_be.wasm" ]; then
     echo "[compiler-gate] FAIL: gc_sibling_slot_reuse.vibe did not compile on the $gcss_be backend (#1985)" >&2
-    cat "$gcssdir/mixed.$gcss_be.wasm.diag" 2>/dev/null >&2 || true
+    cat "$gcssdir/mixed.$gcss_be.wasm.diag" >&2 2>/dev/null || true
     exit 1
   fi
   gcss_out="$(VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh "$gcssdir/mixed.$gcss_be.wasm" 2>&1 | tail -1)"
@@ -1158,7 +1158,7 @@ for gcss_be in linear gc; do
     "fixtures/gc_nested_branch_locals.vibe" "$gcssdir/nested.$gcss_be.wasm" main >/dev/null 2>&1 || true
   if [ ! -s "$gcssdir/nested.$gcss_be.wasm" ]; then
     echo "[compiler-gate] FAIL: gc_nested_branch_locals.vibe did not compile on the $gcss_be backend (#1985)" >&2
-    cat "$gcssdir/nested.$gcss_be.wasm.diag" 2>/dev/null >&2 || true
+    cat "$gcssdir/nested.$gcss_be.wasm.diag" >&2 2>/dev/null || true
     exit 1
   fi
   gcss_nested_out="$(VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh "$gcssdir/nested.$gcss_be.wasm" 2>&1 | tail -1)"
@@ -1191,7 +1191,7 @@ VIBE_BACKEND=gc VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_IMPORT_ABI=raw \
   "fixtures/gc_for_in_string_test.vibe" "$gcstrdir/out.wasm" main >/dev/null 2>&1 || true
 if [ ! -s "$gcstrdir/out.wasm" ]; then
   echo "[compiler-gate] FAIL: gc String for-in fixture did not compile" >&2
-  cat "$gcstrdir/out.wasm.diag" 2>/dev/null >&2 || true
+  cat "$gcstrdir/out.wasm.diag" >&2 2>/dev/null || true
   exit 1
 fi
 gcstr_out="$(VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh "$gcstrdir/out.wasm" 2>&1 | tail -1)"
@@ -1218,7 +1218,7 @@ VIBE_BACKEND=gc VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_IMPORT_ABI=raw \
   "fixtures/gc_backend_effect_evidence_dict.vibe" "$gcedir/out.wasm" main >/dev/null 2>&1 || true
 if [ ! -s "$gcedir/out.wasm" ]; then
   echo "[compiler-gate] FAIL: gc_backend_effect_evidence_dict.vibe did not compile under VIBE_BACKEND=gc" >&2
-  cat "$gcedir/out.wasm.diag" 2>/dev/null >&2 || true
+  cat "$gcedir/out.wasm.diag" >&2 2>/dev/null || true
   exit 1
 fi
 gce_out="$(VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh "$gcedir/out.wasm" 2>&1 | tail -1)"
@@ -1258,7 +1258,7 @@ VIBE_BACKEND=gc VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_IMPORT_ABI=raw \
   fixtures/effect_local_closure_by_value_wrapper.vibe "$gcdeaddir/out.wasm" __no_entry__ >/dev/null 2>&1 || true
 if [ ! -s "$gcdeaddir/out.wasm" ]; then
   echo "[compiler-gate] FAIL: effect_local_closure_by_value_wrapper.vibe did not compile under VIBE_BACKEND=gc" >&2
-  cat "$gcdeaddir/out.wasm.diag" 2>/dev/null >&2 || true
+  cat "$gcdeaddir/out.wasm.diag" >&2 2>/dev/null || true
   exit 1
 fi
 if ! gcdead_out="$(VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh --invoke _start "$gcdeaddir/out.wasm" 2>&1)"; then
@@ -1299,7 +1299,7 @@ VIBE_BACKEND=gc VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=r
   fixtures/effect_effectset_expansion.vibe "$gcselfdir/out.wasm" __no_entry__ >/dev/null 2>&1 || true
 if [ ! -s "$gcselfdir/out.wasm" ]; then
   echo "[compiler-gate] FAIL: effect_effectset_expansion.vibe did not compile under VIBE_BACKEND=gc (self-discharging drop or #1595 call-inertness regressed)" >&2
-  cat "$gcselfdir/out.wasm.diag" 2>/dev/null >&2 || true
+  cat "$gcselfdir/out.wasm.diag" >&2 2>/dev/null || true
   exit 1
 fi
 if ! gcself_out="$(VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh --invoke _start "$gcselfdir/out.wasm" 2>&1)"; then
@@ -1336,7 +1336,7 @@ for sdc_backend in "" gc; do
     fixtures/effect_self_discharging_callee.vibe "$sdcdir/out.wasm" __no_entry__ >/dev/null 2>&1 || true
   if [ ! -s "$sdcdir/out.wasm" ]; then
     echo "[compiler-gate] FAIL: effect_self_discharging_callee.vibe did not compile${sdc_backend:+ under VIBE_BACKEND=$sdc_backend} (#1595 call-inertness regressed)" >&2
-    cat "$sdcdir/out.wasm.diag" 2>/dev/null >&2 || true
+    cat "$sdcdir/out.wasm.diag" >&2 2>/dev/null || true
     exit 1
   fi
   if ! sdc_out="$(VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh --invoke _start "$sdcdir/out.wasm" 2>&1)"; then
@@ -1355,7 +1355,7 @@ if [ -s "$sdcdir/rej.wasm" ]; then
 fi
 if ! grep -qF "hides a perform from it" "$sdcdir/rej.wasm.diag" 2>/dev/null; then
   echo "[compiler-gate] FAIL: err_effect_self_discharge_arm_reperform.vibe rejection lacks the #1591 culprit diagnostic (want 'hides a perform from it')" >&2
-  cat "$sdcdir/rej.wasm.diag" 2>/dev/null >&2 || true
+  cat "$sdcdir/rej.wasm.diag" >&2 2>/dev/null || true
   exit 1
 fi
 rm -rf "$sdcdir"
@@ -1396,7 +1396,7 @@ VIBE_BACKEND=gc VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_IMPORT_ABI=raw \
   fixtures/effect_handle_call_evidence_closure_literal.vibe "$gcclosdir/out.wasm" __no_entry__ >/dev/null 2>&1 || true
 if [ ! -s "$gcclosdir/out.wasm" ]; then
   echo "[compiler-gate] FAIL: effect_handle_call_evidence_closure_literal.vibe did not compile under VIBE_BACKEND=gc" >&2
-  cat "$gcclosdir/out.wasm.diag" 2>/dev/null >&2 || true
+  cat "$gcclosdir/out.wasm.diag" >&2 2>/dev/null || true
   exit 1
 fi
 if ! gcclos_out="$(VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh --invoke _start "$gcclosdir/out.wasm" 2>&1)"; then
@@ -1428,7 +1428,7 @@ VIBE_BACKEND=gc VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_IMPORT_ABI=raw \
   fixtures/gc_backend_effect_pure_builtin_index.vibe "$gcidxdir/out.wasm" __no_entry__ >/dev/null 2>&1 || true
 if [ ! -s "$gcidxdir/out.wasm" ]; then
   echo "[compiler-gate] FAIL: gc_backend_effect_pure_builtin_index.vibe did not compile under VIBE_BACKEND=gc" >&2
-  cat "$gcidxdir/out.wasm.diag" 2>/dev/null >&2 || true
+  cat "$gcidxdir/out.wasm.diag" >&2 2>/dev/null || true
   exit 1
 fi
 if ! gcidx_out="$(VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh --invoke _start "$gcidxdir/out.wasm" 2>&1)"; then
@@ -1458,7 +1458,7 @@ VIBE_BACKEND=gc VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_IMPORT_ABI=raw \
   fixtures/gc_backend_suberror_ctor.vibe "$gcsuberrdir/out.wasm" __no_entry__ >/dev/null 2>&1 || true
 if [ ! -s "$gcsuberrdir/out.wasm" ]; then
   echo "[compiler-gate] FAIL: gc_backend_suberror_ctor.vibe did not compile under VIBE_BACKEND=gc" >&2
-  cat "$gcsuberrdir/out.wasm.diag" 2>/dev/null >&2 || true
+  cat "$gcsuberrdir/out.wasm.diag" >&2 2>/dev/null || true
   exit 1
 fi
 if ! gcsuberr_out="$(VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh --invoke _start "$gcsuberrdir/out.wasm" 2>&1)"; then
@@ -1589,7 +1589,7 @@ VIBE_EMIT_WIT=1 VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_IMPORT_ABI=raw \
   "fixtures/wit_gen_http.vibe" "$witdir/out.wit" main >/dev/null 2>&1 || true
 if [ ! -s "$witdir/out.wit" ]; then
   echo "[compiler-gate] FAIL: VIBE_EMIT_WIT produced no output" >&2
-  cat "$witdir/out.wit.diag" 2>/dev/null >&2 || true
+  cat "$witdir/out.wit.diag" >&2 2>/dev/null || true
   exit 1
 fi
 if ! diff -u "fixtures/wit_gen_http.golden.wit" "$witdir/out.wit" >&2; then
@@ -1615,7 +1615,7 @@ VIBE_SERVE_COMPONENT=1 VIBE_SERVE_WIT_OUT="$svdir/handler.wit" \
   "fixtures/serve_handler_smoke.vibe" "$svdir/handler.component.wasm" main >/dev/null 2>&1 || true
 if [ ! -s "$svdir/handler.component.wasm" ]; then
   echo "[compiler-gate] FAIL: VIBE_SERVE_COMPONENT produced no component" >&2
-  cat "$svdir/handler.component.wasm.diag" 2>/dev/null >&2 || true
+  cat "$svdir/handler.component.wasm.diag" >&2 2>/dev/null || true
   exit 1
 fi
 sv_magic="$(od -An -t x1 -N 4 "$svdir/handler.component.wasm" | tr -d ' \n')"
@@ -1682,7 +1682,7 @@ for gcb_fixture in to_string_bool_gc_test to_string_shadow_gc_test to_string_boo
     "fixtures/${gcb_fixture}.vibe" "$gcbdir/${gcb_fixture}.wasm" __no_entry__ >/dev/null 2>&1 || true
   if [ ! -s "$gcbdir/${gcb_fixture}.wasm" ]; then
     echo "[compiler-gate] FAIL: gc-lane regression fixture ${gcb_fixture}.vibe did not compile" >&2
-    cat "$gcbdir/${gcb_fixture}.wasm.diag" 2>/dev/null >&2 || true
+    cat "$gcbdir/${gcb_fixture}.wasm.diag" >&2 2>/dev/null || true
     exit 1
   fi
   if ! VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh \
@@ -1722,7 +1722,7 @@ VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   fixtures/effect_handle_replay_corruption.vibe "$m2dir/m2.wasm" __no_entry__ >/dev/null 2>&1 || true
 if [ ! -s "$m2dir/m2.wasm" ]; then
   echo "[compiler-gate] FAIL: effect_handle_replay_corruption.vibe did not compile" >&2
-  cat "$m2dir/m2.wasm.diag" 2>/dev/null >&2 || true
+  cat "$m2dir/m2.wasm.diag" >&2 2>/dev/null || true
   exit 1
 fi
 if ! m2_out="$(VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh --invoke _start "$m2dir/m2.wasm" 2>&1)"; then
@@ -1755,7 +1755,7 @@ VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   fixtures/effect_row_operation_item.vibe "$a71dir/out.wasm" __no_entry__ >/dev/null 2>&1 || true
 if [ ! -s "$a71dir/out.wasm" ]; then
   echo "[compiler-gate] FAIL: effect_row_operation_item.vibe did not compile (with Effect::op row-item grammar regressed, or #1595 self-discharging call-inertness regressed)" >&2
-  cat "$a71dir/out.wasm.diag" 2>/dev/null >&2 || true
+  cat "$a71dir/out.wasm.diag" >&2 2>/dev/null || true
   exit 1
 fi
 if ! a71_out="$(VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh --invoke _start "$a71dir/out.wasm" 2>&1)"; then
@@ -1790,7 +1790,7 @@ VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   fixtures/effect_effectset_expansion.vibe "$a71bdir/out.wasm" __no_entry__ >/dev/null 2>&1 || true
 if [ ! -s "$a71bdir/out.wasm" ]; then
   echo "[compiler-gate] FAIL: effect_effectset_expansion.vibe did not compile -- effectset row expansion regressed" >&2
-  cat "$a71bdir/out.wasm.diag" 2>/dev/null >&2 || true
+  cat "$a71bdir/out.wasm.diag" >&2 2>/dev/null || true
   exit 1
 fi
 if ! a71b_out="$(VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh --invoke _start "$a71bdir/out.wasm" 2>&1)"; then
@@ -1826,7 +1826,7 @@ if [ -s "$a71cdir/cycle.wasm" ]; then
 fi
 if ! grep -q "effectset cycle: A -> B -> A" "$a71cdir/cycle.wasm.diag" 2>/dev/null; then
   echo "[compiler-gate] FAIL: err_effectset_cycle.vibe did not produce the expected cycle diagnostic" >&2
-  cat "$a71cdir/cycle.wasm.diag" 2>/dev/null >&2 || true
+  cat "$a71cdir/cycle.wasm.diag" >&2 2>/dev/null || true
   exit 1
 fi
 # #1571: the expectation for this rejection is the diagnostic grep below,
@@ -1841,7 +1841,7 @@ if [ -s "$a71cdir/collision.wasm" ]; then
 fi
 if ! grep -q "collides with an operation of the same name" "$a71cdir/collision.wasm.diag" 2>/dev/null; then
   echo "[compiler-gate] FAIL: err_effectset_operation_collision.vibe did not produce the expected collision diagnostic" >&2
-  cat "$a71cdir/collision.wasm.diag" 2>/dev/null >&2 || true
+  cat "$a71cdir/collision.wasm.diag" >&2 2>/dev/null || true
   exit 1
 fi
 rm -rf "$a71cdir"
@@ -1870,7 +1870,7 @@ VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   fixtures/effect_effectset_param_expansion.vibe "$a71ddir/out.wasm" __no_entry__ >/dev/null 2>&1 || true
 if [ ! -s "$a71ddir/out.wasm" ]; then
   echo "[compiler-gate] FAIL: effect_effectset_param_expansion.vibe did not compile -- parameter-type effectset expansion regressed" >&2
-  cat "$a71ddir/out.wasm.diag" 2>/dev/null >&2 || true
+  cat "$a71ddir/out.wasm.diag" >&2 2>/dev/null || true
   exit 1
 fi
 if ! a71d_out="$(VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh --invoke _start "$a71ddir/out.wasm" 2>&1)"; then
@@ -1905,7 +1905,7 @@ VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   fixtures/effect_handle_operation_level_discharge.vibe "$a71edir/out.wasm" __no_entry__ >/dev/null 2>&1 || true
 if [ ! -s "$a71edir/out.wasm" ]; then
   echo "[compiler-gate] FAIL: effect_handle_operation_level_discharge.vibe did not compile -- handler operation-level discharge regressed" >&2
-  cat "$a71edir/out.wasm.diag" 2>/dev/null >&2 || true
+  cat "$a71edir/out.wasm.diag" >&2 2>/dev/null || true
   exit 1
 fi
 if ! a71e_out="$(VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh --invoke _start "$a71edir/out.wasm" 2>&1)"; then
@@ -1936,7 +1936,7 @@ VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   "fixtures/contract_effectset_vpkg_main.vibe" "$a71fdir/out.wasm" main >/dev/null 2>&1 || true
 if [ ! -s "$a71fdir/out.wasm" ]; then
   echo "[compiler-gate] FAIL: contract_effectset_vpkg_main.vibe did not compile -- effectset contract passthrough regressed" >&2
-  cat "$a71fdir/out.wasm.diag" 2>/dev/null >&2 || true
+  cat "$a71fdir/out.wasm.diag" >&2 2>/dev/null || true
   exit 1
 fi
 a71f_out="$(VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh "$a71fdir/out.wasm" 2>&1 | tail -1)"
@@ -1967,7 +1967,7 @@ VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   "fixtures/contract_effectset_signature_alias_main.vibe" "$a71gdir/out.wasm" main >/dev/null 2>&1 || true
 if [ ! -s "$a71gdir/out.wasm" ]; then
   echo "[compiler-gate] FAIL: contract_effectset_signature_alias_main.vibe did not compile -- effectset-aware contract signature matching regressed" >&2
-  cat "$a71gdir/out.wasm.diag" 2>/dev/null >&2 || true
+  cat "$a71gdir/out.wasm.diag" >&2 2>/dev/null || true
   exit 1
 fi
 a71g_out="$(VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh "$a71gdir/out.wasm" 2>&1 | tail -1)"
@@ -1999,7 +1999,7 @@ VIBE_EMIT_WIT=1 VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_IMPORT_ABI=raw \
   "fixtures/wit_gen_effectset.vibe" "$witesdir/out.wit" main >/dev/null 2>&1 || true
 if [ ! -s "$witesdir/out.wit" ]; then
   echo "[compiler-gate] FAIL: VIBE_EMIT_WIT produced no output for wit_gen_effectset.vibe" >&2
-  cat "$witesdir/out.wit.diag" 2>/dev/null >&2 || true
+  cat "$witesdir/out.wit.diag" >&2 2>/dev/null || true
   exit 1
 fi
 if ! diff -u "fixtures/wit_gen_effectset.golden.wit" "$witesdir/out.wit" >&2; then
@@ -2031,7 +2031,7 @@ VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   fixtures/effect_handle_call_evidence.vibe "$edpdir/out.wasm" __no_entry__ >/dev/null 2>&1 || true
 if [ ! -s "$edpdir/out.wasm" ]; then
   echo "[compiler-gate] FAIL: effect_handle_call_evidence.vibe did not compile" >&2
-  cat "$edpdir/out.wasm.diag" 2>/dev/null >&2 || true
+  cat "$edpdir/out.wasm.diag" >&2 2>/dev/null || true
   exit 1
 fi
 if ! edp_out="$(VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh --invoke _start "$edpdir/out.wasm" 2>&1)"; then
@@ -2071,7 +2071,7 @@ VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   fixtures/effect_handle_call_evidence_branch.vibe "$edpbdir/out.wasm" __no_entry__ >/dev/null 2>&1 || true
 if [ ! -s "$edpbdir/out.wasm" ]; then
   echo "[compiler-gate] FAIL: effect_handle_call_evidence_branch.vibe did not compile" >&2
-  cat "$edpbdir/out.wasm.diag" 2>/dev/null >&2 || true
+  cat "$edpbdir/out.wasm.diag" >&2 2>/dev/null || true
   exit 1
 fi
 if ! edpb_out="$(VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh --invoke _start "$edpbdir/out.wasm" 2>&1)"; then
@@ -2107,7 +2107,7 @@ VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   fixtures/effect_handle_call_evidence_error_mix.vibe "$edpemdir/out.wasm" __no_entry__ >/dev/null 2>&1 || true
 if [ ! -s "$edpemdir/out.wasm" ]; then
   echo "[compiler-gate] FAIL: effect_handle_call_evidence_error_mix.vibe did not compile" >&2
-  cat "$edpemdir/out.wasm.diag" 2>/dev/null >&2 || true
+  cat "$edpemdir/out.wasm.diag" >&2 2>/dev/null || true
   exit 1
 fi
 if ! edpem_out="$(VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh --invoke _start "$edpemdir/out.wasm" 2>&1)"; then
@@ -2148,7 +2148,7 @@ VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   fixtures/effect_handle_multi_effect_row_nested.vibe "$edpmedir/out.wasm" __no_entry__ >/dev/null 2>&1 || true
 if [ ! -s "$edpmedir/out.wasm" ]; then
   echo "[compiler-gate] FAIL: effect_handle_multi_effect_row_nested.vibe did not compile" >&2
-  cat "$edpmedir/out.wasm.diag" 2>/dev/null >&2 || true
+  cat "$edpmedir/out.wasm.diag" >&2 2>/dev/null || true
   exit 1
 fi
 if ! edpme_out="$(VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh --invoke _start "$edpmedir/out.wasm" 2>&1)"; then
@@ -2179,7 +2179,7 @@ VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   fixtures/effect_handle_multi_effect_nested_handles.vibe "$edpnhdir/out.wasm" __no_entry__ >/dev/null 2>&1 || true
 if [ ! -s "$edpnhdir/out.wasm" ]; then
   echo "[compiler-gate] FAIL: effect_handle_multi_effect_nested_handles.vibe did not compile" >&2
-  cat "$edpnhdir/out.wasm.diag" 2>/dev/null >&2 || true
+  cat "$edpnhdir/out.wasm.diag" >&2 2>/dev/null || true
   exit 1
 fi
 if ! edpnh_out="$(VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh --invoke _start "$edpnhdir/out.wasm" 2>&1)"; then
@@ -2225,7 +2225,7 @@ VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   fixtures/effect_handle_call_evidence_let_bound.vibe "$edpletdir/out.wasm" __no_entry__ >/dev/null 2>&1 || true
 if [ ! -s "$edpletdir/out.wasm" ]; then
   echo "[compiler-gate] FAIL: effect_handle_call_evidence_let_bound.vibe did not compile" >&2
-  cat "$edpletdir/out.wasm.diag" 2>/dev/null >&2 || true
+  cat "$edpletdir/out.wasm.diag" >&2 2>/dev/null || true
   exit 1
 fi
 if ! edplet_out="$(VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh --invoke _start "$edpletdir/out.wasm" 2>&1)"; then
@@ -2260,7 +2260,7 @@ VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   fixtures/effect_handle_call_evidence_pure_helper.vibe "$edppurdir/out.wasm" __no_entry__ >/dev/null 2>&1 || true
 if [ ! -s "$edppurdir/out.wasm" ]; then
   echo "[compiler-gate] FAIL: effect_handle_call_evidence_pure_helper.vibe did not compile" >&2
-  cat "$edppurdir/out.wasm.diag" 2>/dev/null >&2 || true
+  cat "$edppurdir/out.wasm.diag" >&2 2>/dev/null || true
   exit 1
 fi
 if ! edppur_out="$(VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh --invoke _start "$edppurdir/out.wasm" 2>&1)"; then
@@ -2293,7 +2293,7 @@ VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   fixtures/effect_handle_call_evidence_struct_field.vibe "$edpdotdir/out.wasm" __no_entry__ >/dev/null 2>&1 || true
 if [ ! -s "$edpdotdir/out.wasm" ]; then
   echo "[compiler-gate] FAIL: effect_handle_call_evidence_struct_field.vibe did not compile" >&2
-  cat "$edpdotdir/out.wasm.diag" 2>/dev/null >&2 || true
+  cat "$edpdotdir/out.wasm.diag" >&2 2>/dev/null || true
   exit 1
 fi
 if ! edpdot_out="$(VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh --invoke _start "$edpdotdir/out.wasm" 2>&1)"; then
@@ -2327,7 +2327,7 @@ VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   fixtures/effect_handle_call_evidence_closure_literal.vibe "$edpclodir/out.wasm" __no_entry__ >/dev/null 2>&1 || true
 if [ ! -s "$edpclodir/out.wasm" ]; then
   echo "[compiler-gate] FAIL: effect_handle_call_evidence_closure_literal.vibe did not compile" >&2
-  cat "$edpclodir/out.wasm.diag" 2>/dev/null >&2 || true
+  cat "$edpclodir/out.wasm.diag" >&2 2>/dev/null || true
   exit 1
 fi
 if ! edpclo_out="$(VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh --invoke _start "$edpclodir/out.wasm" 2>&1)"; then
@@ -2367,7 +2367,7 @@ VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   fixtures/effect_handle_call_evidence_effectset_alias.vibe "$edpesdir/out.wasm" __no_entry__ >/dev/null 2>&1 || true
 if [ ! -s "$edpesdir/out.wasm" ]; then
   echo "[compiler-gate] FAIL: effect_handle_call_evidence_effectset_alias.vibe did not compile" >&2
-  cat "$edpesdir/out.wasm.diag" 2>/dev/null >&2 || true
+  cat "$edpesdir/out.wasm.diag" >&2 2>/dev/null || true
   exit 1
 fi
 if ! edpes_out="$(VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh --invoke _start "$edpesdir/out.wasm" 2>&1)"; then
@@ -2396,7 +2396,7 @@ VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   fixtures/effect_handle_call_evidence_qualified_op.vibe "$edpqodir/out.wasm" __no_entry__ >/dev/null 2>&1 || true
 if [ ! -s "$edpqodir/out.wasm" ]; then
   echo "[compiler-gate] FAIL: effect_handle_call_evidence_qualified_op.vibe did not compile" >&2
-  cat "$edpqodir/out.wasm.diag" 2>/dev/null >&2 || true
+  cat "$edpqodir/out.wasm.diag" >&2 2>/dev/null || true
   exit 1
 fi
 if ! edpqo_out="$(VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh --invoke _start "$edpqodir/out.wasm" 2>&1)"; then
@@ -2427,7 +2427,7 @@ VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   fixtures/effect_handle_call_evidence_row_variable_tail.vibe "$edprvdir/out.wasm" __no_entry__ >/dev/null 2>&1 || true
 if [ ! -s "$edprvdir/out.wasm" ]; then
   echo "[compiler-gate] FAIL: effect_handle_call_evidence_row_variable_tail.vibe did not compile" >&2
-  cat "$edprvdir/out.wasm.diag" 2>/dev/null >&2 || true
+  cat "$edprvdir/out.wasm.diag" >&2 2>/dev/null || true
   exit 1
 fi
 if ! edprv_out="$(VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh --invoke _start "$edprvdir/out.wasm" 2>&1)"; then
@@ -2460,7 +2460,7 @@ VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   fixtures/effect_handle_call_evidence_local_closure_capture_free.vibe "$edplccfdir/out.wasm" __no_entry__ >/dev/null 2>&1 || true
 if [ ! -s "$edplccfdir/out.wasm" ]; then
   echo "[compiler-gate] FAIL: effect_handle_call_evidence_local_closure_capture_free.vibe did not compile" >&2
-  cat "$edplccfdir/out.wasm.diag" 2>/dev/null >&2 || true
+  cat "$edplccfdir/out.wasm.diag" >&2 2>/dev/null || true
   exit 1
 fi
 if ! edplccf_out="$(VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh --invoke _start "$edplccfdir/out.wasm" 2>&1)"; then
@@ -2493,7 +2493,7 @@ VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   fixtures/effect_local_closure_capture_conversion.vibe "$lcccdir/out.wasm" __no_entry__ >/dev/null 2>&1 || true
 if [ ! -s "$lcccdir/out.wasm" ]; then
   echo "[compiler-gate] FAIL: effect_local_closure_capture_conversion.vibe did not compile" >&2
-  cat "$lcccdir/out.wasm.diag" 2>/dev/null >&2 || true
+  cat "$lcccdir/out.wasm.diag" >&2 2>/dev/null || true
   exit 1
 fi
 if ! lccc_out="$(VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh --invoke _start "$lcccdir/out.wasm" 2>&1)"; then
@@ -2525,7 +2525,7 @@ VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   fixtures/effect_local_closure_by_value_wrapper.vibe "$lcbvwdir/out.wasm" __no_entry__ >/dev/null 2>&1 || true
 if [ ! -s "$lcbvwdir/out.wasm" ]; then
   echo "[compiler-gate] FAIL: effect_local_closure_by_value_wrapper.vibe did not compile" >&2
-  cat "$lcbvwdir/out.wasm.diag" 2>/dev/null >&2 || true
+  cat "$lcbvwdir/out.wasm.diag" >&2 2>/dev/null || true
   exit 1
 fi
 if ! lcbvw_out="$(VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh --invoke _start "$lcbvwdir/out.wasm" 2>&1)"; then
@@ -2557,7 +2557,7 @@ VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   fixtures/effect_local_closure_wrapper_referenced_as_value.vibe "$lcwrvdir/out.wasm" __no_entry__ >/dev/null 2>&1 || true
 if [ ! -s "$lcwrvdir/out.wasm" ]; then
   echo "[compiler-gate] FAIL: effect_local_closure_wrapper_referenced_as_value.vibe did not compile" >&2
-  cat "$lcwrvdir/out.wasm.diag" 2>/dev/null >&2 || true
+  cat "$lcwrvdir/out.wasm.diag" >&2 2>/dev/null || true
   exit 1
 fi
 if ! lcwrv_out="$(VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh --invoke _start "$lcwrvdir/out.wasm" 2>&1)"; then
@@ -2587,7 +2587,7 @@ VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   fixtures/local_closure_wrapper_wrong_arity_not_inlined.vibe "$lcwadir/out.wasm" __no_entry__ >/dev/null 2>&1 || true
 if [ ! -s "$lcwadir/out.wasm" ]; then
   echo "[compiler-gate] FAIL: local_closure_wrapper_wrong_arity_not_inlined.vibe did not compile" >&2
-  cat "$lcwadir/out.wasm.diag" 2>/dev/null >&2 || true
+  cat "$lcwadir/out.wasm.diag" >&2 2>/dev/null || true
   exit 1
 fi
 if ! lcwa_out="$(VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh --invoke _start "$lcwadir/out.wasm" 2>&1)"; then
@@ -2624,7 +2624,7 @@ VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   fixtures/effect_inline_lambda_literal_hof_arg.vibe "$illhadir/out.wasm" __no_entry__ >/dev/null 2>&1 || true
 if [ ! -s "$illhadir/out.wasm" ]; then
   echo "[compiler-gate] FAIL: effect_inline_lambda_literal_hof_arg.vibe did not compile" >&2
-  cat "$illhadir/out.wasm.diag" 2>/dev/null >&2 || true
+  cat "$illhadir/out.wasm.diag" >&2 2>/dev/null || true
   exit 1
 fi
 if ! illha_out="$(VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh --invoke _start "$illhadir/out.wasm" 2>&1)"; then
@@ -2653,7 +2653,7 @@ VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   fixtures/effect_inline_lambda_literal_labeled_arg.vibe "$illladir/out.wasm" __no_entry__ >/dev/null 2>&1 || true
 if [ ! -s "$illladir/out.wasm" ]; then
   echo "[compiler-gate] FAIL: effect_inline_lambda_literal_labeled_arg.vibe did not compile" >&2
-  cat "$illladir/out.wasm.diag" 2>/dev/null >&2 || true
+  cat "$illladir/out.wasm.diag" >&2 2>/dev/null || true
   exit 1
 fi
 if ! illla_out="$(VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh --invoke _start "$illladir/out.wasm" 2>&1)"; then
@@ -2683,7 +2683,7 @@ VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   fixtures/dtpw_wrapper_shadowed_by_parameter.vibe "$dtpwsdir/out.wasm" __no_entry__ >/dev/null 2>&1 || true
 if [ ! -s "$dtpwsdir/out.wasm" ]; then
   echo "[compiler-gate] FAIL: dtpw_wrapper_shadowed_by_parameter.vibe did not compile" >&2
-  cat "$dtpwsdir/out.wasm.diag" 2>/dev/null >&2 || true
+  cat "$dtpwsdir/out.wasm.diag" >&2 2>/dev/null || true
   exit 1
 fi
 if ! dtpws_out="$(VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh --invoke _start "$dtpwsdir/out.wasm" 2>&1)"; then
@@ -2715,7 +2715,7 @@ VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   fixtures/evidence_dict_needing_shadowed_by_local.vibe "$edpsdir/out.wasm" __no_entry__ >/dev/null 2>&1 || true
 if [ ! -s "$edpsdir/out.wasm" ]; then
   echo "[compiler-gate] FAIL: evidence_dict_needing_shadowed_by_local.vibe did not compile" >&2
-  cat "$edpsdir/out.wasm.diag" 2>/dev/null >&2 || true
+  cat "$edpsdir/out.wasm.diag" >&2 2>/dev/null || true
   exit 1
 fi
 if ! edps_out="$(VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh --invoke _start "$edpsdir/out.wasm" 2>&1)"; then
@@ -2754,7 +2754,7 @@ VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   fixtures/effect_local_closure_by_value_hof_general.vibe "$edpgdir/out.wasm" __no_entry__ >/dev/null 2>&1 || true
 if [ ! -s "$edpgdir/out.wasm" ]; then
   echo "[compiler-gate] FAIL: effect_local_closure_by_value_hof_general.vibe did not compile" >&2
-  cat "$edpgdir/out.wasm.diag" 2>/dev/null >&2 || true
+  cat "$edpgdir/out.wasm.diag" >&2 2>/dev/null || true
   exit 1
 fi
 if ! edpg_out="$(VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh --invoke _start "$edpgdir/out.wasm" 2>&1)"; then
@@ -2787,7 +2787,7 @@ VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   fixtures/effect_local_closure_by_value_hof_escaping.vibe "$edpedir/out.wasm" __no_entry__ >/dev/null 2>&1 || true
 if [ ! -s "$edpedir/out.wasm" ]; then
   echo "[compiler-gate] FAIL: effect_local_closure_by_value_hof_escaping.vibe did not compile" >&2
-  cat "$edpedir/out.wasm.diag" 2>/dev/null >&2 || true
+  cat "$edpedir/out.wasm.diag" >&2 2>/dev/null || true
   exit 1
 fi
 if ! edpe_out="$(VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh --invoke _start "$edpedir/out.wasm" 2>&1)"; then
@@ -2811,7 +2811,7 @@ for cbvs_rc in 1 0; do
     fixtures/closure_by_value_store_test.vibe "$cbvsdir/out.wasm" __no_entry__ >/dev/null 2>&1 || true
   if [ ! -s "$cbvsdir/out.wasm" ]; then
     echo "[compiler-gate] FAIL: closure_by_value_store_test.vibe did not compile under VIBE_RC=$cbvs_rc" >&2
-    cat "$cbvsdir/out.wasm.diag" 2>/dev/null >&2 || true
+    cat "$cbvsdir/out.wasm.diag" >&2 2>/dev/null || true
     exit 1
   fi
   if ! cbvs_out="$(VIBE_RC="$cbvs_rc" VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh --invoke _start "$cbvsdir/out.wasm" 2>&1)"; then
@@ -2847,7 +2847,7 @@ VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
   fixtures/effect_local_closure_handle_owner_param.vibe "$edphdir/out.wasm" __no_entry__ >/dev/null 2>&1 || true
 if [ ! -s "$edphdir/out.wasm" ]; then
   echo "[compiler-gate] FAIL: effect_local_closure_handle_owner_param.vibe did not compile" >&2
-  cat "$edphdir/out.wasm.diag" 2>/dev/null >&2 || true
+  cat "$edphdir/out.wasm.diag" >&2 2>/dev/null || true
   exit 1
 fi
 if ! edph_out="$(VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/run_wasm_vibe_host_runner.sh --invoke _start "$edphdir/out.wasm" 2>&1)"; then

--- a/tests/gates/tooling-accounting/coverage/coverage_driver_exposure_test.sh
+++ b/tests/gates/tooling-accounting/coverage/coverage_driver_exposure_test.sh
@@ -141,7 +141,7 @@ expect_rejected() { # label driver source diagnostic-fragment
   fi
   if [ ! -s "$output.diag" ] || ! grep -Fq "$expected" "$output.diag"; then
     echo "coverage-driver-exposure: $label missing diagnostic '$expected'" >&2
-    cat "$output.diag" 2>/dev/null >&2 || true
+    cat "$output.diag" >&2 2>/dev/null || true
     exit 1
   fi
 }


### PR DESCRIPTION
Closes #2688.

## The bug

`cat "$out.diag" 2>/dev/null >&2 || true` is how the gate runners and helper scripts surface a compile-diagnostic sidecar on a failure path. Redirections apply left to right: `2>/dev/null` points stderr at /dev/null **first**, then `>&2` dups stdout onto that — so the diagnostic goes to /dev/null and only the caller's generic line (`... did not compile`) is ever seen. A red CI lane whose root cause is a compile diagnostic then shows nothing but the assertion name. #2676 fixed the launcher and the pkg scripts; this sweeps the rest.

## Sweep

419 executable occurrences across 15 files reordered to `>&2 2>/dev/null` (content to stderr, only the reader's own missing-file error dropped):

- 11 × `scripts/*.sh`
- `tests/gates/{early,mid,late}/run.sh`
- `tests/gates/tooling-accounting/coverage/coverage_driver_exposure_test.sh`

The one remaining occurrence is a whole-line comment in `tests/integration/install/install_test.sh` that documents the historical bug by showing the broken form; reordering it would make the sentence false, so it stays as prose.

## Guard (so it cannot come back)

`scripts/check_gate_portability.sh` gains a fifth rule flagging `2>/dev/null >&2` (and the `1>&2` synonym, any inter-token whitespace). It is a correctness defect rather than a portability one, but it is lexical and shares the machinery, and it reached every directory the launcher and gates cat a sidecar from — so unlike the other rules (scripts/ only) this one scans `runtime`, `scripts`, `tests`, `install`, `.github` and `.claude`, `sh` + `mjs`. The reverse order `>&2 2>/dev/null` and the correct discard-both `>/dev/null 2>&1` have a different token order and do not match; whole-line comments (`#` or `//`) are skipped, so the documenting comment above is not a finding; the gate excludes its own file and self-test.

## Red/green

`scripts/check_gate_portability_test.sh` gains three cases: the idiom in an executable line is rejected and the finding names the reason; the corrected `>&2 2>/dev/null` and the discard-both `>/dev/null 2>&1` both pass; the idiom in a whole-line comment is not a finding. Each red case asserts the fixture landed before trusting the verdict (#2248).

## Verification

- `check_gate_portability.sh` — ok on the real tree
- `check_gate_portability_test.sh` — 21/21 (18 pre-existing + 3 new)
- `check_gate_self_tests.sh` — ok
- `bash -n` on every swept script
- a micro-check that the reordered redirection sends the sidecar to stderr and silences the missing-file case, while the old order swallowed both

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019vCFHoPYJxzou2BsMeWU1S

---
_Generated by [Claude Code](https://claude.ai/code/session_019vCFHoPYJxzou2BsMeWU1S)_