### PR TITLE
#2510 criterion 5: giving a COMPILE the check lane's env reuse is a 2.4x regression

### DIFF
--- a/docs/incremental-build.md
+++ b/docs/incremental-build.md
@@ -1156,12 +1156,27 @@ across two independent invocations:
 | **whole-compile total, one-leaf edit** | **848.7 MB** | **1,434.3 MB** |
 
 **Reuse on is 2.4x worse on the edit it was supposed to fix, and 6.1x worse
-cold.** The cold row is the one that says why: a cold compile has nothing to
-reuse, so every byte of that 1.38 GB is the machinery's WRITE side — building
-and publishing the per-module dependency-transport environments — paid in full
-for a read that cannot happen. The unchanged row is identical to the byte in
-both lanes, which says the reuse arm is not even reached there: the
-conservative fingerprint already short-circuits that case.
+cold.** The cold row is the one that bounds it: a cold compile can reuse
+nothing, so every byte of that 1.38 GB is the transport machinery running for
+a read that cannot succeed. The unchanged row is identical to the byte in both
+lanes, which says the reuse arm is not even reached there: the conservative
+fingerprint already short-circuits that case.
+
+**What the cold row does NOT say is that the cost is publication** (Codex P2 on
+the PR that recorded this, and correct). On a miss the enabled lane pays TWICE
+over, in two different places, and both are inside that number:
+
+- `finish_typecheck_fs_impl` builds `typing_dependency_transport_input_key`
+  from the module's verbatim source plus each dependency's exact env text, then
+  calls `load_typing_dependency_env_reuse_target` — which on a cold compile
+  misses for every module;
+- `commit_module_outcome` then builds *the same large key again* and publishes
+  the eligibility and the sidecar.
+
+So the cold figure is **miss-path lookup plus publication**, with the key
+construction paid twice per module, and nothing here separates them. Splitting
+those three terms is the next measurement, not a conclusion this table
+supports.
 
 **It is not wrong, just slower.** Compiling the same corpus with the flag on
 and off, body cache off so a replayed body cannot mask a difference, gives
@@ -1173,9 +1188,9 @@ What this rules out is the shortcut, not the goal. Criterion 5 still needs the
 check phase bounded by the edited module, but reusing the check lane's
 transport as-is makes a compile worse, because a compile consumes more of a
 module's check than the public env carries (the typed-lowering offsets the
