### PR TITLE
#2633: take the module tag from provenance — parsing a name for it has no correct rule

### DIFF
--- a/lib/@vibe/compiler/codegen/wasi/index.vpkg
+++ b/lib/@vibe/compiler/codegen/wasi/index.vpkg
@@ -86,7 +86,7 @@ fn late_dce_prune_module(mod_bytes: Bytes) -> Bytes
 fn late_dce_prune_module_for(mod_bytes: Bytes, entry_name: String, exports_stripped: Bool) -> Bytes
 fn late_dce_prune_refusal() -> Int
 fn prelude_pass_module_oracle_step(k: Int, a: Array[Stmt], c: Array[Stmt], c_file_id: Array[Int], file_count: Int, entry_name: String, checker_eq_offsets: Array[Int], checker_eq_type_keys: Array[String], render: (Stmt) -> String) -> String with Exception
-fn prelude_module_full_oracle_line(a: Array[Stmt], c: Array[Stmt], c_file_id: Array[Int], file_count: Int, entry_name: String, checker_eq_offsets: Array[Int], checker_eq_type_keys: Array[String], import_closure: Array[Array[Int]], render: (Stmt) -> String) -> String with Exception
+fn prelude_module_full_oracle_line(a: Array[Stmt], c: Array[Stmt], c_file_id: Array[Int], file_count: Int, entry_name: String, checker_eq_offsets: Array[Int], checker_eq_type_keys: Array[String], import_closure: Array[Array[Int]], render: (Stmt) -> String, module_paths: Array[String]) -> String with Exception
 
 // #2388 / #2575 item 3: the LINK step of a per-module prelude -- fold the
 // program-level helpers each module synthesized for itself into one, by

--- a/lib/@vibe/compiler/codegen/wasi/linked_compile.vibe
+++ b/lib/@vibe/compiler/codegen/wasi/linked_compile.vibe
@@ -733,6 +733,18 @@ fn lc_int_array_has(xs: Array[Int], v: Int) -> Bool {
   found
 }
 
+/// #2704: the tag the merge stamps declarations of `path` with, computed by
+/// the merge's own mangler rather than recovered from a name.
+///
+/// `namespace_private_name(path, "")` is `"" ++ "_dep_" ++
+/// sanitize_namespace_path(path)`, so dropping the 5-character marker leaves
+/// exactly the sanitized path. Going through the shipped function means this
+/// cannot drift from the spelling the merge actually produces.
+fn lc_tag_of_path(path: String) -> String {
+  let stamped = namespace_private_name(path, "")
+  String::substring(stamped, 5, String::length(stamped))
+}
+
 /// `s` up to the first `::`, or all of it. A qualified operation is spelled
 /// `ns ++ marker ++ tag ++ "::" ++ op`, so the stamp is always in the part
 /// before the `::` and a marker inside the operation name is not one.
@@ -798,114 +810,6 @@ fn lc_registered_tag_of(n: String, tag_owner: MutMap[String, Int]) -> (String, B
     i = i + 1
   }
   (best, best_exp)
