### PR TITLE
#2633: the CTX instrument counted wrong, and its control could not fail

### DIFF
--- a/lib/@vibe/compiler/codegen/wasi/linked_compile.vibe
+++ b/lib/@vibe/compiler/codegen/wasi/linked_compile.vibe
@@ -733,76 +733,46 @@ fn lc_int_array_has(xs: Array[Int], v: Int) -> Bool {
   found
 }
 
-/// #2633: whether `n` is a name the MERGE stamped with its defining module.
+/// #2701: the registered tag a name is stamped with and WHICH MARKER carries
+/// it -- `("", false)` when the name is not stamped.
 ///
-/// The merge spells these `name ++ "_exp_" ++ sanitize_namespace_path(path)`
-/// (and `_dep_` for a private one), so the test is the marker plus a tag that
-/// looks like a sanitized path. `sanitize_namespace_path` maps every character
-/// outside `[A-Za-z0-9_]` to `_`, so a `.vibe` path always sanitizes to a tag
-/// ending `_vibe` -- which is what distinguishes a stamped name from a source
-/// identifier that merely contains `_dep_`. A qualified operation carries the
-/// tag before a `::`, so the tail is cut there first. Exactly the program's own
-/// cross-module declarations carry a stamp, so a builtin (`String::concat`,
-/// `Array::get`) cannot be mistaken for one and no builtin allow-list is
-/// needed to tell them apart.
+/// Three properties, each of which was a defect before it was one (Codex
+/// rounds 3 and 4):
 ///
-/// This used to test for the literal `_exp_lib__` / `_dep_lib__`, which is the
-/// same predicate ONLY for files under `lib/`: the `lib__` is nothing but the
-/// sanitized first path segment. Every compiler-closure measurement was
-/// therefore right, and every FIXTURE reading was vacuously zero -- a two-file
-/// program written to `/tmp` gets the tag `_tmp_...`, matches nothing, and
-/// reports a clean context whatever the context actually holds. The all-zero
-/// two-module pin this instrument shipped with could not have failed.
-fn lc_name_is_module_mangled(n: String) -> Bool {
-  lc_mangle_tail_is_path(n, "_exp_") || lc_mangle_tail_is_path(n, "_dep_")
-}
-
-/// The tag following `marker` in `n`, cut at a qualifying `::`, tested for the
-/// shape `sanitize_namespace_path` produces for a `.vibe` source path.
-fn lc_mangle_tail_is_path(n: String, marker: String) -> Bool {
-  let at = String::index_of(n, marker)
-  if at < 0 {
-    false
-  } else {
-    let tag = lc_cut_at_qualifier(String::substring(n, at + String::length(marker), String::length(n)))
-    String::length(tag) > 5 && String::ends_with(tag, "_vibe")
-  }
-}
-
-/// Of a name already known to be merge-stamped, whether the stamp is the
-/// EXPORTED one. Same `lib__`-independence as the predicate above: the split
-/// between "the contract publishes this" and "this is private to its module"
-/// must not depend on where the file happens to live.
-fn lc_name_is_exported_mangled(n: String) -> Bool {
-  lc_mangle_tail_is_path(n, "_exp_")
-}
-
-/// #2701 (Codex round 3): the registered tag a name is stamped with, or "".
+/// 1. Only the NAMESPACE PORTION is scanned. A qualified operation is spelled
+///    `ns ++ marker ++ tag ++ "::" ++ op`, so the stamp is always before the
+///    `::` and a marker inside the OPERATION name is not one. Scanning the
+///    whole string let `Trait_exp_<B>::render_dep_cache_vibe` replace B's real
+///    tag with `cache_vibe` whenever some module carried that tag.
 ///
-/// A stamp is a SUFFIX, so the marker that introduces it is the LAST one whose
-/// tail is a tag some module actually carries -- not the first `_exp_` in the
-/// string. Both failure modes of first-occurrence parsing are closed here:
+/// 2. Markers are read RIGHT TO LEFT, because the stamp is a SUFFIX. Taking
+///    the first one reads a tag out of the SOURCE name when that name contains
+///    a marker itself: `render_exp_cache_vibe_exp__tmp_dep_vibe` is stamped
+///    `_tmp_dep_vibe`, and first-occurrence parsing answered a tag no module
+///    carries, so the reference was dropped with no trace.
 ///
-///   render_exp_cache_vibe                    no tail is a registered tag -> ""
-///   render_exp_cache_vibe_exp__tmp_dep_vibe  the LAST marker gives the real tag
+/// 3. The `_exp_` / `_dep_` answer is the marker attached to THE REGISTERED
+///    TAG, not the first marker-shaped substring. A private
+///    `render_exp_cache_vibe_dep_<owner>` resolves its tag correctly and was
+///    still reported EXPORTED, because an earlier `_exp_` had a tail that
+///    also ended `_vibe` -- putting a private name into the `exp_*`
+///    classifiers, which exist to separate exactly these two things.
 ///