-reuse arm republishes, #2391) and pays to publish the env regardless. The next
-measurement is where inside that 1.38 GB the write side actually goes — not
-another cache. The per-file AST cache was built before it was measured and
+reuse arm republishes, #2391) and pays the whole transport whether or not the
+read succeeds. The next measurement is the split named above — key
+construction, miss-path lookup, publication — not another cache. The per-file AST cache was built before it was measured and
 came back at exactly zero (#2668); this is the same mistake one step later,
 caught by measuring first. Filed as #2728.
 

--- a/docs/incremental-build.md
+++ b/docs/incremental-build.md
@@ -1138,6 +1138,47 @@ to one leaf must re-check that leaf and the modules whose interfaces it
 changes, not the whole closure. That is #1379's semantic-module granularity,
 and this row is the number it has to move.
 
+##### The obvious candidate is measured, and it is a REGRESSION (2026-09-12)
+
+The check lane has had typing-dependency env reuse (TDRE8) as its production
+default for a while, and on that lane a one-leaf edit re-checks exactly **1 of
+197** planned modules. The obvious move was to give a COMPILE the same reuse,
+so `VIBE_UNSTABLE_TYPING_DEP_ENV_REUSE_COMPILE=1` exists. Measured on the same
+corpus, same instrument, same three temperatures, reproduced byte-for-byte
+across two independent invocations:
+
+| check phase (`source_groups -> prepared_db`) | reuse off (today's default) | reuse on |
+|---|---:|---:|
+| cold | 270.9 MB | **1,647.1 MB** |
+| unchanged (warm) | 11.4 MB | 11.4 MB |
+| one-leaf edit | 344.9 MB | **812.7 MB** |
+| **whole-compile total, cold** | **946.2 MB** | **2,322.4 MB** |
+| **whole-compile total, one-leaf edit** | **848.7 MB** | **1,434.3 MB** |
+
+**Reuse on is 2.4x worse on the edit it was supposed to fix, and 6.1x worse
+cold.** The cold row is the one that says why: a cold compile has nothing to
+reuse, so every byte of that 1.38 GB is the machinery's WRITE side — building
+and publishing the per-module dependency-transport environments — paid in full
+for a read that cannot happen. The unchanged row is identical to the byte in
+both lanes, which says the reuse arm is not even reached there: the
+conservative fingerprint already short-circuits that case.
+
+**It is not wrong, just slower.** Compiling the same corpus with the flag on
+and off, body cache off so a replayed body cannot mask a difference, gives
+byte-identical output at both temperatures (cold and leaf-edited,
+`sha256` equal). So the flag stays as the instrument that produced this table,
+and stays OFF.
+
+What this rules out is the shortcut, not the goal. Criterion 5 still needs the
+check phase bounded by the edited module, but reusing the check lane's
+transport as-is makes a compile worse, because a compile consumes more of a
+module's check than the public env carries (the typed-lowering offsets the
+reuse arm republishes, #2391) and pays to publish the env regardless. The next
+measurement is where inside that 1.38 GB the write side actually goes — not
+another cache. The per-file AST cache was built before it was measured and
+came back at exactly zero (#2668); this is the same mistake one step later,
+caught by measuring first. Filed as #2728.
+
 #### And what it costs in ALLOCATION — the #2510 criterion-5 KPI (2026-09-11)
 
 The section above bounds the split's cost in wall time. The KPI #2510 actually

--- a/docs/incremental-build.md
+++ b/docs/incremental-build.md
@@ -1140,9 +1140,10 @@ and this row is the number it has to move.
 
 ##### The obvious candidate is measured, and it is a REGRESSION (2026-09-12)
 
-The check lane has had typing-dependency env reuse (TDRE8) as its production
-default for a while, and on that lane a one-leaf edit re-checks exactly **1 of
-197** planned modules. The obvious move was to give a COMPILE the same reuse,
+The check lane has had typing-dependency env reuse as its production default
+for a while — **TDRE9** at this commit; `TDRE8` was the retired protocol v23
+replaced, and the section below already says so — and on that lane a one-leaf
+edit re-checks exactly **1 of 197** planned modules. The obvious move was to give a COMPILE the same reuse,
 so `VIBE_UNSTABLE_TYPING_DEP_ENV_REUSE_COMPILE=1` exists. Measured on the same
 corpus, same instrument, same three temperatures, reproduced byte-for-byte
 across two independent invocations:
@@ -1166,31 +1167,46 @@ fingerprint already short-circuits that case.
 the PR that recorded this, and correct). On a miss the enabled lane pays TWICE
 over, in two different places, and both are inside that number:
 
-- `finish_typecheck_fs_impl` builds `typing_dependency_transport_input_key`
-  from the module's verbatim source plus each dependency's exact env text, then
-  calls `load_typing_dependency_env_reuse_target` — which on a cold compile
-  misses for every module;
-- `commit_module_outcome` then builds *the same large key again* and publishes
-  the eligibility and the sidecar.
+- `finish_typecheck_fs_impl` calls `typing_dependency_env_reuse_is_eligible`,
+  then builds `typing_dependency_transport_input_key` from the module's
+  verbatim source plus each dependency's exact env text, then calls
+  `load_typing_dependency_env_reuse_target` — which on a cold compile misses
+  for every module;
+- `commit_module_outcome` then runs the eligibility walk again, builds *the
+  same large key again*, and publishes the eligibility and the sidecar.
 
-So the cold figure is **miss-path lookup plus publication**, with the key
-construction paid twice per module, and nothing here separates them. Splitting
-those three terms is the next measurement, not a conclusion this table
-supports.
+**The eligibility walk is not a cheap predicate.** For each dependency it does
+`Fs::exists`, `Fs::read_file`, a binding parse, and
+`load_canonical_typing_dependency_env_reuse_target` — reading and parsing that
+dependency's canonical target env text. On a non-leaf module with many
+dependencies it is a plausible dominant term on its own, and like the key it
+is paid twice.
 
-**It is not wrong, just slower.** Compiling the same corpus with the flag on
-and off, body cache off so a replayed body cannot mask a difference, gives
-byte-identical output at both temperatures (cold and leaf-edited,
-`sha256` equal). So the flag stays as the instrument that produced this table,
-and stays OFF.
+So the cold figure is **eligibility validation plus miss-path lookup plus
+publication**, with both the eligibility walk and the key construction paid
+twice per module, and nothing here separates them. Splitting those four terms
+is the next measurement, not a conclusion this table supports.
+
+**Nothing here shows it is WRONG either — and nothing here shows it is
+right.** Compiling the same corpus with the flag on and off, body cache off so
+a replayed body cannot mask a difference, gives byte-identical output at both
+temperatures (`sha256` equal). Read what those two comparisons can actually
+see: the cold one has no reuse hit to get wrong, and the edited one appends a
+COMMENT, so the program is semantically unchanged and a stale reused env would
+produce the same answer as a fresh one. **Neither exercises a reuse hit on a
+program whose meaning changed**, which is the case that could be silently
+wrong. So the flag stays as the instrument that produced this table, and stays
+OFF, on correctness grounds as much as cost.
 
 What this rules out is the shortcut, not the goal. Criterion 5 still needs the
 check phase bounded by the edited module, but reusing the check lane's
 transport as-is makes a compile worse, because a compile consumes more of a
 module's check than the public env carries (the typed-lowering offsets the
 reuse arm republishes, #2391) and pays the whole transport whether or not the
-read succeeds. The next measurement is the split named above — key
-construction, miss-path lookup, publication — not another cache. The per-file AST cache was built before it was measured and
+read succeeds. The next measurement is the split named above — eligibility
+validation, key construction, miss-path lookup, publication — not another
+cache. Enabling it needs an ORACLE too, over edit shapes that actually change
+meaning; the comparisons above do not stand in for one. The per-file AST cache was built before it was measured and
 came back at exactly zero (#2668); this is the same mistake one step later,
 caught by measuring first. Filed as #2728.
 

--- a/docs/incremental-build.md
+++ b/docs/incremental-build.md
@@ -1205,8 +1205,23 @@ module's check than the public env carries (the typed-lowering offsets the
 reuse arm republishes, #2391) and pays the whole transport whether or not the
 read succeeds. The next measurement is the split named above — eligibility
 validation, key construction, miss-path lookup, publication — not another
-cache. Enabling it needs an ORACLE too, over edit shapes that actually change
-meaning; the comparisons above do not stand in for one. The per-file AST cache was built before it was measured and
+cache.
+
+Enabling it needs an **oracle** too, and most edit shapes cannot be one. The
+input key is the module's verbatim source plus each dependency's exact env
+text (`typing_dependency_transport_input_key`), so editing the module under
+test changes its own key, and editing a dependency's *interface* changes every
+consumer's key — both **miss** and are freshly checked, and an oracle built
+from them passes whether or not the reuse arm is correct. The shape that
+**hits** is a dependency-body edit that changes meaning while leaving that
+dependency's public `TypeEnv` text identical: the consumer's key is unchanged,
+the hit happens, and the open question is whether the compile-only state it
+republishes (the typed-lowering offsets, #2391) is still right. The public env
+being equal is what makes the hit happen and is exactly why the public env
+cannot detect the problem. So the oracle is that edit shape, plus a check that
+the unchanged consumer really recorded a dependency-transport hit — without
+it the oracle is vacuous in the same way the comparisons above are — plus the
+wasm compared against reuse disabled. The per-file AST cache was built before it was measured and
 came back at exactly zero (#2668); this is the same mistake one step later,
 caught by measuring first. Filed as #2728.
 

--- a/lib/@vibe/compiler/cli_adapter.vibe
+++ b/lib/@vibe/compiler/cli_adapter.vibe
@@ -948,11 +948,33 @@ fn cli_main_with_lanes(fs_lanes: (FsLane, String, String) -> (Bytes, String) wit
   // build spends 11.3 MB there (`scripts/compile_phase_memory.sh`). That one
   // phase is the whole gap between a warm build and a cold one.
   //
-  // It stays opt-in until a compile's output is shown byte-identical with it
-  // on and off across the edit shapes -- a compile consumes more of a module's
-  // check than the public env (the typed-lowering offsets the reuse arm
-  // republishes, #2391), and "the check lane proves it" is a claim about the
-  // check lane.
+  // MEASURED 2026-09-12, and it is a REGRESSION -- this stays off, and the
+  // reason is no longer "unproven". Same corpus, same heap-mark instrument,
+  // reproduced to the byte across two invocations
+  // (`scripts/compile_phase_memory.sh`), check phase:
+  //
+  //              off (default)      on
+  //   cold           270.9 MB   1647.1 MB
+  //   unchanged       11.4 MB     11.4 MB
+  //   leaf-edited    344.9 MB    812.7 MB
+  //
+  // 2.4x worse on the very edit it was meant to fix, 6.1x cold. The COLD row
+  // is the diagnosis: a cold compile has nothing to reuse, so all of that
+  // 1.38 GB is the WRITE side -- building and publishing the per-module
+  // dependency-transport envs -- paid for a read that cannot happen. The
+  // unchanged row is identical in both lanes, so the reuse arm is not even
+  // reached there; the conservative fingerprint short-circuits it.
+  //
+  // It is not WRONG: with the body cache off so a replayed body cannot mask a
+  // difference, a compile's output is byte-identical with the flag on and off
+  // at both temperatures. So this is kept as the instrument that produced
+  // that table, not as a switch anyone should flip.
+  //
+  // The deletion condition is therefore NOT "the output matches" -- that is
+  // already true. It is that the write side stops costing more than the read
+  // saves. A compile consumes more of a module's check than the public env
+  // carries (the typed-lowering offsets the reuse arm republishes, #2391),
+  // and "the check lane proves it" was a claim about the check lane. #2728.
   //
   // It is read in EXPRESSION position and named in `OBSERVATION_ONLY`
   // (`scripts/check_selector_precedence.sh`) for the same reason

--- a/lib/@vibe/compiler/cli_adapter.vibe
+++ b/lib/@vibe/compiler/cli_adapter.vibe
@@ -936,8 +936,9 @@ fn cli_main_with_lanes(fs_lanes: (FsLane, String, String) -> (Bytes, String) wit
   //
   // #2510 criterion 5, OPT-IN and off by default:
   // `VIBE_UNSTABLE_TYPING_DEP_ENV_REUSE_COMPILE=1` lets a COMPILE take the
-  // same reuse the check lane has had as production default since TDRE8, so
-  // the reset below reads the opt-in rather than a bare `false`.
+  // same reuse the check lane has as production default (TDRE9; TDRE8 is the
+  // retired protocol v23 replaced), so the reset below reads the opt-in rather
+  // than a bare `false`.
   //
   // The measurement that asks for it: with reuse on, a one-leaf edit to the
   // compiler's own closure re-checks exactly ONE of 197 planned modules
@@ -965,23 +966,34 @@ fn cli_main_with_lanes(fs_lanes: (FsLane, String, String) -> (Bytes, String) wit
   // there; the conservative fingerprint short-circuits it.
   //
   // It does NOT say the cost is publication. On a miss the enabled lane pays
-  // in two places: `finish_typecheck_fs_impl` builds
+  // in two places: `finish_typecheck_fs_impl` runs
+  // `typing_dependency_env_reuse_is_eligible`, builds
   // `typing_dependency_transport_input_key` (verbatim source plus each
   // dependency's exact env text) and calls
   // `load_typing_dependency_env_reuse_target`, which misses for every module
-  // on a cold compile; then `commit_module_outcome` builds the same large key
-  // AGAIN and publishes the eligibility and sidecar. Lookup, publication, and
-  // a key constructed twice per module are all inside that one number, and
-  // nothing measured here separates them.
+  // on a cold compile; then `commit_module_outcome` runs the eligibility walk
+  // again, builds the same large key AGAIN, and publishes the eligibility and
+  // sidecar. The eligibility walk is not a cheap predicate: per dependency it
+  // is `Fs::exists` + `Fs::read_file` + a binding parse +
+  // `load_canonical_typing_dependency_env_reuse_target`. Four terms, two of
+  // them paid twice per module, all inside that one number, and nothing
+  // measured here separates them.
   //
-  // It is not WRONG: with the body cache off so a replayed body cannot mask a
+  // Nothing measured here shows it is WRONG, and nothing shows it is RIGHT
+  // either. With the body cache off so a replayed body cannot mask a
   // difference, a compile's output is byte-identical with the flag on and off
-  // at both temperatures. So this is kept as the instrument that produced
-  // that table, not as a switch anyone should flip.
+  // at both temperatures -- but the cold comparison has no reuse hit to get
+  // wrong, and the edited one appends a COMMENT, so the program's meaning is
+  // unchanged and a stale reused env answers the same as a fresh one. Neither
+  // exercises a reuse hit on a program whose meaning changed, which is the
+  // case that could be silently wrong. So this is kept as the instrument that
+  // produced the table, not as a switch anyone should flip.
   //
-  // The deletion condition is therefore NOT "the output matches" -- that is
-  // already true. It is that the transport stops costing more than the read
-  // saves, which needs the split above measured first. A compile consumes more of a module's check than the public env
+  // The deletion condition is therefore BOTH halves, and the correctness half
+  // is not discharged: an oracle over edit shapes that actually change meaning
+  // (an interface change, a type change, a removed export), AND the transport
+  // ceasing to cost more than the read saves, which needs the four-term split
+  // above measured first. A compile consumes more of a module's check than the public env
   // carries (the typed-lowering offsets the reuse arm republishes, #2391),
   // and "the check lane proves it" was a claim about the check lane. #2728.
   //

--- a/lib/@vibe/compiler/cli_adapter.vibe
+++ b/lib/@vibe/compiler/cli_adapter.vibe
@@ -959,11 +959,20 @@ fn cli_main_with_lanes(fs_lanes: (FsLane, String, String) -> (Bytes, String) wit
   //   leaf-edited    344.9 MB    812.7 MB
   //
   // 2.4x worse on the very edit it was meant to fix, 6.1x cold. The COLD row
-  // is the diagnosis: a cold compile has nothing to reuse, so all of that
-  // 1.38 GB is the WRITE side -- building and publishing the per-module
-  // dependency-transport envs -- paid for a read that cannot happen. The
-  // unchanged row is identical in both lanes, so the reuse arm is not even
-  // reached there; the conservative fingerprint short-circuits it.
+  // BOUNDS it: a cold compile can reuse nothing, so all of that 1.38 GB is the
+  // transport machinery running for a read that cannot succeed. The unchanged
+  // row is identical in both lanes, so the reuse arm is not even reached
+  // there; the conservative fingerprint short-circuits it.
+  //
+  // It does NOT say the cost is publication. On a miss the enabled lane pays
+  // in two places: `finish_typecheck_fs_impl` builds
+  // `typing_dependency_transport_input_key` (verbatim source plus each
+  // dependency's exact env text) and calls
+  // `load_typing_dependency_env_reuse_target`, which misses for every module
+  // on a cold compile; then `commit_module_outcome` builds the same large key
+  // AGAIN and publishes the eligibility and sidecar. Lookup, publication, and
+  // a key constructed twice per module are all inside that one number, and
+  // nothing measured here separates them.
   //
   // It is not WRONG: with the body cache off so a replayed body cannot mask a
   // difference, a compile's output is byte-identical with the flag on and off
@@ -971,8 +980,8 @@ fn cli_main_with_lanes(fs_lanes: (FsLane, String, String) -> (Bytes, String) wit
   // that table, not as a switch anyone should flip.
   //
   // The deletion condition is therefore NOT "the output matches" -- that is
-  // already true. It is that the write side stops costing more than the read
-  // saves. A compile consumes more of a module's check than the public env
+  // already true. It is that the transport stops costing more than the read
+  // saves, which needs the split above measured first. A compile consumes more of a module's check than the public env
   // carries (the typed-lowering offsets the reuse arm republishes, #2391),
   // and "the check lane proves it" was a claim about the check lane. #2728.
   //

--- a/lib/@vibe/compiler/cli_adapter.vibe
+++ b/lib/@vibe/compiler/cli_adapter.vibe
@@ -990,10 +990,26 @@ fn cli_main_with_lanes(fs_lanes: (FsLane, String, String) -> (Bytes, String) wit
   // produced the table, not as a switch anyone should flip.
   //
   // The deletion condition is therefore BOTH halves, and the correctness half
-  // is not discharged: an oracle over edit shapes that actually change meaning
-  // (an interface change, a type change, a removed export), AND the transport
-  // ceasing to cost more than the read saves, which needs the four-term split
-  // above measured first. A compile consumes more of a module's check than the public env
+  // is not discharged. It needs an oracle that actually reaches a reuse HIT,
+  // which most edit shapes cannot: the input key is the module's VERBATIM
+  // source plus each dependency's exact env text
+  // (`typing_dependency_transport_input_key`), so editing the module under
+  // test changes its own key and editing a dependency's INTERFACE changes
+  // every consumer's key -- both MISS and are freshly checked, and an oracle
+  // built from them passes whether or not the reuse arm is correct.
+  //
+  // The shape that hits is a dependency-body edit that changes MEANING while
+  // leaving the dependency's public `TypeEnv` text identical: the consumer's
+  // key is then unchanged, the hit happens, and the question is whether the
+  // compile-only state it republishes (the typed-lowering offsets, #2391) is
+  // still right. The public env being equal is exactly what makes the hit
+  // happen and exactly why the public env cannot detect the problem.
+  //
+  // So: that edit shape, a check that the unchanged consumer really recorded
+  // a dependency-transport hit (or the oracle is vacuous again), and the wasm
+  // compared against reuse disabled. AND the transport ceasing to cost more
+  // than the read saves, which needs the four-term split above measured
+  // first. A compile consumes more of a module's check than the public env
   // carries (the typed-lowering offsets the reuse arm republishes, #2391),
   // and "the check lane proves it" was a claim about the check lane. #2728.
   //


### PR DESCRIPTION
Closes nothing; records a measurement and corrects a comment that would have led someone to ship a regression. Filed as #2728.

## The shortcut that was obvious, and wrong

The phase measurement on #2720 found the check phase is the whole remaining gap for #2510's fifth criterion: a leaf-edited compile pays **344.9 MB** there against an unchanged build's **11.4 MB** — *more than a cold compile's 270.9 MB*. Meanwhile the check lane has had typing-dependency env reuse (**TDRE9**) as its production default for a while, and there a one-leaf edit re-checks exactly **1 of 197** planned modules.

So: give a compile the same reuse. `VIBE_UNSTABLE_TYPING_DEP_ENV_REUSE_COMPILE` was added for exactly that on #2726, off by default.

## What it measures

`scripts/compile_phase_memory.sh`, the compiler's own closure (197 files), leaf `lib/@vibe/core/defaults.vibe`, three temperatures sharing one `VIBE_BUILD_CACHE_DIR`, **reproduced byte-for-byte across two independent invocations**. Check phase (`source_groups -> prepared_db`):

| | reuse off (today's default) | reuse on |
|---|---:|---:|
| cold | 270.9 MB | **1,647.1 MB** |
| unchanged (warm) | 11.4 MB | 11.4 MB |
| one-leaf edit | 344.9 MB | **812.7 MB** |
| whole-compile total, cold | 946.2 MB | 2,322.4 MB |
| whole-compile total, one-leaf edit | 848.7 MB | 1,434.3 MB |

**2.4x worse on the very edit it was meant to fix; 6.1x worse cold.**

## What the rows say

- **The cold row bounds it.** A cold compile can reuse nothing, so every byte of that extra 1.38 GB is the transport machinery running for a read that cannot succeed.
- **The unchanged row is identical to the byte in both lanes**, so the reuse arm is not even reached there: the conservative fingerprint already short-circuits that case.

## What the cold row does NOT say

It does **not** say the cost is publication. The first version of this PR claimed that, and it was wrong — caught in review here, verified against the call sites, and fixed. On a miss the enabled lane pays **four** terms, two of them twice per module:

- `finish_typecheck_fs_impl` runs `typing_dependency_env_reuse_is_eligible`, builds `typing_dependency_transport_input_key` (the module's verbatim source plus each dependency's exact env text), and calls `load_typing_dependency_env_reuse_target` — which misses for every module on a cold compile;
- `commit_module_outcome` then runs the eligibility walk **again**, builds the same large key **again**, and publishes the eligibility and the sidecar.

The eligibility walk is not a cheap predicate: per dependency it does `Fs::exists`, `Fs::read_file`, a binding parse, and `load_canonical_typing_dependency_env_reuse_target`, reading and parsing that dependency's canonical target env text. On a non-leaf module it is a plausible dominant term on its own.

So the cold figure is **eligibility validation plus key construction plus miss-path lookup plus publication**, and nothing measured here separates them.

## What this does NOT establish: correctness

Compiling with the flag on and off, body cache off so a replayed body cannot mask a difference, gives byte-identical output at both temperatures. **That evidence is structurally incapable of catching the failure it would have to catch** — also caught in review here:

- the **cold** comparison has no reuse hit to get wrong;
- the **edited** comparison appends a *comment* (`compile_phase_memory.sh:109`), so the program's meaning is unchanged and a stale reused env answers exactly what a fresh one does.

Neither exercises a reuse hit on a program whose meaning changed, which is the only case that could be silently wrong. An earlier revision of this PR said "it is not wrong, just slower" and made cost the sole remaining condition for enabling the flag; that is retracted.

## The oracle that would establish it — and the shapes that cannot

A third review round caught the next layer of the same mistake: the oracle an earlier revision proposed (*an interface change, a type change, a removed export*) **cannot test the reuse arm at all**. `typing_dependency_transport_input_key` is built from the module's verbatim `source` plus, per dependency, `dep_path` and `persistent_type_env_cache_text(dep_env)`. So editing the module under test changes its own segment, and editing a dependency's *interface* changes `persistent_type_env_cache_text` for every consumer. All three shapes **miss** and are freshly checked, and an oracle built from them passes whether or not the reuse arm is correct.

The shape that **hits** is a dependency-**body** edit that changes meaning while leaving that dependency's public `TypeEnv` text identical. The consumer's key is then unchanged, the hit happens, and what is at risk is the compile-only state the arm republishes — the typed-lowering offsets (#2391). **The public env being equal is what makes the hit happen, and is exactly why the public env cannot detect the problem.**

So the oracle is: that edit shape, plus a check that the unchanged consumer really recorded a dependency-transport hit (without it the oracle is vacuous in the same way the byte-identity comparisons are), plus the wasm compared against reuse disabled.

## The flag's deletion condition

**Both halves, and the correctness half is not discharged**: the oracle above, **and** the transport ceasing to cost more than the read saves, which needs the four-term split measured first. The table and both conditions sit at the flag itself, so nobody has to find this PR to know. The flag stays in the tree as the instrument that produced the table, off by default.

## Why the check lane's evidence did not transfer

A compile consumes more of a module's check than the public env carries — the typed-lowering offsets the reuse arm republishes (#2391) — and it pays the whole transport whether or not the read succeeds.

## Next

Not another cache: split the four terms and measure each. Key construction and the eligibility walk are the first suspects on the code alone, since both are duplicated and both scale with text and dependency count rather than with anything being reused; if either dominates, doing it once and threading the result is cheap and independent of the rest. That is a hypothesis for the split to confirm, not a finding.

The per-file AST cache was built before it was measured and came back at exactly zero (#2668); this would have been the same mistake one step later, and measuring first caught it.

## Scope

Comment and documentation only — no behavior change. `docs/incremental-build.md` gains the table and the reading; `cli_adapter.vibe`'s flag comment gains the same table, the oracle specification, and both deletion conditions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CCUq2wJKeDzguGzmx78HkZ