### PR TITLE
#2633: run the oracle on the closure production uses — content reaches 0

### DIFF
--- a/docs/incremental-build.md
+++ b/docs/incremental-build.md
@@ -181,11 +181,6 @@ CLI closure (369 modules) took `keyed content` 1 → 0 and `CTX unresolved_exp`
 denominator unchanged at 25 556 — the per-module lane reproducing the
 whole-program prelude exactly.
 
-(An earlier revision of this section said the header scan "does not distinguish"
-re-export edges, "so this takes the narrower side". That was wrong:
-`module_reexport_deps_fs` has returned exactly that subset since #2658, and
-production has used it all along.)
-
 `edges_unresolved` is reported for its own reason: a dropped edge narrows a
 module's context further, and a closure built from every edge and one built from
 half of them otherwise look identical.
@@ -258,7 +253,7 @@ for name and body for body.
 counts the merge-stamped names the context scan judged, so a zero here is an
 answer rather than a scan that matched nothing (#2633).
 
-`copies=444` is what remains after the link and is not a difference: each is a
+`copies=448` is what remains after the link and is not a difference: each is a
 module's own `reexport_boundary` marker, one per module, which no link should
 merge. `dup_defs=5` equals `linked_dups=5`, so the link removed none of the
 definitions the program legitimately carries twice and left nothing unfolded.
@@ -1285,8 +1280,9 @@ declared and performed in `core/module_graph_path.vibe`, and handled in
 decision as interface data on *dependencies* cannot work — a dependency's
 contract cannot hold a decision that depends on its dependents. What decomposes
 is the *inputs*: measured, the union of the per-module (declared, handled,
-performed) facts equals the whole-program facts (`EVIDENCE declared=6 handled=4
-performed=3`), sampled immediately before the pass runs. So the module collects,
+performed) facts equals the whole-program facts (`EVIDENCE declared=6 handled=5
+performed=4` on the closure measured above), sampled immediately before the pass
+runs. So the module collects,
 the link unions and decides, and the link rewrites — with the rewrite then
 cacheable per function keyed on (body fingerprint, migration set). #2633.
 

--- a/docs/incremental-build.md
+++ b/docs/incremental-build.md
@@ -152,22 +152,40 @@ links the per-module results and compares by declaration key
 (`prelude_module_full_oracle_report_fs`). What each file is given as *context*
 decides what its green means.
 