-}
-
-/// #2701 (Codex round 5): every tail in `n`'s namespace portion that could be
-/// a module tag -- the text after each `_exp_` / `_dep_`, shape-filtered.
-///
-/// A LIST rather than an answer, because no scan direction is correct on its
-/// own. Round 3 needed the LAST marker (a source name containing `_exp_`
-/// stamped with a real tag); round 5 needs an EARLIER one (a sanitized PATH
-/// containing `_dep_` -- `fixtures/import_visibility_dep_a.vibe` is in this
-/// repo, and reading its last marker yields `a_vibe`). The two cases demand
-/// opposite rules, so one name in isolation cannot settle it; the caller
-/// decides by agreement across a module's declarations instead.
-fn lc_name_tag_candidates(n: String, out: Array[String]) -> Unit {
-  let ns = lc_cut_at_qualifier(n)
-  let mut i = 0
-  while i + 5 <= String::length(ns) {
-    let marker = String::substring(ns, i, i + 5)
-    if marker == "_exp_" || marker == "_dep_" {
-      let tag = String::substring(ns, i + 5, String::length(ns))
-      if String::length(tag) > 5 && String::ends_with(tag, "_vibe") && !lc_str_array_has(out, tag) {
-        Array::push(out, tag)
-      } else {
-        ()
-      }
-    } else {
-      ()
-    }
-    i = i + 1
-  }
-}
-
-/// The entries of `a` that also appear in `b`.
-fn lc_str_intersect(a: Array[String], b: Array[String]) -> Array[String] {
-  let out: Array[String] = []
-  let mut i = 0
-  while i < Array::length(a) {
-    if lc_str_array_has(b, Array::get(a, i)) {
-      Array::push(out, Array::get(a, i))
-    } else {
-      ()
-    }
-    i = i + 1
-  }
-  out
-}
-
-/// #2701: the tag a module's declarations AGREE on, or "" -- bumping
-/// `amb` when its own declarations cannot settle it.
-///
-/// Every stamped declaration of a module ends `<marker><tag>` for the SAME
-/// tag, so the real tag is a candidate of every one of them. The two kinds of
-/// spurious candidate are separated by that:
-///
-///   from a marker INSIDE the tag   a proper suffix, so SHORTER -- survives the
-///                                  intersection, loses on length
-///   from a marker inside the SOURCE name   LONGER than the tag, but carries
-///                                  that declaration's own text, so it does not
-///                                  survive the intersection
-///
-/// Hence: intersect, then take the longest. A module with exactly ONE stamped
-/// declaration has nothing to intersect against, so a second candidate there
-/// is genuinely undecidable from names -- it is counted and the module is left
-/// out of `tag_owner`, rather than guessed at. Silence about what cannot be
-/// determined is the failure mode this whole instrument exists to avoid.
-fn lc_module_tag_of_agreed(part: Array[Stmt], amb: Array[Int]) -> String {
-  let names: MutMap[String, Int] = MutMap::new_string()
-  lc_decl_names_into(part, names)
-  let decl_names = MutMap::keys(names)
-  let mut acc: Array[String] = []
-  let mut seen_any = false
-  let mut stamped_decls = 0
-  let mut i = 0
-  while i < Array::length(decl_names) {
-    let cand: Array[String] = []
-    lc_name_tag_candidates(Array::get(decl_names, i), cand)
-    if Array::length(cand) > 0 {
-      stamped_decls = stamped_decls + 1
-      if seen_any {
-        acc = lc_str_intersect(acc, cand)
-      } else {
-        acc = cand
-        seen_any = true
-      }
-    } else {
-      ()
-    }
-    i = i + 1
-  }
-  if Array::length(acc) == 0 {
-    ""
-  } else if Array::length(acc) == 1 {
-    Array::get(acc, 0)
-  } else if stamped_decls < 2 {
-    Array::set(amb, 0, Array::get(amb, 0) + 1)
-    ""
-  } else {
-    let mut best = ""
-    let mut bi = 0
-    while bi < Array::length(acc) {
-      if String::length(Array::get(acc, bi)) > String::length(best) {
-        best = Array::get(acc, bi)
-      } else {
-        ()
-      }
-      bi = bi + 1
-    }
-    best
-  }
 }
 
 /// Every top-level name a statement list DECLARES -- values AND types AND
@@ -4572,7 +4476,7 @@ fn effect_lowering_prelude_split_checked(stmts: Array[Stmt], entry_name: String,
         explicit_ops: collect_explicit_derived_op_names(stmts)
       }
     }
