### PR TITLE
#2669 step 2b: four review findings on the widened body cache (#2720 merged without them)

### DIFF
--- a/docs/incremental-build.md
+++ b/docs/incremental-build.md
@@ -989,26 +989,37 @@ by reading:
   guards reject — a new closure, a new literal, a reordered declaration — would
   lose the prefix it replays today: a regression dressed as an improvement.
 
-Measured on the compiler's own closure (`codegen_lexer_test.vibe`, 193 files,
-5242 functions), `scripts/body_cache_reuse.sh`, one temperature per process
+Measured on the compiler's own closure (`codegen_lexer_test.vibe`, 196 files,
+5263 functions), `scripts/body_cache_reuse.sh`, one temperature per process
 sharing one `VIBE_BUILD_CACHE_DIR`:
 
 | temperature | offered | recompiled | heap_delta |
 |---|---:|---:|---:|
-| cold | 0 | 5242 | 1,074,931,408 |
-| unchanged (warm) | 4394 | 848 | 653,882,856 |
-| comment-edited | 4394 | **848** | 922,784,296 |
+| cold | 0 | 5263 | 1,081,422,048 |
+| unchanged (warm) | 4431 | 832 | 659,839,296 |
+| comment-edited | 4431 | **832** | 930,477,800 |
+| reverted (a second one-file edit) | 4431 | 832 | 665,264,816 |
 
-`offered + recompiled == 5242` exactly: everything the file table offered was
+`offered + recompiled == 5263` exactly: everything the file table offered was
 replayed. Under the prefix rule the same edit offers **0** — `defaults.vibe` is
 early in merge order, so the unchanged leading run ends before almost
-everything. The ~848 that always recompile are the pin region's pads and the
+everything. The ~832 that always recompile are the pin region's pads and the
 prelude-synthesized region, which the filter excludes by construction.
 
 The allocation figure is the KPI, and it moved by less than the reuse did:
-1.075 GB cold against 0.923 GB after the edit. Codegen is 28.7% of a warm
+1.081 GB cold against 0.930 GB after the edit. Codegen is 28.7% of a warm
 compile (measured above), so replaying 84% of the bodies cannot move more than
 that share, and the front end still runs whole-program.
+
+`VIBE_BODY_CACHE_REUSE_MODE=verify` reports the SAME counts on every warm row
+(`offered=4431 recompiled=832`) and `recompiled=-1` on the cold one, which is
+that lane saying no replay compile ran at all: nothing was offered, so there
+was nothing to replay. The number is the REPLAY compile's harvest. It used to
+be the FRESH compile's, which by construction holds every function, so every
+verify row read as a full rebuild whatever it actually reused (Codex P2 on the
+PR); the agreement with `on` above is what says the count now means something.
+Each warm verify row allocates ~0.432 GB more than its `on` counterpart, which
+is the second compile it performs to have something to compare against.
 
 ##### What the edit classes actually do (#2669, step 2b)
 
@@ -1021,18 +1032,53 @@ to equal a fresh compile every time:
 | a comment | partial | yes |
 | an Int literal inside a body | partial | yes |
 | lengthening a string literal | none | yes |
-| adding a function | none (layout) | yes |
+| adding a function | unoffered | yes |
 | exchanging two declarations | none | yes |
 | adding a closure | none | yes |
-| adding a type declaration ahead | none (layout) | yes |
+| adding a type declaration ahead | unoffered | yes |
 | exchanging two struct fields | none | yes |
-| adding an effect declaration ahead | none (layout) | yes |
+| adding an effect declaration ahead | unoffered | yes |
+| a callee's return type, Int to Bool | partial | yes |
 | changing a const's value | partial | yes |
 
-"none (layout)" is the file table refusing before any guard is consulted: those
-edits change the file's statement count, so the file indices are not this
-build's. The two `partial` rows are what the step buys; the rest are the
-conservative fallback, and each is a case relocation would later convert.
+`unoffered` is the file table refusing before any guard is consulted: those
+edits change the file's statement count, so the stored indices are not this
+build's. `none` is the lane being offered entries and replaying nothing of
+them — a guard declined, and the prefix it narrowed to is empty because the
+edit is in the first file. The `partial` rows are what the step buys; the rest
+are the conservative fallback, and each is a case relocation would later
+convert.
+
+The Int-to-Bool row is there because review raised it as a P0: a callee that
+changes between two scalar return types keeps its name, arity and
+scalar-return classification, so no name-keyed table separates the two, while
+the checker's per-call-site render and `eq` tables do. Two measurements came
+back, pointing opposite ways, and both belong here.
+
+**The channel is real.** Reading the untouched consumer's own typed-lowering
+rows while editing the callee's file: a comment, a same-length body edit and a
+body edit that lengthens the callee's file all leave them at `[715]`; the
+`Int`-to-`Bool` change moves them to `[717]`. So those rows track the
+interfaces a module reads rather than the bytes anyone else adds — an
+untouched consumer's classification really does move on an upstream interface
+change, and nothing name-keyed is watching it. `guard_typed_lowering`, a
+per-FILE fingerprint of `module_typed_lowering_offsets_for_path` and
+`module_typed_eq_rows_for_path`, is that watch.
+
+**The row does not prove the guard necessary.** Rebuilt with the stamp
+neutered, so the guard is never consulted, the row still reports `partial` and
+`equal=true`: the callee's return classification is program-wide, a
+`guard_layout` slot moves, and the lane declines before the typed-lowering
+guard could matter. It is carried on the same footing as the ten `guard_layout`
+slots below that this corpus leaves unproven. The shape that would separate
+them — a classification moving through a type alias or a generic
+instantiation, with every layout slot still — is the one the fixture cannot
+build.
+
+It is per file and not whole-program for a third measured reason: a
+whole-program comparison declines on every edit there is, since the edited file
+moves its own slot. Measured with the comparison whole-program, every row in
+the table above that reuses went to reusing nothing.
 
 **The guard set is sufficient — every row is byte-exact — and the test proves
 some of it necessary rather than all of it.** Dropping a slot and re-running:

