### PR TITLE
#2633: a CTX instrument — 118 exported cross-module names reach no context

### DIFF
--- a/lib/@vibe/compiler/codegen/wasi/linked_compile.vibe
+++ b/lib/@vibe/compiler/codegen/wasi/linked_compile.vibe
@@ -708,6 +708,79 @@ fn lc_concat_ints_into(dst: Array[Int], src: Array[Int]) -> Unit {
   }
 }
 
+/// #2633: a name the MERGE mangled with its defining module -- `_exp_lib__`
+/// for an exported declaration, `_dep_lib__` for a private one. Exactly the
+/// program's own cross-module declarations carry these, so a builtin
+/// (`String::concat`, `Array::get`) cannot be mistaken for one and no builtin
+/// allow-list is needed to tell them apart.
+fn lc_name_is_module_mangled(n: String) -> Bool {
+  String::index_of(n, "_exp_lib__") >= 0 || String::index_of(n, "_dep_lib__") >= 0
+}
+
+fn lc_decl_names_into(stmts: Array[Stmt], into: MutMap[String, Int]) -> Unit {
+  let mut i = 0
+  while i < Array::length(stmts) {
+    match Array::get(stmts, i) {
+      SLet(_, _, n, _, _) => MutMap::set(into, n, 1),
+      SLetMut(n, _, _) => MutMap::set(into, n, 1),
+      SFnDecl(_, n, _, _, _) => MutMap::set(into, n, 1),
+      _ => ()
+    }
+    i = i + 1
+  }
+}
+
+/// #2633: the mangled names a module REFERS TO that are neither declared in
+/// its own statements nor present in the context it was handed.
+///
+/// This is the instrument the issue's last open question needs. The final
+/// `content` row turns on whether the owning module's `fn_returns` carries an
+/// imported function's return type, and `fn_returns` is built from `ctx ++
+/// own`. Reading the code could not settle whether the declaration reaches
+/// `ctx`: every step downstream of that checked out, and one attribution
+/// (`SFnDecl` missing from `oracle_is_interface_stmt`) turned out to be dead
+/// code, because the parser lowers `SFnDecl` to `SLet` before the prelude ever
+/// runs. So it is measured instead of argued.
+///
+/// Empty output is the claim that every cross-module name a module uses is one
+/// its context gave it.
+fn lc_ctx_unresolved_into(part: Array[Stmt], ctx: Array[Stmt], out: Array[String]) -> Unit {
+  let have: MutMap[String, Int] = MutMap::new_string()
+  lc_decl_names_into(part, have)
+  lc_decl_names_into(ctx, have)
+  let no_fn_names: Array[String] = []
+  let mut i = 0
+  while i < Array::length(part) {
+    match Array::get(part, i) {
+      SLet(_, _, _, _, v) => match v {
+        EFn(_, _, params, _, _, body) => {
+          let pnames: Array[String] = []
+          let mut pi = 0
+          while pi < Array::length(params) {
+            let (pn, _) = Array::get(params, pi)
+            Array::push(pnames, pn)
+            pi = pi + 1
+          }
+          let fv = collect_free_vars(body, pnames, no_fn_names)
+          let mut fj = 0
+          while fj < Array::length(fv) {
+            let n = Array::get(fv, fj)
+            if lc_name_is_module_mangled(n) && !MutMap::has(have, n) && !lc_str_array_has(out, n) {
+              Array::push(out, n)
+            } else {
+              ()
+            }
+            fj = fj + 1
+          }
+        },
+        _ => ()
+      },
+      _ => ()
+    }
+    i = i + 1
+  }
+}
+
 fn lc_str_array_has(xs: Array[String], n: String) -> Bool {
   let mut i = 0
   let mut found = false
@@ -5389,6 +5462,10 @@ fn prelude_run_per_module(c: Array[Stmt], c_file_id: Array[Int], file_count: Int
       }
       vj = vj + 1
     }
+    // #2633: what this module was GIVEN against what it USES, before anything
+    // reads the context.
+    Array::push(st.an_ctx_sizes, Array::length(ctx))
+    lc_ctx_unresolved_into(part, ctx, st.an_ctx_unresolved)
     let synthesized = desugar_trait_dicts_module_with_facts(part, ctx, "f\{fi}", checker_eq_offsets, checker_eq_type_keys, env.trait_facts)
     lc_union_into(st.requests, eq_synthesis_requests_list())
     lc_union_into(st.refusals, eq_typed_refusals_list())
