### PR TITLE
`vibe symbols`: NAME carries no ascii whitespace, so every row splits into its documented fields (#2723)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -485,6 +485,8 @@ vibe symbols file.vibe
 # literal, so its spaces, tabs and newlines are escaped (`\s` `\t` `\n`
 # `\v` `\f` `\r`, backslash doubled) and every row splits into the same
 # fields (#2723). DOC is exempt -- it is last, and nothing is parsed after it.
+# Split on ASCII: a NBSP inside a label is NOT escaped (the separators are
+# ascii spaces), so a Unicode-aware class drops the row instead of reading it.
 vibe symbols lib
 vibe symbols --with-path file.vibe
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -481,6 +481,10 @@ vibe symbols file.vibe
 # An unrecognised argument is REFUSED (it used to be accepted and ignored), a
 # file that cannot be parsed is NAMED on stderr while the rows that were read
 # still reach stdout, and either failure exits non-zero.
+# NAME carries NO ascii whitespace: a `test` / `bench` label is a string
+# literal, so its spaces, tabs and newlines are escaped (`\s` `\t` `\n`
+# `\v` `\f` `\r`, backslash doubled) and every row splits into the same
+# fields (#2723). DOC is exempt -- it is last, and nothing is parsed after it.
 vibe symbols lib
 vibe symbols --with-path file.vibe
 

--- a/clients/js/lsp_server.js
+++ b/clients/js/lsp_server.js
@@ -566,13 +566,18 @@ function bindingOccurrences(uri, position) {
   }
 }
 
-// One `vibe symbols` row: `NAME KIND START END [DOC]`. NAME never contains
-// ascii whitespace -- a `test` / `bench` label is a string literal, so its
-// spaces, tabs and newlines are escaped (#2723) -- and DOC is last precisely
+// One `vibe symbols` row: `NAME KIND START END [DOC]`. DOC is last precisely
 // because it can contain anything, so it is matched and ignored rather than
 // left to end the row: requiring the line to STOP after END silently dropped
 // every declaration that carries a `///` doc comment.
-const SYMBOL_ROW_RE = /^(\S+)\s+(\d+)\s+(\d+)\s+(\d+)(?:\s+(.*))?$/;
+//
+// The classes are spelled out in ASCII because the producer's contract is
+// ASCII: NAME escapes ascii whitespace (#2723) and nothing else, so a label
+// written with a NBSP or an ideographic space carries that byte raw. JS's
+// \s / \S are Unicode-aware, so `\S+` stopped at the NBSP and the row matched
+// nothing -- and silently, since compilerSymbols returns the rows it did parse
+// rather than falling back. Separators are a single ascii space.
+const SYMBOL_ROW_RE = /^([^ \t]+)[ \t]+(\d+)[ \t]+(\d+)[ \t]+(\d+)(?:[ \t]+(.*))?$/;
 
 // Reverse the NAME escaping, or the editor shows `adds\stwo` where the source
 // says `adds two`. Backslash is doubled on the way out, so consuming exactly