--- a/lib/@vibe/compiler/cli_adapter.vibe
+++ b/lib/@vibe/compiler/cli_adapter.vibe
@@ -933,7 +933,34 @@ fn cli_main_with_lanes(fs_lanes: (FsLane, String, String) -> (Bytes, String) wit
   // check-only branch may enable it after strict policy validation below;
   // build/codegen lanes stay conservative, and a prior check in a long-lived
   // instance cannot leak its policy into a later invocation.
-  set_experimental_typing_dependency_env_reuse_enabled(false)
+  //
+  // #2510 criterion 5, OPT-IN and off by default:
+  // `VIBE_UNSTABLE_TYPING_DEP_ENV_REUSE_COMPILE=1` lets a COMPILE take the
+  // same reuse the check lane has had as production default since TDRE8, so
+  // the reset below reads the opt-in rather than a bare `false`.
+  //
+  // The measurement that asks for it: with reuse on, a one-leaf edit to the
+  // compiler's own closure re-checks exactly ONE of 197 planned modules
+  // (`modules_rechecked: 1`, 130 reused through the dependency-transport env
+  // and 66 through the conservative fingerprint). With it off -- which is what
+  // every build does today -- the same edit costs the compile 331.4 MB in its
+  // check phase, MORE than a cold check's 269.2 MB, while an unchanged warm
+  // build spends 11.3 MB there (`scripts/compile_phase_memory.sh`). That one
+  // phase is the whole gap between a warm build and a cold one.
+  //
+  // It stays opt-in until a compile's output is shown byte-identical with it
+  // on and off across the edit shapes -- a compile consumes more of a module's
+  // check than the public env (the typed-lowering offsets the reuse arm
+  // republishes, #2391), and "the check lane proves it" is a claim about the
+  // check lane.
+  //
+  // It is read in EXPRESSION position and named in `OBSERVATION_ONLY`
+  // (`scripts/check_selector_precedence.sh`) for the same reason
+  // `VIBE_UNSTABLE` is: it picks no verb, it modifies whichever lane was
+  // already selected, and a caller sets it deliberately -- entering
+  // `VIBE_SELECTOR_ORDER` would make `selector_clears_before` strip it on the
+  // compile lanes it exists for.
+  set_experimental_typing_dependency_env_reuse_enabled(Env::get("VIBE_UNSTABLE_TYPING_DEP_ENV_REUSE_COMPILE") == "1")
   // #2513: the `#cfg` flag set, for every module this invocation parses and
   // for every cache key it touches. Set before ANY lane runs, like the
   // switches below.

--- a/lib/@vibe/compiler/codegen/common_base/common_base.vibe
+++ b/lib/@vibe/compiler/codegen/common_base/common_base.vibe
@@ -357,6 +357,33 @@ export struct CodegenBodyCache {
   /// The LENGTH is a schema check: a compile whose slot count differs from the
   /// harvest's is one whose enumeration changed, and it declines.
   guard_layout: Array[Int];
+  /// #2669 step 2b (Codex P0): the checker's PER-MODULE typed-lowering
+  /// classification, fingerprinted in each module's OWN coordinates.
+  ///
+  /// `guard_layout` folds `float_ret_fn_names` but deliberately not the three
+  /// typed-lowering OFFSET arrays, because those are positions in the merged
+  /// text -- a comment anywhere shifts every offset after it, and folding them
+  /// made a comment-only edit decline the whole widened lane (measured:
+  /// `offered=4394 recompiled=5155`, a cold build in all but name).
+  ///
+  /// What that leaves unpinned is the CLASSIFICATION those offsets carry, and
+  /// one class of it is name-keyed nowhere: a callee that changes from `Int` to
+  /// `Bool` keeps its name, its arity and its scalar-return classification,
+  /// while every render and `eq` argument fed by it changes tag. So this
+  /// fingerprints each module's own table -- `module_typed_lowering_offsets_for_path`
+  /// and `module_typed_eq_rows_for_path`, before the merge rebases them.
+  ///
+  /// Those rows follow the INTERFACES a module reads, not the text anyone else
+  /// moves. Measured on a two-file chain, editing the callee's file and reading
+  /// the untouched CONSUMER's rows: a comment, a same-length body edit, and a
+  /// body edit that LENGTHENS the callee's file all leave them at `[715]`;
+  /// changing the callee's return type from `Int` to `Bool` moves them to
+  /// `[717]`. That is the dependence this guard exists to see, and the reason
+  /// the merged arrays cannot stand in for it.
+  ///
+  /// Filled in by the FS lane, which is the layer that knows the file list;
+  /// empty on every in-process lane, where it pins nothing and nothing reads it.
+  guard_typed_lowering: Array[Int];
   /// #2669 step 2b, and NOT part of the artifact: what the CONSUMING build's
   /// file table said, filled in by `decode_body_cache_payload_for` and read by
   /// the body loop. One element, the merged-statement limit of the unchanged
@@ -401,6 +428,7 @@ export fn codegen_body_cache_new() -> CodegenBodyCache {
     guard_borrow_masks: array_empty(),
     guard_unmangled_names: array_empty(),
     guard_layout: array_empty(),
+    guard_typed_lowering: array_empty(),
     consumer_src_limit: array_empty()
   }
 }
@@ -768,6 +796,11 @@ fn bcc_copy_guards(src: CodegenBodyCache, out: CodegenBodyCache) -> Unit {
     Array::push(out.guard_layout, Array::get(src.guard_layout, gw))
     gw = gw + 1
   }
+  let mut gt = 0
+  while gt < Array::length(src.guard_typed_lowering) {
+    Array::push(out.guard_typed_lowering, Array::get(src.guard_typed_lowering, gt))
+    gt = gt + 1
+  }
 }
 
 /// #2388 step 3: exact int-list equality, the mask half of the borrow guard.
