### PR TITLE
Installed `vibe fmt` refuses a file that does not parse (#2636 on the adapter route); a raw-string or `#|` test label spans its content

### DIFF
--- a/docs/editor-and-debugging.md
+++ b/docs/editor-and-debugging.md
@@ -123,8 +123,8 @@ vibe check --single-file --json <file.vibe>  # same diagnostics as a JSON array 
   | 23 | Struct | `struct` |
   | 24 | Event | `effect` |
   | 26 | TypeParameter | `type` alias |
-  | 27 | Test (not an LSP kind) | a `test "X"` block, span = the label inside the quotes |
-  | 28 | Bench (not an LSP kind) | a `bench "X"` block, span = the label inside the quotes |
+  | 27 | Test (not an LSP kind) | a `test "X"` block, span = the label inside its delimiters (`"…"`, `r"…"`, `#\|…`) |
+  | 28 | Bench (not an LSP kind) | a `bench "X"` block, span = the label inside its delimiters |
 - **`--single-file` analyzes ONE file and does not follow its imports**, so on a
   file with imports it reports names it cannot see as undefined. A file that is
   perfectly valid under a plain `vibe check` can come back with

--- a/lib/@vibe/compiler/cli_adapter.vibe
+++ b/lib/@vibe/compiler/cli_adapter.vibe
@@ -523,6 +523,16 @@ fn adapter_program_parses(src: String) -> Bool {
   } with { Exception::Throw(_) => false }
 }
 