@@ -5713,6 +5790,10 @@ struct PreludeSplitStats {
   // The OR the split lane actually seeded with, so the caller can compare it
   // against the whole program's instead of assuming they agree.
   an_bret_seed: Array[Int];
+  // #2633: per-module context sizes, and the mangled cross-module names a
+  // module uses that its context did not give it.
+  an_ctx_sizes: Array[Int];
+  an_ctx_unresolved: Array[String];
   // #2638: the two fixpoints over `trial` -- concatenated, link-passes applied,
   // NOT folded. Isolates the fold from the link-only passes.
   an_bret_trial: Array[String];
@@ -5759,6 +5840,8 @@ fn prelude_split_stats_new() -> PreludeSplitStats {
     an_shadow: lc_fresh_int_array(),
     an_bret_shadow: lc_fresh_int_array(),
     an_bret_seed: lc_fresh_int_array(),
+    an_ctx_sizes: lc_fresh_int_array(),
+    an_ctx_unresolved: lc_fresh_string_array(),
     an_bret_trial: lc_fresh_string_array(),
     an_view_trial: lc_fresh_string_array(),
     an_mrv_names: lc_fresh_string_array(),
@@ -6033,7 +6116,69 @@ export fn prelude_module_full_oracle_line(a: Array[Stmt], c: Array[Stmt], c_file
       _ => Array::get(st.an_bret_seed, 0)
     }), String::concat("/", Int::to_string(borrow_ret_shadow_mask(a))))), String::concat(String::concat(" link_bret_cat=", lc_set_cmp_counted(an_bret_w, an_bret_catr)), String::concat(String::concat(" link_view=", lc_set_cmp_counted(an_view_w, st.an_view_link)), String::concat(String::concat(" link_view_self=", lc_set_cmp_counted(an_view_w, an_view_self)), String::concat(String::concat(" link_view_asm=", lc_set_cmp_counted(an_view_w, an_view_asm)), String::concat(String::concat(" link_bret_trial=", lc_set_cmp_counted(an_bret_w, st.an_bret_trial)), String::concat(" link_view_trial=", lc_set_cmp_counted(an_view_w, st.an_view_trial)))))))))))))))))))))
   }
-  let an_line = String::concat(String::concat(an_head, an_cols), "\n")
+  // #2633: the context instrument. `decls` is the total number of declarations
+  // handed to modules, `zero` how many modules got none, and `unresolved` the
+  // mangled cross-module names a module uses that its context did not supply --
+  // empty meaning every one was given.
+  let mut ctx_decls = 0
+  let mut ctx_zero = 0
+  let mut cxi = 0
+  while cxi < Array::length(st.an_ctx_sizes) {
+    let n = Array::get(st.an_ctx_sizes, cxi)
+    ctx_decls = ctx_decls + n
+    if n == 0 {
+      ctx_zero = ctx_zero + 1
+    } else {
+      ()
+    }
+    cxi = cxi + 1
+  }
+  // Split by SPELLING, which is the whole point: `_exp_` is an EXPORTED
+  // declaration, so a module that uses one and was not given it is a context
+  // gap. `_dep_` is private to its defining module, which
+  // `oracle_is_interface_stmt` excludes on purpose -- a module referring to one
+  // is a different finding (a private name reaching across a module boundary),
+  // not a gap in what the contract publishes.
+  let mut ctx_unres_exp = 0
+  let mut ctx_unres_dep = 0
+  let mut first_exp = ""
+  let mut first_dep = ""
+  let mut cui = 0
+  while cui < Array::length(st.an_ctx_unresolved) {
+    let n = Array::get(st.an_ctx_unresolved, cui)
+    if String::index_of(n, "_exp_lib__") >= 0 {
+      ctx_unres_exp = ctx_unres_exp + 1
+      if first_exp == "" {
+        first_exp = n
+      } else {
+        ()
+      }
+    } else {
+      ctx_unres_dep = ctx_unres_dep + 1
+      if first_dep == "" {
+        first_dep = n
+      } else {
+        ()
+      }
+    }
+    cui = cui + 1
+  }
+  let mut ctx_line = "CTX decls="
+  ctx_line = String::concat(ctx_line, Int::to_string(ctx_decls))
+  ctx_line = String::concat(ctx_line, " modules=")
+  ctx_line = String::concat(ctx_line, Int::to_string(Array::length(st.an_ctx_sizes)))
+  ctx_line = String::concat(ctx_line, " zero=")
+  ctx_line = String::concat(ctx_line, Int::to_string(ctx_zero))
+  ctx_line = String::concat(ctx_line, " unresolved_exp=")
+  ctx_line = String::concat(ctx_line, Int::to_string(ctx_unres_exp))
+  ctx_line = String::concat(ctx_line, ":")
+  ctx_line = String::concat(ctx_line, first_exp)
+  ctx_line = String::concat(ctx_line, " unresolved_dep=")
+  ctx_line = String::concat(ctx_line, Int::to_string(ctx_unres_dep))
+  ctx_line = String::concat(ctx_line, ":")
+  ctx_line = String::concat(ctx_line, first_dep)
+  ctx_line = String::concat(ctx_line, "\n")
+  let an_line = String::concat(String::concat(String::concat(an_head, an_cols), "\n"), ctx_line)
   let line = String::concat(String::concat(head, mid), tail)
   let mut collision_lines = ""
   let mut ldi = 0

--- a/lib/@vibe/compiler/tests/prelude_module_oracle_test.vibe
+++ b/lib/@vibe/compiler/tests/prelude_module_oracle_test.vibe
@@ -61,6 +61,11 @@ fn synth_line_of(report: String) -> String {
   report_line_of(report, "SYNTH ")
 }
 
