### PR TITLE
#2669: pin the cache-reuse baseline, and name why the prefix rule exists

### DIFF
--- a/lib/@vibe/compiler/tests/codegen_body_cache_persist_test.vibe
+++ b/lib/@vibe/compiler/tests/codegen_body_cache_persist_test.vibe
@@ -452,3 +452,41 @@ test "a persisted cache carrying a negative function index is refused" {
   }
   inspect(accepted, content = "accepted")
 }
+
+test "#2669: index-keyed replay reuses everything while the assignment agrees" {
+  // THE BASELINE step 2 has to improve, pinned before the work rather than
+  // claimed after it. `body_cache_out` records exactly the functions a build
+  // COMPILED -- `codegen_body_cache_record` runs only on the non-replay
+  // branch -- so its length is the recompile count directly, with no
+  // instrumentation and no proxy.
+  let src = "let alpha: () -> Int = () -> { 1 }\nlet beta: () -> Int = () -> { alpha() + 1 }\nlet run: () -> Int = () -> { beta() + alpha() }"
+  let out_a = codegen_body_cache_new()
+  let cold = compile_wasi_module_rc_body_cached(parse_program(lex(src)), "run", codegen_body_cache_new(), out_a)
+  inspect(Array::length(out_a.fn_indices), content = "3")
+  // Handed that harvest, the same program recompiles NOTHING and answers the
+  // same bytes. Full reuse is available -- when the index assignment agrees.
+  let out_b = codegen_body_cache_new()
+  let warm = compile_wasi_module_rc_body_cached(parse_program(lex(src)), "run", out_a, out_b)
+  inspect(Array::length(out_b.fn_indices), content = "0")
+  assert(bytes_eq(cold, warm))
+}
+
+//# `codegen_body_cache_find` keys on the FUNCTION INDEX, so an entry is only
+//# meaningful in a build that assigns that index to the same function. The FS
+//# layer supplies exactly that: `decode_body_cache_payload_for` keeps the
+//# unchanged PREFIX of files and `codegen_body_cache_filter_src_below` trims
+//# to it, and over an identical prefix index i names the same function in both
+//# builds. The prefix rule is not timidity -- it IS the precondition.
+//#
+//# Measured (#2669, not asserted here because it describes a misuse rather
+//# than a behaviour worth freezing): hand this entry point a harvest whose
+//# assignment does NOT agree -- insert a function ahead of the others -- and
+//# it replays 3 of 4 bodies into the wrong slots and answers a module that
+//# differs from a fresh compile. Production cannot reach that, because the
+//# prefix filter is upstream of it.
+//#
+//# That is what makes the prefix rule expensive: an edit early in merge order
+//# invalidates everything after it, whether or not those bodies changed. Step
+//# 2 removes the cost by removing the dependence -- key the lookup on function
+//# IDENTITY and relocate the references -- at which point the precondition is
+//# no longer needed and the filter can keep every unchanged file.


### PR DESCRIPTION
Follows #2710. Small: one test and a note. It exists because the next step claims the cache will reuse more, and that needs a number measured **before** the work rather than asserted after it.

## The number was already available

`codegen_body_cache_record` runs only on the non-replay branch, so `body_cache_out.fn_indices` **is** the set of functions a build recompiled — not a proxy for it, the set. No instrumentation, no new API, no telemetry plumbing.

Baseline pinned: a cold compile records **3**; handing that harvest back for the same program records **0** and answers identical bytes. Full reuse is available when the index assignment agrees.

## Why the prefix rule exists

I had been describing `decode_body_cache_payload_for`'s leading-prefix rule as conservatism. It isn't — it's the **precondition**.

`codegen_body_cache_find` keys on the **function index**. An entry therefore means something only in a build that assigns that index to the same function, and keeping the unchanged prefix is exactly what makes index *i* name the same function on both sides.

Measured while establishing that, by handing the in-memory entry point a harvest whose assignment does **not** agree (one function inserted ahead of the others):

- it replays **3 of 4** bodies into the wrong slots,
- and answers a module that **differs** from a fresh compile.

Production cannot reach that — `decode_body_cache_payload_for` and `codegen_body_cache_filter_src_below` are upstream of it — so this is an unstated precondition of an internal entry point rather than a live defect. It's recorded as a note rather than frozen as a test, because asserting it would be asserting a misuse.

## What it means for the next step

It explains the cost precisely: an edit early in merge order invalidates everything after it whether or not those bodies changed. That's the 93%-of-a-cold-build figure in miniature.

Step 2 removes the cost by removing the dependence — key the lookup on function **identity** and relocate the references (`rebuild_body_relocs` and the records #2705/#2710 landed) — at which point the precondition is gone and the filter can keep every unchanged file. This test is the before-half of that measurement.

## Verification

`codegen_body_cache_persist_test.vibe` — 12 tests, run against the stage2 built from this tree rather than the committed seed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CCUq2wJKeDzguGzmx78HkZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01CCUq2wJKeDzguGzmx78HkZ)_