### PR TITLE
#2728 slice 1: compute the TDRE9 eligibility walk and input key once, not twice

### DIFF
--- a/lib/@vibe/compiler/runtime/typecheck_fs.vibe
+++ b/lib/@vibe/compiler/runtime/typecheck_fs.vibe
@@ -5081,7 +5081,12 @@ export fn check_module_with_typing_artifact_observation(job: ModuleJob) -> Modul
 
 /// Coordinator-owned commit. Every filesystem and accumulator write for a
 /// module happens here and nowhere else.
-fn commit_module_outcome(rdb: RippleDb, env_cache: Array[(String, TypeEnv)], dep_source_cache: Array[(String, String)], parse_count: Int, job: ModuleJob, outcome: ModuleOutcome) -> (String, RippleDb, Array[(String, TypeEnv)], Array[(String, String)], Int) with Exception + Fs {
+/// #2728 slice 1: `reuse_eligible` and `reuse_input_key` are what the caller
+/// already computed for the TDRE9 lookup, threaded in rather than recomputed.
+/// `None` for either means the caller did not compute it, and this function
+/// falls back to computing it itself -- so the fallback keeps the old
+/// behaviour if a second call site ever appears.
+fn commit_module_outcome(rdb: RippleDb, env_cache: Array[(String, TypeEnv)], dep_source_cache: Array[(String, String)], parse_count: Int, job: ModuleJob, outcome: ModuleOutcome, reuse_eligible: Option[Bool], reuse_input_key: Option[String]) -> (String, RippleDb, Array[(String, TypeEnv)], Array[(String, String)], Int) with Exception + Fs {
   match outcome {
     // Diagnostics are values as far as the worker is concerned, but the
     // driver still fails fast on the first one so the observable behaviour
@@ -5110,8 +5115,15 @@ fn commit_module_outcome(rdb: RippleDb, env_cache: Array[(String, TypeEnv)], dep
       // alias last. Diagnosed/thrown checks never enter this Checked arm. Keep
       // the extra canonical target text and input serialization wholly inside
       // the enabled, transitively eligible experimental lane.
-      if experimental_typing_dependency_env_reuse_enabled() && typing_dependency_env_reuse_is_eligible(job.dep_fps) {
-        let input_key = typing_dependency_transport_input_key(path, job.source, typing_semantics_seed(), job.dep_envs)
+      let eligible_here = match reuse_eligible {
+        Some(known) => known,
+        None => experimental_typing_dependency_env_reuse_enabled() && typing_dependency_env_reuse_is_eligible(job.dep_fps)
+      }
+      if eligible_here {
+        let input_key = match reuse_input_key {
+          Some(known_key) => known_key,
+          None => typing_dependency_transport_input_key(path, job.source, typing_semantics_seed(), job.dep_envs)
+        }
         publish_typing_dependency_env_reuse_eligibility(input_key, fingerprint, target_text)
         write_typing_dependency_env_reuse_sidecar(input_key, fingerprint, target_text)
       } else {
@@ -5399,9 +5411,39 @@ fn finish_typecheck_fs_impl(rdb: RippleDb, env_cache: Array[(String, TypeEnv)], 
       // once: lookup, check, and publication must describe the same value.
       let coordinated_env_cache = ensure_env_cache_for_paths(rdb, env_cache, deps)
       let projected_dep_envs = project_exact_dependency_envs(deps, coordinated_env_cache)
-      let reused_env = if experimental_typing_dependency_env_reuse_enabled() {
-        if typing_dependency_env_reuse_is_eligible(dep_fps) {
-          let input_key = typing_dependency_transport_input_key(path, source, typing_semantics_seed(), projected_dep_envs)
+      // #2728 slice 1: the eligibility walk and the input key are computed
+      // HERE and threaded to `commit_module_outcome`, which used to recompute
+      // both from `job.dep_fps` / `job.source` / `job.dep_envs` and the
+      // `Checked`-bound path. Those are the same values by construction -- the
+      // `ModuleJob` below is built from exactly these, `commit_module_outcome`
+      // has one call site, and `Checked` is constructed only from `job.path`
+      // -- so this removes a duplicate, not a difference.
+      //
+      // Neither is cheap. The walk reads and parses every dependency's
+      // canonical target env text, and the key embeds this module's verbatim
+      // source plus each dependency's exact env text, so both scale with text
+      // and dependency count rather than with anything being reused. Paying
+      // them twice per module is a term of the cold regression #2728 measures.
+      //
+      // Hoisting is also safe in TIME, not only in the values: the second
+      // evaluation used to happen after `check_module`, and the walk reads one
+      // WITNESS per dependency. A module's dependencies are checked before it
+      // -- they have to be, they feed `projected_dep_envs` -- so each of their
+      // witnesses is already published or already absent by the time this
+      // module is looked at, and nothing between these two points writes one.
+      // The later evaluation could therefore never have answered differently.
+      let reuse_eligible = if experimental_typing_dependency_env_reuse_enabled() {
+        typing_dependency_env_reuse_is_eligible(dep_fps)
+      } else {
+        false
+      }
+      let reuse_input_key = if reuse_eligible {
+        Some(typing_dependency_transport_input_key(path, source, typing_semantics_seed(), projected_dep_envs))
+      } else {
+        None
+      }
+      let reused_env = match reuse_input_key {
+        Some(input_key) => {
           match load_typing_dependency_env_reuse_target(input_key) {
             // #2391: the transported env must bring the module's float
             // offsets along, or the reuse would publish a conservative env
@@ -5421,11 +5463,8 @@ fn finish_typecheck_fs_impl(rdb: RippleDb, env_cache: Array[(String, TypeEnv)], 
             },
             None => None
           }
-        } else {
-          None
-        }
-      } else {
-        None
+        },
+        None => None
       }
       match reused_env {
         Some((input_key, target_fingerprint, target_text, target_env)) => {
@@ -5460,7 +5499,7 @@ fn finish_typecheck_fs_impl(rdb: RippleDb, env_cache: Array[(String, TypeEnv)], 
             dep_envs: projected_dep_envs
           }
           let outcome = check_module(job)
-          commit_module_outcome(rdb, coordinated_env_cache, dep_source_cache, parse_count + 1, job, outcome)
+          commit_module_outcome(rdb, coordinated_env_cache, dep_source_cache, parse_count + 1, job, outcome, Some(reuse_eligible), reuse_input_key)
         }
       }
     }


### PR DESCRIPTION
Part of #2728 / #2510 criterion 5. Removes 40.6% of the cold TDRE9 regression, and — stated up front because it is the half that matters — removes **nothing** from the leaf edit that motivated the work.

## What was duplicated

`finish_typecheck_fs_impl` computes `typing_dependency_env_reuse_is_eligible(dep_fps)` and, when that holds, `typing_dependency_transport_input_key(path, source, seed, projected_dep_envs)`. `commit_module_outcome` then recomputed **both**, from `job.dep_fps`, `job.source`, `job.dep_envs` and the `Checked`-bound path. Both are now hoisted in the caller and threaded down.

Neither is cheap. The walk reads and parses every dependency's canonical target env text; the key embeds this module's verbatim source plus each dependency's exact env text. Both scale with text and dependency count rather than with anything being reused, and on a cold compile every module pays both twice. #2728 named them as the first suspects for exactly this reason.

## That the two computations coincide is verified, not assumed

This is the typing hot path, so three separate ways:

- **Same values.** The `ModuleJob` is built in the same scope as `{path, source, deps, dep_fps, dep_envs: projected_dep_envs}`, so the fields the callee read are the caller's own bindings.
- **Same path.** `commit_module_outcome` has exactly one call site, and `ModuleOutcome::Checked` is constructed at exactly one site, from `job.path`. So the `path` bound by the `Checked` pattern is `job.path`.
- **Same in time**, which is the part that is not textual. The second evaluation used to happen *after* `check_module`, and the walk reads one **witness** per dependency. A module's dependencies are checked before it — they have to be, they feed `projected_dep_envs` — so each of their witnesses is already published or already absent by then, and nothing between the two points writes one. The later evaluation could never have answered differently.

`commit_module_outcome` keeps a fallback that recomputes when handed `None`, so a second call site appearing later cannot silently inherit this argument.

## Measured

Both compilers built from **this** tree, so the only difference is the hoist. `scripts/compile_phase_memory.sh`, the compiler's own closure (197 files), check phase (`source_groups -> prepared_db`):

| | reuse off | reuse on, no hoist | reuse on, hoisted |
|---|---:|---:|---:|
| cold | 274.3 MB | 1,760.6 MB | **1,157.1 MB** |
| unchanged | 11.9 MB | 11.87 MB | 11.87 MB |
| leaf-edited | 351.3 MB | 879.54 MB | 879.49 MB |

**Cold drops 603.5 MB — 40.6% of the 1,486.3 MB cold regression over reuse-off.** Whole-compile cold total: 2,439.8 MB → 1,836.3 MB.

**It removes nothing from the leaf edit** (46 KB, noise). That is structural rather than disappointing: on a warm edit most modules **hit**, and a hit is served by the `Some` arm without ever reaching `commit_module_outcome`, so there was no duplicate there to remove. Reuse-on still costs the edit 879.5 MB against reuse-off's 351.3 MB, so **the flag stays off** and the rest of the four-term split still matters.

## The comparison had to be controlled to say any of that

Measured against #2728's published baseline instead — a stage2 from `6e87b41`, before main absorbed #2730 and #2725 — the cold win reads as 490 MB and the leaf edit reads as a **67 MB regression**. A change that only removes work cannot make a temperature worse, and that contradiction is what exposed the confound. Both numbers above come from stage2 builds of the same tree differing only in `typecheck_fs.vibe`.

## Behaviour preservation, checked rather than asserted

Compiling the closure with both compilers, body cache off so a replayed body cannot mask a difference, gives **byte-identical output cold and on the warm edited run that mixes hits with misses**. Cold is the case this change actually affects (every module misses, so every module reaches the changed code); the warm run is included because it exercises the hit path and the miss path in the same compile.

`pkf run test` (the full operation gate) is running on this head and will be reported.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CCUq2wJKeDzguGzmx78HkZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01CCUq2wJKeDzguGzmx78HkZ)_