### PR TITLE
`vibe symbols`: a multi-line `#|` label spans its literal and stays on one row (Codex on #2718)

### DIFF
--- a/docs/editor-and-debugging.md
+++ b/docs/editor-and-debugging.md
@@ -87,17 +87,31 @@ vibe check --single-file --json <file.vibe>  # same diagnostics as a JSON array 
   `START END` are byte offsets of the declaration name. Because it walks the
   parsed AST (not a line regex) it handles multi-line declarations and
   module-nested symbols and never reports a name that only appears in a string
-  or comment. Tests and benches are Function (12). An empty test/bench name
-  is outlined as the keyword `test`/`bench`. An `impl Trait for T` is one
-  Method (6) named after `T` — the impl statement does not carry method
-  children.
+  or comment. Tests and benches are Test (27) / Bench (28) — see the legend
+  below. An empty test/bench name is outlined as the keyword `test`/`bench`.
+  An `impl Trait for T` is one Method (6) named after `T` — the impl
+  statement does not carry method children.
 - **Doc comments (`DOC`).** A declaration's `///` doc comment is appended as a
   fifth field, present only when it has one — a declaration without a doc emits
   the same four fields it always did, with no trailing space. The doc is last
-  because it is the only field that can contain spaces, so `cut -d" " -f1-4`
+  because it was the only field that could contain spaces, so `cut -d" " -f1-4`
   still reads the fixed part; inside it a newline is the two characters `\n`
   and a backslash is doubled, so one declaration is always one line. The
   structured form (real newlines, for LSP detail) is `symbol_spans_with_docs`.
+- **A label is a string, so `NAME` is escaped too.** A declaration's name is an
+  identifier, but a `test` / `bench` label is a string literal: it can hold a
+  backslash, and a multi-line `#|` label holds a real newline. In `NAME` those
+  are written `\\`, `\n` and `\r`, so **one symbol is always one line** —
+  unescaped, a two-line label printed as two rows and a reader counted a symbol
+  that does not exist. `cut -d" " -f1-4` is still not enough for a label,
+  because `NAME` can contain a SPACE and nothing yet says where it ends
+  (#2723). The structured form has the real name.
+- **A multi-line `#|` label spans the literal, not its content.** `"…"`,
+  `r"…"` and a single-line `#|…` report the bytes inside the delimiters. A
+  `#|` block continued on the next line is the one spelling whose content is
+  not contiguous — the lexer joins the lines and drops the indentation and the
+  continuation `#|` — so `START END` covers the whole literal token instead of
+  a range that would present those delimiters as label text.
 - **SymbolKind legend v2 (2026-09-12).** `KIND` integers are LSP
   [`SymbolKind`](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#symbolKind)
   values, plus two of the command's own past that range: 27 Test and 28

--- a/lib/@vibe/compiler/cli_adapter.vibe
+++ b/lib/@vibe/compiler/cli_adapter.vibe
@@ -352,11 +352,47 @@ fn escape_doc_field(text: String) -> String {
   StringBuilder::freeze(acc)
 }
 
+/// Escape a NAME so it survives as ONE line. A declaration's name cannot
+/// contain either byte, but a `test` / `bench` label is a string literal and
+/// a multi-line `#|` one carries a real newline (Codex on #2718) -- emitted
+/// raw it splits one record across two lines, so a reader counting rows sees
+/// a symbol that does not exist. Same reversible scheme as the doc field
+/// (backslash first), with `\r` kept rather than dropped: a byte inside a
+/// name is not noise to discard.
+fn escape_name_field(text: String) -> String {
+  let n = String::length(text)
+  let acc = StringBuilder::new()
+  let mut i = 0
+  while i < n {
+    let c = String::char_code_at(text, i)
+    if c == 92 {
+      StringBuilder::push(acc, "\\\\")
+    } else {
+      if c == 10 {
+        StringBuilder::push(acc, "\\n")
+      } else {
+        if c == 13 {
+          StringBuilder::push(acc, "\\r")
+        } else {
+          StringBuilder::push(acc, String::from_char_code(c))
+        }
+      }
+    }
+    i = i + 1
+  }
+  StringBuilder::freeze(acc)
+}
+
 /// One `NAME KIND START END` per declaration, with the `///` doc comment
 /// appended as a FIFTH field when the declaration has one. The doc goes last
-/// because it is the only field that can contain spaces, so `cut -f1-4` still
-/// reads the fixed part -- and a declaration with no doc emits exactly the
-/// four fields it always did, with no trailing space.
+/// because it WAS the only field that could contain spaces, so `cut -f1-4`
+/// still reads the fixed part -- and a declaration with no doc emits exactly
+/// the four fields it always did, with no trailing space. That reasoning
+/// stopped holding when a `test` / `bench` label became a symbol: its NAME is
+/// a string literal, usually a sentence. Which encoding those rows get is a
+/// contract decision, tracked in #2723. A newline in a NAME is escaped here
+/// regardless (`escape_name_field`) -- it breaks the RECORD boundary, not
+/// merely the field one, so a reader counts a symbol that does not exist.
 fn join_symbol_spans(syms: Array[(String, Int, Int, Int, String)]) -> String {
   let n = Array::length(syms)
   // O(N) join via StringBuilder; per-record String::concat was O(N²) (issue #366).
@@ -368,7 +404,7 @@ fn join_symbol_spans(syms: Array[(String, Int, Int, Int, String)]) -> String {
     if String::length(name) == 0 {
       ()
     } else {
-      let head = String::concat(name, String::concat(" ", String::concat(__to_string(kind), String::concat(" ", String::concat(__to_string(s), String::concat(" ", __to_string(e)))))))
+      let head = String::concat(escape_name_field(name), String::concat(" ", String::concat(__to_string(kind), String::concat(" ", String::concat(__to_string(s), String::concat(" ", __to_string(e)))))))
       let line = if String::length(doc) == 0 {
         head
       } else {
@@ -403,7 +439,7 @@ fn join_symbol_spans_with_path(rows: Array[(String, String, Int, Int, Int, Strin
     if String::length(name) == 0 {
       ()
     } else {
-      let head = String::concat(path, String::concat(" ", String::concat(name, String::concat(" ", String::concat(__to_string(kind), String::concat(" ", String::concat(__to_string(s), String::concat(" ", __to_string(e)))))))))
+      let head = String::concat(path, String::concat(" ", String::concat(escape_name_field(name), String::concat(" ", String::concat(__to_string(kind), String::concat(" ", String::concat(__to_string(s), String::concat(" ", __to_string(e)))))))))
       let line = if String::length(doc) == 0 {
         head
       } else {

--- a/lib/@vibe/compiler/runtime/symbol_spans.vibe
+++ b/lib/@vibe/compiler/runtime/symbol_spans.vibe
@@ -189,14 +189,44 @@ fn sym_string_is(t: Token, text: String) -> Bool {
   }
 }
 
+/// Does the source slice `[s, e)` cross a line boundary? Only a `#|` block
+/// can, and only by continuing on the next physical line.
+fn sym_span_has_newline(source: String, s: Int, e: Int) -> Bool {
+  let n = String::length(source)
+  let hi = if e < n {
+    e
+  } else {
+    n
+  }
+  let mut i = s
+  let mut found = false
+  while i < hi && !found {
+    if String::char_code_at(source, i) == '\n' {
+      found = true
+    } else {
+      ()
+    }
+    i = i + 1
+  }
+  found
+}
+
 /// The bytes of a string literal token's CONTENT, read from its delimiters
 /// in the source: a plain `"…"` is one byte in on each side, a raw `r"…"`
-/// two in and one back, and a `#|…` block starts two in and runs to the
-/// token's end (the lexer ends it at the line end, so nothing trails). An
-/// unrecognised spelling keeps the whole token rather than guessing. All
-/// three lex to one `TString`, so the token alone cannot say which (Codex on
-/// #2708: `test r"name"` reported the opening quote as the label's first
-/// byte).
+/// two in and one back, and a single-line `#|…` block starts two in and runs
+/// to the token's end. An unrecognised spelling keeps the whole token rather
+/// than guessing. All three lex to one `TString`, so the token alone cannot
+/// say which (Codex on #2708: `test r"name"` reported the opening quote as
+/// the label's first byte).
+///
+/// A `#|` block that CONTINUES over several physical lines is the one
+/// spelling whose content is not contiguous in the source: the lexer joins
+/// each line's text with "\n" and drops the indentation and the continuation
+/// `#|`, so no single interval holds the content and nothing else. There the
+/// whole literal token is returned instead of a range that would present
+/// those delimiters as label text (Codex on #2718). A trailing `\r` is not
+/// content either way: the lexer strips it per line but ends the token at
+/// the `\n`, so a CRLF source would otherwise carry it inside the span.
 fn sym_string_content_span(source: String, s: Int, e: Int) -> (Int, Int) {
   let n = String::length(source)
   let c0 = if s < n {
@@ -222,11 +252,20 @@ fn sym_string_content_span(source: String, s: Int, e: Int) -> (Int, Int) {
       s + 2
     })
   } else if c0 == '#' && c1 == '|' {
-    (s + 2, if e > s + 2 {
-      e
+    let stop = if e > s && e <= n && String::char_code_at(source, e - 1) == '\r' {
+      e - 1
     } else {
-      s + 2
-    })
+      e
+    }
+    if sym_span_has_newline(source, s, stop) {
+      (s, stop)
+    } else {
+      (s + 2, if stop > s + 2 {
+        stop
+      } else {
+        s + 2
+      })
+    }
   } else {
     (s, e)
   }

--- a/lib/@vibe/compiler/runtime/symbol_spans_test.vibe
+++ b/lib/@vibe/compiler/runtime/symbol_spans_test.vibe
@@ -152,6 +152,27 @@ test "symbol_spans: a #| block label starts after the delimiter (Codex on #2708)
   inspect(String::concat(name, String::concat(" ", String::concat(__to_string(kind), String::concat(" ", String::concat(__to_string(s), String::concat(" ", __to_string(e))))))), "adds 27 7 11")
 }
 
+test "symbol_spans: a multi-line #| label reports the whole literal token (Codex on #2718)" {
+  // `test #|one` continued by `     #|two` at the same column. The lexer
+  // joins the two lines as "one\ntwo" and drops the indentation and the
+  // second `#|`, so NO interval holds the content and nothing else: bytes
+  // 7..21 would read `one\n     #|two`, presenting the delimiters as label
+  // text. The literal token (5..21) is reported instead.
+  let src = "test #|one\n     #|two\n{\n  let _ = 1\n}\n"
+  let syms = symbol_spans(src)
+  let (_, kind, s, e) = Array::get(syms, 0)
+  assert(sym_has(syms, "one\ntwo", 27))
+  inspect(String::concat(__to_string(kind), String::concat(" ", String::concat(__to_string(s), String::concat(" ", __to_string(e))))), "27 5 21")
+}
+
+test "symbol_spans: a #| label's span stops before a CRLF's carriage return (Codex on #2718)" {
+  // The lexer strips the `\r` from each line's content but ends the token at
+  // the `\n`, so the byte before the token's end is not label text.
+  let syms = symbol_spans("test #|adds\r\n{\n  let _ = 1\n}\n")
+  let (name, kind, s, e) = Array::get(syms, 0)
+  inspect(String::concat(name, String::concat(" ", String::concat(__to_string(kind), String::concat(" ", String::concat(__to_string(s), String::concat(" ", __to_string(e))))))), "adds 27 7 11")
+}
+
 test "symbol_spans: a declaration is located at its token, never at a copy inside a comment (#2632)" {
   // The #2626 counterexample: the comment carries the name first (bytes
   // 14..28, quoted on both sides); the declaration's own token is at 30.

--- a/scripts/test_vibe_symbols.sh
+++ b/scripts/test_vibe_symbols.sh
@@ -163,6 +163,21 @@ else
   bad "symbols should report [adds 27 7 11] for a raw-string label; got: $out_rl"
 fi
 
+# 7d. Codex on #2718: a `#|` label continued on a second physical line. The
+#     lexer joins the lines as "one\ntwo" and drops the indentation and the
+#     continuation `#|`, so no interval holds the content and nothing else --
+#     7..21 would read `one\n     #|two`. The literal token (5..21) is
+#     reported instead, and the newline in the NAME is escaped so the record
+#     stays on ONE line (it used to print as two).
+ml="$WORK/multiline_label.vibe"
+printf 'test #|one\n     #|two\n{ let _ = 1 }\n' > "$ml"
+out_ml="$("$VIBE" symbols "$ml" 2>/dev/null || true)"
+if [ "$out_ml" = 'one\ntwo 27 5 21' ]; then
+  ok "symbols keeps a multi-line #| label on one row, spanning the literal"
+else
+  bad "symbols should report [one\\ntwo 27 5 21] for a multi-line label; got: $out_ml"
+fi
+
 # --- #2381: arguments are no longer accepted and ignored --------------------
 # Every case below used to print a.vibe's outline and exit 0, so a caller who
 # believed they had asked about two files -- or who typo'd a flag -- got a


### PR DESCRIPTION
Closes the Codex thread on #2718 ([discussion_r3996791487](https://github.com/mizchi/vibe-lang/pull/2718#discussion_r3996791487)), which landed four minutes after that PR opened and was never addressed there. Reproduced on a stage2 built from the merged `5df75ae`.

A `test` label written as a continued `#|` block:

```
test #|one
     #|two
{ let _ = 1 }
```

```
$ vibe symbols multi.vibe
one
two 27 7 21
```

Two defects in one row.

## The span covered the delimiters (the reported finding)

`7..21` slices as `one\n     #|two`. A continued `#|` block is the one label spelling whose content is **not contiguous** in the source: the lexer joins each line's text with `\n` and drops the indentation and the continuation `#|`, so no single interval holds the content and nothing else.

Took the first of the two options in the review — represent the literal honestly. The span is now the whole literal token, `5..21`: it contains no byte outside the literal and claims nothing about where the content sits. `"…"`, `r"…"` and a single-line `#|…` still report the content inside their delimiters, where it *is* contiguous. A trailing `\r` is trimmed in both branches, since the lexer strips it per line but ends the token at the `\n`.

## The record split across two lines

`join_symbol_spans` emitted `NAME` raw, so the newline inside the label ended the row early: `one` became a phantom symbol and `two 27 7 21` a symbol whose name is half a label. That breaks the invariant the whole surface is built on — one record per line.

`NAME` is now escaped the way `DOC` already was: `\\`, `\n`, and `\r` **kept** rather than dropped, because a byte inside a name is not noise to discard. A declaration's name can contain none of the three, so every existing row is byte-identical.

## Not fixed here: the space

A label is a sentence, so `NAME` can contain spaces and `NAME KIND START END` still cannot be split into fields for label rows — `adds two numbers 27 6 22` reads `KIND=two`. That is pre-existing, it is the same class of defect, and picking between escaping the space, quoting the name, and moving to a tab separator is a contract decision, so it is filed as **#2723 (P0)** rather than decided here.

The doc comments that justified `DOC` going last because it "is the only field that can contain spaces" now say what is actually true and point at that issue. `docs/editor-and-debugging.md` also still said tests and benches were Function (12), which #2632 ended.

## Validation

Both halves are red-tested: with the span fix reverted the new unit test reports `27 7 21`, and with the CR trim reverted it reports `adds 27 7 12`.

On a stage2 built from this branch: the full compiler gate, `scripts/test_vibe_symbols.sh` (21 cases, one new), `scripts/test_vibe_fmt_launcher.sh`, `scripts/check_gate_portability.sh`, `scripts/check_selector_precedence.sh`, `scripts/check_source_range_contract.sh`, the size ratchet and pre-commit. `symbol_spans_test.vibe` (18 tests) passes on both the seed and that stage2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F7tdQxr8PHL7ZAma4XAF8P

---
_Generated by [Claude Code](https://claude.ai/code/session_01F7tdQxr8PHL7ZAma4XAF8P)_