### PR TITLE
perf(compiler): narrow tuple-unbox and capture analysis

### DIFF
--- a/lib/@vibe/compiler/codegen/common_analysis/common_analysis.vibe
+++ b/lib/@vibe/compiler/codegen/common_analysis/common_analysis.vibe
@@ -1407,6 +1407,82 @@ export fn scope_tail_proj_root(e: Expr) -> String {
   }
 }
 
+// #1935: allocation-free negative filter before collecting a closure's free
+// variables. This asks only whether the spelling occurs, including write-only
+// assignment targets. It deliberately ignores binders: shadowing belongs to
+// the existing capture judgment, and a false positive only costs that walk.
+// Interpolation is opaque at this AST layer, so it cannot certify absence.
+fn capture_body_mentions_name(e: Expr, name: String) -> Bool {
+  match e {
+    EIdent(n, _) => n == name,
+    EAssign(n, v, b) => n == name || capture_body_mentions_name(v, name) || capture_body_mentions_name(b, name),
+    EAssignOp(n, _, v, b) => n == name || capture_body_mentions_name(v, name) || capture_body_mentions_name(b, name),
+    EInt(_) => false,
+    EFloat(_) => false,
+    EString(_) => false,
+    EBool(_) => false,
+    EUnit => false,
+    EStringInterp(_) => true,
+    ELet(_, v, b, _) => capture_body_mentions_name(v, name) || capture_body_mentions_name(b, name),
+    ELetMut(_, v, b, _) => capture_body_mentions_name(v, name) || capture_body_mentions_name(b, name),
+    ELetRec(_, v, b) => capture_body_mentions_name(v, name) || capture_body_mentions_name(b, name),
+    ESeq(a, b) => capture_body_mentions_name(a, name) || capture_body_mentions_name(b, name),
+    EBinOp(_, a, b, _) => capture_body_mentions_name(a, name) || capture_body_mentions_name(b, name),
+    EIf(c, t, f) => capture_body_mentions_name(c, name) || capture_body_mentions_name(t, name) || capture_body_mentions_name(f, name),
+    EWhile(c, b) => capture_body_mentions_name(c, name) || capture_body_mentions_name(b, name),
+    EForIn(_, _, iter, b) => capture_body_mentions_name(iter, name) || capture_body_mentions_name(b, name),
+    ECall(callee, args, _) => capture_body_mentions_name(callee, name) || capture_list_mentions_name(args, name),
+    ETuple(items) => capture_list_mentions_name(items, name),
+    EArray(items) => capture_list_mentions_name(items, name),
+    EContinue(items) => capture_list_mentions_name(items, name),
+    ERecord(_, fields, _) => capture_fields_mention_name(fields, name),
+    EMap(fields) => capture_fields_mention_name(fields, name),
+    ELoop(inits, body) => capture_fields_mention_name(inits, name) || capture_body_mentions_name(body, name),
+    EMatch(scrutinee, arms) => capture_body_mentions_name(scrutinee, name) || capture_arms_mention_name(arms, name),
+    EHandle(body, arms) => capture_body_mentions_name(body, name) || capture_arms_mention_name(arms, name),
+    EFn(_, _, _, _, _, body) => capture_body_mentions_name(body, name),
+    EUnaryOp(_, body) => capture_body_mentions_name(body, name),
+    EDot(body, _, _, _) => capture_body_mentions_name(body, name),
+    ELabeledArg(_, _, body) => capture_body_mentions_name(body, name),
+    EReturn(body) => capture_body_mentions_name(body, name),
+    ESpread(body) => capture_body_mentions_name(body, name),
+    EBreak(Some(body)) => capture_body_mentions_name(body, name),
+    EBreak(None) => false
+  }
+}
+
+fn capture_list_mentions_name(items: Array[Expr], name: String) -> Bool {
+  let mut i = 0
+  let mut found = false
+  while !found && i < Array::length(items) {
+    found = capture_body_mentions_name(Array::get(items, i), name)
+    i = i + 1
+  }
+  found
+}
+
+fn capture_fields_mention_name(fields: Array[(String, Expr)], name: String) -> Bool {
+  let mut i = 0
+  let mut found = false
+  while !found && i < Array::length(fields) {
+    let (_, value) = Array::get(fields, i)
+    found = capture_body_mentions_name(value, name)
+    i = i + 1
+  }
+  found
+}
+
+fn capture_arms_mention_name(arms: Array[(Pat, Expr)], name: String) -> Bool {
+  let mut i = 0
+  let mut found = false
+  while !found && i < Array::length(arms) {
+    let (_, body) = Array::get(arms, i)
+    found = capture_body_mentions_name(body, name)
+    i = i + 1
+  }
+  found
+}
+
 /// Check if a mutable variable is captured by any nested EFn in the given expression
 export fn is_mut_captured_in(expr: Expr, name: String) -> Bool {
   match expr {
@@ -1504,7 +1580,7 @@ export fn is_mut_captured_in(expr: Expr, name: String) -> Bool {
         }
         pi = pi + 1
       }
-      if shadowed {
+      if shadowed || !capture_body_mentions_name(fn_body, name) {
         false
       }
       else {

--- a/lib/@vibe/compiler/normalize/unbox_tuple_loop.vibe
+++ b/lib/@vibe/compiler/normalize/unbox_tuple_loop.vibe
@@ -1042,15 +1042,26 @@ fn unbox_tuple_loop_params_drive(stmts: Array[Stmt]) -> Unit {
   while i < Array::length(stmts) {
     let st = Array::get(stmts, i)
     match st {
-      SLet(a, b, name, ty, body) => Array::set(stmts, i, SLet(a, b, name, ty, utl_drive(body))),
-      SLetMut(name, ty, body) => Array::set(stmts, i, SLetMut(name, ty, utl_drive(body))),
-      SExpr(e) => Array::set(stmts, i, SExpr(utl_drive(e))),
-      STest(name, body) => Array::set(stmts, i, STest(name, utl_drive(body))),
-      SBench(name, body) => Array::set(stmts, i, SBench(name, utl_drive(body))),
-      SLetPat(p, body) => Array::set(stmts, i, SLetPat(p, utl_drive(body))),
-      SModule(exp, name, inner) => {
+      SLet(a, b, name, ty, body) => if has_unbox_tuple_candidate_expr(body) {
+        Array::set(stmts, i, SLet(a, b, name, ty, utl_drive(body)))
+      },
+      SLetMut(name, ty, body) => if has_unbox_tuple_candidate_expr(body) {
+        Array::set(stmts, i, SLetMut(name, ty, utl_drive(body)))
+      },
+      SExpr(e) => if has_unbox_tuple_candidate_expr(e) {
+        Array::set(stmts, i, SExpr(utl_drive(e)))
+      },
+      STest(name, body) => if has_unbox_tuple_candidate_expr(body) {
+        Array::set(stmts, i, STest(name, utl_drive(body)))
+      },
+      SBench(name, body) => if has_unbox_tuple_candidate_expr(body) {
+        Array::set(stmts, i, SBench(name, utl_drive(body)))
+      },
+      SLetPat(p, body) => if has_unbox_tuple_candidate_expr(body) {
+        Array::set(stmts, i, SLetPat(p, utl_drive(body)))
+      },
+      SModule(_, _, inner) => {
         unbox_tuple_loop_params_drive(inner)
-        Array::set(stmts, i, SModule(exp, name, inner))
       },
       _ => ()
     }
@@ -1060,11 +1071,8 @@ fn unbox_tuple_loop_params_drive(stmts: Array[Stmt]) -> Unit {
 
 /// Split every eligible tuple `let mut` in `stmts` into scalar `let mut`s,
 /// IN PLACE. Run at both linear codegen entries, after the checker.
-/// #1935: skip the walk when no 2..8-ary tuple `let mut` exists.
+/// #1935: select each statement body independently. One candidate elsewhere
+/// in the program must not make us rebuild every unrelated function/module.
 export fn unbox_tuple_loop_params(stmts: Array[Stmt]) -> Unit {
-  if !has_unbox_tuple_candidate(stmts) {
-    ()
-  } else {
-    unbox_tuple_loop_params_drive(stmts)
-  }
+  unbox_tuple_loop_params_drive(stmts)
 }

--- a/lib/@vibe/compiler/normalize/unbox_tuple_loop_test.vibe
+++ b/lib/@vibe/compiler/normalize/unbox_tuple_loop_test.vibe
@@ -81,3 +81,23 @@ test "unbox still rewrites an eligible tuple let mut after the pre-scan" {
     _ => assert(false)
   }
 }
+
+test "one candidate does not rebuild unrelated function bodies" {
+  let mut body = EInt(0)
+  let mut i = 0
+  while i < 512 {
+    body = ESeq(EInt(i), body)
+    i = i + 1
+  }
+  let stmts: Array[Stmt] = [
+    SExpr(EFn([], [], [], None, None, body)),
+    SModule(false, "M", [SExpr(tuple_let_mut("s", destr_body()))])
+  ]
+  // Warm the reusable child stack before measuring the rewrite itself.
+  inspect(has_unbox_tuple_candidate(stmts), content = "true")
+  let before = Profiler::heap_bytes()
+  unbox_tuple_loop_params(stmts)
+  let allocated = Profiler::heap_bytes() - before
+  // Rewriting the tiny candidate fits here; copying 512 unrelated nodes does not.
+  inspect(allocated < 4096, content = "true")
+}

--- a/lib/@vibe/compiler/tests/capture_candidate_test.vibe
+++ b/lib/@vibe/compiler/tests/capture_candidate_test.vibe
@@ -1,0 +1,113 @@
+import @vibe/compiler/core {
+  Expr, Pat, Stmt
+}
+import @vibe/compiler/codegen/common_analysis {
+  compute_borrow_param_user_fns, is_mut_captured_in
+}
+
+fn closure(body: Expr) -> Expr {
+  EFn([], [], [], None, None, body)
+}
+
+test "a closure without the queried name needs no free-variable allocation" {
+  let body = closure(ELet("local", EInt(1), EIdent("local", -1), -1))
+  let before = Profiler::heap_bytes()
+  let captured = is_mut_captured_in(body, "absent")
+  let allocated = Profiler::heap_bytes() - before
+  inspect(captured, content = "false")
+  inspect(allocated, content = "0")
+}
+
+test "reads and write-only captures remain candidates" {
+  inspect(is_mut_captured_in(closure(EIdent("x", -1)), "x"), content = "true")
+  inspect(is_mut_captured_in(closure(EAssign("x", EInt(2), EUnit)), "x"), content = "true")
+  inspect(is_mut_captured_in(closure(EAssignOp("x", "+", EInt(2), EUnit)), "x"), content = "true")
+}
+
+test "nested closure candidates survive control-flow payloads" {
+  let capture = closure(EIdent("x", -1))
+  inspect(is_mut_captured_in(EBreak(Some(capture)), "x"), content = "true")
+  inspect(is_mut_captured_in(EContinue([capture]), "x"), content = "true")
+  inspect(is_mut_captured_in(closure(closure(EIdent("x", -1))), "x"), content = "true")
+}
+
+test "a capture under every expression child remains visible" {
+  let c = closure(EIdent("x", -1))
+  let z = EInt(0)
+  let arms: Array[(Pat, Expr)] = [(PWild, c)]
+  let parents: Array[Expr] = [
+    ELet("other", c, z, -1),
+    ELet("other", z, c, -1),
+    ELetMut("other", c, z, -1),
+    ELetMut("other", z, c, -1),
+    ELetRec("other", c, z),
+    ELetRec("other", z, c),
+    EAssign("other", c, z),
+    EAssign("other", z, c),
+    EAssignOp("other", "+", c, z),
+    EAssignOp("other", "+", z, c),
+    ESeq(c, z),
+    ESeq(z, c),
+    EBinOp("+", c, z, -1),
+    EBinOp("+", z, c, -1),
+    EIf(c, z, z),
+    EIf(z, c, z),
+    EIf(z, z, c),
+    EWhile(c, z),
+    EWhile(z, c),
+    EForIn("other", None, c, z),
+    EForIn("other", None, z, c),
+    ECall(c, [], -1),
+    ECall(z, [c], -1),
+    ETuple([c]),
+    EArray([c]),
+    EContinue([c]),
+    ERecord("Box", [("field", c)], []),
+    EMap([("key", c)]),
+    ELoop([("other", c)], z),
+    ELoop([], c),
+    EMatch(c, []),
+    EMatch(z, arms),
+    EHandle(c, []),
+    EHandle(z, arms),
+    closure(c),
+    EUnaryOp("-", c),
+    EDot(c, "field", -1, -1),
+    ELabeledArg("arg", "~", c),
+    EReturn(c),
+    ESpread(c),
+    EBreak(Some(c))
+  ]
+  let mut i = 0
+  let mut all_captured = true
+  while i < Array::length(parents) {
+    if !is_mut_captured_in(closure(Array::get(parents, i)), "x") {
+      all_captured = false
+    }
+    i = i + 1
+  }
+  inspect(all_captured, content = "true")
+}
+
+test "the pre-scan leaves shadowing to the existing capture judgment" {
+  let shadowed = EFn([], [], [("x", None)], None, None, EIdent("x", -1))
+  inspect(is_mut_captured_in(shadowed, "x"), content = "false")
+  let local = closure(ELet("x", EInt(1), EIdent("x", -1), -1))
+  inspect(is_mut_captured_in(local, "x"), content = "false")
+  let init_capture = ELet("x", closure(EIdent("x", -1)), EUnit, -1)
+  inspect(is_mut_captured_in(init_capture, "x"), content = "true")
+}
+
+test "borrow inference distinguishes unrelated closures from write-only captures" {
+  let read = ECall(EIdent("Array::length", -1), [EIdent("xs", -1)], -1)
+  let unrelated = ESeq(closure(EIdent("other", -1)), read)
+  let write_only = ESeq(closure(EAssign("xs", EArray([]), EUnit)), read)
+  let decls: Array[Stmt] = [
+    SLet(false, false, "reader", None, EFn([], [], [("xs", None)], None, None, unrelated)),
+    SLet(false, false, "writer", None, EFn([], [], [("xs", None)], None, None, write_only))
+  ]
+  let masks: Array[Int] = []
+  let names = compute_borrow_param_user_fns(decls, [], masks)
+  inspect(names, content = "[reader]")
+  inspect(masks, content = "[1]")
+}


### PR DESCRIPTION
One eligible tuple binding currently makes tuple unboxing rebuild unrelated function bodies across the program. Capture analysis also collects a closure's free variables even when the queried name cannot occur. Select tuple-unbox statement bodies independently and add an allocation-free negative filter before free-variable collection, reducing selfcompile heap allocation by about 15.4 MB.

The capture filter includes write-only assignment targets and all expression children, treats opaque interpolation conservatively, and leaves shadowing and ownership decisions to the existing analysis. Borrow inference benefits through the shared capture entry point.

Fixes #1935.

### Performance

Baseline: `6c4ed21af240e0df8c485f30b17e148cc320e2d0`. Compile the same final `lib/@vibe/cli/entry.vibe` closure with baseline/candidate stage2 compilers, Node v24.21.0, `VIBE_FS_COMPILE=1`, `VIBE_IMPORT_ABI=raw`, and `VIBE_RC=0`. Four alternating baseline/candidate pairs each use a fresh `VIBE_BUILD_CACHE_DIR` for the cold compile and the same cache for its following warm compile.

| Cache | Baseline heap bytes | Candidate heap bytes | Saved | Baseline wall median | Candidate wall median |
| --- | ---: | ---: | ---: | ---: | ---: |
| Cold | 2,048,114,200 | 2,032,733,024 | 15,381,176 (0.75%) | 4,845.5 ms | 4,889.5 ms |
| Warm | 1,486,404,016 | 1,471,023,192 | 15,380,824 (1.03%) | 3,661.0 ms | 3,752.0 ms |

Heap counts repeat exactly. Wall medians increased by 0.9% and 2.5% with substantial run-to-run variation; **no end-to-end speedup is claimed**. Separate fresh-cache ablations attribute approximately 14.82 MB to tuple-unbox selection and 0.57 MB to the capture filter.

All 16 selfcompile outputs are byte-identical (SHA-256 `c988b7fd10e6f2b5bd527fd68ae8f1fd39a9b72bb66a4bfa070079b05910a23d`).

### Validation

- Red/Green: baseline fails the unrelated-function allocation bound and allocates 320 bytes for a closure without the queried name; the candidate passes the bound and allocates zero bytes for that capture query.
- Regression coverage includes candidate presence/absence, nested modules/closures, every expression-child position, shadowing, write-only captures, and borrow masks.
- Tuple-unbox and write-only-capture fixtures compile to identical wasm and execute successfully across filesystem/single-source and bump/RC configurations (eight comparisons).
- Candidate stage2 equals stage3 and the compiler built by the full gate.
- `pkf run full-gate` passed; all 1,196 active unit-test files and 287 affected test files passed with the rebuilt compiler.
- All `release-check` component checks passed. The aggregate run was resumed after two local environment failures described below, executing the remaining task commands in dependency order with the already-validated generation.
- `pkf run pre-commit` passed with the AST review tier required; formatting and `git diff --check` passed.

Local gates used the already-installed GNU Bash/awk/grep/sed/wc on macOS. The CLI newline check compares `wc` output as a string, so BSD `wc`'s padding makes an actual zero-byte output fail that check; GNU `wc` passes. Stale ignored benchmark artifacts containing retired syntax were preserved outside `lib/` before the tree-wide source scan. The document-classification check used a staged-index export via `VIBE_DOC_CLASSIFICATION_ROOT`: the local checkout contains 3,074 ignored historical evaluation outputs, all absent from the index. No tracked files were removed.
