### PR TITLE
#2669 slice 1 follow-up: five review fixes that missed the #2702 merge, including one that invalidates a claim now in main

### DIFF
--- a/docs/incremental-build.md
+++ b/docs/incremental-build.md
@@ -677,21 +677,41 @@ assumed to be one byte wide. That is what made its coverage measurable rather
 than asserted. `scripts/reloc_roundtrip.sh` runs it over whole modules and
 requires an identity rebuild to be byte-identical:
 
-| module | bodies | sites | func | type | global | tag | blocktype | mismatches |
+| module | bodies | sites | func | type | global | table | tag | mismatches |
 |---|---:|---:|---:|---:|---:|---:|---:|---:|
-| the compiler's own stage2 | 6681 | 142,360 | 101,449 | 1315 | 38,616 | 980 | 0 | 0 |
-| a linear probe | 14 | 47 | 28 | 0 | 19 | 0 | 0 | 0 |
-| a gc-lane probe | 61 | 142 | 78 | 2 | 62 | 0 | 0 | 0 |
+| the compiler's own stage2 | 6681 | 143,675 | 101,449 | 1315 | 38,616 | 1315 | 980 | 0 |
+| a linear probe | 13 | 51 | 34 | 0 | 17 | 0 | 0 | 0 |
+| a gc-lane probe | 61 | 151 | 75 | 14 | 62 | 0 | 0 | 0 |
+
+Nine reference kinds are recorded: function, type, global, table, tag,
+blocktype, heap type, data segment and element segment. **Every immediate the
+decoder reads goes through either a recording helper or a NAMED skip
+helper** — `skip_local_index`, `skip_literal_uleb`, `skip_literal_sleb` — for
+a reason the review history makes concrete: four classes were found missing
+one at a time (tags, blocktypes, table indices, segment indices), and in every
+case the miss looked like `let (_, p) = read_uleb_at(...)`, which is
+indistinguishable from a reference someone forgot. With the immediates
+classified, `_` is not a shape the code offers.
 
 The per-kind breakdown is printed rather than just the total, because a kind
-that never appears is a code path no real input exercised — worth seeing
-rather than assuming. Two are in that position: **blocktype type indices and
-table indices appear in none of these modules**, so their only coverage is a
-synthetic test case, and the tests say so where they sit. A blocktype that is
-a type index is the s33 case `emit_if_type_index` emits for the gc backend's
-`gc_native_array_block_type_idx`; it rebuilds through a SIGNED writer, because
-type index 64 is `0x40` unsigned and a lone `0x40` sleb byte reads back as
-−64, an "empty" blocktype — a different instruction.
+that never appears is a code path no real input exercised. Four are in that
+position — blocktype, heap type, data and element segment indices read zero on
+every module here — so their only coverage is synthetic, and the tests say so
+where they sit.
+
+**The oracle can report success while scanning the wrong region**, which is
+the sharpest thing this exercise established and the reason "it round-trips"
+is not sufficient on its own. The locals header decides where the first
+instruction is, and a version of that walk which advanced a fixed byte per
+local group was wrong for the gc backend's typed reference locals
+(`0x63 <typeidx>`, `backend_body.vibe`). Measured on a probe that has three
+such local groups: the broken walk started one byte early, read the type index
+as an instruction, resynchronised, and produced a **different but
+self-consistent** classification — one type site reported as a blocktype
+site — with `identity_mismatch=0`. It passed. The probe in
+`scripts/reloc_roundtrip.sh` was then rewritten to contain such locals,
+because the previous one had none: a probe that cannot reach a construct is
+not coverage of it.
 
 The linear lanes passed on the first run; the first gc-lane module refused
 `0xfb` by name, which is how the wasm-gc opcode family got added rather than

--- a/lib/@vibe/compiler/codegen/reloc/index.vpkg
+++ b/lib/@vibe/compiler/codegen/reloc/index.vpkg
@@ -40,6 +40,12 @@ let reloc_kind_tag: Int
 
 let reloc_kind_blocktype: Int
 
+let reloc_kind_heaptype: Int
+
+let reloc_kind_data: Int
+
+let reloc_kind_elem: Int
+
 fn body_relocs_new() -> BodyRelocs
 
 fn body_relocs_count(r: BodyRelocs) -> Int

--- a/lib/@vibe/compiler/codegen/reloc/reloc_scan.vibe
+++ b/lib/@vibe/compiler/codegen/reloc/reloc_scan.vibe
@@ -59,6 +59,21 @@ export let reloc_kind_tag: Int = 5
 /// `0xC0 0x00` signed, because a lone `0x40` sleb byte reads as -64.
 export let reloc_kind_blocktype: Int = 6
 