--- a/clients/js/lsp_server.js
+++ b/clients/js/lsp_server.js
@@ -517,9 +517,10 @@ function typeAt(uri, position) {
   const tmp = path.join(dir, `.vibe-lsp-ty-${process.pid}-${Math.abs(hash(uri))}.vibe`);
   try {
     fs.writeFileSync(tmp, doc.text, "utf8");
-    // LSP positions are 0-based; `vibe type-at` expects 1-based line/col.
+    // LSP positions are 0-based UTF-16; `vibe type-at` expects a 1-based line
+    // and a 1-based BYTE column.
     const line = String(position.line + 1);
-    const col = String(position.character + 1);
+    const col = String(positionToByteCol(doc.text, position));
     const res = spawnSync(VIBE_BIN, ["type-at", tmp, line, col], { encoding: "utf8" });
     return (res.stdout || "").trim();
   } catch {
@@ -530,7 +531,50 @@ function typeAt(uri, position) {
   }
 }
 
-// Convert a 0-based char offset into an LSP {line, character} position.
+// The compiler answers in BYTE offsets and takes BYTE columns (ADR-0108,
+// docs/source-range-contract.md); LSP positions are 0-based lines and UTF-16
+// code units. The two agree only while a line is ascii, so this boundary
+// converts in BOTH directions, as lib/@vibe/lsp does at its own. Without it one
+// multibyte character earlier in the file shifts every range after it, and a
+// hover on a line containing one asks the compiler about the wrong column.
+// `offsetToPosition` below is NOT this: it takes an offset already measured in
+// UTF-16 units, which is what the JS-side workspace index produces.
+function utf8Len(cp) {
+  return cp < 0x80 ? 1 : cp < 0x800 ? 2 : cp < 0x10000 ? 3 : 4;
+}
+
+// A compiler BYTE offset -> an LSP position.
+function byteOffsetToPosition(text, byteOff) {
+  let line = 0, lineStartUnit = 0, bytes = 0, unit = 0;
+  while (unit < text.length && bytes < byteOff) {
+    const cp = text.codePointAt(unit);
+    bytes += utf8Len(cp);
+    unit += cp > 0xffff ? 2 : 1;
+    if (cp === 10) { line++; lineStartUnit = unit; }
+  }
+  return { line, character: unit - lineStartUnit };
+}
+
+// An LSP position -> the compiler's 1-based BYTE column. `\r` is line content,
+// so a CRLF file does not shift a column.
+function positionToByteCol(text, position) {
+  let lineStart = 0;
+  for (let l = 0; l < position.line; l++) {
+    const nl = text.indexOf("\n", lineStart);
+    if (nl < 0) { lineStart = text.length; break; }
+    lineStart = nl + 1;
+  }
+  let bytes = 0, unit = 0;
+  while (unit < position.character && lineStart + unit < text.length) {
+    const cp = text.codePointAt(lineStart + unit);
+    if (cp === 10) break;
+    bytes += utf8Len(cp);
+    unit += cp > 0xffff ? 2 : 1;
+  }
+  return bytes + 1;
+}
+
+// Convert a 0-based UTF-16 offset into an LSP {line, character} position.
 function offsetToPosition(text, off) {
   let line = 0, lineStart = 0;
   const n = Math.min(off, text.length);
@@ -551,11 +595,11 @@ function bindingOccurrences(uri, position) {
   const tmp = path.join(dir, `.vibe-lsp-ba-${process.pid}-${Math.abs(hash(uri))}.vibe`);
   try {
     fs.writeFileSync(tmp, doc.text, "utf8");
-    const res = spawnSync(VIBE_BIN, ["binding-at", tmp, String(position.line + 1), String(position.character + 1)], { encoding: "utf8" });
+    const res = spawnSync(VIBE_BIN, ["binding-at", tmp, String(position.line + 1), String(positionToByteCol(doc.text, position))], { encoding: "utf8" });
     const ranges = [];
     for (const l of (res.stdout || "").split(/\r?\n/)) {
       const m = /^\s*(\d+)\s+(\d+)\s*$/.exec(l);
-      if (m) ranges.push({ start: offsetToPosition(doc.text, +m[1]), end: offsetToPosition(doc.text, +m[2]) });
+      if (m) ranges.push({ start: byteOffsetToPosition(doc.text, +m[1]), end: byteOffsetToPosition(doc.text, +m[2]) });
     }
     return ranges.length ? ranges : null;
   } catch {
@@ -631,8 +675,8 @@ function compilerSymbols(uri) {
           name: decodeSymbolName(m[1]),
           kind: lspSymbolKind(+m[2]),
           selectionRange: {
-            start: offsetToPosition(doc.text, +m[3]),
-            end: offsetToPosition(doc.text, +m[4]),
+            start: byteOffsetToPosition(doc.text, +m[3]),
+            end: byteOffsetToPosition(doc.text, +m[4]),
           },
         });
       }

--- a/clients/js/lsp_server.js
+++ b/clients/js/lsp_server.js
@@ -566,8 +566,44 @@ function bindingOccurrences(uri, position) {
   }
 }
 
-// AST-accurate declaration outline via `vibe symbols` (one "NAME KIND START END"
-// per line; KIND = LSP SymbolKind, START/END = char offsets of the name).
+// One `vibe symbols` row: `NAME KIND START END [DOC]`. NAME never contains
+// ascii whitespace -- a `test` / `bench` label is a string literal, so its
+// spaces, tabs and newlines are escaped (#2723) -- and DOC is last precisely
+// because it can contain anything, so it is matched and ignored rather than
+// left to end the row: requiring the line to STOP after END silently dropped
+// every declaration that carries a `///` doc comment.
+const SYMBOL_ROW_RE = /^(\S+)\s+(\d+)\s+(\d+)\s+(\d+)(?:\s+(.*))?$/;
+
+// Reverse the NAME escaping, or the editor shows `adds\stwo` where the source
+// says `adds two`. Backslash is doubled on the way out, so consuming exactly
+// one byte after each backslash, left to right, is exact.
+function decodeSymbolName(text) {
+  if (text.indexOf("\\") < 0) return text;
+  let out = "";
+  for (let i = 0; i < text.length; i++) {
+    if (text[i] !== "\\" || i + 1 >= text.length) { out += text[i]; continue; }
+    const c = text[++i];
+    if (c === "s") out += " ";
+    else if (c === "t") out += "\t";
+    else if (c === "n") out += "\n";
+    else if (c === "v") out += "\v";
+    else if (c === "f") out += "\f";
+    else if (c === "r") out += "\r";
+    else if (c === "\\") out += "\\";
+    else out += "\\" + c;
+  }
+  return out;
+}
+
+// `vibe symbols` legend v2 added two kinds past the LSP range: 27 Test and 28
+// Bench, so a consumer can tell a block label from a declaration of the same
+// spelling (#2632). The protocol has no such values, so they become Function
+// (12) at this boundary -- the same mapping lib/@vibe/lsp applies.
+function lspSymbolKind(kind) {
+  return kind === 27 || kind === 28 ? 12 : kind;
+}
+
+// AST-accurate declaration outline via `vibe symbols`.
 // Returns an array of { name, kind, selectionRange } (selectionRange spans the
 // name), or null when unavailable (older compiler / no symbols) so callers can
 // fall back to the line-regex scan. Unlike the regex, this handles multi-line
@@ -584,11 +620,11 @@ function compilerSymbols(uri) {
     const res = spawnSync(VIBE_BIN, ["symbols", tmp], { encoding: "utf8" });
     const out = [];
     for (const l of (res.stdout || "").split(/\r?\n/)) {
-      const m = /^(\S+)\s+(\d+)\s+(\d+)\s+(\d+)\s*$/.exec(l);
+      const m = SYMBOL_ROW_RE.exec(l);
       if (m) {
         out.push({
-          name: m[1],
-          kind: +m[2],
+          name: decodeSymbolName(m[1]),
+          kind: lspSymbolKind(+m[2]),
           selectionRange: {
             start: offsetToPosition(doc.text, +m[3]),
             end: offsetToPosition(doc.text, +m[4]),

--- a/docs/editor-and-debugging.md
+++ b/docs/editor-and-debugging.md
@@ -99,13 +99,17 @@ vibe check --single-file --json <file.vibe>  # same diagnostics as a JSON array 
   and a backslash is doubled, so one declaration is always one line. The
   structured form (real newlines, for LSP detail) is `symbol_spans_with_docs`.
 - **A label is a string, so `NAME` is escaped too.** A declaration's name is an
-  identifier, but a `test` / `bench` label is a string literal: it can hold a
-  backslash, and a multi-line `#|` label holds a real newline. In `NAME` those
-  are written `\\`, `\n` and `\r`, so **one symbol is always one line** —
-  unescaped, a two-line label printed as two rows and a reader counted a symbol
-  that does not exist. `cut -d" " -f1-4` is still not enough for a label,
-  because `NAME` can contain a SPACE and nothing yet says where it ends
-  (#2723). The structured form has the real name.
+  identifier, but a `test` / `bench` label is a string literal: almost every one
+  holds spaces, a multi-line `#|` label holds a real newline, and any of them
+  can hold a backslash. **`NAME` therefore carries no ASCII whitespace at
+  all** — backslash first (that is what makes it reversible), then space
+  `\s`, tab `\t`, LF `\n`, VT `\v`, FF `\f`, CR `\r` — so every row is one
+  line of five whitespace-separated fields and `cut -d" " -f1-4` reads the
+  fixed part of a label row as well as a declaration's. Unescaped, a two-line
+  label printed as two rows (a reader counted a symbol that did not exist) and
+  `adds two numbers 27 6 22` read `KIND=two` (#2718, #2723). `DOC` needs none
+  of this because it is last and nothing is parsed after it. The structured
+  form (`symbol_spans_with_docs`) has the real name.
 - **A multi-line `#|` label spans the literal, not its content.** `"…"`,
   `r"…"` and a single-line `#|…` report the bytes inside the delimiters. A
   `#|` block continued on the next line is the one spelling whose content is

--- a/docs/editor-and-debugging.md
+++ b/docs/editor-and-debugging.md
@@ -101,15 +101,21 @@ vibe check --single-file --json <file.vibe>  # same diagnostics as a JSON array 
 - **A label is a string, so `NAME` is escaped too.** A declaration's name is an
   identifier, but a `test` / `bench` label is a string literal: almost every one
   holds spaces, a multi-line `#|` label holds a real newline, and any of them
-  can hold a backslash. **`NAME` therefore carries no ASCII whitespace at
-  all** — backslash first (that is what makes it reversible), then space
-  `\s`, tab `\t`, LF `\n`, VT `\v`, FF `\f`, CR `\r` — so every row is one
-  line of five whitespace-separated fields and `cut -d" " -f1-4` reads the
-  fixed part of a label row as well as a declaration's. Unescaped, a two-line
-  label printed as two rows (a reader counted a symbol that did not exist) and
-  `adds two numbers 27 6 22` read `KIND=two` (#2718, #2723). `DOC` needs none
-  of this because it is last and nothing is parsed after it. The structured
-  form (`symbol_spans_with_docs`) has the real name.
+  can hold a backslash. Unescaped, a two-line label printed as two rows — a
+  reader counted a symbol that did not exist — and `adds two numbers 27 6 22`
+  read `KIND=two` (#2718, #2723). **`NAME` therefore carries no ASCII
+  whitespace at all**: backslash first (that is what makes it reversible),
+  then space `\s`, tab `\t`, LF `\n`, VT `\v`, FF `\f`, CR `\r`. Every row is
+  one line of the same four fixed fields, plus `DOC` when the declaration has
+  one, so `cut -d" " -f1-4` reads the fixed part of a label row as well as a
+  declaration's. `DOC` needs none of this because it is last and nothing is
+  parsed after it, and the structured form (`symbol_spans_with_docs`) has the
+  real name.
+  **ASCII is all that is escaped**, deliberately: a label written with a NBSP
+  or an ideographic space carries that byte raw, because escaping it would
+  change a name for no gain — the separators are ASCII spaces. A consumer must
+  therefore split on ASCII; a Unicode-aware class (JavaScript's `\s`, Python's
+  `str.split()`) treats the NBSP as a separator and drops the row.
 - **A multi-line `#|` label spans the literal, not its content.** `"…"`,
   `r"…"` and a single-line `#|…` report the bytes inside the delimiters. A
   `#|` block continued on the next line is the one spelling whose content is

--- a/lib/@vibe/compiler/cli_adapter.vibe
+++ b/lib/@vibe/compiler/cli_adapter.vibe
@@ -352,47 +352,88 @@ fn escape_doc_field(text: String) -> String {
   StringBuilder::freeze(acc)
 }
 
-/// Escape a NAME so it survives as ONE line. A declaration's name cannot
-/// contain either byte, but a `test` / `bench` label is a string literal and
-/// a multi-line `#|` one carries a real newline (Codex on #2718) -- emitted
-/// raw it splits one record across two lines, so a reader counting rows sees
-/// a symbol that does not exist. Same reversible scheme as the doc field
-/// (backslash first), with `\r` kept rather than dropped: a byte inside a
-/// name is not noise to discard.
-fn escape_name_field(text: String) -> String {
+/// Does this NAME contain a byte that would break the row? Backslash (which
+/// makes the escaping reversible) and every ASCII whitespace byte: tab, LF,
+/// VT, FF, CR (9..13) and space. A declaration's name contains none of them,
+/// so this answers false for nearly every row and `escape_name_field` hands
+/// the string straight back.
+fn name_field_needs_escape(text: String) -> Bool {
   let n = String::length(text)
-  let acc = StringBuilder::new()
   let mut i = 0
-  while i < n {
+  let mut found = false
+  while i < n && !found {
     let c = String::char_code_at(text, i)
-    if c == 92 {
-      StringBuilder::push(acc, "\\\\")
+    if c == 92 || c == 32 || (c >= 9 && c <= 13) {
+      found = true
     } else {
-      if c == 10 {
-        StringBuilder::push(acc, "\\n")
-      } else {
-        if c == 13 {
-          StringBuilder::push(acc, "\\r")
-        } else {
-          StringBuilder::push(acc, String::from_char_code(c))
-        }
-      }
+      ()
     }
     i = i + 1
   }
-  StringBuilder::freeze(acc)
+  found
+}
+
+/// The escaped spelling of one NAME byte.
+fn name_field_escape_of(c: Int) -> String {
+  if c == 92 {
+    "\\\\"
+  } else if c == 32 {
+    "\\s"
+  } else if c == 9 {
+    "\\t"
+  } else if c == 10 {
+    "\\n"
+  } else if c == 11 {
+    "\\v"
+  } else if c == 12 {
+    "\\f"
+  } else if c == 13 {
+    "\\r"
+  } else {
+    String::from_char_code(c)
+  }
+}
+
+/// Escape a NAME so the row stays ONE line of FIXED fields. A declaration's
+/// name is an identifier and contains none of these bytes, but a `test` /
+/// `bench` label is a string literal: a multi-line `#|` one carries a real
+/// newline (Codex on #2718), and almost every label carries spaces (#2723).
+/// Unescaped, the first split one record across two lines -- a reader counting
+/// rows saw a symbol that does not exist -- and the second made `NAME KIND
+/// START END` unsplittable, so `adds two numbers 27 6 22` read KIND=`two`
+/// with nothing to signal it.
+///
+/// So NAME carries no ASCII whitespace at all: backslash first (which is what
+/// makes it reversible), then space `\s`, tab `\t`, LF `\n`, VT `\v`, FF `\f`
+/// and CR `\r`. DOC needs none of this because it is LAST and nothing is
+/// parsed after it; NAME is positional, so the property it needs is stronger.
+/// `\r` is escaped rather than dropped as DOC drops it: a byte inside a name
+/// is not noise to discard. The structured form
+/// (`symbol_spans` / `symbol_spans_with_docs`) has the real name.
+fn escape_name_field(text: String) -> String {
+  if !name_field_needs_escape(text) {
+    text
+  } else {
+    let n = String::length(text)
+    let acc = StringBuilder::new()
+    let mut i = 0
+    while i < n {
+      StringBuilder::push(acc, name_field_escape_of(String::char_code_at(text, i)))
+      i = i + 1
+    }
+    StringBuilder::freeze(acc)
+  }
 }
 
 /// One `NAME KIND START END` per declaration, with the `///` doc comment
 /// appended as a FIFTH field when the declaration has one. The doc goes last
 /// because it WAS the only field that could contain spaces, so `cut -f1-4`
 /// still reads the fixed part -- and a declaration with no doc emits exactly
-/// the four fields it always did, with no trailing space. That reasoning
-/// stopped holding when a `test` / `bench` label became a symbol: its NAME is
-/// a string literal, usually a sentence. Which encoding those rows get is a
-/// contract decision, tracked in #2723. A newline in a NAME is escaped here
-/// regardless (`escape_name_field`) -- it breaks the RECORD boundary, not
-/// merely the field one, so a reader counts a symbol that does not exist.
+/// the four fields it always did, with no trailing space. DOC stayed the only
+/// field allowed to hold a space when a `test` / `bench` label became a
+/// symbol, whose NAME is a string literal and usually a sentence: NAME is
+/// escaped to carry no ASCII whitespace at all (`escape_name_field`, #2723),
+/// so every row splits on whitespace into the same five fields.
 fn join_symbol_spans(syms: Array[(String, Int, Int, Int, String)]) -> String {
   let n = Array::length(syms)
   // O(N) join via StringBuilder; per-record String::concat was O(N²) (issue #366).

--- a/scripts/test_vibe_lsp.js
+++ b/scripts/test_vibe_lsp.js
@@ -183,6 +183,43 @@ const isDiag = (uri) => (m) => m.method === "textDocument/publishDiagnostics" &&
     check("a label containing a NBSP survives the row parser", labNames.includes("counts\u00a0items"));
   }
 
+  // The compiler answers in BYTE offsets and takes BYTE columns; LSP positions
+  // are UTF-16 code units. This file puts two 4-byte emoji in the middle of it,
+  // so after them every byte offset runs 4 ahead of the UTF-16 offset the
+  // editor uses, and the column of anything later on that LINE runs 4 ahead
+  // too. Both directions are asserted: an outline range must still land on the
+  // name, and a hover must still reach the right identifier.
+  const mbUri = "file:///tmp/vibe-lsp-test-bytes.vibe";
+  const mbText =
+    "export let f = (n: Int) -> Int {\n" +
+    "  let doubled = n * 2\n" +
+    "  String::length(\"\u{1F38C}\u{1F38C}\") + doubled\n" +
+    "}\n" +
+    "export let after = (x: Int) -> Int { x }\n";
+  send({ jsonrpc: "2.0", method: "textDocument/didOpen", params: { textDocument: { uri: mbUri, languageId: "vibe", version: 1, text: mbText } } });
+  await waitFor(isDiag(mbUri));
+  send({ jsonrpc: "2.0", id: 33, method: "textDocument/documentSymbol", params: { textDocument: { uri: mbUri } } });
+  const mbSyms = (await waitFor((m) => m.id === 33)).result || [];
+  const afterSym = mbSyms.find((s) => s.name === "after");
+  if (!afterSym) {
+    console.log("skip: byte-offset ranges (compiler outline unavailable)");
+  } else {
+    const r = afterSym.selectionRange || afterSym.range;
+    const rLine = mbText.split(/\n/)[r.start.line] || "";
+    check("an outline range lands on the name after multibyte text",
+      rLine.slice(r.start.character, r.end.character) === "after");
+  }
+
+  // Hover on `doubled`, which sits AFTER the two emoji on its own line. With
+  // the UTF-16 column sent as a byte column the cursor lands inside the string
+  // literal instead, and the inferred type is not the binding's.
+  const mbCol = (mbText.split(/\n/)[2] || "").indexOf("doubled");
+  send({ jsonrpc: "2.0", id: 34, method: "textDocument/hover", params: { textDocument: { uri: mbUri }, position: { line: 2, character: mbCol + 1 } } });
+  const mbHov = await waitFor((m) => m.id === 34);
+  const mbHovVal = mbHov.result ? JSON.stringify(mbHov.result.contents) : "";
+  check("a hover after multibyte text on the same line reaches the identifier",
+    /doubled/.test(mbHovVal) && /Int/.test(mbHovVal));
+
   // definition: cursor on `helper` in main's body -> jumps to helper's decl (line 1)
   const callLine = goodText.split(/\r?\n/)[2]; // "export let main = () -> Int { helper(21) }"
   const helperCol = callLine.indexOf("helper");

--- a/scripts/test_vibe_lsp.js
+++ b/scripts/test_vibe_lsp.js
@@ -150,6 +150,34 @@ const isDiag = (uri) => (m) => m.method === "textDocument/publishDiagnostics" &&
   checkAst("outline finds a struct symbol", astNames.includes("Vec"));
   checkAst("outline excludes a name that only appears in a comment", !astNames.includes("ghost"));
 
+  // A `test` label and a documented declaration, both of which the row parser
+  // used to mishandle: NAME escapes its whitespace so the row stays field-split
+  // (#2723) and must be DECODED here, a row carrying a DOC field must still be
+  // read (requiring the line to stop after END dropped every declaration with a
+  // `///` comment), and kind 27 Test is outside the protocol's SymbolKind range
+  // so it maps to Function (12), as lib/@vibe/lsp does.
+  const labUri = "file:///tmp/vibe-lsp-test-label.vibe";
+  const labText =
+    "/// Doc on a declaration.\nexport let documented = (x: Int) -> Int { x }\n" +
+    "\ntest \"adds two numbers\" {\n  let _ = 1\n}\n";
+  send({ jsonrpc: "2.0", method: "textDocument/didOpen", params: { textDocument: { uri: labUri, languageId: "vibe", version: 1, text: labText } } });
+  await waitFor(isDiag(labUri));
+  send({ jsonrpc: "2.0", id: 32, method: "textDocument/documentSymbol", params: { textDocument: { uri: labUri } } });
+  const labSyms = (await waitFor((m) => m.id === 32)).result || [];
+  const labNames = labSyms.map((s) => s.name);
+  // Capability probe: only a compiler that reports block labels can satisfy
+  // these. An older one answers without the label, and the row parser is never
+  // handed one to decode.
+  const labelName = labNames.find((n) => n.indexOf("adds") === 0);
+  if (!labelName) {
+    console.log("skip: label outline (this compiler does not report block labels)");
+  } else {
+    check("a label's name is decoded, not the escaped spelling", labelName === "adds two numbers");
+    check("a label's kind is inside the protocol's SymbolKind range",
+      labSyms.filter((s) => s.name === labelName).every((s) => s.kind >= 1 && s.kind <= 26));
+    check("a declaration carrying a doc comment is still in the outline", labNames.includes("documented"));
+  }
+
   // definition: cursor on `helper` in main's body -> jumps to helper's decl (line 1)
   const callLine = goodText.split(/\r?\n/)[2]; // "export let main = () -> Int { helper(21) }"
   const helperCol = callLine.indexOf("helper");

--- a/scripts/test_vibe_lsp.js
+++ b/scripts/test_vibe_lsp.js
@@ -159,7 +159,8 @@ const isDiag = (uri) => (m) => m.method === "textDocument/publishDiagnostics" &&
   const labUri = "file:///tmp/vibe-lsp-test-label.vibe";
   const labText =
     "/// Doc on a declaration.\nexport let documented = (x: Int) -> Int { x }\n" +
-    "\ntest \"adds two numbers\" {\n  let _ = 1\n}\n";
+    "\ntest \"adds two numbers\" {\n  let _ = 1\n}\n" +
+    "\ntest \"counts\u00a0items\" {\n  let _ = 2\n}\n";
   send({ jsonrpc: "2.0", method: "textDocument/didOpen", params: { textDocument: { uri: labUri, languageId: "vibe", version: 1, text: labText } } });
   await waitFor(isDiag(labUri));
   send({ jsonrpc: "2.0", id: 32, method: "textDocument/documentSymbol", params: { textDocument: { uri: labUri } } });
@@ -176,6 +177,10 @@ const isDiag = (uri) => (m) => m.method === "textDocument/publishDiagnostics" &&
     check("a label's kind is inside the protocol's SymbolKind range",
       labSyms.filter((s) => s.name === labelName).every((s) => s.kind >= 1 && s.kind <= 26));
     check("a declaration carrying a doc comment is still in the outline", labNames.includes("documented"));
+    // NON-ascii whitespace inside a label reaches the row raw -- the producer
+    // escapes ascii whitespace and nothing else -- so the row parser must split
+    // on ascii, not on JS's Unicode-aware \s.
+    check("a label containing a NBSP survives the row parser", labNames.includes("counts\u00a0items"));
   }
 
   // definition: cursor on `helper` in main's body -> jumps to helper's decl (line 1)

--- a/scripts/test_vibe_symbols.sh
+++ b/scripts/test_vibe_symbols.sh
@@ -178,6 +178,46 @@ else
   bad "symbols should report [one\\ntwo 27 5 21] for a multi-line label; got: $out_ml"
 fi
 
+# 7e. #2723: a label is a string literal, so almost every one carries spaces.
+#     Emitted raw, `adds two numbers 27 6 22` read KIND=`two` to anything that
+#     splits on whitespace -- right values, an encoding that does not say where
+#     a field ends. NAME now carries no ASCII whitespace at all.
+sl="$WORK/spaced_label.vibe"
+printf 'test "adds two numbers" { let _ = 1 }\n' > "$sl"
+out_sl="$("$VIBE" symbols "$sl" 2>/dev/null || true)"
+if [ "$out_sl" = 'adds\stwo\snumbers 27 6 22' ]; then
+  ok "symbols escapes the spaces in a label"
+else
+  bad "symbols should report [adds\\stwo\\snumbers 27 6 22]; got: $out_sl"
+fi
+kind_sl="$(printf '%s\n' "$out_sl" | awk '{print $2}')"
+if [ "$kind_sl" = "27" ]; then
+  ok "a label row's KIND is readable by splitting on whitespace"
+else
+  bad "field 2 of [$out_sl] should be 27; got: $kind_sl"
+fi
+
+tl="$WORK/tab_label.vibe"
+printf 'test "adds\\ttwo" { let _ = 1 }\n' > "$tl"
+out_tl="$("$VIBE" symbols "$tl" 2>/dev/null || true)"
+if [ "$out_tl" = 'adds\ttwo 27 6 15' ]; then
+  ok "symbols escapes a tab inside a label"
+else
+  bad "symbols should report [adds\\ttwo 27 6 15]; got: $out_tl"
+fi
+
+# The same property over a REAL corpus rather than a crafted file: every label
+# in these *_test.vibe files is a sentence. In the batch form KIND is the third
+# field, and it is an integer on every row or the format is not splittable.
+sweep_out="$("$VIBE" symbols "$ROOT_DIR/lib/@vibe/compiler/runtime" 2>/dev/null || true)"
+sweep_rows="$(printf '%s\n' "$sweep_out" | awk 'NF > 0' | wc -l | tr -d ' ')"
+sweep_bad="$(printf '%s\n' "$sweep_out" | awk 'NF > 0 && $3 !~ /^[0-9]+$/' | head -3)"
+if [ "$sweep_rows" -gt 100 ] && [ -z "$sweep_bad" ]; then
+  ok "every row of a directory sweep ($sweep_rows rows) has an integer KIND"
+else
+  bad "sweep rows=$sweep_rows, rows with a non-integer KIND: $sweep_bad"
+fi
+
 # --- #2381: arguments are no longer accepted and ignored --------------------
 # Every case below used to print a.vibe's outline and exit 0, so a caller who
 # believed they had asked about two files -- or who typo'd a flag -- got a


### PR DESCRIPTION
Closes #2723, the only open P0.

**One thing to redirect if you disagree:** the issue listed three encodings and I picked escaping over quoting and over a tab separator. The reasoning is below; if you want one of the others, only `name_field_escape_of`, the JS client's decoder and the test expectations change — the plumbing, the corpus test and the docs stay as they are.

## The defect

A `test` / `bench` label is a string literal, and almost every one in this tree is a sentence. Emitted raw into a field-positional row, measured on `652c7ef`:

```
$ vibe symbols spaced.vibe
adds two numbers 27 6 22
helper 12 65 71 Doc line.
$ awk '{print $2}' < out
two
12
```

Every value in that row is right. The encoding does not say where a field ends, so a reader following the documented `NAME KIND START END [DOC]` takes `KIND=two` and coordinates `numbers` / `27` out of a well-formed answer, with nothing to signal it — the P0 test, "nobody can notice". Every `*_test.vibe` in the tree hits it, and the CLI's stated first reader is an LLM.

## The fix

`NAME` now carries **no ascii whitespace at all**: backslash first (that is what makes it reversible), then space `\s`, tab `\t`, LF `\n`, VT `\v`, FF `\f`, CR `\r`.

```
adds\stwo\snumbers 27 6 22
helper 12 65 71 Doc line.
```

`awk '{print $2}'` now reads `27` and `12`.

**Why escaping and not quoting or tabs.** The newline and the CR already had to be escaped last week for the record boundary (#2718), so the row already had an escape scheme with a reversible backslash. Extending it costs one mechanism; quoting adds a second one a reader must implement on top of the first, and still leaves `awk '{print $2}'` wrong. A tab separator would work, but it rewrites every row, every consumer, and the format as documented in three places — a large change to fix a case that only labels hit.

`DOC` stays exempt: it is last, and nothing is parsed after it. **Only ascii is escaped**, deliberately: a NBSP or ideographic space inside a label rides through raw, because escaping it would change a name to buy nothing — the separators are ascii spaces. So the rule a consumer needs is "split on ascii", and both docs now say it.

An identifier contains none of these bytes, so `escape_name_field` hands the string straight back for every declaration row — the common path allocates nothing, which matters because `vibe symbols lib` sweeps the whole tree in one process.

## Commits 2–4: the one consumer that reads the rows as text

Codex caught that `clients/js/lsp_server.js` parses `vibe symbols` output and would have shown `adds\stwo\snumbers` in the editor. Checking its one regex against real rows found **five** defects, all the same statement — that client never implemented the documented row:

```
"helper 12 65 71"           -> helper kind=12
"helper 12 65 71 Doc line." -> NO MATCH (row dropped)
"adds two numbers 27 6 22"  -> NO MATCH (row dropped)
```

1. **NAME used raw** — the reported one. Now decoded back to the source label.
2. **`\s*$` after END required the line to stop there**, so every declaration carrying a `///` doc comment was silently dropped from the outline. Pre-existing since the DOC field landed.
3. **The kind was passed through raw**, so a label would reach the editor as 27 Test, outside the protocol's `SymbolKind` range. It maps to Function (12) here now, as `lib/@vibe/lsp` already does at its boundary.
4. **`\S` / `\s` are Unicode-aware in JS**, so a label containing a NBSP matched nothing — and silently, since `compilerSymbols` returns the rows it did parse rather than falling back. The classes are spelled out in ascii now, matching the producer's contract.
5. **Byte offsets were fed to a UTF-16 indexer, in both directions.** `m[3]`/`m[4]` are byte offsets handed to `offsetToPosition`, and `type-at` / `binding-at` were handed `position.character + 1` as a 1-based **byte** column — so one multibyte character shifted every later range, and a hover on a line containing one asked about the wrong column. `byteOffsetToPosition` and `positionToByteCol` now convert at the boundary (ADR-0108, `docs/source-range-contract.md`). `offsetToPosition` keeps its one remaining caller, the JS-side workspace index, whose offsets are already UTF-16 — converting those would have introduced the same bug.

Only (1) is new. (2), (4) and (5) have been wrong for a while; the escaping is what made label rows reach that parser at all, which is how they surfaced.

`lib/@vibe/lsp` needs none of this: it calls the library, which has the real name and its own conversion.

## Pinned

In `scripts/test_vibe_symbols.sh`:

1. the exact row for a spaced label, and one for a tab inside a label;
2. `awk '{print $2}'` on it reading `27` — the property, not a restatement of the output;
3. a **real corpus**: sweeping `lib/@vibe/compiler/runtime`, whose `*_test.vibe` labels are sentences, and asserting every row's `KIND` field is an integer. A crafted file proves the escaper ran; the sweep proves nothing else in the tree still produces an unsplittable row.

In `scripts/test_vibe_lsp.js`: a documented declaration and a spaced label in one file (decoded name, in-range kind, doc-bearing row kept), a NBSP label, and a file with two 4-byte emoji in the middle of it — an outline range must still slice to the declaration's name, and a hover on an identifier sitting after the emoji on the same line must still reach it.

Every one is red-tested singly: reverting each fix fails its own check and only its own (26 passed / 0 failed; each revert gives 25 / 1).

## Validation

On a stage2 built from this branch: the full compiler gate, `scripts/test_vibe_symbols.sh` (25 cases, four new), `scripts/test_vibe_fmt_launcher.sh`, `scripts/check_gate_portability.sh`, `scripts/check_selector_precedence.sh`, `scripts/check_source_range_contract.sh`, the size ratchet and pre-commit. `symbol_spans_test.vibe` passes on both the seed and that stage2. The JS suites (`test_vibe_lsp.js` 26/26, `test_vibe_lsp_workspace.js` 12/12) pass against a `vibe` installed from this checkout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F7tdQxr8PHL7ZAma4XAF8P