### PR TITLE
feat(compiler): add complete checked-program binary transport

### DIFF
--- a/docs/checked-body-transport.md
+++ b/docs/checked-body-transport.md
@@ -1,70 +1,97 @@
 # Checked body transport
 
-Issue #1958 owns the shadow-only authority boundary for future incremental
-owner reuse. No artifact described here is a production cache or reuse input.
+Issue #2505 owns the boundary between module checking and code generation.
+`checker/artifacts/program` transports the complete current `CheckedProgram`.
+Decoding reconstructs values directly from bytes: it neither parses source nor
+reruns inference, and no current syntax or semantic constructor is omitted.
 
-The implementation is split into two layers:
+`runtime.check_module_with_program_transport(job)` returns the ordinary
+`ModuleOutcome` together with bytes from that same successful checker invocation,
+using the job's actual dependency environments. Diagnosed modules return no
+bytes; parse failures propagate unchanged. Ordinary `check_module` does not
+construct this transport.
 
-- `CheckedImplementationBodyArtifact` retains exact ingested source, binding
-  provenance, exported-interface bytes, and the successful empty-diagnostic
-  identity.
-- `NormalizedCheckedLeafArtifact` is the first versioned normalized typed-IR
-  pilot. Its contract is strict and intentionally much smaller than the AST.
-  Unsupported nodes return `None`; they are never reconstructed from source or
-  approximated by name.
+These bytes are **transport, not evidence that a module is reusable**. A decoder
+cannot establish that bytes came from a successful producer. Persistent storage,
+current-input validation and production cache consumption are not connected to
+this format yet.
 
-## V1 coverage
+## Complete program payload
 
-| Layer | Constructor or field | V1 status |
-|---|---|---|
-| Statement | one unannotated top-level `SLet` | supported |
-| Expression | `EInt`, `EBool`, `EString`, `EUnit` | supported |
-| Function | top-level `EFn`, including generic schemes and trait-bound rows; parameter names, checked return and effect row | supported pilot |
-| Function body | scalar leaves, identifiers/calls, immutable/recursive/mutable lets and assignment, sequence/branch/match/handle/loops, tuple/array/record/map construction, unary/binary/dot, return/break/continue | supported pilot |
-| Pattern | wild, bind, int/string/bool, constructor, tuple, struct, or-pattern | supported pilot |
-| Surface type field | all current `TypeExpr` constructors, including function effects | structured pilot for explicit record arguments |
-| Checked type | every current constructor, including `CtRecord`, `CtVar`, `CtForAll` bounds, and explicit `CtUnknown` | structured pilot |
-| Expression | every other `Expr` constructor | fail closed |
-| Statement | every other `Stmt` constructor | fail closed |
-| Checked type | final environment type of a scalar `SLet` binding | canonical text retained |
-| Type environment | every current `TypeEnv` constructor, exact order/duplicates/cache rows/origins, complete `TypeDef`, trait method, bound, and generic provenance fields | structured shadow transport |
-| Substitution | complete lossless `Subst` | not yet supported |
-| Type definitions | complete checked declaration closure | existing narrow artifact only; not yet joined |
-| Occurrences | complete typed occurrence table | existing path artifact only; not yet joined |
-| Docs and locations | exact source plus parser binder rows | retained by the body aggregate |
-| Diagnostics | successful canonical empty typing set | retained; diagnosed builds publish nothing |
+| Field | Retained data |
+|---|---|
+| `checked_stmts` | Complete post-desugar `Array[Stmt]`: every expression, pattern, surface type, import kind, declaration field and byte offset |
+| `final_env` | Every `TypeEnv` node, value type and binding origin; exact chain order, duplicates, cached indexes, mutable-cell escape facts, trait methods and generic provenance |
+| `type_defs` | Every complete `TypeDef`, in original order |
+| `final_subst` | Every `Subst` node, including both `SubstCached` maps, bounds and effect-variable bindings |
+| `typed_occurrences` | Append-ordered `(offset, Type)` rows, including duplicate offsets |
 
-## Single-function join pilot
+`typed_occurrences` is what the production checker records, not a fully
+elaborated typed IR. Additional lowering channels, including typed-equality
+keys, must join the enclosing module artifact before it can replace all
+codegen inputs.
 
-The shadow-only `NormalizedCheckedFunctionJoinArtifact` retains one successful
-function's exact source and binder rows together with its normalized body,
-structured final value binding, structured final substitution, and the
-append-aligned `(offset, role, lane, Type)` occurrence rows. Construction uses
-the complete expression-path observation and requires every row to belong to
-the single retained statement. Missing, duplicate-offset, malformed, stale,
-and cross-authority data fail closed during decoding or explicit authority
-matching. `SubstCached` remains ineligible because its map representation is
-an implementation cache rather than canonical substitution authority.
+Syntax trees use the existing [AST Binary ABI](ast_binary_abi.md), including
+exact IEEE-754 float bits. There is no second syntax codec.
 
-This pilot is not complete `TypeEnv` transport: it retains only the selected
-function binding. It does not change the unsupported statuses in the table or
-authorize production reuse.
+## Wire format: `vCHK` version 1
 
-The separate `NormalizedValueTypeEnvArtifact` covers every current environment
-node. Unlike the production persistent-env codec, it retains module-export
-origin provenance, exact flat/cached row order (including duplicates), mutable
-cell escape facts, complete type-definition closures, and trait method/generic
-metadata. Cached name/value length mismatches fail closed. A seeded checker
-final environment is part of the round-trip fixtures. The environment remains
-a separate shadow artifact; joining it into the function artifact is deferred
-to a schema-version change rather than silently widening its existing v1.
+Four bytes `vCHK`, unsigned canonical LEB128 version `1`, two unsigned checksum
+values, then the five fields in table order. The AST field includes its `vAST`
+header. Arrays encode a count followed by elements; tuples and structs retain
+field order. Primitive encodings and checked readers come from the AST codec.
 
-## Remaining work
+Checksums cover every payload byte using the codegen body cache's arithmetic:
+seeds `17` and `29`, multipliers `131` and `137`, moduli `2147483647` and
+`2147483629`. They detect corruption, not producer authenticity or freshness.
 