+/// "" when `src` parses, else the parser's message -- the VIBE_FMT branch
+/// puts it in the `.diag` sidecar so the refusal names what is wrong with the
+/// file (lib/@vibe/cli/fmt_entry.vibe's `parse_error_of`, #2636).
+fn adapter_parse_error_of(src: String) -> String {
+  handle {
+    let _ = parse_program(lex(src))
+    ""
+  } with { Exception::Throw(msg) => msg }
+}
+
 fn adapter_string_to_bytes(s: String) -> Bytes {
   let out = Array::slice([0], 0, 0)
   let len = String::length(s)
@@ -1587,10 +1597,12 @@ fn cli_main_with_lanes(fs_lanes: (FsLane, String, String) -> (Bytes, String) wit
   // the path an installed user runs, where no CI fmt gate is watching.
   //
   // On refusal the INPUT is written back, so the caller always has a valid
-  // file at output_path; the non-zero return is what says "I refused". The
-  // runner exits 0 whatever this returns and prints the value as the last
-  // stdout line, so runtime/vibe's `fmt` arm reads that line -- discarding it
-  // is how a refusal once looked exactly like "nothing to change" (#1821).
+  // file at output_path; the non-zero return is what says "I refused": 2 when
+  // the input does not parse (the parse error is in the `.diag` sidecar), 1
+  // when the formatted output does not parse and the input did. The runner
+  // exits 0 whatever this returns and prints the value as the last stdout
+  // line, so runtime/vibe's `fmt` arm reads that line -- discarding it is how
+  // a refusal once looked exactly like "nothing to change" (#1821).
   if Env::get("VIBE_FMT") == "1" {
     let src = Fs::read_file(input_path)
     // #730 (D-3): pinned form is canonical, so fmt completes an unpinned
@@ -1604,17 +1616,24 @@ fn cli_main_with_lanes(fs_lanes: (FsLane, String, String) -> (Bytes, String) wit
     // require-head split (#1435, #2253 round 6).
     let formatted = format_source(input_path, fmt_pre)
     // A `.vpkg` header is not vibe syntax, so a whole-file parse never
-    // succeeds for one and the comparison would say nothing. format_vpkg
+    // succeeds for one and the questions below would say nothing. format_vpkg
     // already refuses to touch a header it cannot read -- the same policy
     // reached by a different route (#1435).
     //
-    // Only a rewrite that BREAKS something is rejected. A file that did not
-    // parse to begin with is still formatted: the promise is "no worse", not
-    // "only valid input". A require-pin head is not vibe syntax either and
-    // is reattached verbatim, so the parse question is asked of the BODY --
-    // both source and output start their body at the same boundary
-    // (source_header_end; -1 refused and 0 absent both mean "the body is
-    // the whole file").
+    // Two questions, both asked of the BODY (a require-pin head is not vibe
+    // syntax either and is reattached verbatim, so source and output start
+    // their body at the same boundary -- source_header_end; -1 refused and 0
+    // absent both mean "the body is the whole file"). First: does the INPUT
+    // parse? If not it is not a program, and no spelling is minted for it
+    // (#2636: `cond ? a : b` was reflowed into text that still did not parse,
+    // which `--check` then certified. lib/@vibe/cli/fmt_entry.vibe refused
+    // that first; this branch -- the route an installed user takes -- kept
+    // formatting under an older "no worse" promise until Codex found it on
+    // #2708). The parse error goes to the `.diag` sidecar and the verdict is
+    // 2, which runtime/vibe's `fmt` arm reports as "does not parse" with the
+    // edit named, not as a formatter bug. Second: does the OUTPUT parse? A
+    // rewrite that breaks a program that parsed is the formatter's own
+    // defect, verdict 1.
     let fmt_head_end = if adapter_path_has_suffix(input_path, ".vpkg") {
       0
     } else {
@@ -1627,7 +1646,18 @@ fn cli_main_with_lanes(fs_lanes: (FsLane, String, String) -> (Bytes, String) wit
     }
     let fmt_body = String::substring(fmt_pre, fmt_head_end, String::length(fmt_pre))
     let fmt_formatted_body = String::substring(formatted, fmt_head_end, String::length(formatted))
-    if !adapter_path_has_suffix(input_path, ".vpkg") && adapter_program_parses(fmt_body) && !adapter_program_parses(fmt_formatted_body) {
+    let fmt_is_vpkg = adapter_path_has_suffix(input_path, ".vpkg")
+    let fmt_input_error = if fmt_is_vpkg {
+      ""
+    } else {
+      adapter_parse_error_of(fmt_body)
+    }
+    if String::length(fmt_input_error) > 0 {
+      let _ = emit_compile_diag(output_path, String::concat("vibe fmt: refusing to format ", String::concat(input_path, String::concat(": it does not parse\n  ", fmt_input_error))))
+      Fs::write_bytes(output_path, adapter_string_to_bytes(src))
+      return 2
+    }
+    if !fmt_is_vpkg && !adapter_program_parses(fmt_formatted_body) {
       Fs::write_bytes(output_path, adapter_string_to_bytes(src))
       return 1
     }

--- a/lib/@vibe/compiler/runtime/symbol_spans.vibe
+++ b/lib/@vibe/compiler/runtime/symbol_spans.vibe
@@ -189,13 +189,57 @@ fn sym_string_is(t: Token, text: String) -> Bool {
   }
 }
 
-/// A `test "X"` / `bench "X"` block: its span is the label's text inside the
-/// quotes (the string literal token after the keyword), or the keyword itself
-/// when the label is empty (the parser rejects an unnamed block; `test ""` is
-/// the stand-in, and the keyword is the stable outline name for it, #1944).
-/// Kind 27 / 28, not Function: a block label is not a declaration of the
-/// spelling it carries (#2632).
-fn sym_emit_block(out: Array[(String, Int, Int, Int)], tokens: Array[Token], starts: Array[Int], ends: Array[Int], label: String, keyword: String, kind: Int, floor: Array[Int], hi: Int) -> Unit {
+/// The bytes of a string literal token's CONTENT, read from its delimiters
+/// in the source: a plain `"…"` is one byte in on each side, a raw `r"…"`
+/// two in and one back, and a `#|…` block starts two in and runs to the
+/// token's end (the lexer ends it at the line end, so nothing trails). An
+/// unrecognised spelling keeps the whole token rather than guessing. All
+/// three lex to one `TString`, so the token alone cannot say which (Codex on
+/// #2708: `test r"name"` reported the opening quote as the label's first
+/// byte).
+fn sym_string_content_span(source: String, s: Int, e: Int) -> (Int, Int) {
+  let n = String::length(source)
+  let c0 = if s < n {
+    String::char_code_at(source, s)
+  } else {
+    0
+  }
+  let c1 = if s + 1 < n {
+    String::char_code_at(source, s + 1)
+  } else {
+    0
+  }
+  if c0 == '"' {
+    (s + 1, if e - 1 > s + 1 {
+      e - 1
+    } else {
+      s + 1
+    })
+  } else if c0 == 'r' && c1 == '"' {
+    (s + 2, if e - 1 > s + 2 {
+      e - 1
+    } else {
+      s + 2
+    })
+  } else if c0 == '#' && c1 == '|' {
+    (s + 2, if e > s + 2 {
+      e
+    } else {
+      s + 2
+    })
+  } else {
+    (s, e)
+  }
+}
+
+/// A `test "X"` / `bench "X"` block: its span is the label's text inside its
+/// delimiters (the string literal token after the keyword --
+/// `sym_string_content_span`), or the keyword itself when the label is empty
+/// (the parser rejects an unnamed block; `test ""` is the stand-in, and the
+/// keyword is the stable outline name for it, #1944). Kind 27 / 28, not
+/// Function: a block label is not a declaration of the spelling it carries
+/// (#2632).
+fn sym_emit_block(out: Array[(String, Int, Int, Int)], source: String, tokens: Array[Token], starts: Array[Int], ends: Array[Int], label: String, keyword: String, kind: Int, floor: Array[Int], hi: Int) -> Unit {
   let ntok = Array::length(tokens)
   let mut k = sym_first_token_at(starts, Array::get(floor, 0))
   let mut found = false
@@ -208,7 +252,8 @@ fn sym_emit_block(out: Array[(String, Int, Int, Int)], tokens: Array[Token], sta
       } else if k + 1 < ntok && sym_string_is(Array::get(tokens, k + 1), label) {
         let s = Array::get(starts, k + 1)
         let e = Array::get(ends, k + 1)
-        Array::push(out, (label, kind, s + 1, e - 1))
+        let (cs, ce) = sym_string_content_span(source, s, e)
+        Array::push(out, (label, kind, cs, ce))
         Array::set(floor, 0, e)
         found = true
       } else {
@@ -254,7 +299,7 @@ fn sym_let_kind(body: Expr) -> Int {
 /// Tests/benches are 27 / 28 (see the header). An `impl Trait for T` is one
 /// Method (6) named after T, located after the `for` token: SImpl carries no
 /// method children (`parse_program_spans` skips the body).
-fn sym_walk_stmt(out: Array[(String, Int, Int, Int)], tokens: Array[Token], starts: Array[Int], ends: Array[Int], stmt: Stmt, floor: Array[Int], hi: Int) -> Unit {
+fn sym_walk_stmt(out: Array[(String, Int, Int, Int)], source: String, tokens: Array[Token], starts: Array[Int], ends: Array[Int], stmt: Stmt, floor: Array[Int], hi: Int) -> Unit {
   match stmt {
     SLet(_, _, name, _, body) => sym_emit(out, tokens, starts, ends, name, sym_let_kind(body), floor, hi),
     SFnDecl(_, name, _, _, _) => sym_emit(out, tokens, starts, ends, name, 12, floor, hi),
@@ -274,13 +319,13 @@ fn sym_walk_stmt(out: Array[(String, Int, Int, Int)], tokens: Array[Token], star
       sym_emit(out, tokens, starts, ends, type_name, 6, floor, hi)
     },
     SEffectDef(_, name, _, _) => sym_emit(out, tokens, starts, ends, name, 24, floor, hi),
-    STest(name, _) => sym_emit_block(out, tokens, starts, ends, name, "test", 27, floor, hi),
-    SBench(name, _) => sym_emit_block(out, tokens, starts, ends, name, "bench", 28, floor, hi),
+    STest(name, _) => sym_emit_block(out, source, tokens, starts, ends, name, "test", 27, floor, hi),
+    SBench(name, _) => sym_emit_block(out, source, tokens, starts, ends, name, "bench", 28, floor, hi),
     SModule(_, name, body) => {
       sym_emit(out, tokens, starts, ends, name, 2, floor, hi)
       let mut j = 0
       while j < Array::length(body) {
-        sym_walk_stmt(out, tokens, starts, ends, Array::get(body, j), floor, hi)
+        sym_walk_stmt(out, source, tokens, starts, ends, Array::get(body, j), floor, hi)
         j = j + 1
       }
     },
@@ -312,7 +357,7 @@ fn symbol_spans_impl(source: String) -> Array[(String, Int, Int, Int)] with Exce
         String::length(source)
       }
       let floor = sym_box_int(lo)
-      sym_walk_stmt(out, tokens, starts, ends, Array::get(span_stmts, i), floor, hi)
+      sym_walk_stmt(out, source, tokens, starts, ends, Array::get(span_stmts, i), floor, hi)
       i = i + 1
     }
     out

--- a/lib/@vibe/compiler/runtime/symbol_spans_test.vibe
+++ b/lib/@vibe/compiler/runtime/symbol_spans_test.vibe
@@ -136,6 +136,22 @@ test "symbol_spans: a label's span is the text inside the quotes" {
   inspect(String::concat(name, String::concat(" ", String::concat(__to_string(kind), String::concat(" ", String::concat(__to_string(s), String::concat(" ", __to_string(e))))))), "adds 27 6 10")
 }
 
+test "symbol_spans: a raw-string label starts after the r and the quote (Codex on #2708)" {
+  // `test r"adds"` -- the TString token starts at the `r` (byte 5), so the
+  // label's own bytes are 7..11, not 6..11.
+  let syms = symbol_spans("test r\"adds\" {\n  let _ = 1\n}\n")
+  let (name, kind, s, e) = Array::get(syms, 0)
+  inspect(String::concat(name, String::concat(" ", String::concat(__to_string(kind), String::concat(" ", String::concat(__to_string(s), String::concat(" ", __to_string(e))))))), "adds 27 7 11")
+}
+
+test "symbol_spans: a #| block label starts after the delimiter (Codex on #2708)" {
+  // `test #|adds` with the block on the next line: the token starts at the
+  // `#` (byte 5) and ends at the line end (11); the label is 7..11.
+  let syms = symbol_spans("test #|adds\n{\n  let _ = 1\n}\n")
+  let (name, kind, s, e) = Array::get(syms, 0)
+  inspect(String::concat(name, String::concat(" ", String::concat(__to_string(kind), String::concat(" ", String::concat(__to_string(s), String::concat(" ", __to_string(e))))))), "adds 27 7 11")
+}
+
 test "symbol_spans: a declaration is located at its token, never at a copy inside a comment (#2632)" {
   // The #2626 counterexample: the comment carries the name first (bytes
   // 14..28, quoted on both sides); the declaration's own token is at 30.

--- a/runtime/vibe
+++ b/runtime/vibe
@@ -2484,6 +2484,24 @@ case "$cmd" in
       [ -s "$out.err" ] && cat "$out.err" >&2
       die "fmt failed: $src"
     fi
+    if [ "$frc" = "2" ]; then
+      # The INPUT does not parse (#2636): the adapter wrote the parse error to
+      # $out.diag and the input back to $out. Not a formatter defect -- say
+      # what is wrong with the file and name the edit, and leave it alone in
+      # every mode (a --check that compared $out to $src would call it
+      # "formatted"; that is the fixpoint #2636 is about).
+      [ -s "$out.err" ] && cat "$out.err" >&2
+      if [ -s "$out.diag" ]; then
+        cat "$out.diag" >&2
+        echo >&2
+      else
+        echo "vibe fmt: refusing to format $src: it does not parse" >&2
+      fi
+      echo "  Fix the program first. The formatter only reflows source the compiler" >&2
+      echo "  accepts; reflowing text it rejects would mint a spelling for a program" >&2
+      echo "  that does not exist (#2636). The file is unchanged." >&2
+      exit 1
+    fi
     if [ "$frc" != "0" ]; then
       # The guard fired: the formatted output does not parse and the input
       # did. $out holds the INPUT unchanged, so writing it would be a silent

--- a/scripts/test_vibe_fmt_launcher.sh
+++ b/scripts/test_vibe_fmt_launcher.sh
@@ -86,6 +86,32 @@ for mode in "" "--check" "--stdout"; do
 done
 [ "$(cat "$SRC")" = "let   a=1" ] || fail "a refused format still rewrote the source file"
 
+# THE OTHER REFUSAL (#2636, Codex on #2708). The runner reports 2 -- the INPUT
+# does not parse -- writes the parse error to $out.diag and the input back to
+# $out. The arm must print that error and name the edit, NOT the "bug in the
+# formatter" text of verdict 1, and must leave the file alone in every mode.
+PARSE_REFUSE_RUNNER="$TMP_DIR/parse-refuse-runner"
+printf '%s\n' \
+  '#!/usr/bin/env bash' \
+  'cat "$2" > "$3"' \
+  'printf "vibe fmt: refusing to format %s: it does not parse\n  unexpected token: ?" "$2" > "$3.diag"' \
+  'echo 2' > "$PARSE_REFUSE_RUNNER"
+chmod +x "$PARSE_REFUSE_RUNNER"
+printf 'let a=x?1:2\n' > "$SRC"
+for mode in "" "--check" "--stdout"; do
+  # shellcheck disable=SC2086
+  if VIBE_RUNNER="$PARSE_REFUSE_RUNNER" VIBE_CLI_WASM="$CLI" \
+    bash "$ROOT_DIR/runtime/vibe" fmt $mode "$SRC" > "$OUT" 2> "$ERR"; then
+    fail "an input that does not parse was formatted (exit 0) in mode '${mode:-write}'"
+  fi
+  grep -q "does not parse" "$ERR" || fail "an input that does not parse was not reported as such in mode '${mode:-write}'"
+  grep -q "unexpected token" "$ERR" || fail "the parse error did not reach the user in mode '${mode:-write}'"
+  if grep -q "bug in" "$ERR"; then
+    fail "an input that does not parse was reported as a formatter bug in mode '${mode:-write}'"
+  fi
+done
+[ "$(cat "$SRC")" = "let a=x?1:2" ] || fail "an input that does not parse was rewritten"
+
 # A runner that produces no output must not be reported as a clean format.
 EMPTY_RUNNER="$TMP_DIR/empty-runner"
 printf '%s\n' '#!/usr/bin/env bash' 'exit 23' > "$EMPTY_RUNNER"

--- a/scripts/test_vibe_symbols.sh
+++ b/scripts/test_vibe_symbols.sh
@@ -152,6 +152,17 @@ else
   bad "symbols should report [String::length 12 30 44]; got: $out_cm2"
 fi
 
+# 7c. Codex on #2708: a raw-string label `r"name"` starts its span at the name,
+#     not at the opening quote (the TString token starts at the `r`).
+rl="$WORK/raw_label.vibe"
+printf 'test r"adds" { let _ = 1 }\n' > "$rl"
+out_rl="$("$VIBE" symbols "$rl" 2>/dev/null || true)"
+if [ "$out_rl" = "adds 27 7 11" ]; then
+  ok "symbols starts a raw-string label at the name"
+else
+  bad "symbols should report [adds 27 7 11] for a raw-string label; got: $out_rl"
+fi
+
 # --- #2381: arguments are no longer accepted and ignored --------------------
 # Every case below used to print a.vibe's outline and exit 0, so a caller who
 # believed they had asked about two files -- or who typo'd a flag -- got a

--- a/tests/gates/late/run.sh
+++ b/tests/gates/late/run.sh
@@ -6178,6 +6178,36 @@ if ! cmp -s "$fmtdir/expected.vibe" "$fmtdir/out.vibe"; then
 fi
 rm -rf "$fmtdir"
 echo "[compiler-gate] vibe fmt ok (#2149)"
+#      ...and #2636 on that same INSTALLED route (Codex on #2708): the branch
+#      above is what runtime/vibe's `fmt` arm runs, and it formatted input that
+#      did not parse -- `a==0?"z":"nz"` came back reflowed as
+#      `a == 0?"z": "nz"` with verdict 0, which `--check` then certified.
+#      Verdict 2, the input written back byte-for-byte, and the parse error in
+#      the .diag sidecar; the messy file above already pins that a program
+#      which parses is still formatted with verdict 0.
+fmtdir="_build/_gate_vibe_fmt_parse"
+rm -rf "$fmtdir"; mkdir -p "$fmtdir"
+printf 'fn f(a: Int) -> String {\n  a==0?"z":"nz"\n}\n' > "$fmtdir/ternary.vibe"
+fmt_rc="$(VIBE_PREOPEN_DIR="$ROOT_DIR" VIBE_IMPORT_ABI=raw VIBE_FMT=1 \
+  bash scripts/run_wasm_vibe_host_runner.sh --invoke cli_main "$stage2_wasm" \
+  "$fmtdir/ternary.vibe" "$fmtdir/out.vibe" 2>"$fmtdir/run.err" | tail -1 || true)"
+if [ "$fmt_rc" != "2" ]; then
+  echo "[compiler-gate] FAIL: VIBE_FMT on a file that does not parse returned '$fmt_rc', not 2 -- the installed vibe fmt formats programs the compiler rejects (#2636)" >&2
+  cat "$fmtdir/run.err" >&2 || true
+  exit 1
+fi
+if ! cmp -s "$fmtdir/ternary.vibe" "$fmtdir/out.vibe"; then
+  echo "[compiler-gate] FAIL: VIBE_FMT rewrote a file that does not parse (#2636)" >&2
+  diff -u "$fmtdir/ternary.vibe" "$fmtdir/out.vibe" >&2 || true
+  exit 1
+fi
+if ! grep -qF 'does not parse' "$fmtdir/out.vibe.diag" 2>/dev/null || ! grep -qF 'unexpected token' "$fmtdir/out.vibe.diag" 2>/dev/null; then
+  echo "[compiler-gate] FAIL: VIBE_FMT's refusal did not name the parse error in the .diag sidecar (#2636)" >&2
+  cat "$fmtdir/out.vibe.diag" >&2 2>/dev/null || true
+  exit 1
+fi
+rm -rf "$fmtdir"
+echo "[compiler-gate] vibe fmt refuses a file that does not parse on the installed route ok (#2636)"
 
 # 108/108. The ADR-0068 concurrency surface is opt-in (#2248).
 #      docs/spec/stable-surface.md said the unstable surface "is reached only


### PR DESCRIPTION
The two findings Codex posted on #2708 four minutes before it merged, both reproduced on main. #2717 merged one commit earlier than this one, so these carry over into their own pull request.

## The installed `vibe fmt` still formatted a file that does not parse (P1)

`runtime/vibe fmt` runs `cli_adapter.vibe`'s `VIBE_FMT` branch, not `lib/@vibe/cli/fmt_entry.vibe` — the entry #2636 fixed — and that branch kept the older "no worse" promise. Measured on the merged stage2:

```
$ printf 'fn f(a: Int) -> String {\n  a==0?"z":"nz"\n}\n' > ternary.vibe
$ VIBE_FMT=1 ... cli_main ternary.vibe out.vibe
0
$ cat out.vibe
fn f(a: Int) -> String {
  a == 0?"z": "nz"
}
```

Verdict 0 on text the compiler rejects, which `--check` then certifies — the #2636 symptom, on the route an installed user takes.

The branch now asks `fmt_entry`'s two questions in the same order. An input body that does not parse is written back byte-for-byte with the parse error in the `.diag` sidecar and verdict 2; the launcher reports that as "does not parse" with the edit named, not as a formatter bug. Only then is a rewrite that breaks a parsing input refused with verdict 1, which is the formatter's own defect and keeps its existing message.

Pinned two ways, because the shell arm and the guest branch rot separately: `scripts/test_vibe_fmt_launcher.sh` drives a fake runner that reports 2 and asserts all three modes exit non-zero, print the parse error, do not print the "bug in the formatter" text, and leave the file alone; a late-gate row runs the real stage2 on the ternary file and asserts verdict 2, the input unchanged, and the parse error in the sidecar.

## A raw-string test label's span started at the opening quote (P2)

`test r"name"` and a `#|` block both lex to one `TString` whose token starts at the `r` / `#`, and the block emitter assumed one-byte quotes — measured, `test r"adds"` reported `adds 27 46 51` where the label's bytes are 47..51. The content span is now read from the delimiters in the source (`sym_string_content_span`: `"…"` one byte in on each side, `r"…"` two in and one back, `#|…` two in to the token's end, anything else the whole token). `symbol_spans_test.vibe` pins `adds 27 7 11` for both spellings and `scripts/test_vibe_symbols.sh` the raw-string one through the CLI.

## Validation

On a stage2 built from this branch: the full compiler gate including the new late-gate row, `scripts/test_vibe_symbols.sh` (20 cases), `scripts/test_vibe_fmt_launcher.sh`, `scripts/check_selector_precedence.sh`, `scripts/check_gate_portability.sh`, the size ratchet and pre-commit. The touched unit tests pass on both the seed and that stage2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F7tdQxr8PHL7ZAma4XAF8P

---
_Generated by [Claude Code](https://claude.ai/code/session_01F7tdQxr8PHL7ZAma4XAF8P)_