-That context is each module's **own direct imports**, taken from the loader's
+That context is each module's own direct imports **plus everything reachable
+across re-export edges** (`exact_import_closure`, #2658) — the same closure
+production's `ordinary_lane_module_split` builds. Both come from the loader's
 header scan (`load_or_parse_module_header_fs` — the same scan the FS typecheck
 lane plans module order with), with a dependency that names a `.vpkg` contract
-expanded to that package's sibling implementations. It has to come from the
-loader because the merge drops `SImport` / `SReExport` as already resolved, so
-the edges cannot be read back off the merged program. The counters only mean
-what they say under a rule that matches a real compile; what that takes is
+expanded to that package's sibling implementations, and the re-export subset
+from `module_reexport_deps_fs`. It has to come from the loader because the merge
+drops `SImport` / `SReExport` as already resolved, so the edges cannot be read
+back off the merged program. The counters only mean what they say under a rule
+that matches a real compile; what that takes is
 [The context rule](#the-context-rule) below.
 
-**One hop, not transitive.** Closing transitively hands A the declarations of a
-module C that A's dependency B imports *privately* — context no real compile of
-A exposes. Closing only across re-export edges would be the exact rule, and the
-header scan does not distinguish them (it returns a module's deps and its export
-*names*, with no record of which deps a dep re-exports), so this takes the
-narrower side. That narrowing is not free of consequences in either direction —
-[The context rule](#the-context-rule) below says what it can and cannot hide.
+**Re-export edges, not transitive.** Closing transitively hands A the
+declarations of a module C that A's dependency B imports *privately* — context
+no real compile of A exposes. Closing across **re-export** edges is a different
+thing: what B re-exports is precisely what a real compile of A does see, so
+including it is not a widening at all.
+
+The oracle measured on direct edges only until #2633, on the reasoning that for
+a measurement, being handed context a module lacks is the one failure mode that
+makes a green meaningless. That reasoning is sound and does not apply here: it
+was written against the transitive rule. Measuring *without* the re-export edges
+made the oracle solve a harder problem than the thing it models, and part of its
+residue was an artifact of that. Adopting the exact closure on the compiler's own
+CLI closure (369 modules) took `keyed content` 1 → 0 and `CTX unresolved_exp`
+83 → 0, with `missing` / `extra` / `collisions` already 0 and the `seen`
+denominator unchanged at 25 556 — the per-module lane reproducing the
+whole-program prelude exactly.
+
+(An earlier revision of this section said the header scan "does not distinguish"
+re-export edges, "so this takes the narrower side". That was wrong:
+`module_reexport_deps_fs` has returned exactly that subset since #2658, and
+production has used it all along.)
+
 `edges_unresolved` is reported for its own reason: a dropped edge narrows a
 module's context further, and a closure built from every edge and one built from
 half of them otherwise look identical.
@@ -209,7 +227,10 @@ unreachable on the whole-program lane the rule is unconditional rather than
 lane-dependent. `invisible_split` is unaffected by the fix and should be: those
 nominals are still invisible to the modules comparing them — what changed is
 that their invisibility no longer reaches the body. That is why `collisions=0`
-survived the narrowing that took `invisible_split` from 2 to 15.
+survived the narrowing that took `invisible_split` from 2 to 15. Widening back
+to the exact closure moves it the other way — 2 on the compiler's closure today
+— for the same reason and with `collisions=0` again unaffected: the count tracks
+what a module can see, and the fix is what keeps that from reaching the body.
 
 The link still folds only by a key a module reported as **synthesized**, and
 still content-checks the bodies under it. That is not redundant with the above:
@@ -219,17 +240,23 @@ kept body.
 ### The per-module prelude reproduces the whole-program prelude exactly
 
 ```
-CLOSURE files=365 edges=11342 unresolved=0
-FULL stmts=9876 split=10033 linked=9876 folded=157 modules=365 collisions=0
-     invisible_whole=0 invisible_split=8 linked_dups=5
-keyed missing=0 extra=0 copies=444 content=0 renames=0 dup_keys=451 dup_defs=5
-EVIDENCE declared=6 handled=4 performed=3
+CLOSURE files=369 edges=15874 unresolved=0
+FULL stmts=10242 split=10413 linked=10242 folded=171 modules=369 collisions=0
+     invisible_whole=0 invisible_split=2 linked_dups=5
+keyed missing=0 extra=0 copies=448 content=0 renames=0 dup_keys=455 dup_defs=5
+EVIDENCE declared=6 handled=5 performed=4
+CTX  unresolved_exp=0 unresolved_dep=0 exp_unknown=0 seen=25556 amb=0
 ```
 
-`lib/@vibe/cli/entry.vibe`, 365 modules. **`linked` equals `stmts`, and
-`missing`, `extra`, `content` and `renames` are all zero.** Compiling the
-compiler's own CLI closure per module and linking produces every declaration the
-whole-program prelude produces, name for name and body for body.
+`lib/@vibe/cli/entry.vibe`, 369 modules, measured 2026-09-12 on the exact
+closure. **`linked` equals `stmts`, and `missing`, `extra`, `content` and
+`renames` are all zero.** Compiling the compiler's own CLI closure per module
+and linking produces every declaration the whole-program prelude produces, name
+for name and body for body.
+
+`seen=25556` is the denominator the two `unresolved` zeros are read against: it
+counts the merge-stamped names the context scan judged, so a zero here is an
+answer rather than a scan that matched nothing (#2633).
 
 `copies=444` is what remains after the link and is not a difference: each is a
 module's own `reexport_boundary` marker, one per module, which no link should

--- a/lib/@vibe/compiler/codegen/wasi/linked_compile.vibe
+++ b/lib/@vibe/compiler/codegen/wasi/linked_compile.vibe
@@ -5845,17 +5845,22 @@ fn prelude_run_per_module(c: Array[Stmt], c_file_id: Array[Int], file_count: Int
     //               (`module_reexport_deps_fs`). Exact, and necessary: a module
     //               that cannot see what its dependency re-exports lowers a
     //               call to a bounded generic without the witness argument.
-    //   oracle      `oracle_import_closure` -- DIRECT edges only. An
-    //               under-approximation on purpose: for a MEASUREMENT, being
-    //               given context a module does not have is the one failure
-    //               mode that makes a green meaningless.
+    //   oracle      `exact_import_closure` TOO, since #2633. It measured on
+    //               `oracle_import_closure` (DIRECT edges only) until then, to
+    //               avoid the one failure mode that makes a green meaningless
+    //               -- being given context a module does not have. But a
+    //               re-export edge is not that: it is context a real compile of
+    //               that module HAS, so measuring without it made the oracle
+    //               solve a harder problem than the thing it models. The
+    //               objection that rule was written for is a TRANSITIVE closure
+    //               (A imports B, B imports C privately), which reaches neither.
     //
-    // So the `CTX exp_outside` count (83 on the compiler's closure) is the
-    // ORACLE lane's, not production's, and it is the price of that deliberate
-    // conservatism -- not a missing capability. Whether the oracle should adopt
-    // the exact closure is a live question, since measuring with LESS context
-    // than production has makes the oracle solve a harder problem than the
-    // thing it models; `ModuleSplit.closure_exact` already records which it got.
+    // Adopting it took the per-module lane to full agreement on the compiler's
+    // own closure (369 modules): `keyed content` 1 -> 0 and `CTX
+    // unresolved_exp` 83 -> 0, with `missing`/`extra`/`collisions` already 0 and
+    // `seen=25556` unchanged. The direct-only figures are a stricter lower bound
+    // on what a module needs and are recorded at the call site in
+    // `prelude_module_full_oracle_report_fs`.
     //
     // An index out of range is a caller that built the closure over a
     // different file space, which would silently hand a module some other

--- a/lib/@vibe/compiler/entry/compiler/file_compile/file_compile.vibe
+++ b/lib/@vibe/compiler/entry/compiler/file_compile/file_compile.vibe
@@ -564,7 +564,42 @@ export fn prelude_module_full_oracle_report_fs(entry_path: String, entry_name: S
   let module_paths: Array[String] = []
   let (c, files, c_file_id, eq) = prelude_oracle_merge(source_groups, module_paths)
   let (eq_offs, eq_keys) = eq
-  let (import_closure, unresolved_edges) = oracle_import_closure(source_groups)
+  // #2633: the closure PRODUCTION uses (`ordinary_lane_module_split`), not the
+  // direct-edge-only one. The oracle answers "does the per-module lane
+  // reproduce the whole-program one", and the per-module lane production runs
+  // has direct imports plus re-export chains, taken from the loader via
+  // `module_reexport_deps_fs`.
+  //
+  // The objection recorded in `oracle_import_closure` is against a TRANSITIVE
+  // closure -- A imports B, B imports C privately, and a transitive closure
+  // hands A the declarations of C, which no real compile of A exposes. It does
+  // not reach this one: direct plus RE-EXPORT edges only is exactly what a real
+  // compile of that module sees, so this is not context a module lacks.
+  //
+  // Measured on `lib/@vibe/cli/entry.vibe`, 369 modules (2026-09-12), the two
+  // closures side by side:
+  //
+  //                        direct-only   exact
+  //   keyed content                  1       0
+  //   unresolved_exp                83       0
+  //   invisible_split                8       2
+  //   zero (modules given none)     37      30
+  //   decls handed out         121 981 167 382
+  //   seen (denominator)        25 556  25 556
+  //   missing / extra / collisions 0/0/0   0/0/0
+  //
+  // `content` reaching 0 is the per-module lane reproducing the whole-program
+  // prelude exactly. The row that closed was
+  // `parse_contract_program_spans`, whose thrown payload's type comes through
+  // `fn_returns` from `allows_outside_entry_error` -- declared in
+  // `@vibe/parser/parser_base.vibe` and reaching `contract.vibe` via a
+  // RE-EXPORT. It was recorded on #2633 three times as the `__exn_kind_cell`
+  // family (#2510's); the shape is that, the cause was this closure.
+  //
+  // The direct-only figures are a stricter lower bound on what a module needs.
+  // That signal is kept HERE, in writing, rather than by measuring a lane
+  // production does not run.
+  let (import_closure, unresolved_edges) = exact_import_closure(source_groups)
   // The closure is indexed by FLAT SOURCE, the oracle by MERGED FILE ID. They
   // are the same space only because the merge keeps one file entry per flat
   // source; if that ever stops holding, every row would be read for the wrong
@@ -687,7 +722,9 @@ export fn prelude_ordinary_lane_prov_report_fs(entry_path: String) -> String wit
 /// real import graph.
 export fn prelude_module_import_closure_report_fs(entry_path: String) -> String with Exception + Fs {
   let source_groups = collect_source_groups_fs(entry_path)
-  let (closure, unresolved) = oracle_import_closure(source_groups)
+  // #2633: the closure the full oracle ACTUALLY runs under, so this report
+  // cannot describe a different one than the lane it is named for.
+  let (closure, unresolved) = exact_import_closure(source_groups)
   let mut edges = 0
   let mut i = 0
   while i < Array::length(closure) {

--- a/lib/@vibe/compiler/tests/prelude_module_oracle_test.vibe
+++ b/lib/@vibe/compiler/tests/prelude_module_oracle_test.vibe
@@ -620,6 +620,24 @@ test "the import closure the oracle runs under is the module's own, and places e
   Fs::write_file(lone_b, "test \"lone\" {\n  inspect(1, content = \"1\")\n}\n")
   let _ = lone_a
   inspect(String::trim(prelude_module_import_closure_report_fs(lone_b)), content = "CLOSURE files=1 edges=0 unresolved=0")
+  // #2633: the same chain, except `mid` RE-EXPORTS `leaf` instead of importing
+  // it privately. Now a real compile of `main` DOES see `leaf`'s declarations,
+  // so the closure carries the extra edge and this reads 3 where the private
+  // chain above reads 2.
+  //
+  // This pair is what makes the pin discriminating. The oracle used to run on
+  // a direct-edge-only closure, which answers 2 for BOTH chains -- so the case
+  // above could not tell the two closures apart, and adopting the one
+  // production uses would have passed it unchanged. A re-export is the only
+  // shape where "direct" and "exact" differ, so it is the only shape that
+  // tests which one is wired.
+  let rx_leaf = "/tmp/vibe_closure_rx_leaf.vibe"
+  let rx_mid = "/tmp/vibe_closure_rx_mid.vibe"
+  let rx_main = "/tmp/vibe_closure_rx_main.vibe"
+  Fs::write_file(rx_leaf, "export fn leaf() -> Int {\n  1\n}\n")
+  Fs::write_file(rx_mid, "export ./vibe_closure_rx_leaf.vibe {\n  leaf\n}\n")
+  Fs::write_file(rx_main, "import ./vibe_closure_rx_mid.vibe {\n  leaf\n}\n\ntest \"rx\" {\n  inspect(leaf(), content = \"1\")\n}\n")
+  inspect(String::trim(prelude_module_import_closure_report_fs(rx_main)), content = "CLOSURE files=3 edges=3 unresolved=0")
 }
 
 // #2388: the prelude's VALIDATORS -- `zero_alloc_check` and
@@ -803,8 +821,18 @@ test "a report's deferrals are its own, not the previous report's" {
   let c = "/tmp/vibe_defer_reset_c.vibe"
   let a = "/tmp/vibe_defer_reset_a.vibe"
   Fs::write_file(b, "export struct Box[T] {\n  v: T\n}\n\nexport fn make_box(n: Int) -> Box[Int] {\n  Box::{ v: n }\n}\n")
-  Fs::write_file(c, "export ./vibe_defer_reset_b.vibe {\n  Box, make_box\n}\n")
-  Fs::write_file(a, "import ./vibe_defer_reset_c.vibe {\n  make_box\n}\n\ntest \"t\" {\n  let p = make_box(1)\n  let q = make_box(1)\n  inspect(p == q, content = \"true\")\n}\n")
+  // #2633: `c` imports `Box` PRIVATELY and re-exposes only a function
+  // returning `Box[Int]`, so `a` cannot see `Box` under ANY closure.
+  //
+  // This program used to re-export `Box` from `c`, which deferred only because
+  // the oracle ran on a direct-edge-only closure. Once it runs on the closure
+  // production uses, a re-export edge puts `b` in `a`'s closure, `a` sees `Box`
+  // and generates the specialization itself: `deferred=0 minted=0`, and this
+  // test silently stopped having a deferral to check the reset of. A private
+  // chain is the shape that defers for a reason the closure cannot remove --
+  // and it reproduces the SAME line, so the expectation below is unchanged.
+  Fs::write_file(c, "import ./vibe_defer_reset_b.vibe {\n  Box, make_box\n}\n\nexport fn mk(n: Int) -> Box[Int] {\n  make_box(n)\n}\n")
+  Fs::write_file(a, "import ./vibe_defer_reset_c.vibe {\n  mk\n}\n\ntest \"t\" {\n  let p = mk(1)\n  let q = mk(1)\n  inspect(p == q, content = \"true\")\n}\n")
   // The deferring program, and the line that says so: one request the whole
   // program makes and the split does not, one row the typed channel refused,
   // and the link minting the helper from the deferral.


### PR DESCRIPTION
Closes the last open question on #2633, and advances #2575 item 2. Oracle only — no production code path changes (`use_split` is false at every production caller; this changes which closure the *measurement* runs under).

**This is a design decision, so it is a PR rather than a push.** The numbers below are the argument.

## The question

The oracle ran on a **direct-edge-only** closure while production's `ordinary_lane_module_split` runs on `exact_import_closure` — direct imports plus re-export chains, taken from the loader via `module_reexport_deps_fs`. So the oracle was solving a *harder* problem than the thing it models, and part of its residue was an artifact of that choice rather than of the per-module design.

## Measured

`lib/@vibe/cli/entry.vibe`, 369 modules, both stable on re-run:

| | direct-only | **exact** |
|---|---:|---:|
| `keyed content` | 1 | **0** |
| `unresolved_exp` | 83 | **0** |
| `exp_outside` | 83 | **0** |
| `invisible_split` | 8 | **2** |
| `zero` (modules given no context) | 37 | **30** |
| `decls` handed out | 121 981 | **167 382** |
| `seen` (denominator) | 25 556 | 25 556 |
| `missing` / `extra` / `collisions` | 0 / 0 / 0 | 0 / 0 / 0 |

```
FULL  stmts=10242 split=10413 linked=10242 modules=369 collisions=0
      invisible_whole=0 invisible_split=2
keyed missing=0 extra=0 content=0 content_keys=
CTX   unresolved_exp=0: unresolved_dep=0: exp_unknown=0 seen=25556 amb=0
```

**`linked == stmts` with `missing=0 extra=0 content=0`** — the per-module lane reproduces the whole-program prelude exactly, name for name and body for body.

## Why this is not "context a module does not have"

The objection recorded in `oracle_import_closure` is against a **transitive** closure: A imports B, B imports C *privately*, and a transitive closure hands A the declarations of C, which no real compile of A exposes. That objection does not reach this one — direct plus **re-export edges only** is exactly what a real compile of that module sees.

## A correction I owe the issue

I wrote three times that the remaining `content` row was "the `__exn_kind_cell` family, #2510's, tracked there". The **shape** is that; the **cause** was not. The row was `parse_contract_program_spans`, whose thrown payload's type comes through `fn_returns` from `allows_outside_entry_error` — declared in `@vibe/parser/parser_base.vibe` and reaching `contract.vibe` **via a re-export**. Under the exact closure no row arises.

## Two pins needed real work, because the swap would otherwise have passed them while removing what they check

- **The CLOSURE pin** used a chain of plain imports, where exact and direct both answer `edges=2`. It could not tell the two closures apart. Added the re-export variant, which answers **3** where the private chain answers **2** — a re-export being the only shape where they differ, and so the only shape that tests which one is wired.

- **The deferral-reset test's program re-exported `Box`.** Under the exact closure a re-export edge puts the declaring module in the closure, so it stopped deferring (`deferred=0 minted=0`) and the test silently lost the deferral it exists to check the reset of. Swapped to a **private chain** — `c` imports `Box` privately and re-exposes only a function returning `Box[Int]`, so `a` cannot see `Box` under any closure. It reproduces the **same** SYNTH line, so the expectation is unchanged.

`prelude_module_import_closure_report_fs` moves with the oracle, so the report cannot describe a different closure than the lane it is named for.

## What is lost, and where it is kept

The direct-only figures are a stricter lower bound on what a module needs. That signal goes away; the table above is recorded at the call site in the source so it is not lost, but it is not worth measuring a lane production does not run to preserve.

The pins do not become vacuous — the failure mode this issue spent a long time on. `seen=25556` is unchanged and non-zero, and `invisible_split=2` still moves.

## Review rounds (Codex), all addressed and resolved

1. **The documented closure contract was left behind** — `docs/incremental-build.md` still defined the context as direct imports only, and `linked_compile.vibe` still called the exact-closure decision "a live question". The doc also carried a claim that was **already false before this PR**: that the header scan cannot distinguish re-export edges. Fixed in `c67492c`.
2. **`copies=448` in the snapshot, `444` in the sentence explaining it.** Swept the section for the same shape and found one more (`EVIDENCE handled=4 performed=3` against the refreshed `handled=5 performed=4`). Both now measured. Fixed in `cc2dedb`.
3. **A parenthetical preserving the abandoned wording** — CLAUDE.md requires the final state with the discarded path left to `git log`, and I had overridden that with my own judgement. Removed in `cc2dedb`.
4. Clean on `cc2dedb`, no findings.

## Verification

| check | result |
|---|---|
| CI | check suite completed with **no failures** on `cc2dedb` (current head) |
| Codex review | **no findings** on `cc2dedb`; all three earlier threads resolved |
| `scripts/compiler_gate.sh` | `[compiler-gate] ok`, exit 0, self-tests `passed: 5, failed: 0` — run on `fa0498d`. The two commits since are **documentation and one comment block only** (verified: no non-comment source line differs between `fa0498d` and `cc2dedb`), so the gate was not re-run. |
| `prelude_module_oracle_test.vibe` | 10 tests pass |
| `vibe check` / `vibe_fmt --check` | clean |
| closure measurement | stable across re-runs |
| merge state | no conflict with main (`git merge-tree`, 0 conflicts) |
| other oracle-touching tests | `prelude_split_bytes_test` passes its closure explicitly (unaffected); `prelude_split_fs_lane_test` only mentions it in a comment |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NAeZzkckdAwtQiubBFpdmM