+/// The report's `CTX ...` line, or "" (#2633).
+fn ctx_line_of(report: String) -> String {
+  report_line_of(report, "CTX ")
+}
+
 /// The report's `DIAGS ...` line, or "" .
 fn diag_line_of(report: String) -> String {
   report_line_of(report, "DIAGS ")
@@ -336,6 +341,21 @@ test "the whole prelude per module reproduces the whole-program prelude" {
   // DIRECTLY, which is weaker and more useful: a need that reaches the link
   // only through another need.
   inspect(String::trim(synth_line_of(report)), content = "SYNTH requests=0 typed_refused=0 deferred=0 minted=0 indirect=0")
+  // #2633: what each module was GIVEN against what it USES. `decls` is the
+  // total handed out, `zero` the modules given none, and the two `unresolved`
+  // counts the MANGLED cross-module names a module refers to that its context
+  // did not supply -- split by spelling, because the two mean different
+  // things. `_exp_` is an exported declaration, which a `.vpkg` publishes, so
+  // a module using one it was not given is a gap in the context rule. `_dep_`
+  // is private to its defining module and `oracle_is_interface_stmt` excludes
+  // it deliberately, so a reference to one is a private name crossing a module
+  // boundary -- a different finding, not a gap.
+  //
+  // Zero here on a two-module program, which is the point of pinning it: the
+  // closure measurement reads `unresolved_exp=118 unresolved_dep=67 zero=37`,
+  // and without a program where the instrument reads zero those numbers could
+  // be the instrument miscounting rather than the context missing.
+  inspect(String::trim(ctx_line_of(report)), content = "CTX decls=1 modules=2 zero=1 unresolved_exp=0: unresolved_dep=0:")
   // #2388: the VALIDATING passes, which produce diagnostics rather than
   // rewrites and are therefore invisible to a comparison keyed on
   // declarations. `0` here is both lanes silent on a clean program; the test


### PR DESCRIPTION
Blocks #2575 item 2. Oracle only — no production code is touched.

## Why

#2633's last open question was whether a module's context actually carries the declarations it uses. Reading the code could not settle it: every step downstream of `ctx` checked out (`stmts = ctx ++ own`, `collect_fn_returns` over it, `fn_return_head_of` reading the annotation rather than the stripped body).

The one attribution I built from reading turned out to be **dead code**. `oracle_is_interface_stmt` has no `SFnDecl` arm, and `collect_fn_returns` carries a comment about exactly that omission ("the more common spelling … was invisible here"), so it looked like the same class of bug. I added the arms and measured: every number in the report was identical, because `lower_fn_decl_stmt` runs in the **parser** — `SFnDecl` never reaches the prelude. Not shipped.

So: measured instead of argued.

## The measurement

New `CTX` line. Compiler's CLI closure:

```
CTX decls=120787 modules=366 zero=37
    unresolved_exp=118:__to_string_exp_lib__vibe_parser_polyfill_vibe
    unresolved_dep=67:AvlNode_dep_lib__vibe_core_sortedmap_vibe
```

Three facts, none previously measured:

- **37 of 366 modules are handed no context at all.**
- **118 exported cross-module names are used by a module that was not given them.** An exported declaration is exactly what a `.vpkg` publishes, so each of these is a gap between the oracle's context rule and the contract.
- **67 private names are referenced across a module boundary.** A different finding, not a gap — `oracle_is_interface_stmt` excludes `_dep_` deliberately, so this is a private name escaping its module.

## Two design points that carry the result

**The split by spelling is the whole design.** `_exp_` vs `_dep_` separates "the context rule is incomplete" from "a private name crossed a boundary". Without it the 185 total reads as one number meaning neither — my first cut reported exactly that, and its first entry was a `_dep_` name, which would have pointed at the wrong conclusion.

**Restricting to mangled names** is what makes the count trustworthy without a builtin allow-list: only the merge's own cross-module declarations carry `_exp_lib__` / `_dep_lib__`, so `String::concat` and `Array::get` cannot be miscounted as gaps.

## The control

Pinned on the two-module fixture at `CTX decls=1 modules=2 zero=1 unresolved_exp=0: unresolved_dep=0:`.

That control is the point. Without a program where the instrument reads **zero**, 118 and 67 could be the instrument miscounting rather than the context missing — and on this issue three prior attributions (including mine, above) were wrong.

## What this does and does not do

It does **not** fix the remaining `content=1` row. It establishes the category that row belongs to, which is what the issue was stuck on: the context rule is demonstrably short of what modules use, for exported names a contract already publishes.

## Verification

| check | result |
|---|---|
| `scripts/compiler_gate.sh` | `[compiler-gate] ok` — 63 suites, **0 failed** |
| `prelude_module_oracle_test.vibe` | 9 tests pass |
| `vibe check` / `vibe_fmt --check` | clean on both files |

No output-equivalence run: the diff touches only `prelude_module_full_oracle_line` and its stats struct, which production never reaches (`use_split` is false at every production caller).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NAeZzkckdAwtQiubBFpdmM

---
_Generated by [Claude Code](https://claude.ai/code/session_01NAeZzkckdAwtQiubBFpdmM)_