-/// The first is a legal source identifier in an entry module, which is never
-/// stamped at all; the second is a genuinely stamped name whose SOURCE name
-/// happens to contain the marker, which first-occurrence parsing resolved to a
-/// tag nobody carries and therefore dropped silently.
-///
-/// Matching against registered tags rather than a shape is what makes this
-/// exact: `tag_owner` is built from module PATHS through the merge's own
-/// mangler, so a tail either is a module's tag or it is not.
-fn lc_registered_tag_of(n: String, tag_owner: MutMap[String, Int]) -> String {
+/// Matching against registered tags rather than a name shape is what makes it
+/// exact: a tail either is some module's tag or it is not.
+fn lc_registered_tag_of(n: String, tag_owner: MutMap[String, Int]) -> (String, Bool) {
+  let ns = lc_cut_at_qualifier(n)
   let mut best = ""
+  let mut best_exp = false
   let mut i = 0
-  while i < String::length(n) {
-    let is_marker = (String::char_code_at(n, i) == '_') && (i + 5 <= String::length(n)) && (String::substring(n, i, i + 5) == "_exp_" || String::substring(n, i, i + 5) == "_dep_")
-    if is_marker {
-      let tag = lc_cut_at_qualifier(String::substring(n, i + 5, String::length(n)))
+  while i + 5 <= String::length(ns) {
+    let marker = String::substring(ns, i, i + 5)
+    let is_exp = marker == "_exp_"
+    if is_exp || marker == "_dep_" {
+      let tag = String::substring(ns, i + 5, String::length(ns))
       if MutMap::has(tag_owner, tag) {
         best = tag
+        best_exp = is_exp
       } else {
         ()
       }
@@ -811,7 +781,7 @@ fn lc_registered_tag_of(n: String, tag_owner: MutMap[String, Int]) -> String {
     }
     i = i + 1
   }
-  best
+  (best, best_exp)
 }
 
 /// #2633: the MODULE TAG a mangled name carries -- `..._exp_lib__vibe_parser_polyfill_vibe`
@@ -951,7 +921,7 @@ fn lc_decl_names_into(stmts: Array[Stmt], into: MutMap[String, Int]) -> Unit {
 ///
 /// Empty output is the claim that every cross-module name a module uses is one
 /// its context gave it.
-fn lc_ctx_unresolved_into(part: Array[Stmt], ctx: Array[Stmt], out: Array[String], visible: Array[Int], tag_owner: MutMap[String, Int], self_fi: Int, cls: Array[Int], ifaces: Array[Array[Stmt]]) -> Unit {
+fn lc_ctx_unresolved_into(part: Array[Stmt], ctx: Array[Stmt], out: Array[String], out_exp: Array[Int], visible: Array[Int], tag_owner: MutMap[String, Int], self_fi: Int, cls: Array[Int], ifaces: Array[Array[Stmt]]) -> Unit {
   let have: MutMap[String, Int] = MutMap::new_string()
   lc_decl_names_into(part, have)
   lc_decl_names_into(ctx, have)
@@ -987,7 +957,7 @@ fn lc_ctx_unresolved_into(part: Array[Stmt], ctx: Array[Stmt], out: Array[String
             // report the scan exercising cross-module names it never saw. A
             // denominator that can be inflated by a plausible function name is
             // worth no more than the zero it was added to qualify.
-            let n_tag = lc_registered_tag_of(n, tag_owner)
+            let (n_tag, n_exp) = lc_registered_tag_of(n, tag_owner)
             let stamped = n_tag != ""
             if stamped {
               Array::set(cls, 5, Array::get(cls, 5) + 1)
@@ -996,6 +966,16 @@ fn lc_ctx_unresolved_into(part: Array[Stmt], ctx: Array[Stmt], out: Array[String
             }
             if stamped && !MutMap::has(have, n) && !lc_str_array_has(out, n) {
               Array::push(out, n)
+              // #2701 (Codex round 4): the `_exp_` / `_dep_` answer is recorded
+              // HERE, where `tag_owner` says which marker carries the tag.
+              // Re-deriving it from the name later cannot be done correctly --
+              // the report has no `tag_owner` -- and doing it by shape put
+              // private names into the exported classifiers.
+              Array::push(out_exp, if n_exp {
+                1
+              } else {
+                0
+              })
               // #2633: and WHY it is missing. The name names its definer, so
               // ask whether that module is in this one's import closure.
               // `cls[0]` counts "the definer IS in the closure" -- the context
@@ -1003,7 +983,7 @@ fn lc_ctx_unresolved_into(part: Array[Stmt], ctx: Array[Stmt], out: Array[String
               // closure is short. `cls[2]` is a name whose definer this run
               // could not identify at all, kept separate rather than folded
               // into either answer.
-              if lc_name_is_exported_mangled(n) {
+              if n_exp {
                 let owner = match MutMap::get(tag_owner, n_tag) {
                   Some(oi) => oi,
                   None => 0 - 1
@@ -5834,7 +5814,7 @@ fn prelude_run_per_module(c: Array[Stmt], c_file_id: Array[Int], file_count: Int
     // #2633: what this module was GIVEN against what it USES, before anything
     // reads the context.
     Array::push(st.an_ctx_sizes, Array::length(ctx))
-    lc_ctx_unresolved_into(part, ctx, st.an_ctx_unresolved, visible, tag_owner, fi, st.an_ctx_cls, ifaces)
+    lc_ctx_unresolved_into(part, ctx, st.an_ctx_unresolved, st.an_ctx_unresolved_exp, visible, tag_owner, fi, st.an_ctx_cls, ifaces)
     let synthesized = desugar_trait_dicts_module_with_facts(part, ctx, "f\{fi}", checker_eq_offsets, checker_eq_type_keys, env.trait_facts)
     lc_union_into(st.requests, eq_synthesis_requests_list())
     lc_union_into(st.refusals, eq_typed_refusals_list())
@@ -6167,6 +6147,7 @@ struct PreludeSplitStats {
   // owner's interface, present in it but skipped by the context loop] for the
   // unresolved EXPORTED names.
   an_ctx_cls: Array[Int];
+  an_ctx_unresolved_exp: Array[Int];
   // #2638: the two fixpoints over `trial` -- concatenated, link-passes applied,
   // NOT folded. Isolates the fold from the link-only passes.
   an_bret_trial: Array[String];
@@ -6216,6 +6197,7 @@ fn prelude_split_stats_new() -> PreludeSplitStats {
     an_ctx_sizes: lc_fresh_int_array(),
     an_ctx_unresolved: lc_fresh_string_array(),
     an_ctx_cls: [0, 0, 0, 0, 0, 0],
+    an_ctx_unresolved_exp: [],
     an_bret_trial: lc_fresh_string_array(),
     an_view_trial: lc_fresh_string_array(),
     an_mrv_names: lc_fresh_string_array(),
@@ -6520,7 +6502,7 @@ export fn prelude_module_full_oracle_line(a: Array[Stmt], c: Array[Stmt], c_file
   let mut cui = 0
   while cui < Array::length(st.an_ctx_unresolved) {
     let n = Array::get(st.an_ctx_unresolved, cui)
-    if lc_name_is_exported_mangled(n) {
+    if cui < Array::length(st.an_ctx_unresolved_exp) && Array::get(st.an_ctx_unresolved_exp, cui) == 1 {
       ctx_unres_exp = ctx_unres_exp + 1
       if first_exp == "" {
         first_exp = n

--- a/lib/@vibe/compiler/codegen/wasi/linked_compile.vibe
+++ b/lib/@vibe/compiler/codegen/wasi/linked_compile.vibe
@@ -708,29 +708,14 @@ fn lc_concat_ints_into(dst: Array[Int], src: Array[Int]) -> Unit {
   }
 }
 
-/// #2633: a name the MERGE mangled with its defining module -- `_exp_lib__`
-/// for an exported declaration, `_dep_lib__` for a private one. Exactly the
-/// program's own cross-module declarations carry these, so a builtin
-/// (`String::concat`, `Array::get`) cannot be mistaken for one and no builtin
-/// allow-list is needed to tell them apart.
 /// #2633: does this module's PUBLISHED interface declare `n`?
 fn lc_iface_declares(iface: Array[Stmt], n: String) -> Bool {
-  let mut i = 0
-  let mut found = false
-  while i < Array::length(iface) {
-    let nm = match Array::get(iface, i) {
-      SLet(_, _, d, _, _) => d,
-      SFnDecl(_, d, _, _, _) => d,
-      _ => ""
-    }
-    if nm == n {
-      found = true
-    } else {
-      ()
-    }
-    i = i + 1
-  }
-  found
+  // Same collector as `lc_decl_names_into`, for the same reason: asking
+  // whether an interface publishes a name has to know that an enum publishes
+  // its constructors too.
+  let names: MutMap[String, Int] = MutMap::new_string()
+  lc_decl_names_into(iface, names)
+  MutMap::has(names, n)
 }
 
 fn lc_int_array_has(xs: Array[Int], v: Int) -> Bool {
@@ -747,8 +732,54 @@ fn lc_int_array_has(xs: Array[Int], v: Int) -> Bool {
   found
 }
 
+/// #2633: whether `n` is a name the MERGE stamped with its defining module.
+///
+/// The merge spells these `name ++ "_exp_" ++ sanitize_namespace_path(path)`
+/// (and `_dep_` for a private one), so the test is the marker plus a tag that
+/// looks like a sanitized path. `sanitize_namespace_path` maps every character
+/// outside `[A-Za-z0-9_]` to `_`, so a `.vibe` path always sanitizes to a tag
+/// ending `_vibe` -- which is what distinguishes a stamped name from a source
+/// identifier that merely contains `_dep_`. A qualified operation carries the
+/// tag before a `::`, so the tail is cut there first. Exactly the program's own
+/// cross-module declarations carry a stamp, so a builtin (`String::concat`,
+/// `Array::get`) cannot be mistaken for one and no builtin allow-list is
+/// needed to tell them apart.
+///
+/// This used to test for the literal `_exp_lib__` / `_dep_lib__`, which is the
+/// same predicate ONLY for files under `lib/`: the `lib__` is nothing but the
+/// sanitized first path segment. Every compiler-closure measurement was
+/// therefore right, and every FIXTURE reading was vacuously zero -- a two-file
+/// program written to `/tmp` gets the tag `_tmp_...`, matches nothing, and
+/// reports a clean context whatever the context actually holds. The all-zero
+/// two-module pin this instrument shipped with could not have failed.
 fn lc_name_is_module_mangled(n: String) -> Bool {
-  String::index_of(n, "_exp_lib__") >= 0 || String::index_of(n, "_dep_lib__") >= 0
+  lc_mangle_tail_is_path(n, "_exp_") || lc_mangle_tail_is_path(n, "_dep_")
+}
+
+/// The tag following `marker` in `n`, cut at a qualifying `::`, tested for the
+/// shape `sanitize_namespace_path` produces for a `.vibe` source path.
+fn lc_mangle_tail_is_path(n: String, marker: String) -> Bool {
+  let at = String::index_of(n, marker)
+  if at < 0 {
+    false
+  } else {
+    let rest = String::substring(n, at + String::length(marker), String::length(n))
+    let cut = String::index_of(rest, "::")
+    let tag = if cut < 0 {
+      rest
+    } else {
+      String::substring(rest, 0, cut)
+    }
+    String::length(tag) > 5 && String::ends_with(tag, "_vibe")
+  }
+}
+
+/// Of a name already known to be merge-stamped, whether the stamp is the
+/// EXPORTED one. Same `lib__`-independence as the predicate above: the split
+/// between "the contract publishes this" and "this is private to its module"
+/// must not depend on where the file happens to live.
+fn lc_name_is_exported_mangled(n: String) -> Bool {
+  lc_mangle_tail_is_path(n, "_exp_")
 }
 
 /// #2633: the MODULE TAG a mangled name carries -- `..._exp_lib__vibe_parser_polyfill_vibe`
@@ -758,11 +789,14 @@ fn lc_name_is_module_mangled(n: String) -> Bool {
 /// cannot drift from whatever spelling the merge actually produced. "" when
 /// the name is not mangled.
 fn lc_mangle_tag_of(n: String) -> String {
-  let e = String::index_of(n, "_exp_lib__")
+  // The marker only -- `lib__` is the sanitized first path segment, not part
+  // of the spelling, and requiring it made every tag outside `lib/` read "".
+  // The `+ 5` skips `_exp_` / `_dep_`, so the tag is the sanitized path.
+  let e = String::index_of(n, "_exp_")
   if e >= 0 {
     String::substring(n, e + 5, String::length(n))
   } else {
-    let d = String::index_of(n, "_dep_lib__")
+    let d = String::index_of(n, "_dep_")
     if d >= 0 {
       String::substring(n, d + 5, String::length(n))
     } else {
@@ -792,6 +826,17 @@ fn lc_module_tag_of(part: Array[Stmt]) -> String {
   ""
 }
 
+/// Every top-level name a statement list DECLARES -- values AND types AND
+/// their constructors.
+///
+/// The constructor arms are not decoration. `AvlNode` is a variant of the enum
+/// `AvlTree`, and the merge mangles variants like any other cross-module name;
+/// a collector that saw only `SLet` / `SFnDecl` reported every constructor
+/// reference as a name nobody declared -- including inside the very module
+/// that declares the enum. That is the same defect this instrument was built
+/// to find, one level up, and it was inflating the counts it reports until
+/// the `_dep_` head (`AvlNode_dep_lib__vibe_core_sortedmap_vibe`) gave it
+/// away.
 fn lc_decl_names_into(stmts: Array[Stmt], into: MutMap[String, Int]) -> Unit {
   let mut i = 0
   while i < Array::length(stmts) {
@@ -799,6 +844,26 @@ fn lc_decl_names_into(stmts: Array[Stmt], into: MutMap[String, Int]) -> Unit {
       SLet(_, _, n, _, _) => MutMap::set(into, n, 1),
       SLetMut(n, _, _) => MutMap::set(into, n, 1),
       SFnDecl(_, n, _, _, _) => MutMap::set(into, n, 1),
+      SStruct(_, n, _, _, _, _) => MutMap::set(into, n, 1),
+      STypeAlias(_, n, _, _) => MutMap::set(into, n, 1),
+      SEnum(_, n, _, variants, _) => {
+        MutMap::set(into, n, 1)
+        let mut vi = 0
+        while vi < Array::length(variants) {
+          let (vn, _) = Array::get(variants, vi)
+          MutMap::set(into, vn, 1)
+          vi = vi + 1
+        }
+      },
+      SSuberror(_, n, variants) => {
+        MutMap::set(into, n, 1)
+        let mut vi = 0
+        while vi < Array::length(variants) {
+          let (vn, _) = Array::get(variants, vi)
+          MutMap::set(into, vn, 1)
+          vi = vi + 1
+        }
+      },
       _ => ()
     }
     i = i + 1
@@ -849,7 +914,7 @@ fn lc_ctx_unresolved_into(part: Array[Stmt], ctx: Array[Stmt], out: Array[String
               // closure is short. `cls[2]` is a name whose definer this run
               // could not identify at all, kept separate rather than folded
               // into either answer.
-              if String::index_of(n, "_exp_lib__") >= 0 {
+              if lc_name_is_exported_mangled(n) {
                 let owner = match MutMap::get(tag_owner, lc_mangle_tag_of(n)) {
                   Some(oi) => oi,
                   None => 0 - 1
@@ -6347,7 +6412,7 @@ export fn prelude_module_full_oracle_line(a: Array[Stmt], c: Array[Stmt], c_file
   let mut cui = 0
   while cui < Array::length(st.an_ctx_unresolved) {
     let n = Array::get(st.an_ctx_unresolved, cui)
-    if String::index_of(n, "_exp_lib__") >= 0 {
+    if lc_name_is_exported_mangled(n) {
       ctx_unres_exp = ctx_unres_exp + 1
       if first_exp == "" {
         first_exp = n

--- a/lib/@vibe/compiler/codegen/wasi/linked_compile.vibe
+++ b/lib/@vibe/compiler/codegen/wasi/linked_compile.vibe
@@ -28,6 +28,7 @@ import @vibe/compiler/core {
   is_exception_effect_name,
   leb128_encode_s64,
   leb128_encode_u32,
+  namespace_private_name,
   namespace_rename_originals_reset,
   rewrite_import_alias_expr,
   rewrite_top_level_fn_alias_refs,
@@ -776,6 +777,43 @@ fn lc_name_is_exported_mangled(n: String) -> Bool {
   lc_mangle_tail_is_path(n, "_exp_")
 }
 
+/// #2701 (Codex round 3): the registered tag a name is stamped with, or "".
+///
+/// A stamp is a SUFFIX, so the marker that introduces it is the LAST one whose
+/// tail is a tag some module actually carries -- not the first `_exp_` in the
+/// string. Both failure modes of first-occurrence parsing are closed here:
+///
+///   render_exp_cache_vibe                    no tail is a registered tag -> ""
+///   render_exp_cache_vibe_exp__tmp_dep_vibe  the LAST marker gives the real tag
+///
+/// The first is a legal source identifier in an entry module, which is never
+/// stamped at all; the second is a genuinely stamped name whose SOURCE name
+/// happens to contain the marker, which first-occurrence parsing resolved to a
+/// tag nobody carries and therefore dropped silently.
+///
+/// Matching against registered tags rather than a shape is what makes this
+/// exact: `tag_owner` is built from module PATHS through the merge's own
+/// mangler, so a tail either is a module's tag or it is not.
+fn lc_registered_tag_of(n: String, tag_owner: MutMap[String, Int]) -> String {
+  let mut best = ""
+  let mut i = 0
+  while i < String::length(n) {
+    let is_marker = (String::char_code_at(n, i) == '_') && (i + 5 <= String::length(n)) && (String::substring(n, i, i + 5) == "_exp_" || String::substring(n, i, i + 5) == "_dep_")
+    if is_marker {
+      let tag = lc_cut_at_qualifier(String::substring(n, i + 5, String::length(n)))
+      if MutMap::has(tag_owner, tag) {
+        best = tag
+      } else {
+        ()
+      }
+    } else {
+      ()
+    }
+    i = i + 1
+  }
+  best
+}
+
 /// #2633: the MODULE TAG a mangled name carries -- `..._exp_lib__vibe_parser_polyfill_vibe`
 /// yields `lib__vibe_parser_polyfill_vibe`, and `_dep_` the same.
 ///
@@ -792,17 +830,28 @@ fn lc_mangle_tag_of(n: String) -> String {
   // `::op`, misses `tag_owner`, and the name is counted `exp_unknown` instead
   // of being placed -- and worse, `lc_module_tag_of` would register that
   // spelling as the module's own tag if such a declaration came first.
-  let e = String::index_of(n, "_exp_")
-  if e >= 0 {
-    lc_cut_at_qualifier(String::substring(n, e + 5, String::length(n)))
-  } else {
-    let d = String::index_of(n, "_dep_")
-    if d >= 0 {
-      lc_cut_at_qualifier(String::substring(n, d + 5, String::length(n)))
+  // Scanned RIGHT TO LEFT, because a stamp is a SUFFIX. Taking the first
+  // `_exp_` reads a tag out of the SOURCE name when that name contains the
+  // marker itself: `render_exp_cache_vibe_exp__tmp_dep_vibe` is stamped with
+  // `_tmp_dep_vibe`, and first-occurrence parsing answered
+  // `cache_vibe_exp__tmp_dep_vibe` -- a tag no module carries, so every
+  // reference to it was dropped without trace (Codex round 3 on #2701).
+  let mut best = ""
+  let mut i = 0
+  while i < String::length(n) {
+    if (i + 5 <= String::length(n)) && (String::substring(n, i, i + 5) == "_exp_" || String::substring(n, i, i + 5) == "_dep_") {
+      let tag = lc_cut_at_qualifier(String::substring(n, i + 5, String::length(n)))
+      if String::length(tag) > 5 && String::ends_with(tag, "_vibe") {
+        best = tag
+      } else {
+        ()
+      }
     } else {
-      ""
+      ()
     }
+    i = i + 1
   }
+  best
 }
 
 /// `s` up to the first `::`, or all of it.
@@ -938,7 +987,8 @@ fn lc_ctx_unresolved_into(part: Array[Stmt], ctx: Array[Stmt], out: Array[String
             // report the scan exercising cross-module names it never saw. A
             // denominator that can be inflated by a plausible function name is
             // worth no more than the zero it was added to qualify.
-            let stamped = lc_name_is_module_mangled(n) && MutMap::has(tag_owner, lc_mangle_tag_of(n))
+            let n_tag = lc_registered_tag_of(n, tag_owner)
+            let stamped = n_tag != ""
             if stamped {
               Array::set(cls, 5, Array::get(cls, 5) + 1)
             } else {
@@ -954,7 +1004,7 @@ fn lc_ctx_unresolved_into(part: Array[Stmt], ctx: Array[Stmt], out: Array[String
               // could not identify at all, kept separate rather than folded
               // into either answer.
               if lc_name_is_exported_mangled(n) {
-                let owner = match MutMap::get(tag_owner, lc_mangle_tag_of(n)) {
+                let owner = match MutMap::get(tag_owner, n_tag) {
                   Some(oi) => oi,
                   None => 0 - 1
                 }
@@ -5669,10 +5719,29 @@ fn prelude_run_per_module(c: Array[Stmt], c_file_id: Array[Int], file_count: Int
   // #2633: which module each mangle tag belongs to, so an unresolved name can
   // be asked WHERE it was defined and whether that module is in the closure of
   // the one that used it.
+  //
+  // Built from the module PATHS through the merge's own mangler when the
+  // caller supplies them (the oracle does; production passes none because it
+  // emits no CTX line). Reading a tag off the path is exact; recovering it by
+  // parsing a declaration NAME is not, and doing so let an entry module
+  // register a tag derived from a legal source identifier -- which then made
+  // the membership test below certify the very name it was added to reject
+  // (Codex round 3 on #2701).
   let tag_owner: MutMap[String, Int] = MutMap::new_string()
   let mut tf = 0
   while tf < file_count {
-    let t = lc_module_tag_of(Array::get(parts, tf))
+    // The ENTRY module is excluded, and that is the fix rather than a
+    // shortcut (Codex round 3 on #2701). Entry declarations are never stamped,
+    // so any tag recovered from one is spurious by construction -- a legal
+    // `render_exp_cache_vibe` yields `cache_vibe`, which would then be
+    // registered as a real tag and make the membership test certify the very
+    // name it exists to reject. Skipping it needs no new information: the
+    // entry module is already identified, as `entry_fid`.
+    let t = if tf == entry_fid {
+      ""
+    } else {
+      lc_module_tag_of(Array::get(parts, tf))
+    }
     if t != "" && !MutMap::has(tag_owner, t) {
       MutMap::set(tag_owner, t, tf)
     } else {

--- a/lib/@vibe/compiler/codegen/wasi/linked_compile.vibe
+++ b/lib/@vibe/compiler/codegen/wasi/linked_compile.vibe
@@ -763,13 +763,7 @@ fn lc_mangle_tail_is_path(n: String, marker: String) -> Bool {
   if at < 0 {
     false
   } else {
-    let rest = String::substring(n, at + String::length(marker), String::length(n))
-    let cut = String::index_of(rest, "::")
-    let tag = if cut < 0 {
-      rest
-    } else {
-      String::substring(rest, 0, cut)
-    }
+    let tag = lc_cut_at_qualifier(String::substring(n, at + String::length(marker), String::length(n)))
     String::length(tag) > 5 && String::ends_with(tag, "_vibe")
   }
 }
@@ -792,16 +786,32 @@ fn lc_mangle_tag_of(n: String) -> String {
   // The marker only -- `lib__` is the sanitized first path segment, not part
   // of the spelling, and requiring it made every tag outside `lib/` read "".
   // The `+ 5` skips `_exp_` / `_dep_`, so the tag is the sanitized path.
+  //
+  // Cut at `::` exactly as the predicate does. A qualified operation is spelled
+  // `ns ++ "_exp_" ++ path ++ "::" ++ op`, so without the cut the tag carries
+  // `::op`, misses `tag_owner`, and the name is counted `exp_unknown` instead
+  // of being placed -- and worse, `lc_module_tag_of` would register that
+  // spelling as the module's own tag if such a declaration came first.
   let e = String::index_of(n, "_exp_")
   if e >= 0 {
-    String::substring(n, e + 5, String::length(n))
+    lc_cut_at_qualifier(String::substring(n, e + 5, String::length(n)))
   } else {
     let d = String::index_of(n, "_dep_")
     if d >= 0 {
-      String::substring(n, d + 5, String::length(n))
+      lc_cut_at_qualifier(String::substring(n, d + 5, String::length(n)))
     } else {
       ""
     }
+  }
+}
+
+/// `s` up to the first `::`, or all of it.
+fn lc_cut_at_qualifier(s: String) -> String {
+  let cut = String::index_of(s, "::")
+  if cut < 0 {
+    s
+  } else {
+    String::substring(s, 0, cut)
   }
 }
 
@@ -811,9 +821,17 @@ fn lc_mangle_tag_of(n: String) -> String {
 fn lc_module_tag_of(part: Array[Stmt]) -> String {
   let mut i = 0
   while i < Array::length(part) {
+    // Every declaration form the merge stamps, not just the value ones: a
+    // module declaring only an enum would otherwise register no tag, and
+    // `tag_owner` is what decides whether a stamped name can be placed.
     let t = match Array::get(part, i) {
       SLet(_, _, n, _, _) => lc_mangle_tag_of(n),
+      SLetMut(n, _, _) => lc_mangle_tag_of(n),
       SFnDecl(_, n, _, _, _) => lc_mangle_tag_of(n),
+      SStruct(_, n, _, _, _, _) => lc_mangle_tag_of(n),
+      STypeAlias(_, n, _, _) => lc_mangle_tag_of(n),
+      SEnum(_, n, _, _, _) => lc_mangle_tag_of(n),
+      SSuberror(_, n, _) => lc_mangle_tag_of(n),
       _ => ""
     }
     if t != "" {
@@ -911,12 +929,22 @@ fn lc_ctx_unresolved_into(part: Array[Stmt], ctx: Array[Stmt], out: Array[String
             // nothing at all -- which is exactly how the original two-module
             // pin passed while being incapable of failing, and how it stayed
             // that way through two attempts to red-test it.
-            if lc_name_is_module_mangled(n) {
+            //
+            // The tag is checked against the tags modules ACTUALLY carry, not
+            // against a name shape (Codex on #2701). `_exp_` / `_dep_` plus a
+            // `_vibe` tail is a legal source identifier -- an entry-module
+            // `render_exp_cache_vibe` has it and is never renamed, entry
+            // declarations not being stamped at all -- so a shape test would
+            // report the scan exercising cross-module names it never saw. A
+            // denominator that can be inflated by a plausible function name is
+            // worth no more than the zero it was added to qualify.
+            let stamped = lc_name_is_module_mangled(n) && MutMap::has(tag_owner, lc_mangle_tag_of(n))
+            if stamped {
               Array::set(cls, 5, Array::get(cls, 5) + 1)
             } else {
               ()
             }
-            if lc_name_is_module_mangled(n) && !MutMap::has(have, n) && !lc_str_array_has(out, n) {
+            if stamped && !MutMap::has(have, n) && !lc_str_array_has(out, n) {
               Array::push(out, n)
               // #2633: and WHY it is missing. The name names its definer, so
               // ask whether that module is in this one's import closure.

--- a/lib/@vibe/compiler/codegen/wasi/linked_compile.vibe
+++ b/lib/@vibe/compiler/codegen/wasi/linked_compile.vibe
@@ -905,6 +905,17 @@ fn lc_ctx_unresolved_into(part: Array[Stmt], ctx: Array[Stmt], out: Array[String
           let mut fj = 0
           while fj < Array::length(fv) {
             let n = Array::get(fv, fj)
+            // #2633: the DENOMINATOR. `cls[5]` counts every merge-stamped name
+            // this scan looked at, resolved or not. Without it an
+            // `unresolved=0` cannot be told apart from a scan that matched
+            // nothing at all -- which is exactly how the original two-module
+            // pin passed while being incapable of failing, and how it stayed
+            // that way through two attempts to red-test it.
+            if lc_name_is_module_mangled(n) {
+              Array::set(cls, 5, Array::get(cls, 5) + 1)
+            } else {
+              ()
+            }
             if lc_name_is_module_mangled(n) && !MutMap::has(have, n) && !lc_str_array_has(out, n) {
               Array::push(out, n)
               // #2633: and WHY it is missing. The name names its definer, so
@@ -6107,7 +6118,7 @@ fn prelude_split_stats_new() -> PreludeSplitStats {
     an_bret_seed: lc_fresh_int_array(),
     an_ctx_sizes: lc_fresh_int_array(),
     an_ctx_unresolved: lc_fresh_string_array(),
-    an_ctx_cls: [0, 0, 0, 0, 0],
+    an_ctx_cls: [0, 0, 0, 0, 0, 0],
     an_bret_trial: lc_fresh_string_array(),
     an_view_trial: lc_fresh_string_array(),
     an_mrv_names: lc_fresh_string_array(),
@@ -6453,6 +6464,11 @@ export fn prelude_module_full_oracle_line(a: Array[Stmt], c: Array[Stmt], c_file
   ctx_line = String::concat(ctx_line, Int::to_string(Array::get(st.an_ctx_cls, 3)))
   ctx_line = String::concat(ctx_line, " filt_own_key_skip=")
   ctx_line = String::concat(ctx_line, Int::to_string(Array::get(st.an_ctx_cls, 4)))
+  // The denominator for both `unresolved` counts: merge-stamped names this
+  // scan actually looked at. `unresolved_*=0` with `seen=0` says the scan
+  // matched nothing and the zeros mean nothing.
+  ctx_line = String::concat(ctx_line, " seen=")
+  ctx_line = String::concat(ctx_line, Int::to_string(Array::get(st.an_ctx_cls, 5)))
   ctx_line = String::concat(ctx_line, "\n")
   let an_line = String::concat(String::concat(String::concat(an_head, an_cols), "\n"), ctx_line)
   let line = String::concat(String::concat(head, mid), tail)

--- a/lib/@vibe/compiler/tests/prelude_module_oracle_test.vibe
+++ b/lib/@vibe/compiler/tests/prelude_module_oracle_test.vibe
@@ -808,3 +808,31 @@ test "a report's deferrals are its own, not the previous report's" {
   Fs::write_file(main2, "import ./vibe_defer_reset_dep2.vibe {\n  twice\n}\n\ntest \"t\" {\n  inspect(twice(2), content = \"4\")\n}\n")
   inspect(String::trim(synth_line_of(prelude_module_full_oracle_report_fs(main2, "__no_entry__"))), content = "SYNTH requests=0 typed_refused=0 deferred=0 minted=0 indirect=0")
 }
+
+test "a type declaration counts as declaring its own name, and an enum its constructors" {
+  let dep = "/tmp/vibe_ctx_typedecl_dep.vibe"
+  let main = "/tmp/vibe_ctx_typedecl_main.vibe"
+  // Every shape the collector has to know about, in one module: an exported
+  // enum whose constructors are used BOTH by its own module and across the
+  // boundary, a private enum used only at home, an exported struct, and a type
+  // alias naming the enum.
+  Fs::write_file(dep, "export enum Hue {\n  Crimson;\n  Azure\n}\n\nexport type Shade = Hue\n\nexport struct Paint {\n  hue: Hue\n}\n\nenum Secret {\n  Hidden(Int)\n}\n\nfn secret_of(n: Int) -> Int {\n  match Hidden(n) {\n    Hidden(v) => v\n  }\n}\n\nexport fn default_paint() -> Paint {\n  Paint::{ hue: Crimson }\n}\n\nexport fn home_use() -> Int {\n  let s: Shade = Azure\n  match s {\n    Crimson => secret_of(1)\n    Azure => secret_of(2)\n  }\n}\n")
+  Fs::write_file(main, "import ./vibe_ctx_typedecl_dep.vibe {\n  Hue, Paint, Crimson, Azure, default_paint, home_use\n}\n\nfn away_use() -> Int {\n  let p: Paint = default_paint()\n  match p.hue {\n    Crimson => 10\n    Azure => 20\n  }\n}\n\ntest \"t\" {\n  inspect(away_use() + home_use(), content = \"12\")\n}\n")
+  let report = prelude_module_full_oracle_report_fs(main, "__no_entry__")
+  // Zero on both halves, and this program is the reason the pin exists.
+  //
+  // `lc_decl_names_into` used to collect only `SLet` / `SLetMut` / `SFnDecl`,
+  // so a module that declares `enum Hue { Crimson; Azure }` and then WRITES
+  // `Crimson` was reported as using a name nobody declared -- in its own
+  // module. The all-zero two-module pin above could not see that: it declares
+  // no type at all, so the instrument's blind spot and a genuinely complete
+  // context read identically there.
+  //
+  // On the compiler's own closure the same defect was the WHOLE of the `_dep_`
+  // residue: 67 names, of which `AvlNode` (a constructor of `enum AvlTree` in
+  // `lib/@vibe/core/sortedmap.vibe`) was the head, and the corrected
+  // instrument reports 0. The `_exp_` count (83) did not move, because that
+  // half has a different cause -- all 83 are `exp_outside`, so the definer is
+  // not in the closure at all and no collector can reach them.
+  inspect(String::trim(ctx_line_of(report)), content = "CTX decls=5 modules=2 zero=1 unresolved_exp=0: unresolved_dep=0: exp_in_closure=0 exp_outside=0 exp_unknown=0 filt_not_published=0 filt_own_key_skip=0")
+}

--- a/lib/@vibe/compiler/tests/prelude_module_oracle_test.vibe
+++ b/lib/@vibe/compiler/tests/prelude_module_oracle_test.vibe
@@ -385,10 +385,19 @@ test "the whole prelude per module reproduces the whole-program prelude" {
   // was being detected. The remaining 83 are the other cause (the closure does
   // not reach the definer) and are untouched by this.
   //
-  // Zero here on a two-module program, which is the point of pinning it: those
-  // numbers could otherwise be the instrument miscounting rather than the
-  // context missing.
-  inspect(String::trim(ctx_line_of(report)), content = "CTX decls=1 modules=2 zero=1 unresolved_exp=0: unresolved_dep=0: exp_in_closure=0 exp_outside=0 exp_unknown=0 filt_not_published=0 filt_own_key_skip=0")
+  // `seen=0` is the honest reading of this pin, and it is pinned BECAUSE it is
+  // zero. `seen` counts the merge-stamped names the scan looked at, so this
+  // program gives it nothing to look at and its two `unresolved` zeros assert
+  // nothing whatever about the context rule.
+  //
+  // This pin was cited (in #2696) as the control backing the closure numbers --
+  // "without a program where the instrument reads zero, 118 and 67 could be the
+  // instrument miscounting rather than the context missing". It never was one:
+  // an all-zero assertion is worth nothing until the same assertion has been
+  // seen non-zero, and nothing here can move it. The test below is the control;
+  // this one is kept, with `seen` exposed, so the difference is visible rather
+  // than inferred.
+  inspect(String::trim(ctx_line_of(report)), content = "CTX decls=1 modules=2 zero=1 unresolved_exp=0: unresolved_dep=0: exp_in_closure=0 exp_outside=0 exp_unknown=0 filt_not_published=0 filt_own_key_skip=0 seen=0")
   // #2388: the VALIDATING passes, which produce diagnostics rather than
   // rewrites and are therefore invisible to a comparison keyed on
   // declarations. `0` here is both lanes silent on a clean program; the test
@@ -816,23 +825,36 @@ test "a type declaration counts as declaring its own name, and an enum its const
   // enum whose constructors are used BOTH by its own module and across the
   // boundary, a private enum used only at home, an exported struct, and a type
   // alias naming the enum.
-  Fs::write_file(dep, "export enum Hue {\n  Crimson;\n  Azure\n}\n\nexport type Shade = Hue\n\nexport struct Paint {\n  hue: Hue\n}\n\nenum Secret {\n  Hidden(Int)\n}\n\nfn secret_of(n: Int) -> Int {\n  match Hidden(n) {\n    Hidden(v) => v\n  }\n}\n\nexport fn default_paint() -> Paint {\n  Paint::{ hue: Crimson }\n}\n\nexport fn home_use() -> Int {\n  let s: Shade = Azure\n  match s {\n    Crimson => secret_of(1)\n    Azure => secret_of(2)\n  }\n}\n")
+  Fs::write_file(dep, "export enum Hue {\n  Crimson;\n  Azure\n}\n\nexport type Shade = Hue\n\nexport struct Paint {\n  hue: Hue\n}\n\nenum Secret {\n  Hidden(Int)\n}\n\nfn make_secret(n: Int) -> Secret {\n  Hidden(n)\n}\n\nfn secret_of(n: Int) -> Int {\n  let s = make_secret(n)\n  match s {\n    Hidden(v) => v\n  }\n}\n\nexport fn default_paint() -> Paint {\n  Paint::{ hue: Crimson }\n}\n\nexport fn home_use() -> Int {\n  let s: Shade = Azure\n  match s {\n    Crimson => secret_of(1)\n    Azure => secret_of(2)\n  }\n}\n")
   Fs::write_file(main, "import ./vibe_ctx_typedecl_dep.vibe {\n  Hue, Paint, Crimson, Azure, default_paint, home_use\n}\n\nfn away_use() -> Int {\n  let p: Paint = default_paint()\n  match p.hue {\n    Crimson => 10\n    Azure => 20\n  }\n}\n\ntest \"t\" {\n  inspect(away_use() + home_use(), content = \"12\")\n}\n")
   let report = prelude_module_full_oracle_report_fs(main, "__no_entry__")
-  // Zero on both halves, and this program is the reason the pin exists.
+  // The control for the CTX line: `seen=4` says the scan had four
+  // merge-stamped names to judge, and both `unresolved` counts are zero
+  // because the contexts really do supply them.
   //
-  // `lc_decl_names_into` used to collect only `SLet` / `SLetMut` / `SFnDecl`,
-  // so a module that declares `enum Hue { Crimson; Azure }` and then WRITES
-  // `Crimson` was reported as using a name nobody declared -- in its own
-  // module. The all-zero two-module pin above could not see that: it declares
-  // no type at all, so the instrument's blind spot and a genuinely complete
-  // context read identically there.
+  // Red-tested as a 2x2 over the two defects this fixture pins, measured by
+  // mutating the source and re-running (2026-09-12):
   //
-  // On the compiler's own closure the same defect was the WHOLE of the `_dep_`
-  // residue: 67 names, of which `AvlNode` (a constructor of `enum AvlTree` in
-  // `lib/@vibe/core/sortedmap.vibe`) was the head, and the corrected
-  // instrument reports 0. The `_exp_` count (83) did not move, because that
-  // half has a different cause -- all 83 are `exp_outside`, so the definer is
-  // not in the closure at all and no collector can reach them.
-  inspect(String::trim(ctx_line_of(report)), content = "CTX decls=5 modules=2 zero=1 unresolved_exp=0: unresolved_dep=0: exp_in_closure=0 exp_outside=0 exp_unknown=0 filt_not_published=0 filt_own_key_skip=0")
+  //   predicate  collector | result
+  //   old        old       | seen=0  unresolved_dep=0   the defect is INVISIBLE
+  //   new        old       | seen=4  unresolved_dep=1:Hidden_dep__tmp_..._vibe
+  //   new        new       | seen=4  unresolved_dep=0   (this pin)
+  //
+  // Both fixes are load-bearing, and the top row is why the pin above proves
+  // nothing. `lc_decl_names_into` used to collect only `SLet` / `SLetMut` /
+  // `SFnDecl`, so a module declaring `enum Secret { Hidden(Int) }` and then
+  // writing `Hidden` was reported as using a name nobody declared -- in its own
+  // module. `lc_name_is_module_mangled` used to require the literal
+  // `_dep_lib__`, so this program (written to `/tmp`, hence the tag
+  // `_tmp_..._vibe`) matched nothing and reported a clean context regardless.
+  //
+  // On the compiler's own closure the collector defect was the WHOLE of the
+  // `_dep_` residue: 67 names, headed by `AvlNode` (a constructor of
+  // `enum AvlTree` in `lib/@vibe/core/sortedmap.vibe`), corrected to 0. The
+  // `_exp_` count (83) did not move, because that half has a different cause --
+  // all 83 are `exp_outside`, so the definer is not in the closure at all and
+  // no collector can reach them. Relaxing the predicate left every closure
+  // column byte-identical, which is the check that it did not widen what
+  // counts as a stamped name on real code.
+  inspect(String::trim(ctx_line_of(report)), content = "CTX decls=5 modules=2 zero=1 unresolved_exp=0: unresolved_dep=0: exp_in_closure=0 exp_outside=0 exp_unknown=0 filt_not_published=0 filt_own_key_skip=0 seen=4")
 }


### PR DESCRIPTION
Advances #2633 (blocks #2575 item 2). Oracle only — no production code is touched (`use_split` is false at every production caller).

Five defects in the instrument itself, each found by the one before it. Three were mine to start with; two more came from review of the fix.

## 1. The collector did not count type declarations

`lc_decl_names_into` collected only `SLet` / `SLetMut` / `SFnDecl`. The merge mangles an enum variant like any other cross-module name, so `enum AvlTree { AvlNode(..) .. }` in `lib/@vibe/core/sortedmap.vibe` made `AvlNode_dep_lib__vibe_core_sortedmap_vibe` read as a name nobody declared — **inside sortedmap itself**.

That was the whole of the reported `_dep_` residue:

```
unresolved_dep=67:AvlNode_dep_lib__vibe_core_sortedmap_vibe   →   unresolved_dep=0:
```

Those 67 were published three times on the issue and in merged #2696 as "a private name escaping its module". **There is no leak.**

`unresolved_exp` stays at 83, which is the check that the widening is confined: `have` is built from the module's own statements plus its context, so a name resolves only where something declares it. Since `oracle_is_interface_stmt` *does* admit exported enums the fix could have moved the `_exp_` half — it did not, because all 83 are `exp_outside` (the definer is not in the closure at all).

`lc_iface_declares` gets the same collector: asking whether an interface publishes a name has to know that an enum publishes its constructors.

## 2. The mangled-name predicate was testing a path prefix

`lc_name_is_module_mangled` tested for the literal `_exp_lib__` / `_dep_lib__`. The merge spells a stamp `name ++ "_exp_" ++ sanitize_namespace_path(path)`, so **the `lib__` is nothing but the sanitized first path segment** — right for files under `lib/`, blind everywhere else. A fixture written to `/tmp` gets the tag `_tmp_...`, matches nothing, and reports a clean context whatever the context holds.

## 3. The control could not fail

The CTX line now carries `seen`: the merge-stamped names the scan actually looked at. `unresolved=0 seen=0` is a scan that matched nothing; `unresolved=0 seen=4` is an answer.

Measured on the two-module fixture #2696 called the control — *"without a program where the instrument reads zero, 118 and 67 could be the instrument miscounting rather than the context missing"*:

```
seen=0
```

It gave the scan nothing to look at. Its zeros asserted nothing and could not move. It is kept, with `seen` exposed, so the difference is visible rather than inferred; the type-declaration fixture is the control now.

## 4 & 5. From review (Codex), both real

**A name shape is not a merge stamp.** `_exp_` / `_dep_` plus a `_vibe` tail is a legal source identifier — an entry-module `render_exp_cache_vibe` has it and is never stamped, entry declarations not being renamed — so the shape test counted references to it and inflated `seen`. A denominator a plausible function name can inflate is worth no more than the zero it was added to qualify. The scan now requires the tag to be one a module **actually carries** (`tag_owner`), the authoritative set.

That fix had a trap: `lc_module_tag_of` builds `tag_owner` and read only `SLet` / `SFnDecl`, so a module declaring **only** an enum registered no tag and its stamped names would have gone untestable the moment membership became the test — the same omission as defect 1, one level further out. Fixed together.

**The tag was not cut at `::` although the predicate cuts there.** My own call, kept "minimal" to reduce risk right after relaxing the predicate, which instead made the two disagree about the same string. Beyond the `exp_unknown` miscount: `lc_module_tag_of` takes the first stamped declaration's tag as *the module's* tag, so a qualified operation appearing first would register `_..._vibe::op` and poison `tag_owner` for every lookup against that module. Both paths now go through one `lc_cut_at_qualifier`.

## The red test, and the two that were invalid

```
predicate  collector | result
old        old       | seen=0  unresolved_dep=0   the defect is INVISIBLE
new        old       | seen=4  unresolved_dep=1:Hidden_dep__tmp_vibe_ctx_typedecl_dep_vibe
new        new       | seen=4  unresolved_dep=0   (the pin)
```

Both fixes are load-bearing, and the top row is the state that shipped.

Two earlier attempts reported GREEN and were **invalid experiments**, worth recording because the failure looks exactly like a negative result. `vibe test` resolves the test's imports from the filesystem, so the oracle code that runs is the working tree's — not the compiler wasm passed via `VIBE_TEST_CLI_WASM`, which only compiles the test. Mutating the tree, building a stage2, then restoring the tree before probing measured unmutated code both times. A build predating the `seen` counter printing `seen=4` is what gave it away. The mutation has to be in the tree **when the probe runs**, which also makes it free — no rebuild is involved.

## Verification

Compiler CLI closure, byte-identical on every column across both the predicate relaxation and the review fixes:

```
CTX decls=121778 modules=366 zero=36 unresolved_exp=83 unresolved_dep=0
    exp_in_closure=0 exp_outside=83 exp_unknown=0
    filt_not_published=0 filt_own_key_skip=0 seen=25458
```

83 unresolved out of 25 458 stamped names judged — the first time that zero has had a scale attached.

| check | result |
|---|---|
| `scripts/compiler_gate.sh` | `[compiler-gate] ok`, exit 0 on `5894622`; re-running on `e5ea478` |
| gate self-tests (#2248) | `passed: 5, failed: 0`; all 10 cases ok |
| `prelude_module_oracle_test.vibe` | 10 tests pass |
| `vibe check` / `vibe_fmt --check` | clean |
| red test | the 2x2 above, re-run after the review fixes and still red |
| closure re-measurement | byte-identical, twice |

No output-equivalence run: the diff touches only `prelude_module_full_oracle_line` and its stats struct, which production never reaches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NAeZzkckdAwtQiubBFpdmM