### PR TITLE
fix: preserve grep ranges for lowered assignments

### DIFF
--- a/docs/editor-and-debugging.md
+++ b/docs/editor-and-debugging.md
@@ -315,12 +315,6 @@ $ vibe grep --pattern 'f($(x:expr))' lib
 error: grep pattern: unknown metavariable kind `expr` — use one of exp, id, const, arg, args, pat, type
 ```
 
-`text` is the **printer's canonical rendering** of the matched node and is the
-exact, complete description of what matched. `end` is a *lower bound* on the
-source extent: only identifier-shaped tokens carry offsets in this AST, so
-trailing punctuation and literals are not counted. Use `text`, not `[start,
-end)`, when you need to know what the match was.
-
 A file that does not parse is skipped, not fatal: a repo sweep must not stop at
 the first work-in-progress file. The skip is reported on stderr
 (`warning: grep: skipped \`path\` because it could not be parsed`) so empty

--- a/lib/@vibe/compiler/runtime/grep_source_ranges_test.vibe
+++ b/lib/@vibe/compiler/runtime/grep_source_ranges_test.vibe
@@ -145,3 +145,15 @@ test "grep a captured block includes its bindings and result" {
   inspect(slices("let x = f({ let n = 1; n + 2 })", "f($(b:exp))"), "f({ let n = 1; n + 2 })\nb={ let n = 1; n + 2 }\n")
   inspect(slices("let x = f({ let n = 1; n + 2 })", "{ let $(n:id) = $(v:exp); $(b:exp) }"), "{ let n = 1; n + 2 }\nn=n\nv=1\nb=n + 2\n")
 }
+
+test "grep index assignments retain their statement and operand ranges" {
+  let pattern = "$(a:exp)[$(i:exp)] = $(v:exp)"
+  let expected = "arr[i] = value\na=arr\ni=i\nv=value\n"
+  inspect(slices("arr[i] = value", pattern), expected)
+  inspect(slices("fn f() -> Unit { arr[i] = value; () }", pattern), expected)
+  inspect(slices("fn f() -> Unit { match x { _ => arr[i] = value } }", pattern), expected)
+  inspect(slices("fn f() -> Unit { handle { get() } with E { Get(n) => arr[i] = value } }", pattern), expected)
+  inspect(slices("fn f() -> Unit { handle { get() } with { E::Get(n) => arr[i] = value } }", pattern), expected)
+  inspect(slices("fn f() -> Unit { let* x = get(); arr[i] = value; () }", pattern), expected)
+  inspect(slices("fn f() -> Unit { obj.field = value; () }", "__set_field($(r:exp), \"field\", $(v:exp))"), "obj.field = value\nr=obj\nv=value\n")
+}

--- a/lib/@vibe/parser/parser.vibe
+++ b/lib/@vibe/parser/parser.vibe
@@ -611,7 +611,7 @@ export fn parse_stmt_preserving_with_binder_context(tokens: Array[Token], starts
                 Array::push(set_args, Array::get(idx_args, 0))
                 Array::push(set_args, Array::get(idx_args, 1))
                 Array::push(set_args, val)
-                (SExpr(ECall(EIdent("Array::set", -1), set_args, -1)), vn)
+                (SExpr(source_wrap_expr(ECall(EIdent("Array::set", -1), set_args, -1), pos, vn, context)), vn)
               } else {
                 (SExpr(e), next)
               }

--- a/lib/@vibe/parser/parser_expr_dispatch.vibe
+++ b/lib/@vibe/parser/parser_expr_dispatch.vibe
@@ -440,7 +440,7 @@ fn collect_match_arms(tokens: Array[Token], starts: Array[Int], pos: Int, b: Arr
   let mut bn = raw_bn
   if arm_assign_follows(peek(tokens, raw_bn)) {
     let (assigned, after_assign) = parse_arm_assign_tail(tokens, raw_body, raw_bn, parse_recur, context)
-    body = assigned
+    body = source_wrap_expr(assigned, arrow, after_assign, context)
     bn = after_assign
   }
   let body_rows = binder_capture_take_from(context, body_mark)
@@ -522,7 +522,7 @@ fn parse_handle_arm(tokens: Array[Token], starts: Array[Int], pos: Int, effect_n
   let mut next = raw_next
   if arm_assign_follows(peek(tokens, raw_next)) {
     let (assigned, after_assign) = parse_arm_assign_tail(tokens, raw_expr, raw_next, parse_recur, context)
-    expr = assigned
+    expr = source_wrap_expr(assigned, arrow_pos, after_assign, context)
     next = after_assign
   }
   ((source_wrap_pat(qualified_pat, pos, pat_next, context), expr), next)
@@ -567,7 +567,7 @@ fn parse_qualified_handle_arm(tokens: Array[Token], starts: Array[Int], pos: Int
   let mut next = raw_next
   if arm_assign_follows(peek(tokens, raw_next)) {
     let (assigned, after_assign) = parse_arm_assign_tail(tokens, raw_expr, raw_next, parse_recur, context)
-    expr = assigned
+    expr = source_wrap_expr(assigned, arrow_pos, after_assign, context)
     next = after_assign
   }
   ((source_set_pat_qualifier(source_wrap_pat(source_rewrap_pat(pat, qualified_pat), pos, pat_next, context), pos, operation_pos - 1, context), expr), next)
@@ -1364,7 +1364,7 @@ fn parse_impl_block(tokens: Array[Token], starts: Array[Int], pos: Int, parse_re
                 Array::push(set_args, obj)
                 Array::push(set_args, EString(field))
                 Array::push(set_args, val)
-                ArrayBuilder::push(steps, StepSeq(ECall(EIdent("__set_field", -1), set_args, -1)))
+                ArrayBuilder::push(steps, StepSeq(source_wrap_expr(ECall(EIdent("__set_field", -1), set_args, -1), p, block_source_end(tokens, next_pos), context)))
                 p = next_pos
               },
               ECall(sidx_callee, sidx_args, _) => {
@@ -1380,7 +1380,7 @@ fn parse_impl_block(tokens: Array[Token], starts: Array[Int], pos: Int, parse_re
                   Array::push(set_args, Array::get(sidx_args, 0))
                   Array::push(set_args, Array::get(sidx_args, 1))
                   Array::push(set_args, val)
-                  ArrayBuilder::push(steps, StepSeq(ECall(EIdent("Array::set", -1), set_args, -1)))
+                  ArrayBuilder::push(steps, StepSeq(source_wrap_expr(ECall(EIdent("Array::set", -1), set_args, -1), p, block_source_end(tokens, next_pos), context)))
                   p = next_pos
                 } else {
                   throw("invalid assignment target")


### PR DESCRIPTION
`vibe grep` matched `arr[i] = value` but reported a synthetic match with null bounds because the parser lowered the assignment to an unlocated `Array::set` call. Preserve the statement interval on lowered assignments at the top level, in blocks, and in match/handle arms. Operand captures retain their individual source ranges. Field assignments in blocks receive the same treatment.

Remove the obsolete documentation paragraph that still described `end` as a lower bound.

Follow-up to #2719, addressing its two review findings after that PR merged.

Validation:
- Regression cases cover top-level/block assignments, match arms, both handler forms, railway continuations, and field writes.
- 87 targeted tests, source-range negative controls, and CLI byte slicing pass with a fresh stage2.
- Normal and annotated parsing agree across 2,397 accepted fixture/library sources; stage2 and stage3 are byte-identical.