-    let linked = prelude_run_per_module(stmts, split.stmt_file_id, split.file_count, entry_name, checker_eq_offsets, checker_eq_type_keys, split.import_closure, render, st, env, 1)
+    let linked = prelude_run_per_module(stmts, split.stmt_file_id, split.file_count, entry_name, checker_eq_offsets, checker_eq_type_keys, split.import_closure, render, st, env, 1, lc_fresh_string_array())
     // A COLLISION IS AN ERROR HERE (#2647 Codex P1). `prelude_run_per_module`
     // links with the REPORTING fold, which keeps the first definition and
     // records the conflict -- right for a measurement, which wants to know how
@@ -5654,7 +5558,7 @@ fn lc_entry_module_of(c: Array[Stmt], c_file_id: Array[Int], entry_name: String,
 /// partition cannot classify a heap value returned by an imported function and
 /// omits the annotation the merged run adds -- a different ownership
 /// classification reaching Perceus and codegen.
-fn prelude_run_per_module(c: Array[Stmt], c_file_id: Array[Int], file_count: Int, entry_name: String, checker_eq_offsets: Array[Int], checker_eq_type_keys: Array[String], import_closure: Array[Array[Int]], render: (Stmt) -> String, st: PreludeSplitStats, env: PreludeEnv, first_pass: Int) -> Array[Stmt] with Exception {
+fn prelude_run_per_module(c: Array[Stmt], c_file_id: Array[Int], file_count: Int, entry_name: String, checker_eq_offsets: Array[Int], checker_eq_type_keys: Array[String], import_closure: Array[Array[Int]], render: (Stmt) -> String, st: PreludeSplitStats, env: PreludeEnv, first_pass: Int, module_paths: Array[String]) -> Array[Stmt] with Exception {
   // WHICH module owns the entry, derived rather than assumed (#2647 Codex
   // round 4). This was `file_count - 1`, which is true of the merge -- a root's
   // dependencies come first -- but nothing in `ModuleSplit` records it and
@@ -5763,10 +5667,25 @@ fn prelude_run_per_module(c: Array[Stmt], c_file_id: Array[Int], file_count: Int
     // registered as a real tag and make the membership test certify the very
     // name it exists to reject. Skipping it needs no new information: the
     // entry module is already identified, as `entry_fid`.
+    // From the module's PATH through the merge's own mangler. Every attempt to
+    // recover a tag by PARSING a declaration name failed, in both directions
+    // and then in neither: the first marker is wrong when a source name
+    // contains one, the last is wrong when the PATH contains one, and
+    // agreement across declarations is wrong when two declarations SHARE a
+    // marker-bearing suffix -- a case that is genuinely indistinguishable from
+    // the legitimate one (Codex rounds 3, 5 and 6 on #2701/#2704). There is no
+    // parsing rule, so the tag comes from provenance instead.
     let t = if tf == entry_fid {
       ""
+    } else if tf >= Array::length(module_paths) {
+      // No provenance for this module, so it gets no tag and its stamped
+      // names are not judged. COUNTED rather than guessed: the alternative is
+      // parsing a name for its tag, which three review rounds established has
+      // no correct rule.
+      Array::set(ctx_amb, 0, Array::get(ctx_amb, 0) + 1)
+      ""
     } else {
-      lc_module_tag_of_agreed(Array::get(parts, tf), ctx_amb)
+      lc_tag_of_path(Array::get(module_paths, tf))
     }
     if t != "" && !MutMap::has(tag_owner, t) {
       MutMap::set(tag_owner, t, tf)
@@ -6258,7 +6177,7 @@ fn prelude_split_stats_new() -> PreludeSplitStats {
   }
 }
 
-export fn prelude_module_full_oracle_line(a: Array[Stmt], c: Array[Stmt], c_file_id: Array[Int], file_count: Int, entry_name: String, checker_eq_offsets: Array[Int], checker_eq_type_keys: Array[String], import_closure: Array[Array[Int]], render: (Stmt) -> String) -> String with Exception {
+export fn prelude_module_full_oracle_line(a: Array[Stmt], c: Array[Stmt], c_file_id: Array[Int], file_count: Int, entry_name: String, checker_eq_offsets: Array[Int], checker_eq_type_keys: Array[String], import_closure: Array[Array[Int]], render: (Stmt) -> String, module_paths: Array[String]) -> String with Exception {
   let entry_fid = file_count - 1
   // #2637 review (Codex P2): production runs `fold_const_bool_params` and
   // `dce_stmts` BETWEEN the prelude and the three analyses sampled below, and
@@ -6387,7 +6306,7 @@ export fn prelude_module_full_oracle_line(a: Array[Stmt], c: Array[Stmt], c_file
   let whole_invisible = eq_invisible_nominals_list()
   eq_invisible_nominals_reset()
   let st = prelude_split_stats_new()
-  let linked = prelude_run_per_module(c, c_file_id, file_count, entry_name, checker_eq_offsets, checker_eq_type_keys, import_closure, render, st, prelude_env_none(), 0)
+  let linked = prelude_run_per_module(c, c_file_id, file_count, entry_name, checker_eq_offsets, checker_eq_type_keys, import_closure, render, st, prelude_env_none(), 0, module_paths)
   let split_invisible = eq_invisible_nominals_list()
   let ev_req_u = st.requests
   let ev_ref_u = st.refusals
@@ -6596,9 +6515,10 @@ export fn prelude_module_full_oracle_line(a: Array[Stmt], c: Array[Stmt], c_file
   // matched nothing and the zeros mean nothing.
   ctx_line = String::concat(ctx_line, " seen=")
   ctx_line = String::concat(ctx_line, Int::to_string(Array::get(st.an_ctx_cls, 5)))
-  // Modules whose own declarations cannot settle their tag. Reported rather
-  // than guessed: a wrong tag moves rows between `unresolved_exp` and
-  // `unresolved_dep`, which is the one distinction this line exists to make.
+  // Modules with no path provenance, whose tag is therefore unknown and whose
+  // stamped names go unjudged. Reported rather than guessed: a wrong tag moves
+  // rows between `unresolved_exp` and `unresolved_dep`, the one distinction
+  // this line exists to make.
   ctx_line = String::concat(ctx_line, " amb=")
   ctx_line = String::concat(ctx_line, Int::to_string(Array::get(st.an_ctx_amb, 0)))
   ctx_line = String::concat(ctx_line, "\n")

--- a/lib/@vibe/compiler/entry/compiler/file_compile/file_compile.vibe
+++ b/lib/@vibe/compiler/entry/compiler/file_compile/file_compile.vibe
@@ -540,11 +540,11 @@ fn build_grouped_merged_stmts_gc(source_groups: Array[(String, Array[(String, St
 export fn prelude_module_oracle_report_fs(entry_path: String, entry_name: String, pass_limit: Int) -> String with Exception + Fs {
   let source_groups = collect_source_groups_fs(entry_path)
   let _ = prepare_file_fs_from_source_groups_persistent_cached(db_new(), entry_path, source_groups)
-  let (a, _, _, _) = prelude_oracle_merge(source_groups)
+  let (a, _, _, _) = prelude_oracle_merge(source_groups, lc_ignored_paths())
   let mut report = ""
   let mut k = 0
   while k <= pass_limit {
-    let (c, files, c_file_id, eq) = prelude_oracle_merge(source_groups)
+    let (c, files, c_file_id, eq) = prelude_oracle_merge(source_groups, lc_ignored_paths())
     let (eq_offs, eq_keys) = eq
     report = String::concat(report, prelude_pass_module_oracle_step(k, a, c, c_file_id, Array::length(files), entry_name, eq_offs, eq_keys, print_stmt))
     k = k + 1
@@ -560,8 +560,9 @@ export fn prelude_module_oracle_report_fs(entry_path: String, entry_name: String
 export fn prelude_module_full_oracle_report_fs(entry_path: String, entry_name: String) -> String with Exception + Fs {
   let source_groups = collect_source_groups_fs(entry_path)
   let _ = prepare_file_fs_from_source_groups_persistent_cached(db_new(), entry_path, source_groups)
-  let (a, _, _, _) = prelude_oracle_merge(source_groups)
-  let (c, files, c_file_id, eq) = prelude_oracle_merge(source_groups)
+  let (a, _, _, _) = prelude_oracle_merge(source_groups, lc_ignored_paths())
+  let module_paths: Array[String] = []
+  let (c, files, c_file_id, eq) = prelude_oracle_merge(source_groups, module_paths)
   let (eq_offs, eq_keys) = eq
   let (import_closure, unresolved_edges) = oracle_import_closure(source_groups)
   // The closure is indexed by FLAT SOURCE, the oracle by MERGED FILE ID. They
@@ -574,7 +575,7 @@ export fn prelude_module_full_oracle_report_fs(entry_path: String, entry_name: S
   } else {
     ()
   }
-  let line = prelude_module_full_oracle_line(a, c, c_file_id, Array::length(files), entry_name, eq_offs, eq_keys, import_closure, print_stmt)
+  let line = prelude_module_full_oracle_line(a, c, c_file_id, Array::length(files), entry_name, eq_offs, eq_keys, import_closure, print_stmt, module_paths)
   String::concat(String::concat(line, "edges_unresolved="), String::concat(Int::to_string(unresolved_edges), "\n"))
 }
 
@@ -1027,7 +1028,12 @@ fn exact_import_closure(source_groups: Array[(String, Array[(String, String)])])
   }
 }
 
-fn prelude_oracle_merge(source_groups: Array[(String, Array[(String, String)])]) -> (Array[Stmt], Array[String], Array[Int], (Array[Int], Array[String])) with Exception {
+/// A throwaway sink for the path out-param, for callers that do not want it.
+fn lc_ignored_paths() -> Array[String] {
+  []
+}
+
+fn prelude_oracle_merge(source_groups: Array[(String, Array[(String, String)])], out_paths: Array[String]) -> (Array[Stmt], Array[String], Array[Int], (Array[Int], Array[String])) with Exception {
   let flat_paths: Array[String] = []
   let flat_bases: Array[Int] = []
   let clone_float_offsets: Array[Int] = []
@@ -1039,6 +1045,16 @@ fn prelude_oracle_merge(source_groups: Array[(String, Array[(String, String)])])
     throw("prelude oracle: the binop rewrite changed the statement count")
   } else {
     ()
+  }
+  // #2704: the SOURCE PATHS, in merged-file-id order. `flat_paths` is filled
+  // from the very `file_paths` array the merge mangles with
+  // (`build_grouped_merged_stmts_impl` pushes `file_paths[source_idx]`), so
+  // `sanitize_namespace_path` of one of these IS a module's stamp -- no
+  // parsing, no ambiguity. `files` is NOT this: it is `path_basename(...)`.
+  let mut fp = 0
+  while fp < Array::length(flat_paths) {
+    Array::push(out_paths, Array::get(flat_paths, fp))
+    fp = fp + 1
   }
   (stmts, files, stmt_file_id, (eq_offs, eq_keys))
 }

--- a/lib/@vibe/compiler/tests/prelude_split_bytes_test.vibe
+++ b/lib/@vibe/compiler/tests/prelude_split_bytes_test.vibe
@@ -255,10 +255,13 @@ test "the residual-order counter can fire" {
     Array::push(ids, i - i / 2 * 2)
     i = i + 1
   }
+  // No path provenance: this program is synthesized from source strings and
+  // has no files, so the CTX instrument reports `amb=` rather than inventing
+  // module tags. This test reads only the ORDER line.
   let report = prelude_module_full_oracle_line(a, c, ids, 2, "main", no_ints(), no_keys(), [
     [1],
     [0]
-  ], print_stmt)
+  ], print_stmt, no_keys())
   // Two of the four source statements land at a different index once the map
   // interleaves them; `of=4` is how many statements the comparison covers
   // after the synthesized ones are removed.


### PR DESCRIPTION
Follow-up to #2704, which merged at `31b60d1` before this commit was pushed. Advances #2633. Oracle only — no production code is touched (`use_split` is false at every production caller).

**Main currently carries the rule this replaces**, and Codex disproved it on #2704 after the merge. Where two declarations share a marker-bearing suffix — `foo_dep_shared_vibe` and `bar_dep_shared_vibe` — both yield `<real-tag>` *and* `shared_vibe_exp_<real-tag>`; the spurious candidate survives the intersection, is longer, and gets picked, while `amb` reads 0 because two declarations agreed. `{T, X}` with T a suffix of X is genuinely indistinguishable from `{T, suffix-of-T}`.

## The rule set is exhausted

| rule | wrong when | round |
|---|---|---|
| first marker | the **source name** contains one | 3 |
| last marker | the **path** contains one | 5 |
| agreement + longest | declarations **share** one | 6 |

Three review rounds, three rules, three counter-examples. There is no parsing rule, and the tag comes from provenance instead.

## `flat_paths` was always the mangling path

`build_grouped_merged_stmts_impl` fills `flat_paths_out` from `file_paths[source_idx]` — the same array `build_merged_source_with_plan` hands to `namespace_private_value_stmts_after_renames`.

I ruled it out in round 3 by comparing it **pairwise against `parts[0]`** and seeing a mismatch. That test could not have worked: the entry module carries no stamp, so index 0 is exactly where the two arrays must disagree even when both are correct. I then reported "neither array holds the mangling path" as a finding, which was the bad test talking, and spent two rounds on heuristics instead. `files` is the array that genuinely isn't the path — it is `path_basename(flat_path)`.

`prelude_oracle_merge` now hands the paths out, and `lc_tag_of_path` computes a module's tag through the merge's own mangler (`namespace_private_name(path, "")` minus the 5-character marker), so it cannot drift from the spelling the merge produces. The candidate/intersection machinery (`lc_name_tag_candidates`, `lc_str_intersect`, `lc_module_tag_of_agreed`) is deleted — with exact tags there is nothing to guess.

`amb` is repurposed to what it can now honestly mean: modules with **no path provenance**, whose stamped names go unjudged.

## Verification

```
compiler CLI closure   seen=25483 amb=0      (stable across three runs)
                       decls=121778 modules=366 zero=36
                       unresolved_exp=83 unresolved_dep=0 exp_unknown=0
                       keyed missing=0 extra=0 content=1
fixtures/import_visibility_test.vibe   seen=1 amb=0
```

Both fixture pins unchanged.

| check | result |
|---|---|
| `scripts/compiler_gate.sh` | `[compiler-gate] ok`, exit 0 |
| gate self-tests (#2248) | `passed: 5, failed: 0` |
| `prelude_module_oracle_test.vibe` | 10 tests pass |
| `vibe check` / `vibe_fmt --check` | clean (incl. `.vpkg`) |

### Red tests — both by mutating the tree and re-running, no rebuild

- **collector arms reverted** → `unresolved_dep=1:Hidden_dep__tmp_vibe_ctx_typedecl_dep_vibe`
- **provenance starved** → `seen=0 amb=365` on the closure, `seen=0 amb=1` on the fixture: the instrument *says* it could not judge instead of reporting a clean zero

The second is the red test #2704 was missing, and which its PR body flagged as missing. That `amb` is testable at all, where the agreement heuristic's was not, is itself the argument for provenance over inference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NAeZzkckdAwtQiubBFpdmM

---
_Generated by [Claude Code](https://claude.ai/code/session_01NAeZzkckdAwtQiubBFpdmM)_