-Before production owner reuse can be considered, a later schema version must
-cover every reachable `Stmt`, `Expr`, `Pat`, and `TypeExpr` field; structured
-`Type`, `TypeEnv`, `Subst`, `TypeDef`, and typed-occurrence transport; import and
-mode assumptions; and cold/shadow reconstruction parity across the hostile
-corpus. New constructors must make decoding or production eligibility fail
-closed until their codecs and round-trip fixtures land. #1959 is the earliest
-place allowed to connect a completed transport to planning or reuse.
+Semantic tags are one byte. Existing tags and field order are fixed; changing
+payload shape requires a new version.
+
+| Tree | Tags in order, starting at 1 |
+|---|---|
+| `Type` | `CtInt`, `CtDouble`, `CtBool`, `CtString`, `CtChar`, `CtUnit`, `CtTuple`, `CtArray`, `CtOption`, `CtFn`, `CtEnum`, `CtStruct`, `CtBytes`, `CtNamed`, `CtConstructor`, `CtApplied`, `CtVar`, `CtForAll`, `CtUnknown`, `CtRecord` |
+| `TypeDef` | `TDEnum`, `TDStruct`, `TDAlias`, `TDEffect`, `TDEffectSet` |
+| `BindingOrigin` | `BindingOriginUnavailable`, `BindingOriginModuleExport`, `BindingOriginReExportSurface` |
+| `TypeEnv` | `EnvEmpty`, `EnvBind`, `EnvTraitDef`, `EnvTraitImpl`, `EnvTraitImplGen`, `EnvTypeDefs`, `EnvMutCell`, `EnvFlat`, `EnvCached` |
+| `Subst` | `SubstEmpty`, `SubstBind`, `SubstBound`, `SubstCached`, `SubstEffBind` |
+
+`EnvValueBinding` encodes its type then origin. Substitution maps encode entries
+in `Map::keys` order. Duplicate map keys are malformed; duplicate environment
+rows and occurrence offsets remain intact. `EnvCached` name/value counts must
+agree. Unsupported versions, unknown tags, invalid primitives, truncation,
+checksum mismatch, inconsistent indexes and trailing bytes return `None`.
+Writers match every constructor explicitly; extending an enum requires updating
+its codec and conformance tests.
+
+## Source and identity boundaries
+
+Source text is outside `CheckedProgram`. The existing
+`CheckedImplementationBodyArtifact` retains exact ingested source, including
+comments, docs and whitespace, plus parser-authoritative binder rows. Its narrow
+normalized leaf/function observation formats remain separate APIs; their
+coverage limits do not constrain `vCHK`.
+
+For reusable modules, exact source remains an input identity: comments and
+whitespace invalidate the stored body and locations. Exported-interface identity
+must describe typed public declarations independently of private bodies. Source
+or full program bytes must never stand in for public identity. Docs and positions
+must refresh even when the typed public interface is unchanged.
+
+The remaining #2505 integration must bind program, source/binder data, public
+interface, dependency assumptions, mode and lowering tables in one validated
+module artifact. Fresh and transported builds must agree on output **and
+diagnostics** across the full corpus before production reuse is enabled.
+Missing, stale, cross-mode or corrupt artifacts must fall back to checking.
+The per-module prelude (#2510) then consumes the artifact's tables.
+
+## Verification
+
+`checker/artifacts/program/program_test.vibe` covers every semantic constructor,
+a seeded checker result, restored lookup/provenance/substitution behavior,
+independent wire fixtures, malformed input and fresh-versus-restored Wasm.
+The existing AST binary tests cover every embedded syntax constructor.
+
+`runtime/module_program_transport_test.vibe` checks against a dependency
+environment and proves type, import, effect and parse failures retain ordinary
+checker diagnostics and produce no successful transport.

--- a/lib/@vibe/compiler/checker/artifacts/program/index.vpkg
+++ b/lib/@vibe/compiler/checker/artifacts/program/index.vpkg
@@ -1,0 +1,16 @@
+name = @vibe/compiler/checker/artifacts/program
+version = 0.0.1
+description =
+  #|Lossless transport of complete checked programs.
+deps = {
+  @vibe/compiler/cache : 0.0.1
+  @vibe/compiler/checker : 0.0.1
+  @vibe/compiler/core : 0.0.1
+}
+
+import @vibe/compiler/checker {
+  CheckedProgram
+}
+
+fn encode_checked_program(checked: CheckedProgram) -> Bytes
+fn decode_checked_program(bytes: Bytes) -> Option[CheckedProgram]

--- a/lib/@vibe/compiler/checker/artifacts/program/program.vibe
+++ b/lib/@vibe/compiler/checker/artifacts/program/program.vibe
@@ -1,0 +1,1042 @@
+import @vibe/compiler/cache {
+  AstBinaryReader,
+  ast_binary_read_bool_checked,
+  ast_binary_read_byte_checked,
+  ast_binary_read_count_checked,
+  ast_binary_read_module,
+  ast_binary_read_optstr_checked,
+  ast_binary_read_string_checked,
+  ast_binary_read_svarint_checked,
+  ast_binary_read_type_expr,
+  ast_binary_read_varint_checked,
+  ast_binary_reader_new,
+  ast_binary_reader_remaining,
+  ast_binary_write_bool,
+  ast_binary_write_module,
+  ast_binary_write_optstr,
+  ast_binary_write_string,
+  ast_binary_write_svarint,
+  ast_binary_write_type_expr,
+  ast_binary_write_varint
+}
+import @vibe/compiler/checker {
+  CheckedProgram
+}
+import @vibe/compiler/core {
+  BindingOrigin, EnvValueBinding, Subst, Type, TypeDef, TypeEnv, TypeExpr
+}
+
+/// Lossless transport of the production checker's result. Encoding does not
+/// attest checker success: cache policy must bind these bytes to trusted inputs.
+export fn encode_checked_program(checked: CheckedProgram) -> Bytes {
+  let payload = Bytes::new()
+  ast_binary_write_module(payload, checked.checked_stmts)
+  cp_write_env(payload, checked.final_env)
+  cp_write_array_type_def(payload, checked.type_defs)
+  cp_write_subst(payload, checked.final_subst)
+  cp_write_array_tuple_int_type(payload, checked.typed_occurrences)
+  let out = Bytes::new()
+  Bytes::push(out, 'v')
+  Bytes::push(out, 'C')
+  Bytes::push(out, 'H')
+  Bytes::push(out, 'K')
+  ast_binary_write_varint(out, 1)
+  let (first, second) = cp_checksum(payload, 0)
+  ast_binary_write_varint(out, first)
+  ast_binary_write_varint(out, second)
+  Bytes::append(out, payload)
+  out
+}
+
+/// Malformed or corrupt transport is a miss. No reconstruction parses source
+/// or reruns inference; every restored field comes from its encoded value.
+export fn decode_checked_program(bytes: Bytes) -> Option[CheckedProgram] {
+  handle {
+    let reader = ast_binary_reader_new(bytes)
+    if ast_binary_read_byte_checked(reader) != 'v' ||
+    ast_binary_read_byte_checked(reader) != 'C' ||
+    ast_binary_read_byte_checked(reader) != 'H' ||
+    ast_binary_read_byte_checked(reader) != 'K' ||
+    ast_binary_read_varint_checked(reader) != 1 {
+      throw("checked program: unsupported header")
+    }
+    let first = ast_binary_read_varint_checked(reader)
+    let second = ast_binary_read_varint_checked(reader)
+    let start = Bytes::length(bytes) - ast_binary_reader_remaining(reader)
+    let (expected_first, expected_second) = cp_checksum(bytes, start)
+    if first != expected_first || second != expected_second {
+      throw("checked program: checksum mismatch")
+    }
+    let checked_stmts = ast_binary_read_module(reader)
+    let final_env = cp_read_env(reader)
+    let type_defs = cp_read_array_type_def(reader)
+    let final_subst = cp_read_subst(reader)
+    let typed_occurrences = cp_read_array_tuple_int_type(reader)
+    if ast_binary_reader_remaining(reader) != 0 {
+      throw("checked program: trailing bytes")
+    }
+    Some(CheckedProgram::{
+      checked_stmts,
+      final_env,
+      type_defs,
+      final_subst,
+      typed_occurrences
+    })
+  } with { Exception::Throw(_) => None }
+}
+
+// Same corruption-detection arithmetic as the production codegen body cache.
+// This is not a proof of checker success or a substitute for input validation.
+fn cp_checksum(bytes: Bytes, start: Int) -> (Int, Int) {
+  let mut first = 17
+  let mut second = 29
+  let mut i = start
+  while i < Bytes::length(bytes) {
+    let byte = Bytes::get(bytes, i)
+    first = (first * 131 + byte) % 2147483647
+    second = (second * 137 + byte) % 2147483629
+    i = i + 1
+  }
+  (first, second)
+}
+
+fn cp_write_type(out: Bytes, value: Type) -> Unit {
+  match value {
+    CtInt => {
+      Bytes::push(out, 1)
+    },
+    CtDouble => {
+      Bytes::push(out, 2)
+    },
+    CtBool => {
+      Bytes::push(out, 3)
+    },
+    CtString => {
+      Bytes::push(out, 4)
+    },
+    CtChar => {
+      Bytes::push(out, 5)
+    },
+    CtUnit => {
+      Bytes::push(out, 6)
+    },
+    CtTuple(field_0) => {
+      Bytes::push(out, 7)
+      cp_write_array_type(out, field_0)
+    },
+    CtArray(field_0) => {
+      Bytes::push(out, 8)
+      cp_write_type(out, field_0)
+    },
+    CtOption(field_0) => {
+      Bytes::push(out, 9)
+      cp_write_type(out, field_0)
+    },
+    CtFn(field_0, field_1, field_2) => {
+      Bytes::push(out, 10)
+      cp_write_array_type(out, field_0)
+      cp_write_type(out, field_1)
+      ast_binary_write_optstr(out, field_2)
+    },
+    CtEnum(field_0) => {
+      Bytes::push(out, 11)
+      ast_binary_write_string(out, field_0)
+    },
+    CtStruct(field_0) => {
+      Bytes::push(out, 12)
+      ast_binary_write_string(out, field_0)
+    },
+    CtBytes => {
+      Bytes::push(out, 13)
+    },
+    CtNamed(field_0, field_1) => {
+      Bytes::push(out, 14)
+      ast_binary_write_string(out, field_0)
+      cp_write_array_type(out, field_1)
+    },
+    CtConstructor(field_0, field_1) => {
+      Bytes::push(out, 15)
+      ast_binary_write_string(out, field_0)
+      ast_binary_write_svarint(out, field_1)
+    },
+    CtApplied(field_0, field_1) => {
+      Bytes::push(out, 16)
+      cp_write_type(out, field_0)
+      cp_write_array_type(out, field_1)
+    },
+    CtVar(field_0) => {
+      Bytes::push(out, 17)
+      ast_binary_write_svarint(out, field_0)
+    },
+    CtForAll(field_0, field_1, field_2) => {
+      Bytes::push(out, 18)
+      cp_write_array_int(out, field_0)
+      cp_write_array_tuple_int_array_string(out, field_1)
+      cp_write_type(out, field_2)
+    },
+    CtUnknown => {
+      Bytes::push(out, 19)
+    },
+    CtRecord(field_0) => {
+      Bytes::push(out, 20)
+      cp_write_array_tuple_string_type(out, field_0)
+    },
+  }
+}
+
+fn cp_read_type(reader: AstBinaryReader) -> Type with Exception {
+  let tag = ast_binary_read_byte_checked(reader)
+  match tag {
+    1 => {
+      CtInt
+    },
+    2 => {
+      CtDouble
+    },
+    3 => {
+      CtBool
+    },
+    4 => {
+      CtString
+    },
+    5 => {
+      CtChar
+    },
+    6 => {
+      CtUnit
+    },
+    7 => {
+      let field_0 = cp_read_array_type(reader)
+      CtTuple(field_0)
+    },
+    8 => {
+      let field_0 = cp_read_type(reader)
+      CtArray(field_0)
+    },
+    9 => {
+      let field_0 = cp_read_type(reader)
+      CtOption(field_0)
+    },
+    10 => {
+      let field_0 = cp_read_array_type(reader)
+      let field_1 = cp_read_type(reader)
+      let field_2 = ast_binary_read_optstr_checked(reader)
+      CtFn(field_0, field_1, field_2)
+    },
+    11 => {
+      let field_0 = ast_binary_read_string_checked(reader)
+      CtEnum(field_0)
+    },
+    12 => {
+      let field_0 = ast_binary_read_string_checked(reader)
+      CtStruct(field_0)
+    },
+    13 => {
+      CtBytes
+    },
+    14 => {
+      let field_0 = ast_binary_read_string_checked(reader)
+      let field_1 = cp_read_array_type(reader)
+      CtNamed(field_0, field_1)
+    },
+    15 => {
+      let field_0 = ast_binary_read_string_checked(reader)
+      let field_1 = ast_binary_read_svarint_checked(reader)
+      CtConstructor(field_0, field_1)
+    },
+    16 => {
+      let field_0 = cp_read_type(reader)
+      let field_1 = cp_read_array_type(reader)
+      CtApplied(field_0, field_1)
+    },
+    17 => {
+      let field_0 = ast_binary_read_svarint_checked(reader)
+      CtVar(field_0)
+    },
+    18 => {
+      let field_0 = cp_read_array_int(reader)
+      let field_1 = cp_read_array_tuple_int_array_string(reader)
+      let field_2 = cp_read_type(reader)
+      CtForAll(field_0, field_1, field_2)
+    },
+    19 => {
+      CtUnknown
+    },
+    20 => {
+      let field_0 = cp_read_array_tuple_string_type(reader)
+      CtRecord(field_0)
+    },
+    _ => throw("checked program: unknown Type tag")
+  }
+}
+
+fn cp_write_type_def(out: Bytes, value: TypeDef) -> Unit {
+  match value {
+    TDEnum(field_0, field_1, field_2) => {
+      Bytes::push(out, 1)
+      ast_binary_write_string(out, field_0)
+      cp_write_array_string(out, field_1)
+      cp_write_array_tuple_string_array_type(out, field_2)
+    },
+    TDStruct(field_0, field_1, field_2, field_3) => {
+      Bytes::push(out, 2)
+      ast_binary_write_string(out, field_0)
+      cp_write_array_tuple_string_type(out, field_1)
+      cp_write_array_string(out, field_2)
+      cp_write_array_string(out, field_3)
+    },
+    TDAlias(field_0, field_1, field_2) => {
+      Bytes::push(out, 3)
+      ast_binary_write_string(out, field_0)
+      cp_write_array_string(out, field_1)
+      cp_write_type(out, field_2)
+    },
+    TDEffect(field_0, field_1, field_2) => {
+      Bytes::push(out, 4)
+      ast_binary_write_string(out, field_0)
+      cp_write_array_tuple_string_array_type_type(out, field_1)
+      cp_write_array_string(out, field_2)
+    },
+    TDEffectSet(field_0, field_1) => {
+      Bytes::push(out, 5)
+      ast_binary_write_string(out, field_0)
+      cp_write_array_string(out, field_1)
+    },
+  }
+}
+
+fn cp_read_type_def(reader: AstBinaryReader) -> TypeDef with Exception {
+  let tag = ast_binary_read_byte_checked(reader)
+  match tag {
+    1 => {
+      let field_0 = ast_binary_read_string_checked(reader)
+      let field_1 = cp_read_array_string(reader)
+      let field_2 = cp_read_array_tuple_string_array_type(reader)
+      TDEnum(field_0, field_1, field_2)
+    },
+    2 => {
+      let field_0 = ast_binary_read_string_checked(reader)
+      let field_1 = cp_read_array_tuple_string_type(reader)
+      let field_2 = cp_read_array_string(reader)
+      let field_3 = cp_read_array_string(reader)
+      TDStruct(field_0, field_1, field_2, field_3)
+    },
+    3 => {
+      let field_0 = ast_binary_read_string_checked(reader)
+      let field_1 = cp_read_array_string(reader)
+      let field_2 = cp_read_type(reader)
+      TDAlias(field_0, field_1, field_2)
+    },
+    4 => {
+      let field_0 = ast_binary_read_string_checked(reader)
+      let field_1 = cp_read_array_tuple_string_array_type_type(reader)
+      let field_2 = cp_read_array_string(reader)
+      TDEffect(field_0, field_1, field_2)
+    },
+    5 => {
+      let field_0 = ast_binary_read_string_checked(reader)
+      let field_1 = cp_read_array_string(reader)
+      TDEffectSet(field_0, field_1)
+    },
+    _ => throw("checked program: unknown TypeDef tag")
+  }
+}
+
+fn cp_write_origin(out: Bytes, value: BindingOrigin) -> Unit {
+  match value {
+    BindingOriginUnavailable => {
+      Bytes::push(out, 1)
+    },
+    BindingOriginModuleExport(field_0, field_1) => {
+      Bytes::push(out, 2)
+      ast_binary_write_string(out, field_0)
+      ast_binary_write_string(out, field_1)
+    },
+    BindingOriginReExportSurface(field_0, field_1) => {
+      Bytes::push(out, 3)
+      ast_binary_write_string(out, field_0)
+      ast_binary_write_string(out, field_1)
+    },
+  }
+}
+
+fn cp_read_origin(reader: AstBinaryReader) -> BindingOrigin with Exception {
+  let tag = ast_binary_read_byte_checked(reader)
+  match tag {
+    1 => {
+      BindingOriginUnavailable
+    },
+    2 => {
+      let field_0 = ast_binary_read_string_checked(reader)
+      let field_1 = ast_binary_read_string_checked(reader)
+      BindingOriginModuleExport(field_0, field_1)
+    },
+    3 => {
+      let field_0 = ast_binary_read_string_checked(reader)
+      let field_1 = ast_binary_read_string_checked(reader)
+      BindingOriginReExportSurface(field_0, field_1)
+    },
+    _ => throw("checked program: unknown BindingOrigin tag")
+  }
+}
+
+fn cp_write_env(out: Bytes, value: TypeEnv) -> Unit {
+  match value {
+    EnvEmpty => {
+      Bytes::push(out, 1)
+    },
+    EnvBind(field_0, field_1, field_2) => {
+      Bytes::push(out, 2)
+      ast_binary_write_string(out, field_0)
+      cp_write_binding(out, field_1)
+      cp_write_env(out, field_2)
+    },
+    EnvTraitDef(field_0, field_1, field_2, field_3, field_4, field_5, field_6) => {
+      Bytes::push(out, 3)
+      ast_binary_write_string(out, field_0)
+      cp_write_array_string(out, field_1)
+      ast_binary_write_bool(out, field_2)
+      cp_write_array_tuple_string_array_surface_type_surface_type(out, field_3)
+      cp_write_env(out, field_4)
+      cp_write_array_string(out, field_5)
+      cp_write_array_tuple_string_array_string_array_tuple_string_array_string(out, field_6)
+    },
+    EnvTraitImpl(field_0, field_1, field_2) => {
+      Bytes::push(out, 4)
+      ast_binary_write_string(out, field_0)
+      cp_write_type(out, field_1)
+      cp_write_env(out, field_2)
+    },
+    EnvTraitImplGen(field_0, field_1, field_2, field_3, field_4) => {
+      Bytes::push(out, 5)
+      ast_binary_write_string(out, field_0)
+      cp_write_array_string(out, field_1)
+      cp_write_array_tuple_string_array_string(out, field_2)
+      cp_write_type(out, field_3)
+      cp_write_env(out, field_4)
+    },
+    EnvTypeDefs(field_0, field_1, field_2) => {
+      Bytes::push(out, 6)
+      cp_write_array_type_def(out, field_0)
+      cp_write_array_string(out, field_1)
+      cp_write_env(out, field_2)
+    },
+    EnvMutCell(field_0, field_1, field_2) => {
+      Bytes::push(out, 7)
+      ast_binary_write_string(out, field_0)
+      ast_binary_write_bool(out, field_1)
+      cp_write_env(out, field_2)
+    },
+    EnvFlat(field_0) => {
+      Bytes::push(out, 8)
+      cp_write_array_tuple_string_binding(out, field_0)
+    },
+    EnvCached(field_0, field_1, field_2) => {
+      Bytes::push(out, 9)
+      cp_write_array_string(out, field_0)
+      cp_write_array_binding(out, field_1)
+      cp_write_env(out, field_2)
+    },
+  }
+}
+
+fn cp_read_env(reader: AstBinaryReader) -> TypeEnv with Exception {
+  let tag = ast_binary_read_byte_checked(reader)
+  match tag {
+    1 => {
+      EnvEmpty
+    },
+    2 => {
+      let field_0 = ast_binary_read_string_checked(reader)
+      let field_1 = cp_read_binding(reader)
+      let field_2 = cp_read_env(reader)
+      EnvBind(field_0, field_1, field_2)
+    },
+    3 => {
+      let field_0 = ast_binary_read_string_checked(reader)
+      let field_1 = cp_read_array_string(reader)
+      let field_2 = ast_binary_read_bool_checked(reader)
+      let field_3 = cp_read_array_tuple_string_array_surface_type_surface_type(reader)
+      let field_4 = cp_read_env(reader)
+      let field_5 = cp_read_array_string(reader)
+      let field_6 = cp_read_array_tuple_string_array_string_array_tuple_string_array_string(reader)
+      EnvTraitDef(field_0, field_1, field_2, field_3, field_4, field_5, field_6)
+    },
+    4 => {
+      let field_0 = ast_binary_read_string_checked(reader)
+      let field_1 = cp_read_type(reader)
+      let field_2 = cp_read_env(reader)
+      EnvTraitImpl(field_0, field_1, field_2)
+    },
+    5 => {
+      let field_0 = ast_binary_read_string_checked(reader)
+      let field_1 = cp_read_array_string(reader)
+      let field_2 = cp_read_array_tuple_string_array_string(reader)
+      let field_3 = cp_read_type(reader)
+      let field_4 = cp_read_env(reader)
+      EnvTraitImplGen(field_0, field_1, field_2, field_3, field_4)
+    },
+    6 => {
+      let field_0 = cp_read_array_type_def(reader)
+      let field_1 = cp_read_array_string(reader)
+      let field_2 = cp_read_env(reader)
+      EnvTypeDefs(field_0, field_1, field_2)
+    },
+    7 => {
+      let field_0 = ast_binary_read_string_checked(reader)
+      let field_1 = ast_binary_read_bool_checked(reader)
+      let field_2 = cp_read_env(reader)
+      EnvMutCell(field_0, field_1, field_2)
+    },
+    8 => {
+      let field_0 = cp_read_array_tuple_string_binding(reader)
+      EnvFlat(field_0)
+    },
+    9 => {
+      let field_0 = cp_read_array_string(reader)
+      let field_1 = cp_read_array_binding(reader)
+      let field_2 = cp_read_env(reader)
+      if Array::length(field_0) != Array::length(field_1) {
+        throw("checked program: cached environment rows disagree")
+      }
+      EnvCached(field_0, field_1, field_2)
+    },
+    _ => throw("checked program: unknown TypeEnv tag")
+  }
+}
+
+fn cp_write_subst(out: Bytes, value: Subst) -> Unit {
+  match value {
+    SubstEmpty => {
+      Bytes::push(out, 1)
+    },
+    SubstBind(field_0, field_1, field_2) => {
+      Bytes::push(out, 2)
+      ast_binary_write_svarint(out, field_0)
+      cp_write_type(out, field_1)
+      cp_write_subst(out, field_2)
+    },
+    SubstBound(field_0, field_1, field_2) => {
+      Bytes::push(out, 3)
+      ast_binary_write_svarint(out, field_0)
+      cp_write_array_string(out, field_1)
+      cp_write_subst(out, field_2)
+    },
+    SubstCached(field_0, field_1, field_2) => {
+      Bytes::push(out, 4)
+      cp_write_map_type(out, field_0)
+      cp_write_map_array_string(out, field_1)
+      cp_write_subst(out, field_2)
+    },
+    SubstEffBind(field_0, field_1, field_2) => {
+      Bytes::push(out, 5)
+      ast_binary_write_string(out, field_0)
+      ast_binary_write_string(out, field_1)
+      cp_write_subst(out, field_2)
+    },
+  }
+}
+
+fn cp_read_subst(reader: AstBinaryReader) -> Subst with Exception {
+  let tag = ast_binary_read_byte_checked(reader)
+  match tag {
+    1 => {
+      SubstEmpty
+    },
+    2 => {
+      let field_0 = ast_binary_read_svarint_checked(reader)
+      let field_1 = cp_read_type(reader)
+      let field_2 = cp_read_subst(reader)
+      SubstBind(field_0, field_1, field_2)
+    },
+    3 => {
+      let field_0 = ast_binary_read_svarint_checked(reader)
+      let field_1 = cp_read_array_string(reader)
+      let field_2 = cp_read_subst(reader)
+      SubstBound(field_0, field_1, field_2)
+    },
+    4 => {
+      let field_0 = cp_read_map_type(reader)
+      let field_1 = cp_read_map_array_string(reader)
+      let field_2 = cp_read_subst(reader)
+      SubstCached(field_0, field_1, field_2)
+    },
+    5 => {
+      let field_0 = ast_binary_read_string_checked(reader)
+      let field_1 = ast_binary_read_string_checked(reader)
+      let field_2 = cp_read_subst(reader)
+      SubstEffBind(field_0, field_1, field_2)
+    },
+    _ => throw("checked program: unknown Subst tag")
+  }
+}
+
+fn cp_write_binding(out: Bytes, value: EnvValueBinding) -> Unit {
+  cp_write_type(out, value.ty)
+  cp_write_origin(out, value.origin)
+}
+
+fn cp_read_binding(reader: AstBinaryReader) -> EnvValueBinding with Exception {
+  let ty = cp_read_type(reader)
+  let origin = cp_read_origin(reader)
+  EnvValueBinding::{ ty, origin }
+}
+
+fn cp_write_array_type_def(out: Bytes, value: Array[TypeDef]) -> Unit {
+  ast_binary_write_varint(out, Array::length(value))
+  let mut i = 0
+  while i < Array::length(value) {
+    cp_write_type_def(out, Array::get(value, i))
+    i = i + 1
+  }
+}
+
+fn cp_read_array_type_def(reader: AstBinaryReader) -> Array[TypeDef] with Exception {
+  let count = ast_binary_read_count_checked(reader)
+  let items: Array[TypeDef] = []
+  let mut i = 0
+  while i < count {
+    Array::push(items, cp_read_type_def(reader))
+    i = i + 1
+  }
+  items
+}
+
+fn cp_write_array_tuple_int_type(out: Bytes, value: Array[(Int, Type)]) -> Unit {
+  ast_binary_write_varint(out, Array::length(value))
+  let mut i = 0
+  while i < Array::length(value) {
+    cp_write_tuple_int_type(out, Array::get(value, i))
+    i = i + 1
+  }
+}
+
+fn cp_read_array_tuple_int_type(reader: AstBinaryReader) -> Array[(Int, Type)] with Exception {
+  let count = ast_binary_read_count_checked(reader)
+  let items: Array[(Int, Type)] = []
+  let mut i = 0
+  while i < count {
+    Array::push(items, cp_read_tuple_int_type(reader))
+    i = i + 1
+  }
+  items
+}
+
+fn cp_write_array_type(out: Bytes, value: Array[Type]) -> Unit {
+  ast_binary_write_varint(out, Array::length(value))
+  let mut i = 0
+  while i < Array::length(value) {
+    cp_write_type(out, Array::get(value, i))
+    i = i + 1
+  }
+}
+
+fn cp_read_array_type(reader: AstBinaryReader) -> Array[Type] with Exception {
+  let count = ast_binary_read_count_checked(reader)
+  let items: Array[Type] = []
+  let mut i = 0
+  while i < count {
+    Array::push(items, cp_read_type(reader))
+    i = i + 1
+  }
+  items
+}
+
+fn cp_write_array_int(out: Bytes, value: Array[Int]) -> Unit {
+  ast_binary_write_varint(out, Array::length(value))
+  let mut i = 0
+  while i < Array::length(value) {
+    ast_binary_write_svarint(out, Array::get(value, i))
+    i = i + 1
+  }
+}
+
+fn cp_read_array_int(reader: AstBinaryReader) -> Array[Int] with Exception {
+  let count = ast_binary_read_count_checked(reader)
+  let items: Array[Int] = []
+  let mut i = 0
+  while i < count {
+    Array::push(items, ast_binary_read_svarint_checked(reader))
+    i = i + 1
+  }
+  items
+}
+
+fn cp_write_array_tuple_int_array_string(out: Bytes, value: Array[(Int, Array[String])]) -> Unit {
+  ast_binary_write_varint(out, Array::length(value))
+  let mut i = 0
+  while i < Array::length(value) {
+    cp_write_tuple_int_array_string(out, Array::get(value, i))
+    i = i + 1
+  }
+}
+
+fn cp_read_array_tuple_int_array_string(reader: AstBinaryReader) -> Array[(Int, Array[String])] with Exception {
+  let count = ast_binary_read_count_checked(reader)
+  let items: Array[(Int, Array[String])] = []
+  let mut i = 0
+  while i < count {
+    Array::push(items, cp_read_tuple_int_array_string(reader))
+    i = i + 1
+  }
+  items
+}
+
+fn cp_write_array_tuple_string_type(out: Bytes, value: Array[(String, Type)]) -> Unit {
+  ast_binary_write_varint(out, Array::length(value))
+  let mut i = 0
+  while i < Array::length(value) {
+    cp_write_tuple_string_type(out, Array::get(value, i))
+    i = i + 1
+  }
+}
+
+fn cp_read_array_tuple_string_type(reader: AstBinaryReader) -> Array[(String, Type)] with Exception {
+  let count = ast_binary_read_count_checked(reader)
+  let items: Array[(String, Type)] = []
+  let mut i = 0
+  while i < count {
+    Array::push(items, cp_read_tuple_string_type(reader))
+    i = i + 1
+  }
+  items
+}
+
+fn cp_write_array_string(out: Bytes, value: Array[String]) -> Unit {
+  ast_binary_write_varint(out, Array::length(value))
+  let mut i = 0
+  while i < Array::length(value) {
+    ast_binary_write_string(out, Array::get(value, i))
+    i = i + 1
+  }
+}
+
+fn cp_read_array_string(reader: AstBinaryReader) -> Array[String] with Exception {
+  let count = ast_binary_read_count_checked(reader)
+  let items: Array[String] = []
+  let mut i = 0
+  while i < count {
+    Array::push(items, ast_binary_read_string_checked(reader))
+    i = i + 1
+  }
+  items
+}
+
+fn cp_write_array_tuple_string_array_type(out: Bytes, value: Array[(String, Array[Type])]) -> Unit {
+  ast_binary_write_varint(out, Array::length(value))
+  let mut i = 0
+  while i < Array::length(value) {
+    cp_write_tuple_string_array_type(out, Array::get(value, i))
+    i = i + 1
+  }
+}
+
+fn cp_read_array_tuple_string_array_type(reader: AstBinaryReader) -> Array[(String, Array[Type])] with Exception {
+  let count = ast_binary_read_count_checked(reader)
+  let items: Array[(String, Array[Type])] = []
+  let mut i = 0
+  while i < count {
+    Array::push(items, cp_read_tuple_string_array_type(reader))
+    i = i + 1
+  }
+  items
+}
+
+fn cp_write_array_tuple_string_array_type_type(out: Bytes, value: Array[(String, Array[Type], Type)]) -> Unit {
+  ast_binary_write_varint(out, Array::length(value))
+  let mut i = 0
+  while i < Array::length(value) {
+    cp_write_tuple_string_array_type_type(out, Array::get(value, i))
+    i = i + 1
+  }
+}
+
+fn cp_read_array_tuple_string_array_type_type(reader: AstBinaryReader) -> Array[(String, Array[Type], Type)] with Exception {
+  let count = ast_binary_read_count_checked(reader)
+  let items: Array[(String, Array[Type], Type)] = []
+  let mut i = 0
+  while i < count {
+    Array::push(items, cp_read_tuple_string_array_type_type(reader))
+    i = i + 1
+  }
+  items
+}
+
+fn cp_write_array_tuple_string_array_surface_type_surface_type(out: Bytes, value: Array[(String, Array[TypeExpr], TypeExpr)]) -> Unit {
+  ast_binary_write_varint(out, Array::length(value))
+  let mut i = 0
+  while i < Array::length(value) {
+    cp_write_tuple_string_array_surface_type_surface_type(out, Array::get(value, i))
+    i = i + 1
+  }
+}
+
+fn cp_read_array_tuple_string_array_surface_type_surface_type(reader: AstBinaryReader) -> Array[(String, Array[TypeExpr], TypeExpr)] with Exception {
+  let count = ast_binary_read_count_checked(reader)
+  let items: Array[(String, Array[TypeExpr], TypeExpr)] = []
+  let mut i = 0
+  while i < count {
+    Array::push(items, cp_read_tuple_string_array_surface_type_surface_type(reader))
+    i = i + 1
+  }
+  items
+}
+
+fn cp_write_array_tuple_string_array_string_array_tuple_string_array_string(out: Bytes, value: Array[(String, Array[String], Array[(String, Array[String])])]) -> Unit {
+  ast_binary_write_varint(out, Array::length(value))
+  let mut i = 0
+  while i < Array::length(value) {
+    cp_write_tuple_string_array_string_array_tuple_string_array_string(out, Array::get(value, i))
+    i = i + 1
+  }
+}
+
+fn cp_read_array_tuple_string_array_string_array_tuple_string_array_string(reader: AstBinaryReader) -> Array[(String, Array[String], Array[(String, Array[String])])] with Exception {
+  let count = ast_binary_read_count_checked(reader)
+  let items: Array[(String, Array[String], Array[(String, Array[String])])] = []
+  let mut i = 0
+  while i < count {
+    Array::push(items, cp_read_tuple_string_array_string_array_tuple_string_array_string(reader))
+    i = i + 1
+  }
+  items
+}
+
+fn cp_write_array_tuple_string_array_string(out: Bytes, value: Array[(String, Array[String])]) -> Unit {
+  ast_binary_write_varint(out, Array::length(value))
+  let mut i = 0
+  while i < Array::length(value) {
+    cp_write_tuple_string_array_string(out, Array::get(value, i))
+    i = i + 1
+  }
+}
+
+fn cp_read_array_tuple_string_array_string(reader: AstBinaryReader) -> Array[(String, Array[String])] with Exception {
+  let count = ast_binary_read_count_checked(reader)
+  let items: Array[(String, Array[String])] = []
+  let mut i = 0
+  while i < count {
+    Array::push(items, cp_read_tuple_string_array_string(reader))
+    i = i + 1
+  }
+  items
+}
+
+fn cp_write_array_tuple_string_binding(out: Bytes, value: Array[(String, EnvValueBinding)]) -> Unit {
+  ast_binary_write_varint(out, Array::length(value))
+  let mut i = 0
+  while i < Array::length(value) {
+    cp_write_tuple_string_binding(out, Array::get(value, i))
+    i = i + 1
+  }
+}
+
+fn cp_read_array_tuple_string_binding(reader: AstBinaryReader) -> Array[(String, EnvValueBinding)] with Exception {
+  let count = ast_binary_read_count_checked(reader)
+  let items: Array[(String, EnvValueBinding)] = []
+  let mut i = 0
+  while i < count {
+    Array::push(items, cp_read_tuple_string_binding(reader))
+    i = i + 1
+  }
+  items
+}
+
+fn cp_write_array_binding(out: Bytes, value: Array[EnvValueBinding]) -> Unit {
+  ast_binary_write_varint(out, Array::length(value))
+  let mut i = 0
+  while i < Array::length(value) {
+    cp_write_binding(out, Array::get(value, i))
+    i = i + 1
+  }
+}
+
+fn cp_read_array_binding(reader: AstBinaryReader) -> Array[EnvValueBinding] with Exception {
+  let count = ast_binary_read_count_checked(reader)
+  let items: Array[EnvValueBinding] = []
+  let mut i = 0
+  while i < count {
+    Array::push(items, cp_read_binding(reader))
+    i = i + 1
+  }
+  items
+}
+
+fn cp_write_map_type(out: Bytes, value: Map[String, Type]) -> Unit {
+  let keys = Map::keys(value)
+  ast_binary_write_varint(out, Array::length(keys))
+  let mut i = 0
+  while i < Array::length(keys) {
+    let key = Array::get(keys, i)
+    ast_binary_write_string(out, key)
+    cp_write_type(out, Map::get(value, key))
+    i = i + 1
+  }
+}
+
+fn cp_read_map_type(reader: AstBinaryReader) -> Map[String, Type] with Exception {
+  let pairs = cp_read_array_tuple_string_type(reader)
+  let mut result: Map[String, Type] = Map::new()
+  let mut i = 0
+  while i < Array::length(pairs) {
+    let (key, value) = Array::get(pairs, i)
+    if Map::has_key(result, key) {
+      throw("checked program: duplicate substitution cache key")
+    }
+    result = Map::set(result, key, value)
+    i = i + 1
+  }
+  result
+}
+
+fn cp_write_map_array_string(out: Bytes, value: Map[String, Array[String]]) -> Unit {
+  let keys = Map::keys(value)
+  ast_binary_write_varint(out, Array::length(keys))
+  let mut i = 0
+  while i < Array::length(keys) {
+    let key = Array::get(keys, i)
+    ast_binary_write_string(out, key)
+    cp_write_array_string(out, Map::get(value, key))
+    i = i + 1
+  }
+}
+
+fn cp_read_map_array_string(reader: AstBinaryReader) -> Map[String, Array[String]] with Exception {
+  let pairs = cp_read_array_tuple_string_array_string(reader)
+  let mut result: Map[String, Array[String]] = Map::new()
+  let mut i = 0
+  while i < Array::length(pairs) {
+    let (key, value) = Array::get(pairs, i)
+    if Map::has_key(result, key) {
+      throw("checked program: duplicate substitution bound cache key")
+    }
+    result = Map::set(result, key, value)
+    i = i + 1
+  }
+  result
+}
+
+fn cp_write_tuple_int_type(out: Bytes, value: (Int, Type)) -> Unit {
+  ast_binary_write_svarint(out, value.0)
+  cp_write_type(out, value.1)
+}
+
+fn cp_read_tuple_int_type(reader: AstBinaryReader) -> (Int, Type) with Exception {
+  let field_0 = ast_binary_read_svarint_checked(reader)
+  let field_1 = cp_read_type(reader)
+  (field_0, field_1)
+}
+
+fn cp_write_tuple_int_array_string(out: Bytes, value: (Int, Array[String])) -> Unit {
+  ast_binary_write_svarint(out, value.0)
+  cp_write_array_string(out, value.1)
+}
+
+fn cp_read_tuple_int_array_string(reader: AstBinaryReader) -> (Int, Array[String]) with Exception {
+  let field_0 = ast_binary_read_svarint_checked(reader)
+  let field_1 = cp_read_array_string(reader)
+  (field_0, field_1)
+}
+
+fn cp_write_tuple_string_type(out: Bytes, value: (String, Type)) -> Unit {
+  ast_binary_write_string(out, value.0)
+  cp_write_type(out, value.1)
+}
+
+fn cp_read_tuple_string_type(reader: AstBinaryReader) -> (String, Type) with Exception {
+  let field_0 = ast_binary_read_string_checked(reader)
+  let field_1 = cp_read_type(reader)
+  (field_0, field_1)
+}
+
+fn cp_write_tuple_string_array_type(out: Bytes, value: (String, Array[Type])) -> Unit {
+  ast_binary_write_string(out, value.0)
+  cp_write_array_type(out, value.1)
+}
+
+fn cp_read_tuple_string_array_type(reader: AstBinaryReader) -> (String, Array[Type]) with Exception {
+  let field_0 = ast_binary_read_string_checked(reader)
+  let field_1 = cp_read_array_type(reader)
+  (field_0, field_1)
+}
+
+fn cp_write_tuple_string_array_type_type(out: Bytes, value: (String, Array[Type], Type)) -> Unit {
+  ast_binary_write_string(out, value.0)
+  cp_write_array_type(out, value.1)
+  cp_write_type(out, value.2)
+}
+
+fn cp_read_tuple_string_array_type_type(reader: AstBinaryReader) -> (String, Array[Type], Type) with Exception {
+  let field_0 = ast_binary_read_string_checked(reader)
+  let field_1 = cp_read_array_type(reader)
+  let field_2 = cp_read_type(reader)
+  (field_0, field_1, field_2)
+}
+
+fn cp_write_tuple_string_array_surface_type_surface_type(out: Bytes, value: (String, Array[TypeExpr], TypeExpr)) -> Unit {
+  ast_binary_write_string(out, value.0)
+  cp_write_array_surface_type(out, value.1)
+  ast_binary_write_type_expr(out, value.2)
+}
+
+fn cp_read_tuple_string_array_surface_type_surface_type(reader: AstBinaryReader) -> (String, Array[TypeExpr], TypeExpr) with Exception {
+  let field_0 = ast_binary_read_string_checked(reader)
+  let field_1 = cp_read_array_surface_type(reader)
+  let field_2 = ast_binary_read_type_expr(reader)
+  (field_0, field_1, field_2)
+}
+
+fn cp_write_tuple_string_array_string_array_tuple_string_array_string(out: Bytes, value: (String, Array[String], Array[(String, Array[String])])) -> Unit {
+  ast_binary_write_string(out, value.0)
+  cp_write_array_string(out, value.1)
+  cp_write_array_tuple_string_array_string(out, value.2)
+}
+
+fn cp_read_tuple_string_array_string_array_tuple_string_array_string(reader: AstBinaryReader) -> (String, Array[String], Array[(String, Array[String])]) with Exception {
+  let field_0 = ast_binary_read_string_checked(reader)
+  let field_1 = cp_read_array_string(reader)
+  let field_2 = cp_read_array_tuple_string_array_string(reader)
+  (field_0, field_1, field_2)
+}
+
+fn cp_write_tuple_string_array_string(out: Bytes, value: (String, Array[String])) -> Unit {
+  ast_binary_write_string(out, value.0)
+  cp_write_array_string(out, value.1)
+}
+
+fn cp_read_tuple_string_array_string(reader: AstBinaryReader) -> (String, Array[String]) with Exception {
+  let field_0 = ast_binary_read_string_checked(reader)
+  let field_1 = cp_read_array_string(reader)
+  (field_0, field_1)
+}
+
+fn cp_write_tuple_string_binding(out: Bytes, value: (String, EnvValueBinding)) -> Unit {
+  ast_binary_write_string(out, value.0)
+  cp_write_binding(out, value.1)
+}
+
+fn cp_read_tuple_string_binding(reader: AstBinaryReader) -> (String, EnvValueBinding) with Exception {
+  let field_0 = ast_binary_read_string_checked(reader)
+  let field_1 = cp_read_binding(reader)
+  (field_0, field_1)
+}
+
+fn cp_write_array_surface_type(out: Bytes, value: Array[TypeExpr]) -> Unit {
+  ast_binary_write_varint(out, Array::length(value))
+  let mut i = 0
+  while i < Array::length(value) {
+    ast_binary_write_type_expr(out, Array::get(value, i))
+    i = i + 1
+  }
+}
+
+fn cp_read_array_surface_type(reader: AstBinaryReader) -> Array[TypeExpr] with Exception {
+  let count = ast_binary_read_count_checked(reader)
+  let items: Array[TypeExpr] = []
+  let mut i = 0
+  while i < count {
+    Array::push(items, ast_binary_read_type_expr(reader))
+    i = i + 1
+  }
+  items
+}

--- a/lib/@vibe/compiler/checker/artifacts/program/program_test.vibe
+++ b/lib/@vibe/compiler/checker/artifacts/program/program_test.vibe
@@ -1,0 +1,305 @@
+import @vibe/compiler/checker/artifacts/program {
+  decode_checked_program, encode_checked_program
+}
+
+import @vibe/compiler/checker/artifacts {
+  checked_exported_interface_artifact_fingerprint_v1, checked_exported_interface_artifact_from_checked_program
+}
+
+import @vibe/compiler/checker {
+  CheckedProgram, check_program_result
+}
+
+import @vibe/compiler/core {
+  BindingOrigin,
+  EnvValueBinding,
+  Expr,
+  Stmt,
+  Subst,
+  Type,
+  TypeDef,
+  TypeEnv,
+  TypeExpr,
+  env_lookup,
+  env_lookup_binding,
+  env_mut_escape,
+  env_selectable_type_defs,
+  subst_apply,
+  trait_defined,
+  type_to_string
+}
+
+import @vibe/compiler/cache {
+  ast_binary_write_varint
+}
+
+import @vibe/compiler/codegen/wasi {
+  compile_wasi_module_rc_impl
+}
+
+import @vibe/compiler/syntax {
+  lex_with_offsets, parse_program_located
+}
+
+fn checked_source(source: String) -> CheckedProgram with Exception {
+  let (tokens, offsets, _) = lex_with_offsets(source)
+  check_program_result(parse_program_located(tokens, offsets, source))
+}
+
+fn restored(checked: CheckedProgram) -> CheckedProgram with Exception {
+  match decode_checked_program(encode_checked_program(checked)) {
+    Some(value) => value,
+    None => throw("checked program did not decode")
+  }
+}
+
+fn public_identity(checked: CheckedProgram) -> String with Exception {
+  match checked_exported_interface_artifact_from_checked_program(checked) {
+    Some(artifact) => checked_exported_interface_artifact_fingerprint_v1(artifact),
+    None => throw("missing public interface")
+  }
+}
+
+test "transport keeps public identity separate from private body and location edits" {
+  let before = restored(checked_source("fn hidden() -> Int { 1 }\nexport let api = 42"))
+  let body_edit = restored(checked_source("fn hidden() -> Int { 2 }\nexport let api = 42"))
+  let location_edit = restored(checked_source("// changed location\nfn hidden() -> Int { 1 }\nexport let api = 42"))
+  let public_edit = restored(checked_source("fn hidden() -> Int { 1 }\nexport let api = \"42\""))
+  inspect(public_identity(before) == public_identity(body_edit), content = "true")
+  inspect(public_identity(before) == public_identity(location_edit), content = "true")
+  inspect(public_identity(before) != public_identity(public_edit), content = "true")
+  inspect(encode_checked_program(before) != encode_checked_program(body_edit), content = "true")
+}
+
+test "checked program transport restores a complete production result" {
+  let source =
+  "export struct Box[T] { value: T }\nexport fn make(n: Int) -> Box[Int] { Box[Int]::{ value: n } }\nfn value(n: Int) -> Int { let p = make(n); p.value }\nlet answer = value(42)"
+  let original = checked_source(source)
+  let decoded = restored(original)
+  inspect(Array::length(decoded.checked_stmts), content = "4")
+  inspect(Array::length(decoded.type_defs) == Array::length(original.type_defs), content = "true")
+  inspect(Array::length(decoded.typed_occurrences) == Array::length(original.typed_occurrences), content = "true")
+  inspect(Array::length(decoded.typed_occurrences) > 0, content = "true")
+  inspect(env_lookup(decoded.final_env, "answer") is Some(CtInt), content = "true")
+  inspect(encode_checked_program(decoded) == encode_checked_program(original), content = "true")
+}
+
+test "checked program transport preserves lookup order provenance and cached substitution" {
+  let exported = EnvValueBinding::{
+    ty: CtString,
+    origin: BindingOriginModuleExport("dep.vibe", "public")
+  }
+  let hidden = EnvValueBinding::{ ty: CtInt, origin: BindingOriginUnavailable }
+  let env = EnvCached(["x", "x"], [exported, hidden], EnvMutCell("cell", true, EnvBind("x", exported, EnvFlat([
+    ("x", hidden)
+  ]))))
+  let subst = SubstCached(Map::from_pairs([
+    ("7", CtDouble),
+    ("8", CtString),
+    ("9", CtInt)
+  ]), Map::from_pairs([("7", ["Eq"]), ("8", ["Show"])]), SubstEffBind("e", "Stdout", SubstBound(7, [
+    "Eq"
+  ], SubstBind(7, CtDouble, SubstEmpty))))
+  let original = CheckedProgram::{
+    checked_stmts: [SExpr(EInt(42))],
+    final_env: env,
+    type_defs: [],
+    final_subst: subst,
+    typed_occurrences: [(17, CtVar(7)), (17, CtString)]
+  }
+  let decoded = restored(original)
+  inspect(encode_checked_program(decoded) == encode_checked_program(original), content = "true")
+  inspect(env_lookup(decoded.final_env, "x") is Some(CtString), content = "true")
+  inspect(env_mut_escape(decoded.final_env, "cell") is Some(true), content = "true")
+  match env_lookup_binding(decoded.final_env, "x") {
+    Some(binding) => match binding.origin {
+      BindingOriginModuleExport(path, name) => inspect((path, name), content = "(dep.vibe, public)"),
+      _ => assert(false)
+    },
+    None => assert(false)
+  }
+  inspect(subst_apply(decoded.final_subst, CtVar(7)) is CtDouble, content = "true")
+  inspect(subst_apply(decoded.final_subst, CtVar(8)) is CtString, content = "true")
+  let rows: Array[(Int, String)] = for row in decoded.typed_occurrences {
+    (row.0, type_to_string(row.1))
+  }
+  inspect(rows, content = "[(17, ?t7), (17, String)]")
+}
+
+test "checked program transport rejects truncation trailing bytes and unknown versions" {
+  let encoded = encode_checked_program(checked_source("let answer = 42"))
+  let mut end = 0
+  while end < 32 && end < Bytes::length(encoded) {
+    inspect(decode_checked_program(Bytes::slice(encoded, 0, end)) is None, content = "true")
+    inspect(decode_checked_program(Bytes::slice(encoded, 0, Bytes::length(encoded) - end - 1)) is None, content = "true")
+    end = end + 1
+  }
+  let trailing = Bytes::slice(encoded, 0, Bytes::length(encoded))
+  Bytes::push(trailing, 0)
+  inspect(decode_checked_program(trailing) is None, content = "true")
+  let version = Bytes::slice(encoded, 0, Bytes::length(encoded))
+  Bytes::set(version, 4, 255)
+  inspect(decode_checked_program(version) is None, content = "true")
+  let changed = Bytes::slice(encoded, 0, Bytes::length(encoded))
+  let last = Bytes::length(changed) - 1
+  Bytes::set(changed, last, Bytes::get(changed, last)^1)
+  inspect(decode_checked_program(changed) is None, content = "true")
+}
+
+test "checked program transport covers every semantic type and declaration" {
+  let types: Array[Type] = [
+    CtInt,
+    CtDouble,
+    CtBool,
+    CtString,
+    CtChar,
+    CtUnit,
+    CtTuple([CtInt, CtString]),
+    CtArray(CtDouble),
+    CtOption(CtChar),
+    CtFn([CtInt, CtChar], CtString, Some("Stdout")),
+    CtFn([], CtUnit, None),
+    CtEnum("Choice"),
+    CtStruct("Point"),
+    CtBytes,
+    CtNamed("Box", [CtInt]),
+    CtConstructor("Array", 1),
+    CtApplied(CtVar(7), [CtString]),
+    CtVar(8),
+    CtForAll([9, 10], [(10, ["Eq", "Ord"])], CtFn([CtVar(9)], CtVar(10), Some("e"))),
+    CtUnknown,
+    CtRecord([("a", CtInt), ("b", CtString)])
+  ]
+  let defs: Array[TypeDef] = [
+    TDEnum("Choice", ["T"], [("Value", [CtNamed("T", [])]), ("Empty", [])]),
+    TDStruct("Point", [("x", CtInt)], ["x"], []),
+    TDAlias("Count", [], CtInt),
+    TDEffect("Log", [("Emit", [CtString], CtUnit)], ["T"]),
+    TDEffectSet("Console", ["Log"])
+  ]
+  let env = EnvTraitDef("Show", ["Eq"], false, [
+    ("show", [TyName("Self"), TyTuple([TyUnit])], TyFn([], TyName("String"), Some("Log")))
+  ], EnvTraitImpl("Show", CtInt, EnvTraitImplGen("Eq", ["T"], [("T", ["Eq"])], CtNamed("Box", [
+    CtNamed("T", [])
+  ]), EnvTypeDefs(defs, ["Choice", "Point"], EnvBind("surface", EnvValueBinding::{
+    ty: CtInt,
+    origin: BindingOriginReExportSurface("facade.vibe", "answer")
+  }, EnvEmpty)))), ["Self"], [("show", ["U"], [("U", ["Show"])])])
+  let rows: Array[(Int, Type)] = []
+  let mut i = 0
+  while i < Array::length(types) {
+    Array::push(rows, (i, Array::get(types, i)))
+    i = i + 1
+  }
+  let original = CheckedProgram::{
+    checked_stmts: [],
+    final_env: env,
+    type_defs: defs,
+    final_subst: SubstEmpty,
+    typed_occurrences: rows
+  }
+  let decoded = restored(original)
+  inspect(encode_checked_program(decoded) == encode_checked_program(original), content = "true")
+  inspect(env_selectable_type_defs(decoded.final_env), content = "[Choice, Point]")
+  inspect(trait_defined(decoded.final_env, "Show"), content = "true")
+  let names: Array[String] = for row in decoded.typed_occurrences {
+    type_to_string(row.1)
+  }
+  inspect(Array::length(names), content = "21")
+  inspect(Array::get(names, 1), content = "Double")
+  inspect(Array::get(names, 17), content = "?t8")
+}
+
+// Handcrafted wire payloads exercise the decoder independently of its writer.
+fn test_wire(payload: Array[Int]) -> Bytes {
+  let out = Bytes::from_array([118, 67, 72, 75, 1])
+  let mut first = 17
+  let mut second = 29
+  for byte in payload {
+    first = (first * 131 + byte) % 2147483647
+    second = (second * 137 + byte) % 2147483629
+  }
+  ast_binary_write_varint(out, first)
+  ast_binary_write_varint(out, second)
+  Bytes::append(out, Bytes::from_array(payload))
+  out
+}
+
+test "checked program transport validates structure even with a valid checksum" {
+  // Empty AST, empty environment, no declarations, empty substitution, no rows.
+  let empty = test_wire([118, 65, 83, 84, 1, 0, 1, 0, 1, 0])
+  inspect(decode_checked_program(empty) is Some(_), content = "true")
+  let minimal = CheckedProgram::{
+    checked_stmts: [],
+    final_env: EnvEmpty,
+    type_defs: [],
+    final_subst: SubstEmpty,
+    typed_occurrences: []
+  }
+  inspect(encode_checked_program(minimal) == empty, content = "true")
+  // Unknown environment tag; unknown substitution tag; trailing payload.
+  inspect(decode_checked_program(test_wire([118, 65, 83, 84, 1, 0, 255, 0, 1, 0])) is None, content = "true")
+  inspect(decode_checked_program(test_wire([118, 65, 83, 84, 1, 0, 1, 0, 255, 0])) is None, content = "true")
+  inspect(decode_checked_program(test_wire([
+    118,
+    65,
+    83,
+    84,
+    1,
+    0,
+    1,
+    0,
+    1,
+    0,
+    0
+  ])) is None, content = "true")
+  // An EnvCached with one name but no values cannot be a usable index.
+  inspect(decode_checked_program(test_wire([
+    118,
+    65,
+    83,
+    84,
+    1,
+    0,
+    9,
+    1,
+    1,
+    120,
+    0,
+    1,
+    0,
+    1,
+    0
+  ])) is None, content = "true")
+  // A noncanonical zero count must not be accepted as an empty AST.
+  inspect(decode_checked_program(test_wire([
+    118,
+    65,
+    83,
+    84,
+    1,
+    128,
+    0,
+    1,
+    0,
+    1,
+    0
+  ])) is None, content = "true")
+}
+
+test "checked program transport generates the same wasm as a fresh check" {
+  let sources = [
+    "fn run() -> Int { 42 }",
+    "fn run() -> Int { let mut n = 0; while n < 10 { n = n + 1 }; n }",
+    "struct Box[T] { value: T }\nfn run() -> Int { let b = Box[Int]::{ value: 42 }; b.value }",
+    "fn run() -> Int { let x = 9; let f = (n) -> { x - n }; f(2) }",
+    "enum Choice { A(Int); B }\nfn run() -> Int { match A(42) { A(n) => n, B => 0 } }"
+  ]
+  for source in sources {
+    let original = checked_source(source)
+    let decoded = restored(original)
+    let fresh = compile_wasi_module_rc_impl(original.checked_stmts, "run")
+    let transported = compile_wasi_module_rc_impl(decoded.checked_stmts, "run")
+    inspect(fresh == transported, content = "true")
+  }
+}

--- a/lib/@vibe/compiler/compiler_sources_manifest.tsv
+++ b/lib/@vibe/compiler/compiler_sources_manifest.tsv
@@ -97,6 +97,8 @@ checker	checker/artifacts/checked_type_defs_artifact.vibe
 checker	checker/artifacts/checked_direct_expression_return_observation.vibe
 checker	checker/artifacts/checked_typed_occurrence_expression_path_artifact.vibe
 checker	checker/artifacts/checked_implementation_body_artifact.vibe
+checker	checker/artifacts/program/index.vpkg
+checker	checker/artifacts/program/program.vibe
 checker	checker/artifacts/checked_typed_occurrence_statement_observation.vibe
 checker	checker/artifacts/checked_typed_occurrence_role_lane_observation.vibe
 checker	checker/artifacts/checked_typed_occurrence_expression_path_observation.vibe

--- a/lib/@vibe/compiler/fmt/lexer/lexer.vibe
+++ b/lib/@vibe/compiler/fmt/lexer/lexer.vibe
@@ -688,7 +688,7 @@ fn lx_char(lx: LX) -> LTok {
   }
 }
 