+/// A heap type that is a TYPE INDEX: the `ref.test` / `ref.cast` /
+/// `br_on_cast` / `ref.null` operand. Same s33 encoding as a blocktype, and
+/// the same rule -- negative is an abstract heap type, non-negative is an
+/// index. Separate kind because a consumer resolving these is answering a
+/// different question from "what block type does this region have".
+export let reloc_kind_heaptype: Int = 7
+
+/// Data and element SEGMENT indices (`memory.init`, `data.drop`,
+/// `array.new_data`, `array.init_data`; `table.init`, `elem.drop`,
+/// `array.new_elem`, `array.init_elem`). Reordering segments leaves a cached
+/// body initialising an array from unrelated contents.
+export let reloc_kind_data: Int = 8
+
+export let reloc_kind_elem: Int = 9
+
 /// Every reference one body makes, as parallel arrays -- the shape
 /// `CodegenBodyCache` already uses for everything it carries.
 ///
@@ -242,32 +257,20 @@ fn step_instr(body: Bytes, pos: Int, out: BodyRelocs) -> Int with Exception {
   } else if op == 0x02 || op == 0x03 || op == 0x04 {
     // block / loop / if <blocktype>: a value type when negative, a TYPE INDEX
     // when not -- and then it relocates.
-    let (v, p) = read_sleb_at(body, pos + 1)
-    if v >= 0 {
-      Array::push(out.offsets, pos + 1)
-      Array::push(out.kinds, reloc_kind_blocktype)
-      Array::push(out.values, v)
-      Array::push(out.widths, p - pos - 1)
-    } else {
-      ()
-    }
-    p
+    push_signed_reloc(body, pos + 1, reloc_kind_blocktype, out)
   } else if op == 0x0C || op == 0x0D {
-    // br / br_if <labelidx>  -- a LOCAL index, never relocated
-    let (_, p) = read_uleb_at(body, pos + 1)
-    p
+    // br / br_if <labelidx> -- local to the enclosing blocks
+    skip_local_index(body, pos + 1)
   } else if op == 0x0E {
     // br_table vec(labelidx) labelidx
     let (count, p0) = read_uleb_at(body, pos + 1)
     let mut p = p0
     let mut i = 0
     while i < count {
-      let (_, np) = read_uleb_at(body, p)
-      p = np
+      p = skip_local_index(body, p)
       i = i + 1
     }
-    let (_, pe) = read_uleb_at(body, p)
-    pe
+    skip_local_index(body, p)
   } else if op == 0x10 {
     // call <funcidx>  -- RELOCATION
     let (v, p) = read_uleb_at(body, pos + 1)
@@ -285,14 +288,11 @@ fn step_instr(body: Bytes, pos: Int, out: BodyRelocs) -> Int with Exception {
     Array::push(out.widths, p - pos - 1)
     p
   } else if op == 0x11 {
-    // call_indirect <typeidx> <tableidx>  -- the TYPE index relocates
-    let (v, p1) = read_uleb_at(body, pos + 1)
-    Array::push(out.offsets, pos + 1)
-    Array::push(out.kinds, reloc_kind_type)
-    Array::push(out.values, v)
-    Array::push(out.widths, p1 - pos - 1)
-    let (_, p2) = read_uleb_at(body, p1)
-    p2
+    // call_indirect <typeidx> <tableidx> -- BOTH relocate. The table index
+    // was skipped until review pointed out that a module with more than one
+    // table dispatches through the wrong one after a reassignment.
+    let p1 = push_reloc(body, pos + 1, reloc_kind_type, out)
+    push_reloc(body, p1, reloc_kind_table, out)
   } else if op == 0x23 || op == 0x24 {
     // global.get / global.set <globalidx>  -- RELOCATION
     let (v, p) = read_uleb_at(body, pos + 1)
@@ -310,24 +310,21 @@ fn step_instr(body: Bytes, pos: Int, out: BodyRelocs) -> Int with Exception {
     Array::push(out.widths, p - pos - 1)
     p
   } else if op >= 0x20 && op <= 0x22 {
-    // local.get / local.set / local.tee <localidx>  -- LOCAL, never relocated
-    let (_, p) = read_uleb_at(body, pos + 1)
-    p
+    // local.get / local.set / local.tee <localidx> -- frame-local
+    skip_local_index(body, pos + 1)
   } else if op >= 0x28 && op <= 0x3E {
     // every load and store: <memarg>
     skip_memarg(body, pos + 1)
   } else if op == 0x3F || op == 0x40 {
-    // memory.size / memory.grow <memidx>
-    let (_, p) = read_uleb_at(body, pos + 1)
-    p
+    // memory.size / memory.grow <memidx> -- one memory only in this target
+    skip_literal_uleb(body, pos + 1)
   } else if op == 0x41 || op == 0x42 {
     // i32.const / i64.const <sleb>
     //
     // A function VALUE and a data pointer both ride here (see the header).
     // Not reported: nothing in the encoding separates them from an ordinary
     // constant, and a guess would be wrong some of the time.
-    let (_, p) = read_sleb_at(body, pos + 1)
-    p
+    skip_literal_sleb(body, pos + 1)
   } else if op == 0x43 {
     pos + 5
   } else if op == 0x44 {
@@ -337,15 +334,16 @@ fn step_instr(body: Bytes, pos: Int, out: BodyRelocs) -> Int with Exception {
     let (count, p0) = read_uleb_at(body, pos + 1)
     p0 + count
   } else if op == 0xD0 {
-    // ref.null <heaptype>
-    let (_, p) = read_sleb_at(body, pos + 1)
-    p
+    // ref.null <heaptype> -- an index when non-negative
+    push_signed_reloc(body, pos + 1, reloc_kind_heaptype, out)
   } else if op == 0x08 {
     // throw <tagidx>  -- RELOCATION
     push_reloc(body, pos + 1, reloc_kind_tag, out)
   } else if op == 0x1F {
-    // try_table <blocktype> vec(catch)
-    let (_, p1) = read_sleb_at(body, pos + 1)
+    // try_table <blocktype> vec(catch) -- the blocktype is a type index when
+    // non-negative, exactly as in block/loop/if. Fixing those and not this one
+    // is what "one class at a time" looks like from the outside.
+    let p1 = push_signed_reloc(body, pos + 1, reloc_kind_blocktype, out)
     let (count, p2) = read_uleb_at(body, p1)
     let mut p = p2
     let mut i = 0
@@ -356,11 +354,10 @@ fn step_instr(body: Bytes, pos: Int, out: BodyRelocs) -> Int with Exception {
         // catch / catch_ref: <tagidx> <labelidx>. The tag RELOCATES; the
         // label is local to the enclosing block and never does.
         let pa = push_reloc(body, p, reloc_kind_tag, out)
-        let (_, pb) = read_uleb_at(body, pa)
-        p = pb
+        p = skip_local_index(body, pa)
       } else {
-        let (_, pa) = read_uleb_at(body, p)
-        p = pa
+        // catch_all / catch_all_ref: <labelidx> only
+        p = skip_local_index(body, p)
       }
       i = i + 1
     }
@@ -399,16 +396,23 @@ fn step_gc(body: Bytes, pos: Int, out: BodyRelocs) -> Int with Exception {
     // array.get{,_s,_u} / array.set / array.fill: <typeidx>
     push_type_reloc(body, p0, out)
   } else if sub >= 2 && sub <= 5 {
-    // struct.get{,_s,_u} / struct.set: <typeidx> <fieldidx>
+    // struct.get{,_s,_u} / struct.set: <typeidx> <fieldidx>. The field index
+    // is positional WITHIN the struct type, so it moves only if the type
+    // does -- and then the type index above carries the whole thing.
     let p1 = push_type_reloc(body, p0, out)
-    let (_, p2) = read_uleb_at(body, p1)
-    p2
-  } else if sub == 8 || (sub >= 9 && sub <= 10) || (sub >= 18 && sub <= 19) {
-    // array.new_fixed <typeidx> <n>; array.new_data/elem <typeidx> <idx>;
-    // array.init_data/elem <typeidx> <idx>
+    skip_local_index(body, p1)
+  } else if sub == 8 {
+    // array.new_fixed <typeidx> <n> -- n is a LENGTH, not an index
     let p1 = push_type_reloc(body, p0, out)
-    let (_, p2) = read_uleb_at(body, p1)
-    p2
+    skip_literal_uleb(body, p1)
+  } else if sub == 9 || sub == 18 {
+    // array.new_data / array.init_data <typeidx> <dataidx>
+    let p1 = push_type_reloc(body, p0, out)
+    push_reloc(body, p1, reloc_kind_data, out)
+  } else if sub == 10 || sub == 19 {
+    // array.new_elem / array.init_elem <typeidx> <elemidx>
+    let p1 = push_type_reloc(body, p0, out)
+    push_reloc(body, p1, reloc_kind_elem, out)
   } else if sub == 17 {
     // array.copy <typeidx> <typeidx>
     let p1 = push_type_reloc(body, p0, out)
@@ -418,19 +422,44 @@ fn step_gc(body: Bytes, pos: Int, out: BodyRelocs) -> Int with Exception {
     // i31.get_s; i31.get_u -- no immediate
     p0
   } else if sub >= 20 && sub <= 23 {
-    // ref.test / ref.cast, null and non-null: <heaptype>
-    let (_, p1) = read_sleb_at(body, p0)
-    p1
+    // ref.test / ref.cast, null and non-null: <heaptype> -- a TYPE INDEX when
+    // non-negative, so a reassignment makes the rebuilt body test or cast
+    // against the wrong nominal type WHILE STILL VALIDATING.
+    push_signed_reloc(body, p0, reloc_kind_heaptype, out)
   } else if sub == 24 || sub == 25 {
     // br_on_cast / br_on_cast_fail: <castflags> <labelidx> <heaptype> <heaptype>
     let p1 = p0 + 1
-    let (_, p2) = read_uleb_at(body, p1)
-    let (_, p3) = read_sleb_at(body, p2)
-    let (_, p4) = read_sleb_at(body, p3)
-    p4
+    let p2 = skip_local_index(body, p1)
+    let p3 = push_signed_reloc(body, p2, reloc_kind_heaptype, out)
+    push_signed_reloc(body, p3, reloc_kind_heaptype, out)
   } else {
     throw(String::concat("reloc_scan: unknown 0xFB sub-opcode ", __to_string(sub)))
   }
+}
+
+/// EVERY immediate this decoder reads goes through exactly one of the
+/// following: `push_reloc` / `push_signed_reloc` when it names a global index
+/// space, or one of the `skip_*` helpers when it does not. That is the point
+/// of them -- a bare `let (_, p) = read_uleb_at(...)` is indistinguishable
+/// from a reference someone forgot to record, and review found four such
+/// omissions here one at a time (tags, blocktypes, table indices, segment
+/// indices) before the immediates were classified this way instead.
+///
+/// So: if you add an instruction, every immediate in it must be spelled with
+/// one of these. `_` is not an option the shape of this code offers.
+fn skip_local_index(body: Bytes, pos: Int) -> Int with Exception {
+  let (_, p) = read_uleb_at(body, pos)
+  p
+}
+
+fn skip_literal_uleb(body: Bytes, pos: Int) -> Int with Exception {
+  let (_, p) = read_uleb_at(body, pos)
+  p
+}
+
+fn skip_literal_sleb(body: Bytes, pos: Int) -> Int with Exception {
+  let (_, p) = read_sleb_at(body, pos)
+  p
 }
 
 /// Read an index at `pos`, record it as a relocation site of `kind`, and
@@ -448,6 +477,21 @@ fn push_type_reloc(body: Bytes, pos: Int, out: BodyRelocs) -> Int with Exception
   push_reloc(body, pos, reloc_kind_type, out)
 }
 
+/// An s33 that is a type index when non-negative and an abstract type when
+/// not. Records only in the first case; the position advances either way.
+fn push_signed_reloc(body: Bytes, pos: Int, kind: Int, out: BodyRelocs) -> Int with Exception {
+  let (v, p) = read_sleb_at(body, pos)
+  if v >= 0 {
+    Array::push(out.offsets, pos)
+    Array::push(out.kinds, kind)
+    Array::push(out.values, v)
+    Array::push(out.widths, p - pos)
+  } else {
+    ()
+  }
+  p
+}
+
 /// The 0xFC prefix: saturating truncation, and the bulk memory / table ops.
 fn step_misc(body: Bytes, pos: Int, out: BodyRelocs) -> Int with Exception {
   let (sub, p0) = read_uleb_at(body, pos + 1)
@@ -456,27 +500,31 @@ fn step_misc(body: Bytes, pos: Int, out: BodyRelocs) -> Int with Exception {
     p0
   } else if sub == 8 {
     // memory.init <dataidx> <memidx>
-    let (_, p1) = read_uleb_at(body, p0)
+    let p1 = push_reloc(body, p0, reloc_kind_data, out)
     p1 + 1
   } else if sub == 9 {
     // data.drop <dataidx>
-    let (_, p1) = read_uleb_at(body, p0)
-    p1
+    push_reloc(body, p0, reloc_kind_data, out)
   } else if sub == 10 {
     // memory.copy <memidx> <memidx>
     p0 + 2
   } else if sub == 11 {
     // memory.fill <memidx>
     p0 + 1
-  } else if sub == 12 || sub == 14 {
-    // table.init <elemidx> <tableidx> / table.copy <tableidx> <tableidx>
-    let (_, p1) = read_uleb_at(body, p0)
-    let (_, p2) = read_uleb_at(body, p1)
-    p2
-  } else if sub == 13 || sub == 15 || sub == 16 || sub == 17 {
-    // elem.drop <elemidx>; table.grow/size/fill <tableidx>
-    let (_, p1) = read_uleb_at(body, p0)
-    p1
+  } else if sub == 12 {
+    // table.init <elemidx> <tableidx>
+    let p1 = push_reloc(body, p0, reloc_kind_elem, out)
+    push_reloc(body, p1, reloc_kind_table, out)
+  } else if sub == 14 {
+    // table.copy <tableidx> <tableidx>
+    let p1 = push_reloc(body, p0, reloc_kind_table, out)
+    push_reloc(body, p1, reloc_kind_table, out)
+  } else if sub == 13 {
+    // elem.drop <elemidx>
+    push_reloc(body, p0, reloc_kind_elem, out)
+  } else if sub == 15 || sub == 16 || sub == 17 {
+    // table.grow / table.size / table.fill <tableidx>
+    push_reloc(body, p0, reloc_kind_table, out)
   } else {
     throw(String::concat("reloc_scan: unknown 0xFC sub-opcode ", __to_string(sub)))
   }
@@ -577,7 +625,8 @@ export fn rebuild_body_relocs(body: Bytes, start: Int, end_pos: Int, r: BodyRelo
       Bytes::push(out, Bytes::get(body, c))
       c = c + 1
     }
-    if Array::get(r.kinds, i) == reloc_kind_blocktype {
+    let kind_i = Array::get(r.kinds, i)
+    if kind_i == reloc_kind_blocktype || kind_i == reloc_kind_heaptype {
       write_sleb(out, Array::get(new_values, i))
     } else {
       write_uleb(out, Array::get(new_values, i))

--- a/lib/@vibe/compiler/codegen/reloc/reloc_scan_test.vibe
+++ b/lib/@vibe/compiler/codegen/reloc/reloc_scan_test.vibe
@@ -10,7 +10,17 @@
 //# Imports
 
 import @vibe/compiler/codegen/reloc {
-  rebuild_body_relocs, reloc_kind_blocktype, reloc_kind_func, reloc_kind_global, reloc_kind_tag, reloc_kind_type, scan_body_relocs
+  rebuild_body_relocs,
+  reloc_kind_blocktype,
+  reloc_kind_data,
+  reloc_kind_elem,
+  reloc_kind_func,
+  reloc_kind_global,
+  reloc_kind_heaptype,
+  reloc_kind_table,
+  reloc_kind_tag,
+  reloc_kind_type,
+  scan_body_relocs
 }
 
 //# Functions
@@ -79,13 +89,20 @@ test "a relocation that crosses the LEB width band changes the body LENGTH" {
 
 test "global.get and call_indirect report their own kinds" {
   // global.get 1 ; call_indirect type=2 table=0 ; end
+  //
+  // THREE sites, not two: call_indirect's second immediate is a table index
+  // and relocates as well. This case asserted two until that was recorded,
+  // and failing was the right behaviour -- an expectation written against a
+  // scanner that missed a reference class encodes the miss.
   let codes = [0x23, 0x01, 0x11, 0x02, 0x00, 0x0B]
   let (offsets, kinds, values, _widths) = scan_all(codes)
-  assert_eq(Array::length(offsets), 2)
+  assert_eq(Array::length(offsets), 3)
   assert_eq(Array::get(kinds, 0), reloc_kind_global)
   assert_eq(Array::get(values, 0), 1)
   assert_eq(Array::get(kinds, 1), reloc_kind_type)
   assert_eq(Array::get(values, 1), 2)
+  assert_eq(Array::get(kinds, 2), reloc_kind_table)
+  assert_eq(Array::get(values, 2), 0)
 }
 
 test "an i64.const is walked but never reported" {
@@ -229,4 +246,49 @@ test "a blocktype that is a TYPE INDEX relocates, and rebuilds SIGNED" {
   let r2 = scan_body_relocs(moved, 0, Bytes::length(moved))
   assert_eq(Array::get(r2.values, 0), 64)
   assert_eq(Array::get(r2.kinds, 0), reloc_kind_blocktype)
+}
+
+test "call_indirect relocates BOTH immediates, and try_table's blocktype too" {
+  // call_indirect type=2 table=1 ; end
+  let (_o, k, v, _w) = scan_all([0x11, 0x02, 0x01, 0x0B])
+  assert_eq(Array::length(k), 2)
+  assert_eq(Array::get(k, 0), reloc_kind_type)
+  assert_eq(Array::get(v, 0), 2)
+  assert_eq(Array::get(k, 1), reloc_kind_table)
+  assert_eq(Array::get(v, 1), 1)
+  // try_table (type 5) [catch_all label=0] ; end ; end
+  let (_o2, k2, v2, _w2) = scan_all([0x1F, 0x05, 0x01, 0x02, 0x00, 0x0B, 0x0B])
+  assert_eq(Array::length(k2), 1)
+  assert_eq(Array::get(k2, 0), reloc_kind_blocktype)
+  assert_eq(Array::get(v2, 0), 5)
+}
+
+test "segment and heap-type indices relocate" {
+  // 0xFC 8 = memory.init <dataidx> <memidx> ; 0xFC 13 = elem.drop <elemidx>
+  let (_o, k, v, _w) = scan_all([0xFC, 0x08, 0x04, 0x00, 0xFC, 0x0D, 0x06, 0x0B])
+  assert_eq(Array::length(k), 2)
+  assert_eq(Array::get(k, 0), reloc_kind_data)
+  assert_eq(Array::get(v, 0), 4)
+  assert_eq(Array::get(k, 1), reloc_kind_elem)
+  assert_eq(Array::get(v, 1), 6)
+  // 0xFB 20 = ref.test <heaptype>. Non-negative is a TYPE INDEX; an abstract
+  // heap type is negative and must NOT be reported.
+  let (_o2, k2, v2, _w2) = scan_all([0xFB, 0x14, 0x09, 0x0B])
+  assert_eq(Array::length(k2), 1)
+  assert_eq(Array::get(k2, 0), reloc_kind_heaptype)
+  assert_eq(Array::get(v2, 0), 9)
+  // ref.null with the abstract `func` heap type (-16, sleb 0x70)
+  let (o3, _k3, _v3, _w3) = scan_all([0xD0, 0x70, 0x0B])
+  assert_eq(Array::length(o3), 0)
+  // and a heap type rebuilds SIGNED, like a blocktype
+  let codes = [0xFB, 0x14, 0x09, 0x0B]
+  let b = body_of(codes)
+  let r = scan_body_relocs(b, 0, Bytes::length(b))
+  assert_eq(bytes_to_ints(rebuild_body_relocs(b, 0, Bytes::length(b), r, [64])), [
+    0xFB,
+    0x14,
+    0xC0,
+    0x00,
+    0x0B
+  ])
 }

--- a/scripts/reloc_roundtrip.sh
+++ b/scripts/reloc_roundtrip.sh
@@ -32,32 +32,31 @@ targets=("$@")
 if [ "${#targets[@]}" -eq 0 ]; then
   probe_dir="_build/_reloc_probe"
   mkdir -p "$probe_dir"
+  # The probe source is chosen so the gc lane emits TYPED REFERENCE LOCALS
+  # (`0x63 <typeidx>`), which the earlier one did not: measured, 3 such local
+  # groups here against 0 before. That matters because the locals header walk
+  # is what finds the first instruction, and a version of it that advanced a
+  # fixed byte per group reported SUCCESS on this module while scanning from
+  # one byte early -- classifying a type site as a blocktype site and still
+  # round-tripping. A probe that cannot reach a construct is not coverage of
+  # it.
   cat > "$probe_dir/gcprobe.vibe" <<'PROBE'
-struct P { x: Int; y: Int }
+struct Pt { x: Int; y: Int }
 
-fn mk(a: Int) -> P {
-  P::{ x: a, y: a + 1 }
+fn build() -> Array[Int] {
+  let xs = [1, 2, 3, 4]
+  xs
 }
 
-fn sum(ps: Array[P]) -> Int {
-  let mut t = 0
-  let mut i = 0
-  while i < Array::length(ps) {
-    let p = Array::get(ps, i)
-    t = t + p.x + p.y
-    i = i + 1
-  }
-  t
+fn mid(p: Pt) -> Int {
+  p.x + p.y
 }
 
 fn main() -> Int {
-  let ps = []
-  let mut i = 0
-  while i < 8 {
-    Array::push(ps, mk(i))
-    i = i + 1
-  }
-  sum(ps)
+  let xs = build()
+  let p = Pt::{ x: Array::get(xs, 0), y: Array::get(xs, 3) }
+  let ys = [mid(p), mid(p)]
+  Array::get(ys, 0) + Array::get(ys, 1) + Array::length(xs)
 }
 PROBE
   for backend in linear gc; do

--- a/scripts/reloc_roundtrip.vibex
+++ b/scripts/reloc_roundtrip.vibex
@@ -18,8 +18,27 @@
 // it at the compiler's own output and every refusal names the opcode still
 // missing.
 import @vibe/compiler/codegen/reloc {
-  BodyRelocs, rebuild_body_relocs, reloc_kind_blocktype, reloc_kind_func, reloc_kind_global,
-  reloc_kind_table, reloc_kind_tag, reloc_kind_type, scan_body_relocs
+  BodyRelocs, rebuild_body_relocs, reloc_kind_blocktype, reloc_kind_data, reloc_kind_elem,
+  reloc_kind_func, reloc_kind_global, reloc_kind_heaptype, reloc_kind_table, reloc_kind_tag,
+  reloc_kind_type, scan_body_relocs
+}
+
+fn read_sleb(b: Bytes, pos: Int) -> (Int, Int) {
+  let mut result = 0
+  let mut shift = 0
+  let mut p = pos
+  let mut done = false
+  let mut last = 0
+  while !done {
+    let byte = Bytes::get(b, p)
+    last = byte
+    result = result | ((byte & 127) << shift)
+    shift = shift + 7
+    p = p + 1
+    if (byte & 128) == 0 { done = true } else { () }
+  }
+  if (last & 64) != 0 && shift < 63 { result = result - (1 << shift) } else { () }
+  (result, p)
 }
 
 fn read_uleb(b: Bytes, pos: Int) -> (Int, Int) {
@@ -38,13 +57,35 @@ fn read_uleb(b: Bytes, pos: Int) -> (Int, Int) {
 }
 
 /// Skip the code entry's locals header: vec((count, valtype)).
+///
+/// A valtype is NOT always one byte. The gc backend emits a typed reference
+/// local as `0x63 <typeidx>` (`backend_body.vibe`, for native array and
+/// struct locals), so advancing a fixed byte per group left the type index to
+/// be read as the first instruction. Worse than an error: if that byte
+/// happens to be a valid no-immediate opcode the walk resynchronises and the
+/// oracle reports SUCCESS while having scanned the wrong region. Found by
+/// review, and it means this oracle's gc-lane result before the fix was not
+/// evidence of anything.
+fn skip_valtype(b: Bytes, pos: Int) -> Int {
+  let t = Bytes::get(b, pos)
+  if t == 0x63 || t == 0x64 {
+    // ref null <heaptype> / ref <heaptype>: an s33 follows
+    let (_, p) = read_sleb(b, pos + 1)
+    p
+  } else {
+    // numeric (0x7F..0x7C), v128 (0x7B), and the abstract reference
+    // shorthands (0x6F..0x65, 0x70, 0x6E, ...) are all a single byte
+    pos + 1
+  }
+}
+
 fn skip_locals(b: Bytes, pos: Int) -> Int {
   let (groups, p0) = read_uleb(b, pos)
   let mut p = p0
   let mut i = 0
   while i < groups {
     let (_, pn) = read_uleb(b, p)
-    p = pn + 1
+    p = skip_valtype(b, pn)
     i = i + 1
   }
   p
@@ -104,6 +145,9 @@ fn main() -> Unit allows Exception + Fs + Stdout + Env {
   let mut n_table = 0
   let mut n_tag = 0
   let mut n_blocktype = 0
+  let mut n_heaptype = 0
+  let mut n_data = 0
+  let mut n_elem = 0
   let mut identity_mismatch = 0
   let mut perturb_unchanged = 0
   while scanned < body_count {
@@ -125,6 +169,9 @@ fn main() -> Unit allows Exception + Fs + Stdout + Env {
       else if k == reloc_kind_table { n_table = n_table + 1 }
       else if k == reloc_kind_tag { n_tag = n_tag + 1 }
       else if k == reloc_kind_blocktype { n_blocktype = n_blocktype + 1 }
+      else if k == reloc_kind_heaptype { n_heaptype = n_heaptype + 1 }
+      else if k == reloc_kind_data { n_data = n_data + 1 }
+      else if k == reloc_kind_elem { n_elem = n_elem + 1 }
       else { () }
       ki = ki + 1
     }
@@ -175,6 +222,12 @@ fn main() -> Unit allows Exception + Fs + Stdout + Env {
   StringBuilder::push(out, __to_string(n_tag))
   StringBuilder::push(out, " blocktype=")
   StringBuilder::push(out, __to_string(n_blocktype))
+  StringBuilder::push(out, " heaptype=")
+  StringBuilder::push(out, __to_string(n_heaptype))
+  StringBuilder::push(out, " data=")
+  StringBuilder::push(out, __to_string(n_data))
+  StringBuilder::push(out, " elem=")
+  StringBuilder::push(out, __to_string(n_elem))
   StringBuilder::push(out, " identity_mismatch=")
   StringBuilder::push(out, __to_string(identity_mismatch))
   StringBuilder::push(out, " perturb_unchanged=")


### PR DESCRIPTION
#2702 merged at `1c73f99`, about a minute before `e9d7a03` was pushed. So the five findings from Codex's third round are **not in main**, and one of them matters enough to say plainly:

> **`docs/incremental-build.md` currently on main states a gc-lane result that rests on a decoder bug. That claim is not evidence, and this PR corrects it.**

Same commit, re-based onto `3a8c420`. Nothing new since the replies on #2702.

## The one that invalidates a claim

`skip_locals` in `reloc_roundtrip.vibex` advanced a fixed byte per local group. The gc backend emits a typed reference local as `0x63 <typeidx>` (`backend_body.vibe`), so the walk began **one byte early** and read a type index as the first instruction.

Reproduced on a probe with three such local groups:

| | type | blocktype | identity_mismatch |
|---|---:|---:|---:|
| the walk as merged | 13 | 1 | **0 — reported success** |
| fixed | 14 | 0 | 0 |

It resynchronised and produced a **different but self-consistent** classification — one type site reported as a blocktype site — while round-tripping perfectly. It passed.

And the probe #2702 was citing for "the gc lane passes" contained **zero** typed reference locals (measured: 0 groups, against 3 in the replacement), so it never reached the bug. The probe source is replaced with one that does. *A probe that cannot reach a construct is not coverage of it.*

## The pattern, and why this round stopped patching branches

Four reference classes had been found **one at a time** — tags, blocktypes, table indices, segment indices — and in every case the miss looked identical in the source:

```vibe
let (_, p) = read_uleb_at(body, pos + 1)   // dropped a reference, or skipped deliberately?
```

Indistinguishable. So every immediate is now **classified**: either a recording helper (`push_reloc`, `push_signed_reloc`) or a **named** skip (`skip_local_index`, `skip_literal_uleb`, `skip_literal_sleb`). `_` is no longer a shape the code offers, so "is every reference recorded" is answerable by looking.

## The five

| finding | fix |
|---|---|
| `call_indirect`'s table index discarded | recorded, plus the `step_misc` table operands (`table.init`/`copy`/`grow`/`size`/`fill`) |
| `try_table`'s blocktype discarded | same signed recorder as `block`/`loop`/`if` |
| data / element segment indices discarded | `reloc_kind_data` / `reloc_kind_elem` across all eight sites |
| heap types in `ref.test`/`ref.cast`/`ref.null`/`br_on_cast` | `reloc_kind_heaptype`, signed, only when non-negative |
| the locals-header walk | `skip_valtype` decodes `0x63`/`0x64` + s33 |

Nine kinds now. stage2's site count **142,360 → 143,675**, the +1315 being exactly the `call_indirect` table indices — one per type index, as it must be.

One thing separated rather than lumped while doing this: `array.new_fixed`'s second immediate looks identical in the encoding but is a **length**, not an index, so it goes through `skip_literal_uleb`. It had been sharing a branch with the segment forms, which is how it would have been mis-recorded the moment that branch started recording.

## An existing test failed, and was right to

`global.get` + `call_indirect` asserted **two** relocation sites. That expectation encoded the missing table index. Updated to three.

## Verification

11/11 unit tests (was 9), the three-module oracle with per-kind breakdown, the red/green above on a probe that reaches the construct, `check_vibe_fmt.sh` (1161 files, 0 violations), `check_gate_portability.sh`, `check_gate_self_tests.sh`, `check_doc_path_citations.sh`, `check_doc_commands.sh`, and the pre-commit lint gates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CCUq2wJKeDzguGzmx78HkZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01CCUq2wJKeDzguGzmx78HkZ)_