### PR TITLE
#2669 slices 1b + 2: bodies do relocate (89.1%), and the compiler now records what a scan cannot find

### DIFF
--- a/docs/incremental-build.md
+++ b/docs/incremental-build.md
@@ -741,34 +741,47 @@ itself emitted for B**.
 
 | | count | share |
 |---|---:|---:|
-| bodies compared (present in both by name) | 4356 | |
-| **relocated byte-identically to the compiler's own output** | **3943** | **90.5%** |
-| mismatch, body carries a non-function reference (this tool's limit) | 299 | 6.9% |
-| mismatch, **encoding-blind** | 114 | 2.6% |
+| bodies compared | 4351 | |
+| **relocated byte-identically to the compiler's own output** | **3968** | **91.2%** |
+| mismatch, cause not determinable | 284 | 6.5% |
+| mismatch, unambiguously **encoding-blind** | 99 | 2.3% |
+| skipped: the name is carried by more than one function | 5 | |
+| shared functions whose index actually moved | 4266 | |
 
-**90.5% of bodies survive a module reorder byte for byte**, using nothing but
+**91.2% of bodies survive a module reorder byte for byte**, using nothing but
 the references the instruction encoding exposes. That is the first direct
 evidence that index-independent bodies work rather than an argument that they
 should.
 
-The two mismatch classes are different in kind, which is why they are counted
-apart:
+**99 is a LOWER BOUND on what the emitter must record, not the number.** Only
+bodies with no confound are in it: a body can carry both a non-function
+reference (passed through here, because wasm gives those spaces no name
+section to map through) and an encoding-blind `i64.const`, and an unresolved
+function target is also passed through. Either makes the cause undeterminable
+from the binary, so those 284 are counted apart rather than attributed. A real
+link has the symbol tables this tool lacks and would resolve most of them; how
+many of the 284 are ALSO encoding-blind is not knowable here.
 
-- The **299** carry a reference in a space wasm gives no name section for
-  (type, table, tag, global, data, elem), so this tool passes the value
-  through unchanged and cannot do better from the binary alone. A real link
-  has those symbol tables and would remap them; this is the measurement's
-  limit, not the approach's.
-- The **114** carry no such reference. Every reference the encoding exposes
-  was remapped, so what remains is a reference it does NOT expose — the
-  `i64.const` function values and data pointers. **That is the number the
-  emitter has to close**, measured rather than estimated, and it is 2.6%.
+Three things this measurement needs in order to mean anything, each of which
+it got wrong first and reports now:
 
-Forcing a module reorder requires editing at least one existing body —
-something has to call across the new import — so a couple of the 114 are
-genuine source changes rather than relocation failures. The wrapper keeps that
-edit to one function and names it in its own output (`encode_url_safe`), so
-the figure can be read with that in mind instead of quietly inflated.
+- **Duplicate names are refused, not resolved first-wins.** The compiler emits
+  many functions called `__rt_gen` — `linked_compile.vibe` labels every
+  unassigned generated slot that way in a loop. Taking the first match compared
+  each of them against the wrong body and remapped every call to one into the
+  wrong target, which both manufactures mismatches and can count a comparison
+  against the WRONG body as a match. The first published figure (4356 / 3943 /
+  90.5%) had those rows in it.
+- **The reorder is asserted, not assumed.** `moved_index` counts shared
+  functions whose index actually differs, and a run where it is zero FAILS.
+  Without that, a corpus that never reaches the edited file would report every
+  body as relocated — a perfect score measuring nothing. Handing the tool the
+  same module twice produces exactly that: `matched=4351 mismatched=0`, and
+  the guard rejects it.
+- **The one edited body is named.** Forcing a module reorder requires editing
+  something — a call has to cross the new import — so the wrapper keeps that to
+  one function and prints its name, rather than letting it inflate the figure
+  silently.
 
 **What the scan cannot see, and why the link must record instead of derive.**
 A `call` immediate is self-describing — the opcode says the next uleb is a

--- a/docs/incremental-build.md
+++ b/docs/incremental-build.md
@@ -727,6 +727,49 @@ holding a stale tag routes a `perform` to the wrong handler with nothing
 failing at build time. Recording them raised stage2's site count from 141,380
 to 142,360 — 980 references that were silently going to be left behind.
 
+##### Does a body actually relocate? (#2669, slice 1b)
+
+The round-trip above proves the walk does not desynchronise. It does not prove
+the central claim, which is that a body compiled against ONE index assignment
+can be moved onto ANOTHER. `scripts/reloc_crossbuild.sh` tests that directly:
+it builds the compiler's own closure twice — the second with one import added
+to `lib/@vibe/core/base64.vibe`, which pulls `hex.vibe` earlier in the module
+order and moves most of the function index space — then takes each of A's
+bodies, rewrites every function reference from A's index space into B's by
+resolving through the name section, and compares against **what the compiler
+itself emitted for B**.
+
+| | count | share |
+|---|---:|---:|
+| bodies compared (present in both by name) | 4356 | |
+| **relocated byte-identically to the compiler's own output** | **3943** | **90.5%** |
+| mismatch, body carries a non-function reference (this tool's limit) | 299 | 6.9% |
+| mismatch, **encoding-blind** | 114 | 2.6% |
+
+**90.5% of bodies survive a module reorder byte for byte**, using nothing but
+the references the instruction encoding exposes. That is the first direct
+evidence that index-independent bodies work rather than an argument that they
+should.
+
+The two mismatch classes are different in kind, which is why they are counted
+apart:
+
+- The **299** carry a reference in a space wasm gives no name section for
+  (type, table, tag, global, data, elem), so this tool passes the value
+  through unchanged and cannot do better from the binary alone. A real link
+  has those symbol tables and would remap them; this is the measurement's
+  limit, not the approach's.
+- The **114** carry no such reference. Every reference the encoding exposes
+  was remapped, so what remains is a reference it does NOT expose — the
+  `i64.const` function values and data pointers. **That is the number the
+  emitter has to close**, measured rather than estimated, and it is 2.6%.
+
+Forcing a module reorder requires editing at least one existing body —
+something has to call across the new import — so a couple of the 114 are
+genuine source changes rather than relocation failures. The wrapper keeps that
+edit to one function and names it in its own output (`encode_url_safe`), so
+the figure can be read with that in mind instead of quietly inflated.
+
 **What the scan cannot see, and why the link must record instead of derive.**
 A `call` immediate is self-describing — the opcode says the next uleb is a
 funcidx. A function used as a VALUE is not: it is an `i64.const (idx*4+2)`,

--- a/docs/incremental-build.md
+++ b/docs/incremental-build.md
@@ -891,6 +891,31 @@ widened to drop its pending test: that version still passed. Both lambda bodies
 have to contain a function value of their own, which is what the committed case
 does. Three of four mutations failing is not a passing grade for the fourth.
 
+**What it costs, on the KPI this issue is about.** The recording is not free,
+and a memory regression on a memory issue should be stated rather than left in
+a report:
+
+| | selfcompile memory |
+|---|---:|
+| slice 1b alone (scripts and docs, no compiler change) | 852 MiB |
+| with slice 2's recording | 857 MiB (**+0.63%**) |
+
+Those two are the per-PR perf reports for `cb5bc9c` and `0ea74ec`, which share
+the same main baseline (`595fed3eb`) and differ by exactly the slice-2 commits
+— so the +5 MiB is attributable without building anything extra. Earlier
+reports on this branch used older baselines and are NOT comparable: main moved
+under them, which is most of what makes a "+x% vs main" row hard to read at
+all. Compiled code grew 0.21% (the verifier and the recorder are new code in
+the compiler's own wasm).
+
+Most of the 5 MiB is the log itself — four parallel arrays growing with every
+function-value reference in the program — which is the mechanism, not overhead
+around it. A smaller share is the fresh one-element owner cell allocated per
+function body; one module-level cell with save/restore in `compile_lambda`
+would remove it, and is worth doing only if this number ever matters. The
+trade is 0.63% now against what the warm build currently costs: 765 MB for a
+one-module edit, 93% of a cold build.
+
 **What is NOT recorded yet, said plainly.** Data pointers — the other class the
 scan cannot see — have no kind number yet, because numbering one before
 anything emits it would be a promise and the numbers are append-only. And a

--- a/docs/incremental-build.md
+++ b/docs/incremental-build.md
@@ -833,6 +833,65 @@ monotonic. Red-tested by running the pre-fix version on that same pair under a
 second), and by confirming the added-function run reports byte-identical
 figures after the change.
 
+##### What a scan cannot find, recorded at emission (#2669, slice 2)
+
+The measurement above relocates a body using only what the instruction
+encoding exposes, and 98 of its mismatches are bodies where every such
+reference was remapped and the body still differs. What is left in those is a
+reference the encoding does not mark. Two shapes, both on the RC lane:
+
+| shape | what it is |
+|---|---|
+| `i64.const ((slot << 2) \| 2)` | a function used as a VALUE — passed by name, or a captureless lambda |
+| `i32.const slot` | the funcref-table slot a CAPTURING lambda stores into its closure header |
+
+Neither is distinguishable from an ordinary integer constant, so the emitter
+has to record them as it writes them. `CompileCtx` carries a blind-reference
+log (`blind_reloc_*`), shared by reference into per-lambda derived contexts the
+way `table_slots_used` already is, and `blind_reloc_record` appends one entry
+per emission. The offset it stores is where the constant's **opcode** goes, not
+where its immediate starts — so a consumer can check the byte it is about to
+rewrite instead of trusting the arithmetic that produced the offset.
+
+**Two checks, because a wrong record cannot be noticed later.** These are the
+references nothing in the bytes marks as references. A stale offset does not
+fail to resolve; it resolves, rewrites an unrelated operand, and the module
+still validates. There is no later stage that would catch it, so both checks
+run on every compile rather than in a test:
+
+- **Every record is checked against the byte it names** (`lc_verify_blind_relocs`).
+  The opcode must be the one the kind implies and the constant must decode —
+  signed, since both immediates are sLEB — to exactly what the record says the
+  reference is. A few thousand records on a compiler-sized program, two byte
+  reads and one LEB decode each.
+- **The record count must equal the funcref-slot count**, per compiled
+  function. This is what makes the recording COMPLETE rather than believed
+  complete: a function value is emitted at exactly the points that append to
+  `table_slots_used`, and each appends one slot and records one reference. A
+  new emission site that forgot to record shows up as a count that does not
+  match, on the next build, instead of as a cached body that relocates one
+  reference short.
+
+**Owners, and the part with room to be wrong.** A record belongs to the BODY it
+sits in, which is a user function or a lambda. A lambda's index is not drawn
+from the frozen plan until its body is finished, so records made while
+compiling one are written under a pending owner and reassigned afterwards —
+and a nested lambda, which finishes first, must keep its own. If the outer
+reassignment claimed the inner's records, their offsets would be read against
+the outer body and land on unrelated bytes; the check above is what turns that
+into a failed build. `lib/@vibe/compiler/tests/blind_reloc_test.vibe` compiles
+one program per shape, including the nested case.
+
+**What is NOT recorded yet, said plainly.** Data pointers — the other class the
+scan cannot see — have no kind number yet, because numbering one before
+anything emits it would be a promise and the numbers are append-only. And a
+REPLAYED function re-pushes its recorded funcref slots from
+`CodegenBodyCache` without re-running codegen, so it contributes slots and no
+blind references: a replaying build's log is incomplete by exactly that
+amount, which is why the paired count is checked only for functions that were
+compiled. Carrying these in the cache is what removes the asymmetry, and it
+belongs with the consumer that reads them back.
+
 #### And what it costs in ALLOCATION — the #2510 criterion-5 KPI (2026-09-11)
 
 The section above bounds the split's cost in wall time. The KPI #2510 actually

--- a/docs/incremental-build.md
+++ b/docs/incremental-build.md
@@ -742,16 +742,28 @@ itself emitted for B**.
 | | count | share |
 |---|---:|---:|
 | bodies compared | 4351 | |
-| **relocated byte-identically to the compiler's own output** | **3968** | **91.2%** |
-| mismatch, cause not determinable | 284 | 6.5% |
-| mismatch, unambiguously **encoding-blind** | 99 | 2.3% |
-| skipped: the name is carried by more than one function | 5 | |
+| **REWRITTEN: at least one reference moved** | **3158** | |
+| **rewritten AND byte-identical to the compiler's own output** | **2814** | **89.1%** |
+| rewritten, mismatched | 344 | 10.9% |
+| not rewritten — an identity rebuild, no evidence either way | 1193 | |
+| mismatch, cause not determinable (of all 383) | 284 | |
+| mismatch, unambiguously **encoding-blind** (of all 383) | 99 | |
+| skipped: the name is ambiguous on one side or the other | 5 | |
 | shared functions whose index actually moved | 4266 | |
 
-**91.2% of bodies survive a module reorder byte for byte**, using nothing but
-the references the instruction encoding exposes. That is the first direct
-evidence that index-independent bodies work rather than an argument that they
-should.
+**89.1% of the bodies this measurement can speak for survive a module reorder
+byte for byte**, using nothing but the references the instruction encoding
+exposes. That is the first direct evidence that index-independent bodies work
+rather than an argument that they should.
+
+**The load-bearing figure is 2814 / 3158, not 3968 / 4351.** A function's own
+index is not encoded in its body, so "the assignment moved" does not mean "this
+body was rewritten": 1193 of the 4351 reference only functions that held still,
+and are rebuilt by an identity operation. Their match says nothing about
+relocation, and counting them flattered the first published rate (91.2%) over
+the real one (89.1%). Measured the other way round, with the remap forced to
+the identity on the same pair, matched falls **3968 → 1154** — so the remap is
+worth 2814 bodies, and that is the claim.
 
 **99 is a LOWER BOUND on what the emitter must record, not the number.** Only
 bodies with no confound are in it: a body can carry both a non-function
@@ -772,12 +784,22 @@ it got wrong first and reports now:
   wrong target, which both manufactures mismatches and can count a comparison
   against the WRONG body as a match. The first published figure (4356 / 3943 /
   90.5%) had those rows in it.
-- **The reorder is asserted, not assumed.** `moved_index` counts shared
-  functions whose index actually differs, and a run where it is zero FAILS.
-  Without that, a corpus that never reaches the edited file would report every
-  body as relocated — a perfect score measuring nothing. Handing the tool the
-  same module twice produces exactly that: `matched=4351 mismatched=0`, and
-  the guard rejects it.
+- **Duplicate names are refused on BOTH sides.** Checking only the target
+  module was the first version of that fix and it is not enough: if A carries
+  two `__rt_gen` and B carries one, both A bodies are compared against that
+  single B body and every A-side reference to either collapses onto it. On this
+  particular pair the two-sided check changes no number — the duplicates exist
+  on both sides — but an explicitly supplied pair can exhibit it.
+- **The reorder is asserted, not assumed, and then so is the REWRITE.** Two
+  guards, because the first alone can pass vacuously. `moved_index` counts
+  shared functions whose index differs, and zero FAILS — handing the tool the
+  same module twice gives `matched=4351 mismatched=0 moved_index=0`, a perfect
+  score, rejected. But a function's own index is not in its body, so that only
+  establishes the assignment moved. `rewritten_matched` counts bodies where a
+  reference was rewritten to a different index AND the result is byte-identical;
+  zero of those FAILS too. Red-tested by forcing the remap to the identity on
+  the real pair: `moved_index=4266 rewritten=0`, so the first guard passes and
+  the second one fires.
 - **The one edited body is named.** Forcing a module reorder requires editing
   something — a call has to cross the new import — so the wrapper keeps that to
   one function and prints its name, rather than letting it inflate the figure

--- a/docs/incremental-build.md
+++ b/docs/incremental-build.md
@@ -741,31 +741,32 @@ itself emitted for B**.
 
 | | count | share |
 |---|---:|---:|
-| bodies compared | 4351 | |
-| **REWRITTEN: at least one reference moved** | **3158** | |
+| bodies compared | 4350 | |
+| **REWRITTEN: at least one reference moved** | **3157** | |
 | **rewritten AND byte-identical to the compiler's own output** | **2814** | **89.1%** |
-| rewritten, mismatched | 344 | 10.9% |
+| rewritten, mismatched | 343 | 10.9% |
 | not rewritten — an identity rebuild, no evidence either way | 1193 | |
-| mismatch, cause not determinable (of all 383) | 284 | |
-| mismatch, unambiguously **encoding-blind** (of all 383) | 99 | |
+| mismatch, cause not determinable (of all 382) | 284 | |
+| mismatch, unambiguously **encoding-blind** (of all 382) | 98 | |
 | skipped: the name is ambiguous on one side or the other | 5 | |
-| shared functions whose index actually moved | 4266 | |
+| excluded: the body the wrapper EDITED, not a relocation case | 1 | |
+| shared functions whose index actually moved | 4265 | |
 
 **89.1% of the bodies this measurement can speak for survive a module reorder
 byte for byte**, using nothing but the references the instruction encoding
 exposes. That is the first direct evidence that index-independent bodies work
 rather than an argument that they should.
 
-**The load-bearing figure is 2814 / 3158, not 3968 / 4351.** A function's own
+**The load-bearing figure is 2814 / 3157, not 3968 / 4350.** A function's own
 index is not encoded in its body, so "the assignment moved" does not mean "this
-body was rewritten": 1193 of the 4351 reference only functions that held still,
+body was rewritten": 1193 of the 4350 reference only functions that held still,
 and are rebuilt by an identity operation. Their match says nothing about
 relocation, and counting them flattered the first published rate (91.2%) over
 the real one (89.1%). Measured the other way round, with the remap forced to
 the identity on the same pair, matched falls **3968 → 1154** — so the remap is
 worth 2814 bodies, and that is the claim.
 
-**99 is a LOWER BOUND on what the emitter must record, not the number.** Only
+**98 is a LOWER BOUND on what the emitter must record, not the number.** Only
 bodies with no confound are in it: a body can carry both a non-function
 reference (passed through here, because wasm gives those spaces no name
 section to map through) and an encoding-blind `i64.const`, and an unresolved
@@ -800,10 +801,14 @@ it got wrong first and reports now:
   zero of those FAILS too. Red-tested by forcing the remap to the identity on
   the real pair: `moved_index=4266 rewritten=0`, so the first guard passes and
   the second one fires.
-- **The one edited body is named.** Forcing a module reorder requires editing
-  something — a call has to cross the new import — so the wrapper keeps that to
-  one function and prints its name, rather than letting it inflate the figure
-  silently.
+- **The one edited body is EXCLUDED, not merely named.** Forcing a module
+  reorder requires editing something — a call has to cross the new import — so
+  that body's two versions are different source programs and comparing them
+  measures the edit. Naming it in the output left it in the denominator and,
+  measured, inside the encoding-blind bucket: excluding it moves the bound from
+  99 to **98** and the compared total from 4351 to 4350. The wrapper passes the
+  name and the tool FAILS if it matches nothing, so a rename cannot put the
+  confound back in silence.
 
 **What the scan cannot see, and why the link must record instead of derive.**
 A `call` immediate is self-describing — the opcode says the next uleb is a

--- a/docs/incremental-build.md
+++ b/docs/incremental-build.md
@@ -882,6 +882,15 @@ the outer body and land on unrelated bytes; the check above is what turns that
 into a failed build. `lib/@vibe/compiler/tests/blind_reloc_test.vibe` compiles
 one program per shape, including the nested case.
 
+That nested case had to be BUILT rather than picked, and the first version of
+it proved nothing. The obvious spelling of nested lambdas — a closure over an
+enclosing binding — does not reach the hazard at all: a capturing lambda's slot
+is emitted into the ENCLOSING buffer, so the inner body records nothing and an
+outer reassignment has nothing to steal. Measured, with the reassignment
+widened to drop its pending test: that version still passed. Both lambda bodies
+have to contain a function value of their own, which is what the committed case
+does. Three of four mutations failing is not a passing grade for the fourth.
+
 **What is NOT recorded yet, said plainly.** Data pointers — the other class the
 scan cannot see — have no kind number yet, because numbering one before
 anything emits it would be a promise and the numbers are append-only. And a

--- a/lib/@vibe/compiler/codegen/common_base/common_base.vibe
+++ b/lib/@vibe/compiler/codegen/common_base/common_base.vibe
@@ -24,6 +24,10 @@ import @vibe/core {
   MutMap, array_empty
 }
 
+import @vibe/compiler/codegen/reloc {
+  blind_owner_pending
+}
+
 import @vibe/compiler/codegen/wasm_emit {
   emit_block_i64,
   emit_br,
@@ -1610,7 +1614,27 @@ export struct CompileCtx {
   // enclosing top-level index would point at the wrong function entirely.
   // That is a known, documented gap (like the funcmap's entry-file-only
   // scope): lambda-body statements are simply absent from the linemap.
-  linemap: LineMapState
+  linemap: LineMapState;
+  // #2669 slice 2: where THIS body puts a reference the instruction encoding
+  // cannot expose. A `call` immediate says what it is -- the opcode declares
+  // the next uleb a funcidx -- but a function used as a VALUE is an
+  // `i64.const ((slot << 2) | 2)` and a data pointer rides an `i64.const` the
+  // same way, indistinguishable from an ordinary constant by any amount of
+  // decoding. A cached body cannot be moved onto another index assignment
+  // without them, and they cannot be recovered afterwards, so they are
+  // recorded here as they are written (blind_reloc_record).
+  //
+  // `blind_reloc_owner_cell` is a one-element cell naming the body being
+  // filled, and an EMPTY one disables recording entirely -- the same
+  // convention `lambda_plan_next` uses for "this ctx was built outside the
+  // planned body loop". The three payload arrays are shared BY REFERENCE into
+  // per-lambda derived ctxs, like table_slots_used, so a nested lambda's
+  // records land in the module-level arrays; only the cell is per-body.
+  blind_reloc_owner_cell: Array[Int];
+  blind_reloc_owners: Array[Int];
+  blind_reloc_offsets: Array[Int];
+  blind_reloc_kinds: Array[Int];
+  blind_reloc_syms: Array[Int]
 }
 
 /// Interior-line breakpoints (span-arc step5, multi-file): per-file provenance the
@@ -1706,6 +1730,48 @@ export fn linemap_disabled() -> LineMapState {
     offsets: array_empty(),
     file_ids: array_empty(),
     lines: array_empty()
+  }
+}
+
+/// #2669 slice 2: record one reference the instruction encoding does not
+/// expose, at the byte `buf` is about to receive.
+///
+/// The offset is where the CONSTANT'S OPCODE goes, not where its immediate
+/// starts. That is deliberate: a consumer can assert the byte it finds there
+/// is the opcode it expects (`0x42` for i64.const, `0x41` for i32.const)
+/// before rewriting, so an off-by-one is caught rather than silently
+/// patching an operand of the previous instruction.
+///
+/// A no-op when the owner cell is empty -- every ctx built outside a body
+/// loop that harvests these, including the whole gc lane.
+export fn blind_reloc_record(ctx: CompileCtx, buf: Bytes, kind: Int, sym: Int) -> Unit {
+  if Array::length(ctx.blind_reloc_owner_cell) > 0 {
+    Array::push(ctx.blind_reloc_owners, Array::get(ctx.blind_reloc_owner_cell, 0))
+    Array::push(ctx.blind_reloc_offsets, Bytes::length(buf))
+    Array::push(ctx.blind_reloc_kinds, kind)
+    Array::push(ctx.blind_reloc_syms, sym)
+  } else {
+    ()
+  }
+}
+
+/// Give every still-`pending` record appended since `lo` the owner `owner`.
+///
+/// A lambda's index comes from the frozen plan AFTER its body is compiled, so
+/// the records that body made cannot know their owner when they are written.
+/// Records from a NESTED lambda in the same range were already reassigned by
+/// that lambda's own call, which is why the pending test -- not the range
+/// alone -- decides.
+export fn blind_reloc_assign_pending(ctx: CompileCtx, lo: Int, owner: Int) -> Unit {
+  let n = Array::length(ctx.blind_reloc_owners)
+  let mut i = lo
+  while i < n {
+    if Array::get(ctx.blind_reloc_owners, i) == blind_owner_pending {
+      Array::set(ctx.blind_reloc_owners, i, owner)
+    } else {
+      ()
+    }
+    i = i + 1
   }
 }
 

--- a/lib/@vibe/compiler/codegen/common_base/index.vpkg
+++ b/lib/@vibe/compiler/codegen/common_base/index.vpkg
@@ -4,6 +4,7 @@ description =
   #|@vibe/compiler/codegen/common_base — the shared codegen substrate: the
 deps = {
   @vibe/ast : 0.0.1
+  @vibe/compiler/codegen/reloc : 0.0.1
   @vibe/compiler/codegen/wasm_emit : 0.0.1
   @vibe/compiler/core : 0.0.1
   @vibe/compiler/normalize : 0.0.1
@@ -314,6 +315,10 @@ fn suspend_cps_pass(stmts: Array[Stmt]) -> Array[String]
 // coordinator can hand bodies out per function and collect them back without
 // codegen growing an `Fs` row (that row propagates into the signatures of user
 // programs that call compile_wasi_module). See common_base.vibe.
+fn blind_reloc_record(ctx: CompileCtx, buf: Bytes, kind: Int, sym: Int) -> Unit
+
+fn blind_reloc_assign_pending(ctx: CompileCtx, lo: Int, owner: Int) -> Unit
+
 fn codegen_body_cache_new() -> CodegenBodyCache
 fn codegen_body_cache_find(cache: CodegenBodyCache, fn_index: Int) -> Int
 // #2388 step 3 follow-up: the same lookup without the per-function scan --

--- a/lib/@vibe/compiler/codegen/expr/compile_expr.vibe
+++ b/lib/@vibe/compiler/codegen/expr/compile_expr.vibe
@@ -21,6 +21,10 @@ import @vibe/core {
   array_empty
 }
 
+import @vibe/compiler/codegen/reloc {
+  blind_kind_fn_value
+}
+
 import @vibe/compiler/codegen/common_analysis {
   collect_free_vars, collect_strings_stmts, emit_closure_call_tail, emit_closure_resolve, emit_i64_extend_i32_u, is_mut_captured_in
 }
@@ -34,6 +38,7 @@ import @vibe/compiler/codegen/common_base {
   agg_expr_of_ident,
   agg_info_of_ident,
   agg_log_reset_above2,
+  blind_reloc_record,
   codegen_unresolved_name_prefix,
   codegen_unresolved_name_suffix,
   cov_emit_branch,
@@ -1175,6 +1180,7 @@ export fn compile_expr(buf: Bytes, expr: Expr, local_names: Array[String], next_
           } else {
             let table_slot = fidx - ctx.func_offset
             Array::push(ctx.table_slots_used, table_slot)
+            blind_reloc_record(ctx, buf, blind_kind_fn_value, table_slot)
             emit_i64_const(buf, (table_slot<<2)|2)
             next_local
           }

--- a/lib/@vibe/compiler/codegen/expr/compile_lambda.vibe
+++ b/lib/@vibe/compiler/codegen/expr/compile_lambda.vibe
@@ -23,6 +23,10 @@ import @vibe/compiler/perceus {
   build_perceus_plan_pinned, pa_is_alias_dup, pa_is_drop, pa_is_dup, pa_is_reuse_token, param_is_heap_in_body
 }
 
+import @vibe/compiler/codegen/reloc {
+  blind_kind_fn_value, blind_kind_table_slot_i32, blind_owner_of_lambda, blind_owner_pending
+}
+
 import @vibe/compiler/codegen/common_analysis {
   collect_free_vars,
   collect_free_vars_indexed,
@@ -43,6 +47,8 @@ import @vibe/compiler/codegen/common_base {
   FuncTable,
   LambdaTable,
   StrTable,
+  blind_reloc_assign_pending,
+  blind_reloc_record,
   emit_binop_op,
   emit_heap_grow_after_heap_set,
   emit_i32_eq,
@@ -450,6 +456,10 @@ export fn compile_lambda(buf: Bytes, params: Array[(String, Option[TypeExpr])], 
     }
     lfs_i = lfs_i + 1
   }
+  // #2669 slice 2: everything recorded from here on belongs to THIS lambda's
+  // body (or to one nested inside it, which reassigns its own) until the
+  // plan hands over an index below.
+  let blind_lo = Array::length(ctx.blind_reloc_owners)
   let lam_ctx = CompileCtx::{
     func_table: ctx.func_table,
     str_table: ctx.str_table,
@@ -535,7 +545,17 @@ export fn compile_lambda(buf: Bytes, params: Array[(String, Option[TypeExpr])], 
     // the wrong buffer. Force disabled rather than propagating ctx.linemap
     // (documented gap: lambda-body statements are absent from the static
     // linemap; their live `--break`/dbg_line hooks are unaffected).
-    linemap: linemap_disabled()
+    linemap: linemap_disabled(),
+    // #2669 slice 2: the payload arrays are SHARED, like table_slots_used --
+    // a lambda body's references belong in the module-level log. Only the
+    // owner cell is this body's own, and it holds `pending` because the
+    // lambda's index is not drawn from the plan until the body is finished
+    // (see blind_reloc_assign_pending below).
+    blind_reloc_owner_cell: [blind_owner_pending],
+    blind_reloc_owners: ctx.blind_reloc_owners,
+    blind_reloc_offsets: ctx.blind_reloc_offsets,
+    blind_reloc_kinds: ctx.blind_reloc_kinds,
+    blind_reloc_syms: ctx.blind_reloc_syms
   }
   if ctx.enable_rc {
     let mut dpi = 0
@@ -653,9 +673,11 @@ export fn compile_lambda(buf: Bytes, params: Array[(String, Option[TypeExpr])], 
   }
   Array::push(ctx.lambda_table.meta_i32, 0)
   Array::push(ctx.lambda_table.meta_i64, extra_lam)
+  blind_reloc_assign_pending(ctx, blind_lo, blind_owner_of_lambda(lambda_idx))
   let table_slot = ctx.lambda_slot_base + lambda_idx
   Array::push(ctx.table_slots_used, table_slot)
   if num_captures == 0 {
+    blind_reloc_record(ctx, buf, blind_kind_fn_value, table_slot)
     emit_i64_const(buf, (table_slot<<2)|2)
     next_local
   } else {
@@ -686,6 +708,7 @@ export fn compile_lambda(buf: Bytes, params: Array[(String, Option[TypeExpr])], 
       emit_i32_store8(buf, 0, 7)
       emit_local_get(buf, ptr_local)
       emit_i32_wrap_i64(buf)
+      blind_reloc_record(ctx, buf, blind_kind_table_slot_i32, table_slot)
       emit_i32_const(buf, table_slot)
       emit_i32_store(buf, 2, 8)
       emit_local_get(buf, ptr_local)
@@ -703,6 +726,7 @@ export fn compile_lambda(buf: Bytes, params: Array[(String, Option[TypeExpr])], 
       emit_heap_grow_after_heap_set(buf, ctx)
       emit_local_get(buf, ptr_local)
       emit_i32_wrap_i64(buf)
+      blind_reloc_record(ctx, buf, blind_kind_table_slot_i32, table_slot)
       emit_i32_const(buf, table_slot)
       emit_i32_store(buf, 2, 0)
       emit_local_get(buf, ptr_local)

--- a/lib/@vibe/compiler/codegen/expr/compile_module_expr.vibe
+++ b/lib/@vibe/compiler/codegen/expr/compile_module_expr.vibe
@@ -307,7 +307,15 @@ export fn compile_module_expr_with_typed_offsets(stmts: Array[Stmt], checker_flo
         // Empty: this ctx is built outside the planned body loop, so there is
         // no preassigned lambda range to check against (#1259).
         lambda_plan_next: fresh_int_array(),
-        linemap: linemap_disabled()
+        linemap: linemap_disabled(),
+        // #2669 slice 2: empty cell = record nothing. Nothing harvests this
+        // path's bodies, so there is no consumer for the references and no
+        // owner numbering to record them under.
+        blind_reloc_owner_cell: fresh_int_array(),
+        blind_reloc_owners: fresh_int_array(),
+        blind_reloc_offsets: fresh_int_array(),
+        blind_reloc_kinds: fresh_int_array(),
+        blind_reloc_syms: fresh_int_array()
       }
       let final_nl = compile_expr(body_buf, body, local_names, param_count, compile_ctx, -1)
       Array::push(bodies, body_buf)

--- a/lib/@vibe/compiler/codegen/expr/index.vpkg
+++ b/lib/@vibe/compiler/codegen/expr/index.vpkg
@@ -6,6 +6,7 @@ deps = {
   @vibe/compiler/codegen/common_analysis : 0.0.1
   @vibe/compiler/codegen/common_base : 0.0.1
   @vibe/compiler/codegen/common_extractors : 0.0.1
+  @vibe/compiler/codegen/reloc : 0.0.1
   @vibe/compiler/codegen/wasm_emit : 0.0.1
   @vibe/compiler/core : 0.0.1
   @vibe/compiler/perceus : 0.0.1

--- a/lib/@vibe/compiler/codegen/reloc/index.vpkg
+++ b/lib/@vibe/compiler/codegen/reloc/index.vpkg
@@ -46,6 +46,18 @@ let reloc_kind_data: Int
 
 let reloc_kind_elem: Int
 
+let blind_kind_fn_value: Int
+
+let blind_kind_table_slot_i32: Int
+
+let blind_owner_pending: Int
+
+fn blind_owner_of_lambda(lambda_idx: Int) -> Int
+
+fn blind_owner_lambda_index(owner: Int) -> Int
+
+fn blind_owner_is_lambda(owner: Int) -> Bool
+
 fn body_relocs_new() -> BodyRelocs
 
 fn body_relocs_count(r: BodyRelocs) -> Int

--- a/lib/@vibe/compiler/codegen/reloc/reloc_scan.vibe
+++ b/lib/@vibe/compiler/codegen/reloc/reloc_scan.vibe
@@ -74,6 +74,50 @@ export let reloc_kind_data: Int = 8
 
 export let reloc_kind_elem: Int = 9
 
+//# The classes the instruction encoding does NOT expose (#2669 slice 2).
+//#
+//# These are not found by scanning: they ride an `i64.const` / `i32.const`
+//# that is byte-for-byte an ordinary constant. The EMITTER records them, at
+//# the sites that already exist for another reason -- `CompileCtx`'s
+//# `table_slots_used` log is appended at exactly the points a function value
+//# is emitted, so the set is closed and stays closed: a new function-value
+//# site that forgot to record would also break the element section.
+//#
+//# Numbered from 101 so a consumer can hold scanned and recorded references
+//# in ONE table with no extra tag. Stored in artifacts, so append-only.
+
+/// `i64.const ((slot << 2) | 2)` -- a function used as a VALUE. `sym` is the
+/// funcref-table slot, `aux` unused.
+export let blind_kind_fn_value: Int = 101
+
+/// `i32.const slot` -- the funcref-table slot stored into a closure header by
+/// the capturing lambda form. Same symbol, different encoding and width.
+///
+/// The other class named above -- a DATA POINTER, which rides an `i64.const`
+/// the same way -- has no kind here yet. Numbering it before anything emits
+/// it would be a promise, and the numbers are append-only, so it gets one
+/// when the emitter records it.
+export let blind_kind_table_slot_i32: Int = 102
+
+/// The owner of a recorded reference is the body it sits in: a user function
+/// by index, or a lambda. A lambda's index is not known until AFTER its body
+/// has been compiled (`compile_lambda` takes it from the frozen plan at the
+/// end), so records made while compiling one are owned by `pending` and
+/// reassigned when the index arrives.
+export let blind_owner_pending: Int = -1
+
+export fn blind_owner_of_lambda(lambda_idx: Int) -> Int {
+  0 - 2 - lambda_idx
+}
+
+export fn blind_owner_lambda_index(owner: Int) -> Int {
+  0 - 2 - owner
+}
+
+export fn blind_owner_is_lambda(owner: Int) -> Bool {
+  owner <= 0 - 2
+}
+
 /// Every reference one body makes, as parallel arrays -- the shape
 /// `CodegenBodyCache` already uses for everything it carries.
 ///

--- a/lib/@vibe/compiler/codegen/wasi/index.vpkg
+++ b/lib/@vibe/compiler/codegen/wasi/index.vpkg
@@ -9,6 +9,7 @@ deps = {
   @vibe/compiler/codegen/common_base : 0.0.1
   @vibe/compiler/codegen/common_extractors : 0.0.1
   @vibe/compiler/codegen/expr : 0.0.1
+  @vibe/compiler/codegen/reloc : 0.0.1
   @vibe/compiler/codegen/wasm_emit : 0.0.1
   @vibe/compiler/core : 0.0.1
   @vibe/compiler/normalize : 0.0.1

--- a/lib/@vibe/compiler/codegen/wasi/linked_compile.vibe
+++ b/lib/@vibe/compiler/codegen/wasi/linked_compile.vibe
@@ -165,6 +165,10 @@ import @vibe/compiler/codegen/builtin_bodies {
   static_str_len_body
 }
 
+import @vibe/compiler/codegen/reloc {
+  blind_kind_fn_value, blind_kind_table_slot_i32, blind_owner_lambda_index, blind_owner_pending
+}
+
 import @vibe/compiler/codegen/common_analysis {
   bmask_has,
   borrow_round0_link,
@@ -1295,6 +1299,113 @@ fn lc_fresh_type_expr_array() -> Array[TypeExpr] {
 /// each index is known (linemap_hdrlen_by_bi below: one entry per user
 /// function, filled in `ci` order as each function's locals header is
 /// assembled).
+/// #2669 slice 2: LEB128, signed, at `p` in `body`. `i64.const` and
+/// `i32.const` immediates are both signed; reading one unsigned would agree
+/// exactly where small slot numbers live and disagree everywhere a check
+/// would matter, so the decode has to sign-extend.
+fn lc_read_sleb(body: Bytes, p: Int) -> Int with Exception {
+  let n = Bytes::length(body)
+  let mut acc = 0
+  let mut shift = 0
+  let mut i = p
+  let mut last = 0
+  let mut done = false
+  while !done {
+    if i >= n {
+      throw("blind reloc: constant runs past the end of the body")
+    } else {
+      ()
+    }
+    let byte = Bytes::get(body, i)
+    last = byte
+    acc = acc|((byte&127)<<shift)
+    shift = shift + 7
+    i = i + 1
+    if (byte&128) == 0 {
+      done = true
+    } else {
+      ()
+    }
+  }
+  if shift < 64 && (last&64) != 0 {
+    acc|(0 - (1<<shift))
+  } else {
+    acc
+  }
+}
+
+/// #2669 slice 2: every recorded reference must name the constant it claims.
+///
+/// See the call site for why this is not optional. `owners` are body ids -- a
+/// user function by index, a lambda as `blind_owner_of_lambda` -- and the
+/// offsets are relative to that body's instruction stream, which is what
+/// `bodies` holds (the locals header is prepended later, at code-section
+/// assembly).
+fn lc_verify_blind_relocs(bodies: Array[Bytes], num_generated: Int, lambda_ci_base: Int, owners: Array[Int], offsets: Array[Int], kinds: Array[Int], syms: Array[Int]) -> Unit with Exception {
+  let n = Array::length(owners)
+  let mut k = 0
+  while k < n {
+    let owner = Array::get(owners, k)
+    // A record still owned by `pending` means a lambda body was compiled and
+    // its planned index never arrived, so the reference belongs to no body at
+    // all. Louder than leaving it to be misattributed.
+    if owner == blind_owner_pending {
+      throw("blind reloc: a recorded reference was never assigned an owner (a lambda body compiled without taking its planned index)")
+    } else {
+      ()
+    }
+    let ci = if owner >= 0 {
+      num_generated + owner
+    } else {
+      lambda_ci_base + blind_owner_lambda_index(owner)
+    }
+    // Late DCE replaces an unused GENERATED helper's body with a one-byte
+    // stub, which would leave a record naming it pointing into a body that no
+    // longer exists. None can: an owner is a user function or a lambda, and
+    // both map above num_generated. Checked, not assumed -- the two sites are
+    // far apart and only one of them would have to move.
+    if ci < num_generated || ci >= Array::length(bodies) {
+      throw(String::concat("blind reloc: owner maps outside the user code range: owner ", String::concat(__to_string(owner), String::concat(" -> code index ", __to_string(ci)))))
+    } else {
+      ()
+    }
+    let body = Array::get(bodies, ci)
+    let off = Array::get(offsets, k)
+    if off < 0 || off >= Bytes::length(body) {
+      throw(String::concat("blind reloc: offset outside the body: code index ", String::concat(__to_string(ci), String::concat(" offset ", __to_string(off)))))
+    } else {
+      ()
+    }
+    let kind = Array::get(kinds, k)
+    let sym = Array::get(syms, k)
+    let opcode = Bytes::get(body, off)
+    let want_op = if kind == blind_kind_fn_value {
+      66
+    } else if kind == blind_kind_table_slot_i32 {
+      65
+    } else {
+      throw(String::concat("blind reloc: unknown kind ", __to_string(kind)))
+    }
+    let want_val = if kind == blind_kind_fn_value {
+      (sym<<2)|2
+    } else {
+      sym
+    }
+    if opcode != want_op {
+      throw(String::concat("blind reloc: expected opcode ", String::concat(__to_string(want_op), String::concat(" at code index ", String::concat(__to_string(ci), String::concat(" offset ", String::concat(__to_string(off), String::concat(", found ", __to_string(opcode)))))))))
+    } else {
+      ()
+    }
+    let got = lc_read_sleb(body, off + 1)
+    if got != want_val {
+      throw(String::concat("blind reloc: constant at code index ", String::concat(__to_string(ci), String::concat(" offset ", String::concat(__to_string(off), String::concat(" decodes to ", String::concat(__to_string(got), String::concat(", recorded ", __to_string(want_val)))))))))
+    } else {
+      ()
+    }
+    k = k + 1
+  }
+}
+
 fn lc_fresh_int_array_of_len(n: Int, fill: Int) -> Array[Int] {
   let arr = lc_fresh_int_array()
   let mut i = 0
@@ -10780,6 +10891,16 @@ export fn compile_wasi_module_linked_impl_with_split(stmts: Array[Stmt], entry_n
   // array by reference — and consumed by the element-section emission, which
   // registers only the recorded slots.
   let table_slots_used = lc_fresh_int_array()
+  // #2669 slice 2: module-wide log of the references the instruction encoding
+  // does not expose -- function values and data pointers, which ride an
+  // ordinary-looking constant (see CompileCtx.blind_reloc_*). Created once and
+  // shared by reference into every per-body CompileCtx below, exactly like
+  // table_slots_used, and checked against the emitted bodies below
+  // (lc_verify_blind_relocs) before anything is allowed to depend on them.
+  let blind_owners = lc_fresh_int_array()
+  let blind_offsets = lc_fresh_int_array()
+  let blind_kinds = lc_fresh_int_array()
+  let blind_syms = lc_fresh_int_array()
   let bodies = lc_fresh_bytes_array()
   let meta_i32 = lc_fresh_int_array()
   let meta_i64 = lc_fresh_int_array()
@@ -11188,6 +11309,8 @@ export fn compile_wasi_module_linked_impl_with_split(stmts: Array[Stmt], entry_n
         // The log is module-level and append-only, so the function's own
         // contribution is exactly the suffix it grows below.
         let __slot_lo = Array::length(table_slots_used)
+        // #2669 slice 2: the same suffix, for the blind-reference log.
+        let __blind_lo = Array::length(blind_owners)
         let __bi_stmt = Array::get(stmts, Array::get(fn_stmt_indices, bi))
         // #703 follow-up: under RC, lift temporary match scrutinees into lets so the
         // Perceus pass (which drops named bindings) reclaims them. Applied here, the
@@ -11615,7 +11738,15 @@ export fn compile_wasi_module_linked_impl_with_split(stmts: Array[Stmt], entry_n
           pending_letrec_self_name: lc_fresh_string_array(),
           table_slots_used: table_slots_used,
           lambda_plan_next: lambda_plan_cell,
-          linemap: linemap_state
+          linemap: linemap_state,
+          // #2669 slice 2: this body is user function `bi`. The cell is fresh
+          // per body (it names the owner); the payload arrays are the
+          // module-wide ones.
+          blind_reloc_owner_cell: [bi],
+          blind_reloc_owners: blind_owners,
+          blind_reloc_offsets: blind_offsets,
+          blind_reloc_kinds: blind_kinds,
+          blind_reloc_syms: blind_syms
         }
         if is_efn(__bi_expr) {
           // #715: `lc_norm_params` (built above from `get_efn_params(__bi_expr)`)
@@ -12071,6 +12202,32 @@ export fn compile_wasi_module_linked_impl_with_split(stmts: Array[Stmt], entry_n
         // Harvest is unconditional and cheap (it copies references into parallel
         // arrays, it does not re-encode). The cache is only READ when a caller
         // supplies one.
+        // #2669 slice 2: the blind-reference log and the funcref-slot log must
+        // grow BY THE SAME AMOUNT over this function's compile.
+        //
+        // This is what keeps the recording COMPLETE rather than merely
+        // believed complete. A function value is emitted at exactly the points
+        // that append to `table_slots_used` -- compile_expr's
+        // named-function-as-value branch and compile_lambda's single
+        // `table_slot` computation, which feeds both the captureless
+        // `i64.const` and the capturing closure header's `i32.const`. Each
+        // appends one slot and records one reference. So a new emission site
+        // that forgot to record, or a record without an emission, shows up
+        // here as a count that does not match, on every compile, instead of as
+        // a cached body that relocates one reference short.
+        //
+        // Compiled functions only: a REPLAYED function re-pushes its recorded
+        // slots from the cache without re-running codegen, so it contributes
+        // slots and no blind references. That asymmetry is the reason a
+        // replaying build's blind log is incomplete, and carrying these in
+        // `CodegenBodyCache` is what removes it.
+        let __blind_grew = Array::length(blind_owners) - __blind_lo
+        let __slots_grew = Array::length(table_slots_used) - __slot_lo
+        if __blind_grew != __slots_grew {
+          throw(String::concat("blind reloc: function ", String::concat(__to_string(bi), String::concat(" appended ", String::concat(__to_string(__slots_grew), String::concat(" funcref slots but ", String::concat(__to_string(__blind_grew), " blind references -- a function-value emission site records one or the other, never just one")))))))
+        } else {
+          ()
+        }
         codegen_body_cache_record(body_cache_out, bi, Array::get(fn_stmt_indices, bi), bodies, meta_i32, meta_i64, meta_v128, lt_w, Array::get(lambda_bases, bi), lambda_planned_end, table_slots_used, __slot_lo, Array::length(table_slots_used))
       }
     }
@@ -12189,6 +12346,27 @@ export fn compile_wasi_module_linked_impl_with_split(stmts: Array[Stmt], entry_n
     Array::push(meta_v128, 0)
     li = li + 1
   }
+  // #2669 slice 2: where lambda bodies begin in `bodies`. DERIVED from the
+  // array that was just filled rather than spelled as
+  // `num_generated + num_user_funcs + 2` -- the `+ 2` would be a silent
+  // assumption about `_start` and `run`, and a third synthesized body would
+  // misattribute every recorded lambda reference. Nothing appends to `bodies`
+  // after this point.
+  let lambda_ci_base = Array::length(bodies) - num_lambdas
+  // #2669 slice 2: CHECK every recorded reference against the byte it names.
+  //
+  // A wrong record is the worst thing this mechanism can produce and the
+  // hardest to notice. The references it holds are the ones nothing in the
+  // bytes marks as references, so a stale offset does not fail to resolve --
+  // it resolves, rewrites an unrelated operand, and the module still
+  // validates. There is no later stage that could catch it.
+  //
+  // So it is checked here, on every compile, against the bodies as emitted:
+  // the opcode at the offset must be the one the kind implies, and the
+  // constant there must decode to exactly what the record says the reference
+  // is. Thousands of records on a compiler-sized program, a couple of byte
+  // reads and one LEB decode each.
+  lc_verify_blind_relocs(bodies, num_generated, lambda_ci_base, blind_owners, blind_offsets, blind_kinds, blind_syms)
   let mut max_closure_arity = -1
   let mut lai = 0
   while lai < num_lambdas {

--- a/lib/@vibe/compiler/tests/blind_reloc_test.vibe
+++ b/lib/@vibe/compiler/tests/blind_reloc_test.vibe
@@ -1,0 +1,85 @@
+//# #2669 slice 2: the compiler records where a body refers to a function by
+//# VALUE, and every record is checked against the byte it names.
+//#
+//# The assertion lives in the compiler, not here. `lc_verify_blind_relocs`
+//# runs on every compile: for each recorded reference, the opcode at the
+//# recorded offset must be the one its kind implies and the constant there
+//# must decode to exactly what the record says the reference is. A second
+//# check pairs the blind log against the funcref-slot log, which is appended
+//# at the same emission sites, so the two must grow by the same amount over a
+//# function's compile. Either one throws.
+//#
+//# So each case below is a whole-module assertion the same way
+//# codegen_body_cache_test's are: it passes only if every record the shape
+//# produces is true. What the cases are for is the OWNER numbering, which is
+//# the part with room to be wrong -- a lambda's index is not drawn from the
+//# plan until its body is finished, so its records are written under a pending
+//# owner and reassigned afterwards, and a nested lambda has to keep its own.
+//# A misassigned owner reads the offsets against another function's body,
+//# which is what the in-compiler check catches.
+//#
+//# Mutation-checked against a compiler with the recorded offset moved by one
+//# byte, with the two kinds swapped, and with the nested-lambda reassignment
+//# widened to claim the inner lambda's records. All three fail here.
+
+//# Imports
+
+import @vibe/compiler/codegen {
+  compile_wasi_module
+}
+
+import @vibe/compiler/syntax {
+  lex
+}
+
+import ../parser.vibe {
+  parse_program
+}
+
+//# Functions
+
+/// Compile, and assert the module is a real one. The interesting assertion
+/// already ran inside: a false record throws rather than returning bytes.
+fn assert_compiles(source: String) -> Unit with Exception {
+  let wasm = compile_wasi_module(parse_program(lex(source)), "main")
+  assert(Bytes::length(wasm) > 8)
+}
+
+test "blind reloc: a named function used as a value" {
+  // `inc` passed by name is compile_expr's `i64.const ((slot << 2) | 2)`.
+  assert_compiles("fn twice(f: (Int) -> Int, x: Int) -> Int {\n  f(f(x))\n}\n\nfn inc(n: Int) -> Int {\n  n + 1\n}\n\nfn main allows Stdout {\n  println(Int::to_string(twice(inc, 3)))\n}\n",)
+}
+
+test "blind reloc: a captureless lambda takes the same i64 form" {
+  assert_compiles("fn twice(f: (Int) -> Int, x: Int) -> Int {\n  f(f(x))\n}\n\nfn main allows Stdout {\n  println(Int::to_string(twice((v) -> {\n    v + 1\n  }, 3)))\n}\n",)
+}
+
+test "blind reloc: a capturing lambda stores its slot as an i32" {
+  // The capturing form puts the slot in the closure header instead of folding
+  // it into a function value, so this is the case that distinguishes the two
+  // kinds -- and the case where reading the constant with the wrong opcode
+  // expectation would be caught.
+  assert_compiles("fn twice(f: (Int) -> Int, x: Int) -> Int {\n  f(f(x))\n}\n\nfn bump(n: Int) -> Int {\n  twice((v) -> {\n    v + n\n  }, n)\n}\n\nfn main allows Stdout {\n  println(Int::to_string(bump(3)))\n}\n",)
+}
+
+test "blind reloc: nested lambdas keep their own owners" {
+  // The shape the pending-owner reassignment exists for. The inner lambda
+  // finishes first and claims its own records; the outer one must then claim
+  // only what is left. If it claimed the inner's too, those offsets would be
+  // read against the outer lambda's body and land on unrelated bytes.
+  assert_compiles("fn make_adder(n: Int) -> (Int) -> Int {\n  (x) -> {\n    let inner = (y) -> {\n      y + n\n    }\n    inner(x) + n\n  }\n}\n\nfn main allows Stdout {\n  let f = make_adder(2)\n  println(Int::to_string(f(10)))\n}\n",)
+}
+
+test "blind reloc: closures reaching call_indirect, several owners" {
+  // Lambdas in an array, so the module installs several table slots and the
+  // records span more than one owner -- the shape that first exposed the
+  // slot log's own gap in #1259.
+  assert_compiles("fn apply_all(fs: Array[(Int) -> Int], x: Int) -> Int {\n  let mut acc = x\n  let mut i = 0\n  while i < Array::length(fs) {\n    let f = Array::get(fs, i)\n    acc = f(acc)\n    i = i + 1\n  }\n  acc\n}\n\nfn main allows Stdout {\n  let fs = [\n    (v) -> {\n      v + 1\n    },\n    (v) -> {\n      v * 3\n    }\n  ]\n  println(Int::to_string(apply_all(fs, 5)))\n}\n",)
+}
+
+test "blind reloc: a program with no function values records nothing" {
+  // Nothing to record, and nothing spurious recorded: the paired-count check
+  // reads zero on both sides, which it would not if a record were produced
+  // without a slot.
+  assert_compiles("fn add(a: Int, b: Int) -> Int {\n  a + b\n}\n\nfn main allows Stdout {\n  println(Int::to_string(add(2, 3)))\n}\n",)
+}

--- a/lib/@vibe/compiler/tests/blind_reloc_test.vibe
+++ b/lib/@vibe/compiler/tests/blind_reloc_test.vibe
@@ -18,9 +18,17 @@
 //# A misassigned owner reads the offsets against another function's body,
 //# which is what the in-compiler check catches.
 //#
-//# Mutation-checked against a compiler with the recorded offset moved by one
-//# byte, with the two kinds swapped, and with the nested-lambda reassignment
-//# widened to claim the inner lambda's records. All three fail here.
+//# Mutation-checked, four ways, each against a compiler built with that one
+//# change and this file run unmodified. All four FAIL here; unmutated passes.
+//#
+//#   recorded offset + 1                 the byte named is not the opcode
+//#   kind changed at compile_expr        i64.const read as an i32.const
+//#   one record push deleted             the paired counts diverge
+//#   reassignment drops its pending test the outer lambda claims the inner's
+//#
+//# The fourth is the reason the nested case below is shaped the way it is:
+//# the first version of it PASSED under that mutation, which made three out of
+//# four look like a complete result.
 
 //# Imports
 
@@ -63,11 +71,21 @@ test "blind reloc: a capturing lambda stores its slot as an i32" {
 }
 
 test "blind reloc: nested lambdas keep their own owners" {
-  // The shape the pending-owner reassignment exists for. The inner lambda
-  // finishes first and claims its own records; the outer one must then claim
-  // only what is left. If it claimed the inner's too, those offsets would be
-  // read against the outer lambda's body and land on unrelated bytes.
-  assert_compiles("fn make_adder(n: Int) -> (Int) -> Int {\n  (x) -> {\n    let inner = (y) -> {\n      y + n\n    }\n    inner(x) + n\n  }\n}\n\nfn main allows Stdout {\n  let f = make_adder(2)\n  println(Int::to_string(f(10)))\n}\n",)
+  // The shape the pending-owner reassignment exists for, and the one case
+  // here that had to be built rather than picked: a lambda's records are
+  // written under a pending owner and reassigned once the plan hands over its
+  // index, so a nested lambda -- which finishes FIRST -- must already own its
+  // own. An outer reassignment that claimed them would read their offsets
+  // against the outer body.
+  //
+  // Both lambda BODIES have to contain a function value for that to be
+  // reachable, which is why each passes a named function to `twice` rather
+  // than doing arithmetic. The obvious spelling -- a nested closure over `n`
+  // -- does NOT exercise it: a capturing lambda's slot is emitted into the
+  // ENCLOSING buffer, so the inner body records nothing and there is nothing
+  // to steal. Measured: with the reassignment widened to drop its pending
+  // test, that version still passed.
+  assert_compiles("fn twice(f: (Int) -> Int, x: Int) -> Int {\n  f(f(x))\n}\n\nfn inc(n: Int) -> Int {\n  n + 1\n}\n\nfn dbl(n: Int) -> Int {\n  n * 2\n}\n\nfn outer() -> (Int) -> Int {\n  (x) -> {\n    let inner = (y) -> {\n      twice(dbl, y)\n    }\n    inner(twice(inc, x))\n  }\n}\n\nfn main allows Stdout {\n  let f = outer()\n  println(Int::to_string(f(3)))\n}\n",)
 }
 
 test "blind reloc: closures reaching call_indirect, several owners" {

--- a/scripts/reloc_crossbuild.sh
+++ b/scripts/reloc_crossbuild.sh
@@ -37,8 +37,11 @@ cd "$ROOT_DIR"
 . "$ROOT_DIR/scripts/resolve_stage2.sh"
 STAGE2="$(resolve_stage2 reloc-crossbuild "${RELOC_CROSSBUILD_STAGE2:-}")"
 
-if [ "$#" -eq 2 ]; then
-  VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/vibe_run.sh scripts/reloc_crossbuild.vibex -- "$1" "$2"
+# An explicitly supplied pair. A third argument names comma-separated functions
+# whose SOURCE differs between the two modules, to be excluded from the
+# statistics (see the vibex); without one, nothing is excluded.
+if [ "$#" -ge 2 ]; then
+  VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/vibe_run.sh scripts/reloc_crossbuild.vibex -- "$1" "$2" ${3:+"$3"}
   exit $?
 fi
 
@@ -85,7 +88,12 @@ build b
 cp "$work/leaf.orig" "$LEAF"
 
 echo "[reloc-crossbuild] the reordering edit touches ONE existing body:"
-echo "                   encode_url_safe (one added let). Mismatches naming it"
-echo "                   are a source change, not a relocation failure."
+echo "                   encode_url_safe (one added let). It is EXCLUDED from"
+echo "                   the statistics below -- its two versions are different"
+echo "                   source programs, so comparing them measures the edit."
+# The third argument names the function this wrapper EDITED. Its two versions
+# are different source programs, so comparing them would measure the edit and
+# not relocation; the vibex excludes it from the statistics and FAILS if the
+# name matches nothing, so a rename here cannot silently put it back.
 VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/vibe_run.sh scripts/reloc_crossbuild.vibex -- \
-  "$work/a.wasm" "$work/b.wasm"
+  "$work/a.wasm" "$work/b.wasm" encode_url_safe

--- a/scripts/reloc_crossbuild.sh
+++ b/scripts/reloc_crossbuild.sh
@@ -16,6 +16,11 @@
 # function and named in the output below, so the figure can be read with that
 # in mind rather than silently inflated.
 #
+# The vibex REFUSES a run where no shared function changed index: two builds
+# with the same assignment relocate perfectly by doing nothing, and that
+# perfect score measures nothing. Handing it one module twice reports
+# `matched=4351 mismatched=0 moved_index=0` and then fails.
+#
 # Not a `check_*` gate, same as scripts/reloc_roundtrip.sh: it builds the
 # compiler's whole closure twice, which is minutes, for a measurement rather
 # than a pass/fail property. It still FAILS rather than reporting a clean run

--- a/scripts/reloc_crossbuild.sh
+++ b/scripts/reloc_crossbuild.sh
@@ -37,6 +37,20 @@ cd "$ROOT_DIR"
 . "$ROOT_DIR/scripts/resolve_stage2.sh"
 STAGE2="$(resolve_stage2 reloc-crossbuild "${RELOC_CROSSBUILD_STAGE2:-}")"
 
+# Exactly 0, 2 or 3 arguments. Anything else is a typo, and the two ways this
+# used to absorb one were both silent: ONE path fell through to the default
+# builds and reported a confident measurement of an entirely different pair,
+# and a FOURTH argument was accepted and dropped. A measurement tool that
+# answers a question nobody asked is worse than one that refuses.
+case "$#" in
+  0|2|3) ;;
+  *)
+    echo "reloc-crossbuild: usage: $0 [a.wasm b.wasm [edited,fn,names]]" >&2
+    echo "                  (no arguments builds the pair itself)" >&2
+    exit 2
+    ;;
+esac
+
 # An explicitly supplied pair. A third argument names comma-separated functions
 # whose SOURCE differs between the two modules, to be excluded from the
 # statistics (see the vibex); without one, nothing is excluded.

--- a/scripts/reloc_crossbuild.sh
+++ b/scripts/reloc_crossbuild.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# #2669: relocate one build's bodies onto ANOTHER build's index assignment,
+# and compare against what the compiler emitted for that assignment.
+#
+#   bash scripts/reloc_crossbuild.sh [a.wasm b.wasm]
+#
+# With no arguments it builds the pair itself: the compiler's own closure, and
+# the same closure with one import added to `lib/@vibe/core/base64.vibe` --
+# which pulls `hex.vibe` earlier in the module order and moves most of the
+# function index space. That is the edit class #2669 measured as the hardest:
+# two distinct index deltas, one large and negative.
+#
+# Forcing a reorder REQUIRES editing at least one existing body (something has
+# to call across the new import), so a small number of mismatches are genuine
+# source changes rather than relocation failures. The edit is kept to one
+# function and named in the output below, so the figure can be read with that
+# in mind rather than silently inflated.
+#
+# Not a `check_*` gate, same as scripts/reloc_roundtrip.sh: it builds the
+# compiler's whole closure twice, which is minutes, for a measurement rather
+# than a pass/fail property. It still FAILS rather than reporting a clean run
+# when it cannot answer -- a build that does not produce a module, or a pair
+# sharing no named function, stops it.
+set -euo pipefail
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+. "$ROOT_DIR/scripts/resolve_stage2.sh"
+STAGE2="$(resolve_stage2 reloc-crossbuild "${RELOC_CROSSBUILD_STAGE2:-}")"
+
+if [ "$#" -eq 2 ]; then
+  VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/vibe_run.sh scripts/reloc_crossbuild.vibex -- "$1" "$2"
+  exit $?
+fi
+
+CORPUS="${RELOC_CROSSBUILD_CORPUS:-lib/@vibe/compiler/tests/codegen_lexer_test.vibe}"
+LEAF=lib/@vibe/core/base64.vibe
+work="_build/_reloc_crossbuild"
+mkdir -p "$work"
+cp "$LEAF" "$work/leaf.orig"
+trap 'cp "$work/leaf.orig" "$LEAF"' EXIT
+
+build() { # <tag>
+  local out="$work/$1.wasm"
+  rm -f "$out"
+  local rc=0
+  env -u VIBE_RC -u VIBE_BACKEND VIBE_WASM_NAMES=1 VIBE_BUILD_CACHE_DIR="$work/cache_$1" \
+    VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
+    bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$STAGE2" \
+    "$CORPUS" "$out" __no_entry__ >"$work/$1.log" 2>&1 || rc=$?
+  if [ "$rc" -ne 0 ] || [ ! -s "$out" ]; then
+    echo "reloc-crossbuild: FAIL: build $1 produced no module (exit $rc)" >&2
+    exit 1
+  fi
+}
+
+build a
+python3 - "$LEAF" <<'PY'
+import re, sys
+p = sys.argv[1]
+s = open(p).read()
+assert s.count('//# Functions\n') == 1
+s = s.replace('//# Functions\n',
+              '//# Imports\n\nimport ./hex.vibe {\n  hex_encode\n}\n\n//# Functions\n', 1)
+anchor = 'export fn encode_url_safe('
+assert s.count(anchor) == 1
+s = s.replace(anchor,
+              'fn b64_hex_bridge() -> Int {\n  String::length(hex_encode(""))\n}\n\n'
+              + anchor, 1)
+m = re.search(r'export fn encode_url_safe\([^)]*\)[^\{]*\{\n', s)
+assert m
+s = s[:m.end()] + '  let _bridge = b64_hex_bridge()\n' + s[m.end():]
+open(p, 'w').write(s)
+PY
+build b
+cp "$work/leaf.orig" "$LEAF"
+
+echo "[reloc-crossbuild] the reordering edit touches ONE existing body:"
+echo "                   encode_url_safe (one added let). Mismatches naming it"
+echo "                   are a source change, not a relocation failure."
+VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/vibe_run.sh scripts/reloc_crossbuild.vibex -- \
+  "$work/a.wasm" "$work/b.wasm"

--- a/scripts/reloc_crossbuild.sh
+++ b/scripts/reloc_crossbuild.sh
@@ -16,10 +16,15 @@
 # function and named in the output below, so the figure can be read with that
 # in mind rather than silently inflated.
 #
-# The vibex REFUSES a run where no shared function changed index: two builds
-# with the same assignment relocate perfectly by doing nothing, and that
-# perfect score measures nothing. Handing it one module twice reports
-# `matched=4351 mismatched=0 moved_index=0` and then fails.
+# The vibex REFUSES a vacuous run, in two steps. It fails when no shared
+# function changed index -- two builds with the same assignment relocate
+# perfectly by doing nothing, and handing it one module twice reports
+# `matched=4351 mismatched=0 moved_index=0` and then fails. It ALSO fails when
+# no body was both rewritten and byte-identical: a function's own index is not
+# encoded in its body, so a moved assignment does not mean any body was
+# rewritten, and bodies referencing only functions that held still are rebuilt
+# by an identity operation. `rewritten_matched` is the figure the result rests
+# on; `matched` includes those identity rebuilds and reads higher.
 #
 # Not a `check_*` gate, same as scripts/reloc_roundtrip.sh: it builds the
 # compiler's whole closure twice, which is minutes, for a measurement rather

--- a/scripts/reloc_crossbuild.vibex
+++ b/scripts/reloc_crossbuild.vibex
@@ -202,14 +202,30 @@ fn name_of(m: Mod, idx: Int) -> String {
   found
 }
 
+/// The index a NAME resolves to, or -1 when the name is absent, or -2 when it
+/// is AMBIGUOUS -- carried by more than one function.
+///
+/// Taking the first match would be silently wrong here, and the compiler
+/// really does produce duplicates: `linked_compile.vibe` labels every
+/// unassigned generated slot `__rt_gen` in a loop, so a module has many. With
+/// first-wins, every `__rt_gen` body in A is compared against the first one in
+/// B and every call targeting one is remapped to the first -- which
+/// manufactures mismatches AND can count a comparison against the WRONG body
+/// as a match. Found by review on #2705, after the first measurement had
+/// already been published with those rows in it.
 fn index_of_name(m: Mod, name: String) -> Int {
   let n = Array::length(m.names)
   let mut i = 0
   let mut found = -1
+  let mut hits = 0
   while i < n {
-    if Array::get(m.names, i) == name { found = Array::get(m.name_idxs, i); i = n } else { i = i + 1 }
+    if Array::get(m.names, i) == name {
+      hits = hits + 1
+      if hits == 1 { found = Array::get(m.name_idxs, i) } else { () }
+    } else { () }
+    i = i + 1
   }
-  found
+  if hits > 1 { -2 } else { found }
 }
 
 fn body_slot(m: Mod, idx: Int) -> Int {
@@ -247,7 +263,9 @@ fn main() -> Unit allows Exception + Fs + Stdout + Env {
   let mut compared = 0
   let mut matched = 0
   let mut mismatched = 0
-  let mut mismatch_with_nonfunc = 0
+  let mut mismatch_ambiguous_cause = 0
+  let mut ambiguous_name = 0
+  let mut moved_index = 0
   let mut mismatch_encoding_blind = 0
   let mut unresolved_func = 0
   let mut had_nonfunc = 0
@@ -261,10 +279,13 @@ fn main() -> Unit allows Exception + Fs + Stdout + Env {
     let nm = name_of(a, ai)
     let bi = if nm == "" { -1 } else { index_of_name(b, nm) }
     let bs = if bi < 0 { -1 } else { body_slot(b, bi) }
-    if bs < 0 {
+    if bi == -2 {
+      ambiguous_name = ambiguous_name + 1
+    } else if bs < 0 {
       a_only_shape = a_only_shape + 1
     } else {
       compared = compared + 1
+      if ai != bi { moved_index = moved_index + 1 } else { () }
       let a_start = Array::get(a.body_starts, i)
       let a_end = Array::get(a.body_ends, i)
       let r = scan_body_relocs(a.bytes, a_start, a_end)
@@ -282,6 +303,8 @@ fn main() -> Unit allows Exception + Fs + Stdout + Env {
         if kind == reloc_kind_func {
           let target = name_of(a, val)
           let nv = if target == "" { -1 } else { index_of_name(b, target) }
+          // -1 absent, -2 ambiguous: neither can be remapped, and passing the
+          // old value through is a KNOWN-WRONG relocation, not a neutral one.
           if nv < 0 { unresolved = unresolved + 1; Array::push(mapped, val) } else { Array::push(mapped, nv) }
         } else {
           nonfunc = nonfunc + 1
@@ -304,11 +327,20 @@ fn main() -> Unit allows Exception + Fs + Stdout + Env {
         // reference the encoding does NOT expose -- the i64.const function
         // values and data pointers. That is the number the emitter has to
         // close, and it is measured here rather than estimated.
-        if nonfunc > 0 {
-          mismatch_with_nonfunc = mismatch_with_nonfunc + 1
-        } else {
+        // Attribute it, and ONLY when the attribution is unambiguous.
+        //
+        // A body can carry a non-function reference AND an encoding-blind
+        // i64.const at once, and an unresolved function target is passed
+        // through unchanged. Either makes the cause undeterminable from here.
+        // The first version of this put every `nonfunc == 0` mismatch in the
+        // blind bucket and called the total "the number the emitter has to
+        // close"; it is a LOWER BOUND, and only the bodies with neither
+        // confound belong in it.
+        if nonfunc == 0 && unresolved == 0 {
           mismatch_encoding_blind = mismatch_encoding_blind + 1
           if Array::length(examples) < 6 { Array::push(examples, nm) } else { () }
+        } else {
+          mismatch_ambiguous_cause = mismatch_ambiguous_cause + 1
         }
       }
     }
@@ -324,8 +356,12 @@ fn main() -> Unit allows Exception + Fs + Stdout + Env {
   StringBuilder::push(out, __to_string(mismatched))
   StringBuilder::push(out, " mismatch_encoding_blind=")
   StringBuilder::push(out, __to_string(mismatch_encoding_blind))
-  StringBuilder::push(out, " mismatch_with_nonfunc_refs=")
-  StringBuilder::push(out, __to_string(mismatch_with_nonfunc))
+  StringBuilder::push(out, " mismatch_ambiguous_cause=")
+  StringBuilder::push(out, __to_string(mismatch_ambiguous_cause))
+  StringBuilder::push(out, " ambiguous_name_skipped=")
+  StringBuilder::push(out, __to_string(ambiguous_name))
+  StringBuilder::push(out, " moved_index=")
+  StringBuilder::push(out, __to_string(moved_index))
   StringBuilder::push(out, " a_only=")
   StringBuilder::push(out, __to_string(a_only_shape))
   StringBuilder::push(out, " bodies_with_nonfunc_refs=")
@@ -346,5 +382,14 @@ fn main() -> Unit allows Exception + Fs + Stdout + Env {
   } else { () }
   if compared == 0 {
     throw("reloc-crossbuild: nothing compared -- the two modules share no named function")
+  } else { () }
+  // NON-VACUITY. If no shared function moved, the two builds have the same
+  // index assignment and every body "relocates" by doing nothing -- a perfect
+  // score that measures nothing. The whole point is a MOVED assignment, so a
+  // run where none moved is a failed run, not a clean one. (Review on #2705:
+  // a corpus that does not reach the edited file, or an order that already
+  // placed the imported module first, would both land here.)
+  if moved_index == 0 {
+    throw("reloc-crossbuild: no shared function changed index -- the two builds have the SAME assignment, so this run measured nothing")
   } else { () }
 }

--- a/scripts/reloc_crossbuild.vibex
+++ b/scripts/reloc_crossbuild.vibex
@@ -50,10 +50,14 @@ fn read_uleb(b: Bytes, pos: Int) -> (Int, Int) {
   let mut done = false
   while !done {
     let byte = Bytes::get(b, p)
-    result = result | ((byte & 127) << shift)
+    result = result|((byte&127)<<shift)
     shift = shift + 7
     p = p + 1
-    if (byte & 128) == 0 { done = true } else { () }
+    if (byte&128) == 0 {
+      done = true
+    } else {
+      ()
+    }
   }
   (result, p)
 }
@@ -67,12 +71,20 @@ fn read_sleb(b: Bytes, pos: Int) -> (Int, Int) {
   while !done {
     let byte = Bytes::get(b, p)
     last = byte
-    result = result | ((byte & 127) << shift)
+    result = result|((byte&127)<<shift)
     shift = shift + 7
     p = p + 1
-    if (byte & 128) == 0 { done = true } else { () }
+    if (byte&128) == 0 {
+      done = true
+    } else {
+      ()
+    }
   }
-  if (last & 64) != 0 && shift < 63 { result = result - (1 << shift) } else { () }
+  if (last&64) != 0 && shift < 63 {
+    result = result - (1<<shift)
+  } else {
+    ()
+  }
   (result, p)
 }
 
@@ -139,11 +151,19 @@ fn load(path: String) -> Mod with Exception + Fs {
         } else if kind == 1 {
           let fl = Bytes::get(b, pk + 2)
           let (_, pn) = read_uleb(b, pk + 3)
-          if fl == 1 { let (_, pm) = read_uleb(b, pn); pi = pm } else { pi = pn }
+          if fl == 1 {
+            let (_, pm) = read_uleb(b, pn); pi = pm
+          } else {
+            pi = pn
+          }
         } else if kind == 2 {
           let fl = Bytes::get(b, pk + 1)
           let (_, pn) = read_uleb(b, pk + 2)
-          if fl == 1 { let (_, pm) = read_uleb(b, pn); pi = pm } else { pi = pn }
+          if fl == 1 {
+            let (_, pm) = read_uleb(b, pn); pi = pm
+          } else {
+            pi = pn
+          }
         } else {
           pi = pk + 3
         }
@@ -182,14 +202,27 @@ fn load(path: String) -> Mod with Exception + Fs {
               qc = qb + nlen
               k = k + 1
             }
-          } else { () }
+          } else {
+            ()
+          }
           q = sub_end
         }
-      } else { () }
-    } else { () }
+      } else {
+        ()
+      }
+    } else {
+      ()
+    }
     p = section_end
   }
-  Mod::{ names: names, name_idxs: name_idxs, body_idxs: body_idxs, body_starts: body_starts, body_ends: body_ends, bytes: b }
+  Mod::{
+    names: names,
+    name_idxs: name_idxs,
+    body_idxs: body_idxs,
+    body_starts: body_starts,
+    body_ends: body_ends,
+    bytes: b
+  }
 }
 
 fn name_of(m: Mod, idx: Int) -> String {
@@ -197,7 +230,11 @@ fn name_of(m: Mod, idx: Int) -> String {
   let mut i = 0
   let mut found = ""
   while i < n {
-    if Array::get(m.name_idxs, i) == idx { found = Array::get(m.names, i); i = n } else { i = i + 1 }
+    if Array::get(m.name_idxs, i) == idx {
+      found = Array::get(m.names, i); i = n
+    } else {
+      i = i + 1
+    }
   }
   found
 }
@@ -221,11 +258,21 @@ fn index_of_name(m: Mod, name: String) -> Int {
   while i < n {
     if Array::get(m.names, i) == name {
       hits = hits + 1
-      if hits == 1 { found = Array::get(m.name_idxs, i) } else { () }
-    } else { () }
+      if hits == 1 {
+        found = Array::get(m.name_idxs, i)
+      } else {
+        ()
+      }
+    } else {
+      ()
+    }
     i = i + 1
   }
-  if hits > 1 { -2 } else { found }
+  if hits > 1 {
+    -2
+  } else {
+    found
+  }
 }
 
 /// The index A's function `idx` maps to in B, or -1 when its name is absent
@@ -253,7 +300,11 @@ fn body_slot(m: Mod, idx: Int) -> Int {
   let mut i = 0
   let mut found = -1
   while i < n {
-    if Array::get(m.body_idxs, i) == idx { found = i; i = n } else { i = i + 1 }
+    if Array::get(m.body_idxs, i) == idx {
+      found = i; i = n
+    } else {
+      i = i + 1
+    }
   }
   found
 }
@@ -265,21 +316,94 @@ fn spans_equal(ab: Bytes, s: Int, e: Int, other: Bytes) -> Bool {
     let mut i = 0
     let mut same = true
     while i < e - s {
-      if Bytes::get(ab, s + i) != Bytes::get(other, i) { same = false } else { () }
+      if Bytes::get(ab, s + i) != Bytes::get(other, i) {
+        same = false
+      } else {
+        ()
+      }
       i = i + 1
     }
     same
   }
 }
 
+/// Is `name` one of the functions whose SOURCE the caller edited?
+///
+/// Forcing a module reorder requires editing at least one existing body --
+/// something has to call across the new import -- so that body's B version is
+/// a different program from its A version. Comparing them measures the edit,
+/// not relocation: it inflates the denominator and, when the edited body
+/// happens to carry no visible non-function reference, it lands in the
+/// "unambiguously encoding-blind" bucket and inflates the one number this
+/// whole exercise exists to size. Naming it in the output is not enough, so
+/// it is excluded from the statistics. Found by review on #2705.
+///
+/// Matching is on the UNMANGLED base, not a substring: #716 path-mangles a
+/// private definition to `<name>_exp_<path>` / `<name>_dep_<path>`, so an
+/// exact name or one of those two prefixes is the whole rule. A substring
+/// test would quietly take `encode` along with `encode_url_safe`.
+fn is_source_edited(name: String, edited: Array[String]) -> Bool {
+  let mut i = 0
+  let mut hit = false
+  while i < Array::length(edited) {
+    let e = Array::get(edited, i)
+    if name == e || String::starts_with(name, String::concat(e, "_exp_")) || String::starts_with(name, String::concat(e, "_dep_")) {
+      hit = true
+    } else {
+      ()
+    }
+    i = i + 1
+  }
+  hit
+}
+
+fn split_commas(s: String) -> Array[String] {
+  let out: Array[String] = []
+  let mut cur = ""
+  let mut i = 0
+  while i < String::length(s) {
+    let c = String::substring(s, i, i + 1)
+    if c == "," {
+      if String::length(cur) > 0 {
+        Array::push(out, cur)
+      } else {
+        ()
+      }
+      cur = ""
+    } else {
+      cur = String::concat(cur, c)
+    }
+    i = i + 1
+  }
+  if String::length(cur) > 0 {
+    Array::push(out, cur)
+  } else {
+    ()
+  }
+  out
+}
+
 fn main() -> Unit allows Exception + Fs + Stdout + Env {
   if Env::args_len() < 2 {
     println("reloc-crossbuild: usage: vibe run scripts/reloc_crossbuild.vibex -- <a.wasm> <b.wasm>")
     throw("two modules required")
-  } else { () }
+  } else {
+    ()
+  }
   let a = load(Env::args_get(0))
   let b = load(Env::args_get(1))
-
+  // Optional third argument: comma-separated names of functions the caller
+  // EDITED between the two builds. See is_source_edited.
+  let edited = if Env::args_len() > 2 {
+    split_commas(Env::args_get(2))
+  } else {
+    []
+  }
+  let edited_hits: Array[Int] = []
+  let mut eh = 0
+  while eh < Array::length(edited) {
+    Array::push(edited_hits, 0); eh = eh + 1
+  }
   let mut compared = 0
   let mut matched = 0
   let mut mismatched = 0
@@ -293,22 +417,41 @@ fn main() -> Unit allows Exception + Fs + Stdout + Env {
   let mut unresolved_func = 0
   let mut had_nonfunc = 0
   let mut a_only_shape = 0
+  let mut source_edited_excluded = 0
   let examples: Array[String] = []
-
   let n = Array::length(a.body_idxs)
   let mut i = 0
   while i < n {
     let ai = Array::get(a.body_idxs, i)
     let nm = name_of(a, ai)
     let bi = map_index(a, b, ai)
-    let bs = if bi < 0 { -1 } else { body_slot(b, bi) }
+    let bs = if bi < 0 {
+      -1
+    } else {
+      body_slot(b, bi)
+    }
     if bi == -2 {
       ambiguous_name = ambiguous_name + 1
+    } else if bs >= 0 && is_source_edited(nm, edited) {
+      source_edited_excluded = source_edited_excluded + 1
+      let mut ei = 0
+      while ei < Array::length(edited) {
+        if is_source_edited(nm, [Array::get(edited, ei)]) {
+          Array::set(edited_hits, ei, Array::get(edited_hits, ei) + 1)
+        } else {
+          ()
+        }
+        ei = ei + 1
+      }
     } else if bs < 0 {
       a_only_shape = a_only_shape + 1
     } else {
       compared = compared + 1
-      if ai != bi { moved_index = moved_index + 1 } else { () }
+      if ai != bi {
+        moved_index = moved_index + 1
+      } else {
+        ()
+      }
       let a_start = Array::get(a.body_starts, i)
       let a_end = Array::get(a.body_ends, i)
       let r = scan_body_relocs(a.bytes, a_start, a_end)
@@ -338,7 +481,11 @@ fn main() -> Unit allows Exception + Fs + Stdout + Env {
             Array::push(mapped, val)
           } else {
             Array::push(mapped, nv)
-            if nv != val { rewritten = rewritten + 1 } else { () }
+            if nv != val {
+              rewritten = rewritten + 1
+            } else {
+              ()
+            }
           }
         } else {
           nonfunc = nonfunc + 1
@@ -346,15 +493,35 @@ fn main() -> Unit allows Exception + Fs + Stdout + Env {
         }
         k = k + 1
       }
-      if nonfunc > 0 { had_nonfunc = had_nonfunc + 1 } else { () }
-      if unresolved > 0 { unresolved_func = unresolved_func + 1 } else { () }
+      if nonfunc > 0 {
+        had_nonfunc = had_nonfunc + 1
+      } else {
+        ()
+      }
+      if unresolved > 0 {
+        unresolved_func = unresolved_func + 1
+      } else {
+        ()
+      }
       let rebuilt = rebuild_body_relocs(a.bytes, a_start, a_end, r, mapped)
-      if rewritten > 0 { rewritten_bodies = rewritten_bodies + 1 } else { () }
+      if rewritten > 0 {
+        rewritten_bodies = rewritten_bodies + 1
+      } else {
+        ()
+      }
       if spans_equal(b.bytes, Array::get(b.body_starts, bs), Array::get(b.body_ends, bs), rebuilt) {
         matched = matched + 1
-        if rewritten > 0 { rewritten_matched = rewritten_matched + 1 } else { () }
+        if rewritten > 0 {
+          rewritten_matched = rewritten_matched + 1
+        } else {
+          ()
+        }
       } else {
-        if rewritten > 0 { rewritten_mismatched = rewritten_mismatched + 1 } else { () }
+        if rewritten > 0 {
+          rewritten_mismatched = rewritten_mismatched + 1
+        } else {
+          ()
+        }
         mismatched = mismatched + 1
         // Attribute it. A body carrying a non-function reference was passed
         // through unchanged above, so a mismatch there may be this TOOL's
@@ -375,7 +542,11 @@ fn main() -> Unit allows Exception + Fs + Stdout + Env {
         // confound belong in it.
         if nonfunc == 0 && unresolved == 0 {
           mismatch_encoding_blind = mismatch_encoding_blind + 1
-          if Array::length(examples) < 6 { Array::push(examples, nm) } else { () }
+          if Array::length(examples) < 6 {
+            Array::push(examples, nm)
+          } else {
+            ()
+          }
         } else {
           mismatch_ambiguous_cause = mismatch_ambiguous_cause + 1
         }
@@ -383,7 +554,6 @@ fn main() -> Unit allows Exception + Fs + Stdout + Env {
     }
     i = i + 1
   }
-
   let out = StringBuilder::new()
   StringBuilder::push(out, "reloc-crossbuild compared=")
   StringBuilder::push(out, __to_string(compared))
@@ -405,6 +575,8 @@ fn main() -> Unit allows Exception + Fs + Stdout + Env {
   StringBuilder::push(out, __to_string(rewritten_matched))
   StringBuilder::push(out, " rewritten_mismatched=")
   StringBuilder::push(out, __to_string(rewritten_mismatched))
+  StringBuilder::push(out, " source_edited_excluded=")
+  StringBuilder::push(out, __to_string(source_edited_excluded))
   StringBuilder::push(out, " a_only=")
   StringBuilder::push(out, __to_string(a_only_shape))
   StringBuilder::push(out, " bodies_with_nonfunc_refs=")
@@ -422,10 +594,27 @@ fn main() -> Unit allows Exception + Fs + Stdout + Env {
       e = e + 1
     }
     println(StringBuilder::freeze(ex))
-  } else { () }
+  } else {
+    ()
+  }
+  // A name the caller said it edited that matched NOTHING means the exclusion
+  // silently stopped working -- a rename in the wrapper, a change in the
+  // mangling -- and the confound would be back in the numbers with no sign of
+  // it. Same shape as the vacuity guards below.
+  let mut eg = 0
+  while eg < Array::length(edited) {
+    if Array::get(edited_hits, eg) == 0 {
+      throw(String::concat("reloc-crossbuild: no compared body matched the source-edited name '", String::concat(Array::get(edited, eg), "' -- the exclusion is not doing anything")))
+    } else {
+      ()
+    }
+    eg = eg + 1
+  }
   if compared == 0 {
     throw("reloc-crossbuild: nothing compared -- the two modules share no named function")
-  } else { () }
+  } else {
+    ()
+  }
   // NON-VACUITY, in two steps, because the first one is not enough.
   //
   // (1) If no shared function moved, the two builds have the same index
@@ -434,7 +623,9 @@ fn main() -> Unit allows Exception + Fs + Stdout + Env {
   // an order that already placed the imported module first, both land here.
   if moved_index == 0 {
     throw("reloc-crossbuild: no shared function changed index -- the two builds have the SAME assignment, so this run measured nothing")
-  } else { () }
+  } else {
+    ()
+  }
   // (2) A function's own index is NOT encoded in its body, so (1) says the
   // ASSIGNMENT moved, not that any REWRITE happened. Bodies referencing only
   // functions that held still are rebuilt by an identity operation, and would
@@ -445,5 +636,7 @@ fn main() -> Unit allows Exception + Fs + Stdout + Env {
   // #2705, one round after (1).)
   if rewritten_matched == 0 {
     throw("reloc-crossbuild: no body was both rewritten and byte-identical -- every rebuild was an identity operation, so this run says nothing about relocation")
-  } else { () }
+  } else {
+    ()
+  }
 }

--- a/scripts/reloc_crossbuild.vibex
+++ b/scripts/reloc_crossbuild.vibex
@@ -384,9 +384,13 @@ fn split_commas(s: String) -> Array[String] {
 }
 
 fn main() -> Unit allows Exception + Fs + Stdout + Env {
-  if Env::args_len() < 2 {
-    println("reloc-crossbuild: usage: vibe run scripts/reloc_crossbuild.vibex -- <a.wasm> <b.wasm>")
-    throw("two modules required")
+  // Exactly two or three. The shell wrapper validates its own arity, but this
+  // is a documented entry point of its own -- so a mistyped direct run used to
+  // consume the first three arguments, drop the rest, and report statistics
+  // for inputs nobody asked about. Fixing the wrapper alone left that open.
+  if Env::args_len() < 2 || Env::args_len() > 3 {
+    println("reloc-crossbuild: usage: vibe run scripts/reloc_crossbuild.vibex -- <a.wasm> <b.wasm> [edited,fn,names]")
+    throw(String::concat("expected 2 or 3 arguments, got ", __to_string(Env::args_len())))
   } else {
     ()
   }

--- a/scripts/reloc_crossbuild.vibex
+++ b/scripts/reloc_crossbuild.vibex
@@ -228,6 +228,26 @@ fn index_of_name(m: Mod, name: String) -> Int {
   if hits > 1 { -2 } else { found }
 }
 
+/// The index A's function `idx` maps to in B, or -1 when its name is absent
+/// there, or -2 when the name is AMBIGUOUS on EITHER side.
+///
+/// Checking only B was the first fix and it is not enough. If A carries two
+/// functions called `__rt_gen` and B carries one -- a generated helper
+/// removed, say -- both A bodies are compared against that single B body, and
+/// every A-side reference to either collapses onto it. The name has to
+/// identify ONE function on each side before it can carry a mapping. Found by
+/// review on #2705, one round after the B-side-only version.
+fn map_index(a: Mod, b: Mod, idx: Int) -> Int {
+  let nm = name_of(a, idx)
+  if nm == "" {
+    -1
+  } else if index_of_name(a, nm) == -2 {
+    -2
+  } else {
+    index_of_name(b, nm)
+  }
+}
+
 fn body_slot(m: Mod, idx: Int) -> Int {
   let n = Array::length(m.body_idxs)
   let mut i = 0
@@ -266,6 +286,9 @@ fn main() -> Unit allows Exception + Fs + Stdout + Env {
   let mut mismatch_ambiguous_cause = 0
   let mut ambiguous_name = 0
   let mut moved_index = 0
+  let mut rewritten_bodies = 0
+  let mut rewritten_matched = 0
+  let mut rewritten_mismatched = 0
   let mut mismatch_encoding_blind = 0
   let mut unresolved_func = 0
   let mut had_nonfunc = 0
@@ -277,7 +300,7 @@ fn main() -> Unit allows Exception + Fs + Stdout + Env {
   while i < n {
     let ai = Array::get(a.body_idxs, i)
     let nm = name_of(a, ai)
-    let bi = if nm == "" { -1 } else { index_of_name(b, nm) }
+    let bi = map_index(a, b, ai)
     let bs = if bi < 0 { -1 } else { body_slot(b, bi) }
     if bi == -2 {
       ambiguous_name = ambiguous_name + 1
@@ -296,16 +319,27 @@ fn main() -> Unit allows Exception + Fs + Stdout + Env {
       let mapped: Array[Int] = []
       let mut nonfunc = 0
       let mut unresolved = 0
+      // #2705 review: how many of this body's references the remap actually
+      // CHANGED. A body that referenced only functions whose index held still
+      // is rebuilt by an identity operation, and its match is not evidence
+      // that rewriting works.
+      let mut rewritten = 0
       let mut k = 0
       while k < cnt {
         let kind = Array::get(r.kinds, k)
         let val = Array::get(r.values, k)
         if kind == reloc_kind_func {
-          let target = name_of(a, val)
-          let nv = if target == "" { -1 } else { index_of_name(b, target) }
-          // -1 absent, -2 ambiguous: neither can be remapped, and passing the
-          // old value through is a KNOWN-WRONG relocation, not a neutral one.
-          if nv < 0 { unresolved = unresolved + 1; Array::push(mapped, val) } else { Array::push(mapped, nv) }
+          let nv = map_index(a, b, val)
+          // -1 absent, -2 ambiguous on either side: neither can be remapped,
+          // and passing the old value through is a KNOWN-WRONG relocation,
+          // not a neutral one.
+          if nv < 0 {
+            unresolved = unresolved + 1
+            Array::push(mapped, val)
+          } else {
+            Array::push(mapped, nv)
+            if nv != val { rewritten = rewritten + 1 } else { () }
+          }
         } else {
           nonfunc = nonfunc + 1
           Array::push(mapped, val)
@@ -315,9 +349,12 @@ fn main() -> Unit allows Exception + Fs + Stdout + Env {
       if nonfunc > 0 { had_nonfunc = had_nonfunc + 1 } else { () }
       if unresolved > 0 { unresolved_func = unresolved_func + 1 } else { () }
       let rebuilt = rebuild_body_relocs(a.bytes, a_start, a_end, r, mapped)
+      if rewritten > 0 { rewritten_bodies = rewritten_bodies + 1 } else { () }
       if spans_equal(b.bytes, Array::get(b.body_starts, bs), Array::get(b.body_ends, bs), rebuilt) {
         matched = matched + 1
+        if rewritten > 0 { rewritten_matched = rewritten_matched + 1 } else { () }
       } else {
+        if rewritten > 0 { rewritten_mismatched = rewritten_mismatched + 1 } else { () }
         mismatched = mismatched + 1
         // Attribute it. A body carrying a non-function reference was passed
         // through unchanged above, so a mismatch there may be this TOOL's
@@ -362,6 +399,12 @@ fn main() -> Unit allows Exception + Fs + Stdout + Env {
   StringBuilder::push(out, __to_string(ambiguous_name))
   StringBuilder::push(out, " moved_index=")
   StringBuilder::push(out, __to_string(moved_index))
+  StringBuilder::push(out, " rewritten=")
+  StringBuilder::push(out, __to_string(rewritten_bodies))
+  StringBuilder::push(out, " rewritten_matched=")
+  StringBuilder::push(out, __to_string(rewritten_matched))
+  StringBuilder::push(out, " rewritten_mismatched=")
+  StringBuilder::push(out, __to_string(rewritten_mismatched))
   StringBuilder::push(out, " a_only=")
   StringBuilder::push(out, __to_string(a_only_shape))
   StringBuilder::push(out, " bodies_with_nonfunc_refs=")
@@ -383,13 +426,24 @@ fn main() -> Unit allows Exception + Fs + Stdout + Env {
   if compared == 0 {
     throw("reloc-crossbuild: nothing compared -- the two modules share no named function")
   } else { () }
-  // NON-VACUITY. If no shared function moved, the two builds have the same
-  // index assignment and every body "relocates" by doing nothing -- a perfect
-  // score that measures nothing. The whole point is a MOVED assignment, so a
-  // run where none moved is a failed run, not a clean one. (Review on #2705:
-  // a corpus that does not reach the edited file, or an order that already
-  // placed the imported module first, would both land here.)
+  // NON-VACUITY, in two steps, because the first one is not enough.
+  //
+  // (1) If no shared function moved, the two builds have the same index
+  // assignment and every body "relocates" by doing nothing -- a perfect score
+  // that measures nothing. A corpus that does not reach the edited file, or
+  // an order that already placed the imported module first, both land here.
   if moved_index == 0 {
     throw("reloc-crossbuild: no shared function changed index -- the two builds have the SAME assignment, so this run measured nothing")
+  } else { () }
+  // (2) A function's own index is NOT encoded in its body, so (1) says the
+  // ASSIGNMENT moved, not that any REWRITE happened. Bodies referencing only
+  // functions that held still are rebuilt by an identity operation, and would
+  // report a perfect rate while proving nothing. `rewritten_matched` is the
+  // claim this tool actually makes: bodies where at least one reference was
+  // rewritten to a different index AND the result is byte-identical to what
+  // the compiler emitted for B. Zero of those is a failed run. (Review on
+  // #2705, one round after (1).)
+  if rewritten_matched == 0 {
+    throw("reloc-crossbuild: no body was both rewritten and byte-identical -- every rebuild was an identity operation, so this run says nothing about relocation")
   } else { () }
 }

--- a/scripts/reloc_crossbuild.vibex
+++ b/scripts/reloc_crossbuild.vibex
@@ -1,0 +1,350 @@
+// #2669: can a body compiled against ONE index assignment be relocated onto
+// ANOTHER? That is the whole claim of index-independent bodies, and this
+// answers it end to end against two real builds.
+//
+//   vibe run scripts/reloc_crossbuild.vibex -- <a.wasm> <b.wasm>
+//
+// Both built with VIBE_WASM_NAMES=1. For every function present in both by
+// NAME: take A's body, rewrite each function reference from A's index space
+// into B's (by resolving A's index to a name and that name to B's index),
+// and compare the result against B's ACTUAL body.
+//
+// A match means the relocation reproduced, byte for byte, what the compiler
+// itself emitted for the moved assignment. That is a much stronger statement
+// than the identity round-trip in reloc_roundtrip.vibex, which only proves
+// the walk does not desynchronise.
+//
+// THE MISMATCHES ARE THE POINT. `@vibe/compiler/codegen/reloc` can only see
+// references the instruction encoding makes certain. A function used as a
+// VALUE is `i64.const ((slot << 2) | 2)` (compile_expr.vibe) and a string
+// constant's data pointer rides an `i64.const` too (emit_str_ref,
+// bodies_core_b's folded `(off << 32) | len`) -- neither is distinguishable
+// from an ordinary constant. So the count of bodies that do NOT match is a
+// direct measurement of what the emitter would have to record, rather than
+// an estimate. Non-function index spaces (type, table, tag, global, data,
+// elem) are passed through UNCHANGED here and reported separately, because
+// wasm carries no name section for them: a body that moved one of those
+// cannot be remapped from the binary alone either.
+import @vibe/compiler/codegen/reloc {
+  BodyRelocs, rebuild_body_relocs, reloc_kind_func, scan_body_relocs
+}
+
+/// A String is a BYTE string (ADR-0098), so a name is rebuilt one byte at a
+/// time -- `String::from_char_code` takes a byte, and concatenating them
+/// reproduces the section's bytes exactly. No decoding is wanted here: these
+/// are matched against each other, never interpreted.
+fn bytes_range_to_string(b: Bytes, start: Int, end_pos: Int) -> String {
+  let sb = StringBuilder::new()
+  let mut i = start
+  while i < end_pos {
+    StringBuilder::push(sb, String::from_byte(Bytes::get(b, i)))
+    i = i + 1
+  }
+  StringBuilder::freeze(sb)
+}
+
+fn read_uleb(b: Bytes, pos: Int) -> (Int, Int) {
+  let mut result = 0
+  let mut shift = 0
+  let mut p = pos
+  let mut done = false
+  while !done {
+    let byte = Bytes::get(b, p)
+    result = result | ((byte & 127) << shift)
+    shift = shift + 7
+    p = p + 1
+    if (byte & 128) == 0 { done = true } else { () }
+  }
+  (result, p)
+}
+
+fn read_sleb(b: Bytes, pos: Int) -> (Int, Int) {
+  let mut result = 0
+  let mut shift = 0
+  let mut p = pos
+  let mut done = false
+  let mut last = 0
+  while !done {
+    let byte = Bytes::get(b, p)
+    last = byte
+    result = result | ((byte & 127) << shift)
+    shift = shift + 7
+    p = p + 1
+    if (byte & 128) == 0 { done = true } else { () }
+  }
+  if (last & 64) != 0 && shift < 63 { result = result - (1 << shift) } else { () }
+  (result, p)
+}
+
+fn skip_valtype(b: Bytes, pos: Int) -> Int {
+  let t = Bytes::get(b, pos)
+  if t == 0x63 || t == 0x64 {
+    let (_, p) = read_sleb(b, pos + 1)
+    p
+  } else {
+    pos + 1
+  }
+}
+
+fn skip_locals(b: Bytes, pos: Int) -> Int {
+  let (groups, p0) = read_uleb(b, pos)
+  let mut p = p0
+  let mut i = 0
+  while i < groups {
+    let (_, pn) = read_uleb(b, p)
+    p = skip_valtype(b, pn)
+    i = i + 1
+  }
+  p
+}
+
+/// A module reduced to what this comparison needs: every defined function's
+/// instruction region, and the index <-> name mapping from the name section.
+struct Mod {
+  names: Array[String];
+  name_idxs: Array[Int];
+  body_idxs: Array[Int];
+  body_starts: Array[Int];
+  body_ends: Array[Int];
+  bytes: Bytes
+}
+
+fn load(path: String) -> Mod with Exception + Fs {
+  let b = Fs::read_bytes(path)
+  let len = Bytes::length(b)
+  let names: Array[String] = []
+  let name_idxs: Array[Int] = []
+  let body_idxs: Array[Int] = []
+  let body_starts: Array[Int] = []
+  let body_ends: Array[Int] = []
+  let mut imported = 0
+  let mut p = 8
+  while p < len {
+    let sid = Bytes::get(b, p)
+    let (size, p1) = read_uleb(b, p + 1)
+    let section_end = p1 + size
+    if sid == 2 {
+      let (n, pi0) = read_uleb(b, p1)
+      let mut pi = pi0
+      let mut i = 0
+      while i < n {
+        let (l1, pa) = read_uleb(b, pi)
+        let (l2, pb) = read_uleb(b, pa + l1)
+        let pk = pb + l2
+        let kind = Bytes::get(b, pk)
+        if kind == 0 {
+          let (_, pn) = read_uleb(b, pk + 1)
+          imported = imported + 1
+          pi = pn
+        } else if kind == 1 {
+          let fl = Bytes::get(b, pk + 2)
+          let (_, pn) = read_uleb(b, pk + 3)
+          if fl == 1 { let (_, pm) = read_uleb(b, pn); pi = pm } else { pi = pn }
+        } else if kind == 2 {
+          let fl = Bytes::get(b, pk + 1)
+          let (_, pn) = read_uleb(b, pk + 2)
+          if fl == 1 { let (_, pm) = read_uleb(b, pn); pi = pm } else { pi = pn }
+        } else {
+          pi = pk + 3
+        }
+        i = i + 1
+      }
+    } else if sid == 10 {
+      let (n, pc0) = read_uleb(b, p1)
+      let mut pc = pc0
+      let mut i = 0
+      while i < n {
+        let (bsize, bstart) = read_uleb(b, pc)
+        Array::push(body_idxs, imported + i)
+        Array::push(body_starts, skip_locals(b, bstart))
+        Array::push(body_ends, bstart + bsize)
+        pc = bstart + bsize
+        i = i + 1
+      }
+    } else if sid == 0 {
+      let (nl, pn0) = read_uleb(b, p1)
+      let sec_name = bytes_range_to_string(b, pn0, pn0 + nl)
+      if sec_name == "name" {
+        let mut q = pn0 + nl
+        while q < section_end {
+          let sub = Bytes::get(b, q)
+          let (ssz, qs) = read_uleb(b, q + 1)
+          let sub_end = qs + ssz
+          if sub == 1 {
+            let (cnt, qc0) = read_uleb(b, qs)
+            let mut qc = qc0
+            let mut k = 0
+            while k < cnt {
+              let (idx, qa) = read_uleb(b, qc)
+              let (nlen, qb) = read_uleb(b, qa)
+              Array::push(name_idxs, idx)
+              Array::push(names, bytes_range_to_string(b, qb, qb + nlen))
+              qc = qb + nlen
+              k = k + 1
+            }
+          } else { () }
+          q = sub_end
+        }
+      } else { () }
+    } else { () }
+    p = section_end
+  }
+  Mod::{ names: names, name_idxs: name_idxs, body_idxs: body_idxs, body_starts: body_starts, body_ends: body_ends, bytes: b }
+}
+
+fn name_of(m: Mod, idx: Int) -> String {
+  let n = Array::length(m.name_idxs)
+  let mut i = 0
+  let mut found = ""
+  while i < n {
+    if Array::get(m.name_idxs, i) == idx { found = Array::get(m.names, i); i = n } else { i = i + 1 }
+  }
+  found
+}
+
+fn index_of_name(m: Mod, name: String) -> Int {
+  let n = Array::length(m.names)
+  let mut i = 0
+  let mut found = -1
+  while i < n {
+    if Array::get(m.names, i) == name { found = Array::get(m.name_idxs, i); i = n } else { i = i + 1 }
+  }
+  found
+}
+
+fn body_slot(m: Mod, idx: Int) -> Int {
+  let n = Array::length(m.body_idxs)
+  let mut i = 0
+  let mut found = -1
+  while i < n {
+    if Array::get(m.body_idxs, i) == idx { found = i; i = n } else { i = i + 1 }
+  }
+  found
+}
+
+fn spans_equal(ab: Bytes, s: Int, e: Int, other: Bytes) -> Bool {
+  if e - s != Bytes::length(other) {
+    false
+  } else {
+    let mut i = 0
+    let mut same = true
+    while i < e - s {
+      if Bytes::get(ab, s + i) != Bytes::get(other, i) { same = false } else { () }
+      i = i + 1
+    }
+    same
+  }
+}
+
+fn main() -> Unit allows Exception + Fs + Stdout + Env {
+  if Env::args_len() < 2 {
+    println("reloc-crossbuild: usage: vibe run scripts/reloc_crossbuild.vibex -- <a.wasm> <b.wasm>")
+    throw("two modules required")
+  } else { () }
+  let a = load(Env::args_get(0))
+  let b = load(Env::args_get(1))
+
+  let mut compared = 0
+  let mut matched = 0
+  let mut mismatched = 0
+  let mut mismatch_with_nonfunc = 0
+  let mut mismatch_encoding_blind = 0
+  let mut unresolved_func = 0
+  let mut had_nonfunc = 0
+  let mut a_only_shape = 0
+  let examples: Array[String] = []
+
+  let n = Array::length(a.body_idxs)
+  let mut i = 0
+  while i < n {
+    let ai = Array::get(a.body_idxs, i)
+    let nm = name_of(a, ai)
+    let bi = if nm == "" { -1 } else { index_of_name(b, nm) }
+    let bs = if bi < 0 { -1 } else { body_slot(b, bi) }
+    if bs < 0 {
+      a_only_shape = a_only_shape + 1
+    } else {
+      compared = compared + 1
+      let a_start = Array::get(a.body_starts, i)
+      let a_end = Array::get(a.body_ends, i)
+      let r = scan_body_relocs(a.bytes, a_start, a_end)
+      let cnt = Array::length(r.offsets)
+      // Remap: a FUNCTION index goes through the name; everything else is
+      // passed through, and counted, because the binary carries no name for
+      // those spaces to map through.
+      let mapped: Array[Int] = []
+      let mut nonfunc = 0
+      let mut unresolved = 0
+      let mut k = 0
+      while k < cnt {
+        let kind = Array::get(r.kinds, k)
+        let val = Array::get(r.values, k)
+        if kind == reloc_kind_func {
+          let target = name_of(a, val)
+          let nv = if target == "" { -1 } else { index_of_name(b, target) }
+          if nv < 0 { unresolved = unresolved + 1; Array::push(mapped, val) } else { Array::push(mapped, nv) }
+        } else {
+          nonfunc = nonfunc + 1
+          Array::push(mapped, val)
+        }
+        k = k + 1
+      }
+      if nonfunc > 0 { had_nonfunc = had_nonfunc + 1 } else { () }
+      if unresolved > 0 { unresolved_func = unresolved_func + 1 } else { () }
+      let rebuilt = rebuild_body_relocs(a.bytes, a_start, a_end, r, mapped)
+      if spans_equal(b.bytes, Array::get(b.body_starts, bs), Array::get(b.body_ends, bs), rebuilt) {
+        matched = matched + 1
+      } else {
+        mismatched = mismatched + 1
+        // Attribute it. A body carrying a non-function reference was passed
+        // through unchanged above, so a mismatch there may be this TOOL's
+        // limit (wasm has no name section for those spaces) rather than the
+        // approach's. A mismatch with NO such reference cannot be that: every
+        // reference the encoding exposes was remapped, so what is left is a
+        // reference the encoding does NOT expose -- the i64.const function
+        // values and data pointers. That is the number the emitter has to
+        // close, and it is measured here rather than estimated.
+        if nonfunc > 0 {
+          mismatch_with_nonfunc = mismatch_with_nonfunc + 1
+        } else {
+          mismatch_encoding_blind = mismatch_encoding_blind + 1
+          if Array::length(examples) < 6 { Array::push(examples, nm) } else { () }
+        }
+      }
+    }
+    i = i + 1
+  }
+
+  let out = StringBuilder::new()
+  StringBuilder::push(out, "reloc-crossbuild compared=")
+  StringBuilder::push(out, __to_string(compared))
+  StringBuilder::push(out, " matched=")
+  StringBuilder::push(out, __to_string(matched))
+  StringBuilder::push(out, " mismatched=")
+  StringBuilder::push(out, __to_string(mismatched))
+  StringBuilder::push(out, " mismatch_encoding_blind=")
+  StringBuilder::push(out, __to_string(mismatch_encoding_blind))
+  StringBuilder::push(out, " mismatch_with_nonfunc_refs=")
+  StringBuilder::push(out, __to_string(mismatch_with_nonfunc))
+  StringBuilder::push(out, " a_only=")
+  StringBuilder::push(out, __to_string(a_only_shape))
+  StringBuilder::push(out, " bodies_with_nonfunc_refs=")
+  StringBuilder::push(out, __to_string(had_nonfunc))
+  StringBuilder::push(out, " bodies_with_unresolved_func=")
+  StringBuilder::push(out, __to_string(unresolved_func))
+  println(StringBuilder::freeze(out))
+  if Array::length(examples) > 0 {
+    let ex = StringBuilder::new()
+    StringBuilder::push(ex, "reloc-crossbuild encoding-blind-examples")
+    let mut e = 0
+    while e < Array::length(examples) {
+      StringBuilder::push(ex, " ")
+      StringBuilder::push(ex, Array::get(examples, e))
+      e = e + 1
+    }
+    println(StringBuilder::freeze(ex))
+  } else { () }
+  if compared == 0 {
+    throw("reloc-crossbuild: nothing compared -- the two modules share no named function")
+  } else { () }
+}


### PR DESCRIPTION
Two slices of #2669, in the order the evidence demanded: measure whether relocation works at all, then close the gap the measurement exposed.

---

# Slice 1b — do bodies actually relocate?

Slice 1 built the mechanism and proved the instruction walk does not desynchronise. **That is not the claim index-independent bodies rest on.** The claim is that a body compiled against one index assignment can be moved onto another.

`scripts/reloc_crossbuild.sh` tests it end to end: build the compiler's own closure twice (the second with one import added to `lib/@vibe/core/base64.vibe`, which pulls `hex.vibe` earlier in the module order and moves most of the function index space — the edit class #2669 measured as hardest). Then take each of A's bodies, rewrite every function reference from A's index space into B's through the name section, and compare against **what the compiler itself emitted for B**.

| | count | share |
|---|---:|---:|
| bodies compared | 4350 | |
| **REWRITTEN: at least one reference moved** | **3157** | |
| **rewritten AND byte-identical to the compiler's own output** | **2814** | **89.1%** |
| rewritten, mismatched | 343 | 10.9% |
| not rewritten — an identity rebuild, no evidence either way | 1193 | |
| mismatch, cause not determinable (of all 382) | 284 | |
| mismatch, unambiguously **encoding-blind** (of all 382) | 98 | |
| skipped: the name is ambiguous on one side or the other | 5 | |
| excluded: the body the wrapper EDITED, not a relocation case | 1 | |
| shared functions whose index actually moved | 4265 | |

The other direction says it more strongly: forcing the remap to the identity on the same pair drops matched from 3968 to **1154**. The remap is worth 2814 bodies; 1154 is what "do nothing" scores.

## The two mismatch classes are different in kind

- The **284** carry a reference in a space wasm gives no name section for — type, table, tag, global, data, elem — or a function target that could not be resolved. The tool passes those through and cannot do better *from the binary alone*. A real link has those symbol tables. **This is the measurement's limit, not the approach's.**
- The **98** carry no such confound. Every reference the encoding exposes was remapped, so what remains is one it does **not** expose. **A LOWER BOUND on what emission-side recording must close** — measured, not estimated. Not "the number": some of the 284 may need it too.

## What the measurement needed in order to mean anything

Six things, each wrong in an earlier push and corrected here; the review threads have the detail.

- **Duplicate names are refused on both sides.** `linked_compile.vibe:13657` labels many generated functions `__rt_gen` in a loop, so first-wins compared bodies against unrelated ones. Checking only the target module was the first fix and was not enough. **The first published figure (4356 / 3943 / 90.5%) had first-wins rows in it and was not reliable.**
- **The reorder is asserted.** `moved_index` counts shared functions whose index differs; zero FAILS. The same module twice gives `matched=4351 mismatched=0 moved_index=0` — a perfect score, rejected.
- **And so is the rewrite.** A function's own index is not encoded in its body, so that guard establishes only that the *assignment* moved. **1193 bodies reference nothing that moved**; counting them produced 91.2% instead of 89.1%. `rewritten_matched == 0` now fails too. Red-tested by forcing the remap to the identity: `moved_index=4265 rewritten=0`, guard one passes and guard two fires.
- **The one edited body is EXCLUDED, not merely named.** Forcing a reorder requires editing something, so that body's two versions are different source programs. It was in the denominator and — measured — inside the encoding-blind bucket: excluding it moves the bound from 99 to **98**.
- **The exclusion has its own vacuity guard.** A supplied name matching no compared body FAILS the run.
- **A mistyped argument count is refused.** One wasm path used to fall past the explicit-pair branch and run the *default* builds, reporting a confident measurement of a different pair; a fourth argument was accepted and dropped. Now exactly 0, 2 or 3.

---

# Slice 2 — recording the references a scan cannot find

The 98 are bodies where every reference the encoding exposes was remapped and the body still differed. What is left in them is a reference the encoding does not mark. Two shapes on the RC lane:

| shape | what it is |
|---|---|
| `i64.const ((slot << 2) \| 2)` | a function used as a VALUE — passed by name, or a captureless lambda |
| `i32.const slot` | the funcref-table slot a CAPTURING lambda stores into its closure header |

Neither is distinguishable from an ordinary integer constant, so the emitter records them as it writes them. `CompileCtx` carries a blind-reference log, shared by reference into per-lambda derived contexts the way `table_slots_used` already is. The offset stored is where the constant's **opcode** goes, not where its immediate starts — so a consumer can check the byte it is about to rewrite instead of trusting the arithmetic that produced the offset.

## Two checks, on every compile rather than in a test

These are the references nothing in the bytes marks as references. A stale offset does not fail to resolve — it resolves, rewrites an unrelated operand, and the module still validates. No later stage would catch it.

- **`lc_verify_blind_relocs`** — every record against the byte it names: the opcode the kind implies, and a **signed** LEB decode (both immediates are sLEB; an unsigned read would agree exactly where small slot numbers live and disagree wherever a check would matter) equal to what the record claims.
- **Paired counts** — the blind log and the funcref-slot log must grow by the same amount over a compiled function. This is what makes the recording COMPLETE rather than believed complete: a function value is emitted at exactly the points that append to `table_slots_used`, so each appends one slot and records one reference. A new emission site that forgot to record fails the next build instead of producing a cached body that relocates one reference short.

## Owners — the part with room to be wrong

A record belongs to the body it sits in: a user function, or a lambda. A lambda's index is not drawn from the frozen plan until its body is finished, so records made while compiling one are written under a pending owner and reassigned afterwards — and a nested lambda, which finishes first, keeps its own. An outer reassignment that claimed the inner's records would read their offsets against the outer body.

## What it costs, on the KPI this issue is about

| | selfcompile memory |
|---|---:|
| slice 1b alone (scripts and docs, no compiler change) | 852 MiB |
| with slice 2's recording | 857 MiB (**+0.63%**) |

Those are this branch's own perf reports for `cb5bc9c` and `0ea74ec`, which share the main baseline `595fed3eb` and differ by exactly the slice-2 commits — so the +5 MiB is attributable without building anything extra. (The branch's earlier reports used older baselines and are not comparable; main moved under them.) Compiled code grew 0.21%.

Most of the 5 MiB is the log itself, which is the mechanism rather than overhead around it. A smaller share is the fresh one-element owner cell per function body, removable with one module-level cell plus save/restore — recorded as available rather than done. The trade is 0.63% now against a warm build that currently costs 765 MB for a one-module edit, 93% of a cold build.

## Not recorded yet, said rather than left as a trap

Data pointers have no kind number: numbering one before anything emits it would be a promise, and the numbers are append-only. And a **replayed** function re-pushes its recorded slots from `CodegenBodyCache` without re-running codegen, so it contributes slots and no blind references — which is why the paired count is checked only for compiled functions, and why carrying these in the cache belongs with the consumer that reads them back.

**No wasm output changes.** The log is compiler-internal, so every byte-equality gate (compile-vs-replay included) sees what it saw before.

---

## Verification

- **`pkf run test` / `scripts/compiler_gate.sh` green end to end**, self-test lane included.
- **Full bootstrap green**: stage0 → stage1 → stage2 plus both sample validations. stage1 compiles the compiler's own closure with the verification active, so every record on a compiler-sized program passed both checks.
- `lib/@vibe/compiler/tests/blind_reloc_test.vibe` — 6 tests, one program per shape, run against the freshly built stage2 rather than the seed.
- **Mutation-checked four ways**, each a compiler built with that one change, this file unmodified. All four FAIL; unmutated passes:

  | mutation | what it breaks |
  |---|---|
  | recorded offset `+ 1` | the byte named is not the opcode |
  | kind changed at `compile_expr` | an `i64.const` read as an `i32.const` |
  | one record push deleted | the paired counts diverge |
  | reassignment drops its pending test | the outer lambda claims the inner's records |

  **The fourth one found the test, not the compiler.** The nested case as first written PASSED under it, because a *capturing* lambda's slot is emitted into the enclosing buffer — the inner body recorded nothing, so there was nothing to steal. Three of four failing looked like a complete result. Both lambda bodies now carry a function value of their own, and it fails.
- `check_doc_path_citations.sh`, `check_doc_commands.sh`, `check_gate_portability.sh`, `check_gate_self_tests.sh`, and the pre-commit lint gates.
- The cross-build wrapper runs end to end from a clean tree (it restores `base64.vibe` through a trap; `git status` clean afterwards).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CCUq2wJKeDzguGzmx78HkZ