### PR TITLE
#2669 step 2a: key the body cache on function identity, checked against the index

### DIFF
--- a/lib/@vibe/compiler/codegen/common_base/common_base.vibe
+++ b/lib/@vibe/compiler/codegen/common_base/common_base.vibe
@@ -208,6 +208,18 @@ export struct LambdaTable {
 /// the slots the whole-program assembly will install these lambdas at.
 export struct CodegenBodyCache {
   fn_indices: Array[Int];
+  /// #2669 step 2a: the function each entry was harvested from, by NAME.
+  ///
+  /// `fn_indices` keys the lookup today, and that is exactly why
+  /// `decode_body_cache_payload_for` can only keep the unchanged leading
+  /// PREFIX of files: over an identical prefix, cache index i and build index
+  /// i are the same function, and past the first change they are not. The
+  /// prefix rule is that precondition, not caution.
+  ///
+  /// A name does not move when something ahead of it is inserted, so keying
+  /// on it is what lets the filter keep every unchanged file instead. Recorded
+  /// now and checked against the index lookup; nothing depends on it yet.
+  fn_names: Array[String];
   fn_bodies: Array[Bytes];
   fn_meta_i32: Array[Int];
   fn_meta_i64: Array[Int];
@@ -303,6 +315,7 @@ export struct CodegenBodyCache {
 export fn codegen_body_cache_new() -> CodegenBodyCache {
   CodegenBodyCache::{
     fn_indices: array_empty(),
+    fn_names: array_empty(),
     fn_bodies: array_empty(),
     fn_meta_i32: array_empty(),
     fn_meta_i64: array_empty(),
@@ -380,6 +393,66 @@ export fn codegen_body_cache_find(cache: CodegenBodyCache, fn_index: Int) -> Int
 /// So the contract is exact and bounded: for every key in [0, key_count), this
 /// answers what `codegen_body_cache_find` answers, and
 /// `codegen_body_cache_find_at` answers -1 outside it.
+/// #2669 step 2a: the cache slot for the function NAMED `name`, or -1 when
+/// absent, or -2 when the name is carried by more than one entry.
+///
+/// Linear scan, and the REFERENCE for the sorted lookup below -- the same
+/// relationship `codegen_body_cache_find` has with `codegen_body_cache_find_at`.
+///
+/// Ambiguity is refused rather than resolved first-wins. Merged programs
+/// path-mangle private definitions (#716) so user function names should be
+/// unique, but "should be" is what #2705 discovered was false for generated
+/// names, and taking whichever came first there meant comparing a body
+/// against an unrelated one. A duplicated name is a miss, which costs a
+/// recompile; taking the first would cost correctness.
+export fn codegen_body_cache_find_named(cache: CodegenBodyCache, name: String) -> Int {
+  let n = Array::length(cache.fn_names)
+  let mut i = 0
+  let mut found = 0 - 1
+  let mut hits = 0
+  while i < n {
+    if Array::get(cache.fn_names, i) == name {
+      hits = hits + 1
+      if hits == 1 {
+        found = i
+      } else {
+        ()
+      }
+    } else {
+      ()
+    }
+    i = i + 1
+  }
+  if hits > 1 {
+    0 - 2
+  } else {
+    found
+  }
+}
+
+/// Sorted view of the cache's function names plus their original positions,
+/// built ONCE per compile. Without it the body loop would scan every entry
+/// for every function, which is quadratic -- the same reason
+/// `codegen_body_cache_slot_index` exists.
+export fn codegen_body_cache_name_index(cache: CodegenBodyCache) -> (Array[String], Array[Int]) {
+  ctor_sorted_index(cache.fn_names)
+}
+
+/// The cache slot for the function named `name`, via the sorted view. Same
+/// answer as `codegen_body_cache_find_named`, including the -2 for a
+/// duplicated name: `bsearch_leftmost` lands on the FIRST of a run of equal
+/// names, so a second one sitting next to it is what makes the name ambiguous.
+export fn codegen_body_cache_find_named_at(sorted: Array[String], positions: Array[Int], name: String) -> Int {
+  let s = bsearch_leftmost(sorted, name)
+  if s < 0 {
+    0 - 1
+  } else if s + 1 < Array::length(sorted) && Array::get(sorted, s + 1) == name {
+    0 - 2
+  } else {
+    Array::get(positions, s)
+  }
+}
+
 export fn codegen_body_cache_slot_index(cache: CodegenBodyCache, key_count: Int) -> Array[Int] {
   let out: Array[Int] = []
   let mut j = 0
@@ -417,12 +490,13 @@ export fn codegen_body_cache_find_at(slot_index: Array[Int], fn_index: Int) -> I
 /// Reads the LAST entry of `bodies` / `meta_i32` / `meta_i64` -- the loop has
 /// just pushed them -- and the lambda table slice `[lam_lo, lam_hi)`, which is
 /// exactly the range the plan assigned this function.
-export fn codegen_body_cache_record(cache: CodegenBodyCache, fn_index: Int, src_stmt: Int, bodies: Array[Bytes], meta_i32: Array[Int], meta_i64: Array[Int], meta_v128: Array[Int], lt: LambdaTable, lam_lo: Int, lam_hi: Int, slots: Array[Int], slot_lo: Int, slot_hi: Int, blind_bodies: Array[Int], blind_offsets: Array[Int], blind_kinds: Array[Int], blind_syms: Array[Int], blind_lo: Int, blind_hi: Int) -> Unit {
+export fn codegen_body_cache_record(cache: CodegenBodyCache, fn_index: Int, fn_name: String, src_stmt: Int, bodies: Array[Bytes], meta_i32: Array[Int], meta_i64: Array[Int], meta_v128: Array[Int], lt: LambdaTable, lam_lo: Int, lam_hi: Int, slots: Array[Int], slot_lo: Int, slot_hi: Int, blind_bodies: Array[Int], blind_offsets: Array[Int], blind_kinds: Array[Int], blind_syms: Array[Int], blind_lo: Int, blind_hi: Int) -> Unit {
   let n = Array::length(bodies)
   if n == 0 {
     ()
   } else {
     Array::push(cache.fn_indices, fn_index)
+    Array::push(cache.fn_names, fn_name)
     Array::push(cache.fn_src_stmts, src_stmt)
     Array::push(cache.fn_bodies, Array::get(bodies, n - 1))
     Array::push(cache.fn_meta_i32, Array::get(meta_i32, Array::length(meta_i32) - 1))
@@ -483,6 +557,7 @@ export fn codegen_body_cache_merge(a: CodegenBodyCache, b: CodegenBodyCache) -> 
     let mut i = 0
     while i < fn_n {
       Array::push(out.fn_indices, Array::get(src.fn_indices, i))
+      Array::push(out.fn_names, Array::get(src.fn_names, i))
       Array::push(out.fn_src_stmts, Array::get(src.fn_src_stmts, i))
       Array::push(out.fn_bodies, Array::get(src.fn_bodies, i))
       Array::push(out.fn_meta_i32, Array::get(src.fn_meta_i32, i))
@@ -702,6 +777,7 @@ export fn codegen_body_cache_filter_src_below(cache: CodegenBodyCache, limit: In
       let fni = Array::get(cache.fn_indices, i)
       Array::push(keep_fn, fni)
       Array::push(out.fn_indices, fni)
+      Array::push(out.fn_names, Array::get(cache.fn_names, i))
       Array::push(out.fn_src_stmts, src_stmt)
       Array::push(out.fn_bodies, Array::get(cache.fn_bodies, i))
       Array::push(out.fn_meta_i32, Array::get(cache.fn_meta_i32, i))
@@ -879,12 +955,14 @@ export fn codegen_body_cache_to_bytes(cache: CodegenBodyCache) -> Bytes with Exc
   bytebuf_push(buf, 'V')
   bytebuf_push(buf, 'B')
   bytebuf_push(buf, 'C')
-  // #2669 slice 3 bumped this from '1': the stream gained the blind-reference
-  // arrays, so an artifact written by an older compiler must be REJECTED
-  // rather than read short. (The store is keyed on the codegen fingerprint
-  // too, so this is the second line of defence, not the first.)
-  bytebuf_push(buf, '2')
+  // Bumped on every stream change so an artifact written by an older compiler
+  // is REJECTED rather than read short: '1' -> '2' when #2669 slice 3 added
+  // the blind-reference arrays, '2' -> '3' when step 2a added fn_names. (The
+  // store is keyed on the codegen fingerprint too, so this is the second line
+  // of defence, not the first.)
+  bytebuf_push(buf, '3')
   bcc_push_int_array(buf, cache.fn_indices)
+  bcc_push_string_array(buf, cache.fn_names)
   bcc_push_int_array(buf, cache.fn_src_stmts)
   bcc_push_bytes_array(buf, cache.fn_bodies)
   bcc_push_int_array(buf, cache.fn_meta_i32)
@@ -1098,12 +1176,17 @@ fn bcc_read_string_arrays(b: Bytes, pos: Int, out: Array[Array[String]]) -> Int 
 }
 
 export fn codegen_body_cache_from_bytes(b: Bytes) -> Option[CodegenBodyCache] {
-  if Bytes::length(b) < 4 || Bytes::get(b, 0) != 'V' || Bytes::get(b, 1) != 'B' || Bytes::get(b, 2) != 'C' || Bytes::get(b, 3) != '2' {
+  if Bytes::length(b) < 4 || Bytes::get(b, 0) != 'V' || Bytes::get(b, 1) != 'B' || Bytes::get(b, 2) != 'C' || Bytes::get(b, 3) != '3' {
     None
   } else {
     let out = codegen_body_cache_new()
     let mut p = 4
     p = bcc_read_int_array(b, p, out.fn_indices)
+    if p >= 0 {
+      p = bcc_read_string_array(b, p, out.fn_names)
+    } else {
+      ()
+    }
     if p >= 0 {
       p = bcc_read_int_array(b, p, out.fn_src_stmts)
     } else {
@@ -1255,7 +1338,7 @@ export fn codegen_body_cache_from_bytes(b: Bytes) -> Option[CodegenBodyCache] {
       }
       fni = fni + 1
     }
-    if p < 0 || fn_index_negative || Array::length(out.fn_src_stmts) != fn_n || Array::length(out.fn_bodies) != fn_n || Array::length(out.fn_meta_i32) != fn_n || Array::length(out.fn_meta_i64) != fn_n || Array::length(out.fn_meta_v128) != fn_n || Array::length(out.lam_indices) != lam_n || Array::length(out.lam_bodies) != lam_n || Array::length(out.lam_param_counts) != lam_n || Array::length(out.lam_captures) != lam_n || Array::length(out.lam_meta_i32) != lam_n || Array::length(out.lam_meta_i64) != lam_n || Array::length(out.slot_owner) != Array::length(out.slot_values) || Array::length(out.blind_body) != Array::length(out.blind_fn) || Array::length(out.blind_offsets) != Array::length(out.blind_fn) || Array::length(out.blind_kinds) != Array::length(out.blind_fn) || Array::length(out.blind_syms) != Array::length(out.blind_fn) || (guard_n != 0 && guard_n != 5) || Array::length(out.guard_synth_names) != Array::length(out.guard_synth_stmts) || Array::length(out.guard_borrow_names) != Array::length(out.guard_borrow_masks) {
+    if p < 0 || fn_index_negative || Array::length(out.fn_names) != fn_n || Array::length(out.fn_src_stmts) != fn_n || Array::length(out.fn_bodies) != fn_n || Array::length(out.fn_meta_i32) != fn_n || Array::length(out.fn_meta_i64) != fn_n || Array::length(out.fn_meta_v128) != fn_n || Array::length(out.lam_indices) != lam_n || Array::length(out.lam_bodies) != lam_n || Array::length(out.lam_param_counts) != lam_n || Array::length(out.lam_captures) != lam_n || Array::length(out.lam_meta_i32) != lam_n || Array::length(out.lam_meta_i64) != lam_n || Array::length(out.slot_owner) != Array::length(out.slot_values) || Array::length(out.blind_body) != Array::length(out.blind_fn) || Array::length(out.blind_offsets) != Array::length(out.blind_fn) || Array::length(out.blind_kinds) != Array::length(out.blind_fn) || Array::length(out.blind_syms) != Array::length(out.blind_fn) || (guard_n != 0 && guard_n != 5) || Array::length(out.guard_synth_names) != Array::length(out.guard_synth_stmts) || Array::length(out.guard_borrow_names) != Array::length(out.guard_borrow_masks) {
       None
     } else {
       Some(out)

--- a/lib/@vibe/compiler/codegen/common_base/index.vpkg
+++ b/lib/@vibe/compiler/codegen/common_base/index.vpkg
@@ -323,9 +323,15 @@ fn codegen_body_cache_new() -> CodegenBodyCache
 fn codegen_body_cache_find(cache: CodegenBodyCache, fn_index: Int) -> Int
 // #2388 step 3 follow-up: the same lookup without the per-function scan --
 // a direct-address table from function index to cache slot, built once.
+fn codegen_body_cache_find_named(cache: CodegenBodyCache, name: String) -> Int
+
+fn codegen_body_cache_name_index(cache: CodegenBodyCache) -> (Array[String], Array[Int])
+
+fn codegen_body_cache_find_named_at(sorted: Array[String], positions: Array[Int], name: String) -> Int
+
 fn codegen_body_cache_slot_index(cache: CodegenBodyCache, key_count: Int) -> Array[Int]
 fn codegen_body_cache_find_at(slot_index: Array[Int], fn_index: Int) -> Int
-fn codegen_body_cache_record(cache: CodegenBodyCache, fn_index: Int, src_stmt: Int, bodies: Array[Bytes], meta_i32: Array[Int], meta_i64: Array[Int], meta_v128: Array[Int], lt: LambdaTable, lam_lo: Int, lam_hi: Int, slots: Array[Int], slot_lo: Int, slot_hi: Int, blind_bodies: Array[Int], blind_offsets: Array[Int], blind_kinds: Array[Int], blind_syms: Array[Int], blind_lo: Int, blind_hi: Int) -> Unit
+fn codegen_body_cache_record(cache: CodegenBodyCache, fn_index: Int, fn_name: String, src_stmt: Int, bodies: Array[Bytes], meta_i32: Array[Int], meta_i64: Array[Int], meta_v128: Array[Int], lt: LambdaTable, lam_lo: Int, lam_hi: Int, slots: Array[Int], slot_lo: Int, slot_hi: Int, blind_bodies: Array[Int], blind_offsets: Array[Int], blind_kinds: Array[Int], blind_syms: Array[Int], blind_lo: Int, blind_hi: Int) -> Unit
 fn codegen_body_cache_merge(a: CodegenBodyCache, b: CodegenBodyCache) -> CodegenBodyCache
 fn codegen_body_cache_replay(cache: CodegenBodyCache, at: Int, bodies: Array[Bytes], meta_i32: Array[Int], meta_i64: Array[Int], meta_v128: Array[Int], lt: LambdaTable, slots: Array[Int], blind_bodies: Array[Int], blind_offsets: Array[Int], blind_kinds: Array[Int], blind_syms: Array[Int]) -> Unit
 fn codegen_body_cache_filter_src_below(cache: CodegenBodyCache, limit: Int) -> CodegenBodyCache

--- a/lib/@vibe/compiler/codegen/wasi/linked_compile.vibe
+++ b/lib/@vibe/compiler/codegen/wasi/linked_compile.vibe
@@ -11243,7 +11243,18 @@ export fn compile_wasi_module_linked_impl_with_split(stmts: Array[Stmt], entry_n
       // it: there will be nothing left to agree with.
       if body_cache_in_ok {
         let __named_hit = codegen_body_cache_find_named_at(body_cache_names_sorted, body_cache_names_pos, Array::get(fn_names_list, bi))
-        if __named_hit != __cache_hit {
+        // -2 is AMBIGUOUS, which the name lookup documents as a miss, so it is
+        // not a disagreement to report -- comparing a miss sentinel against a
+        // hit would abort every warm compile of a unit that happens to contain
+        // two functions of one name. Those exist: two `test "..."` blocks with
+        // the same title lower to the same `__test_` function, and
+        // `lib/@vibe/compiler/tests/builtins_extended_test.vibe` has a pair.
+        // Found by review on #2714, and the contract it violates is the one
+        // the previous commit wrote down.
+        //
+        // Step 2b turns this into declining replay for that function. A miss
+        // costs a recompile; resolving it first-wins would cost correctness.
+        if __named_hit != 0 - 2 && __named_hit != __cache_hit {
           throw(String::concat("body cache: the name and index lookups disagree for function ", String::concat(__to_string(bi), String::concat(" (", String::concat(Array::get(fn_names_list, bi), String::concat("): by index ", String::concat(__to_string(__cache_hit), String::concat(", by name ", __to_string(__named_hit)))))))))
         } else {
           ()

--- a/lib/@vibe/compiler/codegen/wasi/linked_compile.vibe
+++ b/lib/@vibe/compiler/codegen/wasi/linked_compile.vibe
@@ -212,7 +212,9 @@ import @vibe/compiler/codegen/common_base {
   bcc_int_lists_equal,
   bcc_string_lists_equal,
   codegen_body_cache_find_at,
+  codegen_body_cache_find_named_at,
   codegen_body_cache_merge,
+  codegen_body_cache_name_index,
   codegen_body_cache_new,
   codegen_body_cache_record,
   codegen_body_cache_replay,
@@ -10486,6 +10488,10 @@ export fn compile_wasi_module_linked_impl_with_split(stmts: Array[Stmt], entry_n
   // probe counted the bodies), paid on the lane that exists to make a warm
   // compile cheap.
   let body_cache_slot_index = codegen_body_cache_slot_index(body_cache_in, num_user_funcs)
+  // #2669 step 2a: the same table, keyed on the function's NAME. Built once
+  // beside the index one and checked against it per function below; nothing
+  // reads it as the answer yet.
+  let (body_cache_names_sorted, body_cache_names_pos) = codegen_body_cache_name_index(body_cache_in)
   let body_cache_in_ok = if Array::length(body_cache_in.fn_indices) == 0 {
     true
   } else if pin_region_capacity < 0 {
@@ -11221,6 +11227,29 @@ export fn compile_wasi_module_linked_impl_with_split(stmts: Array[Stmt], entry_n
         codegen_body_cache_find_at(body_cache_slot_index, bi)
       } else {
         0 - 1
+      }
+      // #2669 step 2a: the name-keyed lookup must answer what the index-keyed
+      // one answers, HERE, before anything is allowed to depend on it.
+      //
+      // Under the prefix filter they cannot disagree: `decode_body_cache_payload_for`
+      // keeps only files that match in path, fingerprint and statement count,
+      // in order, so over that region index i and the function named at i are
+      // the same entry. That is what makes the index key sound and the name
+      // key a faithful replacement for it -- and a disagreement would mean the
+      // prefix invariant is not holding, which is worth stopping for rather
+      // than quietly preferring one answer.
+      //
+      // Step 2b drops the index lookup, at which point this check goes with
+      // it: there will be nothing left to agree with.
+      if body_cache_in_ok {
+        let __named_hit = codegen_body_cache_find_named_at(body_cache_names_sorted, body_cache_names_pos, Array::get(fn_names_list, bi))
+        if __named_hit != __cache_hit {
+          throw(String::concat("body cache: the name and index lookups disagree for function ", String::concat(__to_string(bi), String::concat(" (", String::concat(Array::get(fn_names_list, bi), String::concat("): by index ", String::concat(__to_string(__cache_hit), String::concat(", by name ", __to_string(__named_hit)))))))))
+        } else {
+          ()
+        }
+      } else {
+        ()
       }
       if __cache_hit >= 0 {
         let __r_slot_lo = Array::length(table_slots_used)
@@ -12162,7 +12191,7 @@ export fn compile_wasi_module_linked_impl_with_split(stmts: Array[Stmt], entry_n
         } else {
           ()
         }
-        codegen_body_cache_record(body_cache_out, bi, Array::get(fn_stmt_indices, bi), bodies, meta_i32, meta_i64, meta_v128, lt_w, Array::get(lambda_bases, bi), lambda_planned_end, table_slots_used, __slot_lo, Array::length(table_slots_used), blind_owners, blind_offsets, blind_kinds, blind_syms, __blind_lo, Array::length(blind_owners))
+        codegen_body_cache_record(body_cache_out, bi, Array::get(fn_names_list, bi), Array::get(fn_stmt_indices, bi), bodies, meta_i32, meta_i64, meta_v128, lt_w, Array::get(lambda_bases, bi), lambda_planned_end, table_slots_used, __slot_lo, Array::length(table_slots_used), blind_owners, blind_offsets, blind_kinds, blind_syms, __blind_lo, Array::length(blind_owners))
       }
     }
     bi = bi + 1

--- a/lib/@vibe/compiler/tests/codegen_body_cache_persist_test.vibe
+++ b/lib/@vibe/compiler/tests/codegen_body_cache_persist_test.vibe
@@ -79,12 +79,14 @@ fn remove_file_if_exists(path: String) -> Unit with Fs {
 fn sample_cache() -> CodegenBodyCache {
   let c = codegen_body_cache_new()
   Array::push(c.fn_indices, 0)
+  Array::push(c.fn_names, "alpha")
   Array::push(c.fn_src_stmts, 2)
   Array::push(c.fn_bodies, string_to_bytes("ab"))
   Array::push(c.fn_meta_i32, 1)
   Array::push(c.fn_meta_i64, 2)
   Array::push(c.fn_meta_v128, 0)
   Array::push(c.fn_indices, 3)
+  Array::push(c.fn_names, "beta")
   Array::push(c.fn_src_stmts, 7)
   Array::push(c.fn_bodies, string_to_bytes("cde"))
   Array::push(c.fn_meta_i32, 4)
@@ -138,6 +140,12 @@ test "codegen body cache codec round-trips every field group" {
       inspect(Array::length(d.fn_indices), content = "2")
       inspect(Array::get(d.fn_indices, 1), content = "3")
       inspect(Array::get(d.fn_src_stmts, 0), content = "2")
+      // #2669 step 2a. Asserted rather than merely carried: the previous
+      // column this struct gained (blind_body) round-tripped untested because
+      // the fixture enumerated rows by hand and did not grow with the struct,
+      // and the codec threw on it in production.
+      inspect(Array::get(d.fn_names, 0), content = "alpha")
+      inspect(Array::get(d.fn_names, 1), content = "beta")
       assert(bytes_eq(Array::get(d.fn_bodies, 1), string_to_bytes("cde")))
       inspect(Array::get(d.fn_meta_v128, 1), content = "1")
       inspect(Array::length(d.lam_owner), content = "1")
@@ -327,12 +335,14 @@ test "persisted body cache: verify survives an entry edit; on matches a fresh co
 // read. The scan is the ORACLE here, not a second implementation to eyeball:
 // the two must agree on every key, including the ones no entry holds.
 
-/// A cache carrying only `fn_indices` -- the lookup reads nothing else.
+/// A cache carrying only the lookup keys: `fn_indices`, and since #2669 step
+/// 2a the parallel `fn_names` the name lookup reads.
 fn cache_with_indices(indices: Array[Int]) -> CodegenBodyCache {
   let c = codegen_body_cache_new()
   let mut i = 0
   while i < Array::length(indices) {
     Array::push(c.fn_indices, Array::get(indices, i))
+    Array::push(c.fn_names, String::concat("f", __to_string(Array::get(indices, i))))
     i = i + 1
   }
   c

--- a/lib/@vibe/compiler/tests/codegen_body_cache_persist_test.vibe
+++ b/lib/@vibe/compiler/tests/codegen_body_cache_persist_test.vibe
@@ -11,7 +11,10 @@ import @vibe/compiler/codegen/common_base {
   codegen_body_cache_filter_src_below,
   codegen_body_cache_find,
   codegen_body_cache_find_at,
+  codegen_body_cache_find_named,
+  codegen_body_cache_find_named_at,
   codegen_body_cache_from_bytes,
+  codegen_body_cache_name_index,
   codegen_body_cache_new,
   codegen_body_cache_slot_index,
   codegen_body_cache_to_bytes
@@ -366,6 +369,29 @@ fn lookup_disagreements(c: CodegenBodyCache, key_count: Int) -> String {
     k = k + 1
   }
   String::join(out, ", ")
+}
+
+test "a duplicated function name is a miss on both name lookups" {
+  // Duplicate function names are REAL, not hypothetical: two `test "..."`
+  // blocks with the same title lower to the same `__test_` function, and
+  // `lib/@vibe/compiler/tests/builtins_extended_test.vibe` has such a pair.
+  // Both lookups must answer -2 so a consumer declines replay; resolving
+  // first-wins would hand one function another's body, which is the mistake
+  // #2705 found in the cross-build tool.
+  let c = codegen_body_cache_new()
+  Array::push(c.fn_indices, 0)
+  Array::push(c.fn_names, "solo")
+  Array::push(c.fn_indices, 1)
+  Array::push(c.fn_names, "twin")
+  Array::push(c.fn_indices, 2)
+  Array::push(c.fn_names, "twin")
+  let (sorted, positions) = codegen_body_cache_name_index(c)
+  inspect(codegen_body_cache_find_named(c, "solo"), content = "0")
+  inspect(codegen_body_cache_find_named_at(sorted, positions, "solo"), content = "0")
+  inspect(codegen_body_cache_find_named(c, "twin"), content = "-2")
+  inspect(codegen_body_cache_find_named_at(sorted, positions, "twin"), content = "-2")
+  inspect(codegen_body_cache_find_named(c, "absent"), content = "-1")
+  inspect(codegen_body_cache_find_named_at(sorted, positions, "absent"), content = "-1")
 }
 
 test "the indexed body-cache lookup answers exactly what the scan answers" {


### PR DESCRIPTION
Follows #2712, which established the thing this acts on: `decode_body_cache_payload_for`'s leading-prefix rule is not caution, it is a **precondition**. `codegen_body_cache_find` keys on the function **index**, so an entry means something only in a build that assigns that index to the same function — and an identical prefix is exactly what makes that true. Past the first changed file it stops being true, which is why everything after it is dropped whether or not it changed.

A name does not move when something ahead of it is inserted.

## What changed

The cache records one per entry, with the lookup pair the index key already has:

| | |
|---|---|
| `codegen_body_cache_find_named` | linear scan — the REFERENCE |
| `codegen_body_cache_find_named_at` | sorted view + `bsearch_leftmost` — the fast path |

The sorted view is built once per compile, like `codegen_body_cache_slot_index`, because a per-function scan over the entry list is quadratic. This is the same reference-vs-fast-table discipline `codegen_body_cache_find` / `find_at` already document.

**A duplicated name answers `-2` and counts as a MISS**, not first-wins. Merged programs path-mangle private definitions (#716) so user function names should be unique — but "should be" is what #2705 found was false for generated names, where taking the first meant comparing a body against an unrelated one. A miss costs a recompile; first-wins costs correctness.

## Landed behaviour-preserving, and that is the point

The body loop computes **both** lookups and throws if they disagree.

Under the prefix filter they cannot — that is what the prefix guarantees — so the assertion proves the name path is a faithful replacement *before* anything depends on it. And a disagreement would mean the prefix invariant is not holding, which is worth stopping for rather than quietly preferring one answer.

Step 2b deletes the index lookup, and this check goes with it: there will be nothing left to agree with.

## The fixture lesson, applied rather than repeated

Both hand-built fixtures grew the new column and the round-trip now **asserts** it.

This is the second time this struct gained a column that an enumerated fixture did not. The first — `blind_body` in #2710 — reached production as a codec throw, because the round-trip test covered only the columns that already existed and so proved nothing about the new ones. Adding a column to a struct does not add it to a fixture that lists rows by hand.

Codec magic `VBC2` → `VBC3`: the stream gained a string array, so an artifact from an older compiler is rejected rather than read short.

## Verification

- **Full bootstrap green**: stage0 → stage1 → stage2 plus both sample validations. stage1 compiling the compiler's own closure is what exercises the agreement assertion — it held for every function.
- `codegen_body_cache_persist_test.vibe` — 12 tests, including the new `fn_names` round-trip assertions.
- `codegen_body_cache_test.vibe` — 7 tests: compile-vs-replay byte equality.
- `blind_reloc_test.vibe` — 6 tests.
- All against the stage2 built from this tree, not the committed seed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CCUq2wJKeDzguGzmx78HkZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01CCUq2wJKeDzguGzmx78HkZ)_