-/// Lex a #| multiline string starting at the already-detected '#'.
+/// Lex a #| multiline string after '#' has been consumed, at '|'.
 fn lx_multiline_string(lx: LX) -> LTok {
   // O(N) build via StringBuilder; the per-char `line` and per-line `buf` builds
   // via String::concat were each O(N²) over their length (issue #366).
@@ -714,8 +714,8 @@ fn lx_multiline_string(lx: LX) -> LTok {
     first_line = false
     StringBuilder::push(buf, StringBuilder::freeze(line))
     if lx_peek(lx) == '\n' {
-      lx.pos = lx.pos + 1
       let saved = lx.pos
+      lx.pos = lx.pos + 1
       let mut sk = true
       while sk {
         let c = lx_peek(lx)
@@ -1171,7 +1171,6 @@ fn lx_next(lx: LX) -> LTok {
       }
     } else if c == '#' {
       if lx_peek(lx) == '|' {
-        lx.pos = lx.pos - 1
         lx_multiline_string(lx)
       } else {
         let start = lx.pos - 1

--- a/lib/@vibe/compiler/fmt/multiline_string_test.vibe
+++ b/lib/@vibe/compiler/fmt/multiline_string_test.vibe
@@ -1,0 +1,38 @@
+import @vibe/compiler/fmt {
+  format_script
+}
+import @vibe/compiler/core {
+  Expr, Stmt
+}
+import @vibe/compiler/syntax {
+  lex, parse_program
+}
+
+fn string_and_next(source: String) -> (String, Int) with Exception {
+  let program = parse_program(lex(source))
+  let value = match Array::get(program, 0) {
+    SLet(_, _, _, _, EString(text)) => text,
+    _ => throw("expected a string binding")
+  }
+  let next = match Array::get(program, 1) {
+    SLet(_, _, _, _, EInt(value)) => value,
+    _ => throw("expected a following integer binding")
+  }
+  (value, next)
+}
+
+test "formatter preserves multiline string content and the following statement" {
+  let sources = [
+    "let value =\n  #|first\n  #|second\nlet next = 42\n",
+    "let value =\n  #|\n  #|  indented\n\nlet next = 42\n",
+    "let value =\n  #|one line\n// comment\nlet next = 42\n"
+  ]
+  for source in sources {
+    let before = string_and_next(source)
+    let formatted = format_script(source)
+    let after = string_and_next(formatted)
+    inspect(after == before, content = "true")
+    inspect(format_script(formatted) == formatted, content = "true")
+    inspect(String::contains(formatted, "\nlet next"), content = "true")
+  }
+}

--- a/lib/@vibe/compiler/runtime/index.vpkg
+++ b/lib/@vibe/compiler/runtime/index.vpkg
@@ -7,6 +7,7 @@ deps = {
   @vibe/compiler/cache : 0.0.1
   @vibe/compiler/checker : 0.0.1
   @vibe/compiler/checker/artifacts : 0.0.1
+  @vibe/compiler/checker/artifacts/program : 0.0.1
   @vibe/compiler/codegen : 0.0.1
   @vibe/compiler/codegen/common_analysis : 0.0.1
   @vibe/compiler/codegen/wasi : 0.0.1
@@ -357,6 +358,7 @@ opaque type ModuleOutcome
 opaque type CheckedModuleTypingArtifactFreshnessAttestation
 fn check_module(job: ModuleJob) -> ModuleOutcome with Exception
 fn check_module_with_typing_artifact_observation(job: ModuleJob) -> ModuleOutcome with Exception
+fn check_module_with_program_transport(job: ModuleJob) -> (ModuleOutcome, Option[Bytes]) with Exception
 // Test-only observation of post-success construction attempts.
 fn checked_module_typing_artifact_construction_attempt_count() -> Int
 fn reset_checked_module_typing_artifact_construction_attempt_count() -> Unit

--- a/lib/@vibe/compiler/runtime/module_program_transport_test.vibe
+++ b/lib/@vibe/compiler/runtime/module_program_transport_test.vibe
@@ -1,0 +1,86 @@
+import ./typecheck_fs.vibe {
+  ModuleOutcome, check_module, check_module_with_program_transport
+}
+
+import @vibe/compiler/runtime {
+  ModuleJob
+}
+import @vibe/compiler/checker/artifacts/program {
+  decode_checked_program, encode_checked_program
+}
+import @vibe/compiler/core {
+  BindingOrigin, EnvValueBinding, Type, TypeEnv, env_lookup
+}
+
+fn transport_job(source: String) -> ModuleJob {
+  ModuleJob::{
+    path: "module.vibe",
+    source,
+    deps: ["dep.vibe"],
+    dep_fps: [("dep.vibe", "dep-fingerprint")],
+    dep_envs: [
+      ("dep.vibe", EnvBind("answer", EnvValueBinding::{
+        ty: CtFn([], CtInt, None),
+        origin: BindingOriginModuleExport("dep.vibe", "answer")
+      }, EnvEmpty))
+    ]
+  }
+}
+
+fn outcome_diagnostics(outcome: ModuleOutcome) -> Array[String] {
+  match outcome {
+    Checked(_, _, _, _, _, _, _) => [],
+    Diagnosed(_, diagnostics) => diagnostics
+  }
+}
+
+test "module transport retains the result checked against its actual imports" {
+  let job = transport_job("import ./dep.vibe { answer }\nexport fn run() -> Int { answer() - 2 }")
+  let (outcome, bytes) = check_module_with_program_transport(job)
+  inspect(outcome_diagnostics(outcome), content = "[]")
+  match bytes {
+    Some(encoded) => match decode_checked_program(encoded) {
+      Some(checked) => {
+        inspect(env_lookup(checked.final_env, "run") is Some(CtFn(_, CtInt, _)), content = "true")
+        inspect(Array::length(checked.typed_occurrences) > 0, content = "true")
+        inspect(encode_checked_program(checked) == encoded, content = "true")
+      },
+      None => assert(false)
+    },
+    None => assert(false)
+  }
+}
+
+test "module transport preserves diagnosed outcomes and never publishes a failed check" {
+  let sources = [
+    "import ./dep.vibe { answer }\nexport fn run() -> String { answer() }",
+    "import ./dep.vibe { absent }\nexport fn run() -> Int { absent() }",
+    "effect Log { Emit(String) -> Unit }\nexport fn run() -> Int { perform Log::Emit(\"hi\"); 0 }"
+  ]
+  for source in sources {
+    let job = transport_job(source)
+    let ordinary = outcome_diagnostics(check_module(job))
+    let (outcome, bytes) = check_module_with_program_transport(job)
+    inspect(Array::length(ordinary) > 0, content = "true")
+    inspect(outcome_diagnostics(outcome) == ordinary, content = "true")
+    inspect(bytes is None, content = "true")
+  }
+}
+
+fn parse_failure(source: String, transport: Bool) -> String {
+  handle {
+    if transport {
+      let _ = check_module_with_program_transport(transport_job(source))
+    } else {
+      let _ = check_module(transport_job(source))
+    }
+    ""
+  } with { Exception::Throw(message) => message }
+}
+
+test "module transport preserves parse failures without relabeling them" {
+  let source = "export fn broken("
+  let ordinary = parse_failure(source, false)
+  inspect(String::length(ordinary) > 0, content = "true")
+  inspect(parse_failure(source, true) == ordinary, content = "true")
+}

--- a/lib/@vibe/compiler/runtime/typecheck_fs.vibe
+++ b/lib/@vibe/compiler/runtime/typecheck_fs.vibe
@@ -57,6 +57,10 @@ import @vibe/compiler/checker/artifacts {
   shadow_unattested_checked_module_typing_artifact_v2_from_checked_program
 }
 
+import @vibe/compiler/checker/artifacts/program {
+  encode_checked_program
+}
+
 import @vibe/compiler/core {
   BindingOrigin,
   Expr,
@@ -4985,7 +4989,7 @@ export fn checked_module_typing_artifact_observation_is_fresh_for_job(job: Modul
 /// Pure module check implementation. Artifact observation is explicitly opt-in:
 /// the production incremental path must not allocate canonical shadow bytes for
 /// every checked module when no observer consumes them.
-fn check_module_impl(job: ModuleJob, observe_typing_artifact: Bool) -> ModuleOutcome with Exception {
+fn check_module_impl(job: ModuleJob, observe_typing_artifact: Bool, program_transport: Option[Array[Bytes]]) -> ModuleOutcome with Exception {
   // Parse stays OUTSIDE the handler below: parse errors currently
   // propagate verbatim, while type errors get located and path-prefixed.
   // Folding both into one handler would relabel every parse diagnostic.
@@ -5056,6 +5060,10 @@ fn check_module_impl(job: ModuleJob, observe_typing_artifact: Bool) -> ModuleOut
       } else {
         None
       }
+      match program_transport {
+        Some(output) => Array::push(output, encode_checked_program(checked_program)),
+        None => ()
+      }
       Checked(job.path, fingerprint, checked_env, interface_identity, checked_env_identity, persistent_type_env_transport_identity, module_typing_artifact)
     } with { Exception::Throw(msg) => {
       let located = locate_type_error(job.source, msg)
@@ -5070,13 +5078,28 @@ fn check_module_impl(job: ModuleJob, observe_typing_artifact: Bool) -> ModuleOut
 /// Production module check. No Fs: dependency environments are already values
 /// inside the job. Shadow artifact observation stays disabled by default.
 export fn check_module(job: ModuleJob) -> ModuleOutcome with Exception {
-  check_module_impl(job, false)
+  check_module_impl(job, false, None)
 }
 
 /// Opt-in trusted #1550 observation producer. This runs the same complete module
 /// checker and retains canonical bytes only in its opaque successful outcome.
 export fn check_module_with_typing_artifact_observation(job: ModuleJob) -> ModuleOutcome with Exception {
-  check_module_impl(job, true)
+  check_module_impl(job, true, None)
+}
+
+/// Check against the job's actual import environment and retain the complete
+/// result from that one successful invocation. Diagnosed modules have no bytes;
+/// parse failures propagate exactly as in check_module. This transport has no
+/// persistent identity or cache authority until a coordinator binds its inputs.
+export fn check_module_with_program_transport(job: ModuleJob) -> (ModuleOutcome, Option[Bytes]) with Exception {
+  let output: Array[Bytes] = []
+  let outcome = check_module_impl(job, false, Some(output))
+  let bytes = if Array::length(output) == 1 {
+    Some(Array::get(output, 0))
+  } else {
+    None
+  }
+  (outcome, bytes)
 }
 
 /// Coordinator-owned commit. Every filesystem and accumulator write for a


### PR DESCRIPTION
The existing checked-body artifacts could not reconstruct a complete `CheckedProgram`. Add a versioned `vCHK` transport for all five fields, reusing the complete AST binary codec and encoding every current semantic type, environment, declaration and substitution constructor.

`check_module_with_program_transport(job)` returns bytes from the same successful module-check invocation, including its actual dependency environments. Diagnosed checks publish no bytes, and parse failures retain their existing behavior. Ordinary module checks do not allocate transport bytes.

The decoder rejects malformed primitives, unknown tags, inconsistent cached row counts, duplicate substitution keys, corruption and trailing data. Tests cover restored lookup/provenance/substitution behavior, independent wire fixtures, public-interface identity across private edits, AST codegen parity and module diagnostic parity.

Formatting these regressions exposed a separate `#|` lexer bug: the formatter added a leading `|` to string content and consumed the following statement's newline. Fix both and add a parse-before/after and fixpoint regression.

This advances #2505. Persistent reuse remains a follow-up: the enclosing module artifact must bind source/binder data, dependency identities, mode and additional lowering tables, then pass full output/diagnostic corpus parity before codegen consumes it. The transport checksum detects corruption; it does not attest checker success or freshness. The transport document now states those boundaries and the comment/whitespace/location identity policy.

Validation:
- `pkf run full-gate` passed, including stage2/stage3 byte identity and gate self-tests.
- Full unit battery: 1,245/1,245 active test files passed with the newly built stage2 and a fresh output cache.
- Formatting: 1,256 files checked, no new violations.
- Pre-commit review/architecture/profile/documentation checks passed.
