### PR TITLE
#2669 slice 3 step 1: the body cache carries the blind references, so replay asserts the same pairing

### DIFF
--- a/Taskfile.pkl
+++ b/Taskfile.pkl
@@ -1387,6 +1387,14 @@ local testEditCycleKpi = new Task {
   cache = false
 }
 
+local testRelocCrossbuild = new Task {
+  name = "test-reloc-crossbuild"
+  description = "source-edited bodies are excluded from relocation statistics and evidence guards"
+  cmd = "bash scripts/reloc_crossbuild_test.sh"
+  inputs { ...compilerProbeInputs; ...scriptSources }
+  deps { selfhostGeneration }
+}
+
 local selfhostGenerationGate = new Task {
   name = "generation-gate"
   description = "selfhost operation gate: seed -> stage1 -> stage2 -> stage3 build"
@@ -1935,6 +1943,7 @@ local releaseCheck = new Task {
     // stderr, which is worth exactly as much as the number of places that
     // assertion runs.
     testVibeRun
+    testRelocCrossbuild
   }
 }
 
@@ -2102,6 +2111,7 @@ tasks {
   measureFsHeap
   editCycleKpi
   testEditCycleKpi
+  testRelocCrossbuild
   selfhostPostGenerationGate
   testSelfhostRcBootstrap
   testGcSelfbuild

--- a/docs/incremental-build.md
+++ b/docs/incremental-build.md
@@ -729,15 +729,24 @@ to 142,360 — 980 references that were silently going to be left behind.
 
 ##### Does a body actually relocate? (#2669, slice 1b)
 
-The round-trip above proves the walk does not desynchronise. It does not prove
-the central claim, which is that a body compiled against ONE index assignment
-can be moved onto ANOTHER. `scripts/reloc_crossbuild.sh` tests that directly:
-it builds the compiler's own closure twice — the second with one import added
-to `lib/@vibe/core/base64.vibe`, which pulls `hex.vibe` earlier in the module
-order and moves most of the function index space — then takes each of A's
-bodies, rewrites every function reference from A's index space into B's by
-resolving through the name section, and compares against **what the compiler
-itself emitted for B**.
+The round-trip above proves the walk does not desynchronise. The cross-build
+comparison in `scripts/reloc_crossbuild.sh` tests whether a body compiled
+against one index assignment can be moved onto another: it builds the
+compiler's own closure twice, pulls `hex.vibe` earlier through a new import in
+`lib/@vibe/core/base64.vibe`, remaps function references by their unique names,
+and compares the rebuilt bodies against what the compiler emitted for B.
+
+The perturbation also adds a call to `encode_url_safe`. That function has
+different source in A and B, so the wrapper passes its name in the optional
+third, comma-separated argument. The comparator resolves each name to one
+shared defined function and removes it before **all** counts and non-vacuity
+guards. It reports `source_edited_excluded` separately. Calls
+*to* an excluded function still relocate normally; only its own body is outside
+the sample. Explicitly supplied module pairs must identify their source edits
+the same way: the binary alone cannot establish source equality.
+
+Measured on the compiler closure (`codegen_lexer_test.vibe`), excluding the one
+known source-edited body (compiler sources at `2e9da1132`):
 
 | | count | share |
 |---|---:|---:|
@@ -745,70 +754,41 @@ itself emitted for B**.
 | **REWRITTEN: at least one reference moved** | **3157** | |
 | **rewritten AND byte-identical to the compiler's own output** | **2814** | **89.1%** |
 | rewritten, mismatched | 343 | 10.9% |
-| not rewritten — an identity rebuild, no evidence either way | 1193 | |
+| not rewritten — an identity rebuild, no relocation evidence | 1193 | |
 | mismatch, cause not determinable (of all 382) | 284 | |
-| mismatch, unambiguously **encoding-blind** (of all 382) | 98 | |
-| skipped: the name is ambiguous on one side or the other | 5 | |
-| excluded: the body the wrapper EDITED, not a relocation case | 1 | |
+| mismatch, **encoding-blind** under the unchanged-source condition (of all 382) | 98 | |
+| skipped: known source change | 1 | |
+| skipped: the name is ambiguous on either side | 5 | |
 | shared functions whose index actually moved | 4265 | |
 
-**89.1% of the bodies this measurement can speak for survive a module reorder
-byte for byte**, using nothing but the references the instruction encoding
-exposes. That is the first direct evidence that index-independent bodies work
-rather than an argument that they should.
+The relocation success rate is **2814 / 3157**, restricted to bodies whose
+references were actually rewritten. A containing function's own index does
+not appear in its body, so a moved assignment alone is insufficient evidence.
+The 1193 identity rebuilds do not enter that rate.
 
-**The load-bearing figure is 2814 / 3157, not 3968 / 4350.** A function's own
-index is not encoded in its body, so "the assignment moved" does not mean "this
-body was rewritten": 1193 of the 4350 reference only functions that held still,
-and are rebuilt by an identity operation. Their match says nothing about
-relocation, and counting them flattered the first published rate (91.2%) over
-the real one (89.1%). Measured the other way round, with the remap forced to
-the identity on the same pair, matched falls **3968 → 1154** — so the remap is
-worth 2814 bodies, and that is the claim.
+**98 is a lower bound under the unchanged-source condition.** These mismatches
+carry neither a non-function reference (which this tool passes through) nor an
+unresolved function target. The remaining differences require information the
+instruction encoding does not expose, including function-value and data-pointer
+constants. The 284 other mismatches may carry those constants too, but their
+visible unresolved references prevent a causal attribution. A real link has
+symbol tables for the non-function spaces that this binary comparison lacks.
 
-**98 is a LOWER BOUND on what the emitter must record, not the number.** Only
-bodies with no confound are in it: a body can carry both a non-function
-reference (passed through here, because wasm gives those spaces no name
-section to map through) and an encoding-blind `i64.const`, and an unresolved
-function target is also passed through. Either makes the cause undeterminable
-from the binary, so those 284 are counted apart rather than attributed. A real
-link has the symbol tables this tool lacks and would resolve most of them; how
-many of the 284 are ALSO encoding-blind is not knowable here.
+The comparison refuses an empty sample, a sample with no moved assignment, or
+one with no rewritten byte-identical body. Excluded functions cannot satisfy
+any of these guards. Exact wasm names take precedence; a short name is accepted
+only when it resolves uniquely on both sides. A missing, ambiguous, one-sided,
+empty or duplicate exclusion is an error; it cannot silently leave a known
+edit in the sample. Ambiguous names are also refused for relocation mappings on
+both sides, including references targeting the compiler's repeated `__rt_gen`
+names.
 
-Three things this measurement needs in order to mean anything, each of which
-it got wrong first and reports now:
-
-- **Duplicate names are refused, not resolved first-wins.** The compiler emits
-  many functions called `__rt_gen` — `linked_compile.vibe` labels every
-  unassigned generated slot that way in a loop. Taking the first match compared
-  each of them against the wrong body and remapped every call to one into the
-  wrong target, which both manufactures mismatches and can count a comparison
-  against the WRONG body as a match. The first published figure (4356 / 3943 /
-  90.5%) had those rows in it.
-- **Duplicate names are refused on BOTH sides.** Checking only the target
-  module was the first version of that fix and it is not enough: if A carries
-  two `__rt_gen` and B carries one, both A bodies are compared against that
-  single B body and every A-side reference to either collapses onto it. On this
-  particular pair the two-sided check changes no number — the duplicates exist
-  on both sides — but an explicitly supplied pair can exhibit it.
-- **The reorder is asserted, not assumed, and then so is the REWRITE.** Two
-  guards, because the first alone can pass vacuously. `moved_index` counts
-  shared functions whose index differs, and zero FAILS — handing the tool the
-  same module twice gives `matched=4351 mismatched=0 moved_index=0`, a perfect
-  score, rejected. But a function's own index is not in its body, so that only
-  establishes the assignment moved. `rewritten_matched` counts bodies where a
-  reference was rewritten to a different index AND the result is byte-identical;
-  zero of those FAILS too. Red-tested by forcing the remap to the identity on
-  the real pair: `moved_index=4266 rewritten=0`, so the first guard passes and
-  the second one fires.
-- **The one edited body is EXCLUDED, not merely named.** Forcing a module
-  reorder requires editing something — a call has to cross the new import — so
-  that body's two versions are different source programs and comparing them
-  measures the edit. Naming it in the output left it in the denominator and,
-  measured, inside the encoding-blind bucket: excluding it moves the bound from
-  99 to **98** and the compared total from 4351 to 4350. The wrapper passes the
-  name and the tool FAILS if it matches nothing, so a rename cannot put the
-  confound back in silence.
+`pkf run test-reloc-crossbuild` exercises the production comparator on valid
+small wasm modules. It proves that a source edit enters the old mismatch
+bucket without an exclusion, that excluding it removes it from every relevant
+count while retaining other mismatches and calls to it, and that exclusions
+cannot satisfy the non-vacuity guards. It is included in `release-check` and
+the CI selftests lane.
 
 **What the scan cannot see, and why the link must record instead of derive.**
 A `call` immediate is self-describing — the opcode says the next uleb is a

--- a/lib/@vibe/compiler/codegen/common_base/common_base.vibe
+++ b/lib/@vibe/compiler/codegen/common_base/common_base.vibe
@@ -230,6 +230,24 @@ export struct CodegenBodyCache {
   /// duplicates do not matter, which is what lets slices merge freely.
   slot_owner: Array[Int];
   slot_values: Array[Int];
+  /// #2669 slice 3: the references this function's compile recorded that the
+  /// INSTRUCTION ENCODING does not expose -- a function used as a value, and
+  /// the funcref slot a capturing lambda stores in its closure header. Carried
+  /// for the same reason as slot_owner above: a replayed function never runs
+  /// the emission, so without these a replaying build's log is short by
+  /// exactly the functions it replayed, and the paired-count invariant that
+  /// keeps the recording honest could only be checked on compiled ones.
+  ///
+  /// `blind_fn` is the owning user function, the selection key that lets
+  /// merge and filter reuse the same keep-set logic the slots use.
+  /// `blind_body` is the BODY the record sits in -- the same function, or one
+  /// of its lambdas as `blind_owner_of_lambda` -- because the offset is
+  /// relative to that body's instruction stream and to no other.
+  blind_fn: Array[Int];
+  blind_body: Array[Int];
+  blind_offsets: Array[Int];
+  blind_kinds: Array[Int];
+  blind_syms: Array[Int];
   /// #2388 step 3: the merged-statement index each cached function was
   /// compiled from, parallel to fn_indices (-1 when the recording site has
   /// no statement, e.g. tests that record synthetic entries). Replay ignores
@@ -298,6 +316,11 @@ export fn codegen_body_cache_new() -> CodegenBodyCache {
     lam_meta_i64: array_empty(),
     slot_owner: array_empty(),
     slot_values: array_empty(),
+    blind_fn: array_empty(),
+    blind_body: array_empty(),
+    blind_offsets: array_empty(),
+    blind_kinds: array_empty(),
+    blind_syms: array_empty(),
     fn_src_stmts: array_empty(),
     guard_meta: array_empty(),
     guard_synth_names: array_empty(),
@@ -394,7 +417,7 @@ export fn codegen_body_cache_find_at(slot_index: Array[Int], fn_index: Int) -> I
 /// Reads the LAST entry of `bodies` / `meta_i32` / `meta_i64` -- the loop has
 /// just pushed them -- and the lambda table slice `[lam_lo, lam_hi)`, which is
 /// exactly the range the plan assigned this function.
-export fn codegen_body_cache_record(cache: CodegenBodyCache, fn_index: Int, src_stmt: Int, bodies: Array[Bytes], meta_i32: Array[Int], meta_i64: Array[Int], meta_v128: Array[Int], lt: LambdaTable, lam_lo: Int, lam_hi: Int, slots: Array[Int], slot_lo: Int, slot_hi: Int) -> Unit {
+export fn codegen_body_cache_record(cache: CodegenBodyCache, fn_index: Int, src_stmt: Int, bodies: Array[Bytes], meta_i32: Array[Int], meta_i64: Array[Int], meta_v128: Array[Int], lt: LambdaTable, lam_lo: Int, lam_hi: Int, slots: Array[Int], slot_lo: Int, slot_hi: Int, blind_bodies: Array[Int], blind_offsets: Array[Int], blind_kinds: Array[Int], blind_syms: Array[Int], blind_lo: Int, blind_hi: Int) -> Unit {
   let n = Array::length(bodies)
   if n == 0 {
     ()
@@ -421,6 +444,19 @@ export fn codegen_body_cache_record(cache: CodegenBodyCache, fn_index: Int, src_
       Array::push(cache.slot_owner, fn_index)
       Array::push(cache.slot_values, Array::get(slots, si))
       si = si + 1
+    }
+    // #2669 slice 3: same suffix rule as the slots. The body owner is stored
+    // as recorded rather than rewritten to fn_index -- a record made inside
+    // one of this function's lambdas names that lambda, and its offset means
+    // nothing against any other body.
+    let mut bi = blind_lo
+    while bi < blind_hi {
+      Array::push(cache.blind_fn, fn_index)
+      Array::push(cache.blind_body, Array::get(blind_bodies, bi))
+      Array::push(cache.blind_offsets, Array::get(blind_offsets, bi))
+      Array::push(cache.blind_kinds, Array::get(blind_kinds, bi))
+      Array::push(cache.blind_syms, Array::get(blind_syms, bi))
+      bi = bi + 1
     }
   }
 }
@@ -472,6 +508,16 @@ export fn codegen_body_cache_merge(a: CodegenBodyCache, b: CodegenBodyCache) -> 
       Array::push(out.slot_owner, Array::get(src.slot_owner, k))
       Array::push(out.slot_values, Array::get(src.slot_values, k))
       k = k + 1
+    }
+    let blind_n = Array::length(src.blind_fn)
+    let mut m = 0
+    while m < blind_n {
+      Array::push(out.blind_fn, Array::get(src.blind_fn, m))
+      Array::push(out.blind_body, Array::get(src.blind_body, m))
+      Array::push(out.blind_offsets, Array::get(src.blind_offsets, m))
+      Array::push(out.blind_kinds, Array::get(src.blind_kinds, m))
+      Array::push(out.blind_syms, Array::get(src.blind_syms, m))
+      m = m + 1
     }
     si = si + 1
   }
@@ -582,7 +628,7 @@ export fn bcc_string_lists_equal(a: Array[String], b: Array[String]) -> Bool {
 /// planned: `lt.bodies` is `lam_lo` long when this runs. That is the same
 /// invariant the compile path relies on, so a replayed function and a compiled
 /// one leave the table identical.
-export fn codegen_body_cache_replay(cache: CodegenBodyCache, at: Int, bodies: Array[Bytes], meta_i32: Array[Int], meta_i64: Array[Int], meta_v128: Array[Int], lt: LambdaTable, slots: Array[Int]) -> Unit {
+export fn codegen_body_cache_replay(cache: CodegenBodyCache, at: Int, bodies: Array[Bytes], meta_i32: Array[Int], meta_i64: Array[Int], meta_v128: Array[Int], lt: LambdaTable, slots: Array[Int], blind_bodies: Array[Int], blind_offsets: Array[Int], blind_kinds: Array[Int], blind_syms: Array[Int]) -> Unit {
   let owner = Array::get(cache.fn_indices, at)
   Array::push(bodies, Array::get(cache.fn_bodies, at))
   Array::push(meta_i32, Array::get(cache.fn_meta_i32, at))
@@ -611,6 +657,23 @@ export fn codegen_body_cache_replay(cache: CodegenBodyCache, at: Int, bodies: Ar
       ()
     }
     si = si + 1
+  }
+  // #2669 slice 3: re-push this function's blind references, so a replaying
+  // build's log is the same one a compiling build would have produced. Until
+  // this existed, a replayed function contributed slots and no references,
+  // and the paired-count invariant had to stand down for it.
+  let bn = Array::length(cache.blind_fn)
+  let mut bi = 0
+  while bi < bn {
+    if Array::get(cache.blind_fn, bi) == owner {
+      Array::push(blind_bodies, Array::get(cache.blind_body, bi))
+      Array::push(blind_offsets, Array::get(cache.blind_offsets, bi))
+      Array::push(blind_kinds, Array::get(cache.blind_kinds, bi))
+      Array::push(blind_syms, Array::get(cache.blind_syms, bi))
+    } else {
+      ()
+    }
+    bi = bi + 1
   }
 }
 
@@ -664,6 +727,20 @@ export fn codegen_body_cache_filter_src_below(cache: CodegenBodyCache, limit: In
       ()
     }
     j = j + 1
+  }
+  let mut m = 0
+  while m < Array::length(cache.blind_fn) {
+    let bowner = Array::get(cache.blind_fn, m)
+    if array_contains_int_bcc(keep_fn, bowner) {
+      Array::push(out.blind_fn, bowner)
+      Array::push(out.blind_body, Array::get(cache.blind_body, m))
+      Array::push(out.blind_offsets, Array::get(cache.blind_offsets, m))
+      Array::push(out.blind_kinds, Array::get(cache.blind_kinds, m))
+      Array::push(out.blind_syms, Array::get(cache.blind_syms, m))
+    } else {
+      ()
+    }
+    m = m + 1
   }
   let mut k = 0
   while k < Array::length(cache.slot_owner) {
@@ -773,7 +850,11 @@ export fn codegen_body_cache_to_bytes(cache: CodegenBodyCache) -> Bytes with Exc
   bytebuf_push(buf, 'V')
   bytebuf_push(buf, 'B')
   bytebuf_push(buf, 'C')
-  bytebuf_push(buf, '1')
+  // #2669 slice 3 bumped this from '1': the stream gained the blind-reference
+  // arrays, so an artifact written by an older compiler must be REJECTED
+  // rather than read short. (The store is keyed on the codegen fingerprint
+  // too, so this is the second line of defence, not the first.)
+  bytebuf_push(buf, '2')
   bcc_push_int_array(buf, cache.fn_indices)
   bcc_push_int_array(buf, cache.fn_src_stmts)
   bcc_push_bytes_array(buf, cache.fn_bodies)
@@ -789,6 +870,11 @@ export fn codegen_body_cache_to_bytes(cache: CodegenBodyCache) -> Bytes with Exc
   bcc_push_int_array(buf, cache.lam_meta_i64)
   bcc_push_int_array(buf, cache.slot_owner)
   bcc_push_int_array(buf, cache.slot_values)
+  bcc_push_int_array(buf, cache.blind_fn)
+  bcc_push_int_array(buf, cache.blind_body)
+  bcc_push_int_array(buf, cache.blind_offsets)
+  bcc_push_int_array(buf, cache.blind_kinds)
+  bcc_push_int_array(buf, cache.blind_syms)
   bcc_push_int_array(buf, cache.guard_meta)
   bcc_push_string_array(buf, cache.guard_synth_names)
   bcc_push_int_array(buf, cache.guard_synth_stmts)
@@ -956,7 +1042,7 @@ fn bcc_read_string_arrays(b: Bytes, pos: Int, out: Array[Array[String]]) -> Int 
 }
 
 export fn codegen_body_cache_from_bytes(b: Bytes) -> Option[CodegenBodyCache] {
-  if Bytes::length(b) < 4 || Bytes::get(b, 0) != 'V' || Bytes::get(b, 1) != 'B' || Bytes::get(b, 2) != 'C' || Bytes::get(b, 3) != '1' {
+  if Bytes::length(b) < 4 || Bytes::get(b, 0) != 'V' || Bytes::get(b, 1) != 'B' || Bytes::get(b, 2) != 'C' || Bytes::get(b, 3) != '2' {
     None
   } else {
     let out = codegen_body_cache_new()
@@ -1033,6 +1119,31 @@ export fn codegen_body_cache_from_bytes(b: Bytes) -> Option[CodegenBodyCache] {
       ()
     }
     if p >= 0 {
+      p = bcc_read_int_array(b, p, out.blind_fn)
+    } else {
+      ()
+    }
+    if p >= 0 {
+      p = bcc_read_int_array(b, p, out.blind_body)
+    } else {
+      ()
+    }
+    if p >= 0 {
+      p = bcc_read_int_array(b, p, out.blind_offsets)
+    } else {
+      ()
+    }
+    if p >= 0 {
+      p = bcc_read_int_array(b, p, out.blind_kinds)
+    } else {
+      ()
+    }
+    if p >= 0 {
+      p = bcc_read_int_array(b, p, out.blind_syms)
+    } else {
+      ()
+    }
+    if p >= 0 {
       p = bcc_read_int_array(b, p, out.guard_meta)
     } else {
       ()
@@ -1088,7 +1199,7 @@ export fn codegen_body_cache_from_bytes(b: Bytes) -> Option[CodegenBodyCache] {
       }
       fni = fni + 1
     }
-    if p < 0 || fn_index_negative || Array::length(out.fn_src_stmts) != fn_n || Array::length(out.fn_bodies) != fn_n || Array::length(out.fn_meta_i32) != fn_n || Array::length(out.fn_meta_i64) != fn_n || Array::length(out.fn_meta_v128) != fn_n || Array::length(out.lam_indices) != lam_n || Array::length(out.lam_bodies) != lam_n || Array::length(out.lam_param_counts) != lam_n || Array::length(out.lam_captures) != lam_n || Array::length(out.lam_meta_i32) != lam_n || Array::length(out.lam_meta_i64) != lam_n || Array::length(out.slot_owner) != Array::length(out.slot_values) || (guard_n != 0 && guard_n != 5) || Array::length(out.guard_synth_names) != Array::length(out.guard_synth_stmts) || Array::length(out.guard_borrow_names) != Array::length(out.guard_borrow_masks) {
+    if p < 0 || fn_index_negative || Array::length(out.fn_src_stmts) != fn_n || Array::length(out.fn_bodies) != fn_n || Array::length(out.fn_meta_i32) != fn_n || Array::length(out.fn_meta_i64) != fn_n || Array::length(out.fn_meta_v128) != fn_n || Array::length(out.lam_indices) != lam_n || Array::length(out.lam_bodies) != lam_n || Array::length(out.lam_param_counts) != lam_n || Array::length(out.lam_captures) != lam_n || Array::length(out.lam_meta_i32) != lam_n || Array::length(out.lam_meta_i64) != lam_n || Array::length(out.slot_owner) != Array::length(out.slot_values) || Array::length(out.blind_body) != Array::length(out.blind_fn) || Array::length(out.blind_offsets) != Array::length(out.blind_fn) || Array::length(out.blind_kinds) != Array::length(out.blind_fn) || Array::length(out.blind_syms) != Array::length(out.blind_fn) || (guard_n != 0 && guard_n != 5) || Array::length(out.guard_synth_names) != Array::length(out.guard_synth_stmts) || Array::length(out.guard_borrow_names) != Array::length(out.guard_borrow_masks) {
       None
     } else {
       Some(out)

--- a/lib/@vibe/compiler/codegen/common_base/common_base.vibe
+++ b/lib/@vibe/compiler/codegen/common_base/common_base.vibe
@@ -798,6 +798,35 @@ fn bcc_push_int_array(buf: Bytes, xs: Array[Int]) -> Unit with Exception {
   }
 }
 
+/// #2669 slice 3: an Int array whose values may be BELOW -1.
+///
+/// The plain codec above encodes `v + 1` as an unsigned LEB and throws for
+/// anything under -1, which is right for every column it was written for --
+/// those are indices and counts. `blind_body` is not: a record made inside a
+/// lambda names it as `blind_owner_of_lambda`, i.e. `-2 - lambda_idx`, so
+/// writing it through `bcc_push_int_array` aborted the harvest of any program
+/// with a function value inside a lambda. Found by review on #2710; the
+/// in-process replay test never serializes, so nothing else saw it.
+///
+/// Zigzag, written arithmetically rather than with shifts so it does not
+/// depend on the tagged Int's width: non-negative `v` maps to `2v`, negative
+/// to `-2v - 1`, which is a bijection onto the non-negatives the plain
+/// encoder already accepts.
+fn bcc_push_zigzag_int_array(buf: Bytes, xs: Array[Int]) -> Unit with Exception {
+  bcc_push_int(buf, Array::length(xs))
+  let mut i = 0
+  while i < Array::length(xs) {
+    let v = Array::get(xs, i)
+    let z = if v >= 0 {
+      v * 2
+    } else {
+      0 - v * 2 - 1
+    }
+    bcc_push_int(buf, z)
+    i = i + 1
+  }
+}
+
 fn bcc_push_bytes(buf: Bytes, b: Bytes) -> Unit with Exception {
   bcc_push_int(buf, Bytes::length(b))
   bytebuf_push_buf(buf, b)
@@ -871,7 +900,7 @@ export fn codegen_body_cache_to_bytes(cache: CodegenBodyCache) -> Bytes with Exc
   bcc_push_int_array(buf, cache.slot_owner)
   bcc_push_int_array(buf, cache.slot_values)
   bcc_push_int_array(buf, cache.blind_fn)
-  bcc_push_int_array(buf, cache.blind_body)
+  bcc_push_zigzag_int_array(buf, cache.blind_body)
   bcc_push_int_array(buf, cache.blind_offsets)
   bcc_push_int_array(buf, cache.blind_kinds)
   bcc_push_int_array(buf, cache.blind_syms)
@@ -928,6 +957,33 @@ fn bcc_read_int_array(b: Bytes, pos: Int, out: Array[Int]) -> Int {
       if np < 0 {
         p = 0 - 1
       } else {
+        Array::push(out, v)
+        p = np
+      }
+      i = i + 1
+    }
+    p
+  }
+}
+
+/// The inverse of bcc_push_zigzag_int_array.
+fn bcc_read_zigzag_int_array(b: Bytes, pos: Int, out: Array[Int]) -> Int {
+  let (count, p0) = bcc_read_int(b, pos)
+  if p0 < 0 || count < 0 {
+    0 - 1
+  } else {
+    let mut p = p0
+    let mut i = 0
+    while p >= 0 && i < count {
+      let (z, np) = bcc_read_int(b, p)
+      if np < 0 || z < 0 {
+        p = 0 - 1
+      } else {
+        let v = if z % 2 == 0 {
+          z / 2
+        } else {
+          0 - ((z + 1) / 2)
+        }
         Array::push(out, v)
         p = np
       }
@@ -1124,7 +1180,7 @@ export fn codegen_body_cache_from_bytes(b: Bytes) -> Option[CodegenBodyCache] {
       ()
     }
     if p >= 0 {
-      p = bcc_read_int_array(b, p, out.blind_body)
+      p = bcc_read_zigzag_int_array(b, p, out.blind_body)
     } else {
       ()
     }

--- a/lib/@vibe/compiler/codegen/common_base/index.vpkg
+++ b/lib/@vibe/compiler/codegen/common_base/index.vpkg
@@ -325,9 +325,9 @@ fn codegen_body_cache_find(cache: CodegenBodyCache, fn_index: Int) -> Int
 // a direct-address table from function index to cache slot, built once.
 fn codegen_body_cache_slot_index(cache: CodegenBodyCache, key_count: Int) -> Array[Int]
 fn codegen_body_cache_find_at(slot_index: Array[Int], fn_index: Int) -> Int
-fn codegen_body_cache_record(cache: CodegenBodyCache, fn_index: Int, src_stmt: Int, bodies: Array[Bytes], meta_i32: Array[Int], meta_i64: Array[Int], meta_v128: Array[Int], lt: LambdaTable, lam_lo: Int, lam_hi: Int, slots: Array[Int], slot_lo: Int, slot_hi: Int) -> Unit
+fn codegen_body_cache_record(cache: CodegenBodyCache, fn_index: Int, src_stmt: Int, bodies: Array[Bytes], meta_i32: Array[Int], meta_i64: Array[Int], meta_v128: Array[Int], lt: LambdaTable, lam_lo: Int, lam_hi: Int, slots: Array[Int], slot_lo: Int, slot_hi: Int, blind_bodies: Array[Int], blind_offsets: Array[Int], blind_kinds: Array[Int], blind_syms: Array[Int], blind_lo: Int, blind_hi: Int) -> Unit
 fn codegen_body_cache_merge(a: CodegenBodyCache, b: CodegenBodyCache) -> CodegenBodyCache
-fn codegen_body_cache_replay(cache: CodegenBodyCache, at: Int, bodies: Array[Bytes], meta_i32: Array[Int], meta_i64: Array[Int], meta_v128: Array[Int], lt: LambdaTable, slots: Array[Int]) -> Unit
+fn codegen_body_cache_replay(cache: CodegenBodyCache, at: Int, bodies: Array[Bytes], meta_i32: Array[Int], meta_i64: Array[Int], meta_v128: Array[Int], lt: LambdaTable, slots: Array[Int], blind_bodies: Array[Int], blind_offsets: Array[Int], blind_kinds: Array[Int], blind_syms: Array[Int]) -> Unit
 fn codegen_body_cache_filter_src_below(cache: CodegenBodyCache, limit: Int) -> CodegenBodyCache
 fn bcc_guard_synth_matches(cache: CodegenBodyCache, names: Array[String], stmt_indices: Array[Int], lo: Int, hi: Int) -> Bool
 fn bcc_string_lists_equal(a: Array[String], b: Array[String]) -> Bool

--- a/lib/@vibe/compiler/codegen/wasi/linked_compile.vibe
+++ b/lib/@vibe/compiler/codegen/wasi/linked_compile.vibe
@@ -11223,7 +11223,22 @@ export fn compile_wasi_module_linked_impl_with_split(stmts: Array[Stmt], entry_n
         0 - 1
       }
       if __cache_hit >= 0 {
-        codegen_body_cache_replay(body_cache_in, __cache_hit, bodies, meta_i32, meta_i64, meta_v128, lt_w, table_slots_used)
+        let __r_slot_lo = Array::length(table_slots_used)
+        let __r_blind_lo = Array::length(blind_owners)
+        codegen_body_cache_replay(body_cache_in, __cache_hit, bodies, meta_i32, meta_i64, meta_v128, lt_w, table_slots_used, blind_owners, blind_offsets, blind_kinds, blind_syms)
+        // #2669 slice 3: the SAME pairing the compiled path asserts below.
+        // A replayed function re-pushes both logs from the cache instead of
+        // running the emission, so this says the cache carried a complete
+        // pair -- which is the whole claim of carrying them at all. Before
+        // the cache held these, a replayed function contributed slots and no
+        // references and this check could not exist.
+        let __r_blind_grew = Array::length(blind_owners) - __r_blind_lo
+        let __r_slots_grew = Array::length(table_slots_used) - __r_slot_lo
+        if __r_blind_grew != __r_slots_grew {
+          throw(String::concat("blind reloc: replayed function ", String::concat(__to_string(bi), String::concat(" restored ", String::concat(__to_string(__r_slots_grew), String::concat(" funcref slots but ", String::concat(__to_string(__r_blind_grew), " blind references -- the cache entry is not a complete pair")))))))
+        } else {
+          ()
+        }
       } else {
         // #1259 step 7: where this function's table_slots_used entries start.
         // The log is module-level and append-only, so the function's own
@@ -12136,11 +12151,10 @@ export fn compile_wasi_module_linked_impl_with_split(stmts: Array[Stmt], entry_n
         // here as a count that does not match, on every compile, instead of as
         // a cached body that relocates one reference short.
         //
-        // Compiled functions only: a REPLAYED function re-pushes its recorded
-        // slots from the cache without re-running codegen, so it contributes
-        // slots and no blind references. That asymmetry is the reason a
-        // replaying build's blind log is incomplete, and carrying these in
-        // `CodegenBodyCache` is what removes it.
+        // #2669 slice 3: the replay path above now asserts the same pairing,
+        // because the cache carries the references alongside the slots. The
+        // two checks together say the log is complete however the body got
+        // here.
         let __blind_grew = Array::length(blind_owners) - __blind_lo
         let __slots_grew = Array::length(table_slots_used) - __slot_lo
         if __blind_grew != __slots_grew {
@@ -12148,7 +12162,7 @@ export fn compile_wasi_module_linked_impl_with_split(stmts: Array[Stmt], entry_n
         } else {
           ()
         }
-        codegen_body_cache_record(body_cache_out, bi, Array::get(fn_stmt_indices, bi), bodies, meta_i32, meta_i64, meta_v128, lt_w, Array::get(lambda_bases, bi), lambda_planned_end, table_slots_used, __slot_lo, Array::length(table_slots_used))
+        codegen_body_cache_record(body_cache_out, bi, Array::get(fn_stmt_indices, bi), bodies, meta_i32, meta_i64, meta_v128, lt_w, Array::get(lambda_bases, bi), lambda_planned_end, table_slots_used, __slot_lo, Array::length(table_slots_used), blind_owners, blind_offsets, blind_kinds, blind_syms, __blind_lo, Array::length(blind_owners))
       }
     }
     bi = bi + 1

--- a/lib/@vibe/compiler/tests/codegen_body_cache_persist_test.vibe
+++ b/lib/@vibe/compiler/tests/codegen_body_cache_persist_test.vibe
@@ -99,6 +99,22 @@ fn sample_cache() -> CodegenBodyCache {
   Array::push(c.lam_meta_i64, 0 - 1)
   Array::push(c.slot_owner, 0)
   Array::push(c.slot_values, 1029)
+  // #2669 slice 3: blind references, one owned by the FUNCTION and one owned
+  // by a LAMBDA. The lambda's owner is `blind_owner_of_lambda(5)` = -7, which
+  // is what makes this case load-bearing: the plain int codec encodes `v + 1`
+  // unsigned and throws below -1, so before the zigzag column this aborted
+  // the whole serialization. The sample had no blind rows at all, so the
+  // round-trip proved nothing about them.
+  Array::push(c.blind_fn, 0)
+  Array::push(c.blind_body, 0)
+  Array::push(c.blind_offsets, 17)
+  Array::push(c.blind_kinds, 101)
+  Array::push(c.blind_syms, 42)
+  Array::push(c.blind_fn, 0)
+  Array::push(c.blind_body, 0 - 7)
+  Array::push(c.blind_offsets, 3)
+  Array::push(c.blind_kinds, 102)
+  Array::push(c.blind_syms, 1030)
   Array::push(c.guard_meta, 1)
   Array::push(c.guard_meta, 1024)
   Array::push(c.guard_meta, 2048)
@@ -130,6 +146,16 @@ test "codegen body cache codec round-trips every field group" {
       inspect(Array::get(Array::get(d.lam_captures, 0), 1), content = "bb")
       inspect(Array::get(d.lam_meta_i64, 0), content = "-1")
       inspect(Array::get(d.slot_values, 0), content = "1029")
+      // #2669 slice 3. The second row is the one that matters: its body owner
+      // is a LAMBDA, so the value is negative and the plain column's encoder
+      // refuses it. Round-tripping it exactly is the whole point of giving
+      // this column a zigzag encoding.
+      inspect(Array::length(d.blind_fn), content = "2")
+      inspect(Array::get(d.blind_body, 0), content = "0")
+      inspect(Array::get(d.blind_body, 1), content = "-7")
+      inspect(Array::get(d.blind_offsets, 1), content = "3")
+      inspect(Array::get(d.blind_kinds, 1), content = "102")
+      inspect(Array::get(d.blind_syms, 1), content = "1030")
       inspect(Array::get(d.guard_meta, 2), content = "2048")
       inspect(Array::get(d.guard_meta, 4), content = "40")
       inspect(Array::get(d.guard_synth_names, 0), content = "Pt::equals")

--- a/scripts/reloc_crossbuild.sh
+++ b/scripts/reloc_crossbuild.sh
@@ -2,7 +2,7 @@
 # #2669: relocate one build's bodies onto ANOTHER build's index assignment,
 # and compare against what the compiler emitted for that assignment.
 #
-#   bash scripts/reloc_crossbuild.sh [a.wasm b.wasm]
+#   bash scripts/reloc_crossbuild.sh [a.wasm b.wasm [source-edited-names]]
 #
 # With no arguments it builds the pair itself: the compiler's own closure, and
 # the same closure with one import added to `lib/@vibe/core/base64.vibe` --
@@ -10,11 +10,9 @@
 # function index space. That is the edit class #2669 measured as the hardest:
 # two distinct index deltas, one large and negative.
 #
-# Forcing a reorder REQUIRES editing at least one existing body (something has
-# to call across the new import), so a small number of mismatches are genuine
-# source changes rather than relocation failures. The edit is kept to one
-# function and named in the output below, so the figure can be read with that
-# in mind rather than silently inflated.
+# This perturbation changes one existing body to call across the new import.
+# That body is excluded from all relocation statistics and non-vacuity guards.
+# For explicitly supplied modules, the caller must identify their source edits.
 #
 # The vibex REFUSES a vacuous run, in two steps. It fails when no shared
 # function changed index -- two builds with the same assignment relocate
@@ -55,7 +53,7 @@ esac
 # whose SOURCE differs between the two modules, to be excluded from the
 # statistics (see the vibex); without one, nothing is excluded.
 if [ "$#" -ge 2 ]; then
-  VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/vibe_run.sh scripts/reloc_crossbuild.vibex -- "$1" "$2" ${3:+"$3"}
+  VIBE_PREOPEN_DIR="$ROOT_DIR" bash scripts/vibe_run.sh scripts/reloc_crossbuild.vibex -- "$@"
   exit $?
 fi
 

--- a/scripts/reloc_crossbuild.vibex
+++ b/scripts/reloc_crossbuild.vibex
@@ -2,12 +2,15 @@
 // ANOTHER? That is the whole claim of index-independent bodies, and this
 // answers it end to end against two real builds.
 //
-//   vibe run scripts/reloc_crossbuild.vibex -- <a.wasm> <b.wasm>
+//   vibe run scripts/reloc_crossbuild.vibex -- <a.wasm> <b.wasm> [source-edited-names]
 //
 // Both built with VIBE_WASM_NAMES=1. For every function present in both by
 // NAME: take A's body, rewrite each function reference from A's index space
 // into B's (by resolving A's index to a name and that name to B's index),
 // and compare the result against B's ACTUAL body.
+// The optional third argument is a comma-separated list of source-edited
+// functions. They are excluded from every count and evidence guard; callers
+// must identify all source edits because wasm cannot establish source equality.
 //
 // A match means the relocation reproduced, byte for byte, what the compiler
 // itself emitted for the moved assignment. That is a much stronger statement
@@ -327,60 +330,100 @@ fn spans_equal(ab: Bytes, s: Int, e: Int, other: Bytes) -> Bool {
   }
 }
 
-/// Is `name` one of the functions whose SOURCE the caller edited?
-///
-/// Forcing a module reorder requires editing at least one existing body --
-/// something has to call across the new import -- so that body's B version is
-/// a different program from its A version. Comparing them measures the edit,
-/// not relocation: it inflates the denominator and, when the edited body
-/// happens to carry no visible non-function reference, it lands in the
-/// "unambiguously encoding-blind" bucket and inflates the one number this
-/// whole exercise exists to size. Naming it in the output is not enough, so
-/// it is excluded from the statistics. Found by review on #2705.
-///
-/// Matching is on the UNMANGLED base, not a substring: #716 path-mangles a
-/// private definition to `<name>_exp_<path>` / `<name>_dep_<path>`, so an
-/// exact name or one of those two prefixes is the whole rule. A substring
-/// test would quietly take `encode` along with `encode_url_safe`.
+// Validated exclusions contain exact wasm names. A short name may be accepted
+// at the CLI boundary only when it resolves to one body on each side.
 fn is_source_edited(name: String, edited: Array[String]) -> Bool {
   let mut i = 0
   let mut hit = false
-  while i < Array::length(edited) {
-    let e = Array::get(edited, i)
-    if name == e || String::starts_with(name, String::concat(e, "_exp_")) || String::starts_with(name, String::concat(e, "_dep_")) {
-      hit = true
-    } else {
-      ()
-    }
+  while !hit && i < Array::length(edited) {
+    hit = name == Array::get(edited, i)
     i = i + 1
   }
   hit
 }
 
-fn split_commas(s: String) -> Array[String] {
+fn source_edited_index(m: Mod, name: String) -> Int with Exception {
+  let exact = index_of_name(m, name)
+  if exact == -2 {
+    throw("reloc-crossbuild: source-edited name is ambiguous: " + name)
+  } else {
+    ()
+  }
+  if exact >= 0 {
+    exact
+  } else {
+    let mut found = -1
+    let mut hits = 0
+    let mut i = 0
+    while i < Array::length(m.names) {
+      let candidate = Array::get(m.names, i)
+      if String::starts_with(candidate, name + "_exp_") || String::starts_with(candidate, name + "_dep_") {
+        found = Array::get(m.name_idxs, i)
+        hits = hits + 1
+      } else {
+        ()
+      }
+      i = i + 1
+    }
+    if hits > 1 {
+      throw("reloc-crossbuild: source-edited name is ambiguous: " + name)
+    } else {
+      ()
+    }
+    found
+  }
+}
+
+fn split_commas(s: String) -> Array[String] with Exception {
   let out: Array[String] = []
   let mut cur = ""
   let mut i = 0
   while i < String::length(s) {
     let c = String::substring(s, i, i + 1)
     if c == "," {
-      if String::length(cur) > 0 {
-        Array::push(out, cur)
+      if cur == "" {
+        throw("reloc-crossbuild: source-edited list requires a function name at every position")
       } else {
         ()
       }
+      Array::push(out, cur)
       cur = ""
     } else {
-      cur = String::concat(cur, c)
+      cur = cur + c
     }
     i = i + 1
   }
-  if String::length(cur) > 0 {
-    Array::push(out, cur)
+  if cur == "" {
+    throw("reloc-crossbuild: source-edited list requires a function name at every position")
   } else {
     ()
   }
+  Array::push(out, cur)
   out
+}
+
+fn source_edited_names(a: Mod, b: Mod, requested: Array[String]) -> Array[String] with Exception {
+  let names: Array[String] = []
+  let mut i = 0
+  while i < Array::length(requested) {
+    let name = Array::get(requested, i)
+    let ai = source_edited_index(a, name)
+    let bi = source_edited_index(b, name)
+    if ai < 0 || bi < 0 || body_slot(a, ai) < 0 || body_slot(b, bi) < 0 || map_index(a, b, ai) != bi {
+      throw("reloc-crossbuild: exclusion must name a shared defined function: " + name)
+    } else {
+      ()
+    }
+    let exact = name_of(a, ai)
+    if is_source_edited(exact, names) {
+      throw("reloc-crossbuild: duplicate exclusion: " + name)
+    } else {
+      ()
+    }
+    Array::push(names, exact)
+    i = i + 1
+  }
+  names
 }
 
 fn main() -> Unit allows Exception + Fs + Stdout + Env {
@@ -396,17 +439,12 @@ fn main() -> Unit allows Exception + Fs + Stdout + Env {
   }
   let a = load(Env::args_get(0))
   let b = load(Env::args_get(1))
-  // Optional third argument: comma-separated names of functions the caller
-  // EDITED between the two builds. See is_source_edited.
-  let edited = if Env::args_len() > 2 {
-    split_commas(Env::args_get(2))
+  // Validate every request before reporting any measurement. The binary
+  // cannot establish source equality; callers must identify their edits.
+  let edited = if Env::args_len() == 3 {
+    source_edited_names(a, b, split_commas(Env::args_get(2)))
   } else {
     []
-  }
-  let edited_hits: Array[Int] = []
-  let mut eh = 0
-  while eh < Array::length(edited) {
-    Array::push(edited_hits, 0); eh = eh + 1
   }
   let mut compared = 0
   let mut matched = 0
@@ -434,19 +472,10 @@ fn main() -> Unit allows Exception + Fs + Stdout + Env {
     } else {
       body_slot(b, bi)
     }
-    if bi == -2 {
-      ambiguous_name = ambiguous_name + 1
-    } else if bs >= 0 && is_source_edited(nm, edited) {
+    if is_source_edited(nm, edited) {
       source_edited_excluded = source_edited_excluded + 1
-      let mut ei = 0
-      while ei < Array::length(edited) {
-        if is_source_edited(nm, [Array::get(edited, ei)]) {
-          Array::set(edited_hits, ei, Array::get(edited_hits, ei) + 1)
-        } else {
-          ()
-        }
-        ei = ei + 1
-      }
+    } else if bi == -2 {
+      ambiguous_name = ambiguous_name + 1
     } else if bs < 0 {
       a_only_shape = a_only_shape + 1
     } else {
@@ -600,19 +629,6 @@ fn main() -> Unit allows Exception + Fs + Stdout + Env {
     println(StringBuilder::freeze(ex))
   } else {
     ()
-  }
-  // A name the caller said it edited that matched NOTHING means the exclusion
-  // silently stopped working -- a rename in the wrapper, a change in the
-  // mangling -- and the confound would be back in the numbers with no sign of
-  // it. Same shape as the vacuity guards below.
-  let mut eg = 0
-  while eg < Array::length(edited) {
-    if Array::get(edited_hits, eg) == 0 {
-      throw(String::concat("reloc-crossbuild: no compared body matched the source-edited name '", String::concat(Array::get(edited, eg), "' -- the exclusion is not doing anything")))
-    } else {
-      ()
-    }
-    eg = eg + 1
   }
   if compared == 0 {
     throw("reloc-crossbuild: nothing compared -- the two modules share no named function")

--- a/scripts/reloc_crossbuild_test.sh
+++ b/scripts/reloc_crossbuild_test.sh
@@ -1,0 +1,152 @@
+#!/usr/bin/env bash
+# Exercise the real comparison on small, valid named modules. A deliberate
+# source edit must not become evidence about relocation or satisfy its guards.
+set -euo pipefail
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+. "$ROOT_DIR/scripts/resolve_stage2.sh"
+STAGE2="$(resolve_stage2 reloc-crossbuild-test "${RELOC_CROSSBUILD_STAGE2:-${VIBE_STAGE2_WASM:-}}")"
+mkdir -p _build
+WORK="$(mktemp -d "$ROOT_DIR/_build/reloc_crossbuild_test.XXXXXX")"
+trap 'rm -rf "$WORK"' EXIT
+
+compile_rc=0
+env -u VIBE_RC -u VIBE_BACKEND VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_FS_COMPILE=1 VIBE_IMPORT_ABI=raw \
+  bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$STAGE2" \
+  scripts/reloc_crossbuild.vibex "$WORK/tool.wasm" main >"$WORK/compile.log" 2>&1 || compile_rc=$?
+if [ "$compile_rc" -ne 0 ] || [ ! -s "$WORK/tool.wasm" ]; then
+  cat "$WORK/compile.log" >&2
+  [ ! -f "$WORK/tool.wasm.diag" ] || cat "$WORK/tool.wasm.diag" >&2
+  exit 1
+fi
+
+python3 - "$ROOT_DIR" "$WORK" "$STAGE2" <<'PY'
+import os, pathlib, re, subprocess, sys
+
+root, work = map(pathlib.Path, sys.argv[1:3])
+
+def uleb(n):
+    out = bytearray()
+    while n >= 128:
+        out.append((n & 127) | 128)
+        n >>= 7
+    return bytes(out + bytes([n]))
+
+def blob(b):
+    return uleb(len(b)) + b
+
+def vec(items):
+    return uleb(len(items)) + b''.join(items)
+
+def section(kind, data):
+    return bytes([kind]) + blob(data)
+
+def module(tag, functions):
+    # Every function has type () -> i32. Names are a standard name subsection.
+    names = vec([uleb(i) + blob(name.encode()) for i, (name, _) in enumerate(functions)])
+    data = (b'\0asm\x01\0\0\0' + section(1, vec([b'\x60\x00\x01\x7f']))
+            + section(3, vec([b'\x00'] * len(functions)))
+            + section(10, vec([blob(b'\x00' + body + b'\x0b') for _, body in functions]))
+            + section(0, blob(b'name') + section(1, names)))
+    path = work / (tag + '.wasm')
+    path.write_bytes(data)
+    # An independent validator proves that the fixture is a real module.
+    subprocess.run(['node', '-e', 'new WebAssembly.Module(require("fs").readFileSync(process.argv[1]))', str(path)], check=True)
+    return str(path)
+
+def const(n):
+    return bytes([0x41, n])
+
+def call(n):
+    return b'\x10' + uleb(n)
+
+env = dict(os.environ, VIBE_PREOPEN_DIR=str(root), VIBE_RUNNER_EXIT_WITH_RESULT='1',
+           RELOC_CROSSBUILD_STAGE2=sys.argv[3])
+
+def run(a, b, *args, error=None):
+    p = subprocess.run(['bash', 'scripts/run_wasm_vibe_host_runner.sh', '--invoke', 'main',
+                        str(work / 'tool.wasm'), a, b, *args], env=env, capture_output=True, text=True)
+    output = p.stdout + p.stderr
+    if error is not None:
+        assert p.returncode != 0 and error in output, output
+        return
+    assert p.returncode == 0, output
+    line = next(s for s in p.stdout.splitlines() if s.startswith('reloc-crossbuild compared='))
+    return {k: int(v) for k, v in re.findall(r'(\w+)=(\d+)', line)}
+
+def expect(rows, **wanted):
+    for key, value in wanted.items():
+        assert rows.get(key) == value, (key, value, rows)
+
+# The edited body has no non-function/unresolved reference, so the old tool
+# calls its added instruction encoding-blind. A separate opaque constant
+# mismatch must still count after that source-edited body is excluded.
+a = module('a', [('target', const(7)), ('unchanged', call(0)), ('edited', call(0)),
+                 ('opaque', const(2)), ('caller', call(2))])
+b = module('b', [('padding', const(0)), ('target', const(7)), ('unchanged', call(1)),
+                 ('edited', call(1) + b'\x1a' + const(9)), ('opaque', const(3)), ('caller', call(3))])
+raw = run(a, b)
+expect(raw, compared=5, matched=3, mismatched=2, mismatch_encoding_blind=2,
+       moved_index=5, rewritten=3, rewritten_matched=2, rewritten_mismatched=1)
+print('reloc-crossbuild-test: control contains the source-change confound', flush=True)
+excluded = run(a, b, 'edited')
+expect(excluded, source_edited_excluded=1, compared=4, matched=3, mismatched=1,
+       mismatch_encoding_blind=1, mismatch_ambiguous_cause=0, moved_index=4,
+       rewritten=2, rewritten_matched=2, rewritten_mismatched=0,
+       bodies_with_nonfunc_refs=0, bodies_with_unresolved_func=0)
+print('reloc-crossbuild-test: source edits excluded; real mismatches and calls to excluded bodies retained', flush=True)
+
+# A bare name must not exclude same-named functions in unrelated modules.
+ma = module('modules-a', [('target', const(7)), ('unchanged', call(0)),
+                         ('edited_exp_one', call(0)), ('edited_exp_two', call(0))])
+mb = module('modules-b', [('padding', const(0)), ('target', const(7)), ('unchanged', call(1)),
+                         ('edited_exp_one', call(1) + b'\x1a' + const(9)), ('edited_exp_two', call(1))])
+run(ma, mb, 'edited', error='ambiguous')
+expect(run(ma, mb, 'edited_exp_one'), source_edited_excluded=1, compared=3,
+       matched=3, mismatched=0, rewritten_matched=2)
+
+# Exclusions are exact names, validated on both sides, never silently ignored.
+run(a, b, 'absent', error='shared defined function')
+run(a, b, 'padding', error='shared defined function')
+run(a, b, '', error='requires a function name')
+run(a, b, 'edited,', error='requires a function name')
+run(a, b, ',edited', error='requires a function name')
+run(a, b, 'edited,edited', error='duplicate exclusion')
+run(a, b, 'edited', 'unexpected', error='expected 2 or 3 arguments')
+dup_a = module('dup-a', [('edited', const(1)), ('edited', const(2))])
+dup_b = module('dup-b', [('padding', const(0)), ('edited', const(1)), ('edited', const(2))])
+run(dup_a, b, 'edited', error='ambiguous')
+run(a, dup_b, 'edited', error='ambiguous')
+
+# Multiple explicit exclusions must each be counted once.
+expect(run(a, b, 'edited,opaque'),
+       source_edited_excluded=2, compared=3, matched=3, mismatched=0, mismatch_encoding_blind=0)
+
+# The public wrapper must preserve even an empty third argument, so malformed
+# exclusions reach validation instead of silently turning into an unfiltered run.
+for args, wanted_error in [([a, b, 'edited'], None), ([a, b, ''], 'requires a function name'),
+                           ([a, b, 'edited', 'extra'], 'usage:'),
+                           ([a], 'usage:')]:
+    p = subprocess.run(['bash', 'scripts/reloc_crossbuild.sh', *args], env=env,
+                       capture_output=True, text=True)
+    output = p.stdout + p.stderr
+    if wanted_error:
+        assert p.returncode != 0 and wanted_error in output, output
+    else:
+        assert p.returncode == 0 and 'source_edited_excluded=1' in output, output
+
+# The only rewritten match is excluded: it cannot satisfy the rewrite guard.
+ga = module('guard-a', [('stable', const(7)), ('edited', call(0))])
+gb = module('guard-b', [('edited', call(1)), ('stable', const(7))])
+run(ga, gb)
+run(ga, gb, 'edited', error='no body was both rewritten and byte-identical')
+
+# Nor may the excluded body's moved assignment satisfy the other guard.
+gc = module('guard-c', [('stable', const(7)), ('padding', const(0)), ('edited', call(0))])
+run(ga, gc, 'edited', error='no shared function changed index')
+only_a = module('only-a', [('edited', const(1))])
+only_b = module('only-b', [('padding', const(0)), ('edited', const(2))])
+run(only_a, only_b, 'edited', error='nothing compared')
+print('reloc-crossbuild-test: exclusions cannot satisfy non-vacuity guards', flush=True)
+print('reloc-crossbuild-test: ok', flush=True)
+PY

--- a/tests/gates/selftests/run.sh
+++ b/tests/gates/selftests/run.sh
@@ -44,4 +44,7 @@ bash "$ROOT_DIR/scripts/check_gate_self_tests_test.sh"
 # and `gate_split_cli_cache_is_current` decides WHICH compiler the #2305 lane
 # questions, which is exactly the kind of answer that must not go unchecked.
 bash "$ROOT_DIR/tests/gates/lib_test.sh"
+# The relocation measurement is not a check_* gate, so its synthetic-module
+# regression is explicit here. gate_resolve_stage2 supplies this lane's compiler.
+bash "$ROOT_DIR/scripts/reloc_crossbuild_test.sh"
 echo "[compiler-gate] gate self-tests ok (#2248)"


### PR DESCRIPTION
Follows #2705. Also carries mizchi's `1f90aca` (source-edit exclusions validated before counting, plus `scripts/reloc_crossbuild_test.sh`), which was pushed to this branch after the merge and is included here rather than stranded.

## The gap this closes

Slice 2 shipped with a stated asymmetry. A **replayed** function re-pushes its funcref slots from `CodegenBodyCache` without re-running codegen, so it contributed slots and no blind references — and the paired-count invariant that keeps the recording honest had to stand down for it:

> Compiled functions only: a REPLAYED function re-pushes its recorded slots from the cache without re-running codegen, so it contributes slots and no blind references. That asymmetry is the reason a replaying build's blind log is incomplete, and carrying these in `CodegenBodyCache` is what removes it.

That comment is now deleted, because the thing it described is done.

## What changed

The cache carries the references the way it already carried the slots. **Two owner columns rather than one**, because they answer different questions:

| column | what it is |
|---|---|
| `blind_fn` | the owning USER FUNCTION — the selection key, so `merge` and `filter_src_below` reuse the keep-set logic the slots use |
| `blind_body` | the BODY the record sits in, which may be one of that function's lambdas (`blind_owner_of_lambda`) |

The second is not redundant. An offset is relative to one body's instruction stream and to no other, so rewriting a lambda's record to name its enclosing function would silently point it at the wrong bytes — the exact failure mode slice 2's nested-lambda case exists to catch.

**Replay now asserts the same pairing the compiled path does.** Together the two checks say something neither says alone: *the log a replaying build produces is the log a compiling build would have produced.* This check could not exist before the cache carried these.

Codec magic `VBC1` → `VBC2`, so an artifact written by a compiler without these arrays is rejected rather than read short; the reader's parallel-length validation covers all five new columns.

## The review finding, and why my tests missed it

Codex caught a P1 on the first push: `bcc_push_int` throws for `v < -1` (the column encodes `v + 1` as an unsigned LEB, right for every field it was written for, since those are indices and counts). `blind_body` is not one of those — a lambda's is `-2 - lambda_idx` — so `VIBE_CODEGEN_BODY_CACHE=on`/`verify` would have **aborted** on any harvest containing a function value inside a lambda.

The useful half is why two green tests were blind to it:

| test | why |
|---|---|
| `codegen_body_cache_test` | exercises **in-process** harvest/replay — never serializes, so the codec isn't on its path |
| `codegen_body_cache_persist_test` | serializes, but `sample_cache()` carried **no blind rows at all** |

Adding a column to a struct does not add it to a fixture that enumerates rows by hand. The sample now carries two blind rows, one function-owned and one lambda-owned (`-7`), and the round-trip asserts both. `blind_body` gets a zigzag column confined to the codec, so the representation the verifier and emitter use is untouched; written arithmetically rather than with shifts, so it doesn't depend on the tagged `Int`'s width.

Red-tested by reverting that one call to the plain column — the reported state exactly: **11 passed → 0 passed, 1 failed**.

## Cost

| | selfcompile memory |
|---|---:|
| main, with slice 2 | 857 MiB |
| with the cache columns | 859 MiB (**+0.21%**) |

~1.7 MiB for five columns keyed per function. Same tracking as #2705, against a baseline that now contains slice 2.

## Verification

- **`scripts/compiler_gate.sh` green end to end**, self-test lane included (mizchi's `reloc_crossbuild_test.sh` runs inside it).
- **Full bootstrap green**: stage0 → stage1 → stage2 plus both sample validations.
- `codegen_body_cache_test.vibe` — **7 tests**, the load-bearing one: `compile_wasi_module_replayed` compiles a program twice, once harvesting every body and once replaying every harvested body, and throws on the first differing byte. A cache that dropped or misattributed a record fails here.
- `codegen_body_cache_persist_test.vibe` — 11 tests, now covering a lambda-owned row.
- `blind_reloc_test.vibe` — 6 tests, unchanged from slice 2 and still green.
- All run against the freshly built stage2, not the committed seed.

## What this unblocks

This is the prerequisite, not the payoff. Next: symbolize a body's function references at harvest and re-resolve them at replay, which is what lets `decode_body_cache_payload_for` keep entries past the first changed file instead of dropping everything after it in merge order — today a one-module edit costs 93% of a cold build. The oracle for that already exists and is byte-exact: `VIBE_CODEGEN_BODY_CACHE=verify` compiles twice and throws on the first differing byte, on real edits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CCUq2wJKeDzguGzmx78HkZ