### PR TITLE
#2633: the interface filter missed the bare export block — 35 context misses to 0

### DIFF
--- a/lib/@vibe/compiler/codegen/wasi/linked_compile.vibe
+++ b/lib/@vibe/compiler/codegen/wasi/linked_compile.vibe
@@ -713,6 +713,26 @@ fn lc_concat_ints_into(dst: Array[Int], src: Array[Int]) -> Unit {
 /// program's own cross-module declarations carry these, so a builtin
 /// (`String::concat`, `Array::get`) cannot be mistaken for one and no builtin
 /// allow-list is needed to tell them apart.
+/// #2633: does this module's PUBLISHED interface declare `n`?
+fn lc_iface_declares(iface: Array[Stmt], n: String) -> Bool {
+  let mut i = 0
+  let mut found = false
+  while i < Array::length(iface) {
+    let nm = match Array::get(iface, i) {
+      SLet(_, _, d, _, _) => d,
+      SFnDecl(_, d, _, _, _) => d,
+      _ => ""
+    }
+    if nm == n {
+      found = true
+    } else {
+      ()
+    }
+    i = i + 1
+  }
+  found
+}
+
 fn lc_int_array_has(xs: Array[Int], v: Int) -> Bool {
   let mut i = 0
   let mut found = false
@@ -799,7 +819,7 @@ fn lc_decl_names_into(stmts: Array[Stmt], into: MutMap[String, Int]) -> Unit {
 ///
 /// Empty output is the claim that every cross-module name a module uses is one
 /// its context gave it.
-fn lc_ctx_unresolved_into(part: Array[Stmt], ctx: Array[Stmt], out: Array[String], visible: Array[Int], tag_owner: MutMap[String, Int], self_fi: Int, cls: Array[Int]) -> Unit {
+fn lc_ctx_unresolved_into(part: Array[Stmt], ctx: Array[Stmt], out: Array[String], visible: Array[Int], tag_owner: MutMap[String, Int], self_fi: Int, cls: Array[Int], ifaces: Array[Array[Stmt]]) -> Unit {
   let have: MutMap[String, Int] = MutMap::new_string()
   lc_decl_names_into(part, have)
   lc_decl_names_into(ctx, have)
@@ -838,6 +858,18 @@ fn lc_ctx_unresolved_into(part: Array[Stmt], ctx: Array[Stmt], out: Array[String
                   Array::set(cls, 2, Array::get(cls, 2) + 1)
                 } else if lc_int_array_has(visible, owner) {
                   Array::set(cls, 0, Array::get(cls, 0) + 1)
+                  // #2633: the definer is reachable, so ONE of two things
+                  // removed the declaration. Either the interface filter never
+                  // put it in the owner's published surface
+                  // (`oracle_is_interface_stmt` said no), or it did and the
+                  // context loop skipped it because this module declares the
+                  // same key (`own_keys`). Those want different fixes, so they
+                  // are counted apart rather than as one "filtered".
+                  if lc_iface_declares(Array::get(ifaces, owner), n) {
+                    Array::set(cls, 4, Array::get(cls, 4) + 1)
+                  } else {
+                    Array::set(cls, 3, Array::get(cls, 3) + 1)
+                  }
                 } else {
                   Array::set(cls, 1, Array::get(cls, 1) + 1)
                 }
@@ -4808,6 +4840,53 @@ fn oracle_head(s: String) -> String {
 /// is the bodyless PUBLIC boundary, so a pass reading a dependency's private
 /// declaration stayed green here while a per-module compile could not see it
 /// (Codex P1 on #2622).
+/// #2633: the names a module exports through a BARE EXPORT BLOCK
+/// (`export { a, b }`) rather than through a flag on the declaration.
+///
+/// vibe has both spellings and they are not interchangeable at the source:
+/// `lib/@vibe/parser/polyfill.vibe` uses the block deliberately, because a
+/// contract-undeclared `export let` would be a conformance violation, and
+/// `parser_expr.vibe` REFUSES `export let <pattern> = ..` outright and tells
+/// the author to use a block. So the block is not an oddity to tolerate, it is
+/// the required spelling in cases the flag cannot express.
+///
+/// The merge honours both -- it stamps a block-exported name `_exp_` -- and
+/// the interface filter honoured only the flag, so those declarations were
+/// modelled as published by nothing. Measured: that was ALL 35 of the
+/// in-closure context misses.
+fn oracle_export_block_names(stmts: Array[Stmt]) -> MutMap[String, Int] {
+  let out: MutMap[String, Int] = MutMap::new_string()
+  let mut i = 0
+  while i < Array::length(stmts) {
+    match Array::get(stmts, i) {
+      SExport(names) => {
+        let mut j = 0
+        while j < Array::length(names) {
+          MutMap::set(out, Array::get(names, j), 1)
+          j = j + 1
+        }
+      },
+      _ => ()
+    }
+    i = i + 1
+  }
+  out
+}
+
+/// The interface test, against a module's export-block names as well as the
+/// per-declaration flag.
+fn oracle_is_interface_stmt_with(s: Stmt, block: MutMap[String, Int]) -> Bool {
+  if oracle_is_interface_stmt(s) {
+    true
+  } else {
+    match s {
+      SLet(_, _, n, _, _) => MutMap::has(block, n),
+      SFnDecl(_, n, _, _, _) => MutMap::has(block, n),
+      _ => false
+    }
+  }
+}
+
 fn oracle_is_interface_stmt(s: Stmt) -> Bool {
   match s {
     SEnum(exported, _, _, _, _) => exported,
@@ -5470,9 +5549,10 @@ fn prelude_run_per_module(c: Array[Stmt], c_file_id: Array[Int], file_count: Int
   while pf < file_count {
     let src = Array::get(parts, pf)
     let dst: Array[Stmt] = []
+    let src_export_block = oracle_export_block_names(src)
     let mut ps = 0
     while ps < Array::length(src) {
-      if oracle_is_interface_stmt(Array::get(src, ps)) {
+      if oracle_is_interface_stmt_with(Array::get(src, ps), src_export_block) {
         Array::push(dst, oracle_interface_form(Array::get(src, ps)))
       } else {
         ()
@@ -5556,7 +5636,7 @@ fn prelude_run_per_module(c: Array[Stmt], c_file_id: Array[Int], file_count: Int
     // #2633: what this module was GIVEN against what it USES, before anything
     // reads the context.
     Array::push(st.an_ctx_sizes, Array::length(ctx))
-    lc_ctx_unresolved_into(part, ctx, st.an_ctx_unresolved, visible, tag_owner, fi, st.an_ctx_cls)
+    lc_ctx_unresolved_into(part, ctx, st.an_ctx_unresolved, visible, tag_owner, fi, st.an_ctx_cls, ifaces)
     let synthesized = desugar_trait_dicts_module_with_facts(part, ctx, "f\{fi}", checker_eq_offsets, checker_eq_type_keys, env.trait_facts)
     lc_union_into(st.requests, eq_synthesis_requests_list())
     lc_union_into(st.refusals, eq_typed_refusals_list())
@@ -5885,8 +5965,9 @@ struct PreludeSplitStats {
   // module uses that its context did not give it.
   an_ctx_sizes: Array[Int];
   an_ctx_unresolved: Array[String];
-  // #2633: [definer in closure, definer outside closure, definer unknown] for
-  // the unresolved EXPORTED names.
+  // #2633: [in closure, outside closure, definer unknown, filtered out of the
+  // owner's interface, present in it but skipped by the context loop] for the
+  // unresolved EXPORTED names.
   an_ctx_cls: Array[Int];
   // #2638: the two fixpoints over `trial` -- concatenated, link-passes applied,
   // NOT folded. Isolates the fold from the link-only passes.
@@ -5936,7 +6017,7 @@ fn prelude_split_stats_new() -> PreludeSplitStats {
     an_bret_seed: lc_fresh_int_array(),
     an_ctx_sizes: lc_fresh_int_array(),
     an_ctx_unresolved: lc_fresh_string_array(),
-    an_ctx_cls: [0, 0, 0],
+    an_ctx_cls: [0, 0, 0, 0, 0],
     an_bret_trial: lc_fresh_string_array(),
     an_view_trial: lc_fresh_string_array(),
     an_mrv_names: lc_fresh_string_array(),
@@ -6278,6 +6359,10 @@ export fn prelude_module_full_oracle_line(a: Array[Stmt], c: Array[Stmt], c_file
   ctx_line = String::concat(ctx_line, Int::to_string(Array::get(st.an_ctx_cls, 1)))
   ctx_line = String::concat(ctx_line, " exp_unknown=")
   ctx_line = String::concat(ctx_line, Int::to_string(Array::get(st.an_ctx_cls, 2)))
+  ctx_line = String::concat(ctx_line, " filt_not_published=")
+  ctx_line = String::concat(ctx_line, Int::to_string(Array::get(st.an_ctx_cls, 3)))
+  ctx_line = String::concat(ctx_line, " filt_own_key_skip=")
+  ctx_line = String::concat(ctx_line, Int::to_string(Array::get(st.an_ctx_cls, 4)))
   ctx_line = String::concat(ctx_line, "\n")
   let an_line = String::concat(String::concat(String::concat(an_head, an_cols), "\n"), ctx_line)
   let line = String::concat(String::concat(head, mid), tail)
@@ -6353,9 +6438,10 @@ export fn prelude_pass_module_oracle_step(k: Int, a: Array[Stmt], c: Array[Stmt]
   while pf < file_count {
     let src = Array::get(parts, pf)
     let dst: Array[Stmt] = []
+    let src_export_block = oracle_export_block_names(src)
     let mut ps = 0
     while ps < Array::length(src) {
-      if oracle_is_interface_stmt(Array::get(src, ps)) {
+      if oracle_is_interface_stmt_with(Array::get(src, ps), src_export_block) {
         Array::push(dst, oracle_interface_form(Array::get(src, ps)))
       } else {
         ()

--- a/lib/@vibe/compiler/tests/prelude_module_oracle_test.vibe
+++ b/lib/@vibe/compiler/tests/prelude_module_oracle_test.vibe
@@ -361,14 +361,34 @@ test "the whole prelude per module reproduces the whole-program prelude" {
   //   exp_unknown     the definer could not be identified at all, kept apart
   //                   rather than folded into either answer
   //
-  // On the compiler's closure that reads `unresolved_exp=118 exp_in_closure=35
-  // exp_outside=83 exp_unknown=0`, so both causes are real and `unknown=0`
-  // says neither count is polluted by a name this could not place.
+  // `filt_not_published` / `filt_own_key_skip` split the in-closure half one
+  // level further: the owner's published interface never carried the
+  // declaration, or it did and the context loop skipped it because this module
+  // declares the same key.
+  //
+  // That split is what found the BARE EXPORT BLOCK. All 35 in-closure misses
+  // were `filt_not_published`, none were the key skip, and the filter reads
+  // only the per-declaration `export` flag -- so a name exported by
+  // `export { f }` at the foot of a file was modelled as published by nothing.
+  // `lib/@vibe/parser/polyfill.vibe` does exactly that, deliberately, and
+  // `parser_expr.vibe` REFUSES `export let <pattern> = ..` and tells the
+  // author to use a block, so it is the required spelling in cases the flag
+  // cannot express.
+  //
+  // Honouring it took the closure from
+  //
+  //   unresolved_exp=118 exp_in_closure=35 filt_not_published=35  decls=120878
+  //   unresolved_exp=83  exp_in_closure=0  filt_not_published=0   decls=121778
+  //
+  // -- 900 more declarations reaching contexts, and `missing=0 extra=0
+  // content=1` unchanged across it, so the wider context masked nothing that
+  // was being detected. The remaining 83 are the other cause (the closure does
+  // not reach the definer) and are untouched by this.
   //
   // Zero here on a two-module program, which is the point of pinning it: those
   // numbers could otherwise be the instrument miscounting rather than the
   // context missing.
-  inspect(String::trim(ctx_line_of(report)), content = "CTX decls=1 modules=2 zero=1 unresolved_exp=0: unresolved_dep=0: exp_in_closure=0 exp_outside=0 exp_unknown=0")
+  inspect(String::trim(ctx_line_of(report)), content = "CTX decls=1 modules=2 zero=1 unresolved_exp=0: unresolved_dep=0: exp_in_closure=0 exp_outside=0 exp_unknown=0 filt_not_published=0 filt_own_key_skip=0")
   // #2388: the VALIDATING passes, which produce diagnostics rather than
   // rewrites and are therefore invisible to a comparison keyed on
   // declarations. `0` here is both lanes silent on a clean program; the test


### PR DESCRIPTION
Blocks #2575 item 2. Follows #2698. Oracle only — no production code is touched.

#2698 split the 118 context misses into 83 (the closure does not reach the definer) and 35 (it does, and the declaration was dropped). This closes the 35 — and it turned out to be a real defect in the oracle's model of a contract, not a tuning knob.

## Narrowing it first

Split the 35 one level further before touching anything:

```
filt_not_published=35     the owner's published interface never carried it
filt_own_key_skip=0       the context loop's same-key skip removed none
```

Every one was the interface filter; the skip was exonerated entirely. That pointed at `oracle_is_interface_stmt`, which reads only the per-declaration `export` flag.

## vibe has two export spellings, and the second is not a style choice

```vibe
fn __to_string(n: Int) -> String { .. }   // no flag
export { __to_string }                    // the block
```

`lib/@vibe/parser/polyfill.vibe` uses the block **deliberately** — its own comment says a contract-undeclared `export let` would be a conformance violation — and `parser_expr.vibe` **refuses** `export let <pattern> = ..` outright and tells the author to use a block. So the block is the required spelling where the flag cannot express the intent.

The merge honours both (it stamps a block-exported name `_exp_`). The interface filter honoured only the flag, so a name published that way was modelled as published by nothing.

## Red → Green

Same closure, before and after:

```
unresolved_exp=118  exp_in_closure=35  filt_not_published=35   decls=120878
unresolved_exp=83   exp_in_closure=0   filt_not_published=0    decls=121778
```

**900 more declarations reach contexts**, and `missing=0 extra=0 content=1` is unchanged across it.

That last clause is the one worth stating: widening what a module can see makes the oracle's green *easier*, so a widening has to be justified rather than welcomed. The justification is that the context now matches the contract instead of being narrower than it — and the evidence that nothing was masked is that the keyed comparison did not move.

## Scope

- The remaining **83** are the other cause (the closure does not reach the definer) and are untouched.
- `content=1` is also unchanged. This removes one of the two causes, not the last row.

## Verification

| check | result |
|---|---|
| `scripts/compiler_gate.sh` | `[compiler-gate] ok` — 63 suites, **0 failed** |
| `prelude_module_oracle_test.vibe` | 9 tests pass |
| `vibe check` / `vibe_fmt --check` | clean on both files |

No output-equivalence run: the diff touches only the oracle path, which production never reaches (`use_split` is false at every production caller).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NAeZzkckdAwtQiubBFpdmM

---
_Generated by [Claude Code](https://claude.ai/code/session_01NAeZzkckdAwtQiubBFpdmM)_