@@ -817,11 +850,32 @@ fn bcc_fp_byte(fp: Array[Int], byte: Int) -> Unit {
 }
 
 fn bcc_fp_int(fp: Array[Int], v: Int) -> Unit {
-  // Seven bytes of the value, low first. Wider than any index space this
-  // pins, and it does not depend on the tagged Int's width.
+  // The WHOLE value: a sign byte and nine magnitude bytes, low first.
+  //
+  // Seven bytes was the first version and it was wrong -- 56 bits, against a
+  // 63-bit Int, so `0` and `1 << 56` fingerprinted alike. That is harmless for
+  // an index or a count and not harmless for `const_int_values`, where the
+  // pinned thing is a literal the program embeds: a folded constant edited
+  // between two such values would leave `guard_layout` equal and replay a body
+  // carrying the old number (Codex P1 on this PR).
+  //
+  // Nine bytes is 72 bits, which covers the 62-bit magnitude with room; the
+  // sign rides separately so `acc / 256` never has to mean anything for a
+  // negative, and the magnitude of the most negative Int is taken as
+  // `-(v + 1)` so it cannot overflow on the way in.
+  let neg = v < 0
+  let mut acc = if neg {
+    0 - (v + 1)
+  } else {
+    v
+  }
+  bcc_fp_byte(fp, if neg {
+    1
+  } else {
+    0
+  })
   let mut k = 0
-  let mut acc = v
-  while k < 7 {
+  while k < 9 {
     bcc_fp_byte(fp, acc&255)
     acc = acc / 256
     k = k + 1
@@ -1252,8 +1306,8 @@ export fn codegen_body_cache_to_bytes(cache: CodegenBodyCache) -> Bytes with Exc
   // the blind-reference arrays, '2' -> '3' when step 2a added fn_names. (The
   // store is keyed on the codegen fingerprint too, so this is the second line
   // of defence, not the first.) '3' -> '4' when step 2b added the layout
-  // guard and the per-entry source file that let replay reach past the
-  // leading prefix.
+  // guard, the typed-lowering guard and the per-entry source file that let
+  // replay reach past the leading prefix.
   bytebuf_push(buf, '4')
   bcc_push_int_array(buf, cache.fn_indices)
   bcc_push_string_array(buf, cache.fn_names)
@@ -1285,6 +1339,7 @@ export fn codegen_body_cache_to_bytes(cache: CodegenBodyCache) -> Bytes with Exc
   bcc_push_int_array(buf, cache.guard_borrow_masks)
   bcc_push_string_array(buf, cache.guard_unmangled_names)
   bcc_push_int_array(buf, cache.guard_layout)
+  bcc_push_int_array(buf, cache.guard_typed_lowering)
   bytebuf_to_bytes(buf)
 }
 
@@ -1623,6 +1678,11 @@ export fn codegen_body_cache_from_bytes(b: Bytes) -> Option[CodegenBodyCache] {
     } else {
       ()
     }
+    if p >= 0 {
+      p = bcc_read_int_array(b, p, out.guard_typed_lowering)
+    } else {
+      ()
+    }
     let fn_n = Array::length(out.fn_indices)
     let lam_n = Array::length(out.lam_owner)
     let guard_n = Array::length(out.guard_meta)
@@ -1644,7 +1704,7 @@ export fn codegen_body_cache_from_bytes(b: Bytes) -> Option[CodegenBodyCache] {
       }
       fni = fni + 1
     }
-    if p < 0 || fn_index_negative || Array::length(out.fn_names) != fn_n || Array::length(out.fn_files) != fn_n || Array::length(out.fn_src_stmts) != fn_n || Array::length(out.fn_bodies) != fn_n || Array::length(out.fn_meta_i32) != fn_n || Array::length(out.fn_meta_i64) != fn_n || Array::length(out.fn_meta_v128) != fn_n || Array::length(out.lam_indices) != lam_n || Array::length(out.lam_bodies) != lam_n || Array::length(out.lam_param_counts) != lam_n || Array::length(out.lam_captures) != lam_n || Array::length(out.lam_meta_i32) != lam_n || Array::length(out.lam_meta_i64) != lam_n || Array::length(out.slot_owner) != Array::length(out.slot_values) || Array::length(out.blind_body) != Array::length(out.blind_fn) || Array::length(out.blind_offsets) != Array::length(out.blind_fn) || Array::length(out.blind_kinds) != Array::length(out.blind_fn) || Array::length(out.blind_syms) != Array::length(out.blind_fn) || (guard_n != 0 && guard_n != 5) || Array::length(out.guard_synth_names) != Array::length(out.guard_synth_stmts) || Array::length(out.guard_borrow_names) != Array::length(out.guard_borrow_masks) || Array::length(out.guard_layout) % 2 != 0 {
+    if p < 0 || fn_index_negative || Array::length(out.fn_names) != fn_n || Array::length(out.fn_files) != fn_n || Array::length(out.fn_src_stmts) != fn_n || Array::length(out.fn_bodies) != fn_n || Array::length(out.fn_meta_i32) != fn_n || Array::length(out.fn_meta_i64) != fn_n || Array::length(out.fn_meta_v128) != fn_n || Array::length(out.lam_indices) != lam_n || Array::length(out.lam_bodies) != lam_n || Array::length(out.lam_param_counts) != lam_n || Array::length(out.lam_captures) != lam_n || Array::length(out.lam_meta_i32) != lam_n || Array::length(out.lam_meta_i64) != lam_n || Array::length(out.slot_owner) != Array::length(out.slot_values) || Array::length(out.blind_body) != Array::length(out.blind_fn) || Array::length(out.blind_offsets) != Array::length(out.blind_fn) || Array::length(out.blind_kinds) != Array::length(out.blind_fn) || Array::length(out.blind_syms) != Array::length(out.blind_fn) || (guard_n != 0 && guard_n != 5) || Array::length(out.guard_synth_names) != Array::length(out.guard_synth_stmts) || Array::length(out.guard_borrow_names) != Array::length(out.guard_borrow_masks) || Array::length(out.guard_layout) % 2 != 0 || Array::length(out.guard_typed_lowering) % 2 != 0 {
       None
     } else {
       Some(out)

--- a/lib/@vibe/compiler/entry/compiler/file_compile/file_compile.vibe
+++ b/lib/@vibe/compiler/entry/compiler/file_compile/file_compile.vibe
@@ -63,6 +63,8 @@ import @vibe/compiler/codegen/common_base {
   DbgProv,
   ModuleSplit,
   bcc_int_lists_equal,
+  bcc_layout_fp_ints,
+  bcc_layout_fp_strings,
   bcc_string_lists_equal,
   codegen_body_cache_filter_src_below,
   codegen_body_cache_filter_src_keep,
@@ -114,6 +116,7 @@ import @vibe/compiler/runtime {
   db_store_artifact,
   db_typecheck,
   db_typecheck_fs,
+  module_typed_eq_rows_for_path,
   module_typed_lowering_offsets_for_path,
   parse_program_with_path,
   split_typed_lowering_offsets,
@@ -1762,8 +1765,94 @@ fn decode_body_cache_payload_for(b: Bytes, payload_start: Int, paths: Array[Stri
 /// HERE, against the fresh harvest's guards -- not left to throw as a
 /// verify mismatch. Also decides whether a consumed cache may be merged
 /// back into the refreshed artifact.
+///
+/// #2669 step 2b: `guard_typed_lowering` is deliberately NOT part of this.
+/// It is a per-FILE vector, and the file that was edited legitimately moves
+/// its own slot on every edit -- comparing it elementwise would refuse every
+/// merge there is. That comparison happens where the file list is, at the
+/// decode, and drops exactly the files whose classification moved.
 fn body_cache_guards_equal(a: CodegenBodyCache, b: CodegenBodyCache) -> Bool {
-  Array::length(a.guard_meta) == 5 && bcc_int_lists_equal(a.guard_meta, b.guard_meta) && bcc_string_lists_equal(a.guard_synth_names, b.guard_synth_names) && bcc_int_lists_equal(a.guard_synth_stmts, b.guard_synth_stmts) && bcc_string_lists_equal(a.guard_import_names, b.guard_import_names) && bcc_string_lists_equal(a.guard_borrow_names, b.guard_borrow_names) && bcc_int_lists_equal(a.guard_borrow_masks, b.guard_borrow_masks) && bcc_string_lists_equal(a.guard_unmangled_names, b.guard_unmangled_names) && bcc_int_lists_equal(a.guard_layout, b.guard_layout)
+  body_cache_guards_equal_except_layout(a, b) && bcc_int_lists_equal(a.guard_layout, b.guard_layout)
+}
+
+/// #2669 step 2b: the guard set MINUS `guard_layout`, which is exactly the
+/// set that decides whether the leading PREFIX was replayable.
+///
+/// The body loop narrows to that prefix when a layout guard drifts, so those
+/// functions are replayed and therefore absent from the fresh harvest. Asking
+/// the full set before merging would then persist an artifact with a hole in
+/// it, and the next completely unchanged build would recompile the prefix for
+/// no reason (Codex P2 on this PR).
+fn body_cache_guards_equal_except_layout(a: CodegenBodyCache, b: CodegenBodyCache) -> Bool {
+  Array::length(a.guard_meta) == 5 && bcc_int_lists_equal(a.guard_meta, b.guard_meta) && bcc_string_lists_equal(a.guard_synth_names, b.guard_synth_names) && bcc_int_lists_equal(a.guard_synth_stmts, b.guard_synth_stmts) && bcc_string_lists_equal(a.guard_import_names, b.guard_import_names) && bcc_string_lists_equal(a.guard_borrow_names, b.guard_borrow_names) && bcc_int_lists_equal(a.guard_borrow_masks, b.guard_borrow_masks) && bcc_string_lists_equal(a.guard_unmangled_names, b.guard_unmangled_names)
+}
+
+/// #2669 step 2b (Codex P0): stamp this compile's per-module classification
+/// onto a harvest, but only one that recorded the rest of the guards -- a
+/// harvest with no `guard_meta` is in-process-only and must not look
+/// cross-compile usable because of a column this layer added.
+fn record_typed_lowering_guard(cache: CodegenBodyCache, rows: Array[Int]) -> Unit {
+  Array::truncate(cache.guard_typed_lowering, 0)
+  if Array::length(cache.guard_meta) == 5 {
+    let mut i = 0
+    while i < Array::length(rows) {
+      Array::push(cache.guard_typed_lowering, Array::get(rows, i))
+      i = i + 1
+    }
+  } else {
+    ()
+  }
+}
+
+/// #2669 step 2b (Codex P0): the checker's per-module typed-lowering tables,
+/// fingerprinted in each module's OWN coordinates, six slots per file.
+///
+/// The merged tables `union_module_typed_lowering_with_clones` produces are
+/// positions in the MERGED text, so a comment anywhere shifts every offset
+/// after it -- folding those into the codegen guard made a comment-only edit
+/// decline the whole widened lane. These are the same rows before the rebase,
+/// so a file's contribution moves only when THAT file's own classification
+/// moves, which is the property the guard needs.
+///
+/// It is the CLASSIFICATION that has to be pinned, not the positions: a callee
+/// that changes from `Int` to `Bool` keeps its name, arity and scalar-return
+/// classification, so no name-keyed table separates the two, while every
+/// render and `eq` argument fed by it changes tag.
+///
+/// Measured on a two-file chain, reading the UNTOUCHED consumer's rows while
+/// editing the callee's file: a comment, a same-length body edit and a body
+/// edit that lengthens the file all leave them at `[715]`, and the `Int` to
+/// `Bool` change moves them to `[717]`. So the rows track the interfaces a
+/// module reads and not the bytes anyone else adds -- which is what makes the
+/// per-file comparison at the decode both able to see the interface change and
+/// quiet on every ordinary edit. Pinned by
+/// `tests/typed_lowering_rows_interface_test.vibe`.
+///
+/// The memo these read is populated by the check that just ran and reset at
+/// the start of each walk, so a file with no row contributes an empty slot --
+/// which is what a module that classified nothing has, and is stable.
+fn typed_lowering_guard_for_files(file_paths: Array[String]) -> Array[Int] {
+  let out: Array[Int] = []
+  let mut i = 0
+  while i < Array::length(file_paths) {
+    let path = Array::get(file_paths, i)
+    match module_typed_lowering_offsets_for_path(path) {
+      Some(offsets) => bcc_layout_fp_ints(out, offsets),
+      None => bcc_layout_fp_ints(out, array_empty())
+    }
+    match module_typed_eq_rows_for_path(path) {
+      Some((eq_offs, eq_keys)) => {
+        bcc_layout_fp_ints(out, eq_offs)
+        bcc_layout_fp_strings(out, eq_keys)
+      },
+      None => {
+        bcc_layout_fp_ints(out, array_empty())
+        bcc_layout_fp_strings(out, array_empty())
+      }
+    }
+    i = i + 1
+  }
+  out
 }
 
 /// #2575 item 2: the ordinary lane's statement-to-module map, as a `DbgProv`.
@@ -1946,11 +2035,65 @@ fn compile_file_fs_mode_rc_body_cached_impl(entry_path: String, entry_name: Stri
   // body-level difference between the lanes would then be cached away and the
   // comparison would pass while measuring nothing.
   let caching = cache_mode != "off"
-  let cache_in = if caching {
+  // #2669 step 2b (Codex P0): computed here, after the check has published
+  // every module's table and before any decision reads the cache.
+  let typed_lowering_guard = typed_lowering_guard_for_files(file_paths)
+  let cache_in_decoded = if caching {
     match load_persistent_artifact("codegen-body-cache", entry_name, artifact_key) {
       Some(stored) => decode_body_cache_artifact_for(stored, file_paths, file_fps, file_counts),
       None => codegen_body_cache_new()
     }
+  } else {
+    codegen_body_cache_new()
+  }
+  // The guard is compared PER FILE, and a file whose classification moved is
+  // dropped exactly like a file whose bytes changed -- not by standing the
+  // whole widened lane down.
+  //
+  // That distinction is the whole of it. An edit to a body shifts that file's
+  // own offsets, so a whole-program comparison declines on every edit there is
+  // -- measured, before this was per-file: every row in
+  // `tests/body_cache_edit_classes_test.vibe` that reuses went to reusing
+  // nothing. The file whose slot moved is the one being edited, whose entries
+  // the content fingerprint already drops; what has to be caught is a
+  // DIFFERENT file's classification moving because the edit changed an
+  // interface it reads, and that is its own slot.
+  //
+  // A stored guard of another shape -- an older artifact, a different file
+  // count -- cannot be read per file, so it narrows to the prefix instead.
+  let tl_slots_per_file = 6
+  let tl_comparable = Array::length(cache_in_decoded.guard_typed_lowering) == Array::length(typed_lowering_guard) && Array::length(typed_lowering_guard) == tl_slots_per_file * Array::length(file_paths)
+  let cache_in = if Array::length(cache_in_decoded.guard_typed_lowering) == 0 {
+    cache_in_decoded
+  } else if tl_comparable {
+    let tl_keep_file: Array[Int] = []
+    let mut tl_f = 0
+    while tl_f < Array::length(file_paths) {
+      let mut tl_same = 1
+      let mut tl_k = 0
+      while tl_k < tl_slots_per_file {
+        let at = tl_f * tl_slots_per_file + tl_k
+        if Array::get(cache_in_decoded.guard_typed_lowering, at) != Array::get(typed_lowering_guard, at) {
+          tl_same = 0
+        } else {
+          ()
+        }
+        tl_k = tl_k + 1
+      }
+      Array::push(tl_keep_file, tl_same)
+      tl_f = tl_f + 1
+    }
+    let kept = codegen_body_cache_filter_src_keep(cache_in_decoded, tl_keep_file)
+    let mut tl_c = 0
+    while tl_c < Array::length(cache_in_decoded.consumer_src_limit) {
+      Array::push(kept.consumer_src_limit, Array::get(cache_in_decoded.consumer_src_limit, tl_c))
+      tl_c = tl_c + 1
+    }
+    kept
+  } else if Array::length(cache_in_decoded.consumer_src_limit) == 1 {
+    let narrowed = codegen_body_cache_filter_src_below(cache_in_decoded, Array::get(cache_in_decoded.consumer_src_limit, 0))
+    Array::push(narrowed.consumer_src_limit, Array::get(cache_in_decoded.consumer_src_limit, 0))
+    narrowed
   } else {
     codegen_body_cache_new()
   }
@@ -1962,6 +2105,16 @@ fn compile_file_fs_mode_rc_body_cached_impl(entry_path: String, entry_name: Stri
   } else if cache_mode == "verify" {
     let fresh_out = codegen_body_cache_new()
     let fresh = compile_wasi_module_rc_cached_impl_with_split(merged_stmts, entry_name, codegen_body_cache_new(), fresh_out, lane_prov, float_offsets, int_offsets, bool_offsets, eq_offsets, eq_keys, lane_split, print_stmt)
+    // #2669 step 2b (Codex P2): the count this lane reports must be the REPLAY
+    // compile's, not the fresh one's. `fresh_out` is the harvest of a compile
+    // handed an empty cache, so it always holds every function -- reporting it
+    // would label a full recompile as this temperature's reuse, which is what
+    // `scripts/body_cache_reuse.sh` prints under `mode=verify`. One element
+    // means a replay compile ran and recompiled that many; EMPTY means no
+    // replay compile ran at all (the guards rejected the cache), and the
+    // reported count is -1 rather than a number that reads like reuse.
+    let verify_replay_recompiled: Array[Int] = []
+    record_typed_lowering_guard(fresh_out, typed_lowering_guard)
     if Array::length(cache_in.fn_indices) > 0 && body_cache_guards_equal(cache_in, fresh_out) {
       // Guard drift (an edit flipped a whole-program fact the guards pin)
       // is an EXPECTED cache miss, checked above against the fresh
@@ -1973,7 +2126,9 @@ fn compile_file_fs_mode_rc_body_cached_impl(entry_path: String, entry_name: Stri
       // replay/sliced gates prove that recompile is byte-identical to the
       // first, so any difference here is attributable to the persisted
       // bodies being replayed.
-      let replayed = compile_wasi_module_rc_cached_impl_with_split(merged_stmts, entry_name, cache_in, codegen_body_cache_new(), lane_prov, float_offsets, int_offsets, bool_offsets, eq_offsets, eq_keys, lane_split, print_stmt)
+      let replay_out = codegen_body_cache_new()
+      let replayed = compile_wasi_module_rc_cached_impl_with_split(merged_stmts, entry_name, cache_in, replay_out, lane_prov, float_offsets, int_offsets, bool_offsets, eq_offsets, eq_keys, lane_split, print_stmt)
+      Array::push(verify_replay_recompiled, Array::length(replay_out.fn_indices))
       let fresh_n = Bytes::length(fresh)
       let rn = Bytes::length(replayed)
       if fresh_n != rn {
@@ -1999,10 +2154,11 @@ fn compile_file_fs_mode_rc_body_cached_impl(entry_path: String, entry_name: Stri
       ()
     }
     store_persistent_artifact("codegen-body-cache", entry_name, artifact_key, encode_body_cache_artifact(file_paths, file_fps, file_counts, fresh_out))
-    // Verify compiles everything fresh by construction, so its recompile
-    // count says nothing about reuse; report the REPLAY compile's instead,
-    // which is the lane "on" takes.
-    Array::push(counts_out, Array::length(fresh_out.fn_indices))
+    Array::push(counts_out, if Array::length(verify_replay_recompiled) == 1 {
+      Array::get(verify_replay_recompiled, 0)
+    } else {
+      0 - 1
+    })
     fresh
   } else {
     let cache_out = codegen_body_cache_new()
@@ -2015,9 +2171,21 @@ fn compile_file_fs_mode_rc_body_cached_impl(entry_path: String, entry_name: Stri
     // set on each guard-flipping edit.
     let refreshed = if Array::length(cache_in.fn_indices) > 0 && body_cache_guards_equal(cache_out, cache_in) {
       codegen_body_cache_merge(cache_out, cache_in)
+    } else if Array::length(cache_in.fn_indices) > 0 && Array::length(cache_in.consumer_src_limit) == 1 && body_cache_guards_equal_except_layout(cache_out, cache_in) {
+      // A layout guard drifted, so the body loop replayed only the leading
+      // prefix -- and a replayed function is not re-recorded, so `cache_out`
+      // has a hole exactly there. Carry that prefix back in, or the next
+      // completely unchanged build recompiles it for nothing. The subset is
+      // the SAME one the body loop narrowed to, computed from the same
+      // annotation, so the two cannot disagree about which entries were
+      // replayed.
+      codegen_body_cache_merge(cache_out, codegen_body_cache_filter_src_below(cache_in, Array::get(cache_in.consumer_src_limit, 0)))
     } else {
       cache_out
     }
+    // Stamp the merged harvest, so the artifact records THIS build's per-file
+    // classification rather than whatever the consumed cache carried.
+    record_typed_lowering_guard(refreshed, typed_lowering_guard)
     store_persistent_artifact("codegen-body-cache", entry_name, artifact_key, encode_body_cache_artifact(file_paths, file_fps, file_counts, refreshed))
     Array::push(counts_out, Array::length(cache_out.fn_indices))
     bytes

--- a/lib/@vibe/compiler/tests/body_cache_edit_classes_test.vibe
+++ b/lib/@vibe/compiler/tests/body_cache_edit_classes_test.vibe
@@ -29,13 +29,15 @@
 //# that exercises them. What the whole table DOES establish is sufficiency:
 //# every class answers what a fresh compile answers.
 //#
-//# What is NOT here, and why: an interface change that moves a whole-program
-//# CLASSIFICATION (a callee that stops returning Double, a const that stops
-//# being an Int) also changes the source of everyone who uses it, so there is
-//# no unchanged file left to replay. Those slots are pinned anyway -- a type
-//# alias or a generic instantiation can move a classification without touching
-//# the consumer's text -- but this file cannot reach them, and saying so is
-//# better than a case that passes by editing nothing.
+//# One interface change that moves a whole-program CLASSIFICATION is here --
+//# `render-type`, a callee going from `Int` to `Bool` while the consuming file
+//# is untouched -- and it is the row that says a classification can move
+//# without any name-keyed guard seeing it. The rest of that family cannot be
+//# reached from this fixture: a callee that stops returning `Double`, or a
+//# const that stops being an `Int`, changes the consumer's own text too, so no
+//# unchanged file is left to replay. Those slots are pinned on the
+//# `CompileCtx` enumeration, not on a case here, and saying so is better than
+//# a case that passes by editing nothing.
 
 import @vibe/compiler/entry/compiler/file_compile {
   compile_file_fs_mode_rc, compile_file_fs_mode_rc_body_cached_counted
@@ -92,8 +94,8 @@ let ec_main_path: String = "/tmp/vibe_body_cache_ec_main.vibe"
 /// this file: adding an uncompared struct OR an uncompared enum to a fixture
 /// that otherwise reuses takes its recorded guards from 5 to 0 and its reuse
 /// to nothing. So a fixture with a dead declaration measures the DCE guard,
-/// not the layout guard, and every row below would read `reuse=none` for a
-/// reason that has nothing to do with what it claims to test.
+/// not the layout guard, and every row below would read `reuse=unoffered` for
+/// a reason that has nothing to do with what it claims to test.
 ///
 /// Every later file reaches into it, so each edit is upstream of bodies the
 /// widened lane wants to replay. It carries one of everything the fingerprint
@@ -117,6 +119,7 @@ fn ec_base_a_lines() -> Array[String] {
     "export let ec_k: Int = 7",
     "export let ec_eq: () -> Bool = () -> { [1, 2] == [1, 2] }",
     "export let ec_scale: () -> Double = () -> { 1.5 }",
+    "export let ec_flag: () -> Int = () -> { 1 }",
     "export let ec_name: () -> String = () -> { \"alpha\" }",
     "export let ec_twice: ((Int) -> Int, Int) -> Int = (f, n) -> { f(f(n)) }",
     "export let ec_bump: (Int) -> Int = (n) -> { n + ec_k }",
@@ -138,7 +141,7 @@ fn ec_base_a() -> String {
 /// bytes rather than as nothing at all.
 fn ec_base_b() -> String {
   let parts: Array[String] = [
-    "import ./vibe_body_cache_ec_a.vibe { EcBright, EcDim, EcPoint, EcShade, ec_bump, ec_eq, ec_k, ec_name, ec_noted, ec_point, ec_same, ec_scale, ec_shade, ec_twice }",
+    "import ./vibe_body_cache_ec_a.vibe { EcBright, EcDim, EcPoint, EcShade, ec_bump, ec_eq, ec_flag, ec_k, ec_name, ec_noted, ec_point, ec_same, ec_scale, ec_shade, ec_twice }",
     "export let ec_b_tag: () -> Int = () -> { let mine: EcShade = EcBright(5)\n  match mine { EcDim => 0, EcBright(n) => n } + match ec_shade() { EcDim => 1, EcBright(n) => n } }",
     "export let ec_b_field: () -> Int = () -> { let p: EcPoint = EcPoint::{ x: 9, y: 8 }\n  p.x + p.y * 10 + ec_point().x + ec_point().y * 100 }",
     "export let ec_b_text: () -> String = () -> { String::concat(ec_name(), \"beta\") }",
@@ -146,17 +149,19 @@ fn ec_base_b() -> String {
     "export let ec_b_closure: () -> Int = () -> { let step = (n) -> { n + ec_k }\n  ec_twice(step, 2) }",
     "export let ec_b_double: () -> Double = () -> { ec_scale() * 2.0 }",
     "export let ec_b_effect: () -> Int = () -> { ec_noted() }",
-    "export let ec_b_eq: () -> Int = () -> { (if ec_eq() { 1 } else { 0 }) + ec_same() }"
+    "export let ec_b_eq: () -> Int = () -> { (if ec_eq() { 1 } else { 0 }) + ec_same() }",
+    "export let ec_b_render: () -> String = () -> { \"f=\\{ec_flag()}\" }",
+    "export let ec_b_cmp: () -> Int = () -> { if ec_flag() == ec_flag() { 1 } else { 0 } }"
   ]
   String::join(parts, "\n")
 }
 
 fn ec_base_main() -> String {
   let parts: Array[String] = [
-    "import ./vibe_body_cache_ec_b.vibe { ec_b_closure, ec_b_double, ec_b_effect, ec_b_eq, ec_b_field, ec_b_slot, ec_b_tag, ec_b_text }",
+    "import ./vibe_body_cache_ec_b.vibe { ec_b_closure, ec_b_cmp, ec_b_double, ec_b_effect, ec_b_eq, ec_b_field, ec_b_render, ec_b_slot, ec_b_tag, ec_b_text }",
     "let run: () -> Int = () -> {",
     "  let s = ec_b_tag() + ec_b_field() + ec_b_slot() + ec_b_closure() + ec_b_effect() + ec_b_eq()",
-    "  s + String::length(ec_b_text()) + Double::to_int(ec_b_double())",
+    "  s + String::length(ec_b_text()) + String::length(ec_b_render()) + ec_b_cmp() + Double::to_int(ec_b_double())",
     "}"
   ]
   String::join(parts, "\n")
@@ -227,10 +232,18 @@ fn ec_subs(olds: Array[String], news: Array[String]) -> String with Exception {
 /// the first file, and report what the warm compile reused and whether it
 /// answered what a fresh compile does.
 ///
-/// One line, fixed field order: `<label> reuse=<full|partial|none> equal=<bool>`.
+/// One line, fixed field order:
+/// `<label> reuse=<unoffered|partial|none> equal=<bool>`.
 /// The reuse column is CLASSIFIED rather than counted because the raw count is
 /// dominated by the pin region's 1024 pads, which say nothing about this.
-/// `full` means the widened lane declined and everything recompiled.
+///
+/// The field says REUSE, so the values describe reuse and not the rebuild:
+/// `unoffered` is the file table refusing before any guard is consulted (the
+/// edit moved a statement count, so the stored indices are not this build's),
+/// `none` is the lane being offered entries and replaying nothing of them.
+/// The third case was spelled `full` first, which read as its own opposite --
+/// `reuse=full` on a build that reused nothing -- and the surrounding prose
+/// had to translate it every time.
 fn ec_probe(label: String, edited: String) -> String with Exception + Fs {
   let artifact_path = persistent_artifact_cache_path("codegen-body-cache", "run", String::concat("self-describing-", compact_string_fingerprint(ec_main_path)))
   if Fs::exists(artifact_path) {
@@ -257,11 +270,11 @@ fn ec_probe(label: String, edited: String) -> String with Exception + Fs {
   let warm = compile_file_fs_mode_rc_body_cached_counted(ec_main_path, "run", "on", warm_counts)
   let fresh = compile_file_fs_mode_rc(ec_main_path, "run")
   let reuse = if Array::get(warm_counts, 0) == 0 {
-    "none"
+    "unoffered"
   } else if Array::get(warm_counts, 1) < cold_n {
     "partial"
   } else {
-    "full"
+    "none"
   }
   "\{label} reuse=\{reuse} equal=\{bytes_eq(warm, fresh)}"
 }
@@ -305,6 +318,38 @@ test "#2669: every edit class stays byte-exact under the widened body cache" {
   // Exception tags: effect `effect_names[i]` routes through tag `3 + i`, so an
   // effect declared ahead moves the tag `ec_b_effect` unwinds through.
   Array::push(report, ec_probe("add-effect-ahead", ec_sub("effect EcLog {", "effect EcAhead {\n  Ping(Int) -> Int\n}\neffect EcLog {")))
+  // A typed RENDER/eq classification: `ec_flag` goes from Int to Bool while
+  // keeping its name, its arity, its statement count and its scalar-return
+  // classification, and two functions in the UNCHANGED file `b` consume it --
+  // one interpolating it, one comparing it. No name-keyed table separates Int
+  // from Bool, so nothing in `guard_layout` sees this edit.
+  //
+  // Raised as a P0 by review. Two separate things came back measured, and
+  // they point opposite ways.
+  //
+  // The CHANNEL is real. Reading `b`'s own typed-lowering rows across this
+  // edit, on a two-file version of this chain: a comment, a same-length body
+  // edit and a body edit that lengthens `a` all leave them at `[715]`, and the
+  // `Int` to `Bool` change moves them to `[717]`. So an untouched consumer's
+  // classification does move on an upstream interface change, and no
+  // name-keyed guard is looking at it. `guard_typed_lowering` -- the per-file
+  // fingerprint of the checker's own tables -- is that look.
+  //
+  // The ROW does not prove it necessary. Rebuilt with the stamp neutered, so
+  // the guard is never consulted, this row still reports `partial` and
+  // `equal=true`: `ec_flag`'s return classification is program-wide, so a
+  // `guard_layout` slot moves and the lane declines before the typed-lowering
+  // guard could matter. The guard is carried on the same footing as the ten
+  // `guard_layout` slots the header lists as unproven -- the shape that would
+  // separate them (a classification that moves through a type alias or a
+  // generic instantiation, leaving every layout slot still) is the one this
+  // fixture cannot build.
+  //
+  // What the row DOES establish is that the guard does not over-decline. An
+  // earlier version compared the classification whole-program instead of per
+  // file, and every row here that reuses went to reusing nothing -- the edited
+  // file moves its own slot on every edit.
+  Array::push(report, ec_probe("render-type", ec_sub("export let ec_flag: () -> Int = () -> { 1 }", "export let ec_flag: () -> Bool = () -> { true }")))
   // A const's VALUE. Measured `reuse=partial`, which is itself the finding:
   // `ec_k` is not const-folded into `ec_b_closure` here -- it lowers to a
   // thunk call -- so only its own file's bodies change and the rest replay
@@ -315,5 +360,5 @@ test "#2669: every edit class stays byte-exact under the widened body cache" {
   Array::push(report, ec_probe("const-value", ec_sub("export let ec_k: Int = 7", "export let ec_k: Int = 11")))
   // One line, fixed field order -- the CLI contract, and it keeps the whole
   // table visible in a failure rather than only its first row.
-  inspect(String::join(report, " | "), content = "comment reuse=partial equal=true | int-literal reuse=partial equal=true | string-literal reuse=full equal=true | add-function reuse=none equal=true | swap-order reuse=full equal=true | add-closure reuse=full equal=true | add-type-ahead reuse=none equal=true | swap-struct-fields reuse=full equal=true | add-effect-ahead reuse=none equal=true | const-value reuse=partial equal=true")
+  inspect(String::join(report, " | "), content = "comment reuse=partial equal=true | int-literal reuse=partial equal=true | string-literal reuse=none equal=true | add-function reuse=unoffered equal=true | swap-order reuse=none equal=true | add-closure reuse=none equal=true | add-type-ahead reuse=unoffered equal=true | swap-struct-fields reuse=none equal=true | add-effect-ahead reuse=unoffered equal=true | render-type reuse=partial equal=true | const-value reuse=partial equal=true")
 }

--- a/lib/@vibe/compiler/tests/codegen_body_cache_persist_test.vibe
+++ b/lib/@vibe/compiler/tests/codegen_body_cache_persist_test.vibe
@@ -139,11 +139,13 @@ fn sample_cache() -> CodegenBodyCache {
   Array::push(c.guard_borrow_names, "peek")
   Array::push(c.guard_borrow_masks, 5)
   Array::push(c.guard_unmangled_names, "run")
-  // #2669 step 2b: two layout slots.
+  // #2669 step 2b: two layout slots, and one typed-lowering slot.
   Array::push(c.guard_layout, 3)
   Array::push(c.guard_layout, 12)
   Array::push(c.guard_layout, 99)
   Array::push(c.guard_layout, 77)
+  Array::push(c.guard_typed_lowering, 5)
+  Array::push(c.guard_typed_lowering, 8)
   c
 }
 
@@ -226,6 +228,8 @@ test "codegen body cache codec round-trips every field group" {
       inspect(Array::get(d.guard_unmangled_names, 0), content = "run")
       inspect(Array::length(d.guard_layout), content = "4")
       inspect(Array::get(d.guard_layout, 3), content = "77")
+      inspect(Array::length(d.guard_typed_lowering), content = "2")
+      inspect(Array::get(d.guard_typed_lowering, 1), content = "8")
       // The decode-time annotation is NOT in the stream: it describes the
       // build that read the artifact, not the harvest that wrote it.
       inspect(Array::length(d.consumer_src_limit), content = "0")
@@ -364,6 +368,34 @@ test "#2669: the layout fingerprint separates the values that move a body's byte
   let pos: Array[Int] = []
   bcc_layout_fp_ints(pos, [1])
   assert(!bcc_int_lists_equal(neg, pos))
+  // The WHOLE 63-bit width, not the low 56. `1 << 56` against `0` is the pair
+  // the first version collided (Codex P1): harmless for an index, not harmless
+  // for `const_int_values`, where the pinned thing is a literal a body embeds.
+  //
+  // Red side measured, not assumed: reimplementing the seven-byte encoding
+  // against the same accumulator collides on all THREE of the pairs below
+  // (`0`/`1<<56`, `0`/`1<<61`, `1<<56`/`1<<61`) and the nine-byte one collides
+  // on none. The extremes pair after them is NOT red -- seven bytes already
+  // separated it -- and is here for a different property, that the sign split
+  // handles the ends of the range without trapping on the way in.
+  let zero: Array[Int] = []
+  bcc_layout_fp_ints(zero, [0])
+  let high: Array[Int] = []
+  bcc_layout_fp_ints(high, [1<<56])
+  assert(!bcc_int_lists_equal(zero, high))
+  let higher: Array[Int] = []
+  bcc_layout_fp_ints(higher, [1<<61])
+  assert(!bcc_int_lists_equal(zero, higher))
+  assert(!bcc_int_lists_equal(high, higher))
+  // The extremes round-trip through the sign split rather than trapping. The
+  // most negative Int is not spellable as a literal (the bound is symmetric
+  // about the positive side), so it is built by negating the largest one and
+  // subtracting.
+  let most_negative: Array[Int] = []
+  bcc_layout_fp_ints(most_negative, [0 - 4611686018427387903 - 1])
+  let most_positive: Array[Int] = []
+  bcc_layout_fp_ints(most_positive, [4611686018427387903])
+  assert(!bcc_int_lists_equal(most_negative, most_positive))
   // Accumulation appends: two slots are four ints.
   let two: Array[Int] = []
   bcc_layout_fp_strings(two, ["a"])
@@ -825,6 +857,58 @@ test "#2669: an edit to the FIRST file replays the files after it" {
   assert(Array::get(moved_counts, 0) > 0)
   inspect(Array::get(moved_counts, 1) == cold_n, content = "true")
   assert(bytes_eq(moved, compile_file_fs_mode_rc(main_path, "run")))
+}
+
+test "#2669: a narrowed build keeps its replayed prefix in the artifact" {
+  // Codex P2 on this PR. When a layout guard drifts but the unchanged leading
+  // PREFIX is non-empty, the body loop replays that prefix -- and a replayed
+  // function is not re-recorded, so the fresh harvest has a hole exactly
+  // there. Persisting only the harvest silently drops those entries, and the
+  // next completely unchanged build recompiles them for nothing.
+  //
+  // Three files, and the edit lands on the MIDDLE one so the prefix is real:
+  // `p_a` stays put, `p_b` lengthens a string literal, `p_main` is downstream.
+  // A literal is the edit to pick: it moves the pooled offsets, which live
+  // ONLY in `guard_layout`, so the pre-2b guards still match and the narrowed
+  // merge is the branch under test. An edit that also moves `guard_meta` (a
+  // new closure, say) refuses the merge for the older reason and measures
+  // nothing about this one -- measured, that version of this test passed
+  // whether or not the fix was there.
+  let a_path = "/tmp/vibe_body_cache_pfx_a.vibe"
+  let b_path = "/tmp/vibe_body_cache_pfx_b.vibe"
+  let main_path = "/tmp/vibe_body_cache_pfx_main.vibe"
+  let a_source = "export let p_eq: () -> Bool = () -> { [1, 2] == [1, 2] }\nexport let p_one: () -> String = () -> { \"one\" }\nexport let p_two: () -> Int = () -> { 22 }"
+  let b_base = "import ./vibe_body_cache_pfx_a.vibe { p_one, p_two }\nexport let p_b_one: () -> String = () -> { String::concat(p_one(), \"b\") }\nexport let p_b_two: () -> Int = () -> { String::length(p_b_one()) + p_two() }"
+  let b_closure = "import ./vibe_body_cache_pfx_a.vibe { p_one, p_two }\nexport let p_b_one: () -> String = () -> { String::concat(p_one(), \"b is a good deal longer now\") }\nexport let p_b_two: () -> Int = () -> { String::length(p_b_one()) + p_two() }"
+  let main_source = "import ./vibe_body_cache_pfx_b.vibe { p_b_one, p_b_two }\nlet run: () -> Int = () -> { String::length(p_b_one()) + p_b_two() }"
+  let artifact_path = persistent_artifact_cache_path("codegen-body-cache", "run", String::concat("self-describing-", compact_string_fingerprint(main_path)))
+  remove_file_if_exists(artifact_path)
+  Fs::write_bytes(a_path, string_to_bytes(a_source))
+  Fs::write_bytes(b_path, string_to_bytes(b_base))
+  Fs::write_bytes(main_path, string_to_bytes(main_source))
+  let cold_counts: Array[Int] = []
+  let _cold = compile_file_fs_mode_rc_body_cached_counted(main_path, "run", "on", cold_counts)
+  let cold_n = Array::get(cold_counts, 1)
+  // The narrowing build: `b` gains a closure, so a layout slot moves and the
+  // widened lane declines; `a` is the unchanged prefix and replays.
+  Fs::write_bytes(b_path, string_to_bytes(b_closure))
+  let narrowed_counts: Array[Int] = []
+  let narrowed = compile_file_fs_mode_rc_body_cached_counted(main_path, "run", "on", narrowed_counts)
+  assert(bytes_eq(narrowed, compile_file_fs_mode_rc(main_path, "run")))
+  // Non-vacuity: something must actually have been replayed here, or the
+  // third compile below measures nothing.
+  assert(Array::get(narrowed_counts, 1) < cold_n)
+  // Nothing changed since: every entry the artifact holds is offered, and the
+  // compile rebuilds only what no entry covers. Without the prefix carried
+  // back into the artifact this recompiles the prefix again.
+  let warm_counts: Array[Int] = []
+  let warm = compile_file_fs_mode_rc_body_cached_counted(main_path, "run", "on", warm_counts)
+  assert(bytes_eq(warm, compile_file_fs_mode_rc(main_path, "run")))
+  // The artifact GREW by the prefix the narrowed build replayed: the third
+  // compile is offered more than the second was. Without the carry-back it is
+  // offered the narrowed build's harvest alone, which is missing exactly those
+  // entries.
+  inspect(Array::get(warm_counts, 0) > Array::get(narrowed_counts, 0), content = "true")
 }
 
 //# `codegen_body_cache_find` keys on the FUNCTION INDEX, so an entry is only

--- a/lib/@vibe/compiler/tests/typed_lowering_rows_interface_test.vibe
+++ b/lib/@vibe/compiler/tests/typed_lowering_rows_interface_test.vibe
@@ -1,0 +1,139 @@
+//# #2720 (Codex P0): what moves an UNTOUCHED consumer's typed-lowering rows?
+//#
+//# `guard_typed_lowering` compares these rows PER FILE, and both halves of
+//# that only work if the rows behave a particular way:
+//#
+//#   - they must MOVE when a dependency's interface changes, or the guard
+//#     cannot see the channel review raised -- a callee going from `Int` to
+//#     `Bool` keeps its name, its arity and its scalar-return classification,
+//#     so no name-keyed guard separates the two while every render and `eq`
+//#     argument fed by it changes tag;
+//#   - they must STAY when a dependency's text merely moves, or the guard
+//#     declines on every ordinary edit and the widened body cache is worth
+//#     nothing. An earlier version of the guard compared the merged tables
+//#     instead, whose offsets are positions in the merged text; a comment-only
+//#     edit then took the compiler's own closure to `offered=4394
+//#     recompiled=5155`, a cold build in all but name.
+//#
+//# Both are asserted here as RELATIONS between runs rather than as literal
+//# offsets, because the absolute values depend on the prelude and would pin
+//# something this file is not about.
+
+import @vibe/compiler/entry/compiler/file_compile {
+  compile_file_fs_mode_rc
+}
+
+import @vibe/compiler/runtime {
+  module_typed_eq_rows_for_path, module_typed_lowering_offsets_for_path
+}
+
+//# Helpers
+
+fn string_to_bytes(s: String) -> Bytes {
+  let buf: Array[Int] = []
+  let n = String::length(s)
+  let mut i = 0
+  while i < n {
+    Array::push(buf, String::char_code_at(s, i))
+    i = i + 1
+  }
+  Bytes::from_array(buf)
+}
+
+fn ints_str(xs: Array[Int]) -> String {
+  let parts: Array[String] = []
+  let mut i = 0
+  while i < Array::length(xs) {
+    Array::push(parts, "\{Array::get(xs, i)}")
+    i = i + 1
+  }
+  String::join(parts, ",")
+}
+
+/// Both of a module's typed-lowering tables, as one comparable string.
+fn tl_rows(path: String) -> String {
+  let offs = match module_typed_lowering_offsets_for_path(path) {
+    Some(o) => ints_str(o),
+    None => "-"
+  }
+  let eqs = match module_typed_eq_rows_for_path(path) {
+    Some((eq_offs, eq_keys)) => "\{ints_str(eq_offs)}/\{String::join(eq_keys, ",")}",
+    None => "-"
+  }
+  "[\{offs}][\{eqs}]"
+}
+
+let tli_a_path: String = "/tmp/vibe_tl_iface_a.vibe"
+
+let tli_b_path: String = "/tmp/vibe_tl_iface_b.vibe"
+
+let tli_main_path: String = "/tmp/vibe_tl_iface_main.vibe"
+
+/// The consumer. It never changes, and it reaches `t_flag` through BOTH typed
+/// channels: an interpolation (the render table) and a comparison (the eq
+/// table).
+fn tli_b_source() -> String {
+  let parts: Array[String] = [
+    "import ./vibe_tl_iface_a.vibe { t_flag }",
+    "export let t_render: () -> String = () -> { \"f=\\{t_flag()}\" }",
+    "export let t_cmp: () -> Int = () -> { if t_flag() == t_flag() { 1 } else { 0 } }"
+  ]
+  String::join(parts, "\n")
+}
+
+fn tli_main_source() -> String {
+  let parts: Array[String] = [
+    "import ./vibe_tl_iface_b.vibe { t_cmp, t_render }",
+    "let run: () -> Int = () -> { String::length(t_render()) + t_cmp() }"
+  ]
+  String::join(parts, "\n")
+}
+
+let tli_base_a: String = "export let t_flag: () -> Int = () -> { 1 }"
+
+/// One field of the report: did this edit move the consumer's rows?
+fn tli_row(label: String, got: String, base: String) -> String {
+  let verdict = if got == base {
+    "same"
+  } else {
+    "moved"
+  }
+  "\{label}=\{verdict}"
+}
+
+/// Write `a`, compile the chain, and report the CONSUMER's rows afterwards.
+/// The memo `tl_rows` reads is populated by the check this compile runs.
+fn tli_after(a_source: String) -> String with Exception + Fs {
+  Fs::write_bytes(tli_a_path, string_to_bytes(a_source))
+  let _built = compile_file_fs_mode_rc(tli_main_path, "run")
+  tl_rows(tli_b_path)
+}
+
+//# Tests
+
+test "#2720: a consumer's typed-lowering rows follow its imports' interfaces, not their text" {
+  Fs::write_bytes(tli_b_path, string_to_bytes(tli_b_source()))
+  Fs::write_bytes(tli_main_path, string_to_bytes(tli_main_source()))
+  let base = tli_after(tli_base_a)
+  // Non-vacuity: `b` must actually HAVE rows, or every "same" below is the
+  // trivial equality of two absent tables and the file measures nothing.
+  if base == "[][-]" || base == "[-][-]" {
+    throw("typed-lowering fixture: the consumer recorded no rows: \{base}")
+  } else {
+    ()
+  }
+  let report: Array[String] = []
+  // A comment: `a`'s text grows, its interface does not.
+  Array::push(report, tli_row("comment", tli_after(String::concat(tli_base_a, "\n// touched")), base))
+  // A body edit of the same length.
+  Array::push(report, tli_row("same-len-body", tli_after("export let t_flag: () -> Int = () -> { 2 }"), base))
+  // A body edit that LENGTHENS `a`. This is the one that would fail if the
+  // rows were positions in the merged text.
+  Array::push(report, tli_row("longer-body", tli_after("export let t_flag: () -> Int = () -> { 1 + 0 }"), base))
+  // The interface: same name, same arity, same scalar-return class, different
+  // render and eq tags. This is the one the guard has to see.
+  Array::push(report, tli_row("return-type", tli_after("export let t_flag: () -> Bool = () -> { true }"), base))
+  // And back, so a "moved" above is the edit and not an accumulating memo.
+  Array::push(report, tli_row("restored", tli_after(tli_base_a), base))
+  inspect(String::join(report, " "), content = "comment=same same-len-body=same longer-body=same return-type=moved restored=same")
+}

--- a/scripts/check_selector_precedence.sh
+++ b/scripts/check_selector_precedence.sh
@@ -56,7 +56,12 @@ adapter, launcher, mode, enforced = sys.argv[1], sys.argv[2], sys.argv[3], sys.a
 # VIBE_UNSTABLE is the ADR-0068 opt-in, read inside already-selected branches
 # (`vibe check` / `vibe build` / `vibe serve`); it must not enter
 # VIBE_SELECTOR_ORDER or selector_clears_before would strip it.
-OBSERVATION_ONLY = {"VIBE_DIAGNOSTICS_ALL", "VIBE_PROFILE_MEMORY_MARKS", "VIBE_UNSTABLE"}
+# VIBE_UNSTABLE_TYPING_DEP_ENV_REUSE_COMPILE (#2510 criterion 5) is the same
+# shape: it turns typing-dependency env reuse on for whichever COMPILE lane was
+# already selected, and every compile lane is later in the order, so ordering it
+# would have selector_clears_before unset it on exactly the lanes it exists for.
+OBSERVATION_ONLY = {"VIBE_DIAGNOSTICS_ALL", "VIBE_PROFILE_MEMORY_MARKS", "VIBE_UNSTABLE",
+                    "VIBE_UNSTABLE_TYPING_DEP_ENV_REUSE_COMPILE"}
 
 # The order is SOURCE ORDER, and a selector counts wherever it is tested --
 # `let bytes = if Env::get("VIBE_COVERAGE") == "1" { .. } else if


### PR DESCRIPTION
Follow-up to #2720, which merged at `ce55612` **before these fixes landed**. Four Codex findings on that PR, all fixed here; two of them came back measuring something other than what the review predicted, and both results are in the tree rather than only in this description.

## P0 — the typed render/`eq` classification was not pinned

A callee that changes from `Int` to `Bool` keeps its name, its arity and its scalar-return classification, so no name-keyed guard separates the two, while every render and `eq` argument fed by it changes tag.

`CodegenBodyCache` gains **`guard_typed_lowering`**: a per-**file** fingerprint of `module_typed_lowering_offsets_for_path` and `module_typed_eq_rows_for_path`, taken in each module's OWN coordinates, before `union_module_typed_lowering_with_clones` rebases them. Compared per file at the decode, so a file whose classification moved is dropped exactly like a file whose bytes changed. Codec `VBC3` → `VBC4`; empty on the in-process lanes, where it pins nothing and nothing reads it.

**The channel is real.** `lib/@vibe/compiler/tests/typed_lowering_rows_interface_test.vibe` (new) reads an untouched consumer's own rows while editing the callee's file:

| edit to the callee's file | consumer's rows |
|---|---|
| a comment | `[715]` — unchanged |
| a same-length body edit | `[715]` — unchanged |
| a body edit that **lengthens** the file | `[715]` — unchanged |
| `() -> Int` → `() -> Bool` | `[717]` — **moved** |

So those rows track the interfaces a module reads, not the bytes anyone else adds. That is both why the guard can see this case and why it stays quiet on ordinary edits. Asserted as relations between runs rather than literal offsets, since the absolute values depend on the prelude.

**A live wrong-bytes bug did not reproduce.** `body_cache_edit_classes_test.vibe` gains a `render-type` row — `ec_flag` goes `() -> Int` → `() -> Bool` in the first file while the unchanged second file both interpolates it and compares it, so both halves have a consumer. **Rebuilt with the stamp neutered so the guard is never consulted, the row still reports `partial` / `equal=true`**: `ec_flag`'s return classification is program-wide, a `guard_layout` slot moves, and the lane declines before the typed-lowering guard could matter.

So the guard ships on the same footing as the ten `guard_layout` slots the test header already lists as unproven on this corpus — sufficiency shown, necessity not. The shape that would separate them (a classification moving through a type alias or a generic instantiation, every layout slot still) is named there rather than implied away. The header's previous claim that no such interface change could be reached at all was simply wrong and is replaced.

Per file and not whole-program for a second measured reason: an edit moves the edited file's own offsets, so a whole-program comparison declines on every edit there is — measured, every row in the edit-class table that reuses went to reusing nothing.

## P1 — `bcc_fp_int` hashed 56 of 63 bits

`0` and `1 << 56` fingerprinted alike. Harmless for an index, not harmless for `const_int_values`, where the pinned thing is a literal a body embeds. Now a sign byte plus nine magnitude bytes, the sign riding separately so `acc / 256` never has to mean anything for a negative.

Red side measured, not assumed: reimplementing the seven-byte encoding against the same accumulator collides on `0`/`1<<56`, `0`/`1<<61` and `1<<56`/`1<<61`, and the nine-byte one on none. The extremes pair in the same test is **not** red — seven bytes already separated it — and is there for the sign split's behaviour at the ends of the range; the comment says so instead of implying four red asserts.

## P2 — a narrowed build dropped its replayed prefix

When a layout guard drifts the body loop replays the unchanged prefix, and a replayed function is not re-recorded, so the fresh harvest has a hole exactly there; persisting only that harvest made the next completely unchanged build recompile the prefix. A second merge arm carries it back, keyed on the same `consumer_src_limit` annotation the body loop narrowed by, so the two cannot disagree about which entries were replayed.

The first version of that red test was worthless and is recorded as such: it edited the middle file by adding a closure, which also moves `guard_meta`, so the merge was refused for the older reason and the test passed with or without the fix. Lengthening a string literal moves only the pooled-offset slot, and the test then fails without the fix.

## P2 — verify mode reported the fresh compile's count

`fresh_out` is the harvest of a compile handed an empty cache, so it always holds every function; `scripts/body_cache_reuse.sh` therefore labelled every verify row a full rebuild whatever it reused. The replay compile now gets its own harvest and that count is reported; empty means no replay compile ran at all, reported as `-1` rather than a number that reads like reuse.

Measured, it now agrees with `mode=on` exactly:

| temperature | `on` | `verify` |
|---|---|---|
| cold | `offered=0 recompiled=5263` | `offered=0 recompiled=-1` |
| unchanged | `4431 / 832` | `4431 / 832` |
| comment-edited | `4431 / 832` | `4431 / 832` |
| reverted | `4431 / 832` | `4431 / 832` |

The agreement is what says the count now means something.

## Two things found while fixing those

**`reuse=full` read as its own opposite.** In the edit-class report it meant the lane was offered entries and replayed *none* of them, and the surrounding prose had to translate it every time. The three values are now `unoffered` / `partial` / `none`.

**The new opt-in failed `check_selector_precedence.sh`, correctly.** `VIBE_UNSTABLE_TYPING_DEP_ENV_REUSE_COMPILE` in statement position reads as a lane selector, and ordering it would have `selector_clears_before` unset it on exactly the compile lanes it exists for. It is now read in expression position and named in `OBSERVATION_ONLY` with that reason, the way `VIBE_UNSTABLE` already is. The gate's own self-test still passes all seven historical cases.

## Measured — the compiler's own closure (196 files, 5263 functions)

`scripts/body_cache_reuse.sh`, one temperature per process sharing one `VIBE_BUILD_CACHE_DIR`:

| temperature | offered | recompiled | heap_delta |
|---|---:|---:|---:|
| cold | 0 | 5263 | 1,081,422,048 |
| unchanged (warm) | 4431 | 832 | 659,839,296 |
| comment-edited | 4431 | **832** | 930,477,800 |
| reverted | 4431 | 832 | 665,264,816 |

`offered + recompiled == 5263` exactly. Byte-exact under `VIBE_CODEGEN_BODY_CACHE=verify`.

## What this does not do

`VIBE_UNSTABLE_TYPING_DEP_ENV_REUSE_COMPILE` is added but **off by default** — it lets a compile take the typing-dependency env reuse the check lane has had as production default since TDRE8, which is the remaining #2510 criterion-5 blocker (a one-leaf edit costs a compile 331.4 MB in its check phase against an unchanged warm build's 11.3 MB, and re-checks 1 of 197 modules with reuse on). It stays opt-in until a compile's output is shown byte-identical with it on and off across the edit shapes: a compile consumes more of a module's check than the public env, and "the check lane proves it" is a claim about the check lane.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CCUq2wJKeDzguGzmx78HkZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01CCUq2wJKeDzguGzmx78HkZ)_