### PR TITLE
#2633: the ctx comment describes both closure modes

### DIFF
--- a/lib/@vibe/compiler/codegen/wasi/linked_compile.vibe
+++ b/lib/@vibe/compiler/codegen/wasi/linked_compile.vibe
@@ -5601,22 +5601,32 @@ fn prelude_run_per_module(c: Array[Stmt], c_file_id: Array[Int], file_count: Int
     // edges it is the claim that matters: no module needed anything IT
     // IMPORTS did not have.
     //
-    // DIRECT edges only, and deliberately so -- this comment used to say
-    // "transitive, because a module sees what its dependencies re-export",
-    // which is the justification `oracle_import_closure` itself now calls
-    // wrong as implemented: when A imports B and B imports C PRIVATELY, a
-    // transitive closure hands A the declarations of C, which no real compile
-    // of A exposes. The closure was narrowed; this sentence was not, and it
-    // sat at the one place a reader consults about what a module can see.
+    // The closure is the CALLER'S, and the two callers pass different ones.
+    // This comment previously asserted one rule for both and was wrong about
+    // each: it said "transitive, because a module sees what its dependencies
+    // re-export" (the justification `oracle_import_closure` now calls wrong as
+    // implemented -- a transitive closure hands A the declarations of a module
+    // B imports PRIVATELY), and the correction then over-swung to "direct-only,
+    // and the loader cannot express re-export" (Codex on #2700), which
+    // misdescribes production and denies machinery that already exists.
     //
-    // The cost is measured and reported rather than hidden: on the compiler's
-    // closure, 83 exported cross-module names are used by a module the
-    // direct-only rule did not give them to (the `CTX unresolved_exp` /
-    // `exp_outside` counters). Closing across RE-EXPORT edges only would be
-    // the exact rule, and the loader's header scan cannot express it -- it
-    // returns a module's deps and its export names, with no record of which
-    // deps a dep re-exports. So the gap is a known under-approximation
-    // awaiting loader data, not a bug in this loop.
+    //   production  `exact_import_closure` (#2658) -- direct imports PLUS
+    //               everything reachable across RE-EXPORT edges only, with the
+    //               re-export subset taken from the LOADER
+    //               (`module_reexport_deps_fs`). Exact, and necessary: a module
+    //               that cannot see what its dependency re-exports lowers a
+    //               call to a bounded generic without the witness argument.
+    //   oracle      `oracle_import_closure` -- DIRECT edges only. An
+    //               under-approximation on purpose: for a MEASUREMENT, being
+    //               given context a module does not have is the one failure
+    //               mode that makes a green meaningless.
+    //
+    // So the `CTX exp_outside` count (83 on the compiler's closure) is the
+    // ORACLE lane's, not production's, and it is the price of that deliberate
+    // conservatism -- not a missing capability. Whether the oracle should adopt
+    // the exact closure is a live question, since measuring with LESS context
+    // than production has makes the oracle solve a harder problem than the
+    // thing it models; `ModuleSplit.closure_exact` already records which it got.
     //
     // An index out of range is a caller that built the closure over a
     // different file space, which would silently hand a module some other

--- a/lib/@vibe/compiler/codegen/wasi/linked_compile.vibe
+++ b/lib/@vibe/compiler/codegen/wasi/linked_compile.vibe
@@ -5601,10 +5601,25 @@ fn prelude_run_per_module(c: Array[Stmt], c_file_id: Array[Int], file_count: Int
     // edges it is the claim that matters: no module needed anything IT
     // IMPORTS did not have.
     //
-    // Transitive, because a module sees what its dependencies re-export, and
-    // what this feeds is declaration surface rather than a name-resolution
-    // decision. An index out of range is a caller that built the closure over
-    // a different file space, which would silently hand a module some other
+    // DIRECT edges only, and deliberately so -- this comment used to say
+    // "transitive, because a module sees what its dependencies re-export",
+    // which is the justification `oracle_import_closure` itself now calls
+    // wrong as implemented: when A imports B and B imports C PRIVATELY, a
+    // transitive closure hands A the declarations of C, which no real compile
+    // of A exposes. The closure was narrowed; this sentence was not, and it
+    // sat at the one place a reader consults about what a module can see.
+    //
+    // The cost is measured and reported rather than hidden: on the compiler's
+    // closure, 83 exported cross-module names are used by a module the
+    // direct-only rule did not give them to (the `CTX unresolved_exp` /
+    // `exp_outside` counters). Closing across RE-EXPORT edges only would be
+    // the exact rule, and the loader's header scan cannot express it -- it
+    // returns a module's deps and its export names, with no record of which
+    // deps a dep re-exports. So the gap is a known under-approximation
+    // awaiting loader data, not a bug in this loop.
+    //
+    // An index out of range is a caller that built the closure over a
+    // different file space, which would silently hand a module some other
     // module's context, so it is refused rather than defaulted.
     if Array::length(import_closure) != file_count {
       throw(String::concat("prelude oracle: the import closure has ", String::concat(Int::to_string(Array::length(import_closure)), String::concat(" rows for ", String::concat(Int::to_string(file_count), " modules")))))


### PR DESCRIPTION
Blocks #2575 item 2. Follows #2699. **Comment only — no behaviour changes.**

The comment at the point a module's context is read described one closure rule for a loop that has **two callers with two different rules**. It has now been wrong twice, in opposite directions, and this PR contains both the correction and the correction to the correction.

## What it said, and what is true

| | claim | verdict |
|---|---|---|
| originally | "Transitive, because a module sees what its dependencies re-export" | the exact justification `oracle_import_closure` now calls *wrong as implemented* — a transitive closure hands A the declarations of a module B imports **privately** |
| my first fix (`c19c374`) | "DIRECT edges only … the loader cannot express re-export" | wrong for **production**, and wrong about the loader — caught by Codex |
| now (`5a43c07`) | both modes, named | — |

```
production   exact_import_closure (#2658) — direct imports PLUS everything
             reachable across RE-EXPORT edges only, with that subset taken
             from the LOADER via module_reexport_deps_fs
oracle       oracle_import_closure — DIRECT edges only, deliberately: for a
             measurement, being handed context a module does not have is the
             one failure mode that makes a green meaningless
```

I had quoted `oracle_import_closure`'s own comment and generalised it to the shared loop. That sentence is true of *that function* and predates #2658 adding the exact closure beside it. So I asserted the absence of machinery that is already in use, one call away.

## This relocates the 83

The `CTX exp_outside` count (83 on the compiler's closure, from the counters #2696 / #2698 added) is the **oracle** lane's — the price of its deliberate conservatism — not production missing a capability, and not blocked on loader work.

It opens a real question instead of settling one, which the comment states and does not answer: the oracle measures with **less** context than production has, so it is solving a harder problem than the thing it models, and part of its residue is an artifact of that choice. `ModuleSplit.closure_exact` already records which closure a caller got, so both are available if that turns out to be the wrong trade.

## Method note

I opened this PR drawing the lesson "read the decision before building an instrument" — right about `oracle_import_closure`, wrong in application. I read *one* function's comment and stopped instead of following it to its callers. Reading a decision is not the same as reading the decision that governs the code in front of you.

## Verification

| check | result |
|---|---|
| `scripts/compiler_gate.sh` | `[compiler-gate] ok` — 63 suites, **0 failed** (run on both commits) |
| `vibe check` / `vibe_fmt --check` | clean |
| Codex re-review of `5a43c07` | completed, no findings |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NAeZzkckdAwtQiubBFpdmM